### PR TITLE
Add first Actions

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -1,0 +1,68 @@
+name: buildtest
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'main'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: 4c-dependencies
+  FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
+
+permissions:
+  contents: read
+
+jobs:
+  gcc9:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ppraegla/4c-dependencies:latest
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.github_token }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      CMAKE_PRESET: docker
+      BUILD_TARGETS: full
+    steps:
+      - run: echo ${{ github.repository }}
+      # Due to a bug in runner action the variables $GITHUB_WORKSPACE and ${{ github.workspace }} are different inside a container. https://github.com/actions/runner/issues/2058
+      # The repo gets cloned to `/__w/4C/4C` ($GITHUB_WORKSPACE) while ${{ github.workspace }} points to `/home/runner/work/4C/4C`.`
+      # Use $GITHUB_WORKSPACE instead of ${{ github.workspace }}
+      - uses: actions/checkout@v4
+      - name: Fix git
+        run: git config --global --add safe.directory $GITHUB_WORKSPACE
+      - name: info
+        run: |
+          pwd; ls -l
+      - name: Build
+        run: |
+          echo ${{ github.workspace }}
+          echo $GITHUB_WORKSPACE
+          cmake --version; echo ${{ env.CMAKE_PRESET }}
+          mkdir -p $GITHUB_WORKSPACE/../build
+          cd $GITHUB_WORKSPACE
+          ./utilities/set_up_dev_env.sh
+          cd $GITHUB_WORKSPACE/../build
+          cmake $GITHUB_WORKSPACE --fresh --preset=${{ env.CMAKE_PRESET }}
+          echo Building the following targets ${{ env.BUILD_TARGETS }}
+          time cmake --build . --target ${{ env.BUILD_TARGETS }} -- -j `nproc` 2>&1
+      - name: Test
+        run: |
+          cd $GITHUB_WORKSPACE/../build
+          time ctest -L minimal -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/junit_test_summary.xml
+      - name: Upload build and test logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-and-test-logs
+          path: |
+            junit_test_summary.xml
+          retention-days: 1
+

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -1,0 +1,23 @@
+# Check for code style
+name: checkcode
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  checkcode:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run pre-commit
+        run: |
+          ./utilities/set_up_dev_env.sh
+          source ./utilities/python-venv/bin/activate
+          pre-commit clean
+          pre-commit run --all-files --show-diff-on-failure
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,70 @@
+name: Docker
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/docker.yaml'
+      - 'dependencies/current/'
+      - 'dependencies/testing/'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_SUFFIX: dependencies
+  FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+      #
+    steps:
+      # Hack to get the repository name as lower case as Github does not provide this function: https://github.com/orgs/community/discussions/25768
+      - id: repository-to-lower-case
+        run: |
+          echo "repository=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
+      - run: echo ${{ steps.repository-to-lower-case.outputs.repository }}
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      # - name: Extract metadata (tags, labels) for Docker
+      #   id: meta
+      #   uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+      #   with:
+      #     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ steps.repository-to-lower-case.outputs.repository }}-${{ env.IMAGE_SUFFIX
+            }}:${{ env.FOUR_C_DOCKER_DEPENDENCIES_HASH }}
+          # tags: ${{ steps.meta.outputs.tags }}
+          # labels: ${{ steps.meta.outputs.labels }}
+
+    # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+    # - name: Generate artifact attestation
+    #   uses: actions/attest-build-provenance@v1
+    #   with:
+    #     subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME}}
+    #     subject-digest: ${{ steps.push.outputs.digest }}
+    #     push-to-registry: true
+

--- a/.gitlab/CODEOWNERS
+++ b/.gitlab/CODEOWNERS
@@ -414,6 +414,7 @@ Gemfile.lock                                   @baci/team_infrastructure
 # template files
 .github/ISSUE_TEMPLATE/bug_report.md                                         @baci/baci_developers
 .github/ISSUE_TEMPLATE/enhancement.md                                        @baci/baci_developers
+.github/workflows/                                                           @baci/team_infrastructure
 .github/pull_request_template.md                                             @baci/baci_developers
 .gitlab/issue_templates/BUG_REPORT.md                                        @baci/team_infrastructure
 .gitlab/issue_templates/DEVELOPER_MEETING_TEMPLATE.md                        @baci/baci_developers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,7 @@ enable_testing()
 # NOTE: --mca orte_tmpdir_base [...] can be removed for openmpi >= 4.1.1 according to
 # https://github.com/open-mpi/ompi/issues/8510#issuecomment-1329297350
 set(MPIEXEC_EXTRA_OPTS_FOR_TESTING
-    "--bind-to none --mca orte_tmpdir_base ${PROJECT_BINARY_DIR}/tmp"
+    "--bind-to none --use-hwthread-cpus --mca orte_tmpdir_base ${PROJECT_BINARY_DIR}/tmp"
     )
 
 if(FOUR_C_ENABLE_ADDRESS_SANITIZER)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-> [!WARNING]  
+> [!WARNING]
 > We are currently migrating the project from GitLab. Links might be out-dated. Also, expect the main branch to be rebased.
 
 # 4C

--- a/cmake/functions/four_c_auto_define_module.cmake
+++ b/cmake/functions/four_c_auto_define_module.cmake
@@ -78,9 +78,10 @@ function(four_c_auto_define_module)
   # Add the headers as a file set to the interface library. This will automatically add the current directory as a search directory.
   # Since we append sources to a target successively, we need to add multiple file sets with a unique name. Use
   # the current directory name for this.
+  # Replace non-alphanumeric characters with underscores and make the name lowercase. Drop any leading digits and underscores.
   string(REGEX REPLACE "[^a-zA-Z0-9]" "_" _file_set_name "${CMAKE_CURRENT_SOURCE_DIR}")
   string(TOLOWER "${_file_set_name}" _file_set_name)
-  string(SUBSTRING "${_file_set_name}" 1 -1 _file_set_name)
+  string(REGEX REPLACE "^[0-9_]+" "" _file_set_name "${_file_set_name}")
 
   target_sources(
     ${_target}_deps

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -91,7 +91,7 @@ RUN mkdir ${FOUR_C_TESTING_DEPENDENCIES_DIR}
 RUN /dependencies/testing/llvm/install.sh /usr/local
 
 # Install newer GCC
-RUN /dependencies/testing/gcc/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}
+# RUN /dependencies/testing/gcc/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}
 
 # Install Mathjax
 RUN /dependencies/testing/mathjax/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}

--- a/src/core/comm/tests/4C_comm_utils_test.cpp
+++ b/src/core/comm/tests/4C_comm_utils_test.cpp
@@ -28,7 +28,7 @@ namespace
   {
     // mock up for command line to create communicators
     std::vector<std::string> argv{
-        "dummyEntryInputFile", "-nptype=separateDatFiles", "-ngroup=2", "-glayout=2,3"};
+        "dummyEntryInputFile", "-nptype=separateDatFiles", "-ngroup=2", "-glayout=1,2"};
 
     return Core::Communication::create_comm(argv);
   };

--- a/src/core/comm/tests/CMakeLists.txt
+++ b/src/core/comm/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SOURCE_LIST
 four_c_add_google_test_executable(
   ${TESTNAME}
   NP
-  5
+  3
   SOURCE
   ${SOURCE_LIST}
   )


### PR DESCRIPTION
The following workflows are added:
- Build the docker image containing the dependencies (remove the newer
  gcc compiler because the docker build takes too long otherwise. There
  is limit of 6 hours.
- Checkcode which runs pre-commit (The codeowner check is left out as it
  is tied to Gitlab)
- A first build and test workflow. We only run the minimal test as we
  ran out of disk space when running all tests.

Once this is merged. We are able to test if the actions and triggers work as expected.