### PR TITLE
CI: use separate workflow for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,37 @@
+name: deploy
+
+on:
+  workflow_run:
+    workflows: [documentation]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: doxygen
+          path: ${{ github.workspace }}/doxygen
+      - uses: actions/download-artifact@v4
+        with:
+          name: readthedocs
+          path: ${{ github.workspace }}/readthedocs
+      - uses: actions/upload-pages-artifact@v3
+        id: deployment
+        with:
+          path: ${{ github.workspace }}
+          retention-days: 1
+      - uses: actions/deploy-pages@v4
+

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -80,29 +80,3 @@ jobs:
           name: readthedocs
           path: ${{ github.workspace }}/build/doc/readthedocs/html/
           retention-days: 1
-  deploy:
-    runs-on: ubuntu-20.04
-    if: success() && github.ref == 'refs/heads/main'
-    needs: [doxygen, readthedocs]
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    permissions:
-      pages: write
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: doxygen
-          path: ${{ github.workspace }}/doxygen
-      - uses: actions/download-artifact@v4
-        with:
-          name: readthedocs
-          path: ${{ github.workspace }}/readthedocs
-      - uses: actions/upload-pages-artifact@v3
-        id: deployment
-        with:
-          path: ${{ github.workspace }}
-          retention-days: 1
-      - uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
Try to make the overview of actions a bit more intuitive by not showing the skipped deployment in PRs.