### PR TITLE
Add concurrency to auto-cancel workflows

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -16,6 +16,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   gcc9_build:
     env:

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -9,6 +9,10 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcode:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,6 +14,10 @@ env:
   IMAGE_SUFFIX: dependencies
   FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,6 +16,10 @@ env:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   doxygen:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To not waste resources, we need to cancel redundant workflows