### PR TITLE
Allow manual build of the docker image

### DIFF
--- a/.github/actions/compute-and-check-dependencies-hash/action.yml
+++ b/.github/actions/compute-and-check-dependencies-hash/action.yml
@@ -1,0 +1,31 @@
+name: dependencies hash
+description: Compute and check the docker dependencies hash
+inputs:
+  docker_image_hash:
+    description: 'The hash for the docker image'
+    required: true
+outputs:
+  computed_dependencies_hash:
+    description: 'The computed hash from the dependencies'
+    value: ${{ steps.compute-depencencies-hash.outputs.dependencies_hash }}
+runs:
+  using: composite
+  steps:
+    - id: compute-depencencies-hash
+      name: Compute the dependencies hash
+      run: |
+        cd $GITHUB_WORKSPACE
+        COMPUTED_DOCKER_DEPENDENCIES_HASH=`find dependencies docker -not -wholename '*/trilinos_develop/*' -not -name 'README.md' -type f -exec sha1sum {} \; | sort | sha1sum | cut -c -8`
+        echo "dependencies_hash=$COMPUTED_DOCKER_DEPENDENCIES_HASH" >> $GITHUB_OUTPUT
+        echo "COMPUTED_DOCKER_DEPENDENCIES_HASH=$COMPUTED_DOCKER_DEPENDENCIES_HASH" >> $GITHUB_ENV
+      shell: bash
+    - id: check-if-dependencies-hash-matches
+      name: Check if the dependencies hash matches
+      shell: bash
+      run: |
+        if [[ "$COMPUTED_DOCKER_DEPENDENCIES_HASH" == "${{ inputs.docker_image_hash }}" ]]; then
+          echo "The hash is correct."
+        else
+          echo "The hashes differ. The computed hash is $COMPUTED_DOCKER_DEPENDENCIES_HASH while the specified hash is ${{ inputs.docker_image_hash }}. You probably need to adapt the dependencies hash in the workflow."
+          exit 1
+        fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,24 +1,57 @@
 name: Docker
 
 on:
-  pull_request:
-    branches:
-      - 'main'
-    paths:
-      - '.github/workflows/docker.yaml'
-      - 'dependencies/current/'
-      - 'dependencies/testing/'
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
   IMAGE_SUFFIX: dependencies
   FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
+  IMAGE_PATH: ghcr.io/4c-multiphysics/4c-dependencies
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  check-if-docker-build-is-required:
+    runs-on: ubuntu-latest
+    outputs:
+      dependencies_hash: ${{ steps.compute-dependencies-hash.outputs.dependencies_hash.value }}
+      build_docker_image: ${{ steps.check-if-build-is-required.outputs.build }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: compute-dependencies-hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: check-if-build-is-required
+        name: Check if the docker image needs to be built
+        run: |
+          exit_code=0
+          docker manifest inspect ${{ env.IMAGE_PATH }}:$COMPUTED_DOCKER_DEPENDENCIES_HASH > /dev/null || exit_code=$?
+          echo $exit_code
+          case $exit_code in
+            0)
+              echo "Image exists"
+              echo "build=false" >> $GITHUB_OUTPUT
+              ;;
+            1)
+              echo "Image does not exist"
+              echo "build=true" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "Something went wrong. Exit code $exit_code"
+              exit 1
+              ;;
+          esac
+
   build-and-push-image:
     runs-on: ubuntu-latest
     # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
@@ -28,17 +61,22 @@ jobs:
       attestations: write
       id-token: write
       #
+    needs: check-if-docker-build-is-required
+    if: ${{ needs.check-if-docker-build-is-required.outputs.build_docker_image == 'true' }}
     steps:
       # Hack to get the repository name as lower case as Github does not provide this function: https://github.com/orgs/community/discussions/25768
       - id: repository-to-lower-case
         run: |
           echo "repository=${GITHUB_REPOSITORY@L}" >> $GITHUB_OUTPUT
       - run: echo ${{ steps.repository-to-lower-case.outputs.repository }}
+      - run: |
+          echo ${{ needs.check-if-docker-build-is-required.outputs.build_docker_image }}
+          echo ${{ needs.check-if-docker-build-is-required.outputs.dependencies_hash }}
       - name: Checkout repository
         uses: actions/checkout@v4
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -54,7 +92,7 @@ jobs:
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
         with:
           context: .
           file: docker/Dockerfile


### PR DESCRIPTION
This is the first part of the experiments in PR #17 . Once the `docker.yml` is on the default branch we can try to manually trigger the docker build and I will create another PR were we can try the docker update mechanism.