### PR TITLE
Add buildtest summary

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -110,3 +110,13 @@ jobs:
           path: |
             junit_test_summary-${{ matrix.test-chunk }}.xml
           retention-days: 1
+  ensure_all_tests_pass:
+    needs: [gcc9_test, gcc9_build]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check for successful builds and tests
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+


### PR DESCRIPTION
Add a job after buildtest that fails if one prior job failed.

This is the simplest way (I'm aware of) to tell Github that all jobs must succeed.