### PR TITLE
Update the docker image

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -9,9 +9,7 @@ on:
       - 'main'
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: 4c-dependencies
-  FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
+  FOUR_C_DOCKER_DEPENDENCIES_HASH: 40d8b295
 
 permissions:
   contents: read
@@ -26,7 +24,7 @@ jobs:
       CMAKE_PRESET: docker
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c-dependencies:latest
+      image: ghcr.io/4c-multiphysics/4c-dependencies:40d8b295
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
       credentials:
         username: ${{ github.actor }}
@@ -40,6 +38,10 @@ jobs:
       # The repo gets cloned to `/__w/4C/4C` ($GITHUB_WORKSPACE) while ${{ github.workspace }} points to `/home/runner/work/4C/4C`.`
       # Use $GITHUB_WORKSPACE instead of ${{ github.workspace }}
       - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -65,11 +67,12 @@ jobs:
           path: |
             ${{ github.workspace }}/4C_build.tar
           retention-days: 1
+
   gcc9_test:
     needs: gcc9_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c-dependencies:latest
+      image: ghcr.io/4c-multiphysics/4c-dependencies:40d8b295
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
       credentials:
         username: ${{ github.actor }}
@@ -84,6 +87,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
       - name: Setup developer environment for testing
         run: |
           cd $GITHUB_WORKSPACE
@@ -110,6 +117,7 @@ jobs:
           path: |
             junit_test_summary-${{ matrix.test-chunk }}.xml
           retention-days: 1
+
   ensure_all_tests_pass:
     needs: [gcc9_test, gcc9_build]
     runs-on: ubuntu-latest

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -11,9 +11,6 @@ on:
 env:
   FOUR_C_DOCKER_DEPENDENCIES_HASH: 40d8b295
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
+      - run: apt update
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - 'main'
 
+env:
+  FOUR_C_DOCKER_DEPENDENCIES_HASH: 40d8b295
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,10 +29,11 @@ jobs:
           source ./utilities/python-venv/bin/activate
           pre-commit clean
           pre-commit run --all-files --show-diff-on-failure
+
   clang-tidy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c-dependencies:latest
+      image: ghcr.io/4c-multiphysics/4c-dependencies:40d8b295
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
       credentials:
         username: ${{ github.actor }}
@@ -39,6 +43,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
       - uses: ./.github/actions/configure_4C
         with:
           cmake-preset: docker_codeclimate
@@ -49,10 +57,11 @@ jobs:
           mkdir -p clang-tidy-issues
           ESCAPED_PROJECT_DIR=$(echo "${GITHUB_WORKSPACE}" | sed 's/\//\\\//g')
           run-clang-tidy -j `nproc` -config-file ${GITHUB_WORKSPACE}/utilities/code_climate/clang-tidy-config -use-color -p . -export-fixes ./clang-tidy-issues/ -header-filter "${ESCAPED_PROJECT_DIR}\/.*" 2>&1 | python ${GITHUB_WORKSPACE}/utilities/code_climate/filter_clang_tidy_output.py
+
   verify-headers:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c-dependencies:latest
+      image: ghcr.io/4c-multiphysics/4c-dependencies:40d8b295
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
       credentials:
         username: ${{ github.actor }}
@@ -62,6 +71,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
       - uses: ./.github/actions/configure_4C
         with:
           cmake-preset: docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_SUFFIX: dependencies
-  FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
+  FOUR_C_DOCKER_DEPENDENCIES_HASH: 40d8b295
   IMAGE_PATH: ghcr.io/4c-multiphysics/4c-dependencies
 
 concurrency:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,7 +17,7 @@ jobs:
   check-if-docker-build-is-required:
     runs-on: ubuntu-latest
     outputs:
-      dependencies_hash: ${{ steps.compute-dependencies-hash.outputs.dependencies_hash.value }}
+      dependencies_hash: ${{ steps.compute-dependencies-hash.outputs.dependencies_hash }}
       build_docker_image: ${{ steps.check-if-build-is-required.outputs.build }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,9 +9,7 @@ on:
       - 'main'
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: 4c-dependencies
-  FOUR_C_DOCKER_DEPENDENCIES_HASH: 7a6ad12e
+  FOUR_C_DOCKER_DEPENDENCIES_HASH: 40d8b295
 
 permissions:
   contents: read
@@ -24,7 +22,7 @@ jobs:
   doxygen:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c-dependencies:latest
+      image: ghcr.io/4c-multiphysics/4c-dependencies:40d8b295
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
       credentials:
         username: ${{ github.actor }}
@@ -34,6 +32,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
       - uses: ./.github/actions/configure_4C
         with:
           cmake-preset: docker
@@ -48,10 +50,11 @@ jobs:
           name: doxygen
           path: ${{ github.workspace }}/build/doc/doxygen/html/
           retention-days: 1
+
   readthedocs:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ppraegla/4c-dependencies:latest
+      image: ghcr.io/4c-multiphysics/4c-dependencies:40d8b295
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
       credentials:
         username: ${{ github.actor }}
@@ -61,6 +64,10 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -65,6 +65,7 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $FOUR_C_DOCKER_DEPENDENCIES_HASH
+      - run: apt update
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,9 +11,6 @@ on:
 env:
   FOUR_C_DOCKER_DEPENDENCIES_HASH: 40d8b295
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/dependencies/current/backtrace/install.sh
+++ b/dependencies/current/backtrace/install.sh
@@ -34,4 +34,5 @@ unzip ${VERSION}.zip
 cd libbacktrace-${VERSION}
 ./configure --prefix=${INSTALL_DIR}
 make -j${NPROCS} && make install
-cd .. && rm -rf libbacktrace-${VERSION}
+cd ..
+rm -rf libbacktrace-${VERSION} ${VERSION}.zip

--- a/dependencies/current/qhull/install.sh
+++ b/dependencies/current/qhull/install.sh
@@ -34,4 +34,5 @@ tar -xzf ${VERSION}.tar.gz
 cd qhull-${VERSION}/build
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} ..
 make -j${NPROCS} && make install
-cd ../../ && rm -rf qhull*
+cd ../../
+rm -rf qhull* ${VERSION}.tar.gz

--- a/dependencies/current/suitesparse/install.sh
+++ b/dependencies/current/suitesparse/install.sh
@@ -34,5 +34,5 @@ cd SuiteSparse-${VERSION}/
 make -j${NPROCS} library BLAS=-lblas
 make install INSTALL=${INSTALL_DIR} BLAS=-lblas
 cd ../
-rm -rf SuiteSparse*
+rm -rf SuiteSparse* v${VERSION}.tar.gz
 # Need to specify metis location?

--- a/dependencies/current/superlu_dist/install.sh
+++ b/dependencies/current/superlu_dist/install.sh
@@ -62,3 +62,4 @@ $CMAKE_COMMAND \
 
 make -j${NPROCS} install
 cd ..
+rm -rf $SUPERLU_TAR $SUPERLU_SRC $BUILD_DIR

--- a/dependencies/current/trilinos/install.sh
+++ b/dependencies/current/trilinos/install.sh
@@ -111,3 +111,4 @@ $CMAKE_COMMAND \
 
 make -j${NPROCS} install
 cd ..
+rm -rf Trilinos trilinos_build

--- a/dependencies/testing/mathjax/install.sh
+++ b/dependencies/testing/mathjax/install.sh
@@ -28,3 +28,4 @@ else
 fi
 
 tar -xzf ${VERSION}.tar.gz -C ${INSTALL_DIR}
+rm -rf ${VERSION}.tar.gz

--- a/dependencies/testing/paraview/install.sh
+++ b/dependencies/testing/paraview/install.sh
@@ -28,3 +28,4 @@ else
 fi
 
 tar -xzf paraview.tar.gz -C ${INSTALL_DIR}
+rm -rf paraview.tar.gz

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,8 +15,9 @@ USER root
 
 # Set locale information:. region and timezone
 RUN apt-get update && apt-get install -y locales && \
-    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-RUN locale-gen en_US.UTF-8
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+    locale-gen en_US.UTF-8 && \
+    rm -rf /var/lib/apt/lists/*
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -31,9 +32,9 @@ RUN apt-get update && apt-get install -y \
       sudo \
       unzip \
       vim \
-      wget
-
-RUN apt-get update && apt-get install -y \
+      wget \
+      && \
+    apt-get update && apt-get install -y \
       cxxtest \
       doxygen \
       graphviz \
@@ -55,7 +56,8 @@ RUN apt-get update && apt-get install -y \
       libparmetis-dev \
       metis \
       ninja-build \
-      libyaml-dev
+      libyaml-dev \
+      && rm -rf /var/lib/apt/lists/*
 
 # Create directory for dependencies
 ARG NPROCS=12


### PR DESCRIPTION
This PR updates the docker image. I removed some unnecessary files from the docker image such that we save 3 GB for the resulting image. It is still quite large with 8.7 GB. But for now this should get us around disk space problems on the runner when building the image.

This is a follow-up to #19 .  I pushed the branch directly into the 4c repo in order to be able to use a manual workflow to update the docker image. After that the pipeline triggered by this PR should work :crossed_fingers: 

The update process is quite annoying at the moment because we cannot use a variable for `container.image` such that you need to manually replace all occurrences when you update the docker hash. At the moment, this is quite brittle as the I only check that the pulled files inside the repo match the environment variable, defined in the workflow. So, it can still happen that you run the wrong container if you forget to adapt the image name.

In a follow-up PR I will adapt the check such that we check the docker hash against the actually used image and not the error-prone environment variable in the workflow.