### PR TITLE
CI: don't run checkcode and tests on main

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -62,6 +62,7 @@ jobs:
   gcc9_test:
     needs: gcc9_build
     runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -5,9 +5,6 @@ on:
   pull_request:
     branches:
       - 'main'
-  push:
-    branches:
-      - 'main'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Let's skip a few checks that are not necessary on main. 