### PR TITLE
Add further actions to reduce duplication

### DIFF
--- a/.github/actions/build_4C/action.yml
+++ b/.github/actions/build_4C/action.yml
@@ -1,15 +1,41 @@
 name: Build 4C
 description: Build a specified 4C target
 inputs:
+  cmake-preset:
+    description: Name of the preset
+    required: true
+    default: docker
   build-directory:
     description: Path to the build directory
     required: true
   build-targets:
     description: Targets to build
     required: true
+  use-ccache:
+    description: Use ccache to speed up the build
+    required: false
+    default: "true"
+  additional-cmake-flags:
+    description: Additional flags to pass to CMake
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
+    - shell: bash
+      if: ${{ inputs.use-ccache == 'true' }}
+      run: apt-get update
+    - name: Setup ccache
+      if: ${{ inputs.use-ccache == 'true' }}
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: ${{ github.job }}-${{ inputs.cmake-preset }}
+    - uses: ./.github/actions/configure_4C
+      with:
+        cmake-preset: ${{ inputs.cmake-preset }}
+        build-directory: ${{ inputs.build-directory }}
+        additional-cmake-flags: ${{ ( inputs.use-ccache == 'true' && '-DCMAKE_C_COMPILER_LAUNCHER=ccache
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache' ) }} ${{ inputs.additional-cmake-flags }}
     - name: Build 4C with targets ${{ inputs.build-targets }}
       run: |
         cd $BUILD_DIRECTORY

--- a/.github/actions/download_4C_build/action.yml
+++ b/.github/actions/download_4C_build/action.yml
@@ -1,0 +1,17 @@
+name: Download 4C Build
+description: Downloads the 4C build from an artifact based on the upload_4C_build-action
+inputs:
+  build-job:
+    description: Name of the build-job
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.build-job }}-4C-build
+        path: ${{ github.workspace }}
+    - name: Extract 4C build
+      shell: bash
+      run: |
+        tar -xf $GITHUB_WORKSPACE/4C_build.tar -C /

--- a/.github/actions/upload_4C_build/action.yml
+++ b/.github/actions/upload_4C_build/action.yml
@@ -1,0 +1,23 @@
+name: Upload 4C Build
+description: Uploads the 4C build in a tarball as artifact
+inputs:
+  build-directory:
+    description: Path to the build directory
+    required: true
+  retention-days:
+    description: Number of days to retain the artifact
+    required: false
+    default: "1"
+runs:
+  using: composite
+  steps:
+    - name: Package build directory
+      shell: bash
+      run: tar -cf $GITHUB_WORKSPACE/4C_build.tar $GITHUB_WORKSPACE/build
+    - name: Upload build folder
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ github.job }}-4C-build
+        path: |
+          ${{ github.workspace }}/4C_build.tar
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -14,15 +14,10 @@ concurrency:
 
 jobs:
   gcc9_build:
-    env:
-      CMAKE_PRESET: docker
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     defaults:
       run:
         shell: bash
@@ -35,28 +30,15 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $DEPENDENCIES_HASH
-      - run: apt update
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}-${{ env.CMAKE_PRESET }}
-      - uses: ./.github/actions/configure_4C
-        with:
-          cmake-preset: ${{ env.CMAKE_PRESET }}
-          build-directory: ${{ github.workspace }}/build
-          additional-cmake-flags: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - uses: ./.github/actions/build_4C
         with:
+          cmake-preset: docker
           build-targets: full
           build-directory: ${{ github.workspace }}/build
-      - name: Package build directory
-        run: tar -cvf $GITHUB_WORKSPACE/4C_build.tar $GITHUB_WORKSPACE/build
-      - name: Upload build folder
-        uses: actions/upload-artifact@v4
+          use-ccache: "true"
+      - uses: ./.github/actions/upload_4C_build
         with:
-          name: 4C-build
-          path: |
-            ${{ github.workspace }}/4C_build.tar
+          build-directory: ${{ github.workspace }}/build
           retention-days: 1
 
   gcc9_test:
@@ -66,9 +48,6 @@ jobs:
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     strategy:
       fail-fast: false
       matrix:
@@ -88,38 +67,21 @@ jobs:
           cd $GITHUB_WORKSPACE
           git config --global --add safe.directory $GITHUB_WORKSPACE
           ./utilities/set_up_dev_env.sh
-      - uses: actions/download-artifact@v4
+      - uses: ./.github/actions/download_4C_build
         with:
-          name: 4C-build
-          path: ${{ github.workspace }}
-      - name: Extract 4C build
-        run: |
-          tar -xvf $GITHUB_WORKSPACE/4C_build.tar -C /
+          build-job: gcc9_build
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/junit_test_summary.xml
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
-      - name: Upload test summary
-        if: ${{ always() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-summary-${{ matrix.test-chunk }}
-          path: |
-            junit_test_summary-${{ matrix.test-chunk }}.xml
-          retention-days: 1
 
-  clang18_build_test_minimal:
-    env:
-      CMAKE_PRESET: docker_release_clang18
+  clang18_build:
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     defaults:
       run:
         shell: bash
@@ -132,27 +94,47 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $DEPENDENCIES_HASH
-      - run: apt update
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}-${{ env.CMAKE_PRESET }}
-      - uses: ./.github/actions/configure_4C
-        with:
-          cmake-preset: ${{ env.CMAKE_PRESET }}
-          build-directory: ${{ github.workspace }}/build
-          additional-cmake-flags: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - uses: ./.github/actions/build_4C
         with:
+          cmake-preset: docker_release_clang18
           build-targets: full
           build-directory: ${{ github.workspace }}/build
-      - name: Run minimal tests
+          use-ccache: "true"
+      - uses: ./.github/actions/upload_4C_build
+        with:
+          build-directory: ${{ github.workspace }}/build
+          retention-days: 1
+
+  clang18_test_minimal:
+    needs: clang18_build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          docker_image_hash: $DEPENDENCIES_HASH
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          ./utilities/set_up_dev_env.sh
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: clang18_build
+      - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
           ctest -L minimal -j `nproc` --output-on-failure
 
   ensure_all_tests_pass:
-    needs: [gcc9_test, gcc9_build, clang18_build_test_minimal]
+    needs: [gcc9_test, gcc9_build, clang18_build, clang18_test_minimal]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -29,9 +29,6 @@ jobs:
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     defaults:
       run:
         shell: bash
@@ -57,9 +54,6 @@ jobs:
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     defaults:
       run:
         shell: bash
@@ -69,12 +63,10 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $DEPENDENCIES_HASH
-      - uses: ./.github/actions/configure_4C
-        with:
-          cmake-preset: docker
-          build-directory: ${{ github.workspace }}/../verify-header-build
-          additional-cmake-flags: "-DCMAKE_VERIFY_INTERFACE_HEADER_SETS=\"ON\""
       - uses: ./.github/actions/build_4C
         with:
+          cmake-preset: docker
           build-targets: all_verify_interface_header_sets
           build-directory: ${{ github.workspace }}/../verify-header-build
+          use-ccache: "false"
+          additional-cmake-flags: '-DCMAKE_VERIFY_INTERFACE_HEADER_SETS="ON"'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,9 +18,6 @@ jobs:
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     defaults:
       run:
         shell: bash
@@ -30,14 +27,12 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $DEPENDENCIES_HASH
-      - uses: ./.github/actions/configure_4C
-        with:
-          cmake-preset: docker
-          build-directory: ${{ github.workspace }}/build
       - uses: ./.github/actions/build_4C
         with:
+          cmake-preset: docker
           build-targets: doxygen
           build-directory: ${{ github.workspace }}/build
+          use-ccache: "false"
       - name: Upload doxygen
         uses: actions/upload-artifact@v4
         with:
@@ -46,15 +41,10 @@ jobs:
           retention-days: 1
 
   readthedocs:
-    env:
-      CMAKE_PRESET: docker
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/4c-multiphysics/4c-dependencies:2083744d
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.github_token }}
     defaults:
       run:
         shell: bash
@@ -64,20 +54,12 @@ jobs:
         uses: ./.github/actions/compute-and-check-dependencies-hash
         with:
           docker_image_hash: $DEPENDENCIES_HASH
-      - run: apt update
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ github.job }}-${{ env.CMAKE_PRESET }}
-      - uses: ./.github/actions/configure_4C
-        with:
-          cmake-preset: ${{ env.CMAKE_PRESET }}
-          build-directory: ${{ github.workspace }}/build
-          additional-cmake-flags: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - uses: ./.github/actions/build_4C
         with:
+          cmake-preset: docker
           build-targets: readthedocs
           build-directory: ${{ github.workspace }}/build
+          use-ccache: "true"
       - name: Upload readthedocs
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
This PR preparing us to reuse more of the defined steps to build and test 4C in a workflow running every night.

 * Extends `build_4C` that now internally calls `configure_4C` and prepares `ccache` if wanted.
 * Adds actions to upload and download the build-folder from previous artifacts.
 * separates clang build and test in PR testing.