### PR TITLE
Fix clang-tidy output filter

### DIFF
--- a/utilities/code_climate/filter_clang_tidy_output.py
+++ b/utilities/code_climate/filter_clang_tidy_output.py
@@ -16,7 +16,7 @@ number_of_warnings = re.compile(r"^\d+ warnings generated.$")
 supressed_warnings_hint = re.compile(r"^Suppressed \d+ warnings")
 display_warning_hint = re.compile(r"^Use -header-filter=\.\* to display errors")
 
-clang_invocation = re.compile(r"^\/\S+\/clang-tidy ")
+clang_invocation = re.compile(r"^\/?\S*\/?clang-tidy-?\d* ")
 
 color_output_regex = re.compile(r"\033\[[0-9;]+m")
 


### PR DESCRIPTION
Instead of

```
/usr/local/bin/clang-tidy -header-fi[...]
```
we have to filter 
```
clang-tidy-18 -header-fi[...]
```
now.