### PR TITLE
Wrap more Epetra_Comm calls

### DIFF
--- a/apps/post_processor/4C_post_processor_single_field_writers.cpp
+++ b/apps/post_processor/4C_post_processor_single_field_writers.cpp
@@ -378,7 +378,7 @@ void PoroFluidMultiPhaseFilter::write_all_results(PostField* field)
     if (numdof > mynumdofpernode) mynumdofpernode = numdof;
   }
   int numdofpernode(-1);
-  discret.get_comm().MaxAll(&mynumdofpernode, &numdofpernode, 1);
+  Core::Communication::max_all(&mynumdofpernode, &numdofpernode, 1, discret.get_comm());
 
   // write results for each transported scalar
   for (int k = 1; k <= numdofpernode; k++)
@@ -427,7 +427,7 @@ void ScaTraFilter::write_all_results(PostField* field)
     if (numdof > mynumdofpernode) mynumdofpernode = numdof;
   }
   int numdofpernode(-1);
-  discret.get_comm().MaxAll(&mynumdofpernode, &numdofpernode, 1);
+  Core::Communication::max_all(&mynumdofpernode, &numdofpernode, 1, discret.get_comm());
 
   // write results for each transported scalar
   for (int k = 1; k <= numdofpernode; k++)
@@ -511,7 +511,7 @@ void ElchFilter::write_all_results(PostField* field)
   for (int inode = 0; inode < discret.num_my_row_nodes(); ++inode)
     mynumdofpernodeset.insert(discret.num_dof(discret.l_row_node(inode)));
   int mysize(mynumdofpernodeset.size()), maxsize(-1);
-  discret.get_comm().MaxAll(&mysize, &maxsize, 1);
+  Core::Communication::max_all(&mysize, &maxsize, 1, discret.get_comm());
   std::vector<int> mynumdofpernodevec(mynumdofpernodeset.begin(), mynumdofpernodeset.end());
   mynumdofpernodevec.resize(maxsize, -1);
   std::vector<int> numdofpernodevec(

--- a/apps/pre_exodus/4C_pre_exodus_reader.cpp
+++ b/apps/pre_exodus/4C_pre_exodus_reader.cpp
@@ -9,7 +9,6 @@
 
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 
-#include <Epetra_SerialComm.h>
 #include <exodusII.h>
 #include <Teuchos_Time.hpp>
 #include <Teuchos_TimeMonitor.hpp>
@@ -498,7 +497,6 @@ std::map<int, std::vector<int>> EXODUS::Mesh::get_side_set_conn(const SideSet si
   std::cout << "Creating SideSet Connectivity... " << std::endl;
   fflush(stdout);
 
-  Epetra_SerialComm Comm;
   Teuchos::Time time("", true);
   auto timetot = Teuchos::TimeMonitor::getNewTimer("Side Set Connect total");
   auto time1 = Teuchos::TimeMonitor::getNewTimer("One Side Set");
@@ -638,7 +636,6 @@ std::map<int, std::vector<int>> EXODUS::Mesh::get_side_set_conn(
   std::cout << "Creating SideSet Connectivity with outside-check... " << std::endl;
   fflush(stdout);
 
-  Epetra_SerialComm Comm;
   Teuchos::Time time("", true);
   auto timetot = Teuchos::TimeMonitor::getNewTimer("Side Set Connect total");
   auto time1 = Teuchos::TimeMonitor::getNewTimer("One Side Set");

--- a/src/adapter/4C_adapter_str_redairway.cpp
+++ b/src/adapter/4C_adapter_str_redairway.cpp
@@ -127,7 +127,7 @@ void Adapter::StructureRedAirway::calc_vol(std::map<int, double>& V)
       tmp += elevector3[0];
     }
     double vol = 0.;
-    discretization()->get_comm().SumAll(&tmp, &vol, 1);
+    Core::Communication::sum_all(&tmp, &vol, 1, discretization()->get_comm());
     if (vol < 0.0) vol *= -1.0;
     V[condID] = vol;
   }

--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -639,19 +639,19 @@ void Adapter::StructureBaseAlgorithmNew::detect_element_technologies(
   }
 
   // plasticity - sum over all processors
-  actdis_->get_comm().SumAll(&isplasticity_local, &isplasticity_global, 1);
+  Core::Communication::sum_all(&isplasticity_local, &isplasticity_global, 1, actdis_->get_comm());
   if (isplasticity_global > 0) eletechs.insert(Inpar::Solid::EleTech::plasticity);
 
   // eas - sum over all processors
-  actdis_->get_comm().SumAll(&iseas_local, &iseas_global, 1);
+  Core::Communication::sum_all(&iseas_local, &iseas_global, 1, actdis_->get_comm());
   if (iseas_global > 0) eletechs.insert(Inpar::Solid::EleTech::eas);
 
   // fbar - sum over all processors
-  actdis_->get_comm().SumAll(&isfbar_local, &isfbar_global, 1);
+  Core::Communication::sum_all(&isfbar_local, &isfbar_global, 1, actdis_->get_comm());
   if (isfbar_global > 0) eletechs.insert(Inpar::Solid::EleTech::fbar);
 
   // rotation vector DOFs - sum over all processors
-  actdis_->get_comm().SumAll(&isrotvec_local, &isrotvec_global, 1);
+  Core::Communication::sum_all(&isrotvec_local, &isrotvec_global, 1, actdis_->get_comm());
   if (isrotvec_global > 0) eletechs.insert(Inpar::Solid::EleTech::rotvec);
 }
 

--- a/src/ale/4C_ale_resulttest.cpp
+++ b/src/ale/4C_ale_resulttest.cpp
@@ -36,7 +36,7 @@ void ALE::AleResultTest::test_node(
 
   int havenode(aledis_->have_global_node(node));
   int isnodeofanybody(0);
-  aledis_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, aledis_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/art_net/4C_art_net_artery_resulttest.cpp
+++ b/src/art_net/4C_art_net_artery_resulttest.cpp
@@ -49,7 +49,7 @@ void Arteries::ArteryResultTest::test_node(
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);
-  dis_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, dis_->get_comm());
 
   if (isnodeofanybody == 0)
   {
@@ -104,7 +104,7 @@ void Arteries::ArteryResultTest::test_element(
 
   int haveelement(dis_->have_global_element(element));
   int iselementofanybody(0);
-  dis_->get_comm().SumAll(&haveelement, &iselementofanybody, 1);
+  Core::Communication::sum_all(&haveelement, &iselementofanybody, 1, dis_->get_comm());
 
   if (iselementofanybody == 0)
   {

--- a/src/art_net/4C_art_net_impl_stationary.cpp
+++ b/src/art_net/4C_art_net_impl_stationary.cpp
@@ -280,7 +280,7 @@ void Arteries::ArtNetImplStationary::assemble_mat_and_rhs()
 
   // end time measurement for element
   double mydtele = Teuchos::Time::wallTime() - tcpuele;
-  discret_->get_comm().MaxAll(&mydtele, &dtele_, 1);
+  Core::Communication::max_all(&mydtele, &dtele_, 1, discret_->get_comm());
 
 }  // ArtNetExplicitTimeInt::assemble_mat_and_rhs
 
@@ -313,7 +313,7 @@ void Arteries::ArtNetImplStationary::linear_solve()
 
   // end time measurement for solver
   double mydtsolve = Teuchos::Time::wallTime() - tcpusolve;
-  discret_->get_comm().MaxAll(&mydtsolve, &dtsolve_, 1);
+  Core::Communication::max_all(&mydtsolve, &dtsolve_, 1, discret_->get_comm());
 
 }  // ArtNetImplStationary::linear_solve
 

--- a/src/beam3/4C_beam3_discretization_runtime_vtu_writer.cpp
+++ b/src/beam3/4C_beam3_discretization_runtime_vtu_writer.cpp
@@ -10,6 +10,7 @@
 #include "4C_beam3_base.hpp"
 #include "4C_beam3_reissner.hpp"
 #include "4C_beaminteraction_calc_utils.hpp"
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_condition.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
@@ -1514,7 +1515,8 @@ void BeamDiscretizationRuntimeOutputWriter::append_rve_crosssection_forces(
 
   std::vector<std::vector<double>> global_sum(3, std::vector<double>(3, 0.0));
   for (int dir = 0; dir < 3; ++dir)
-    discretization_->get_comm().SumAll(fint_sum[dir].data(), global_sum[dir].data(), 3);
+    Core::Communication::sum_all(
+        fint_sum[dir].data(), global_sum[dir].data(), 3, discretization_->get_comm());
 
   // loop over all my elements and build force sum of myrank's cut element
   for (unsigned int ibeamele = 0; ibeamele < num_beam_row_elements; ++ibeamele)
@@ -1632,7 +1634,7 @@ int BeamDiscretizationRuntimeOutputWriter::get_global_number_of_gauss_points_per
 {
   int my_num_gp_signed = (int)my_num_gp;
   int global_num_gp = 0;
-  discretization_->get_comm().MaxAll(&my_num_gp_signed, &global_num_gp, 1);
+  Core::Communication::max_all(&my_num_gp_signed, &global_num_gp, 1, discretization_->get_comm());
 
   // Safety checks.
   if (my_num_gp_signed > 0 and my_num_gp_signed != global_num_gp)

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -588,7 +588,7 @@ void Beam3ContactOctTree::create_bounding_boxes(
   double bbgentimelocal = Teuchos::Time::wallTime() - t_AABB;
   double bbgentimeglobal = 0.0;
 
-  searchdis_.Comm().MaxAll(&bbgentimelocal, &bbgentimeglobal, 1);
+  Core::Communication::max_all(&bbgentimelocal, &bbgentimeglobal, 1, searchdis_.Comm());
 
   if (!Core::Communication::my_mpi_rank(searchdis_.Comm()))
     std::cout << "\n\nBBox creation time:\t\t" << bbgentimeglobal << " seconds" << std::endl;
@@ -988,7 +988,7 @@ bool Beam3ContactOctTree::locate_all()
   }
 
   // communicate bbox2octant_ to all Procs
-  searchdis_.get_comm().MaxAll(&maxnumoctlocal, &maxnumoctglobal, 1);
+  Core::Communication::max_all(&maxnumoctlocal, &maxnumoctglobal, 1, searchdis_.get_comm());
   bbox2octant_ = std::make_shared<Core::LinAlg::MultiVector<double>>(
       *(searchdis_.element_col_map()), maxnumoctglobal, true);
 
@@ -1003,8 +1003,8 @@ bool Beam3ContactOctTree::locate_all()
       *(searchdis_.element_row_map()), maxnumoctglobal, true);
   communicate_multi_vector(bbox2octantrow, *bbox2octant_);
 
-  searchdis_.get_comm().MaxAll(&maxdepthlocal, &maxdepthglobal, 1);
-  searchdis_.get_comm().MaxAll(&bboxlengthlocal, &bboxlengthglobal, 1);
+  Core::Communication::max_all(&maxdepthlocal, &maxdepthglobal, 1, searchdis_.get_comm());
+  Core::Communication::max_all(&bboxlengthlocal, &bboxlengthglobal, 1, searchdis_.get_comm());
 
   /* build temporary, fully overlapping map and row map for octree
    * Note: maxdepthglobal does not occur for a converging Newton iteration. Yet, in some cases, when
@@ -1567,8 +1567,8 @@ void Beam3ContactOctTree::bounding_box_intersection(
   double isectimelocal = Teuchos::Time::wallTime() - t_search;
   double isectimeglobal = 0.0;
 
-  searchdis_.Comm().MaxAll(&isectimelocal, &isectimeglobal, 1);
-  discret_.Comm().Barrier();
+  Core::Communication::max_all(&isectimelocal, &isectimeglobal, 1, searchdis_.Comm());
+  Core::Communication::barrier(discret_.Comm());
   if (!Core::Communication::my_mpi_rank(searchdis_.Comm()))
     std::cout << "intersection time:\t\t" << isectimeglobal << " seconds" << std::endl;
 #endif

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
@@ -126,7 +126,8 @@ void BEAMINTERACTION::BeamToSolidMortarManager::setup()
   // to construct the lambda_dof_rowmap_.
   std::vector<int> lambda_dof_per_rank(Core::Communication::num_mpi_ranks(discret_->get_comm()), 0);
   int temp_my_n_lambda_dof = (int)n_lambda_dof;
-  discret_->get_comm().GatherAll(&temp_my_n_lambda_dof, lambda_dof_per_rank.data(), 1);
+  Core::Communication::gather_all(
+      &temp_my_n_lambda_dof, lambda_dof_per_rank.data(), 1, discret_->get_comm());
 
   // Get the start GID for the lambda DOFs on this processor.
   int my_lambda_gid_start_value = start_value_lambda_gid_;

--- a/src/beaminteraction/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/4C_beaminteraction_calc_utils.cpp
@@ -342,11 +342,11 @@ namespace BEAMINTERACTION
 
         // proc i tells all procs how many nodegids it has
         int numnodes = requirednodes.size();
-        discret.get_comm().Broadcast(&numnodes, 1, iproc);
+        Core::Communication::broadcast(&numnodes, 1, iproc, discret.get_comm());
 
         // proc i actually sends nodegids
         requirednodes.resize(numnodes);
-        discret.get_comm().Broadcast(requirednodes.data(), numnodes, iproc);
+        Core::Communication::broadcast(requirednodes.data(), numnodes, iproc, discret.get_comm());
 
         std::set<int> sdata;
         std::set<int> rdata;

--- a/src/beaminteraction/4C_beaminteraction_crosslinker_handler.cpp
+++ b/src/beaminteraction/4C_beaminteraction_crosslinker_handler.cpp
@@ -142,8 +142,9 @@ void BEAMINTERACTION::BeamCrosslinkerHandler::fill_linker_into_bins_round_robin(
 
     // wait for all communication to finish
     exporter.wait(request);
-    binstrategy_->bin_discret()->get_comm().Barrier();  // I feel better this way ;-)
-  }                                                     // end for irobin
+    Core::Communication::barrier(
+        binstrategy_->bin_discret()->get_comm());  // I feel better this way ;-)
+  }                                                // end for irobin
 
   if (homelesslinker.size())
   {
@@ -238,7 +239,8 @@ BEAMINTERACTION::BeamCrosslinkerHandler::fill_linker_into_bins_remote_id_list(
 
   // ---- prepare receiving procs -----
   std::vector<int> summedtargets(numproc, 0);
-  binstrategy_->bin_discret()->get_comm().SumAll(targetprocs.data(), summedtargets.data(), numproc);
+  Core::Communication::sum_all(
+      targetprocs.data(), summedtargets.data(), numproc, binstrategy_->bin_discret()->get_comm());
 
   // ---- send ----
   Core::Communication::Exporter exporter(binstrategy_->bin_discret()->get_comm());
@@ -260,7 +262,8 @@ BEAMINTERACTION::BeamCrosslinkerHandler::fill_linker_into_bins_remote_id_list(
     for (int i = 0; i < length; ++i) exporter.wait(request[i]);
   }
 
-  binstrategy_->bin_discret()->get_comm().Barrier();  // I feel better this way ;-)
+  Core::Communication::barrier(
+      binstrategy_->bin_discret()->get_comm());  // I feel better this way ;-)
 
   return removedlinker;
 }
@@ -364,7 +367,8 @@ BEAMINTERACTION::BeamCrosslinkerHandler::fill_linker_into_bins_using_ghosting(
   // -----------------------------------------------------------------------
   // ---- prepare receiving procs -----
   std::vector<int> summedtargets(numproc, 0);
-  binstrategy_->bin_discret()->get_comm().SumAll(targetprocs.data(), summedtargets.data(), numproc);
+  Core::Communication::sum_all(
+      targetprocs.data(), summedtargets.data(), numproc, binstrategy_->bin_discret()->get_comm());
 
   // ---- receive -----
   receive_linker_and_fill_them_in_bins(summedtargets[myrank_], exporter, homelesslinker);
@@ -373,7 +377,7 @@ BEAMINTERACTION::BeamCrosslinkerHandler::fill_linker_into_bins_using_ghosting(
   for (int i = 0; i < length; ++i) exporter.wait(request[i]);
 
   // should be no time operation (if we have done everything correctly)
-  binstrategy_->bin_discret()->get_comm().Barrier();
+  Core::Communication::barrier(binstrategy_->bin_discret()->get_comm());
 
   return removedlinker;
 }

--- a/src/beaminteraction/4C_beaminteraction_submodel_evaluator_beamcontact.cpp
+++ b/src/beaminteraction/4C_beaminteraction_submodel_evaluator_beamcontact.cpp
@@ -26,6 +26,7 @@
 #include "4C_beaminteraction_submodel_evaluator_beamcontact_assembly_manager_direct.hpp"
 #include "4C_beaminteraction_submodel_evaluator_beamcontact_assembly_manager_indirect.hpp"
 #include "4C_binstrategy.hpp"
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_geometric_search_bvh.hpp"
 #include "4C_fem_geometric_search_params.hpp"
 #include "4C_fem_geometric_search_visualization.hpp"
@@ -1026,7 +1027,7 @@ void BEAMINTERACTION::SUBMODELEVALUATOR::BeamContact::create_beam_contact_elemen
   // simulation crashes if the assembly manager is not on all ranks.
   int my_direct_pairs = assembly_pairs_direct.size();
   int global_direct_pairs = 0;
-  discret().get_comm().SumAll(&my_direct_pairs, &global_direct_pairs, 1);
+  Core::Communication::sum_all(&my_direct_pairs, &global_direct_pairs, 1, discret().get_comm());
 
   // Create the needed assembly manager.
   if (global_direct_pairs > 0)

--- a/src/beaminteraction/4C_beaminteraction_utils_parallel_proctoproc.cpp
+++ b/src/beaminteraction/4C_beaminteraction_utils_parallel_proctoproc.cpp
@@ -64,7 +64,8 @@ void Discret::Utils::i_send_receive_any(Core::FE::Discretization& discret,
   // -----------------------------------------------------------------------
   // ---- prepare receiving procs -----
   std::vector<int> summedtargets(numproc, 0);
-  discret.get_comm().SumAll(targetprocs.data(), summedtargets.data(), numproc);
+  Core::Communication::sum_all(
+      targetprocs.data(), summedtargets.data(), numproc, discret.get_comm());
 
   // ---- receive ----
   for (int rec = 0; rec < summedtargets[myrank]; ++rec)
@@ -94,7 +95,7 @@ void Discret::Utils::i_send_receive_any(Core::FE::Discretization& discret,
   for (int i = 0; i < length; ++i) exporter.wait(request[i]);
 
   // safety, should be a no time operation if everything works fine before
-  discret.get_comm().Barrier();
+  Core::Communication::barrier(discret.get_comm());
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
@@ -635,7 +635,8 @@ void Solid::ModelEvaluator::BrownianDyn::random_numbers_per_element()
   // results of each processor and store the maximal one in
   // maxrandnumelement_
   // -------------------------------------------------------------------------
-  discret_ptr()->get_comm().MaxAll(&randomnumbersperlocalelement, &maxrandnumelement_, 1);
+  Core::Communication::max_all(
+      &randomnumbersperlocalelement, &maxrandnumelement_, 1, discret_ptr()->get_comm());
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/cardiovascular0d/4C_cardiovascular0d_dofset.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_dofset.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_cardiovascular0d_mor_pod.hpp"
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_dofset.hpp"
 
@@ -66,7 +67,7 @@ namespace Utils
       int lmin = dofrowmap_->MinMyGID();
       if (dofrowmap_->NumMyElements() == 0) lmin = std::numeric_limits<int>::max();
       int gmin = std::numeric_limits<int>::max();
-      dofrowmap_->Comm().MinAll(&lmin, &gmin, 1);
+      Core::Communication::min_all(&lmin, &gmin, 1, dofrowmap_->Comm());
       return gmin;
     };
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -320,12 +320,12 @@ void Cardiovascular0D::ProperOrthogonalDecomposition::read_pod_basis_vectors_fro
   std::vector<int> localnumbers(numproc, 0);
   std::vector<int> globalnumbers(numproc, 0);
   localnumbers[mypid] = mymap->NumMyElements();
-  comm.SumAll(localnumbers.data(), globalnumbers.data(), numproc);
+  Core::Communication::sum_all(localnumbers.data(), globalnumbers.data(), numproc, comm);
 
   int factor(0);
   for (int i = 0; i < mypid; i++) factor += globalnumbers[i];
 
-  comm.Barrier();
+  Core::Communication::barrier(comm);
 
   // 64 bit number necessary, as integer can overflow for large matrices
   long long start =
@@ -359,7 +359,7 @@ void Cardiovascular0D::ProperOrthogonalDecomposition::read_pod_basis_vectors_fro
   delete[] memblock;
 
   // all procs wait until proc number 0 did finish the stuff before
-  comm.Barrier();
+  Core::Communication::barrier(comm);
 
   // Inform user
   if (Core::Communication::my_mpi_rank(comm) == 0) std::cout << " --> Successful\n" << std::endl;

--- a/src/constraint/4C_constraint_dofset.hpp
+++ b/src/constraint/4C_constraint_dofset.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_dofset.hpp"
 
@@ -58,7 +59,7 @@ namespace CONSTRAINTS
       int lmin = dofrowmap_->MinMyGID();
       if (dofrowmap_->NumMyElements() == 0) lmin = std::numeric_limits<int>::max();
       int gmin = std::numeric_limits<int>::max();
-      dofrowmap_->Comm().MinAll(&lmin, &gmin, 1);
+      Core::Communication::min_all(&lmin, &gmin, 1, dofrowmap_->Comm());
       return gmin;
     };
 

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
@@ -120,7 +120,8 @@ void CONSTRAINTS::EMBEDDEDMESH::SolidToSolidMortarManager::setup(
   // to construct the lambda_dof_rowmap_.
   std::vector<int> lambda_dof_per_rank(Core::Communication::num_mpi_ranks(discret_->get_comm()), 0);
   int temp_my_n_lambda_dof = (int)n_lambda_dof;
-  discret_->get_comm().GatherAll(&temp_my_n_lambda_dof, &lambda_dof_per_rank[0], 1);
+  Core::Communication::gather_all(
+      &temp_my_n_lambda_dof, &lambda_dof_per_rank[0], 1, discret_->get_comm());
 
   // Get the start GID for the lambda DOFs on this processor.
   int my_lambda_gid_start_value = start_value_lambda_gid_;

--- a/src/contact/4C_contact_abstract_strategy.cpp
+++ b/src/contact/4C_contact_abstract_strategy.cpp
@@ -31,7 +31,6 @@
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_utils_parameter_list.hpp"
 
-#include <Epetra_SerialComm.h>
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
 #include <Teuchos_Time.hpp>
 

--- a/src/contact/4C_contact_interface.cpp
+++ b/src/contact/4C_contact_interface.cpp
@@ -6678,7 +6678,7 @@ void CONTACT::Interface::evaluate_distances(
 
   // loop over proc's slave elements of the interface for integration
   // use standard column map to include processor's ghosted elements
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
 
   for (int i = 0; i < selecolmap_->NumMyElements(); ++i)
   {
@@ -6929,7 +6929,7 @@ void CONTACT::Interface::evaluate_distances(
     }
   }
 
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
 }
 
 /*----------------------------------------------------------------------*
@@ -7026,7 +7026,7 @@ void CONTACT::Interface::evaluate_tangent_norm(double& cnormtan)
 
   // get cnorm from all procs
   double sumcnormtanallprocs = 0.0;
-  get_comm().SumAll(&cnormtan, &sumcnormtanallprocs, 1);
+  Core::Communication::sum_all(&cnormtan, &sumcnormtanallprocs, 1, get_comm());
   cnormtan = sumcnormtanallprocs;
 }
 
@@ -7250,7 +7250,7 @@ bool CONTACT::Interface::update_active_set_semi_smooth()
 
   // broadcast convergence status among processors
   int convcheck = 0;
-  get_comm().MinAll(&localcheck, &convcheck, 1);
+  Core::Communication::min_all(&localcheck, &convcheck, 1, get_comm());
 
   return convcheck;
 }
@@ -7439,8 +7439,8 @@ bool CONTACT::Interface::split_active_dofs()
 
   // communicate countN and countT among procs
   int gcountN, gcountT;
-  get_comm().SumAll(&countN, &gcountN, 1);
-  get_comm().SumAll(&countT, &gcountT, 1);
+  Core::Communication::sum_all(&countN, &gcountN, 1, get_comm());
+  Core::Communication::sum_all(&countT, &gcountT, 1, get_comm());
 
   // check global dimensions
   if ((gcountN + gcountT) != activedofs_->NumGlobalElements())
@@ -7503,7 +7503,7 @@ bool CONTACT::Interface::split_active_dofs()
 
   // communicate countslipT among procs
   int gcountslipT;
-  get_comm().SumAll(&countslipT, &gcountslipT, 1);
+  Core::Communication::sum_all(&countslipT, &gcountslipT, 1, get_comm());
 
   // create Tslipmap objects
   slipt_ = std::make_shared<Epetra_Map>(gcountslipT, countslipT, myslipTgids.data(), 0, get_comm());

--- a/src/contact/4C_contact_interface_tools.cpp
+++ b/src/contact/4C_contact_interface_tools.cpp
@@ -679,7 +679,7 @@ void CONTACT::Interface::visualize_gmsh(
       fclose(fps);
       fclose(fpm);
     }
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 
 
@@ -692,7 +692,7 @@ void CONTACT::Interface::visualize_gmsh(
   int lnslayers = binarytree_->Streenodesmap().size();
   int gnmlayers = binarytree_->Mtreenodesmap().size();
   int gnslayers = 0;
-  Comm().MaxAll(&lnslayers, &gnslayers, 1);
+  Core::Communication::max_all(&lnslayers, &gnslayers, 1, Comm());
 
   // create files for visualization of slave dops for every layer
   std::ostringstream filenametn;
@@ -739,7 +739,7 @@ void CONTACT::Interface::visualize_gmsh(
     }
   }
 
-  Comm().Barrier();
+  Core::Communication::barrier(Comm());
 
   // for every proc, one after another, put data of slabs into files
   for (int i = 0; i < Core::Communication::num_mpi_ranks(Comm()); i++)
@@ -784,10 +784,10 @@ void CONTACT::Interface::visualize_gmsh(
       }
     }
 
-    Comm().Barrier();
+    Core::Communication::barrier(Comm());
   }
 
-  Comm().Barrier();
+  Core::Communication::barrier(Comm());
   // close all slave-gmsh files
   if (Core::Communication::my_mpi_rank(Comm()) == 0)
   {
@@ -804,7 +804,7 @@ void CONTACT::Interface::visualize_gmsh(
       fclose(fp);
     }
   }
-  Comm().Barrier();
+  Core::Communication::barrier(Comm());
 
   // create master slabs
   if (Core::Communication::my_mpi_rank(Comm()) == 0)
@@ -895,7 +895,7 @@ void CONTACT::Interface::visualize_gmsh(
   int lcontactmapsize = (int)(binarytree_->coupling_map()[0].size());
   int gcontactmapsize;
 
-  Comm().MaxAll(&lcontactmapsize, &gcontactmapsize, 1);
+  Core::Communication::max_all(&lcontactmapsize, &gcontactmapsize, 1, Comm());
 
   if (gcontactmapsize > 0)
   {
@@ -958,7 +958,7 @@ void CONTACT::Interface::visualize_gmsh(
           (binarytree_->coupling_map()[1][j])->PrintDopsForGmsh(currentfilename.str().c_str());
         }
       }
-      Comm().Barrier();
+      Core::Communication::barrier(Comm());
     }
 
     // close file
@@ -7082,7 +7082,7 @@ void CONTACT::Interface::write_nodal_coordinates_to_file(
     of.close();
   }
 
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
 
   for (int p = 0; p < Core::Communication::num_mpi_ranks(get_comm()); ++p)
   {
@@ -7111,7 +7111,7 @@ void CONTACT::Interface::write_nodal_coordinates_to_file(
       }
       of.close();
     }
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 }
 

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -4756,7 +4756,7 @@ void CONTACT::LagrangeStrategy::update_active_set()
   // broadcast convergence status among processors
   int convcheck = 0;
   int localcheck = activesetconv_;
-  get_comm().SumAll(&localcheck, &convcheck, 1);
+  Core::Communication::sum_all(&localcheck, &convcheck, 1, get_comm());
 
   // active set is only converged, if converged on all procs
   // if not, increase no. of active set steps too
@@ -4955,7 +4955,7 @@ void CONTACT::LagrangeStrategy::update_active_set_semi_smooth(const bool firstSt
   // broadcast convergence status among processors
   int convcheck = 0;
   int localcheck = activesetconv_;
-  get_comm().SumAll(&localcheck, &convcheck, 1);
+  Core::Communication::sum_all(&localcheck, &convcheck, 1, get_comm());
 
   // active set is only converged, if converged on all procs
   // if not, increase no. of active set steps too
@@ -5150,13 +5150,13 @@ void CONTACT::LagrangeStrategy::update(std::shared_ptr<const Core::LinAlg::Vecto
   ////  {
   ////    lssum+=(*fconservationS)[i];
   ////  }
-  ////  Comm().SumAll(&lssum,&gssum,1);
+  ////  Core::Communication::sum_all(&lssum,&gssum,1, Comm());
   ////  // master
   ////  for (int i=0;i<fconservationM->MyLength();++i)
   ////  {
   ////    lmsum+=(*fconservationM)[i];
   ////  }
-  ////  Comm().SumAll(&lmsum,&gmsum,1);
+  ////  Core::Communication::sum_all(&lmsum,&gmsum,1, Comm());
   //
   //
   //

--- a/src/contact/4C_contact_lagrange_strategy_poro.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_poro.cpp
@@ -21,7 +21,6 @@
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mortar_utils.hpp"
 
-#include <Epetra_SerialComm.h>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/contact/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_tsi.cpp
@@ -23,7 +23,6 @@
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mortar_utils.hpp"
 
-#include <Epetra_SerialComm.h>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -25,7 +25,6 @@
 #include "4C_mortar_utils.hpp"
 
 #include <Epetra_FEVector.h>
-#include <Epetra_SerialComm.h>
 #include <Teuchos_Time.hpp>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -4692,7 +4692,7 @@ bool Wear::LagrangeStrategyWear::redistribute_contact(
   if (!doredist) return false;
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_start = Teuchos::Time::wallTime();
 
   // set old and current displacement state
@@ -4727,7 +4727,7 @@ bool Wear::LagrangeStrategyWear::redistribute_contact(
   setup_wear(true, false);
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   double t_end = Teuchos::Time::wallTime() - t_start;
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
     std::cout << "\nTime for parallel redistribution..............." << std::scientific

--- a/src/contact/4C_contact_manager.cpp
+++ b/src/contact/4C_contact_manager.cpp
@@ -467,7 +467,7 @@ CONTACT::Manager::Manager(Core::FE::Discretization& discret, double alphaf)
       // note that elements in ele1/ele2 already are in column (overlapping) map
       int lsize = (int)currele.size();
       int gsize = 0;
-      get_comm().SumAll(&lsize, &gsize, 1);
+      Core::Communication::sum_all(&lsize, &gsize, 1, get_comm());
 
       std::map<int, std::shared_ptr<Core::Elements::Element>>::iterator fool;
       for (fool = currele.begin(); fool != currele.end(); ++fool)

--- a/src/contact/4C_contact_meshtying_abstract_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_abstract_strategy.cpp
@@ -79,7 +79,7 @@ void CONTACT::MtAbstractStrategy::redistribute_meshtying()
   if (par_redist() && Core::Communication::num_mpi_ranks(get_comm()) > 1)
   {
     // time measurement
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
     const double t_start = Teuchos::Time::wallTime();
 
     // do some more stuff with interfaces
@@ -109,7 +109,7 @@ void CONTACT::MtAbstractStrategy::redistribute_meshtying()
     setup(true);
 
     // time measurement
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
     const double t_sum = Teuchos::Time::wallTime() - t_start;
     if (Core::Communication::my_mpi_rank(get_comm()) == 0)
       std::cout << "\nTime for parallel redistribution..............." << std::scientific
@@ -369,7 +369,7 @@ void CONTACT::MtAbstractStrategy::restrict_meshtying_zone()
   int globalfounduntied = 0;
   for (int i = 0; i < (int)interface_.size(); ++i)
     interface_[i]->detect_tied_slave_nodes(localfounduntied);
-  get_comm().SumAll(&localfounduntied, &globalfounduntied, 1);
+  Core::Communication::sum_all(&localfounduntied, &globalfounduntied, 1, get_comm());
 
   // get out of here if the whole slave surface is tied
   if (globalfounduntied == 0) return;
@@ -987,12 +987,12 @@ void CONTACT::MtAbstractStrategy::interface_forces(bool output)
   // summing up over all processors
   for (int i = 0; i < 3; ++i)
   {
-    get_comm().SumAll(&gfcs[i], &ggfcs[i], 1);
-    get_comm().SumAll(&gfcm[i], &ggfcm[i], 1);
-    get_comm().SumAll(&gmcs[i], &ggmcs[i], 1);
-    get_comm().SumAll(&gmcm[i], &ggmcm[i], 1);
-    get_comm().SumAll(&gmcsnew[i], &ggmcsnew[i], 1);
-    get_comm().SumAll(&gmcmnew[i], &ggmcmnew[i], 1);
+    Core::Communication::sum_all(&gfcs[i], &ggfcs[i], 1, get_comm());
+    Core::Communication::sum_all(&gfcm[i], &ggfcm[i], 1, get_comm());
+    Core::Communication::sum_all(&gmcs[i], &ggmcs[i], 1, get_comm());
+    Core::Communication::sum_all(&gmcm[i], &ggmcm[i], 1, get_comm());
+    Core::Communication::sum_all(&gmcsnew[i], &ggmcsnew[i], 1, get_comm());
+    Core::Communication::sum_all(&gmcmnew[i], &ggmcmnew[i], 1, get_comm());
   }
 
   // print interface results to file
@@ -1056,12 +1056,12 @@ void CONTACT::MtAbstractStrategy::print(std::ostream& os) const
        << "Meshtying interfaces: " << (int)interface_.size() << std::endl
        << "-------------------------------------------------------------\n";
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   for (int i = 0; i < (int)interface_.size(); ++i)
   {
     std::cout << *(interface_[i]);
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
 
   return;
 }

--- a/src/contact/4C_contact_meshtying_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_lagrange_strategy.cpp
@@ -57,7 +57,7 @@ void CONTACT::MtLagrangeStrategy::mortar_coupling(
   }
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_start = Teuchos::Time::wallTime();
 
   // refer call to parent class
@@ -165,7 +165,7 @@ void CONTACT::MtLagrangeStrategy::mortar_coupling(
   lm_diag_matrix_ = nullptr;
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_end = Teuchos::Time::wallTime() - t_start;
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
     std::cout << "in...." << std::scientific << std::setprecision(6) << t_end << " secs"
@@ -193,7 +193,7 @@ CONTACT::MtLagrangeStrategy::mesh_initialization()
   }
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_start = Teuchos::Time::wallTime();
 
   //**********************************************************************
@@ -301,7 +301,7 @@ CONTACT::MtLagrangeStrategy::mesh_initialization()
   MtAbstractStrategy::mesh_initialization(Xslavemod);
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_end = Teuchos::Time::wallTime() - t_start;
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
   {

--- a/src/contact/4C_contact_meshtying_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_lagrange_strategy.cpp
@@ -22,7 +22,6 @@
 #include "4C_mortar_utils.hpp"
 #include "4C_utils_parameter_list.hpp"
 
-#include <Epetra_SerialComm.h>
 #include <Teuchos_Time.hpp>
 #include <Teuchos_TimeMonitor.hpp>
 

--- a/src/contact/4C_contact_meshtying_manager.cpp
+++ b/src/contact/4C_contact_meshtying_manager.cpp
@@ -274,7 +274,7 @@ CONTACT::MtManager::MtManager(Core::FE::Discretization& discret, double alphaf)
       // note that elements in ele1/ele2 already are in column (overlapping) map
       int lsize = static_cast<int>(currele.size());
       int gsize = 0;
-      get_comm().SumAll(&lsize, &gsize, 1);
+      Core::Communication::sum_all(&lsize, &gsize, 1, get_comm());
 
 
       for (const auto& element : currele)

--- a/src/contact/4C_contact_meshtying_penalty_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_penalty_strategy.cpp
@@ -56,7 +56,7 @@ void CONTACT::MtPenaltyStrategy::mortar_coupling(
   }
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_start = Teuchos::Time::wallTime();
 
   // refer call to parent class
@@ -117,7 +117,7 @@ void CONTACT::MtPenaltyStrategy::mortar_coupling(
   stiff_->complete();
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_end = Teuchos::Time::wallTime() - t_start;
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
     std::cout << "in...." << std::scientific << std::setprecision(6) << t_end << " secs"
@@ -144,7 +144,7 @@ CONTACT::MtPenaltyStrategy::mesh_initialization()
   }
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_start = Teuchos::Time::wallTime();
 
   //**********************************************************************
@@ -182,7 +182,7 @@ CONTACT::MtPenaltyStrategy::mesh_initialization()
   MtAbstractStrategy::mesh_initialization(Xslavemod);
 
   // time measurement
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   const double t_end = Teuchos::Time::wallTime() - t_start;
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
   {

--- a/src/contact/4C_contact_meshtying_poro_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_poro_lagrange_strategy.cpp
@@ -11,7 +11,6 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 
-#include <Epetra_SerialComm.h>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/contact/4C_contact_meshtying_strategy_factory.cpp
+++ b/src/contact/4C_contact_meshtying_strategy_factory.cpp
@@ -539,7 +539,7 @@ void Mortar::STRATEGY::FactoryMT::build_interfaces(const Teuchos::ParameterList&
       // note that elements in ele1/ele2 already are in column (overlapping) map
       int lsize = (int)currele.size();
       int gsize = 0;
-      get_comm().SumAll(&lsize, &gsize, 1);
+      Core::Communication::sum_all(&lsize, &gsize, 1, get_comm());
 
 
       std::map<int, std::shared_ptr<Core::Elements::Element>>::iterator fool;

--- a/src/contact/4C_contact_monocoupled_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_monocoupled_lagrange_strategy.cpp
@@ -10,7 +10,6 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 
-#include <Epetra_SerialComm.h>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/contact/4C_contact_penalty_strategy.cpp
+++ b/src/contact/4C_contact_penalty_strategy.cpp
@@ -196,8 +196,8 @@ void CONTACT::PenaltyStrategy::evaluate_contact(
   int localcontact = isincontact;
   int localchange = activesetchange;
 
-  get_comm().SumAll(&localcontact, &globalcontact, 1);
-  get_comm().SumAll(&localchange, &globalchange, 1);
+  Core::Communication::sum_all(&localcontact, &globalcontact, 1, get_comm());
+  Core::Communication::sum_all(&localchange, &globalchange, 1, get_comm());
 
   if (globalcontact >= 1)
   {
@@ -788,8 +788,8 @@ void CONTACT::PenaltyStrategy::assemble()
   int localcontact = isincontact;
   int localchange = activesetchange;
 
-  get_comm().SumAll(&localcontact, &globalcontact, 1);
-  get_comm().SumAll(&localchange, &globalchange, 1);
+  Core::Communication::sum_all(&localcontact, &globalcontact, 1, get_comm());
+  Core::Communication::sum_all(&localchange, &globalchange, 1, get_comm());
 
   if (globalcontact >= 1)
   {

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -1062,7 +1062,7 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
         if (fool->second->owner() == Core::Communication::my_mpi_rank(get_comm())) ++lsize;
 
       int gsize = 0;
-      get_comm().SumAll(&lsize, &gsize, 1);
+      Core::Communication::sum_all(&lsize, &gsize, 1, get_comm());
 
       bool nurbs = false;
       if (currele.size() > 0) nurbs = Core::FE::is_nurbs_celltype(currele.begin()->second->shape());
@@ -1252,7 +1252,7 @@ int CONTACT::STRATEGY::Factory::identify_full_subset(
   int lfullsubmap = static_cast<int>(is_fullsubmap);
   int gfullsubmap = 0;
 
-  get_comm().SumAll(&lfullsubmap, &gfullsubmap, 1);
+  Core::Communication::sum_all(&lfullsubmap, &gfullsubmap, 1, get_comm());
 
   return (gfullsubmap == Core::Communication::num_mpi_ranks(get_comm()) ? sub_id : -1);
 }
@@ -1413,7 +1413,7 @@ void CONTACT::STRATEGY::Factory::find_poro_interface_types(bool& poromaster, boo
   // constellations
   // s-s, p-s, s-p, p-p
   // wait for all processors to determine if they have poro or structural master or slave elements
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   /* FixMe Should become possible for scoped enumeration with C++11,
    * till then we use the shown workaround.
    *  enum Mortar::Element::PhysicalType slaveTypeList[Comm().NumProc()];
@@ -1425,9 +1425,9 @@ void CONTACT::STRATEGY::Factory::find_poro_interface_types(bool& poromaster, boo
   std::vector<int> masterTypeList(Core::Communication::num_mpi_ranks(get_comm()));
   int int_slavetype = static_cast<int>(slavetype);
   int int_mastertype = static_cast<int>(mastertype);
-  get_comm().GatherAll(&int_slavetype, slaveTypeList.data(), 1);
-  get_comm().GatherAll(&int_mastertype, masterTypeList.data(), 1);
-  get_comm().Barrier();
+  Core::Communication::gather_all(&int_slavetype, slaveTypeList.data(), 1, get_comm());
+  Core::Communication::gather_all(&int_mastertype, masterTypeList.data(), 1, get_comm());
+  Core::Communication::barrier(get_comm());
 
   for (int i = 0; i < Core::Communication::num_mpi_ranks(get_comm()); ++i)
   {

--- a/src/contact/4C_contact_wear_interface.cpp
+++ b/src/contact/4C_contact_wear_interface.cpp
@@ -3398,8 +3398,8 @@ bool Wear::WearInterface::build_active_set(bool init)
 
       // TODO: not nice... alternative to sumall?
       int invglobal = 0;
-      get_comm().SumAll(&inv, &invglobal, 1);
-      get_comm().Barrier();
+      Core::Communication::sum_all(&inv, &invglobal, 1, get_comm());
+      Core::Communication::barrier(get_comm());
 
       if (cnode->owner() == Core::Communication::my_mpi_rank(get_comm()) && invglobal > 0)
       {
@@ -4071,7 +4071,7 @@ void Wear::WearInterface::split_slave_dofs()
 
   // communicate countN and countT among procs
   int gcountN;
-  get_comm().SumAll(&countN, &gcountN, 1);
+  Core::Communication::sum_all(&countN, &gcountN, 1, get_comm());
 
   // check global dimensions
   if ((gcountN) != snoderowmap_->NumGlobalElements())
@@ -4128,7 +4128,7 @@ void Wear::WearInterface::split_master_dofs()
 
   // communicate countN and countT among procs
   int gcountN;
-  get_comm().SumAll(&countN, &gcountN, 1);
+  Core::Communication::sum_all(&countN, &gcountN, 1, get_comm());
 
   // check global dimensions
   if ((gcountN) != mnoderowmap_->NumGlobalElements())

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -1495,11 +1495,11 @@ void Core::Binstrategy::BinningStrategy::
     }
 
     // first: proc i tells all procs how many bins it has
-    rowbins.Comm().Broadcast(&numbin, 1, iproc);
+    Core::Communication::broadcast(&numbin, 1, iproc, rowbins.Comm());
     binids.resize(numbin);
     // second: proc i tells all procs which bins it has, now each proc contains
     // rowbingids of iproc in vector binids
-    rowbins.Comm().Broadcast(binids.data(), numbin, iproc);
+    Core::Communication::broadcast(binids.data(), numbin, iproc, rowbins.Comm());
 
     // loop over all own bins and find requested ones, fill in master elements in these bins
     // (map key is bin gid owned by iproc, vector contains all node gids of all procs in this bin)
@@ -1730,8 +1730,8 @@ void Core::Binstrategy::BinningStrategy::
   double globmin[3];
   double globmax[3];
   // do the necessary communication
-  discret.get_comm().MinAll(locmin, globmin, 3);
-  discret.get_comm().MaxAll(locmax, globmax, 3);
+  Core::Communication::min_all(locmin, globmin, 3, discret.get_comm());
+  Core::Communication::max_all(locmax, globmax, 3, discret.get_comm());
 
   // set global XAABB for discret
   for (int dim = 0; dim < 3; ++dim)

--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -107,7 +107,8 @@ namespace Core::Binstrategy::Utils
     // -----------------------------------------------------------------------
     // ---- prepare receiving procs -----
     std::vector<int> summedtargets(numproc, 0);
-    discret.get_comm().SumAll(targetprocs.data(), summedtargets.data(), numproc);
+    Core::Communication::sum_all(
+        targetprocs.data(), summedtargets.data(), numproc, discret.get_comm());
 
     // ---- receive ----
     for (int rec = 0; rec < summedtargets[Core::Communication::my_mpi_rank(discret.get_comm())];
@@ -152,7 +153,7 @@ namespace Core::Binstrategy::Utils
     // wait for all communications to finish
     for (int i = 0; i < length; ++i) exporter.wait(request[i]);
     // safety, should be a no time operation if everything works fine before
-    discret.get_comm().Barrier();
+    Core::Communication::barrier(discret.get_comm());
   }
 
   /*-----------------------------------------------------------------------------*
@@ -201,7 +202,8 @@ namespace Core::Binstrategy::Utils
     // -----------------------------------------------------------------------
     // ---- prepare receiving procs -----
     std::vector<int> summedtargets(numproc, 0);
-    discret.get_comm().SumAll(targetprocs.data(), summedtargets.data(), numproc);
+    Core::Communication::sum_all(
+        targetprocs.data(), summedtargets.data(), numproc, discret.get_comm());
 
     // ---- receive ----
     for (int rec = 0; rec < summedtargets[Core::Communication::my_mpi_rank(discret.get_comm())];
@@ -234,7 +236,7 @@ namespace Core::Binstrategy::Utils
     // wait for all communications to finish
     for (int i = 0; i < length; ++i) exporter.wait(request[i]);
     // safety, should be a no time operation if everything works fine before
-    discret.get_comm().Barrier();
+    Core::Communication::barrier(discret.get_comm());
   }
 
   /*----------------------------------------------------------------------*/

--- a/src/core/comm/src/4C_comm_exporter.cpp
+++ b/src/core/comm/src/4C_comm_exporter.cpp
@@ -213,11 +213,11 @@ void Core::Communication::Exporter::construct_exporter()
     int recvsizes[2];
     recvsizes[0] = sizes[0];
     recvsizes[1] = sizes[1];
-    get_comm().Broadcast(recvsizes, 2, proc);
+    Core::Communication::broadcast(recvsizes, 2, proc, get_comm());
     const int recvsize = recvsizes[0] + recvsizes[1];
     std::vector<int> recvbuff(recvsize);
     if (proc == my_pid()) std::copy(sendbuff.begin(), sendbuff.end(), recvbuff.data());
-    get_comm().Broadcast(recvbuff.data(), recvsize, proc);
+    Core::Communication::broadcast(recvbuff.data(), recvsize, proc, get_comm());
     // const int* have = recvbuff.data();            // this is what proc has
     const int* want = &recvbuff[recvsizes[0]];  // this is what proc needs
 
@@ -234,7 +234,7 @@ void Core::Communication::Exporter::construct_exporter()
         }
       }
     }
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 }
 
@@ -322,7 +322,7 @@ void Core::Communication::Exporter::generic_export(ExporterHelper& helper)
     wait(sendgidrequest);
 
     // make sure we do not get mixed up messages as we use wild card receives here
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 
   helper.post_export_cleanup(this);

--- a/src/core/comm/src/4C_comm_mpi_utils.cpp
+++ b/src/core/comm/src/4C_comm_mpi_utils.cpp
@@ -13,4 +13,6 @@ int Core::Communication::my_mpi_rank(const Epetra_Comm &comm) { return comm.MyPI
 
 int Core::Communication::num_mpi_ranks(const Epetra_Comm &comm) { return comm.NumProc(); }
 
+void Core::Communication::barrier(const Epetra_Comm &comm) { comm.Barrier(); }
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -55,7 +55,7 @@ void Core::FE::Discretization::check_filled_globally()
   /*the global filled flag is set to the minimal value of any local filled flag
    * i.e. if on any processor filled_ == false, the flag globalfilled is set to
    * zero*/
-  get_comm().MinAll(&localfilled, &globalfilled, 1);
+  Core::Communication::min_all(&localfilled, &globalfilled, 1, get_comm());
 
   // if not Filled() == true on all the processors call reset()
   if (!globalfilled) reset();
@@ -301,8 +301,8 @@ void Core::FE::Discretization::print(std::ostream& os) const
     for (ecurr = element_.begin(); ecurr != element_.end(); ++ecurr)
       if (ecurr->second->owner() == Core::Communication::my_mpi_rank(get_comm())) nummyele++;
 
-    get_comm().SumAll(&nummynodes, &numglobalnodes, 1);
-    get_comm().SumAll(&nummyele, &numglobalelements, 1);
+    Core::Communication::sum_all(&nummynodes, &numglobalnodes, 1, get_comm());
+    Core::Communication::sum_all(&nummyele, &numglobalelements, 1, get_comm());
   }
 
   // print head
@@ -319,7 +319,7 @@ void Core::FE::Discretization::print(std::ostream& os) const
       os << "Filled() = false\n";
     os << "--------------------------------------------------\n";
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   for (int proc = 0; proc < Core::Communication::num_mpi_ranks(get_comm()); ++proc)
   {
     if (proc == Core::Communication::my_mpi_rank(get_comm()))
@@ -386,7 +386,7 @@ void Core::FE::Discretization::print(std::ostream& os) const
         os << std::endl;
       }
     }
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 }
 
@@ -771,7 +771,7 @@ void Core::FE::Discretization::compute_null_space_if_necessary(
   // communicate data to procs without row element
   std::array<int, 4> ldata = {numdf, dimns, nv, np};
   std::array<int, 4> gdata = {0, 0, 0, 0};
-  get_comm().MaxAll(ldata.data(), gdata.data(), 4);
+  Core::Communication::max_all(ldata.data(), gdata.data(), 4, get_comm());
   numdf = gdata[0];
   dimns = gdata[1];
   nv = gdata[2];

--- a/src/core/fem/src/discretization/4C_fem_discretization_conditions.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_conditions.cpp
@@ -104,7 +104,7 @@ void Core::FE::Discretization::boundary_conditions_geometry()
       // determine the global number of created elements associated with
       // the active condition
       int count;
-      get_comm().SumAll(&localcount, &count, 1);
+      Core::Communication::sum_all(&localcount, &count, 1, get_comm());
 
       if (numele.find(name) == numele.end())
       {
@@ -146,7 +146,7 @@ void Core::FE::Discretization::assign_global_i_ds(const Epetra_Comm& comm,
   // communicate elements to processor 0
 
   int mysize = sendblock.size();
-  comm.SumAll(&mysize, &size, 1);
+  Core::Communication::sum_all(&mysize, &size, 1, comm);
   int mypos = Core::LinAlg::find_my_pos(sendblock.size(), comm);
 
   std::vector<int> send(size);
@@ -154,7 +154,7 @@ void Core::FE::Discretization::assign_global_i_ds(const Epetra_Comm& comm,
   std::copy(sendblock.begin(), sendblock.end(), &send[mypos]);
   sendblock.clear();
   std::vector<int> recv(size);
-  comm.SumAll(send.data(), recv.data(), size);
+  Core::Communication::sum_all(send.data(), recv.data(), size, comm);
 
   send.clear();
 
@@ -193,9 +193,9 @@ void Core::FE::Discretization::assign_global_i_ds(const Epetra_Comm& comm,
 
   // broadcast sorted elements to all processors
 
-  comm.Broadcast(&size, 1, 0);
+  Core::Communication::broadcast(&size, 1, 0, comm);
   send.resize(size);
-  comm.Broadcast(send.data(), send.size(), 0);
+  Core::Communication::broadcast(send.data(), send.size(), 0, comm);
 
   // Unpack sorted elements. Take element position for gid.
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
@@ -522,7 +522,7 @@ void Core::FE::Discretization::evaluate_scalars(
 
   // reduce
   for (int i = 0; i < numscalars; ++i) (*scalars)(i) = 0.0;
-  get_comm().SumAll(cpuscalars.values(), scalars->values(), numscalars);
+  Core::Communication::sum_all(cpuscalars.values(), scalars->values(), numscalars, get_comm());
 }  // Core::FE::Discretization::EvaluateScalars
 
 
@@ -607,7 +607,7 @@ void Core::FE::Discretization::evaluate_scalars(
   }          // loop over conditions
 
   // communicate results across all processors
-  get_comm().SumAll(cpuscalars.values(), scalars.values(), numscalars);
+  Core::Communication::sum_all(cpuscalars.values(), scalars.values(), numscalars, get_comm());
 }  // Core::FE::Discretization::EvaluateScalars
 
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
@@ -1069,7 +1069,7 @@ void Core::FE::DiscretizationFaces::print_faces(std::ostream& os) const
     for (ecurr = faces_.begin(); ecurr != faces_.end(); ++ecurr)
       if (ecurr->second->owner() == Core::Communication::my_mpi_rank(get_comm())) nummyfaces++;
 
-    get_comm().SumAll(&nummyfaces, &numglobalfaces, 1);
+    Core::Communication::sum_all(&nummyfaces, &numglobalfaces, 1, get_comm());
   }
 
   // print head
@@ -1100,7 +1100,7 @@ void Core::FE::DiscretizationFaces::print_faces(std::ostream& os) const
       }
       os << std::endl;
     }
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 
   return;

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
@@ -182,7 +182,7 @@ void Core::FE::DiscretizationHDG::assign_global_i_ds(const Epetra_Comm& comm,
   // communicate elements to processor 0
 
   int mysize = sendblock.size();
-  comm.SumAll(&mysize, &size, 1);
+  Core::Communication::sum_all(&mysize, &size, 1, comm);
   int mypos = Core::LinAlg::find_my_pos(sendblock.size(), comm);
 
   std::vector<int> send(size);
@@ -190,7 +190,7 @@ void Core::FE::DiscretizationHDG::assign_global_i_ds(const Epetra_Comm& comm,
   std::copy(sendblock.begin(), sendblock.end(), &send[mypos]);
   sendblock.clear();
   std::vector<int> recv(size);
-  comm.SumAll(send.data(), recv.data(), size);
+  Core::Communication::sum_all(send.data(), recv.data(), size, comm);
   send.clear();
 
   // unpack, unify and sort elements on processor 0
@@ -240,9 +240,9 @@ void Core::FE::DiscretizationHDG::assign_global_i_ds(const Epetra_Comm& comm,
 
   // broadcast sorted elements to all processors
 
-  comm.Broadcast(&size, 1, 0);
+  Core::Communication::broadcast(&size, 1, 0, comm);
   send.resize(size);
-  comm.Broadcast(send.data(), send.size(), 0);
+  Core::Communication::broadcast(send.data(), send.size(), 0, comm);
 
   // Unpack sorted elements. Take element position for gid.
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_nullspace.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_nullspace.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_fem_discretization_nullspace.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_elementtype.hpp"
 #include "4C_fem_general_node.hpp"
@@ -39,7 +40,7 @@ namespace Core::FE
         for (int j = 0; j < 3; ++j) x0send[j] += dis.l_row_node(i)->x()[j];
 
       std::array<double, 3> x0;
-      dis.get_comm().SumAll(x0send.data(), x0.data(), 3);
+      Core::Communication::sum_all(x0send.data(), x0.data(), 3, dis.get_comm());
 
       for (int i = 0; i < 3; ++i) x0[i] /= dis.num_global_nodes();
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -126,9 +126,9 @@ void Core::FE::Discretization::proc_zero_distribute_elements_to_all(
   for (auto& fool : sendmap) receivers.push_back(fool.first);
 
   size = (int)receivers.size();
-  get_comm().Broadcast(&size, 1, 0);
+  Core::Communication::broadcast(&size, 1, 0, get_comm());
   if (myrank != 0) receivers.resize(size);
-  get_comm().Broadcast(receivers.data(), size, 0);
+  Core::Communication::broadcast(receivers.data(), size, 0, get_comm());
   int foundme = -1;
   if (myrank != 0)
     for (int i = 0; i < size; ++i)
@@ -181,7 +181,7 @@ void Core::FE::Discretization::proc_zero_distribute_elements_to_all(
   if (!myrank)
     for (int i = 0; i < size; ++i) exporter.wait(request[i]);
 
-  get_comm().Barrier();  // I feel better this way ;-)
+  Core::Communication::barrier(get_comm());  // I feel better this way ;-)
   reset();
 }
 
@@ -227,9 +227,9 @@ void Core::FE::Discretization::proc_zero_distribute_nodes_to_all(Epetra_Map& tar
        ++fool)
     receivers.push_back(fool->first);
   size = (int)receivers.size();
-  get_comm().Broadcast(&size, 1, 0);
+  Core::Communication::broadcast(&size, 1, 0, get_comm());
   if (myrank != 0) receivers.resize(size);
-  get_comm().Broadcast(receivers.data(), size, 0);
+  Core::Communication::broadcast(receivers.data(), size, 0, get_comm());
   int foundme = -1;
   if (myrank != 0)
     for (int i = 0; i < size; ++i)
@@ -284,7 +284,7 @@ void Core::FE::Discretization::proc_zero_distribute_nodes_to_all(Epetra_Map& tar
   if (!myrank)
     for (int i = 0; i < size; ++i) exporter.wait(request[i]);
 
-  get_comm().Barrier();  // feel better this way ;-)
+  Core::Communication::barrier(get_comm());  // feel better this way ;-)
   reset();
 }
 
@@ -478,7 +478,7 @@ Core::FE::Discretization::build_element_row_column(
   // communicate number of nodes per proc
   std::vector<int> nodesperproc(numproc);
   int nummynodes = noderowmap.NumMyElements();
-  get_comm().GatherAll(&nummynodes, nodesperproc.data(), 1);
+  Core::Communication::gather_all(&nummynodes, nodesperproc.data(), 1, get_comm());
 
   // estimate no. of elements equal to no. of nodes
   std::vector<int> myele(nummynodes);
@@ -493,11 +493,11 @@ Core::FE::Discretization::build_element_row_column(
   for (int proc = 0; proc < numproc; ++proc)
   {
     int size = stoposize;
-    get_comm().Broadcast(&size, 1, proc);
+    Core::Communication::broadcast(&size, 1, proc, get_comm());
     if (size > (int)rtopo.size()) rtopo.resize(size);
     if (proc == myrank)
       for (int i = 0; i < size; ++i) rtopo[i] = stopo[i];
-    get_comm().Broadcast(rtopo.data(), size, proc);
+    Core::Communication::broadcast(rtopo.data(), size, proc, get_comm());
     for (int i = 0; i < size;)
     {
       const int elegid = rtopo[i++];

--- a/src/core/fem/src/dofset/4C_fem_dofset.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset.cpp
@@ -60,7 +60,7 @@ void Core::DOFSets::DofSet::print(std::ostream& os) const
       }
       os << std::endl;
     }
-    numdfcolelements_->Comm().Barrier();
+    Core::Communication::barrier(numdfcolelements_->Comm());
   }
   for (int proc = 0; proc < Core::Communication::num_mpi_ranks(numdfcolnodes_->Comm()); ++proc)
   {
@@ -77,7 +77,7 @@ void Core::DOFSets::DofSet::print(std::ostream& os) const
       }
       os << std::endl;
     }
-    numdfcolnodes_->Comm().Barrier();
+    Core::Communication::barrier(numdfcolnodes_->Comm());
   }
   for (int proc = 0; proc < Core::Communication::num_mpi_ranks(numdfcolfaces_->Comm()); ++proc)
   {
@@ -94,7 +94,7 @@ void Core::DOFSets::DofSet::print(std::ostream& os) const
       }
       os << std::endl;
     }
-    numdfcolfaces_->Comm().Barrier();
+    Core::Communication::barrier(numdfcolfaces_->Comm());
   }
 }
 

--- a/src/core/fem/src/dofset/4C_fem_dofset_base.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_base.cpp
@@ -92,7 +92,7 @@ int Core::DOFSets::DofSetBase::max_gi_din_list(const Epetra_Comm& comm) const
     }
   }
   int max;
-  comm.MaxAll(&count, &max, 1);
+  Core::Communication::max_all(&count, &max, 1, comm);
   return max;
 }
 

--- a/src/core/fem/src/dofset/4C_fem_dofset_transparent.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_transparent.cpp
@@ -484,7 +484,7 @@ void Core::DOFSets::TransparentDofSet::receive_block(int numproc, int myrank,
   exporter.wait(request);
 
   // for safety
-  exporter.get_comm().Barrier();
+  Core::Communication::barrier(exporter.get_comm());
 
   return;
 }  // receive_block
@@ -511,7 +511,7 @@ void Core::DOFSets::TransparentDofSet::send_block(int numproc, int myrank,
 
 
   // for safety
-  exporter.get_comm().Barrier();
+  Core::Communication::barrier(exporter.get_comm());
 
   return;
 }  // send_block

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -237,7 +237,7 @@ void Core::FE::DiscretizationCreatorBase::finalize(
   // source discretization.
   int sumeleskips = 0;
   int lnumeleskips = numeleskips_;
-  sourcedis.get_comm().SumAll(&lnumeleskips, &sumeleskips, 1);
+  Core::Communication::sum_all(&lnumeleskips, &sumeleskips, 1, sourcedis.get_comm());
 
   if (sumeleskips == 0)
   {

--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_matchingoctree.cpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_matchingoctree.cpp
@@ -240,7 +240,7 @@ void Core::GeometricSearch::MatchingOctree::create_global_entity_matching(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
     }
     else
@@ -391,7 +391,7 @@ void Core::GeometricSearch::MatchingOctree::create_global_entity_matching(
 
     {
       // for safety
-      exporter.get_comm().Barrier();
+      Core::Communication::barrier(exporter.get_comm());
     }
   }  // end loop np
 }  // MatchingOctree::CreateGlobalNodeMatching

--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_utils.cpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_utils.cpp
@@ -31,9 +31,10 @@ namespace Core::GeometricSearch
     my_predicate_size[myrank] = info.predicate_size;
     my_coupling_pair_size[myrank] = info.coupling_pair_size;
 
-    comm.SumAll(my_primitive_size.data(), primitive_size.data(), numproc);
-    comm.SumAll(my_predicate_size.data(), predicate_size.data(), numproc);
-    comm.SumAll(my_coupling_pair_size.data(), coupling_pair_size.data(), numproc);
+    Core::Communication::sum_all(my_primitive_size.data(), primitive_size.data(), numproc, comm);
+    Core::Communication::sum_all(my_predicate_size.data(), predicate_size.data(), numproc, comm);
+    Core::Communication::sum_all(
+        my_coupling_pair_size.data(), coupling_pair_size.data(), numproc, comm);
 
     if (myrank == 0)
     {

--- a/src/core/fem/tests/geometric_search/4C_geometric_search_test.cpp
+++ b/src/core/fem/tests/geometric_search/4C_geometric_search_test.cpp
@@ -12,13 +12,14 @@
 #include "4C_fem_geometric_search_bounding_volume.hpp"
 #include "4C_fem_geometric_search_utils.hpp"
 
+#include <Epetra_MpiComm.h>
+
 #ifdef FOUR_C_WITH_ARBORX
 
 #include "4C_fem_geometric_search_bvh.hpp"
 #include "4C_fem_geometric_search_utils.hpp"
 #include "4C_geometric_search_create_bounding_volumes_test.hpp"
 
-#include <Epetra_SerialComm.h>
 
 namespace
 {
@@ -31,15 +32,11 @@ namespace
 
     static void TearDownTestSuite() { Kokkos::finalize(); }
 
-    GeometricSearch()
-    {
-      comm_ = Epetra_SerialComm();
-      verbosity_ = Core::IO::minimal;
-    }
+    GeometricSearch() { verbosity_ = Core::IO::minimal; }
 
    protected:
     std::vector<std::pair<int, Core::GeometricSearch::BoundingVolume>> primitives_, predicates_;
-    Epetra_SerialComm comm_;
+    Epetra_MpiComm comm_{MPI_COMM_WORLD};
     Core::IO::Verbositylevel verbosity_;
   };
 

--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -277,13 +277,13 @@ void Core::IO::DiscretizationReader::read_redundant_double_vector(
   }
 
   // communicate the length of the vector to come
-  get_comm().Broadcast(&length, 1, 0);
+  Core::Communication::broadcast(&length, 1, 0, get_comm());
 
   // make vector having the correct length on all procs
   doublevec->resize(length);
 
   // now distribute information to all procs
-  get_comm().Broadcast(doublevec->data(), length, 0);
+  Core::Communication::broadcast(doublevec->data(), length, 0, get_comm());
   return;
 }
 
@@ -306,13 +306,13 @@ void Core::IO::DiscretizationReader::read_redundant_int_vector(
   }
 
   // communicate the length of the vector to come
-  get_comm().Broadcast(&length, 1, 0);
+  Core::Communication::broadcast(&length, 1, 0, get_comm());
 
   // make vector having the correct length on all procs
   intvec->resize(length);
 
   // now distribute information to all procs
-  get_comm().Broadcast(intvec->data(), length, 0);
+  Core::Communication::broadcast(intvec->data(), length, 0, get_comm());
   return;
 }
 

--- a/src/core/io/src/4C_io_control.cpp
+++ b/src/core/io/src/4C_io_control.cpp
@@ -75,11 +75,9 @@ Core::IO::OutputControl::OutputControl(const Epetra_Comm& comm, std::string prob
     {
       int length = static_cast<int>(filename_.length());
       std::vector<int> name(filename_.begin(), filename_.end());
-      int err = comm.Broadcast(&length, 1, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(&length, 1, 0, comm);
       name.resize(length);
-      err = comm.Broadcast(name.data(), length, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(name.data(), length, 0, comm);
       filename_.assign(name.begin(), name.end());
     }
   }
@@ -155,11 +153,9 @@ Core::IO::OutputControl::OutputControl(const Epetra_Comm& comm, std::string prob
     {
       int length = static_cast<int>(filename_.length());
       std::vector<int> name(filename_.begin(), filename_.end());
-      int err = comm.Broadcast(&length, 1, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(&length, 1, 0, comm);
       name.resize(length);
-      err = comm.Broadcast(name.data(), length, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(name.data(), length, 0, comm);
       filename_.assign(name.begin(), name.end());
     }
   }

--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -116,7 +116,8 @@ namespace Core::IO
         ((not noderowmap_last_geometry_set_->SameAs(*discretization_->node_row_map())) or
             (not nodecolmap_last_geometry_set_->SameAs(*discretization_->node_col_map())));
     int map_changed_allproc(0);
-    discretization_->get_comm().MaxAll(&map_changed, &map_changed_allproc, 1);
+    Core::Communication::max_all(
+        &map_changed, &map_changed_allproc, 1, discretization_->get_comm());
 
     // reset geometry of visualization writer
     if (map_changed_allproc) set_geometry_from_discretization();

--- a/src/core/io/src/4C_io_domainreader.cpp
+++ b/src/core/io/src/4C_io_domainreader.cpp
@@ -45,9 +45,9 @@ namespace
     }
 
     ssize_t data_size = data.size();
-    comm.Broadcast(&data_size, 1, 0);
+    Core::Communication::broadcast(&data_size, 1, 0, comm);
     if (myrank != 0) data.resize(data_size, 0);
-    comm.Broadcast(data.data(), data.size(), 0);
+    Core::Communication::broadcast(data.data(), data.size(), 0, comm);
 
     Core::Communication::UnpackBuffer buffer(data);
     if (myrank != 0)

--- a/src/core/io/src/4C_io_elementreader.cpp
+++ b/src/core/io/src/4C_io_elementreader.cpp
@@ -141,10 +141,10 @@ std::pair<int, std::vector<int>> Core::IO::ElementReader::get_element_size_and_i
   }
 
   // Simply allreduce the element ids
-  comm_.Broadcast(&numele, 1, 0);
+  Core::Communication::broadcast(&numele, 1, 0, comm_);
 
   eids.resize(numele);
-  comm_.Broadcast(&eids[0], numele, 0);
+  Core::Communication::broadcast(&eids[0], numele, 0, comm_);
 
   return {numele, eids};
 }

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -1157,8 +1157,8 @@ namespace Core::IO
       int num_lines = lines_.size();
       /* Now that we use a variable number of bytes per line we have to
        * communicate the buffer size as well. */
-      comm_.Broadcast(&arraysize, 1, 0);
-      comm_.Broadcast(&num_lines, 1, 0);
+      Core::Communication::broadcast(&arraysize, 1, 0, comm_);
+      Core::Communication::broadcast(&num_lines, 1, 0, comm_);
 
       if (Core::Communication::my_mpi_rank(comm_) > 0)
       {
@@ -1168,7 +1168,7 @@ namespace Core::IO
       }
 
       // There are no char based functions available! Do it by hand!
-      // comm_.Broadcast(inputfile_.data(),arraysize,0);
+      // Core::Communication::broadcast(inputfile_.data(),arraysize,0, comm_);
 
       const auto& mpicomm = dynamic_cast<const Epetra_MpiComm&>(comm_);
 

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -88,7 +88,7 @@ void Core::IO::MeshReader::read_and_partition()
   // last check if there are enough nodes
   {
     int local_max_node_id = max_node_id;
-    comm_.MaxAll(&local_max_node_id, &max_node_id, 1);
+    Core::Communication::max_all(&local_max_node_id, &max_node_id, 1, comm_);
 
     if (max_node_id > 0 && max_node_id < Core::Communication::num_mpi_ranks(comm_))
       FOUR_C_THROW("Bad idea: Simulation with %d procs for problem with %d nodes",
@@ -120,7 +120,7 @@ void Core::IO::MeshReader::rebalance()
   {
     // global node ids --- this will be a fully redundant vector!
     int numnodes = static_cast<int>(element_readers_[i].get_unique_nodes().size());
-    comm_.Broadcast(&numnodes, 1, 0);
+    Core::Communication::broadcast(&numnodes, 1, 0, comm_);
 
     const auto discret = element_readers_[i].get_dis();
 
@@ -234,7 +234,7 @@ void Core::IO::MeshReader::create_inline_mesh(int& max_node_id)
   {
     // communicate node offset to all procs
     int local_max_node_id = max_node_id;
-    comm_.MaxAll(&local_max_node_id, &max_node_id, 1);
+    Core::Communication::max_all(&local_max_node_id, &max_node_id, 1, comm_);
 
     domain_reader.create_partitioned_mesh(max_node_id);
     domain_reader.complete();

--- a/src/core/io/src/4C_io_walltime_based_restart.cpp
+++ b/src/core/io/src/4C_io_walltime_based_restart.cpp
@@ -83,7 +83,7 @@ bool Core::IO::RestartManager::restart(const int step, const Epetra_Comm& comm)
         if (walltimerestart) ++restartcounter_;
       }
     }
-    comm.Broadcast(&restarttime, 1, 0);
+    Core::Communication::broadcast(&restarttime, 1, 0, comm);
     return restarttime;
   }
 

--- a/src/core/io/tests/4C_io_pstream_test.cpp
+++ b/src/core/io/tests/4C_io_pstream_test.cpp
@@ -9,7 +9,7 @@
 
 #include "4C_io_pstream.hpp"
 
-#include <Epetra_SerialComm.h>
+#include <Epetra_MpiComm.h>
 
 #include <stdexcept>
 
@@ -28,9 +28,10 @@ namespace
   TEST(PstreamTest, DoubleInitializeThrows)
   {
     Core::IO::Pstream ps;
-    ps.setup(true, false, true, Core::IO::undef, std::make_shared<Epetra_SerialComm>(), 0, 4, "");
+    ps.setup(true, false, true, Core::IO::undef, std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD),
+        0, 4, "");
     EXPECT_THROW(ps.setup(false, false, false, Core::IO::standard,
-                     std::make_shared<Epetra_SerialComm>(), 0, 2, ""),
+                     std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 0, 2, ""),
         Core::Exception);
   }
 
@@ -39,7 +40,7 @@ namespace
     using namespace FourC;
     Core::IO::Pstream ps;
     EXPECT_THROW(ps.setup(false, false, false, Core::IO::standard,
-                     std::make_shared<Epetra_SerialComm>(), 4, 2, ""),
+                     std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 4, 2, ""),
         Core::Exception);
   }
 
@@ -47,7 +48,8 @@ namespace
   {
     using namespace FourC;
     Core::IO::Pstream ps;
-    ps.setup(true, false, false, Core::IO::undef, std::make_shared<Epetra_SerialComm>(), 0, 0, "");
+    ps.setup(true, false, false, Core::IO::undef, std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD),
+        0, 0, "");
     EXPECT_NO_THROW(ps.flush());
     EXPECT_NO_THROW(ps << "blub");
     EXPECT_NO_THROW(ps.close());
@@ -57,8 +59,8 @@ namespace
   {
     using namespace FourC;
     Core::IO::Pstream ps;
-    ps.setup(
-        true, false, false, Core::IO::minimal, std::make_shared<Epetra_SerialComm>(), 0, 0, "");
+    ps.setup(true, false, false, Core::IO::minimal,
+        std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 0, 0, "");
     EXPECT_EQ(ps.requested_output_level(), Core::IO::minimal);
     Core::IO::Level &lvl = ps(Core::IO::debug);
     EXPECT_NO_THROW(lvl << 4);
@@ -68,7 +70,8 @@ namespace
   {
     using namespace FourC;
     Core::IO::Pstream ps;
-    ps.setup(false, false, true, Core::IO::debug, std::make_shared<Epetra_SerialComm>(), 0, 0, "");
+    ps.setup(false, false, true, Core::IO::debug, std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD),
+        0, 0, "");
     EXPECT_NO_THROW(ps << 4UL << -5LL << 1337.0 << 42.0f << "blub" << std::string("blah") << "\n");
     EXPECT_NO_THROW(ps.flush());
     EXPECT_NO_THROW(ps.close());
@@ -78,7 +81,8 @@ namespace
   {
     using namespace FourC;
     Core::IO::Pstream ps;
-    ps.setup(false, false, true, Core::IO::debug, std::make_shared<Epetra_SerialComm>(), 0, 0, "");
+    ps.setup(false, false, true, Core::IO::debug, std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD),
+        0, 0, "");
     EXPECT_NO_THROW(ps << "blub" << Core::IO::flush);
     EXPECT_NO_THROW(ps << "blah" << Core::IO::endl);
   }
@@ -87,7 +91,8 @@ namespace
   {
     using namespace FourC;
     Core::IO::Pstream ps;
-    ps.setup(true, false, true, Core::IO::undef, std::make_shared<Epetra_SerialComm>(), 0, 0, "");
+    ps.setup(true, false, true, Core::IO::undef, std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD),
+        0, 0, "");
     Core::IO::Level &lvl = ps(Core::IO::debug);
     EXPECT_NO_THROW(lvl.stream(1.2));
     EXPECT_NO_THROW(lvl << 4);
@@ -98,8 +103,8 @@ namespace
   {
     using namespace FourC;
     Core::IO::Pstream ps;
-    ps.setup(
-        true, false, true, Core::IO::standard, std::make_shared<Epetra_SerialComm>(), 0, 0, "");
+    ps.setup(true, false, true, Core::IO::standard,
+        std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 0, 0, "");
     Core::IO::Level &lvl = ps(Core::IO::debug);
     EXPECT_NO_THROW(lvl << 1.2 << Core::IO::flush);
     EXPECT_NO_THROW(lvl << 23 << Core::IO::endl);

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -511,7 +511,7 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
     if (prod[i] != 0.0) numnonzero++;
 
   int glob_numnonzero = 0;
-  prod.Comm().SumAll(&numnonzero, &glob_numnonzero, 1);
+  Core::Communication::sum_all(&numnonzero, &glob_numnonzero, 1, prod.Comm());
 
   // do stupid conversion into Epetra map
   Epetra_Map mv1map(mv1->Map().NumGlobalElements(), mv1->Map().NumMyElements(),

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
@@ -287,7 +287,7 @@ double Core::LinAlg::MultiMapExtractor::norm2(
   }
 
   double global_norm = 0;
-  fm.Comm().SumAll(&local_norm, &global_norm, 1);
+  Core::Communication::sum_all(&local_norm, &global_norm, 1, fm.Comm());
   return std::sqrt(global_norm);
 }
 

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrixbase.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrixbase.cpp
@@ -289,7 +289,7 @@ bool Core::LinAlg::SparseMatrixBase::is_dbc_applied(
 
   int lisdbc = static_cast<int>(isdbc);
   int gisdbc = 0;
-  Comm().MinAll(&lisdbc, &gisdbc, 1);
+  Core::Communication::min_all(&lisdbc, &gisdbc, 1, Comm());
 
   return (gisdbc == 1);
 }

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -641,7 +641,7 @@ std::shared_ptr<Epetra_Map> Core::LinAlg::split_map(
   }
   myaugids.resize(count);
   int gcount;
-  Comm.SumAll(&count, &gcount, 1);
+  Core::Communication::sum_all(&count, &gcount, 1, Comm);
   std::shared_ptr<Epetra_Map> Aunknown =
       std::make_shared<Epetra_Map>(gcount, count, myaugids.data(), 0, Comm);
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -164,7 +164,7 @@ void Core::LinAlg::add(const Epetra_CrsMatrix& A, const bool transposeA, const d
   int rowsAdded = do_add(*Aprime, scalarA, *B.epetra_matrix(), scalarB);
   int localSuccess = rowsAdded == Aprime->RowMap().NumMyElements();
   int globalSuccess = 0;
-  B.Comm().MinAll(&localSuccess, &globalSuccess, 1);
+  Core::Communication::min_all(&localSuccess, &globalSuccess, 1, B.Comm());
   if (!globalSuccess)
   {
     if (!B.filled()) FOUR_C_THROW("Unexpected state of B (expected: B not filled, got: B filled)");

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
@@ -29,13 +29,13 @@ void Core::LinAlg::print_matrix_in_matlab_format(
   for (int iproc = 0; iproc < num_proc; iproc++)
   {
     int num_rows_iproc = sparsematrix.NumMyRows();
-    comm.Broadcast(&num_rows_iproc, 1, iproc);
+    Core::Communication::broadcast(&num_rows_iproc, 1, iproc, comm);
 
     for (int row_lid_iproc = 0; row_lid_iproc < num_rows_iproc; ++row_lid_iproc)
     {
       // get gid of this row and communicate to all procs
       int row_gid_iproc = iproc == my_PID ? sparsematrix.GRID(row_lid_iproc) : 0;
-      comm.Broadcast(&row_gid_iproc, 1, iproc);
+      Core::Communication::broadcast(&row_gid_iproc, 1, iproc, comm);
 
       // get indices and values of this row and communicate to all procs
       int num_indices_iproc;
@@ -50,12 +50,12 @@ void Core::LinAlg::print_matrix_in_matlab_format(
         sparsematrix.ExtractGlobalRowCopy(row_gid_iproc, max_num_inidces, num_indices_iproc,
             values_iproc.data(), indices_iproc.data());
       }
-      comm.Broadcast(&num_indices_iproc, 1, iproc);
+      Core::Communication::broadcast(&num_indices_iproc, 1, iproc, comm);
       values_iproc.resize(num_indices_iproc);
       indices_iproc.resize(num_indices_iproc);
 
-      comm.Broadcast(values_iproc.data(), num_indices_iproc, iproc);
-      comm.Broadcast(indices_iproc.data(), num_indices_iproc, iproc);
+      Core::Communication::broadcast(values_iproc.data(), num_indices_iproc, iproc, comm);
+      Core::Communication::broadcast(indices_iproc.data(), num_indices_iproc, iproc, comm);
 
       if (my_PID == 0)
       {
@@ -77,7 +77,7 @@ void Core::LinAlg::print_matrix_in_matlab_format(
       }
     }
     // wait, until proc 0 has written
-    comm.Barrier();
+    Core::Communication::barrier(comm);
   }
 }
 
@@ -113,8 +113,8 @@ void Core::LinAlg::print_vector_in_matlab_format(
     int num_elements_iproc = vector.Map().NumMyElements();
     int max_element_size_iproc = vector.Map().MaxElementSize();
 
-    comm.Broadcast(&num_elements_iproc, 1, iproc);
-    comm.Broadcast(&max_element_size_iproc, 1, iproc);
+    Core::Communication::broadcast(&num_elements_iproc, 1, iproc, comm);
+    Core::Communication::broadcast(&max_element_size_iproc, 1, iproc, comm);
 
     std::vector<int> global_elements_iproc(num_elements_iproc);
     std::vector<double> values_iproc(num_elements_iproc);
@@ -130,9 +130,10 @@ void Core::LinAlg::print_vector_in_matlab_format(
       }
     }
 
-    comm.Broadcast(global_elements_iproc.data(), num_elements_iproc, iproc);
-    comm.Broadcast(values_iproc.data(), num_elements_iproc, iproc);
-    comm.Broadcast(first_point_in_element_list_iproc.data(), num_elements_iproc, iproc);
+    Core::Communication::broadcast(global_elements_iproc.data(), num_elements_iproc, iproc, comm);
+    Core::Communication::broadcast(values_iproc.data(), num_elements_iproc, iproc, comm);
+    Core::Communication::broadcast(
+        first_point_in_element_list_iproc.data(), num_elements_iproc, iproc, comm);
 
     if (my_PID == 0)
     {
@@ -166,7 +167,7 @@ void Core::LinAlg::print_vector_in_matlab_format(
       }
     }
     // wait, until proc 0 has written
-    comm.Barrier();
+    Core::Communication::barrier(comm);
   }
 }
 
@@ -186,8 +187,8 @@ void Core::LinAlg::print_map_in_matlab_format(
     int num_elements_iproc = map.NumMyElements();
     int max_element_size_iproc = map.MaxElementSize();
 
-    comm.Broadcast(&num_elements_iproc, 1, iproc);
-    comm.Broadcast(&max_element_size_iproc, 1, iproc);
+    Core::Communication::broadcast(&num_elements_iproc, 1, iproc, comm);
+    Core::Communication::broadcast(&max_element_size_iproc, 1, iproc, comm);
 
     std::vector<int> global_elements_iproc(num_elements_iproc);
 
@@ -196,7 +197,7 @@ void Core::LinAlg::print_map_in_matlab_format(
       for (int i = 0; i < num_elements_iproc; ++i)
         global_elements_iproc[i] = map.MyGlobalElements()[i];
     }
-    comm.Broadcast(global_elements_iproc.data(), num_elements_iproc, iproc);
+    Core::Communication::broadcast(global_elements_iproc.data(), num_elements_iproc, iproc, comm);
 
     if (my_PID == 0)
     {
@@ -225,7 +226,7 @@ void Core::LinAlg::print_map_in_matlab_format(
       os << std::flush;
     }
     // wait, until proc 0 has written
-    comm.Barrier();
+    Core::Communication::barrier(comm);
   }
 }
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
@@ -160,7 +160,7 @@ int Core::LinearSolver::IterativeSolver<MatrixType, VectorType>::solve()
   int my_error = 0;
   if (ret != Belos::Converged) my_error = 1;
   int glob_error = 0;
-  comm_.SumAll(&my_error, &glob_error, 1);
+  Core::Communication::sum_all(&my_error, &glob_error, 1, comm_);
 
   if (glob_error > 0 and Core::Communication::my_mpi_rank(this->comm_) == 0)
     std::cout << std::endl
@@ -199,7 +199,7 @@ bool Core::LinearSolver::IterativeSolver<MatrixType, VectorType>::allow_reuse_pr
   int nProc = Core::Communication::num_mpi_ranks(comm_);
   int lAllowReuse = bAllowReuse == true ? 1 : 0;
   int gAllowReuse = 0;
-  comm_.SumAll(&lAllowReuse, &gAllowReuse, 1);
+  Core::Communication::sum_all(&lAllowReuse, &gAllowReuse, 1, comm_);
 
   return gAllowReuse == nProc;
 }

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -60,7 +60,7 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
     // communicate data to procs without row element
     std::array<int, 4> ldata{numdf, dimns, nv, np};
     std::array<int, 4> gdata{0, 0, 0, 0};
-    dis.get_comm().MaxAll(ldata.data(), gdata.data(), 4);
+    Core::Communication::max_all(ldata.data(), gdata.data(), 4, dis.get_comm());
     numdf = gdata[0];
     dimns = gdata[1];
     nv = gdata[2];

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -361,7 +361,7 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
 
     if (print)
     {
-      dis_to_rebalance.get_comm().Barrier();
+      Core::Communication::barrier(dis_to_rebalance.get_comm());
       for (const auto& it : matched_ele_map)
       {
         std::cout << "ELEMENT : " << it.first << " ->  ( " << it.second[0] << ", " << it.second[1]
@@ -468,7 +468,7 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
     }
     if (print)
     {
-      dis_to_rebalance.get_comm().Barrier();
+      Core::Communication::barrier(dis_to_rebalance.get_comm());
       for (const auto& it : matched_node_map)
       {
         std::cout << "NODE : " << it.first << " ->  ( " << it.second[0] << ", " << it.second[1]

--- a/src/core/rebalance/src/4C_rebalance_print.cpp
+++ b/src/core/rebalance/src/4C_rebalance_print.cpp
@@ -34,10 +34,10 @@ void Core::Rebalance::Utils::print_parallel_distribution(const Core::FE::Discret
     my_n_elements[myrank] = dis.num_my_row_elements();
     my_n_ghostele[myrank] = dis.num_my_col_elements() - my_n_elements[myrank];
 
-    dis.get_comm().SumAll(&my_n_nodes[0], &n_nodes[0], numproc);
-    dis.get_comm().SumAll(&my_n_ghostnodes[0], &n_ghostnodes[0], numproc);
-    dis.get_comm().SumAll(&my_n_elements[0], &n_elements[0], numproc);
-    dis.get_comm().SumAll(&my_n_ghostele[0], &n_ghostele[0], numproc);
+    Core::Communication::sum_all(&my_n_nodes[0], &n_nodes[0], numproc, dis.get_comm());
+    Core::Communication::sum_all(&my_n_ghostnodes[0], &n_ghostnodes[0], numproc, dis.get_comm());
+    Core::Communication::sum_all(&my_n_elements[0], &n_elements[0], numproc, dis.get_comm());
+    Core::Communication::sum_all(&my_n_ghostele[0], &n_ghostele[0], numproc, dis.get_comm());
 
     if (myrank == 0)
     {

--- a/src/core/utils/src/result_test/4C_utils_result_test.cpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.cpp
@@ -168,13 +168,13 @@ void Core::Utils::ResultTestManager::test_all(const Epetra_Comm& comm)
 
   // print number of unevaluated tests to screen
   int guneval_test_count = 0;
-  comm.SumAll(&uneval_test_count, &guneval_test_count, 1);
+  Core::Communication::sum_all(&uneval_test_count, &guneval_test_count, 1, comm);
   if (guneval_test_count > 0 and Core::Communication::my_mpi_rank(comm) == 0)
     Core::IO::cout << guneval_test_count << " tests stay unevaluated" << Core::IO::endl;
 
   // determine the total number of errors
   int numerr;
-  comm.SumAll(&nerr, &numerr, 1);
+  Core::Communication::sum_all(&nerr, &numerr, 1, comm);
 
   if (numerr > 0)
   {
@@ -188,7 +188,7 @@ void Core::Utils::ResultTestManager::test_all(const Epetra_Comm& comm)
   if (test_count > -1)
   {
     int lcount = test_count + uneval_test_count;
-    comm.SumAll(&lcount, &count, 1);
+    Core::Communication::sum_all(&lcount, &count, 1, comm);
 
     /* It's indeed possible to count more tests than expected if you
      * happen to test values of a boundary element. We don't want this

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -60,8 +60,8 @@ void Coupling::Adapter::Coupling::setup_condition_coupling(
   int localslavecount = static_cast<int>(slavenodes.size());
   int slavecount;
 
-  masterdis.get_comm().SumAll(&localmastercount, &mastercount, 1);
-  slavedis.get_comm().SumAll(&localslavecount, &slavecount, 1);
+  Core::Communication::sum_all(&localmastercount, &mastercount, 1, masterdis.get_comm());
+  Core::Communication::sum_all(&localslavecount, &slavecount, 1, slavedis.get_comm());
 
   if (mastercount != slavecount)
     FOUR_C_THROW("got %d master nodes but %d slave nodes for coupling", mastercount, slavecount);
@@ -188,8 +188,8 @@ void Coupling::Adapter::Coupling::setup_constrained_condition_coupling(
   int localslavecount = static_cast<int>(slavenodes.size());
   int slavecount;
 
-  masterdis.get_comm().SumAll(&localmastercount, &mastercount, 1);
-  slavedis.get_comm().SumAll(&localslavecount, &slavecount, 1);
+  Core::Communication::sum_all(&localmastercount, &mastercount, 1, masterdis.get_comm());
+  Core::Communication::sum_all(&localslavecount, &slavecount, 1, slavedis.get_comm());
 
   if (mastercount != slavecount and matchall)
     FOUR_C_THROW("got %d master nodes but %d slave nodes for coupling", mastercount, slavecount);

--- a/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
@@ -126,7 +126,7 @@ bool Coupling::Adapter::MatrixLogicalSplitAndTransform::operator()(
       }
 
     int gsubset = 0;
-    logical_range_map.Comm().MinAll(&subset, &gsubset, 1);
+    Core::Communication::min_all(&subset, &gsubset, 1, logical_range_map.Comm());
 
     // need communication -> call import on permuted map
     if (!gsubset)

--- a/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
@@ -395,7 +395,7 @@ void Coupling::Adapter::CouplingMortar::setup_interface(
   if (masterdis.get() != slavedis.get())
   {
     int nummastermtreles = masterelements.size();
-    comm.SumAll(&nummastermtreles, &eleoffset, 1);
+    Core::Communication::sum_all(&nummastermtreles, &eleoffset, 1, comm);
   }
 
   if (slidingale == true) eleoffset = masterdis->element_row_map()->MaxAllGID() + 1;
@@ -827,7 +827,7 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
     // communicate new position Xnew to all procs
     // (we can use SumAll here, as Xnew will be zero on all processors
     // except for the owner processor of the current node)
-    comm.SumAll(Xnew.data(), Xnewglobal.data(), 3);
+    Core::Communication::sum_all(Xnew.data(), Xnewglobal.data(), 3, comm);
 
     // const_cast to force modifed X() into mtnode
     // const_cast to force modifed xspatial() into mtnode

--- a/src/cut/4C_cut_cutwizard.cpp
+++ b/src/cut/4C_cut_cutwizard.cpp
@@ -736,7 +736,7 @@ void Cut::CutWizard::run_cut(
 )
 {
   // just for time measurement
-  comm_.Barrier();
+  Core::Communication::barrier(comm_);
 
   if (do_mesh_intersection_)
   {
@@ -749,7 +749,7 @@ void Cut::CutWizard::run_cut(
       intersection_->cut_self_cut(include_inner, screenoutput_);
 
       // just for time measurement
-      comm_.Barrier();
+      Core::Communication::barrier(comm_);
 
       const double t_diff = Teuchos::Time::wallTime() - t_start;
       if (myrank_ == 0 and screenoutput_)
@@ -764,7 +764,7 @@ void Cut::CutWizard::run_cut(
       intersection_->cut_collision_detection(include_inner, screenoutput_);
 
       // just for time measurement
-      comm_.Barrier();
+      Core::Communication::barrier(comm_);
 
       const double t_diff = Teuchos::Time::wallTime() - t_start;
       if (myrank_ == 0 and screenoutput_)
@@ -780,7 +780,7 @@ void Cut::CutWizard::run_cut(
     intersection_->cut(screenoutput_);
 
     // just for time measurement
-    comm_.Barrier();
+    Core::Communication::barrier(comm_);
 
     const double t_diff = Teuchos::Time::wallTime() - t_start;
     if (myrank_ == 0 and screenoutput_)
@@ -795,7 +795,7 @@ void Cut::CutWizard::run_cut(
     find_position_dof_sets(include_inner);
 
     // just for time measurement
-    comm_.Barrier();
+    Core::Communication::barrier(comm_);
 
     const double t_diff = Teuchos::Time::wallTime() - t_start;
     if (myrank_ == 0 and screenoutput_)
@@ -812,7 +812,7 @@ void Cut::CutWizard::run_cut(
         include_inner, v_cellgausstype_, b_cellgausstype_, tetcellsonly_, screenoutput_);
 
     // just for time measurement
-    comm_.Barrier();
+    Core::Communication::barrier(comm_);
 
     const double t_diff = Teuchos::Time::wallTime() - t_start;
     if (myrank_ == 0 and screenoutput_)
@@ -828,7 +828,7 @@ void Cut::CutWizard::run_cut(
  *------------------------------------------------------------------------------------------------*/
 void Cut::CutWizard::find_position_dof_sets(bool include_inner)
 {
-  comm_.Barrier();
+  Core::Communication::barrier(comm_);
 
   TEUCHOS_FUNC_TIME_MONITOR("Cut --- 5/6 --- cut_positions_dofsets (parallel)");
 
@@ -879,7 +879,7 @@ void Cut::CutWizard::find_position_dof_sets(bool include_inner)
     }
 
     //--------------------------------------------
-    comm_.Barrier();
+    Core::Communication::barrier(comm_);
 
     // find number and connection of dofsets at nodes from cut volumes
     intersection_->create_nodal_dof_set(include_inner, back_mesh_->get());

--- a/src/cut/4C_cut_parallel.cpp
+++ b/src/cut/4C_cut_parallel.cpp
@@ -41,7 +41,7 @@ Cut::Parallel::Parallel(const std::shared_ptr<Core::FE::Discretization>& discret
 void Cut::Parallel::communicate_node_positions()
 {
   // wait for all processors before the Communication starts
-  discret_->get_comm().Barrier();
+  Core::Communication::barrier(discret_->get_comm());
 
   TEUCHOS_FUNC_TIME_MONITOR("Cut --- 5/6 --- cut_positions_dofsets --- communicate_node_positions");
 
@@ -109,7 +109,7 @@ void Cut::Parallel::communicate_node_positions()
   }
 #endif
 
-  discret_->get_comm().Barrier();
+  Core::Communication::barrier(discret_->get_comm());
 
   //----------------------------------------------------------
 
@@ -164,7 +164,7 @@ void Cut::Parallel::export_communication_finished(bool& procDone)
     if ((bool)allProcsDone == false) procDone = false;
 
     // processors wait for each other
-    discret_->get_comm().Barrier();
+    Core::Communication::barrier(discret_->get_comm());
   }
 
 
@@ -260,7 +260,7 @@ void Cut::Parallel::export_node_position_data()
         //--------------------
       }
 
-      discret_->get_comm().Barrier();  // processors wait for each other
+      Core::Communication::barrier(discret_->get_comm());  // processors wait for each other
     }
 
 
@@ -447,7 +447,7 @@ void Cut::Parallel::set_position_for_node(const Node* n, const Point::PointPosit
 void Cut::Parallel::communicate_node_dof_set_numbers(bool include_inner)
 {
   // wait for all processors before the Communication starts
-  discret_->get_comm().Barrier();
+  Core::Communication::barrier(discret_->get_comm());
 
   TEUCHOS_FUNC_TIME_MONITOR(
       "Cut --- 5/6 --- cut_positions_dofsets --- communicate_node_dof_set_numbers");
@@ -473,7 +473,7 @@ void Cut::Parallel::communicate_node_dof_set_numbers(bool include_inner)
   // procs set the information
   distribute_dof_set_data();
 
-  discret_->get_comm().Barrier();
+  Core::Communication::barrier(discret_->get_comm());
 
   //  const double t_diff = Teuchos::Time::wallTime()-t_start;
   //  if ( myrank_ == 0 )
@@ -553,7 +553,7 @@ void Cut::Parallel::export_dof_set_data(bool include_inner)
 
 
 
-      discret_->get_comm().Barrier();  // processors wait for each other
+      Core::Communication::barrier(discret_->get_comm());  // processors wait for each other
     }
 
 

--- a/src/cut/4C_cut_parentintersection.cpp
+++ b/src/cut/4C_cut_parentintersection.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
 void Cut::ParentIntersection::create_nodal_dof_set(
     bool include_inner, const Core::FE::Discretization& dis)
 {
-  dis.get_comm().Barrier();
+  Core::Communication::barrier(dis.get_comm());
 
   TEUCHOS_FUNC_TIME_MONITOR("Cut --- 5/6 --- cut_positions_dofsets --- CreateNodalDofSet");
 

--- a/src/elemag/4C_elemag_resulttest.cpp
+++ b/src/elemag/4C_elemag_resulttest.cpp
@@ -40,7 +40,7 @@ void EleMag::ElemagResultTest::test_node(
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);
-  dis_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, dis_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/elemag/4C_elemag_timeint.cpp
+++ b/src/elemag/4C_elemag_timeint.cpp
@@ -427,7 +427,8 @@ void EleMag::ElemagTimeInt::set_initial_electric_field(
     elemagele->evaluate(
         initParams, *discret_, la[0].lm_, elemat, elemat, elevec1, elevec2, elevec1);
   }
-  discret_->get_comm().Barrier();  // other procs please wait for the one, who did all the work
+  Core::Communication::barrier(
+      discret_->get_comm());  // other procs please wait for the one, who did all the work
 
   output();
 

--- a/src/fluid/4C_fluid_coupling_red_models.cpp
+++ b/src/fluid/4C_fluid_coupling_red_models.cpp
@@ -503,7 +503,7 @@ void FLD::Utils::FluidCouplingWrapperBase::apply_boundary_conditions(
 
     // update the variable on all of the processors
     double par_var = 0.0;
-    discret_3d_->get_comm().SumAll(&var, &par_var, 1);
+    Core::Communication::sum_all(&var, &par_var, 1, discret_3d_->get_comm());
     (*map_red_dnp_)[VariableWithId.str()] = par_var;
 
     // Apply the boundary condition to the outlets
@@ -875,7 +875,7 @@ double FLD::Utils::FluidCouplingBc::area(double& density, double& viscosity, int
   int theproc = -1;  // the lowest proc that has the desired information
   std::vector<double> alldens(numproc);
 
-  discret_3d_->get_comm().GatherAll(&density, alldens.data(), 1);
+  Core::Communication::gather_all(&density, alldens.data(), 1, discret_3d_->get_comm());
   for (int i = 0; i < numproc; i++)
     if (alldens[i] > 0.0)
     {
@@ -885,13 +885,13 @@ double FLD::Utils::FluidCouplingBc::area(double& density, double& viscosity, int
   if (theproc < 0) FOUR_C_THROW("Something parallel went terribly wrong!");
 
   // do the actual communication of density ...
-  discret_3d_->get_comm().Broadcast(&density, 1, theproc);
+  Core::Communication::broadcast(&density, 1, theproc, discret_3d_->get_comm());
   // ... and viscosity
-  discret_3d_->get_comm().Broadcast(&viscosity, 1, theproc);
+  Core::Communication::broadcast(&viscosity, 1, theproc, discret_3d_->get_comm());
 
   // get total area in parallel case
   double pararea = 0.0;
-  discret_3d_->get_comm().SumAll(&actarea, &pararea, 1);
+  Core::Communication::sum_all(&actarea, &pararea, 1, discret_3d_->get_comm());
 
   if (myrank_ == 0)
   {
@@ -953,7 +953,7 @@ double FLD::Utils::FluidCouplingBc::flow_rate_calculation(double time, double dt
   }
 
   double flowrate = 0.0;
-  dofrowmap->Comm().SumAll(&local_flowrate, &flowrate, 1);
+  Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
   return flowrate;
 }  // FluidImplicitTimeInt::flow_rate_calculation
@@ -1007,7 +1007,7 @@ double FLD::Utils::FluidCouplingBc::pressure_calculation(double time, double dta
 
   // get total flowrate in parallel case
   double parpressure = 0.0;
-  discret_3d_->get_comm().SumAll(&actpressure, &parpressure, 1);
+  Core::Communication::sum_all(&actpressure, &parpressure, 1, discret_3d_->get_comm());
 
   return parpressure;
 }  // FluidImplicitTimeInt::pressure_calculation

--- a/src/fluid/4C_fluid_discret_extractor.cpp
+++ b/src/fluid/4C_fluid_discret_extractor.cpp
@@ -306,7 +306,8 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
           }
 
           // combine marked nodes of all procs
-          childdiscret_->get_comm().SumAll(mytoggle.data(), toggle.data(), toggle.size());
+          Core::Communication::sum_all(
+              mytoggle.data(), toggle.data(), toggle.size(), childdiscret_->get_comm());
 
           // and add nodes to the list of child nodes that will get the condition
           for (unsigned rr = 0; rr < candidates->size(); ++rr)
@@ -466,10 +467,14 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
           childdiscret_->num_my_col_elements() - childdiscret_->num_my_row_elements();
       my_n_dof[myrank] = childdiscret_->dof_row_map()->NumMyElements();
 
-      childdiscret_->get_comm().SumAll(my_n_nodes.data(), n_nodes.data(), numproc);
-      childdiscret_->get_comm().SumAll(my_n_elements.data(), n_elements.data(), numproc);
-      childdiscret_->get_comm().SumAll(my_n_ghostele.data(), n_ghostele.data(), numproc);
-      childdiscret_->get_comm().SumAll(my_n_dof.data(), n_dof.data(), numproc);
+      Core::Communication::sum_all(
+          my_n_nodes.data(), n_nodes.data(), numproc, childdiscret_->get_comm());
+      Core::Communication::sum_all(
+          my_n_elements.data(), n_elements.data(), numproc, childdiscret_->get_comm());
+      Core::Communication::sum_all(
+          my_n_ghostele.data(), n_ghostele.data(), numproc, childdiscret_->get_comm());
+      Core::Communication::sum_all(
+          my_n_dof.data(), n_dof.data(), numproc, childdiscret_->get_comm());
 
       if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
       {

--- a/src/fluid/4C_fluid_impedancecondition.cpp
+++ b/src/fluid/4C_fluid_impedancecondition.cpp
@@ -311,7 +311,7 @@ void FLD::Utils::FluidImpedanceBc::flow_rate_calculation(const int condid)
   }
 
   double flowrate = 0.0;
-  dofrowmap->Comm().SumAll(&local_flowrate, &flowrate, 1);
+  Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
   q_np_ = flowrate;
 
@@ -596,7 +596,7 @@ double FLD::Utils::FluidImpedanceBc::area(const int condid)
 
   // get total area in parallel case
   double pararea = 0.0;
-  discret_->get_comm().SumAll(&actarea, &pararea, 1);
+  Core::Communication::sum_all(&actarea, &pararea, 1, discret_->get_comm());
 
   //  if (myrank_ == 0)
   //    std::cout << "Impedance condition Id: " << condid << ", Area: " << pararea << std::endl;

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1456,7 +1456,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
       // sum up global flow rate over all processors and set to global value
       double flowrate = 0.0;
-      dofrowmap->Comm().SumAll(&local_flowrate, &flowrate, 1);
+      Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
       // set current flow rate
       flowratenp_[fdpcondid] = flowrate;
@@ -1504,7 +1504,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
       // sum up global surface area over all processors
       double area = 0.0;
-      discret_->get_comm().SumAll(&localarea, &area, 1);
+      Core::Communication::sum_all(&localarea, &area, 1, discret_->get_comm());
 
       // clear state
       discret_->clear_state();
@@ -1529,7 +1529,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
       // sum up global pressure integral over all processors
       double pressint = 0.0;
-      discret_->get_comm().SumAll(&localpressint, &pressint, 1);
+      Core::Communication::sum_all(&localpressint, &pressint, 1, discret_->get_comm());
 
       // clear state
       discret_->clear_state();
@@ -2770,10 +2770,12 @@ void FLD::FluidImplicitTimeInt::ale_update(std::string condName)
 
         // Sum variables over all processors to obtain global value
         double globalSumVelnpDotNodeTangent = 0.0;
-        dofrowmap->Comm().SumAll(&localSumVelnpDotNodeTangent, &globalSumVelnpDotNodeTangent, 1);
+        Core::Communication::sum_all(
+            &localSumVelnpDotNodeTangent, &globalSumVelnpDotNodeTangent, 1, dofrowmap->Comm());
 
         int globalNumOfCondNodes = 0;
-        dofrowmap->Comm().SumAll(&localNumOfCondNodes, &globalNumOfCondNodes, 1);
+        Core::Communication::sum_all(
+            &localNumOfCondNodes, &globalNumOfCondNodes, 1, dofrowmap->Comm());
 
         // Finalize calculation of mean tangent velocity
         double lambda = 0.0;
@@ -4216,7 +4218,7 @@ void FLD::FluidImplicitTimeInt::set_initial_flow_field(
       // the noise is proportional to the bulk mean velocity of the
       // undisturbed initial field (=2/3*maximum velocity)
       mybmvel = (2.0 / 3.0) * mybmvel;
-      discret_->get_comm().MaxAll(&mybmvel, &bmvel, 1);
+      Core::Communication::max_all(&mybmvel, &bmvel, 1, discret_->get_comm());
 
       // loop all nodes on the processor
       for (int lnodeid = 0; lnodeid < discret_->num_my_row_nodes(); ++lnodeid)
@@ -6052,8 +6054,8 @@ void FLD::FluidImplicitTimeInt::recompute_mean_csgs_b()
     discret_->clear_state();
 
     // gather contributions of all procs
-    discret_->get_comm().SumAll(&local_sumCai, &global_sumCai, 1);
-    discret_->get_comm().SumAll(&local_sumVol, &global_sumVol, 1);
+    Core::Communication::sum_all(&local_sumCai, &global_sumCai, 1, discret_->get_comm());
+    Core::Communication::sum_all(&local_sumVol, &global_sumVol, 1, discret_->get_comm());
 
     // calculate mean Cai
     meanCai = global_sumCai / global_sumVol;

--- a/src/fluid/4C_fluid_meshtying.cpp
+++ b/src/fluid/4C_fluid_meshtying.cpp
@@ -1476,7 +1476,7 @@ void FLD::Meshtying::analyze_matrix(Core::LinAlg::SparseMatrix& sparsematrix)
       }
     }
 
-    discret_->get_comm().SumAll(&localmatrixentries, &parmatrixentries, 1);
+    Core::Communication::sum_all(&localmatrixentries, &parmatrixentries, 1, discret_->get_comm());
   }
   double normfrob = matrix->NormFrobenius();
   double norminf = matrix->NormInf();

--- a/src/fluid/4C_fluid_result_test.cpp
+++ b/src/fluid/4C_fluid_result_test.cpp
@@ -50,7 +50,7 @@ void FLD::FluidResultTest::test_node(
 
   int havenode(fluiddis_->have_global_node(node));
   int isnodeofanybody(0);
-  fluiddis_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, fluiddis_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/fluid/4C_fluid_timint_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_hdg.cpp
@@ -397,7 +397,7 @@ void FLD::TimIntHDG::set_initial_flow_field(
       }
     }
     double globerror = 0;
-    discret_->get_comm().SumAll(&error, &globerror, 1);
+    Core::Communication::sum_all(&error, &globerror, 1, discret_->get_comm());
     if (Core::Communication::my_mpi_rank(discret_->get_comm()) == 0)
       std::cout << "Error project when setting face twice: " << globerror << std::endl;
   }

--- a/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
+++ b/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
@@ -476,7 +476,7 @@ void FLD::TimIntHDGWeakComp::set_initial_flow_field(
   }
 
   double globerror = 0;
-  discret_->get_comm().SumAll(&error, &globerror, 1);
+  Core::Communication::sum_all(&error, &globerror, 1, discret_->get_comm());
   if (Core::Communication::my_mpi_rank(discret_->get_comm()) == 0)
     std::cout << "Error project when setting face twice: " << globerror << std::endl;
 }

--- a/src/fluid/4C_fluid_timint_stat_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_stat_hdg.cpp
@@ -218,7 +218,7 @@ void FLD::TimIntStationaryHDG::set_initial_flow_field(
     }
   }
   double globerror = 0;
-  discret_->get_comm().SumAll(&error, &globerror, 1);
+  Core::Communication::sum_all(&error, &globerror, 1, discret_->get_comm());
   if (Core::Communication::my_mpi_rank(discret_->get_comm()) == 0)
     std::cout << "Error project when setting face twice: " << globerror << std::endl;
 }

--- a/src/fluid/4C_fluid_utils.cpp
+++ b/src/fluid/4C_fluid_utils.cpp
@@ -709,8 +709,10 @@ void FLD::Utils::lift_drag(const std::shared_ptr<const Core::FE::Discretization>
       }  // end: loop over nodes
 
       // care for the fact that we are (most likely) parallel
-      trueresidual.Comm().SumAll(myforces.data(), ((*liftdragvals)[label]).data(), 3);
-      trueresidual.Comm().SumAll(mymoments.data(), ((*liftdragvals)[label]).data() + 3, 3);
+      Core::Communication::sum_all(
+          myforces.data(), ((*liftdragvals)[label]).data(), 3, trueresidual.Comm());
+      Core::Communication::sum_all(
+          mymoments.data(), ((*liftdragvals)[label]).data() + 3, 3, trueresidual.Comm());
 
       // do the output
       if (myrank == 0)
@@ -856,7 +858,7 @@ std::map<int, double> FLD::Utils::compute_flow_rates(Core::FE::Discretization& d
     }
 
     double flowrate = 0.0;
-    dofrowmap->Comm().SumAll(&local_flowrate, &flowrate, 1);
+    Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
     // if(dofrowmap->Comm().MyPID()==0)
     // std::cout << "gobal flow rate = " << flowrate << "\t condition ID = " << condID << std::endl;

--- a/src/fluid/4C_fluid_xwall.cpp
+++ b/src/fluid/4C_fluid_xwall.cpp
@@ -336,7 +336,7 @@ void FLD::XWall::init_x_wall_maps()
     }
 
     int gcount;
-    (discret_->get_comm()).SumAll(&count, &gcount, 1);
+    Core::Communication::sum_all(&count, &gcount, 1, (discret_->get_comm()));
     dircolnodemap_ =
         std::make_shared<Epetra_Map>(gcount, count, testcollect.data(), 0, discret_->get_comm());
   }  // end loop this conditions
@@ -419,7 +419,7 @@ void FLD::XWall::init_wall_dist()
       if (xwallele) enriched = 1;
     }
     int genriched = 0;
-    (commondis->get_comm()).SumAll(&enriched, &genriched, 1);
+    Core::Communication::sum_all(&enriched, &genriched, 1, (commondis->get_comm()));
     if (genriched > 0) colvec.push_back(gid);
   }
   int count = (int)colvec.size();
@@ -461,7 +461,7 @@ void FLD::XWall::init_wall_dist()
       }
     }
 
-    discret_->get_comm().MinAll(&mydist, &gdist, 1);
+    Core::Communication::min_all(&mydist, &gdist, 1, discret_->get_comm());
 
     // now write this value in the node based vector
     if (xwallrownodemap_->MyGID(xwallgid))
@@ -554,7 +554,7 @@ void FLD::XWall::init_toggle_vector()
   Core::LinAlg::export_to(*xtoggleloc_, *xwalltogglexwdis_);
 
   int gcount;
-  (discret_->get_comm()).SumAll(&count, &gcount, 1);
+  Core::Communication::sum_all(&count, &gcount, 1, (discret_->get_comm()));
   if (myrank_ == 0) std::cout << gcount << " blending nodes identified... ";
 
   if (myrank_ == 0) std::cout << "done!  " << std::endl;

--- a/src/fluid_turbulence/4C_fluid_turbulence_dyn_smag.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_dyn_smag.cpp
@@ -617,9 +617,12 @@ void FLD::DynSmagFilter::dyn_smag_compute_cs()
 
     for (int rr = 0; rr < numlayers; ++rr)
     {
-      discret_->get_comm().SumAll(&(local_count_for_average[rr]), &(count_for_average[rr]), 1);
-      discret_->get_comm().SumAll(&(local_ele_sum_LijMij[rr]), &((*averaged_LijMij)[rr]), 1);
-      discret_->get_comm().SumAll(&(local_ele_sum_MijMij[rr]), &((*averaged_MijMij)[rr]), 1);
+      Core::Communication::sum_all(
+          &(local_count_for_average[rr]), &(count_for_average[rr]), 1, discret_->get_comm());
+      Core::Communication::sum_all(
+          &(local_ele_sum_LijMij[rr]), &((*averaged_LijMij)[rr]), 1, discret_->get_comm());
+      Core::Communication::sum_all(
+          &(local_ele_sum_MijMij[rr]), &((*averaged_MijMij)[rr]), 1, discret_->get_comm());
       if (physicaltype_ == Inpar::FLUID::loma)
       {
         discret_->get_comm().SumAll(
@@ -977,8 +980,10 @@ void FLD::DynSmagFilter::dyn_smag_compute_prt(
     {
       scatradiscret_->get_comm().SumAll(
           &(local_count_for_average[rr]), &(count_for_average[rr]), 1);
-      scatradiscret_->get_comm().SumAll(&(local_ele_sum_LkMk[rr]), &((*averaged_LkMk)[rr]), 1);
-      scatradiscret_->get_comm().SumAll(&(local_ele_sum_MkMk[rr]), &((*averaged_MkMk)[rr]), 1);
+      Core::Communication::sum_all(
+          &(local_ele_sum_LkMk[rr]), &((*averaged_LkMk)[rr]), 1, scatradiscret_->get_comm());
+      Core::Communication::sum_all(
+          &(local_ele_sum_MkMk[rr]), &((*averaged_MkMk)[rr]), 1, scatradiscret_->get_comm());
     }
 
     // do averaging

--- a/src/fluid_turbulence/4C_fluid_turbulence_hit_forcing.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_hit_forcing.cpp
@@ -173,7 +173,7 @@ namespace FLD
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         // unpack received block into set of all coordinates
@@ -501,11 +501,14 @@ namespace FLD
       // get values form all processors
       // number of nodes without slave nodes
       const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-      discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
       //----------------------------------------
       // fast Fourier transformation using FFTW
@@ -926,11 +929,14 @@ namespace FLD
       // get values form all processors
       // number of nodes without slave nodes
       const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-      discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
       //----------------------------------------
       // fast Fourier transformation using FFTW
@@ -1319,11 +1325,14 @@ namespace FLD
       // get values form all processors
       // number of nodes without slave nodes
       const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-      discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
       //----------------------------------------
       // fast Fourier transformation using FFTW
@@ -1753,11 +1762,14 @@ namespace FLD
       // get values form all processors
       // number of nodes without slave nodes
       const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-      discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-      discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
       //----------------------------------------
       // fast Fourier transformation using FFTW

--- a/src/fluid_turbulence/4C_fluid_turbulence_hit_initial_field.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_hit_initial_field.cpp
@@ -146,7 +146,7 @@ namespace FLD
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         // unpack received block into set of all coordinates
@@ -289,9 +289,9 @@ namespace FLD
                 random_theta2 = 0.5 * random->uni() + 0.5;
                 random_phi = 0.5 * random->uni() + 0.5;
               }
-              discret_->get_comm().Broadcast(&random_theta1, 1, 0);
-              discret_->get_comm().Broadcast(&random_theta2, 1, 0);
-              discret_->get_comm().Broadcast(&random_phi, 1, 0);
+              Core::Communication::broadcast(&random_theta1, 1, 0, discret_->get_comm());
+              Core::Communication::broadcast(&random_theta2, 1, 0, discret_->get_comm());
+              Core::Communication::broadcast(&random_phi, 1, 0, discret_->get_comm());
 
               // estimate energy at wave number from energy spectrum
               double energy = 0.0;
@@ -967,9 +967,9 @@ namespace FLD
                 random_theta2 = 0.5 * random->uni() + 0.5;
                 random_phi = 0.5 * random->uni() + 0.5;
               }
-              discret_->get_comm().Broadcast(&random_theta1, 1, 0);
-              discret_->get_comm().Broadcast(&random_theta2, 1, 0);
-              discret_->get_comm().Broadcast(&random_phi, 1, 0);
+              Core::Communication::broadcast(&random_theta1, 1, 0, discret_->get_comm());
+              Core::Communication::broadcast(&random_theta2, 1, 0, discret_->get_comm());
+              Core::Communication::broadcast(&random_phi, 1, 0, discret_->get_comm());
 
               // estimate energy at wave number from energy spectrum
               double energy = 0.0;

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_bfda.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_bfda.cpp
@@ -153,7 +153,7 @@ FLD::TurbulenceStatisticsBfda::TurbulenceStatisticsBfda(
 
     {
       // for safety
-      exporter.get_comm().Barrier();
+      Core::Communication::barrier(exporter.get_comm());
     }
 
     //--------------------------------------------------
@@ -267,7 +267,7 @@ FLD::TurbulenceStatisticsBfda::TurbulenceStatisticsBfda(
 
 
     int countActRadNodeOnAllProcs = 0;
-    discret_->get_comm().SumAll(&actRadNode, &countActRadNodeOnAllProcs, 1);
+    Core::Communication::sum_all(&actRadNode, &countActRadNodeOnAllProcs, 1, discret_->get_comm());
 
     int myrank = Core::Communication::my_mpi_rank(discret_->get_comm());
     int numprocs = Core::Communication::num_mpi_ranks(discret_->get_comm());
@@ -315,7 +315,7 @@ FLD::TurbulenceStatisticsBfda::TurbulenceStatisticsBfda(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -481,7 +481,7 @@ void FLD::TurbulenceStatisticsBfda::do_time_sample(Core::LinAlg::Vector<double>&
 
     // Count nodes on all procs (should be 1)
     int countnodesonallprocs = 1;
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
     if (countnodesonallprocs)
     {
       //----------------------------------------------------------------------
@@ -568,7 +568,7 @@ void FLD::TurbulenceStatisticsBfda::do_time_sample(Core::LinAlg::Vector<double>&
       // Sum nodes on all procs (should be 4 nodes at a specific radius per evaluation plane except
       // of r=0 where it is 1)
       int countnodesonallprocs = 4;
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // At r=0 the loop above wrote 4 times a 1.0 at the same position of the toggle vector so this
       // is a special case

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
@@ -309,7 +309,8 @@ FLD::TurbulenceStatisticsCcy::TurbulenceStatisticsCcy(
     std::vector<int> lnodeshells_numnodes(nodeshells_numnodes);
     std::vector<int> lshellcoordinates_numnodes(shellcoordinates_numnodes);
 
-    discret_->get_comm().SumAll(lnodeplanes.data(), nodeshells_->data(), nodeshells_->size());
+    Core::Communication::sum_all(
+        lnodeplanes.data(), nodeshells_->data(), nodeshells_->size(), discret_->get_comm());
     discret_->get_comm().SumAll(
         lplanecoordinates.data(), shellcoordinates_->data(), shellcoordinates_->size());
 
@@ -1083,7 +1084,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
   {
     lpointcount.push_back(shell->second);
   }
-  discret_->get_comm().SumAll(lpointcount.data(), pointcount.data(), size);
+  Core::Communication::sum_all(lpointcount.data(), pointcount.data(), size, discret_->get_comm());
 
   // collect number of samples
   std::vector<double> lmeanu;
@@ -1138,7 +1139,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanu.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanu.data(), gmeanu.data(), size);
+  Core::Communication::sum_all(lmeanu.data(), gmeanu.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanv.begin();
@@ -1147,7 +1148,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanv.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanv.data(), gmeanv.data(), size);
+  Core::Communication::sum_all(lmeanv.data(), gmeanv.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanw.begin();
@@ -1156,7 +1157,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanw.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanw.data(), gmeanw.data(), size);
+  Core::Communication::sum_all(lmeanw.data(), gmeanw.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanp.begin();
@@ -1165,7 +1166,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanp.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanp.data(), gmeanp.data(), size);
+  Core::Communication::sum_all(lmeanp.data(), gmeanp.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanuu.begin();
@@ -1174,7 +1175,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanuu.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanuu.data(), gmeanuu.data(), size);
+  Core::Communication::sum_all(lmeanuu.data(), gmeanuu.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanvv.begin();
@@ -1183,7 +1184,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanvv.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanvv.data(), gmeanvv.data(), size);
+  Core::Communication::sum_all(lmeanvv.data(), gmeanvv.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanww.begin();
@@ -1192,7 +1193,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanww.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanww.data(), gmeanww.data(), size);
+  Core::Communication::sum_all(lmeanww.data(), gmeanww.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanpp.begin();
@@ -1201,7 +1202,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanpp.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanpp.data(), gmeanpp.data(), size);
+  Core::Communication::sum_all(lmeanpp.data(), gmeanpp.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanuv.begin();
@@ -1210,7 +1211,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanuv.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanuv.data(), gmeanuv.data(), size);
+  Core::Communication::sum_all(lmeanuv.data(), gmeanuv.data(), size, discret_->get_comm());
 
   rr = 0;
   for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanuw.begin();
@@ -1219,7 +1220,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanuw.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanuw.data(), gmeanuw.data(), size);
+  Core::Communication::sum_all(lmeanuw.data(), gmeanuw.data(), size, discret_->get_comm());
 
 
   rr = 0;
@@ -1229,7 +1230,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     lmeanvw.push_back(shell->second / pointcount[rr]);
     ++rr;
   }
-  discret_->get_comm().SumAll(lmeanvw.data(), gmeanvw.data(), size);
+  Core::Communication::sum_all(lmeanvw.data(), gmeanvw.data(), size, discret_->get_comm());
 
   for (int mm = 0; mm < size; ++mm)
   {
@@ -1257,7 +1258,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
       lmeanc.push_back(shell->second / pointcount[rr]);
       ++rr;
     }
-    discret_->get_comm().SumAll(lmeanc.data(), gmeanc.data(), size);
+    Core::Communication::sum_all(lmeanc.data(), gmeanc.data(), size, discret_->get_comm());
 
     rr = 0;
     for (std::map<double, double, PlaneSortCriterion>::iterator shell = meancc.begin();
@@ -1266,7 +1267,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
       lmeancc.push_back(shell->second / pointcount[rr]);
       ++rr;
     }
-    discret_->get_comm().SumAll(lmeancc.data(), gmeancc.data(), size);
+    Core::Communication::sum_all(lmeancc.data(), gmeancc.data(), size, discret_->get_comm());
 
     for (int mm = 0; mm < size; ++mm)
     {
@@ -1297,7 +1298,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
         gmeanphi[rr] = 0.0;  // initialize due to sequential reuse of this vector
         ++rr;
       }
-      discret_->get_comm().SumAll(lmeanphi.data(), gmeanphi.data(), size);
+      Core::Communication::sum_all(lmeanphi.data(), gmeanphi.data(), size, discret_->get_comm());
 
       rr = 0;
       for (std::map<double, double, PlaneSortCriterion>::iterator shell = meanphiphi[k].begin();
@@ -1307,7 +1308,8 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
         gmeanphiphi[rr] = 0.0;  // initialize due to sequential reuse of this vector
         ++rr;
       }
-      discret_->get_comm().SumAll(lmeanphiphi.data(), gmeanphiphi.data(), size);
+      Core::Communication::sum_all(
+          lmeanphiphi.data(), gmeanphiphi.data(), size, discret_->get_comm());
 
       // insert values for scalar field k
       for (int mm = 0; mm < size; ++mm)

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_cha.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_cha.cpp
@@ -284,7 +284,7 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
     {
       double min;
 
-      discret_->get_comm().MinAll(&((*boundingbox_)(0, row)), &min, 1);
+      Core::Communication::min_all(&((*boundingbox_)(0, row)), &min, 1, discret_->get_comm());
       (*boundingbox_)(0, row) = min;
     }
 
@@ -293,7 +293,7 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
     {
       double max;
 
-      discret_->get_comm().MaxAll(&((*boundingbox_)(1, row)), &max, 1);
+      Core::Communication::max_all(&((*boundingbox_)(1, row)), &max, 1, discret_->get_comm());
       (*boundingbox_)(1, row) = max;
     }
 
@@ -346,7 +346,7 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         // Unpack received block into set of all planes.
@@ -608,7 +608,8 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
     std::vector<double> lnodeplanes(*nodeplanes_);
     std::vector<double> lplanecoordinates(*planecoordinates_);
 
-    discret_->get_comm().SumAll(lnodeplanes.data(), nodeplanes_->data(), nodeplanes_->size());
+    Core::Communication::sum_all(
+        lnodeplanes.data(), nodeplanes_->data(), nodeplanes_->size(), discret_->get_comm());
     discret_->get_comm().SumAll(
         lplanecoordinates.data(), planecoordinates_->data(), planecoordinates_->size());
 
@@ -635,7 +636,7 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
     {
       double min;
 
-      discret_->get_comm().MinAll(&((*boundingbox_)(0, row)), &min, 1);
+      Core::Communication::min_all(&((*boundingbox_)(0, row)), &min, 1, discret_->get_comm());
       (*boundingbox_)(0, row) = min;
     }
 
@@ -644,7 +645,7 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
     {
       double max;
 
-      discret_->get_comm().MaxAll(&((*boundingbox_)(1, row)), &max, 1);
+      Core::Communication::max_all(&((*boundingbox_)(1, row)), &max, 1, discret_->get_comm());
       (*boundingbox_)(1, row) = max;
     }
   }
@@ -1434,7 +1435,7 @@ void FLD::TurbulenceStatisticsCha::do_time_sample(
         {
           local_inc += (*toggleu_)[rr] * (*toggleu_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
 
         if (abs(inc) < 1e-9)
         {
@@ -1446,7 +1447,7 @@ void FLD::TurbulenceStatisticsCha::do_time_sample(
         {
           local_inc += (force)[rr] * (*toggleu_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         sumforceu_ += inc;
 
         local_inc = 0.0;
@@ -1454,7 +1455,7 @@ void FLD::TurbulenceStatisticsCha::do_time_sample(
         {
           local_inc += (force)[rr] * (*togglev_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         sumforcev_ += inc;
 
 
@@ -1463,7 +1464,7 @@ void FLD::TurbulenceStatisticsCha::do_time_sample(
         {
           local_inc += (force)[rr] * (*togglew_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         sumforcew_ += inc;
       }
     }
@@ -1960,20 +1961,20 @@ void FLD::TurbulenceStatisticsCha::evaluate_integral_mean_values_in_planes()
 
   //----------------------------------------------------------------------
   // add contributions from all processors
-  discret_->get_comm().SumAll(locarea->data(), globarea->data(), size);
+  Core::Communication::sum_all(locarea->data(), globarea->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumu->data(), globsumu->data(), size);
-  discret_->get_comm().SumAll(locsumv->data(), globsumv->data(), size);
-  discret_->get_comm().SumAll(locsumw->data(), globsumw->data(), size);
-  discret_->get_comm().SumAll(locsump->data(), globsump->data(), size);
+  Core::Communication::sum_all(locsumu->data(), globsumu->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumv->data(), globsumv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumw->data(), globsumw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsump->data(), globsump->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumsqu->data(), globsumsqu->data(), size);
-  discret_->get_comm().SumAll(locsumsqv->data(), globsumsqv->data(), size);
-  discret_->get_comm().SumAll(locsumsqw->data(), globsumsqw->data(), size);
-  discret_->get_comm().SumAll(locsumuv->data(), globsumuv->data(), size);
-  discret_->get_comm().SumAll(locsumuw->data(), globsumuw->data(), size);
-  discret_->get_comm().SumAll(locsumvw->data(), globsumvw->data(), size);
-  discret_->get_comm().SumAll(locsumsqp->data(), globsumsqp->data(), size);
+  Core::Communication::sum_all(locsumsqu->data(), globsumsqu->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqv->data(), globsumsqv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqw->data(), globsumsqw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumuv->data(), globsumuv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumuw->data(), globsumuw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumvw->data(), globsumvw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqp->data(), globsumsqp->data(), size, discret_->get_comm());
 
 
   //----------------------------------------------------------------------
@@ -1984,7 +1985,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_integral_mean_values_in_planes()
 
   if (nurbsdis == nullptr)
   {
-    discret_->get_comm().SumAll(&locprocessedeles, &numele_, 1);
+    Core::Communication::sum_all(&locprocessedeles, &numele_, 1, discret_->get_comm());
   }
   else
   {
@@ -2190,35 +2191,37 @@ void FLD::TurbulenceStatisticsCha::evaluate_loma_integral_mean_values_in_planes(
 
   //----------------------------------------------------------------------
   // add contributions from all processors
-  discret_->get_comm().SumAll(locarea->data(), globarea->data(), size);
+  Core::Communication::sum_all(locarea->data(), globarea->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumu->data(), globsumu->data(), size);
-  discret_->get_comm().SumAll(locsumv->data(), globsumv->data(), size);
-  discret_->get_comm().SumAll(locsumw->data(), globsumw->data(), size);
-  discret_->get_comm().SumAll(locsump->data(), globsump->data(), size);
-  discret_->get_comm().SumAll(locsumrho->data(), globsumrho->data(), size);
-  discret_->get_comm().SumAll(locsumT->data(), globsumT->data(), size);
-  discret_->get_comm().SumAll(locsumrhou->data(), globsumrhou->data(), size);
-  discret_->get_comm().SumAll(locsumrhouT->data(), globsumrhouT->data(), size);
+  Core::Communication::sum_all(locsumu->data(), globsumu->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumv->data(), globsumv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumw->data(), globsumw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsump->data(), globsump->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumrho->data(), globsumrho->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumT->data(), globsumT->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumrhou->data(), globsumrhou->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(
+      locsumrhouT->data(), globsumrhouT->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumsqu->data(), globsumsqu->data(), size);
-  discret_->get_comm().SumAll(locsumsqv->data(), globsumsqv->data(), size);
-  discret_->get_comm().SumAll(locsumsqw->data(), globsumsqw->data(), size);
-  discret_->get_comm().SumAll(locsumsqp->data(), globsumsqp->data(), size);
-  discret_->get_comm().SumAll(locsumsqrho->data(), globsumsqrho->data(), size);
-  discret_->get_comm().SumAll(locsumsqT->data(), globsumsqT->data(), size);
+  Core::Communication::sum_all(locsumsqu->data(), globsumsqu->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqv->data(), globsumsqv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqw->data(), globsumsqw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqp->data(), globsumsqp->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(
+      locsumsqrho->data(), globsumsqrho->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqT->data(), globsumsqT->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumuv->data(), globsumuv->data(), size);
-  discret_->get_comm().SumAll(locsumuw->data(), globsumuw->data(), size);
-  discret_->get_comm().SumAll(locsumvw->data(), globsumvw->data(), size);
-  discret_->get_comm().SumAll(locsumuT->data(), globsumuT->data(), size);
-  discret_->get_comm().SumAll(locsumvT->data(), globsumvT->data(), size);
-  discret_->get_comm().SumAll(locsumwT->data(), globsumwT->data(), size);
+  Core::Communication::sum_all(locsumuv->data(), globsumuv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumuw->data(), globsumuw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumvw->data(), globsumvw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumuT->data(), globsumuT->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumvT->data(), globsumvT->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumwT->data(), globsumwT->data(), size, discret_->get_comm());
 
 
   //----------------------------------------------------------------------
   // the sums are divided by the layers area to get the area average
-  discret_->get_comm().SumAll(&locprocessedeles, &numele_, 1);
+  Core::Communication::sum_all(&locprocessedeles, &numele_, 1, discret_->get_comm());
 
 
   for (unsigned i = 0; i < planecoordinates_->size(); ++i)
@@ -2404,31 +2407,32 @@ void FLD::TurbulenceStatisticsCha::evaluate_scatra_integral_mean_values_in_plane
 
   //----------------------------------------------------------------------
   // add contributions from all processors
-  discret_->get_comm().SumAll(locarea->data(), globarea->data(), size);
+  Core::Communication::sum_all(locarea->data(), globarea->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumu->data(), globsumu->data(), size);
-  discret_->get_comm().SumAll(locsumv->data(), globsumv->data(), size);
-  discret_->get_comm().SumAll(locsumw->data(), globsumw->data(), size);
-  discret_->get_comm().SumAll(locsump->data(), globsump->data(), size);
-  discret_->get_comm().SumAll(locsumphi->data(), globsumphi->data(), size);
+  Core::Communication::sum_all(locsumu->data(), globsumu->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumv->data(), globsumv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumw->data(), globsumw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsump->data(), globsump->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumphi->data(), globsumphi->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumsqu->data(), globsumsqu->data(), size);
-  discret_->get_comm().SumAll(locsumsqv->data(), globsumsqv->data(), size);
-  discret_->get_comm().SumAll(locsumsqw->data(), globsumsqw->data(), size);
-  discret_->get_comm().SumAll(locsumsqp->data(), globsumsqp->data(), size);
-  discret_->get_comm().SumAll(locsumsqphi->data(), globsumsqphi->data(), size);
+  Core::Communication::sum_all(locsumsqu->data(), globsumsqu->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqv->data(), globsumsqv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqw->data(), globsumsqw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumsqp->data(), globsumsqp->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(
+      locsumsqphi->data(), globsumsqphi->data(), size, discret_->get_comm());
 
-  discret_->get_comm().SumAll(locsumuv->data(), globsumuv->data(), size);
-  discret_->get_comm().SumAll(locsumuw->data(), globsumuw->data(), size);
-  discret_->get_comm().SumAll(locsumvw->data(), globsumvw->data(), size);
-  discret_->get_comm().SumAll(locsumuphi->data(), globsumuphi->data(), size);
-  discret_->get_comm().SumAll(locsumvphi->data(), globsumvphi->data(), size);
-  discret_->get_comm().SumAll(locsumwphi->data(), globsumwphi->data(), size);
+  Core::Communication::sum_all(locsumuv->data(), globsumuv->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumuw->data(), globsumuw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumvw->data(), globsumvw->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumuphi->data(), globsumuphi->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumvphi->data(), globsumvphi->data(), size, discret_->get_comm());
+  Core::Communication::sum_all(locsumwphi->data(), globsumwphi->data(), size, discret_->get_comm());
 
 
   //----------------------------------------------------------------------
   // the sums are divided by the layers area to get the area average
-  discret_->get_comm().SumAll(&locprocessedeles, &numele_, 1);
+  Core::Communication::sum_all(&locprocessedeles, &numele_, 1, discret_->get_comm());
 
 
   for (unsigned i = 0; i < planecoordinates_->size(); ++i)
@@ -2558,7 +2562,8 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
 
     int countnodesinplaneonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodesinplane, &countnodesinplaneonallprocs, 1);
+    Core::Communication::sum_all(
+        &countnodesinplane, &countnodesinplaneonallprocs, 1, discret_->get_comm());
 
     if (countnodesinplaneonallprocs)
     {
@@ -2572,7 +2577,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*meanvelnp_)[rr] * (*toggleu_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumu_)[planenum] += inc / countnodesinplaneonallprocs;
 
         local_inc = 0.0;
@@ -2580,7 +2585,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*meanvelnp_)[rr] * (*togglev_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumv_)[planenum] += inc / countnodesinplaneonallprocs;
 
         local_inc = 0.0;
@@ -2588,7 +2593,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*meanvelnp_)[rr] * (*togglew_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumw_)[planenum] += inc / countnodesinplaneonallprocs;
 
         local_inc = 0.0;
@@ -2596,7 +2601,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*meanvelnp_)[rr] * (*togglep_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsump_)[planenum] += inc / countnodesinplaneonallprocs;
 
         //----------------------------------------------------------------------
@@ -2607,7 +2612,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*pointsquaredvelnp_)[rr] * (*toggleu_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumsqu_)[planenum] += inc / countnodesinplaneonallprocs;
 
         local_inc = 0.0;
@@ -2615,7 +2620,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*pointsquaredvelnp_)[rr] * (*togglev_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumsqv_)[planenum] += inc / countnodesinplaneonallprocs;
 
         local_inc = 0.0;
@@ -2623,7 +2628,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*pointsquaredvelnp_)[rr] * (*togglew_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumsqw_)[planenum] += inc / countnodesinplaneonallprocs;
 
         local_inc = 0.0;
@@ -2631,7 +2636,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
         {
           local_inc += (*pointsquaredvelnp_)[rr] * (*togglep_)[rr];
         }
-        discret_->get_comm().SumAll(&local_inc, &inc, 1);
+        Core::Communication::sum_all(&local_inc, &inc, 1, discret_->get_comm());
         (*pointsumsqp_)[planenum] += inc / countnodesinplaneonallprocs;
       }
     }
@@ -3342,61 +3347,85 @@ void FLD::TurbulenceStatisticsCha::evaluate_residuals(
     // global sums
 
     // compute global sum, volume
-    discret_->get_comm().SumAll(local_vol->data(), global_vol->data(), presize);
+    Core::Communication::sum_all(
+        local_vol->data(), global_vol->data(), presize, discret_->get_comm());
 
     // compute global sum, element sizes
-    discret_->get_comm().SumAll(local_incrhk->data(), global_incrhk->data(), presize);
+    Core::Communication::sum_all(
+        local_incrhk->data(), global_incrhk->data(), presize, discret_->get_comm());
 
     // compute global sum, element sizes in viscous regime, Bazilevs parameter
-    discret_->get_comm().SumAll(local_incrhbazilevs->data(), global_incrhbazilevs->data(), presize);
+    Core::Communication::sum_all(
+        local_incrhbazilevs->data(), global_incrhbazilevs->data(), presize, discret_->get_comm());
 
     // compute global sum, element sizes
-    discret_->get_comm().SumAll(local_incrstrle->data(), global_incrstrle->data(), presize);
+    Core::Communication::sum_all(
+        local_incrstrle->data(), global_incrstrle->data(), presize, discret_->get_comm());
 
     // compute global sum, gradient based element sizes
-    discret_->get_comm().SumAll(local_incrgradle->data(), global_incrgradle->data(), presize);
+    Core::Communication::sum_all(
+        local_incrgradle->data(), global_incrgradle->data(), presize, discret_->get_comm());
 
     // compute global sums, stabilisation parameters
-    discret_->get_comm().SumAll(local_incrtauM->data(), global_incrtauM->data(), presize);
-    discret_->get_comm().SumAll(local_incrtauC->data(), global_incrtauC->data(), presize);
+    Core::Communication::sum_all(
+        local_incrtauM->data(), global_incrtauM->data(), presize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incrtauC->data(), global_incrtauC->data(), presize, discret_->get_comm());
 
     // compute global sum, mk
-    discret_->get_comm().SumAll(local_incrmk->data(), global_incrmk->data(), presize);
+    Core::Communication::sum_all(
+        local_incrmk->data(), global_incrmk->data(), presize, discret_->get_comm());
 
     // compute global sums, momentum equation residuals
-    discret_->get_comm().SumAll(local_incrres->data(), global_incrres->data(), velsize);
-    discret_->get_comm().SumAll(local_incrres_sq->data(), global_incrres_sq->data(), velsize);
+    Core::Communication::sum_all(
+        local_incrres->data(), global_incrres->data(), velsize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incrres_sq->data(), global_incrres_sq->data(), velsize, discret_->get_comm());
     discret_->get_comm().SumAll(
         local_incrtauinvsvel->data(), global_incrtauinvsvel->data(), velsize);
-    discret_->get_comm().SumAll(local_incrabsres->data(), global_incrabsres->data(), presize);
+    Core::Communication::sum_all(
+        local_incrabsres->data(), global_incrabsres->data(), presize, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_incrsvelaf->data(), global_incrsvelaf->data(), velsize);
-    discret_->get_comm().SumAll(local_incrsvelaf_sq->data(), global_incrsvelaf_sq->data(), velsize);
-    discret_->get_comm().SumAll(local_incrabssvelaf->data(), global_incrabssvelaf->data(), presize);
+    Core::Communication::sum_all(
+        local_incrsvelaf->data(), global_incrsvelaf->data(), velsize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incrsvelaf_sq->data(), global_incrsvelaf_sq->data(), velsize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incrabssvelaf->data(), global_incrabssvelaf->data(), presize, discret_->get_comm());
 
     // compute global sums, incompressibility residuals
-    discret_->get_comm().SumAll(local_incrresC->data(), global_incrresC->data(), presize);
-    discret_->get_comm().SumAll(local_incrresC_sq->data(), global_incrresC_sq->data(), presize);
+    Core::Communication::sum_all(
+        local_incrresC->data(), global_incrresC->data(), presize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incrresC_sq->data(), global_incrresC_sq->data(), presize, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_incrspressnp->data(), global_incrspressnp->data(), presize);
+    Core::Communication::sum_all(
+        local_incrspressnp->data(), global_incrspressnp->data(), presize, discret_->get_comm());
     discret_->get_comm().SumAll(
         local_incrspressnp_sq->data(), global_incrspressnp_sq->data(), presize);
 
     // compute global sums, disspiation rates
 
-    discret_->get_comm().SumAll(local_incr_eps_pspg->data(), global_incr_eps_pspg->data(), presize);
-    discret_->get_comm().SumAll(local_incr_eps_supg->data(), global_incr_eps_supg->data(), presize);
+    Core::Communication::sum_all(
+        local_incr_eps_pspg->data(), global_incr_eps_pspg->data(), presize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incr_eps_supg->data(), global_incr_eps_supg->data(), presize, discret_->get_comm());
     discret_->get_comm().SumAll(
         local_incr_eps_cross->data(), global_incr_eps_cross->data(), presize);
-    discret_->get_comm().SumAll(local_incr_eps_rey->data(), global_incr_eps_rey->data(), presize);
+    Core::Communication::sum_all(
+        local_incr_eps_rey->data(), global_incr_eps_rey->data(), presize, discret_->get_comm());
     discret_->get_comm().SumAll(
         local_incr_eps_graddiv->data(), global_incr_eps_graddiv->data(), presize);
     discret_->get_comm().SumAll(
         local_incr_eps_eddyvisc->data(), global_incr_eps_eddyvisc->data(), presize);
-    discret_->get_comm().SumAll(local_incr_eps_visc->data(), global_incr_eps_visc->data(), presize);
-    discret_->get_comm().SumAll(local_incr_eps_conv->data(), global_incr_eps_conv->data(), presize);
-    discret_->get_comm().SumAll(local_incr_eps_avm3->data(), global_incr_eps_avm3->data(), presize);
-    discret_->get_comm().SumAll(local_incr_eps_mfs->data(), global_incr_eps_mfs->data(), presize);
+    Core::Communication::sum_all(
+        local_incr_eps_visc->data(), global_incr_eps_visc->data(), presize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incr_eps_conv->data(), global_incr_eps_conv->data(), presize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incr_eps_avm3->data(), global_incr_eps_avm3->data(), presize, discret_->get_comm());
+    Core::Communication::sum_all(
+        local_incr_eps_mfs->data(), global_incr_eps_mfs->data(), presize, discret_->get_comm());
     discret_->get_comm().SumAll(
         local_incr_eps_mfscross->data(), global_incr_eps_mfscross->data(), presize);
     discret_->get_comm().SumAll(
@@ -3631,7 +3660,8 @@ void FLD::TurbulenceStatisticsCha::evaluate_residuals(
       // global sums
 
       // compute global sum, volume
-      discret_->get_comm().SumAll(local_scatra_vol->data(), global_scatra_vol->data(), phisize);
+      Core::Communication::sum_all(
+          local_scatra_vol->data(), global_scatra_vol->data(), phisize, discret_->get_comm());
 
       // compute global sums, stabilisation parameters
       discret_->get_comm().SumAll(

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_hit.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_hit.cpp
@@ -169,7 +169,7 @@ namespace FLD
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         // unpack received block into set of all coordinates
@@ -426,11 +426,14 @@ namespace FLD
     // get values form all processors
     // number of nodes without slave nodes
     const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-    discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
     //----------------------------------------
     // fast Fourier transformation using FFTW
@@ -824,13 +827,17 @@ namespace FLD
     // get values form all processors
     // number of nodes without slave nodes
     const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-    discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_phi.data(), global_phi.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_phi.data(), global_phi.data(), countallnodes, discret_->get_comm());
 
     //----------------------------------------
     // fast Fourier transformation using FFTW
@@ -1899,11 +1906,14 @@ namespace FLD
     // get values form all processors
     // number of nodes without slave nodes
     const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-    discret_->get_comm().SumAll(local_u1.data(), global_u1.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u1.data(), global_u1.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_u2.data(), global_u2.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u2.data(), global_u2.data(), countallnodes, discret_->get_comm());
 
-    discret_->get_comm().SumAll(local_u3.data(), global_u3.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_u3.data(), global_u3.data(), countallnodes, discret_->get_comm());
 
     //----------------------------------------
     // fast Fourier transformation using FFTW

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_ldc.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_ldc.cpp
@@ -108,29 +108,29 @@ FLD::TurbulenceStatisticsLdc::TurbulenceStatisticsLdc(
 
   // communicate x1mins and x1maxs
   double min1;
-  discret_->get_comm().MinAll(&x1min_, &min1, 1);
+  Core::Communication::min_all(&x1min_, &min1, 1, discret_->get_comm());
   x1min_ = min1;
 
   double max1;
-  discret_->get_comm().MaxAll(&x1max_, &max1, 1);
+  Core::Communication::max_all(&x1max_, &max1, 1, discret_->get_comm());
   x1max_ = max1;
 
   // communicate x2mins and x2maxs
   double min2;
-  discret_->get_comm().MinAll(&x2min_, &min2, 1);
+  Core::Communication::min_all(&x2min_, &min2, 1, discret_->get_comm());
   x2min_ = min2;
 
   double max2;
-  discret_->get_comm().MaxAll(&x2max_, &max2, 1);
+  Core::Communication::max_all(&x2max_, &max2, 1, discret_->get_comm());
   x2max_ = max2;
 
   // communicate x3mins and x3maxs
   double min3;
-  discret_->get_comm().MinAll(&x3min_, &min3, 1);
+  Core::Communication::min_all(&x3min_, &min3, 1, discret_->get_comm());
   x3min_ = min3;
 
   double max3;
-  discret_->get_comm().MaxAll(&x3max_, &max3, 1);
+  Core::Communication::max_all(&x3max_, &max3, 1, discret_->get_comm());
   x3max_ = max3;
 
   //--------------------------------------------------------------------
@@ -184,7 +184,7 @@ FLD::TurbulenceStatisticsLdc::TurbulenceStatisticsLdc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -241,7 +241,7 @@ FLD::TurbulenceStatisticsLdc::TurbulenceStatisticsLdc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -298,7 +298,7 @@ FLD::TurbulenceStatisticsLdc::TurbulenceStatisticsLdc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -572,7 +572,7 @@ void FLD::TurbulenceStatisticsLdc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (countnodesonallprocs)
     {
@@ -659,7 +659,7 @@ void FLD::TurbulenceStatisticsLdc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (countnodesonallprocs)
     {
@@ -746,7 +746,7 @@ void FLD::TurbulenceStatisticsLdc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (countnodesonallprocs)
     {
@@ -846,7 +846,7 @@ void FLD::TurbulenceStatisticsLdc::do_loma_time_sample(Core::LinAlg::Vector<doub
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (countnodesonallprocs)
     {
@@ -947,7 +947,7 @@ void FLD::TurbulenceStatisticsLdc::do_loma_time_sample(Core::LinAlg::Vector<doub
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (countnodesonallprocs)
     {
@@ -1047,7 +1047,7 @@ void FLD::TurbulenceStatisticsLdc::do_loma_time_sample(Core::LinAlg::Vector<doub
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (countnodesonallprocs)
     {

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_mean_general.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_mean_general.cpp
@@ -246,7 +246,7 @@ void FLD::TurbulenceStatisticsGeneralMean::space_average_in_one_direction(const 
     }
 
     // do communication for global mins
-    avgcomm.MinAll(&lminxdim, &minxdim, 1);
+    Core::Communication::min_all(&lminxdim, &minxdim, 1, avgcomm);
   }
 
 
@@ -345,7 +345,7 @@ void FLD::TurbulenceStatisticsGeneralMean::space_average_in_one_direction(const 
   {
     int lnumlines = x.size();
 
-    avgcomm.SumAll(&lnumlines, &numlines, 1);
+    Core::Communication::sum_all(&lnumlines, &numlines, 1, avgcomm);
   }
 
   // Remark:
@@ -438,7 +438,7 @@ void FLD::TurbulenceStatisticsGeneralMean::space_average_in_one_direction(const 
       exporter.wait(request);
 
       // for safety
-      exporter.get_comm().Barrier();
+      Core::Communication::barrier(exporter.get_comm());
 
       //--------------------------------------------------
       // Unpack received block
@@ -730,7 +730,7 @@ void FLD::TurbulenceStatisticsGeneralMean::space_average_in_one_direction(const 
       exporter.wait(request);
 
       // for safety
-      exporter.get_comm().Barrier();
+      Core::Communication::barrier(exporter.get_comm());
 
       //--------------------------------------------------
       // Unpack received block

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_ph.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_ph.cpp
@@ -123,7 +123,7 @@ FLD::TurbulenceStatisticsPh::TurbulenceStatisticsPh(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -179,7 +179,7 @@ FLD::TurbulenceStatisticsPh::TurbulenceStatisticsPh(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -353,7 +353,7 @@ FLD::TurbulenceStatisticsPh::TurbulenceStatisticsPh(
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         //--------------------------------------------------
@@ -525,7 +525,7 @@ void FLD::TurbulenceStatisticsPh::do_time_sample(
       }
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -570,7 +570,7 @@ void FLD::TurbulenceStatisticsPh::do_time_sample(
       }
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -615,7 +615,7 @@ void FLD::TurbulenceStatisticsPh::do_time_sample(
       }
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -674,7 +674,7 @@ void FLD::TurbulenceStatisticsPh::do_time_sample(
     }
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     // reduce by 1 due to periodic boundary condition
     countnodesonallprocs -= 1;
@@ -750,7 +750,7 @@ void FLD::TurbulenceStatisticsPh::do_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -788,17 +788,17 @@ void FLD::TurbulenceStatisticsPh::do_time_sample(
         {
           locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuv, &uv, 1);
+        Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuw, &uw, 1);
+        Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locvw, &vw, 1);
+        Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
         //----------------------------------------------------------------------
         // calculate spatial means on this line

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_sqc.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_sqc.cpp
@@ -152,11 +152,11 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
   // communicate x3mins and x3maxs
   double min;
-  discret_->get_comm().MinAll(&x3min_, &min, 1);
+  Core::Communication::min_all(&x3min_, &min, 1, discret_->get_comm());
   x3min_ = min;
 
   double max;
-  discret_->get_comm().MaxAll(&x3max_, &max, 1);
+  Core::Communication::max_all(&x3max_, &max, 1, discret_->get_comm());
   x3max_ = max;
 
   //--------------------------------------------------------------------
@@ -211,7 +211,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -268,7 +268,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -325,7 +325,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -382,7 +382,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -439,7 +439,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -502,7 +502,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
           {
             // for safety
-            exporter.get_comm().Barrier();
+            Core::Communication::barrier(exporter.get_comm());
           }
 
           //--------------------------------------------------
@@ -559,7 +559,7 @@ FLD::TurbulenceStatisticsSqc::TurbulenceStatisticsSqc(
 
           {
             // for safety
-            exporter.get_comm().Barrier();
+            Core::Communication::barrier(exporter.get_comm());
           }
 
           //--------------------------------------------------
@@ -957,7 +957,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -998,17 +998,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1073,7 +1073,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1114,17 +1114,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1190,7 +1190,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1231,17 +1231,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1307,7 +1307,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1348,17 +1348,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1423,7 +1423,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1464,17 +1464,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1539,7 +1539,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1580,17 +1580,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1655,7 +1655,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1696,17 +1696,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line
@@ -1771,7 +1771,7 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
 
     int countnodesonallprocs = 0;
 
-    discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+    Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
     if (homdir_ == "z")
     {
@@ -1812,17 +1812,17 @@ void FLD::TurbulenceStatisticsSqc::do_time_sample(Core::LinAlg::Vector<double>& 
       {
         locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuv, &uv, 1);
+      Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locuw, &uw, 1);
+      Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
       for (int rr = 2; rr < velnp.MyLength(); ++rr)
       {
         locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
       }
-      discret_->get_comm().SumAll(&locvw, &vw, 1);
+      Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
       //----------------------------------------------------------------------
       // calculate spatial means on this line

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_tgv.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_tgv.cpp
@@ -538,59 +538,85 @@ void FLD::TurbulenceStatisticsTgv::evaluate_residuals(
   // global sums
 
   // compute global sum, volume
-  discret_->get_comm().SumAll(local_vol->data(), global_vol->data(), presize);
+  Core::Communication::sum_all(
+      local_vol->data(), global_vol->data(), presize, discret_->get_comm());
 
   // compute global sum, element sizes
-  discret_->get_comm().SumAll(local_incrhk->data(), global_incrhk->data(), presize);
+  Core::Communication::sum_all(
+      local_incrhk->data(), global_incrhk->data(), presize, discret_->get_comm());
 
   // compute global sum, element sizes in viscous regime, Bazilevs parameter
-  discret_->get_comm().SumAll(local_incrhbazilevs->data(), global_incrhbazilevs->data(), presize);
+  Core::Communication::sum_all(
+      local_incrhbazilevs->data(), global_incrhbazilevs->data(), presize, discret_->get_comm());
 
   // compute global sum, element sizes
-  discret_->get_comm().SumAll(local_incrstrle->data(), global_incrstrle->data(), presize);
+  Core::Communication::sum_all(
+      local_incrstrle->data(), global_incrstrle->data(), presize, discret_->get_comm());
 
   // compute global sum, gradient based element sizes
-  discret_->get_comm().SumAll(local_incrgradle->data(), global_incrgradle->data(), presize);
+  Core::Communication::sum_all(
+      local_incrgradle->data(), global_incrgradle->data(), presize, discret_->get_comm());
 
   // compute global sums, stabilisation parameters
-  discret_->get_comm().SumAll(local_incrtauM->data(), global_incrtauM->data(), presize);
-  discret_->get_comm().SumAll(local_incrtauC->data(), global_incrtauC->data(), presize);
+  Core::Communication::sum_all(
+      local_incrtauM->data(), global_incrtauM->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrtauC->data(), global_incrtauC->data(), presize, discret_->get_comm());
 
   // compute global sum, mk
-  discret_->get_comm().SumAll(local_incrmk->data(), global_incrmk->data(), presize);
+  Core::Communication::sum_all(
+      local_incrmk->data(), global_incrmk->data(), presize, discret_->get_comm());
 
   // compute global sums, momentum equation residuals
-  discret_->get_comm().SumAll(local_incrres->data(), global_incrres->data(), velsize);
-  discret_->get_comm().SumAll(local_incrres_sq->data(), global_incrres_sq->data(), velsize);
-  discret_->get_comm().SumAll(local_incrtauinvsvel->data(), global_incrtauinvsvel->data(), velsize);
-  discret_->get_comm().SumAll(local_incrabsres->data(), global_incrabsres->data(), presize);
+  Core::Communication::sum_all(
+      local_incrres->data(), global_incrres->data(), velsize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrres_sq->data(), global_incrres_sq->data(), velsize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrtauinvsvel->data(), global_incrtauinvsvel->data(), velsize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrabsres->data(), global_incrabsres->data(), presize, discret_->get_comm());
 
-  discret_->get_comm().SumAll(local_incrsvelaf->data(), global_incrsvelaf->data(), velsize);
-  discret_->get_comm().SumAll(local_incrsvelaf_sq->data(), global_incrsvelaf_sq->data(), velsize);
-  discret_->get_comm().SumAll(local_incrabssvelaf->data(), global_incrabssvelaf->data(), presize);
+  Core::Communication::sum_all(
+      local_incrsvelaf->data(), global_incrsvelaf->data(), velsize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrsvelaf_sq->data(), global_incrsvelaf_sq->data(), velsize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrabssvelaf->data(), global_incrabssvelaf->data(), presize, discret_->get_comm());
 
   // compute global sums, incompressibility residuals
-  discret_->get_comm().SumAll(local_incrresC->data(), global_incrresC->data(), presize);
-  discret_->get_comm().SumAll(local_incrresC_sq->data(), global_incrresC_sq->data(), presize);
+  Core::Communication::sum_all(
+      local_incrresC->data(), global_incrresC->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incrresC_sq->data(), global_incrresC_sq->data(), presize, discret_->get_comm());
 
-  discret_->get_comm().SumAll(local_incrspressnp->data(), global_incrspressnp->data(), presize);
+  Core::Communication::sum_all(
+      local_incrspressnp->data(), global_incrspressnp->data(), presize, discret_->get_comm());
   discret_->get_comm().SumAll(
       local_incrspressnp_sq->data(), global_incrspressnp_sq->data(), presize);
 
   // compute global sums, dissipation rates
 
-  discret_->get_comm().SumAll(local_incr_eps_pspg->data(), global_incr_eps_pspg->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_supg->data(), global_incr_eps_supg->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_cross->data(), global_incr_eps_cross->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_rey->data(), global_incr_eps_rey->data(), presize);
+  Core::Communication::sum_all(
+      local_incr_eps_pspg->data(), global_incr_eps_pspg->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incr_eps_supg->data(), global_incr_eps_supg->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incr_eps_cross->data(), global_incr_eps_cross->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incr_eps_rey->data(), global_incr_eps_rey->data(), presize, discret_->get_comm());
   discret_->get_comm().SumAll(
       local_incr_eps_graddiv->data(), global_incr_eps_graddiv->data(), presize);
   discret_->get_comm().SumAll(
       local_incr_eps_eddyvisc->data(), global_incr_eps_eddyvisc->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_visc->data(), global_incr_eps_visc->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_conv->data(), global_incr_eps_conv->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_avm3->data(), global_incr_eps_avm3->data(), presize);
-  discret_->get_comm().SumAll(local_incr_eps_mfs->data(), global_incr_eps_mfs->data(), presize);
+  Core::Communication::sum_all(
+      local_incr_eps_visc->data(), global_incr_eps_visc->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incr_eps_conv->data(), global_incr_eps_conv->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incr_eps_avm3->data(), global_incr_eps_avm3->data(), presize, discret_->get_comm());
+  Core::Communication::sum_all(
+      local_incr_eps_mfs->data(), global_incr_eps_mfs->data(), presize, discret_->get_comm());
   discret_->get_comm().SumAll(
       local_incr_eps_mfscross->data(), global_incr_eps_mfscross->data(), presize);
   discret_->get_comm().SumAll(

--- a/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
@@ -403,7 +403,7 @@ void FLD::TransferTurbulentInflowCondition::receive_block(
   exporter.wait(request);
 
   // for safety
-  exporter.get_comm().Barrier();
+  Core::Communication::barrier(exporter.get_comm());
 
   return;
 }  // TransferTurbulentInflowCondition::receive_block
@@ -435,7 +435,7 @@ void FLD::TransferTurbulentInflowCondition::send_block(
 
 
   // for safety
-  exporter.get_comm().Barrier();
+  Core::Communication::barrier(exporter.get_comm());
 
   return;
 }  // TransferTurbulentInflowCondition::send_block

--- a/src/fluid_turbulence/4C_fluid_turbulence_tstatistics_bfs.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_tstatistics_bfs.cpp
@@ -128,20 +128,20 @@ FLD::TurbulenceStatisticsBfs::TurbulenceStatisticsBfs(
 
   // communicate x2mins and x2maxs
   double min2;
-  discret_->get_comm().MinAll(&x2min_, &min2, 1);
+  Core::Communication::min_all(&x2min_, &min2, 1, discret_->get_comm());
   x2min_ = min2;
 
   double max2;
-  discret_->get_comm().MaxAll(&x2max_, &max2, 1);
+  Core::Communication::max_all(&x2max_, &max2, 1, discret_->get_comm());
   x2max_ = max2;
 
   // communicate x3mins and x3maxs
   double min3;
-  discret_->get_comm().MinAll(&x3min_, &min3, 1);
+  Core::Communication::min_all(&x3min_, &min3, 1, discret_->get_comm());
   x3min_ = min3;
 
   double max3;
-  discret_->get_comm().MaxAll(&x3max_, &max3, 1);
+  Core::Communication::max_all(&x3max_, &max3, 1, discret_->get_comm());
   x3max_ = max3;
 
   //--------------------------------------------------------------------
@@ -194,7 +194,7 @@ FLD::TurbulenceStatisticsBfs::TurbulenceStatisticsBfs(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -250,7 +250,7 @@ FLD::TurbulenceStatisticsBfs::TurbulenceStatisticsBfs(
 
       {
         // for safety
-        exporter.get_comm().Barrier();
+        Core::Communication::barrier(exporter.get_comm());
       }
 
       //--------------------------------------------------
@@ -643,7 +643,7 @@ void FLD::TurbulenceStatisticsBfs::do_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -737,7 +737,7 @@ void FLD::TurbulenceStatisticsBfs::do_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -775,17 +775,17 @@ void FLD::TurbulenceStatisticsBfs::do_time_sample(
         {
           locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuv, &uv, 1);
+        Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuw, &uw, 1);
+        Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locvw, &vw, 1);
+        Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
         //----------------------------------------------------------------------
         // calculate spatial means on this line
@@ -887,7 +887,7 @@ void FLD::TurbulenceStatisticsBfs::do_loma_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -987,7 +987,7 @@ void FLD::TurbulenceStatisticsBfs::do_loma_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -1029,17 +1029,17 @@ void FLD::TurbulenceStatisticsBfs::do_loma_time_sample(
         {
           locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuv, &uv, 1);
+        Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuw, &uw, 1);
+        Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locvw, &vw, 1);
+        Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
         double TT;
         squaredscanp_->Dot(*togglep_, &TT);
@@ -1052,12 +1052,12 @@ void FLD::TurbulenceStatisticsBfs::do_loma_time_sample(
         {
           locuT += ((velnp)[rr - 3] * (*toggleu_)[rr - 3]) * ((scanp)[rr] * (*togglep_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuT, &uT, 1);
+        Core::Communication::sum_all(&locuT, &uT, 1, discret_->get_comm());
         for (int rr = 3; rr < velnp.MyLength(); ++rr)
         {
           locvT += ((velnp)[rr - 2] * (*togglev_)[rr - 2]) * ((scanp)[rr] * (*togglep_)[rr]);
         }
-        discret_->get_comm().SumAll(&locvT, &vT, 1);
+        Core::Communication::sum_all(&locvT, &vT, 1, discret_->get_comm());
 
         double rho;
         invscanp_->Dot(*togglep_, &rho);
@@ -1076,13 +1076,13 @@ void FLD::TurbulenceStatisticsBfs::do_loma_time_sample(
           locrhou += (eosfac * ((*invscanp_)[rr] * (*togglep_)[rr])) *
                      ((velnp)[rr - 3] * (*toggleu_)[rr - 3]);
         }
-        discret_->get_comm().SumAll(&locrhou, &rhou, 1);
+        Core::Communication::sum_all(&locrhou, &rhou, 1, discret_->get_comm());
         for (int rr = 3; rr < velnp.MyLength(); ++rr)
         {
           locrhov += (eosfac * ((*invscanp_)[rr] * (*togglep_)[rr])) *
                      ((velnp)[rr - 2] * (*togglev_)[rr - 2]);
         }
-        discret_->get_comm().SumAll(&locrhov, &rhov, 1);
+        Core::Communication::sum_all(&locrhov, &rhov, 1, discret_->get_comm());
 
 
         //----------------------------------------------------------------------
@@ -1189,7 +1189,7 @@ void FLD::TurbulenceStatisticsBfs::do_scatra_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -1282,7 +1282,7 @@ void FLD::TurbulenceStatisticsBfs::do_scatra_time_sample(
 
       int countnodesonallprocs = 0;
 
-      discret_->get_comm().SumAll(&countnodes, &countnodesonallprocs, 1);
+      Core::Communication::sum_all(&countnodes, &countnodesonallprocs, 1, discret_->get_comm());
 
       // reduce by 1 due to periodic boundary condition
       countnodesonallprocs -= 1;
@@ -1324,17 +1324,17 @@ void FLD::TurbulenceStatisticsBfs::do_scatra_time_sample(
         {
           locuv += ((velnp)[rr - 1] * (*toggleu_)[rr - 1]) * ((velnp)[rr] * (*togglev_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuv, &uv, 1);
+        Core::Communication::sum_all(&locuv, &uv, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locuw += ((velnp)[rr - 2] * (*toggleu_)[rr - 2]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuw, &uw, 1);
+        Core::Communication::sum_all(&locuw, &uw, 1, discret_->get_comm());
         for (int rr = 2; rr < velnp.MyLength(); ++rr)
         {
           locvw += ((velnp)[rr - 1] * (*togglev_)[rr - 1]) * ((velnp)[rr] * (*togglew_)[rr]);
         }
-        discret_->get_comm().SumAll(&locvw, &vw, 1);
+        Core::Communication::sum_all(&locvw, &vw, 1, discret_->get_comm());
 
         double TT;
         squaredscanp_->Dot(*togglep_, &TT);
@@ -1347,12 +1347,12 @@ void FLD::TurbulenceStatisticsBfs::do_scatra_time_sample(
         {
           locuT += ((velnp)[rr - 3] * (*toggleu_)[rr - 3]) * ((scanp)[rr] * (*togglep_)[rr]);
         }
-        discret_->get_comm().SumAll(&locuT, &uT, 1);
+        Core::Communication::sum_all(&locuT, &uT, 1, discret_->get_comm());
         for (int rr = 3; rr < velnp.MyLength(); ++rr)
         {
           locvT += ((velnp)[rr - 2] * (*togglev_)[rr - 2]) * ((scanp)[rr] * (*togglep_)[rr]);
         }
-        discret_->get_comm().SumAll(&locvT, &vT, 1);
+        Core::Communication::sum_all(&locvT, &vT, 1, discret_->get_comm());
 
         //----------------------------------------------------------------------
         // calculate spatial means on this line

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
@@ -589,7 +589,7 @@ bool FLD::XFluidFluid::x_timint_project_from_embedded_discretization(
 
   int numfailed = 0;
   int my_numfailed = projection_nodeToDof.size();
-  discret_->get_comm().SumAll(&my_numfailed, &numfailed, 1);
+  Core::Communication::sum_all(&my_numfailed, &numfailed, 1, discret_->get_comm());
 
   return numfailed == 0;
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_resulttest.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_resulttest.cpp
@@ -68,7 +68,7 @@ void FLD::XFluidResultTest::test_node(const Core::IO::InputParameterContainer& c
 {
   int havenode(discret.have_global_node(node));
   int isnodeofanybody(0);
-  discret.get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, discret.get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/fsi/src/utils/4C_fsi_resulttest.cpp
+++ b/src/fsi/src/utils/4C_fsi_resulttest.cpp
@@ -209,7 +209,7 @@ void FSI::FSIResultTest::test_node(
 
   int havenode(slavedisc_->have_global_node(node));
   int isnodeofanybody(0);
-  slavedisc_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, slavedisc_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -132,7 +132,7 @@ FSI::Utils::SlideAleUtils::SlideAleUtils(std::shared_ptr<Core::FE::Discretizatio
     }
   }
 
-  structdis->get_comm().MaxAll(&max_id, &maxid_, 1);
+  Core::Communication::max_all(&max_id, &maxid_, 1, structdis->get_comm());
 
   // declare fluid objects in interface
   std::map<int, std::map<int, std::shared_ptr<Core::Elements::Element>>> fluidelements;
@@ -368,8 +368,8 @@ std::vector<double> FSI::Utils::SlideAleUtils::centerdisp(
   structdis->clear_state();
 
   // Communicate to 'assemble' length and center displacements
-  comm.SumAll(&mylengthcirc, &lengthcirc, 1);
-  comm.SumAll(mycenterdisp.data(), centerdisp.data(), dim);
+  Core::Communication::sum_all(&mylengthcirc, &lengthcirc, 1, comm);
+  Core::Communication::sum_all(mycenterdisp.data(), centerdisp.data(), dim, comm);
 
   if (lengthcirc <= 1.0E-6) FOUR_C_THROW("Zero interface length!");
 
@@ -622,7 +622,7 @@ void FSI::Utils::SlideAleUtils::redundant_elements(
     int globsum = 0;
     int partsum = (vstruslideleids.size());
 
-    comm.SumAll(&partsum, &globsum, 1);
+    Core::Communication::sum_all(&partsum, &globsum, 1, comm);
     // map with ele ids
     Epetra_Map mstruslideleids(globsum, vstruslideleids.size(), vstruslideleids.data(), 0, comm);
     // redundant version of it
@@ -739,8 +739,8 @@ void FSI::Utils::SlideAleUtils::rotation(
     }  // end of ele loop
 
     // Communicate to 'assemble' length and center displacements
-    comm.SumAll(&mylengthcirc, &lengthcirc, 1);
-    comm.SumAll(&myrotation, &rotation, 1);
+    Core::Communication::sum_all(&mylengthcirc, &lengthcirc, 1, comm);
+    Core::Communication::sum_all(&myrotation, &rotation, 1, comm);
 
     if (lengthcirc >= 1.0E-6)
     {

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
@@ -1486,7 +1486,7 @@ bool FSI::MonolithicXFEM::evaluate()
   // structure field
   //-------------------
   {
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
 
     // ------------------------------------------------------------------
     // ------------------------------------------------------------------
@@ -1571,7 +1571,7 @@ bool FSI::MonolithicXFEM::evaluate()
   // * call evaluate routine to assemble fluid rhs and systemmatrix
   //
   {
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
 
     // Teuchos::TimeMonitor::zeroOutTimers();
 

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -2334,7 +2334,7 @@ void Global::read_conditions(Global::Problem& problem, Core::IO::InputFile& inpu
           if (foundit) break;
         }
         int found = 0;
-        dis->get_comm().SumAll(&foundit, &found, 1);
+        Core::Communication::sum_all(&foundit, &found, 1, dis->get_comm());
         if (found)
         {
           // Insert a copy since we might insert the same condition in many discretizations.

--- a/src/immersed_problem/4C_immersed_problem_immersed_base.cpp
+++ b/src/immersed_problem/4C_immersed_problem_immersed_base.cpp
@@ -460,7 +460,7 @@ void Immersed::ImmersedBase::evaluate_interpolation_condition(Core::FE::Discreti
         else
           mygeometrysize = geom.size();
         int maxgeometrysize = -1234;
-        evaldis.get_comm().MaxAll(&mygeometrysize, &maxgeometrysize, 1);
+        Core::Communication::max_all(&mygeometrysize, &maxgeometrysize, 1, evaldis.get_comm());
         curr = geom.begin();
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -620,10 +620,10 @@ std::vector<double> Immersed::ImmersedBase::calc_global_resultantfrom_epetra_vec
     summyrowentriesz += vec_epetra.Values()[i * 3 + 2];
   }
 
-  comm.Barrier();
-  comm.SumAll(&summyrowentriesx, &result_globalx, 1);
-  comm.SumAll(&summyrowentriesy, &result_globaly, 1);
-  comm.SumAll(&summyrowentriesz, &result_globalz, 1);
+  Core::Communication::barrier(comm);
+  Core::Communication::sum_all(&summyrowentriesx, &result_globalx, 1, comm);
+  Core::Communication::sum_all(&summyrowentriesy, &result_globaly, 1, comm);
+  Core::Communication::sum_all(&summyrowentriesz, &result_globalz, 1, comm);
 
   result_L2norm = sqrt(pow(result_globalx, 2) + pow(result_globaly, 2) + pow(result_globalz, 2));
 

--- a/src/immersed_problem/4C_immersed_problem_immersed_base.hpp
+++ b/src/immersed_problem/4C_immersed_problem_immersed_base.hpp
@@ -808,7 +808,7 @@ namespace Immersed
 
         // wait for all communication to finish
         exporter.wait(request);
-        comm.Barrier();
+        Core::Communication::barrier(comm);
       }  // only if num procs > 1
 
       if (mysearchboxgeomsize > 0)
@@ -1129,7 +1129,7 @@ namespace Immersed
 
         // wait for all communication to finish
         exporter.wait(request);
-        comm.Barrier();
+        Core::Communication::barrier(comm);
       }  // only if numproc > 1
 
     }  // end for irobin
@@ -1533,7 +1533,7 @@ namespace Immersed
 
         // wait for all communication to finish
         exporter.wait(request);
-        comm.Barrier();
+        Core::Communication::barrier(comm);
       }  // only if numproc > 1
 
     }  // loop over all procs

--- a/src/immersed_problem/4C_immersed_problem_immersed_partitioned_fsi_dirichletneumann.cpp
+++ b/src/immersed_problem/4C_immersed_problem_immersed_partitioned_fsi_dirichletneumann.cpp
@@ -254,7 +254,7 @@ void Immersed::ImmersedPartitionedFSIDirichletNeumann::setup()
   immersed_info_isvalid_ = false;
 
   // wait for all processors to arrive here
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
 
   // set flag issetup true
   set_is_setup(true);

--- a/src/levelset/4C_levelset_algorithm_reinit.cpp
+++ b/src/levelset/4C_levelset_algorithm_reinit.cpp
@@ -270,8 +270,8 @@ bool ScaTra::LevelSetAlgorithm::convergence_check_reinit()
     // communicate sums
     double global_sum = 0.0;
     int global_num_nodes = 0;
-    discret_->get_comm().SumAll(&local_sum, &global_sum, 1);
-    discret_->get_comm().SumAll(&local_num_nodes, &global_num_nodes, 1);
+    Core::Communication::sum_all(&local_sum, &global_sum, 1, discret_->get_comm());
+    Core::Communication::sum_all(&local_num_nodes, &global_num_nodes, 1, discret_->get_comm());
 
     // compute current error in band
     const double err = global_sum / ((double)global_num_nodes);
@@ -608,8 +608,8 @@ void ScaTra::LevelSetAlgorithm::reinit_geo(
       }
       globalmins.resize(planenormal.size());
       globalmaxs.resize(planenormal.size());
-      discret_->get_comm().MinAll(&min, &(globalmins.back()), 1);
-      discret_->get_comm().MaxAll(&max, &(globalmaxs.back()), 1);
+      Core::Communication::min_all(&min, &(globalmins.back()), 1, discret_->get_comm());
+      Core::Communication::max_all(&max, &(globalmaxs.back()), 1, discret_->get_comm());
     }
   }  // end loop over all surfacepbcs
 
@@ -651,7 +651,8 @@ void ScaTra::LevelSetAlgorithm::reinit_geo(
       }
     }
 
-    discret_->get_comm().SumAll(nodecoords.data(), allnodecoords.data(), (int)nodecoords.size());
+    Core::Communication::sum_all(
+        nodecoords.data(), allnodecoords.data(), (int)nodecoords.size(), discret_->get_comm());
   }
 
   //================================================================

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -556,8 +556,8 @@ void ScaTra::LevelSetAlgorithm::manipulate_fluid_field_for_gfunc()
       }
       globalmins.resize(planenormal.size());
       globalmaxs.resize(planenormal.size());
-      discret_->get_comm().MinAll(&min, &(globalmins.back()), 1);
-      discret_->get_comm().MaxAll(&max, &(globalmaxs.back()), 1);
+      Core::Communication::min_all(&min, &(globalmins.back()), 1, discret_->get_comm());
+      Core::Communication::max_all(&max, &(globalmaxs.back()), 1, discret_->get_comm());
     }
   }  // end loop over all surfacepbcs
 

--- a/src/levelset/4C_levelset_intersection_utils.cpp
+++ b/src/levelset/4C_levelset_intersection_utils.cpp
@@ -57,9 +57,9 @@ void ScaTra::LevelSet::Intersection::capture_zero_level_set(const Core::LinAlg::
   get_zero_level_set(phi, scatradis, elementBoundaryIntCells);
 
   // collect contributions from all procs and store in respective variables
-  scatradis.get_comm().SumAll(&volume_plus(), &volumedomainplus, 1);
-  scatradis.get_comm().SumAll(&volume_minus(), &volumedomainminus, 1);
-  scatradis.get_comm().SumAll(&surface(), &zerosurface, 1);
+  Core::Communication::sum_all(&volume_plus(), &volumedomainplus, 1, scatradis.get_comm());
+  Core::Communication::sum_all(&volume_minus(), &volumedomainminus, 1, scatradis.get_comm());
+  Core::Communication::sum_all(&surface(), &zerosurface, 1, scatradis.get_comm());
 
   // export also interface to all procs
   export_interface(elementBoundaryIntCells, scatradis.get_comm());
@@ -494,7 +494,7 @@ void ScaTra::LevelSet::Intersection::export_interface(
     dataSend = dataRecv;
 
     // processors wait for each other
-    comm.Barrier();
+    Core::Communication::barrier(comm);
   }
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   Core::IO::cout << "proc " << myrank << " interface pieces for " << myinterface.size()

--- a/src/lubrication/src/4C_lubrication_resulttest.cpp
+++ b/src/lubrication/src/4C_lubrication_resulttest.cpp
@@ -43,7 +43,7 @@ void Lubrication::ResultTest::test_node(
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);
-  dis_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, dis_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/mat/4C_mat_micromaterialgp_static.cpp
+++ b/src/mat/4C_mat_micromaterialgp_static.cpp
@@ -52,7 +52,7 @@ Mat::MicroMaterialGP::MicroMaterialGP(
   const Teuchos::ParameterList& sdyn_micro = microproblem->structural_dynamic_params();
 
   dt_ = sdyn_macro.get<double>("TIMESTEP");
-  microdis->get_comm().Broadcast(&dt_, 1, 0);
+  Core::Communication::broadcast(&dt_, 1, 0, microdis->get_comm());
   step_ = 0;
   stepn_ = step_ + 1;
   time_ = 0.;
@@ -148,11 +148,9 @@ void Mat::MicroMaterialGP::new_result_file(bool eleowner, std::string& newfilena
       // broadcast restartname_ for micro scale
       int length = restartname_.length();
       std::vector<int> name(restartname_.begin(), restartname_.end());
-      int err = microdis->get_comm().Broadcast(&length, 1, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(&length, 1, 0, microdis->get_comm());
       name.resize(length);
-      err = microdis->get_comm().Broadcast(name.data(), length, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(name.data(), length, 0, microdis->get_comm());
       restartname_.assign(name.begin(), name.end());
     }
 
@@ -160,11 +158,9 @@ void Mat::MicroMaterialGP::new_result_file(bool eleowner, std::string& newfilena
       // broadcast newfilename for micro scale
       int length = newfilename.length();
       std::vector<int> name(newfilename.begin(), newfilename.end());
-      int err = microdis->get_comm().Broadcast(&length, 1, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(&length, 1, 0, microdis->get_comm());
       name.resize(length);
-      err = microdis->get_comm().Broadcast(name.data(), length, 0);
-      if (err) FOUR_C_THROW("communication error");
+      Core::Communication::broadcast(name.data(), length, 0, microdis->get_comm());
       newfilename.assign(name.begin(), name.end());
     }
   }
@@ -279,8 +275,8 @@ void Mat::MicroMaterialGP::post_setup()
     }
   }
 
-  microdis->get_comm().Broadcast(&step_, 1, 0);
-  microdis->get_comm().Broadcast(&time_, 1, 0);
+  Core::Communication::broadcast(&step_, 1, 0, microdis->get_comm());
+  Core::Communication::broadcast(&time_, 1, 0, microdis->get_comm());
 
   stepn_ = step_ + 1;
   timen_ = time_ + dt_;

--- a/src/mortar/4C_mortar_binarytree.cpp
+++ b/src/mortar/4C_mortar_binarytree.cpp
@@ -489,7 +489,7 @@ void Mortar::BinaryTree::init()
   // print binarytree to std::cout
   for (int k=0;k<Comm().NumProc();++k)
   {
-    Comm().Barrier();
+    Core::Communication::barrier(Comm());
     if (Core::Communication::my_mpi_rank(Comm())==k)
     {
       std::cout << "\n" << Core::Communication::my_mpi_rank(Comm()) << " Print tree with direct
@@ -498,12 +498,12 @@ void Mortar::BinaryTree::init()
       std::cout <<"\n" <<Comm().MyPID()<< " Master Tree:";
       print_tree(mroot_);
     }
-    Comm().Barrier();
+    Core::Communication::barrier(Comm());
   }
 
   for (int k=0;k<Comm().NumProc();++k)
   {
-    Comm().Barrier();
+    Core::Communication::barrier(Comm());
     if (Core::Communication::my_mpi_rank(Comm())==k)
     {
       std::cout << "\n" << Core::Communication::my_mpi_rank(Comm()) << " Print tree with print
@@ -511,7 +511,7 @@ void Mortar::BinaryTree::init()
   Tree:"; print_tree_of_map(streenodesmap_); std::cout <<"\n" <<Comm().MyPID()<< " Master Tree:";
       print_tree_of_map(mtreenodesmap_);
     }
-    Comm().Barrier();
+    Core::Communication::barrier(Comm());
   }
   */
 

--- a/src/mortar/4C_mortar_interface.cpp
+++ b/src/mortar/4C_mortar_interface.cpp
@@ -35,7 +35,6 @@
 #include "4C_utils_parameter_list.hpp"
 
 #include <Epetra_Map.h>
-#include <Epetra_SerialComm.h>
 #include <Teuchos_Time.hpp>
 #include <Teuchos_TimeMonitor.hpp>
 

--- a/src/mortar/4C_mortar_interface_tools.cpp
+++ b/src/mortar/4C_mortar_interface_tools.cpp
@@ -613,7 +613,7 @@ void Mortar::Interface::visualize_gmsh(
       fclose(fps);
       fclose(fpm);
     }
-    get_comm().Barrier();
+    Core::Communication::barrier(get_comm());
   }
 
 
@@ -626,7 +626,7 @@ void Mortar::Interface::visualize_gmsh(
   int lnslayers = binarytree_->Streenodesmap().size();
   int gnmlayers = binarytree_->Mtreenodesmap().size();
   int gnslayers = 0;
-  Comm().MaxAll(&lnslayers, &gnslayers, 1);
+  Core::Communication::max_all(&lnslayers, &gnslayers, 1, Comm());
 
   // create files for visualization of slave dops for every layer
   std::ostringstream filenametn;
@@ -673,7 +673,7 @@ void Mortar::Interface::visualize_gmsh(
     }
   }
 
-  Comm().Barrier();
+  Core::Communication::barrier(Comm());
 
   // for every proc, one after another, put data of slabs into files
   for (int i = 0; i < Core::Communication::num_mpi_ranks(Comm()); i++)
@@ -718,10 +718,10 @@ void Mortar::Interface::visualize_gmsh(
       }
     }
 
-    Comm().Barrier();
+    Core::Communication::barrier(Comm());
   }
 
-  Comm().Barrier();
+  Core::Communication::barrier(Comm());
   // close all slave-gmsh files
   if (Core::Communication::my_mpi_rank(Comm()) == 0)
   {
@@ -738,7 +738,7 @@ void Mortar::Interface::visualize_gmsh(
       fclose(fp);
     }
   }
-  Comm().Barrier();
+  Core::Communication::barrier(Comm());
 
   // create master slabs
   if (Core::Communication::my_mpi_rank(Comm()) == 0)
@@ -829,7 +829,7 @@ void Mortar::Interface::visualize_gmsh(
   int lcontactmapsize = (int)(binarytree_->coupling_map()[0].size());
   int gcontactmapsize;
 
-  Comm().MaxAll(&lcontactmapsize, &gcontactmapsize, 1);
+  Core::Communication::max_all(&lcontactmapsize, &gcontactmapsize, 1, Comm());
 
   if (gcontactmapsize > 0)
   {
@@ -892,7 +892,7 @@ void Mortar::Interface::visualize_gmsh(
           (binarytree_->coupling_map()[1][j])->PrintDopsForGmsh(currentfilename.str().c_str());
         }
       }
-      Comm().Barrier();
+      Core::Communication::barrier(Comm());
     }
 
     // close file

--- a/src/mortar/4C_mortar_manager_base.cpp
+++ b/src/mortar/4C_mortar_manager_base.cpp
@@ -7,7 +7,8 @@
 
 #include "4C_mortar_manager_base.hpp"
 
-#include <Epetra_SerialComm.h>
+#include <Epetra_MpiComm.h>
+
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -34,10 +35,7 @@ Mortar::ManagerBase::ManagerBase()
   // CONTACT::MeshtyingManager class!
   //**********************************************************************
 
-  // create a simple serial communicator
-  comm_ = std::make_shared<Epetra_SerialComm>();
-
-  return;
+  comm_ = std::make_shared<Epetra_MpiComm>(MPI_COMM_SELF);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/particle_algorithm/4C_particle_algorithm.cpp
+++ b/src/particle_algorithm/4C_particle_algorithm.cpp
@@ -733,7 +733,8 @@ bool PARTICLEALGORITHM::ParticleAlgorithm::check_max_position_increment()
   if (particleinteraction_)
   {
     double maxinteractiondistance = particleinteraction_->max_interaction_distance();
-    get_comm().MaxAll(&maxinteractiondistance, &allprocmaxinteractiondistance, 1);
+    Core::Communication::max_all(
+        &maxinteractiondistance, &allprocmaxinteractiondistance, 1, get_comm());
   }
 
   // get max particle position increment since last transfer
@@ -808,7 +809,7 @@ void PARTICLEALGORITHM::ParticleAlgorithm::get_max_particle_position_increment(
     FOUR_C_THROW("a particle traveled more than one bin on this processor!");
 
   // get maximum particle position increment on all processors
-  get_comm().MaxAll(&maxpositionincrement, &allprocmaxpositionincrement, 1);
+  Core::Communication::max_all(&maxpositionincrement, &allprocmaxpositionincrement, 1, get_comm());
 }
 
 void PARTICLEALGORITHM::ParticleAlgorithm::transfer_load_between_procs()
@@ -851,7 +852,7 @@ bool PARTICLEALGORITHM::ParticleAlgorithm::check_load_redistribution_needed()
 
   // get maximum percentage change of particles
   double maxpercentagechange = 0.0;
-  get_comm().MaxAll(&percentagechange, &maxpercentagechange, 1);
+  Core::Communication::max_all(&percentagechange, &maxpercentagechange, 1, get_comm());
 
   // criterion for load redistribution based on maximum percentage change of the number of particles
   redistributeload |= (maxpercentagechange > percentagelimit);

--- a/src/particle_engine/4C_particle_engine.cpp
+++ b/src/particle_engine/4C_particle_engine.cpp
@@ -640,7 +640,7 @@ bool PARTICLEENGINE::ParticleEngine::have_valid_particle_connectivity() const
 
   // check among all processors
   int globalcheck = 0;
-  comm_.MinAll(&localcheck, &globalcheck, 1);
+  Core::Communication::min_all(&localcheck, &globalcheck, 1, comm_);
 
   return globalcheck;
 }
@@ -651,7 +651,7 @@ bool PARTICLEENGINE::ParticleEngine::have_valid_particle_neighbors() const
 
   // check among all processors
   int globalcheck = 0;
-  comm_.MinAll(&localcheck, &globalcheck, 1);
+  Core::Communication::min_all(&localcheck, &globalcheck, 1, comm_);
 
   return globalcheck;
 }
@@ -725,7 +725,7 @@ void PARTICLEENGINE::ParticleEngine::relate_all_particles_to_all_procs(
 
   // get maximum global id on all processors
   int allprocmaxglobalid(0);
-  comm_.MaxAll(&thisprocmaxglobalid, &allprocmaxglobalid, 1);
+  Core::Communication::max_all(&thisprocmaxglobalid, &allprocmaxglobalid, 1, comm_);
 
   // resize to hold all particles
   const int vecsize = allprocmaxglobalid + 1;

--- a/src/particle_engine/4C_particle_engine_communication_utils.cpp
+++ b/src/particle_engine/4C_particle_engine_communication_utils.cpp
@@ -37,7 +37,7 @@ void PARTICLEENGINE::COMMUNICATION::immediate_recv_blocking_send(const Epetra_Co
 
   for (const auto& p : sdata) targetprocs[p.first] = 1;
 
-  comm.SumAll(targetprocs.data(), summedtargets.data(), numproc);
+  Core::Communication::sum_all(targetprocs.data(), summedtargets.data(), numproc, comm);
 
   // number of processors this processor receives data from
   int const numrecvfromprocs = summedtargets[myrank];

--- a/src/particle_interaction/4C_particle_interaction_base.cpp
+++ b/src/particle_interaction/4C_particle_interaction_base.cpp
@@ -79,7 +79,7 @@ void ParticleInteraction::ParticleInteractionBase::
   // get maximum particle interaction distance
   double allprocmaxinteractiondistance = 0.0;
   double maxinteractiondistance = max_interaction_distance();
-  comm_.MaxAll(&maxinteractiondistance, &allprocmaxinteractiondistance, 1);
+  Core::Communication::max_all(&maxinteractiondistance, &allprocmaxinteractiondistance, 1, comm_);
 
   // bin size safety check
   if (allprocmaxinteractiondistance > particleengineinterface_->min_bin_size())

--- a/src/particle_interaction/4C_particle_interaction_dem.cpp
+++ b/src/particle_interaction/4C_particle_interaction_dem.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_particle_interaction_dem.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io_runtime_csv_writer.hpp"
 #include "4C_particle_engine_container.hpp"
@@ -546,7 +547,7 @@ void ParticleInteraction::ParticleInteractionDEM::evaluate_particle_energy() con
   {
     std::vector<double> localkinenergy(1, 0.0);
     evaluate_particle_kinetic_energy(localkinenergy[0]);
-    comm_.SumAll(localkinenergy.data(), kinenergy.data(), 1);
+    Core::Communication::sum_all(localkinenergy.data(), kinenergy.data(), 1, comm_);
   }
 
   // evaluate particle gravitational potential energy contribution
@@ -554,7 +555,7 @@ void ParticleInteraction::ParticleInteractionDEM::evaluate_particle_energy() con
   {
     std::vector<double> localgravpotenergy(1, 0.0);
     evaluate_particle_gravitational_potential_energy(localgravpotenergy[0]);
-    comm_.SumAll(localgravpotenergy.data(), gravpotenergy.data(), 1);
+    Core::Communication::sum_all(localgravpotenergy.data(), gravpotenergy.data(), 1, comm_);
   }
 
   // evaluate elastic potential energy contribution
@@ -562,7 +563,7 @@ void ParticleInteraction::ParticleInteractionDEM::evaluate_particle_energy() con
   {
     std::vector<double> localelastpotenergy(1, 0.0);
     contact_->evaluate_elastic_potential_energy(localelastpotenergy[0]);
-    comm_.SumAll(localelastpotenergy.data(), elastpotenergy.data(), 1);
+    Core::Communication::sum_all(localelastpotenergy.data(), elastpotenergy.data(), 1, comm_);
   }
 
   // get specific runtime csv writer

--- a/src/particle_rigidbody/4C_particle_rigidbody.cpp
+++ b/src/particle_rigidbody/4C_particle_rigidbody.cpp
@@ -211,7 +211,7 @@ void ParticleRigidBody::RigidBodyHandler::set_unique_global_ids_for_all_rigid_bo
 
   // get maximum global id of rigid bodies on all processors
   int allprocmaxglobalid = -1;
-  comm_.MaxAll(&maxglobalid, &allprocmaxglobalid, 1);
+  Core::Communication::max_all(&maxglobalid, &allprocmaxglobalid, 1, comm_);
 
   // number of global ids on all processors
   const int numglobalids = allprocmaxglobalid + 1;
@@ -415,7 +415,7 @@ bool ParticleRigidBody::RigidBodyHandler::have_rigid_body_phase_change(
 
   // check among all processors
   int globalhavephasechange = 0;
-  comm_.MaxAll(&localhavephasechange, &globalhavephasechange, 1);
+  Core::Communication::max_all(&localhavephasechange, &globalhavephasechange, 1, comm_);
 
   return globalhavephasechange;
 }

--- a/src/particle_wall/4C_particle_wall.cpp
+++ b/src/particle_wall/4C_particle_wall.cpp
@@ -225,7 +225,8 @@ void PARTICLEWALL::WallHandlerBase::get_max_wall_position_increment(
       FOUR_C_THROW("a wall node traveled more than one bin on this processor!");
 
     // get maximum position increment on all processors
-    walldiscretization_->get_comm().MaxAll(&maxpositionincrement, &allprocmaxpositionincrement, 1);
+    Core::Communication::max_all(
+        &maxpositionincrement, &allprocmaxpositionincrement, 1, walldiscretization_->get_comm());
   }
 }
 

--- a/src/particle_wall/4C_particle_wall_result_test.cpp
+++ b/src/particle_wall/4C_particle_wall_result_test.cpp
@@ -52,7 +52,7 @@ void PARTICLEWALL::WallResultTest::test_node(
 
   int havenode(walldiscretization_->have_global_node(node));
   int havenodeonanyproc(0);
-  walldiscretization_->get_comm().SumAll(&havenode, &havenodeonanyproc, 1);
+  Core::Communication::sum_all(&havenode, &havenodeonanyproc, 1, walldiscretization_->get_comm());
 
   // safety check
   if (not havenodeonanyproc)

--- a/src/poroelast/4C_poroelast_utils.cpp
+++ b/src/poroelast/4C_poroelast_utils.cpp
@@ -142,7 +142,7 @@ std::shared_ptr<Core::LinAlg::MapExtractor> PoroElast::Utils::build_poro_splitte
 
   // Was at least one PoroP1 found on one processor?
   int glonumporop1 = 0;
-  dis.get_comm().MaxAll(&locporop1, &glonumporop1, 1);
+  Core::Communication::max_all(&locporop1, &glonumporop1, 1, dis.get_comm());
   // Yes, it was. Go ahead for all processors (even if they do not carry any PoroP1 elements)
   if (glonumporop1 > 0)
   {

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
@@ -124,7 +124,7 @@ std::shared_ptr<Core::LinAlg::MapExtractor> PoroElastScaTra::Utils::build_poro_s
 
   // Was at least one PoroP1 found on one processor?
   int glonumporop1 = 0;
-  dis.get_comm().MaxAll(&locporop1, &glonumporop1, 1);
+  Core::Communication::max_all(&locporop1, &glonumporop1, 1, dis.get_comm());
   // Yes, it was. Go ahead for all processors (even if they do not carry any PoroP1 elements)
   if (glonumporop1 > 0)
   {

--- a/src/porofluidmultiphase/4C_porofluidmultiphase_resulttest.cpp
+++ b/src/porofluidmultiphase/4C_porofluidmultiphase_resulttest.cpp
@@ -43,7 +43,8 @@ void POROFLUIDMULTIPHASE::ResultTest::test_node(
 
   int havenode(porotimint_.discretization()->have_global_node(node));
   int isnodeofanybody(0);
-  porotimint_.discretization()->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(
+      &havenode, &isnodeofanybody, 1, porotimint_.discretization()->get_comm());
 
   if (isnodeofanybody == 0)
   {
@@ -91,7 +92,8 @@ void POROFLUIDMULTIPHASE::ResultTest::test_element(
 
   int haveelement(porotimint_.discretization()->have_global_element(element));
   int iselementofanybody(0);
-  porotimint_.discretization()->get_comm().SumAll(&haveelement, &iselementofanybody, 1);
+  Core::Communication::sum_all(
+      &haveelement, &iselementofanybody, 1, porotimint_.discretization()->get_comm());
 
   if (iselementofanybody == 0)
   {

--- a/src/porofluidmultiphase/4C_porofluidmultiphase_timint_implicit.cpp
+++ b/src/porofluidmultiphase/4C_porofluidmultiphase_timint_implicit.cpp
@@ -776,7 +776,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::assemble_mat_and_rhs()
 
   // end time measurement for element
   double mydtele = Teuchos::Time::wallTime() - tcpuele;
-  discret_->get_comm().MaxAll(&mydtele, &dtele_, 1);
+  Core::Communication::max_all(&mydtele, &dtele_, 1, discret_->get_comm());
 
   return;
 }  // TimIntImpl::assemble_mat_and_rhs
@@ -1117,7 +1117,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::linear_solve(
 
   // end time measurement for solver
   double mydtsolve = Teuchos::Time::wallTime() - tcpusolve;
-  discret_->get_comm().MaxAll(&mydtsolve, &dtsolve_, 1);
+  Core::Communication::max_all(&mydtsolve, &dtsolve_, 1, discret_->get_comm());
 
   return;
 }
@@ -2185,7 +2185,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::fd_check()
     // check whether current column index is a valid global column index and continue loop if not
     int collid(sysmat_original->ColMap().LID(colgid));
     int maxcollid(-1);
-    discret_->get_comm().MaxAll(&collid, &maxcollid, 1);
+    Core::Communication::max_all(&collid, &maxcollid, 1, discret_->get_comm());
     if (maxcollid < 0) continue;
 
     // fill state vector with original state variables
@@ -2307,11 +2307,11 @@ void POROFLUIDMULTIPHASE::TimIntImpl::fd_check()
 
   // communicate tracking variables
   int counterglobal(0);
-  discret_->get_comm().SumAll(&counter, &counterglobal, 1);
+  Core::Communication::sum_all(&counter, &counterglobal, 1, discret_->get_comm());
   double maxabserrglobal(0.);
-  discret_->get_comm().MaxAll(&maxabserr, &maxabserrglobal, 1);
+  Core::Communication::max_all(&maxabserr, &maxabserrglobal, 1, discret_->get_comm());
   double maxrelerrglobal(0.);
-  discret_->get_comm().MaxAll(&maxrelerr, &maxrelerrglobal, 1);
+  Core::Communication::max_all(&maxrelerr, &maxrelerrglobal, 1, discret_->get_comm());
 
   // final screen output
   if (myrank_ == 0)

--- a/src/porofluidmultiphase/4C_porofluidmultiphase_utils.cpp
+++ b/src/porofluidmultiphase/4C_porofluidmultiphase_utils.cpp
@@ -379,7 +379,7 @@ std::map<int, std::set<int>> POROFLUIDMULTIPHASE::Utils::oct_tree_search(
     {
       double mydtsearch = timersearch.wallTime() - dtcpu;
       double maxdtsearch = 0.0;
-      contdis.get_comm().MaxAll(&mydtsearch, &maxdtsearch, 1);
+      Core::Communication::max_all(&mydtsearch, &maxdtsearch, 1, contdis.get_comm());
       if (Core::Communication::my_mpi_rank(contdis.get_comm()) == 0)
         std::cout << "Estimated duration: " << 20.0 * (maxdtsearch) << "s" << std::endl;
     }
@@ -388,7 +388,7 @@ std::map<int, std::set<int>> POROFLUIDMULTIPHASE::Utils::oct_tree_search(
   // *********** time measurement ***********
   double mydtsearch = timersearch.wallTime() - dtcpu;
   double maxdtsearch = 0.0;
-  contdis.get_comm().MaxAll(&mydtsearch, &maxdtsearch, 1);
+  Core::Communication::max_all(&mydtsearch, &maxdtsearch, 1, contdis.get_comm());
   // *********** time measurement ***********
   if (Core::Communication::my_mpi_rank(contdis.get_comm()) == 0)
     std::cout << "Completed in " << maxdtsearch << "s" << std::endl;

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_linebased.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_linebased.cpp
@@ -281,7 +281,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::pre_evaluate_c
   // output
   int total_numactive_pairs = 0;
   int numactive_pairs = static_cast<int>(coupl_elepairs_.size());
-  get_comm().SumAll(&numactive_pairs, &total_numactive_pairs, 1);
+  Core::Communication::sum_all(&numactive_pairs, &total_numactive_pairs, 1, get_comm());
   if (myrank_ == 0)
   {
     std::cout << "Only " << total_numactive_pairs
@@ -484,7 +484,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
 
   // user output
   double vol_sumall = 0.0;
-  get_comm().SumAll(&totalvolblood, &vol_sumall, 1);
+  Core::Communication::sum_all(&totalvolblood, &vol_sumall, 1, get_comm());
   if (myrank_ == 0)
   {
     std::cout << "\n<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>" << std::endl;
@@ -1063,7 +1063,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::output_summary
     std::cout << "\nSummary of coupling pairs (segments):" << std::endl;
     std::cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   for (unsigned i = 0; i < coupl_elepairs_.size(); i++)
   {
     std::cout << "Proc " << std::right << std::setw(2) << myrank_ << ": Artery-ele " << std::right
@@ -1072,7 +1072,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::output_summary
               << std::setw(11) << coupl_elepairs_[i]->eta_b() << "] <---> continuous-ele "
               << std::right << std::setw(7) << coupl_elepairs_[i]->ele2_gid() << std::endl;
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   if (myrank_ == 0) std::cout << "\n";
 }
 

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_nodetopoint.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_nodetopoint.cpp
@@ -77,7 +77,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::pre_evaluate
   // output
   int total_numactive_pairs = 0;
   int numactive_pairs = static_cast<int>(coupl_elepairs_.size());
-  get_comm().SumAll(&numactive_pairs, &total_numactive_pairs, 1);
+  Core::Communication::sum_all(&numactive_pairs, &total_numactive_pairs, 1, get_comm());
   if (myrank_ == 0)
   {
     std::cout << total_numactive_pairs
@@ -151,14 +151,14 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::output_coupl
     std::cout << "\nSummary of coupling pairs (segments):" << std::endl;
     std::cout << "^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^" << std::endl;
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   for (const auto& coupl_elepair : coupl_elepairs_)
   {
     std::cout << "Proc " << std::right << std::setw(2) << myrank_ << ": Artery-ele " << std::right
               << std::setw(5) << coupl_elepair->ele1_gid() << ": <---> continuous-ele "
               << std::right << std::setw(7) << coupl_elepair->ele2_gid() << std::endl;
   }
-  get_comm().Barrier();
+  Core::Communication::barrier(get_comm());
   if (myrank_ == 0) std::cout << "\n";
 }
 

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_nonconforming.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_nonconforming.cpp
@@ -280,7 +280,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
   // output
   int total_numactive_pairs = 0;
   numactive_pairs = static_cast<int>(coupl_elepairs_.size());
-  get_comm().SumAll(&numactive_pairs, &total_numactive_pairs, 1);
+  Core::Communication::sum_all(&numactive_pairs, &total_numactive_pairs, 1, get_comm());
 
 
   if (myrank_ == 0)
@@ -373,7 +373,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_cou
   // output
   int total_numactive_pairs = 0;
   numactive_pairs = static_cast<int>(coupl_elepairs_.size());
-  get_comm().SumAll(&numactive_pairs, &total_numactive_pairs, 1);
+  Core::Communication::sum_all(&numactive_pairs, &total_numactive_pairs, 1, get_comm());
 
 
   if (myrank_ == 0)
@@ -412,7 +412,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_varyin
 
   // sum over all procs.
   int sum_has_varying_diam = 0;
-  get_comm().SumAll(&has_varying_diam, &sum_has_varying_diam, 1);
+  Core::Communication::sum_all(&has_varying_diam, &sum_has_varying_diam, 1, get_comm());
   // if one has a varying diameter set the flag to true
   if (sum_has_varying_diam > 0) has_varying_diam_ = true;
 }

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_surfbased.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_surfbased.cpp
@@ -91,7 +91,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::pre_evaluate_c
           mygpvec[igp] = static_cast<int>(((*gp_vector)(igp))[mylid]);
 
       // communicate to all via summation
-      get_comm().SumAll(mygpvec.data(), sumgpvec.data(), numgp_per_artele);
+      Core::Communication::sum_all(mygpvec.data(), sumgpvec.data(), numgp_per_artele, get_comm());
 
       // this is ok for now, either the GID does not exist or the entire element protrudes.
       // Inform user and continue
@@ -137,14 +137,14 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::pre_evaluate_c
     numgp = numgp + coupl_elepairs_[i]->num_gp();
   }
   // safety check
-  get_comm().SumAll(&numgp, &total_num_gp, 1);
+  Core::Communication::sum_all(&numgp, &total_num_gp, 1, get_comm());
   if (numgp_desired != total_num_gp - duplicates)
     FOUR_C_THROW("It seems as if some GPs could not be projected");
 
   // output
   int total_numactive_pairs = 0;
   int numactive_pairs = static_cast<int>(coupl_elepairs_.size());
-  get_comm().SumAll(&numactive_pairs, &total_numactive_pairs, 1);
+  Core::Communication::sum_all(&numactive_pairs, &total_numactive_pairs, 1, get_comm());
   if (contdis_->name() == "porofluid" && myrank_ == 0)
     std::cout << "Only " << total_numactive_pairs
               << " Artery-to-PoroMultiphaseScatra coupling pairs are active" << std::endl;

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_base.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_base.cpp
@@ -200,7 +200,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase::timeloop()
     time_step();
     // *********** time measurement ***********
     double mydttimestep = timertimestep_.wallTime() - dtcpu;
-    get_comm().MaxAll(&mydttimestep, &dttimestep_, 1);
+    Core::Communication::max_all(&mydttimestep, &dttimestep_, 1, get_comm());
     // *********** time measurement ***********
 
     update_and_output();

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
@@ -411,7 +411,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::evaluate(
 
   // *********** time measurement ***********
   double mydtele = timernewton_.wallTime() - dtcpu;
-  get_comm().MaxAll(&mydtele, &dtele_, 1);
+  Core::Communication::max_all(&mydtele, &dtele_, 1, get_comm());
   // *********** time measurement ***********
 }
 
@@ -796,7 +796,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::linear_solve()
 
   // *********** time measurement ***********
   double mydtsolve = timernewton_.wallTime() - dtcpu;
-  get_comm().MaxAll(&mydtsolve, &dtsolve_, 1);
+  Core::Communication::max_all(&mydtsolve, &dtsolve_, 1, get_comm());
   // *********** time measurement ***********
 }
 

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -1882,7 +1882,7 @@ void Airway::RedAirwayImplicitTimeInt::extract_pressure(Core::LinAlg::Vector<dou
       }
     }
     double parpres = 0.;
-    discret_->get_comm().SumAll(&pressure, &parpres, 1);
+    Core::Communication::sum_all(&pressure, &parpres, 1, discret_->get_comm());
     (couppres)[i] = parpres;
   }
 }

--- a/src/red_airways/4C_red_airways_resulttest.cpp
+++ b/src/red_airways/4C_red_airways_resulttest.cpp
@@ -46,7 +46,7 @@ void Airway::RedAirwayResultTest::test_node(
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);
-  dis_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, dis_->get_comm());
 
   if (isnodeofanybody == 0)
   {
@@ -109,7 +109,7 @@ void Airway::RedAirwayResultTest::test_element(
 
   int haveelement(dis_->have_global_element(element));
   int iselementofanybody(0);
-  dis_->get_comm().SumAll(&haveelement, &iselementofanybody, 1);
+  Core::Communication::sum_all(&haveelement, &iselementofanybody, 1, dis_->get_comm());
 
   if (iselementofanybody == 0)
   {

--- a/src/scatra/4C_scatra_resulttest.cpp
+++ b/src/scatra/4C_scatra_resulttest.cpp
@@ -38,7 +38,8 @@ void ScaTra::ScaTraResultTest::test_node(
 
   int havenode(scatratimint_->discretization()->have_global_node(node));
   int isnodeofanybody(0);
-  scatratimint_->discretization()->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(
+      &havenode, &isnodeofanybody, 1, scatratimint_->discretization()->get_comm());
 
   if (isnodeofanybody == 0)
   {
@@ -409,7 +410,8 @@ double ScaTra::ScaTraResultTest::result_special(
     // extract number of degrees of freedom owned by specified processor at specified
     // scatra-scatra coupling interface
     result = strategy->mortar_discretization(interface_num).dof_row_map()->NumMyElements();
-    scatratimint_->discretization()->get_comm().Broadcast(&result, 1, proc_num);
+    Core::Communication::broadcast(
+        &result, 1, proc_num, scatratimint_->discretization()->get_comm());
   }
 
   // test relaxation parameters for partitioned simulations

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -1122,10 +1122,10 @@ ScaTra::ScaTraTimIntElch::evaluate_single_electrode_info_point(
 
   // communicate number of processor owning conditioned node
   int ownerid(-1);
-  discret_->get_comm().MaxAll(&procid, &ownerid, 1);
+  Core::Communication::max_all(&procid, &ownerid, 1, discret_->get_comm());
 
   // broadcast results from processor owning conditioned node to all other processors
-  discret_->get_comm().Broadcast(scalars->values(), numscalars, ownerid);
+  Core::Communication::broadcast(scalars->values(), numscalars, ownerid, discret_->get_comm());
 
   return scalars;
 }
@@ -1538,7 +1538,8 @@ void ScaTra::ScaTraTimIntElch::evaluate_cell_voltage()
         }
 
         // communicate electrode potential
-        discret_->get_comm().SumAll(&potential, &electrodevoltage_[condid], 1);
+        Core::Communication::sum_all(
+            &potential, &electrodevoltage_[condid], 1, discret_->get_comm());
       }
 
     }  // loop over conditions

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -472,7 +472,7 @@ void ScaTra::ScaTraTimIntElchSCL::write_coupling_to_csv(
         }
       }
     }
-    discret_->get_comm().Barrier();
+    Core::Communication::barrier(discret_->get_comm());
   }
 }
 
@@ -710,7 +710,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
   {
     if (iproc == Core::Communication::my_mpi_rank(comm))
       micro_problem_counter += static_cast<int>(num_my_macro_slave_node_gids);
-    comm.Broadcast(&micro_problem_counter, 1, iproc);
+    Core::Communication::broadcast(&micro_problem_counter, 1, iproc, comm);
 
     // start of micro discretization of this proc is end of last proc
     if (iproc == Core::Communication::my_mpi_rank(comm) - 1)

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -575,7 +575,7 @@ void ScaTra::TimIntHDG::set_initial_field(
       }
 
       double globerror = 0;
-      discret_->get_comm().SumAll(&error, &globerror, 1);
+      Core::Communication::sum_all(&error, &globerror, 1, discret_->get_comm());
       if (Core::Communication::my_mpi_rank(discret_->get_comm()) == 0)
         std::cout << "Error project when setting face twice: " << globerror << std::endl;
 
@@ -773,7 +773,7 @@ void ScaTra::TimIntHDG::fd_check()
       // check whether current column index is a valid global column index and continue loop if not
       int collid(sysmatcopy->ColMap().LID(colgid));
       int maxcollid(-1);
-      discret_->get_comm().MaxAll(&collid, &maxcollid, 1);
+      Core::Communication::max_all(&collid, &maxcollid, 1, discret_->get_comm());
       if (maxcollid < 0) continue;
 
       strategy.zero();
@@ -1156,7 +1156,7 @@ void ScaTra::TimIntHDG::adapt_degree()
   }
 
   int degchangeall;
-  discret_->get_comm().SumAll(&degchange, &degchangeall, 1);
+  Core::Communication::sum_all(&degchange, &degchangeall, 1, discret_->get_comm());
 
   if (!degchangeall) return;
 

--- a/src/scatra/4C_scatra_timint_heterogeneous_reaction_strategy.cpp
+++ b/src/scatra/4C_scatra_timint_heterogeneous_reaction_strategy.cpp
@@ -276,7 +276,7 @@ void ScaTra::HeterogeneousReactionStrategy::heterogeneous_reaction_sanity_check(
   }  // loop over row elements
 
 
-  com.Barrier();
+  Core::Communication::barrier(com);
   if (Core::Communication::my_mpi_rank(com) == 0) std::cout << " Passed." << std::endl;
 
   return;

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1566,7 +1566,7 @@ void ScaTra::ScaTraTimIntImpl::time_loop()
     // determine time spent by nonlinear solver and take maximum over all processors via
     // communication
     double mydtnonlinsolve(Teuchos::Time::wallTime() - time), dtnonlinsolve(0.);
-    discret_->get_comm().MaxAll(&mydtnonlinsolve, &dtnonlinsolve, 1);
+    Core::Communication::max_all(&mydtnonlinsolve, &dtnonlinsolve, 1, discret_->get_comm());
 
     // output performance statistics associated with nonlinear solver into *.csv file if applicable
     if (params_->get<bool>("OUTPUTNONLINSOLVERSTATS"))
@@ -2825,7 +2825,7 @@ void ScaTra::ScaTraTimIntImpl::assemble_mat_and_rhs()
 
   // end time measurement for element and take average over all processors via communication
   double mydtele = Teuchos::Time::wallTime() - tcpuele;
-  discret_->get_comm().MaxAll(&mydtele, &dtele_, 1);
+  Core::Communication::max_all(&mydtele, &dtele_, 1, discret_->get_comm());
 }
 
 /*----------------------------------------------------------------------*
@@ -3001,7 +3001,7 @@ void ScaTra::ScaTraTimIntImpl::nonlinear_solve()
 
       // end time measurement for solver and take average over all processors via communication
       double mydtsolve = Teuchos::Time::wallTime() - tcpusolve;
-      discret_->get_comm().MaxAll(&mydtsolve, &dtsolve_, 1);
+      Core::Communication::max_all(&mydtsolve, &dtsolve_, 1, discret_->get_comm());
 
       // output performance statistics associated with linear solver into text file if applicable
       if (params_->get<bool>("OUTPUTLINSOLVERSTATS"))

--- a/src/scatra/4C_scatra_timint_implicit_service.cpp
+++ b/src/scatra/4C_scatra_timint_implicit_service.cpp
@@ -468,7 +468,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> ScaTra::ScaTraTimIntImpl::cal
     discret_->get_comm().SumAll(
         normfluxintegral.data(), parnormfluxintegral.data(), num_dof_per_node());
     double parboundaryint = 0.0;
-    discret_->get_comm().SumAll(&boundaryint, &parboundaryint, 1);
+    Core::Communication::sum_all(&boundaryint, &parboundaryint, 1, discret_->get_comm());
 
     for (int idof = 0; idof < num_dof_per_node(); ++idof)
     {
@@ -1293,7 +1293,7 @@ void ScaTra::ScaTraTimIntImpl::output_integr_reac(const int num)
     // global integral of reaction terms
     std::vector<double> intreacterm(num_scal(), 0.0);
     for (int k = 0; k < num_scal(); ++k)
-      phinp_->Map().Comm().SumAll(&((*myreacnp)[k]), &intreacterm[k], 1);
+      Core::Communication::sum_all(&((*myreacnp)[k]), &intreacterm[k], 1, phinp_->Map().Comm());
 
     // print out values
     if (myrank_ == 0)
@@ -1595,8 +1595,8 @@ void ScaTra::ScaTraTimIntImpl::recompute_mean_csgs_b()
     }
 
     // gather contibutions of all procs
-    discret_->get_comm().SumAll(&local_sumCai, &global_sumCai, 1);
-    discret_->get_comm().SumAll(&local_sumVol, &global_sumVol, 1);
+    Core::Communication::sum_all(&local_sumCai, &global_sumCai, 1, discret_->get_comm());
+    Core::Communication::sum_all(&local_sumVol, &global_sumVol, 1, discret_->get_comm());
 
     // calculate mean Cai
     meanCai = global_sumCai / global_sumVol;
@@ -1926,7 +1926,7 @@ void ScaTra::ScaTraTimIntImpl::fd_check()
     // check whether current column index is a valid global column index and continue loop if not
     int collid(sysmat_original->ColMap().LID(colgid));
     int maxcollid(-1);
-    discret_->get_comm().MaxAll(&collid, &maxcollid, 1);
+    Core::Communication::max_all(&collid, &maxcollid, 1, discret_->get_comm());
     if (maxcollid < 0) continue;
 
     // fill state vector with original state variables
@@ -2047,11 +2047,11 @@ void ScaTra::ScaTraTimIntImpl::fd_check()
 
   // communicate tracking variables
   int counterglobal(0);
-  discret_->get_comm().SumAll(&counter, &counterglobal, 1);
+  Core::Communication::sum_all(&counter, &counterglobal, 1, discret_->get_comm());
   double maxabserrglobal(0.);
-  discret_->get_comm().MaxAll(&maxabserr, &maxabserrglobal, 1);
+  Core::Communication::max_all(&maxabserr, &maxabserrglobal, 1, discret_->get_comm());
   double maxrelerrglobal(0.);
-  discret_->get_comm().MaxAll(&maxrelerr, &maxrelerrglobal, 1);
+  Core::Communication::max_all(&maxrelerr, &maxrelerrglobal, 1, discret_->get_comm());
 
   // final screen output
   if (myrank_ == 0)
@@ -2978,7 +2978,7 @@ void ScaTra::ScalarHandler::setup(const ScaTraTimIntImpl* const scatratimint)
   // number of different numbers of dofs on this procs
   int mysize = static_cast<int>(mynumdofpernode.size());
   // communicate
-  discret->get_comm().MaxAll(&mysize, &maxsize, 1);
+  Core::Communication::max_all(&mysize, &maxsize, 1, discret->get_comm());
 
   // copy mynumdofpernode into std::vector for communication
   std::vector<int> vecmynumdofpernode(mynumdofpernode.begin(), mynumdofpernode.end());
@@ -3041,7 +3041,7 @@ int ScaTra::ScalarHandler::num_dof_per_node_in_condition(
   // number of different numbers of dofs on this procs
   int mysize = static_cast<int>(mynumdofpernode.size());
   // communicate
-  discret.get_comm().MaxAll(&mysize, &maxsize, 1);
+  Core::Communication::max_all(&mysize, &maxsize, 1, discret.get_comm());
 
   // copy mynumdofpernode into std::vector for communication
   std::vector<int> vecmynumdofpernode(mynumdofpernode.begin(), mynumdofpernode.end());

--- a/src/scatra/4C_scatra_timint_loma_genalpha.cpp
+++ b/src/scatra/4C_scatra_timint_loma_genalpha.cpp
@@ -178,8 +178,8 @@ void ScaTra::TimIntLomaGenAlpha::compute_therm_pressure()
   // get integral values in parallel case
   double parnormvelint = 0.0;
   double parnormdifffluxint = 0.0;
-  discret_->get_comm().SumAll(&normvelint, &parnormvelint, 1);
-  discret_->get_comm().SumAll(&normdifffluxint, &parnormdifffluxint, 1);
+  Core::Communication::sum_all(&normvelint, &parnormvelint, 1, discret_->get_comm());
+  Core::Communication::sum_all(&normdifffluxint, &parnormdifffluxint, 1, discret_->get_comm());
 
   // clean up
   discret_->clear_state();

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -2650,7 +2650,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
                 localnumlmdof[mypid] = interfacemaps_->Map(1)->NumMyElements();
               else
                 localnumlmdof[mypid] = interfacemaps_->Map(2)->NumMyElements();
-              comm.SumAll(localnumlmdof.data(), globalnumlmdof.data(), numproc);
+              Core::Communication::sum_all(
+                  localnumlmdof.data(), globalnumlmdof.data(), numproc, comm);
 
               // for each processor, determine offset of minimum Lagrange multiplier dof GID w.r.t.
               // maximum standard dof GID
@@ -3986,7 +3987,8 @@ void ScaTra::MeshtyingStrategyS2I::fd_check(
     // check whether current column index is a valid global column index and continue loop if not
     int collid(sysmat_original.ColMap().LID(colgid));
     int maxcollid(-1);
-    scatratimint_->discretization()->get_comm().MaxAll(&collid, &maxcollid, 1);
+    Core::Communication::max_all(
+        &collid, &maxcollid, 1, scatratimint_->discretization()->get_comm());
     if (maxcollid < 0) continue;
 
     // fill global state vector with original state variables
@@ -4104,11 +4106,14 @@ void ScaTra::MeshtyingStrategyS2I::fd_check(
 
   // communicate tracking variables
   int counterglobal(0);
-  scatratimint_->discretization()->get_comm().SumAll(&counter, &counterglobal, 1);
+  Core::Communication::sum_all(
+      &counter, &counterglobal, 1, scatratimint_->discretization()->get_comm());
   double maxabserrglobal(0.);
-  scatratimint_->discretization()->get_comm().MaxAll(&maxabserr, &maxabserrglobal, 1);
+  Core::Communication::max_all(
+      &maxabserr, &maxabserrglobal, 1, scatratimint_->discretization()->get_comm());
   double maxrelerrglobal(0.);
-  scatratimint_->discretization()->get_comm().MaxAll(&maxrelerr, &maxrelerrglobal, 1);
+  Core::Communication::max_all(
+      &maxrelerr, &maxrelerrglobal, 1, scatratimint_->discretization()->get_comm());
 
   // final screen output
   if (Core::Communication::my_mpi_rank(scatratimint_->discretization()->get_comm()) == 0)

--- a/src/scatra/4C_scatra_turbulence_hit_initial_scalar_field.cpp
+++ b/src/scatra/4C_scatra_turbulence_hit_initial_scalar_field.cpp
@@ -142,7 +142,7 @@ namespace ScaTra
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         // unpack received block into set of all coordinates
@@ -255,7 +255,7 @@ namespace ScaTra
                 // use this version to get random field different from fluid
                 random_theta = 0.5 * random->uni() + 0.5;
               }
-              discret_->get_comm().Broadcast(&random_theta, 1, 0);
+              Core::Communication::broadcast(&random_theta, 1, 0, discret_->get_comm());
 
               // estimate energy at wave number from energy spectrum
               const double energy = calculate_energy_from_spectrum(k);

--- a/src/scatra/4C_scatra_turbulence_hit_scalar_forcing.cpp
+++ b/src/scatra/4C_scatra_turbulence_hit_scalar_forcing.cpp
@@ -161,7 +161,7 @@ namespace ScaTra
 
         {
           // for safety
-          exporter.get_comm().Barrier();
+          Core::Communication::barrier(exporter.get_comm());
         }
 
         // unpack received block into set of all coordinates
@@ -337,7 +337,8 @@ namespace ScaTra
     // get values from all processors
     // number of nodes without slave nodes
     const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-    discret_->get_comm().SumAll(local_phi.data(), global_phi.data(), countallnodes);
+    Core::Communication::sum_all(
+        local_phi.data(), global_phi.data(), countallnodes, discret_->get_comm());
 
     //----------------------------------------
     // fast Fourier transformation using FFTW
@@ -679,7 +680,8 @@ namespace ScaTra
       // get values form all processors
       // number of nodes without slave nodes
       const int countallnodes = nummodes_ * nummodes_ * nummodes_;
-      discret_->get_comm().SumAll(local_phi.data(), global_phi.data(), countallnodes);
+      Core::Communication::sum_all(
+          local_phi.data(), global_phi.data(), countallnodes, discret_->get_comm());
 
       //----------------------------------------
       // fast Fourier transformation using FFTW

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -311,7 +311,7 @@ void SSI::SSIBase::init_discretizations(const Epetra_Comm& comm, const std::stri
           my_node_ids[lid] = scatra_manifold_dis->node_row_map()->GID(lid);
 
         int max_num_nodes = 0;
-        get_comm().MaxAll(&num_my_nodes, &max_num_nodes, 1);
+        Core::Communication::max_all(&num_my_nodes, &max_num_nodes, 1, get_comm());
 
         // resize vector and fill with place holders (-1)
         my_node_ids.resize(max_num_nodes, -1);

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -855,7 +855,7 @@ void SSI::SsiMono::newton_loop()
 
     // time needed for evaluating elements and assembling global system of equations
     double my_evaluation_time = timer_->wallTime() - time_before_evaluate;
-    get_comm().MaxAll(&my_evaluation_time, &dt_eval_, 1);
+    Core::Communication::max_all(&my_evaluation_time, &dt_eval_, 1, get_comm());
 
     // safety check
     if (!ssi_matrices_->system_matrix()->filled())
@@ -874,7 +874,7 @@ void SSI::SsiMono::newton_loop()
 
     // time needed for solving global system of equations
     double my_solve_time = timer_->wallTime() - time_before_solving;
-    get_comm().MaxAll(&my_solve_time, &dt_solve_, 1);
+    Core::Communication::max_all(&my_solve_time, &dt_solve_, 1, get_comm());
 
     // output performance statistics associated with linear solver into text file if
     // applicable
@@ -910,7 +910,7 @@ void SSI::SsiMono::timeloop()
     // determine time spent by nonlinear solver and take maximum over all processors via
     // communication
     double mydtnonlinsolve(timer_->wallTime() - time), dtnonlinsolve(0.);
-    get_comm().MaxAll(&mydtnonlinsolve, &dtnonlinsolve, 1);
+    Core::Communication::max_all(&mydtnonlinsolve, &dtnonlinsolve, 1, get_comm());
 
     // output performance statistics associated with nonlinear solver into *.csv file if
     // applicable
@@ -1241,7 +1241,7 @@ void SSI::SsiMono::calc_initial_potential_field()
 
     // time needed for evaluating elements and assembling global system of equations
     double my_evaluation_time = timer_->wallTime() - time_before_evaluate;
-    get_comm().MaxAll(&my_evaluation_time, &dt_eval_, 1);
+    Core::Communication::max_all(&my_evaluation_time, &dt_eval_, 1, get_comm());
 
     if (strategy_convcheck_->exit_newton_raphson_init_pot_calc(*this)) break;
 
@@ -1255,7 +1255,7 @@ void SSI::SsiMono::calc_initial_potential_field()
 
     // time needed for solving global system of equations
     double my_solve_time = timer_->wallTime() - time_before_solving;
-    get_comm().MaxAll(&my_solve_time, &dt_solve_, 1);
+    Core::Communication::max_all(&my_solve_time, &dt_solve_, 1, get_comm());
 
     // update potential dofs in scatra and manifold fields
     update_iter_scatra();

--- a/src/ssi/4C_ssi_partitioned_2wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_2wc.cpp
@@ -131,7 +131,7 @@ void SSI::SSIPart2WC::timeloop()
     // determine time spent by nonlinear solver and take maximum over all processors via
     // communication
     double mydtnonlinsolve(Teuchos::Time::wallTime() - time), dtnonlinsolve(0.);
-    get_comm().MaxAll(&mydtnonlinsolve, &dtnonlinsolve, 1);
+    Core::Communication::max_all(&mydtnonlinsolve, &dtnonlinsolve, 1, get_comm());
 
     // output performance statistics associated with nonlinear solver into *.csv file if applicable
     if (scatra_field()->scatra_parameter_list()->get<bool>("OUTPUTNONLINSOLVERSTATS"))

--- a/src/ssi/4C_ssi_utils.cpp
+++ b/src/ssi/4C_ssi_utils.cpp
@@ -1075,7 +1075,7 @@ int SSI::Utils::SSIMeshTying::has_gid(
   int my_return_value = has_gid_partial(gid, lower_bound, upper_bound, matching_nodes);
   int glob_return_value;
 
-  comm_.MaxAll(&my_return_value, &glob_return_value, 1);
+  Core::Communication::max_all(&my_return_value, &glob_return_value, 1, comm_);
 
   return glob_return_value;
 }

--- a/src/ssti/4C_ssti_monolithic.cpp
+++ b/src/ssti/4C_ssti_monolithic.cpp
@@ -122,7 +122,7 @@ void SSTI::SSTIMono::assemble_mat_and_rhs()
       residual_, scatra_field()->residual(), *structure_field()->rhs(), thermo_field()->residual());
 
   double mydt = timer_->wallTime() - starttime;
-  get_comm().MaxAll(&mydt, &dtassemble_, 1);
+  Core::Communication::max_all(&mydt, &dtassemble_, 1, get_comm());
 }
 
 /*-------------------------------------------------------------------------------*
@@ -421,7 +421,7 @@ void SSTI::SSTIMono::newton_loop()
   }
 
   double mydt = timer_->wallTime() - starttime;
-  get_comm().MaxAll(&mydt, &dtnewton_, 1);
+  Core::Communication::max_all(&mydt, &dtnewton_, 1, get_comm());
 }
 
 /*--------------------------------------------------------------------------*
@@ -565,7 +565,7 @@ void SSTI::SSTIMono::evaluate_subproblems()
   }
 
   double mydt = timer_->wallTime() - starttime;
-  get_comm().MaxAll(&mydt, &dtevaluate_, 1);
+  Core::Communication::max_all(&mydt, &dtevaluate_, 1, get_comm());
 }
 
 /*--------------------------------------------------------------------------------------*
@@ -592,7 +592,7 @@ void SSTI::SSTIMono::linear_solve()
   strategy_equilibration_->unequilibrate_increment(increment_);
 
   double mydt = timer_->wallTime() - starttime;
-  get_comm().MaxAll(&mydt, &dtsolve_, 1);
+  Core::Communication::max_all(&mydt, &dtsolve_, 1, get_comm());
 }
 
 /*--------------------------------------------------------------------------------------*

--- a/src/sti/4C_sti_algorithm.cpp
+++ b/src/sti/4C_sti_algorithm.cpp
@@ -278,7 +278,7 @@ void STI::Algorithm::time_loop()
     // determine time spent by nonlinear solver and take maximum over all processors via
     // communication
     double mydtnonlinsolve(timer_->wallTime() - time), dtnonlinsolve(0.);
-    get_comm().MaxAll(&mydtnonlinsolve, &dtnonlinsolve, 1);
+    Core::Communication::max_all(&mydtnonlinsolve, &dtnonlinsolve, 1, get_comm());
 
     // output performance statistics associated with nonlinear solver into *.csv file if applicable
     if (fieldparameters_->get<bool>("OUTPUTNONLINSOLVERSTATS"))

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -369,7 +369,7 @@ void STI::Monolithic::fd_check()
     // check whether current column index is a valid global column index and continue loop if not
     int collid(sysmat_original->ColMap().LID(colgid));
     int maxcollid(-1);
-    get_comm().MaxAll(&collid, &maxcollid, 1);
+    Core::Communication::max_all(&collid, &maxcollid, 1, get_comm());
     if (maxcollid < 0) continue;
 
     // fill global state vector with original state variables
@@ -493,11 +493,11 @@ void STI::Monolithic::fd_check()
 
   // communicate tracking variables
   int counterglobal(0);
-  get_comm().SumAll(&counter, &counterglobal, 1);
+  Core::Communication::sum_all(&counter, &counterglobal, 1, get_comm());
   double maxabserrglobal(0.);
-  get_comm().MaxAll(&maxabserr, &maxabserrglobal, 1);
+  Core::Communication::max_all(&maxabserr, &maxabserrglobal, 1, get_comm());
   double maxrelerrglobal(0.);
-  get_comm().MaxAll(&maxrelerr, &maxrelerrglobal, 1);
+  Core::Communication::max_all(&maxrelerr, &maxrelerrglobal, 1, get_comm());
 
   // final screen output
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
@@ -639,7 +639,7 @@ void STI::Monolithic::output_matrix_to_file(
   }
 
   // wait until output is complete
-  comm.Barrier();
+  Core::Communication::barrier(comm);
 
   // throw error to abort simulation for debugging
   FOUR_C_THROW("Matrix was output to *.csv file!");
@@ -726,7 +726,7 @@ void STI::Monolithic::output_vector_to_file(
   }
 
   // wait until output is complete
-  comm.Barrier();
+  Core::Communication::barrier(comm);
 
   // throw error to abort simulation for debugging
   FOUR_C_THROW("Vector was output to *.csv file!");
@@ -1530,7 +1530,7 @@ void STI::Monolithic::solve()
     // determine time needed for evaluating elements and assembling global system of equations,
     // and take maximum over all processors via communication
     double mydtele = timer_->wallTime() - time;
-    get_comm().MaxAll(&mydtele, &dtele_, 1);
+    Core::Communication::max_all(&mydtele, &dtele_, 1, get_comm());
 
     // safety check
     if (!systemmatrix_->filled())
@@ -1563,7 +1563,7 @@ void STI::Monolithic::solve()
     // determine time needed for solving global system of equations,
     // and take maximum over all processors via communication
     double mydtsolve = timer_->wallTime() - time;
-    get_comm().MaxAll(&mydtsolve, &dtsolve_, 1);
+    Core::Communication::max_all(&mydtsolve, &dtsolve_, 1, get_comm());
 
     // output performance statistics associated with linear solver into text file if applicable
     if (fieldparameters_->get<bool>("OUTPUTLINSOLVERSTATS"))

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -91,7 +91,7 @@ MultiScale::MicroStatic::MicroStatic(const int microdisnum, const double V0)
   dt_ = sdyn_macro.get<double>("TIMESTEP");
   // broadcast important data that must be consistent on macro and micro scale (master and
   // supporting procs)
-  discret_->get_comm().Broadcast(&dt_, 1, 0);
+  Core::Communication::broadcast(&dt_, 1, 0, discret_->get_comm());
   time_ = 0.0;
   timen_ = time_ + dt_;
   step_ = 0;
@@ -124,9 +124,9 @@ MultiScale::MicroStatic::MicroStatic(const int microdisnum, const double V0)
 
   // broadcast important data that must be consistent on macro and micro scale (master and
   // supporting procs)
-  discret_->get_comm().Broadcast(&numstep_, 1, 0);
-  discret_->get_comm().Broadcast(&restart_, 1, 0);
-  discret_->get_comm().Broadcast(&restartevry_, 1, 0);
+  Core::Communication::broadcast(&numstep_, 1, 0, discret_->get_comm());
+  Core::Communication::broadcast(&restart_, 1, 0, discret_->get_comm());
+  Core::Communication::broadcast(&restartevry_, 1, 0, discret_->get_comm());
 
   // -------------------------------------------------------------------
   // get a vector layout from the discretization to construct matching
@@ -254,7 +254,7 @@ MultiScale::MicroStatic::MicroStatic(const int microdisnum, const double V0)
   discret_->clear_state();
 
   // compute volume of all elements
-  discret_->get_comm().SumAll(&my_micro_discretization_volume, &V0_, 1);
+  Core::Communication::sum_all(&my_micro_discretization_volume, &V0_, 1, discret_->get_comm());
 
   // compute density of all elements
   double micro_discretization_density_integration = 0.0;
@@ -963,7 +963,7 @@ void MultiScale::MicroStatic::static_homogenization(Core::LinAlg::Matrix<6, 1>* 
       P(i, j) /= V0_;
       // sum P(i,j) over the microdis
       double sum = 0.0;
-      discret_->get_comm().SumAll(&(P(i, j)), &sum, 1);
+      Core::Communication::sum_all(&(P(i, j)), &sum, 1, discret_->get_comm());
       P(i, j) = sum;
     }
   }
@@ -1092,7 +1092,7 @@ void MultiScale::MicroStatic::static_homogenization(Core::LinAlg::Matrix<6, 1>* 
 
     // sum result of matrix-matrix product over procs
     std::vector<double> sum(81, 0.0);
-    discret_->get_comm().SumAll(val.data(), sum.data(), 81);
+    Core::Communication::sum_all(val.data(), sum.data(), 81, discret_->get_comm());
 
     if (Core::Communication::my_mpi_rank(discret_->get_comm()) == 0)
     {

--- a/src/structure/4C_structure_resulttest.cpp
+++ b/src/structure/4C_structure_resulttest.cpp
@@ -47,7 +47,7 @@ void StruResultTest::test_node(
 
   int havenode(strudisc_->have_global_node(node));
   int isnodeofanybody(0);
-  strudisc_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, strudisc_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -2632,8 +2632,8 @@ void Solid::TimInt::output_contact()
     // global quantities (sum over all processors)
     for (int i = 0; i < 3; ++i)
     {
-      cmtbridge_->get_comm().SumAll(&sumangmom[i], &angmom[i], 1);
-      cmtbridge_->get_comm().SumAll(&sumlinmom[i], &linmom[i], 1);
+      Core::Communication::sum_all(&sumangmom[i], &angmom[i], 1, cmtbridge_->get_comm());
+      Core::Communication::sum_all(&sumlinmom[i], &linmom[i], 1, cmtbridge_->get_comm());
     }
 
     //--------------------------Calculation of total kinetic energy
@@ -3010,7 +3010,7 @@ Inpar::Solid::ConvergenceStatus Solid::TimInt::perform_error_action(
       double proc_randnum_get = ((double)rand() / (double)RAND_MAX);
       double proc_randnum = proc_randnum_get;
       double randnum = 1.0;
-      discret_->get_comm().SumAll(&proc_randnum, &randnum, 1);
+      Core::Communication::sum_all(&proc_randnum, &randnum, 1, discret_->get_comm());
       const double numproc = Core::Communication::num_mpi_ranks(discret_->get_comm());
       randnum /= numproc;
       if (rand_tsfac_ > 1.0)

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_structure_new_integrator.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io_pstream.hpp"
@@ -526,7 +527,7 @@ double Solid::Integrator::get_condensed_solution_update_rms(
   // get total dof number
   int gdofnumber = get_condensed_dof_number(qtype);
   // sum over all procs
-  gstate_ptr_->get_comm().SumAll(&myrmsnorm, &grmsnorm, 1);
+  Core::Communication::sum_all(&myrmsnorm, &grmsnorm, 1, gstate_ptr_->get_comm());
 
   // calculate the root mean square and return the value
   return (std::sqrt(grmsnorm) / static_cast<double>(gdofnumber));
@@ -541,7 +542,7 @@ int Solid::Integrator::get_condensed_dof_number(
   // global dof number of the given quantity
   int gdofnumber = 0.0;
   int mydofnumber = eval_data_ptr_->get_my_dof_number(qtype);
-  gstate_ptr_->get_comm().SumAll(&mydofnumber, &gdofnumber, 1);
+  Core::Communication::sum_all(&mydofnumber, &gdofnumber, 1, gstate_ptr_->get_comm());
   return gdofnumber;
 }
 
@@ -557,18 +558,18 @@ double Solid::Integrator::get_condensed_global_norm(
   {
     case ::NOX::Abstract::Vector::OneNorm:
     {
-      gstate_ptr_->get_comm().SumAll(&mynorm, &gnorm, 1);
+      Core::Communication::sum_all(&mynorm, &gnorm, 1, gstate_ptr_->get_comm());
       break;
     }
     case ::NOX::Abstract::Vector::TwoNorm:
     {
-      gstate_ptr_->get_comm().SumAll(&mynorm, &gnorm, 1);
+      Core::Communication::sum_all(&mynorm, &gnorm, 1, gstate_ptr_->get_comm());
       gnorm = std::sqrt(gnorm);
       break;
     }
     case ::NOX::Abstract::Vector::MaxNorm:
     {
-      gstate_ptr_->get_comm().MaxAll(&mynorm, &gnorm, 1);
+      Core::Communication::max_all(&mynorm, &gnorm, 1, gstate_ptr_->get_comm());
       break;
     }
   }

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -461,7 +461,7 @@ void Solid::TimeInt::Base::prepare_output(bool force_prepare_timestep)
     {
       energy_local = energy_data.second;
 
-      dataglobalstate_->get_comm().SumAll(&energy_local, &energy_global, 1);
+      Core::Communication::sum_all(&energy_local, &energy_global, 1, dataglobalstate_->get_comm());
 
       evaldata.set_value_for_energy_type(energy_global, energy_data.first);
     }

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -364,7 +364,7 @@ Inpar::Solid::ConvergenceStatus Solid::TimeInt::Implicit::perform_error_action(
       double proc_randnum = proc_randnum_get;
       double randnum = 1.0;
       const Epetra_Comm& comm = discretization()->get_comm();
-      comm.SumAll(&proc_randnum, &randnum, 1);
+      Core::Communication::sum_all(&proc_randnum, &randnum, 1, comm);
       const double numproc = Core::Communication::num_mpi_ranks(comm);
       randnum /= numproc;
       if (get_random_time_step_factor() > 1.0)

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_generic.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_generic.cpp
@@ -254,7 +254,7 @@ bool Solid::ModelEvaluator::Generic::eval_error_check() const
   // --- check for local errors on each proc and communicate the information ---
   int lerr = (ok ? 0 : 1);
   int gerr = 0;
-  gstate_ptr_->get_comm().SumAll(&lerr, &gerr, 1);
+  Core::Communication::sum_all(&lerr, &gerr, 1, gstate_ptr_->get_comm());
   return (gerr == 0);
 }
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -108,7 +108,8 @@ void Solid::ModelEvaluator::Structure::setup()
       int number_global_beam_elements = 0;
       discretization->get_comm().MaxAll(
           &number_my_solid_elements, &number_global_solid_elements, 1);
-      discretization->get_comm().MaxAll(&number_my_beam_elements, &number_global_beam_elements, 1);
+      Core::Communication::max_all(
+          &number_my_beam_elements, &number_global_beam_elements, 1, discretization->get_comm());
 
       if (global_in_output().get_runtime_output_params()->output_structure() &&
           number_global_solid_elements > 0)
@@ -1578,7 +1579,7 @@ void Solid::ModelEvaluator::Structure::determine_strain_energy(
   {
     double my_int_energy = eval_data().get_energy_data(Solid::internal_energy);
     double gsum = 0.0;
-    discret().get_comm().SumAll(&my_int_energy, &gsum, 1);
+    Core::Communication::sum_all(&my_int_energy, &gsum, 1, discret().get_comm());
 
     eval_data().set_value_for_energy_type(gsum, Solid::internal_energy);
   }

--- a/src/structure_new/src/output/4C_structure_new_gauss_point_data_output_manager.cpp
+++ b/src/structure_new/src/output/4C_structure_new_gauss_point_data_output_manager.cpp
@@ -182,7 +182,7 @@ void Solid::ModelEvaluator::GaussPointDataOutputManager::distribute_quantities(
   const Core::Communication::Exporter exporter(comm);
 
   int max_quantities = quantities_.size();
-  comm.MaxAll(&max_quantities, &max_quantities, 1);
+  Core::Communication::max_all(&max_quantities, &max_quantities, 1, comm);
 
   if (max_quantities == 0)
   {
@@ -191,7 +191,7 @@ void Solid::ModelEvaluator::GaussPointDataOutputManager::distribute_quantities(
   }
 
   // Communicate max number of Gauss points
-  comm.MaxAll(&max_num_gp_, &max_num_gp_, 1);
+  Core::Communication::max_all(&max_num_gp_, &max_num_gp_, 1, comm);
 
   // Collect all quantities on proc 0
   if (Core::Communication::my_mpi_rank(comm) == 0)

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -499,7 +499,7 @@ void Solid::MonitorDbc::get_area(double area[], const Core::Conditions::Conditio
     larea[AreaType::curr] += Core::Geo::element_area(fele->shape(), xyze_curr);
   }
 
-  discret.get_comm().SumAll(larea.data(), area, 2);
+  Core::Communication::sum_all(larea.data(), area, 2, discret.get_comm());
 }
 
 /*----------------------------------------------------------------------------*
@@ -521,7 +521,8 @@ double Solid::MonitorDbc::get_reaction_force(
     for (int i = 0; i < react_maps[d]->NumMyElements(); ++i) lrforce_comp += vals[i];
   }
 
-  discret_ptr_->get_comm().SumAll(lrforce_xyz.data(), rforce_xyz.data(), DIM);
+  Core::Communication::sum_all(
+      lrforce_xyz.data(), rforce_xyz.data(), DIM, discret_ptr_->get_comm());
   return rforce_xyz.norm2();
 }
 
@@ -583,7 +584,8 @@ double Solid::MonitorDbc::get_reaction_moment(Core::LinAlg::Matrix<DIM, 1>& rmom
     lrmoment_xyz += node_reaction_moment;
   }
 
-  discret_ptr_->get_comm().SumAll(lrmoment_xyz.data(), rmoment_xyz.data(), DIM);
+  Core::Communication::sum_all(
+      lrmoment_xyz.data(), rmoment_xyz.data(), DIM, discret_ptr_->get_comm());
   return rmoment_xyz.norm2();
 }
 

--- a/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
@@ -189,7 +189,7 @@ void Solid::ResultTest::test_node(
 
   int havenode(strudisc_->have_global_node(node));
   int isnodeofanybody(0);
-  strudisc_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, strudisc_->get_comm());
 
   if (isnodeofanybody == 0)
   {
@@ -477,13 +477,13 @@ void Solid::ResultTest::test_node_on_geometry(const Core::IO::InputParameterCont
     switch (op)
     {
       case TestOp::sum:
-        disc.get_comm().SumAll(&tmp_result, &result, 1);
+        Core::Communication::sum_all(&tmp_result, &result, 1, disc.get_comm());
         break;
       case TestOp::max:
-        disc.get_comm().MaxAll(&tmp_result, &result, 1);
+        Core::Communication::max_all(&tmp_result, &result, 1, disc.get_comm());
         break;
       case TestOp::min:
-        disc.get_comm().MinAll(&tmp_result, &result, 1);
+        Core::Communication::min_all(&tmp_result, &result, 1, disc.get_comm());
         break;
       default:
         break;

--- a/src/thermo/4C_thermo_resulttest.cpp
+++ b/src/thermo/4C_thermo_resulttest.cpp
@@ -40,7 +40,7 @@ void Thermo::ResultTest::test_node(
 
   int havenode(thrdisc_->have_global_node(node));
   int isnodeofanybody(0);
-  thrdisc_->get_comm().SumAll(&havenode, &isnodeofanybody, 1);
+  Core::Communication::sum_all(&havenode, &isnodeofanybody, 1, thrdisc_->get_comm());
 
   if (isnodeofanybody == 0)
   {

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -2599,7 +2599,8 @@ void TSI::Monolithic::calculate_necking_tsi_results()
   double top_force_global = 0.0;
 
   // sum all nodal forces (top_force_local) in one global vector (top_force_global)
-  structure_field()->discretization()->get_comm().SumAll(&top_force_local, &top_force_global, 1);
+  Core::Communication::sum_all(
+      &top_force_local, &top_force_global, 1, structure_field()->discretization()->get_comm());
 
   // --------------------------------------------- reaction force of whole body
   // due to symmetry only 1/8 is simulated, i.e. only 1/4 of the surface is considered

--- a/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
@@ -773,7 +773,7 @@ void XFEM::MeshCouplingFPI::set_condition_specific_parameters()
       else
         FOUR_C_THROW("Element type != hex8, add it here!");
     }
-    bg_dis_->get_comm().MaxAll(&hmax, &h_scaling_, 1);
+    Core::Communication::max_all(&hmax, &h_scaling_, 1, bg_dis_->get_comm());
     std::cout << "==| XFEM::MeshCouplingFPI: Computed h_scaling for fluidele is: " << h_scaling_
               << "(Proc: " << Core::Communication::my_mpi_rank(bg_dis_->get_comm())
               << ")! |==" << std::endl;

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1838,7 +1838,7 @@ void XFEM::MeshCouplingFSI::set_condition_specific_parameters()
       else
         FOUR_C_THROW("Element type != hex8, add it here!");
     }
-    bg_dis_->get_comm().MaxAll(&hmax, &h_scaling_, 1);
+    Core::Communication::max_all(&hmax, &h_scaling_, 1, bg_dis_->get_comm());
     std::cout << "==| XFEM::MeshCouplingFSI: Computed h_scaling for fluidele is: " << h_scaling_
               << "(Proc: " << Core::Communication::my_mpi_rank(bg_dis_->get_comm())
               << ")! |==" << std::endl;

--- a/src/xfem/4C_xfem_discretization_utils.cpp
+++ b/src/xfem/4C_xfem_discretization_utils.cpp
@@ -553,7 +553,7 @@ XFEM::Utils::XFEMDiscretizationBuilder::split_condition(const Core::Conditions::
     if (nodecolset.find(ngid) != nodecolset.end()) lcount++;
   }
 
-  comm.SumAll(&lcount, &gcount, 1);
+  Core::Communication::sum_all(&lcount, &gcount, 1, comm);
   // return a nullptr pointer, if there is nothing to copy
   if (gcount == 0) return nullptr;
 

--- a/src/xfem/4C_xfem_mesh_projector.cpp
+++ b/src/xfem/4C_xfem_mesh_projector.cpp
@@ -549,7 +549,7 @@ void XFEM::MeshProjector::receive_block(
   exporter.wait(request);
 
   // for safety
-  exporter.get_comm().Barrier();
+  Core::Communication::barrier(exporter.get_comm());
 
   return;
 }
@@ -575,7 +575,7 @@ void XFEM::MeshProjector::send_block(
   exporter.i_send(frompid, topid, sblock.data(), sblock.size(), tag, request);
 
   // for safety
-  exporter.get_comm().Barrier();
+  Core::Communication::barrier(exporter.get_comm());
 
   return;
 }

--- a/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
+++ b/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
@@ -1477,6 +1477,7 @@ void XFEM::XFluidContactComm::create_new_gmsh_files()
   plot_data_.resize(sections.size());
 #endif
 
+  sum_gps_.resize(5);
   std::vector<int> g_sum_gps(5);
   Core::Communication::sum_all(sum_gps_.data(), g_sum_gps.data(), 5, fluiddis_->get_comm());
   if (!Core::Communication::my_mpi_rank(fluiddis_->get_comm()))

--- a/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
+++ b/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
@@ -1478,7 +1478,7 @@ void XFEM::XFluidContactComm::create_new_gmsh_files()
 #endif
 
   std::vector<int> g_sum_gps(5);
-  fluiddis_->get_comm().SumAll(sum_gps_.data(), g_sum_gps.data(), 5);
+  Core::Communication::sum_all(sum_gps_.data(), g_sum_gps.data(), 5, fluiddis_->get_comm());
   if (!Core::Communication::my_mpi_rank(fluiddis_->get_comm()))
   {
     std::cout << "===| Summary Contact GPs |===" << std::endl;

--- a/src/xfem/4C_xfem_xfluid_timeInt.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.cpp
@@ -126,7 +126,8 @@ void XFEM::XFluidTimeInt::set_and_print_status(const bool screenout)
   }
 
   // reduce and sum over all procs
-  dis_->get_comm().SumAll(cpu_methods.data(), glob_methods.data(), nummethods);
+  Core::Communication::sum_all(
+      cpu_methods.data(), glob_methods.data(), nummethods, dis_->get_comm());
 
   if (screenout)
   {
@@ -2177,7 +2178,7 @@ void XFEM::XFluidTimeInt::export_methods(
         }
       }
 
-      dis_->get_comm().Barrier();  // processors wait for each other
+      Core::Communication::barrier(dis_->get_comm());  // processors wait for each other
     }
 
     //---------------------------------------------------------------------------------------------------------------

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
@@ -3274,7 +3274,7 @@ void XFEM::XfluidStd::export_start_data()
         searchedProcs, counter, dMin, (TimeIntData::Type)newtype));
   }
 
-  discret_->get_comm().Barrier();  // processors wait for each other
+  Core::Communication::barrier(discret_->get_comm());  // processors wait for each other
 }  // end exportStartData
 
 
@@ -3383,7 +3383,7 @@ void XFEM::XfluidStd::export_final_data()
     }  // end loop over number of nodes to get
 
     // processors wait for each other
-    discret_->get_comm().Barrier();
+    Core::Communication::barrier(discret_->get_comm());
   }  // end loop over processors
 }  // end exportfinalData
 

--- a/src/xfem/4C_xfem_xfluid_timeInt_std_SemiLagrange.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_std_SemiLagrange.cpp
@@ -1889,7 +1889,7 @@ void XFEM::XfluidSemiLagrange::export_alternativ_algo_data()
     }                 // end loop over number of nodes to get
 
     // processors wait for each other
-    discret_->get_comm().Barrier();
+    Core::Communication::barrier(discret_->get_comm());
   }  // end loop over processors
 }  // end export_alternativ_algo_data
 
@@ -1939,7 +1939,7 @@ void XFEM::XfluidSemiLagrange::export_iter_data(bool& procDone)
     if (allProcsDone == false) procDone = false;
 
     // processors wait for each other
-    discret_->get_comm().Barrier();
+    Core::Communication::barrier(discret_->get_comm());
   }
 
   /*--------------------------------------*
@@ -2015,7 +2015,7 @@ void XFEM::XfluidSemiLagrange::export_iter_data(bool& procDone)
     }  // end loop over number of points to get
 
     // processors wait for each other
-    discret_->get_comm().Barrier();
+    Core::Communication::barrier(discret_->get_comm());
   }  // end if procfinished == false
 }  // end export_iter_data
 

--- a/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
+++ b/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
@@ -12,8 +12,6 @@
 #include "4C_fem_general_element.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
 
-#include <Epetra_SerialComm.h>
-
 #include <array>
 
 const double testTolerance = 1e-14;
@@ -28,7 +26,7 @@ namespace
     Beam3eb()
     {
       testdis_ = std::make_shared<Core::FE::Discretization>(
-          "Beam3eb", std::make_shared<Epetra_SerialComm>(), 3);
+          "Beam3eb", std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 3);
 
       std::vector<std::vector<double>> xrefe{{-0.05, 0.05, 0.3}, {0.45, -0.05, 0.1}};
       std::vector<double> xrefe_full{-0.05, 0.05, 0.3, 0.45, -0.05, 0.1};

--- a/unittests/beam3/4C_beam3_kirchhoff_test.cpp
+++ b/unittests/beam3/4C_beam3_kirchhoff_test.cpp
@@ -11,8 +11,6 @@
 
 #include "4C_fem_general_element.hpp"
 
-#include <Epetra_SerialComm.h>
-
 #include <array>
 
 const double testTolerance = 1e-14;
@@ -27,7 +25,7 @@ namespace
     Beam3k()
     {
       testdis_ = std::make_shared<Core::FE::Discretization>(
-          "Beam3k", std::make_shared<Epetra_SerialComm>(), 3);
+          "Beam3k", std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 3);
 
       std::vector<std::vector<double>> xrefe{{-0.05, 0.05, 0.3}, {0.45, -0.05, 0.1}};
 

--- a/unittests/beam3/4C_beam3_reissner_test.cpp
+++ b/unittests/beam3/4C_beam3_reissner_test.cpp
@@ -11,8 +11,6 @@
 
 #include "4C_fem_general_element.hpp"
 
-#include <Epetra_SerialComm.h>
-
 #include <array>
 
 const double testTolerance = 1e-14;
@@ -27,7 +25,7 @@ namespace
     Beam3r()
     {
       testdis_ = std::make_shared<Core::FE::Discretization>(
-          "Beam3r", std::make_shared<Epetra_SerialComm>(), 3);
+          "Beam3r", std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 3);
 
       std::vector<std::vector<double>> xrefe{{-0.05, 0.05, 0.3}, {0.45, -0.05, 0.1}};
       std::vector<double> xrefe_full{-0.05, 0.05, 0.3, 0.45, -0.05, 0.1};

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_surface_patch_averaged_normals_test.cpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_surface_patch_averaged_normals_test.cpp
@@ -15,7 +15,6 @@
 #include "4C_geometry_pair_scalar_types.hpp"
 #include "4C_linalg_vector.hpp"
 
-#include <Epetra_SerialComm.h>
 
 
 namespace
@@ -33,7 +32,7 @@ namespace
      */
     GeometryPairLineToSurfacePatchTest()
     {
-      std::shared_ptr<Epetra_SerialComm> comm = std::make_shared<Epetra_SerialComm>();
+      auto comm = std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD);
       discret_ = std::make_shared<Core::FE::Discretization>("unit_test", comm, 3);
     }
 

--- a/unittests/io/4C_discretization_nodal_coordinates_test.cpp
+++ b/unittests/io/4C_discretization_nodal_coordinates_test.cpp
@@ -16,7 +16,6 @@
 #include "4C_material_parameter_base.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
-#include <Epetra_SerialComm.h>
 
 namespace
 {
@@ -41,7 +40,7 @@ namespace
     {
       create_material_in_global_problem();
 
-      comm_ = std::make_shared<Epetra_SerialComm>();
+      comm_ = std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD);
       test_discretization_ = std::make_shared<Core::FE::Discretization>("dummy", comm_, 3);
 
       Core::IO::cout.setup(false, false, false, Core::IO::standard, comm_, 0, 0, "dummyFilePrefix");
@@ -67,7 +66,7 @@ namespace
    protected:
     Core::IO::GridGenerator::RectangularCuboidInputs inputData_{};
     std::shared_ptr<Core::FE::Discretization> test_discretization_;
-    std::shared_ptr<Epetra_SerialComm> comm_;
+    std::shared_ptr<Epetra_Comm> comm_;
 
     Core::Utils::SingletonOwnerRegistry::ScopeGuard guard;
   };

--- a/unittests/io/4C_gridgenerator_test.cpp
+++ b/unittests/io/4C_gridgenerator_test.cpp
@@ -18,7 +18,6 @@
 #include "4C_material_parameter_base.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
-#include <Epetra_SerialComm.h>
 
 namespace
 {
@@ -50,7 +49,7 @@ namespace
     void SetUp() override
     {
       create_material_in_global_problem();
-      comm_ = std::make_shared<Epetra_SerialComm>();
+      comm_ = std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD);
       Core::IO::cout.setup(false, false, false, Core::IO::standard, comm_, 0, 0, "dummyFilePrefix");
       testdis_ = std::make_shared<Core::FE::Discretization>("dummy", comm_, 3);
     }

--- a/unittests/so3/4C_so_contact_element_reference_configuration_test.cpp
+++ b/unittests/so3/4C_so_contact_element_reference_configuration_test.cpp
@@ -13,8 +13,6 @@
 #include "4C_so3_tet4.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
 
-#include <Epetra_SerialComm.h>
-
 namespace
 {
   using namespace FourC;
@@ -28,7 +26,7 @@ namespace
     {
       // create a discretization, to store the created elements and nodes
       testdis_ = std::make_shared<Core::FE::Discretization>(
-          "dummy", std::make_shared<Epetra_SerialComm>(), 3);
+          "dummy", std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 3);
 
       // create hex8 element and store it in the test discretization
       const std::array<int, 8> nodeidshex8 = {0, 1, 2, 3, 4, 5, 6, 7};

--- a/unittests/so3/4C_so_hex8_test.cpp
+++ b/unittests/so3/4C_so_hex8_test.cpp
@@ -13,8 +13,6 @@
 #include "4C_so3_hex8.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
-#include <Epetra_SerialComm.h>
-
 #include <array>
 
 namespace
@@ -28,7 +26,7 @@ namespace
     {
       // create a discretization, that creates node to element pointers and keeps the nodes alive
       testdis_ = std::make_shared<Core::FE::Discretization>(
-          "dummy", std::make_shared<Epetra_SerialComm>(), 3);
+          "dummy", std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 3);
 
       // create 8 nodes
       const std::array<int, 8> nodeids = {0, 1, 2, 3, 4, 5, 6, 7};

--- a/unittests/so3/4C_so_tet4_test.cpp
+++ b/unittests/so3/4C_so_tet4_test.cpp
@@ -13,7 +13,6 @@
 #include "4C_so3_tet4.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
-#include <Epetra_SerialComm.h>
 
 namespace
 {
@@ -26,7 +25,7 @@ namespace
     {
       // create a discretization, that creates node to element pointers and keeps the nodes alive
       testdis_ = std::make_shared<Core::FE::Discretization>(
-          "dummy", std::make_shared<Epetra_SerialComm>(), 3);
+          "dummy", std::make_shared<Epetra_MpiComm>(MPI_COMM_WORLD), 3);
 
       // create 4 nodes
       const std::array<int, 4> nodeids = {0, 1, 2, 3};


### PR DESCRIPTION
Part of #82 

This PR replaces most functions of the `Epetra_MpiComm` with our own wrapper version and drops the use of `Epetra_SerialComm`. This change uncovered an existing memory bug in Xfluid which I also fixed here.