### PR TITLE
Add docker image with prebuilt 4c

### DIFF
--- a/.github/workflows/docker_prebuilt_4c.yml
+++ b/.github/workflows/docker_prebuilt_4c.yml
@@ -1,0 +1,62 @@
+name: 4C docker image
+
+on:
+  workflow_run:
+    workflows: [nightly_tests]
+    types: [completed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ghcr.io/4c-multiphysics/4c
+
+jobs:
+  build_4c_image:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.description=Image containing the built 4C code
+      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
+      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
+      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: .
+          file: docker/prebuilt_4C/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:latest
+          # tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.1.4
+        with:
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/docker/prebuilt_4C/Dockerfile
+++ b/docker/prebuilt_4C/Dockerfile
@@ -1,0 +1,16 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+FROM ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:latest
+LABEL org.opencontainers.image.description="Image containing the built 4C code"
+LABEL org.4c-multiphysics.project=4C
+
+RUN git clone https://github.com/4C-multiphysics/4C.git
+
+RUN mkdir 4C/build && cd 4C/build && \
+  cmake ../ --fresh --preset=docker && \
+  cmake --build . --target full -- -j `nproc`

--- a/docker/prebuilt_4C/README.md
+++ b/docker/prebuilt_4C/README.md
@@ -1,0 +1,20 @@
+>**Disclaimer:** this docker image is new. So, the usability might still be suboptimal.
+
+This `Dockerfile` creates an docker image with a ready to use 4C executable.
+
+You can just start the docker image with
+```
+docker run --interactive --tty ghcr.io/4c-multiphysics/4c:latest
+```
+or build it yourself with
+```
+cd docker/prebuilt_4C
+docker build --tag 4c:latest .
+```
+
+Then you can run one of the input files inside the docker image with
+```
+mpirun -np 2 /home/user/4C/build/4C /home/user/4C/tests/input_files/<some input>.dat /home/user/output
+```
+
+If you want to use your own input file you can either use a volume mount (`--mount`) or copy the file into the docker container (`docker cp`).


### PR DESCRIPTION
This PR adds a new docker image where 4C is already built. The plan is to create the docker image once the nightly workflow succeeds. Since we do not have versioning yet, the image is always tagged as `latest`. This docker image can be used in Actions where a 4C build is required or for users who want to quickly check out 4C without needing to build it themselves.

~~This is a first draft as I wanted to get your feedback first, before rebuilding the `4c-dependencies` image because I moved a Dockerfile.~~

The Dockerfile for the dependencies image has been moved to a separate folder in #112. The Dockerfile to build 4c is added to the new folder `prebuilt_4C`.

## Additional info
The pre-built 4C docker image just uses the `4c-dependencies-ubuntu24.04` image out of convenience for now. Originally, I wanted to use a multi-stage build where I just copy the executable to the final image. But then the tests did not work because they need the dat file from the source. I think as a start, we can have the source and build in the final docker image. Later we can focus how we can reduce the size of the docker image because 7.4 GB is huge.

@isteinbrecher  @gilrrei  @davidrudlstorfer  I think this image is a good starting point for further discussions for your use cases in Queens and for the actions meshpy.

## How to use the 4c docker image
Start the docker container with the current directory mounted to `/workspace`
```
docker run --interactive --tty --mount type=bind,source=./,target=/workspace ghcr.io/ppraegla/4c:latest
```
Set the correct owner of the mount (Unfortunately, we need to do that because we are the user `user` inside the docker image and the mount point is owned by root)
```
sudo chown user:user -R /workspace/
```
Run 4C with an input file from the host system and the output is also written to the host system
```
mpirun -np 2 /home/user/4C/build/4C /workspace/particle_dem_1d_radius_from_input.dat /workspace/out
```

This whole process is still a little awkward to use. But may be a good starting point to work with. 