### PR TITLE
Compress build directory for artifact

### DIFF
--- a/.github/actions/download_4C_build/action.yml
+++ b/.github/actions/download_4C_build/action.yml
@@ -14,4 +14,8 @@ runs:
     - name: Extract 4C build
       shell: bash
       run: |
-        tar -xf $GITHUB_WORKSPACE/4C_build.tar -C /
+        tar -xf $GITHUB_WORKSPACE/4C_build.tar.gz -C /
+    - name: Remove tar file
+      shell: bash
+      run: |
+        rm $GITHUB_WORKSPACE/4C_build.tar.gz

--- a/.github/actions/upload_4C_build/action.yml
+++ b/.github/actions/upload_4C_build/action.yml
@@ -11,13 +11,16 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Install pigz
+      shell: bash
+      run: apt-get update && apt-get install -y pigz
     - name: Package build directory
       shell: bash
-      run: tar -cf $GITHUB_WORKSPACE/4C_build.tar $GITHUB_WORKSPACE/build
+      run: tar -c --use-compress-program=pigz -f $GITHUB_WORKSPACE/4C_build.tar.gz $GITHUB_WORKSPACE/build
     - name: Upload build folder
       uses: actions/upload-artifact@v4
       with:
         name: ${{ github.job }}-4C-build
         path: |
-          ${{ github.workspace }}/4C_build.tar
+          ${{ github.workspace }}/4C_build.tar.gz
         retention-days: ${{ inputs.retention-days }}


### PR DESCRIPTION
This adds xz compression for passing the build directory between build- and test stage and removes the archive after reconstructing the build directory.