### PR TITLE
Set clang as the default compiler at LNM workstations

### DIFF
--- a/presets/lnm/workstation/CMakePresets.json
+++ b/presets/lnm/workstation/CMakePresets.json
@@ -15,9 +15,9 @@
         "FOUR_C_TRILINOS_ROOT": "/lnm/lib/packages/trilinos/16-1-0_v2/release-shared",
         "BUILD_SHARED_LIBS": "ON",
         "CMAKE_BUILD_TYPE": "RELEASE",
-        "CMAKE_CXX_COMPILER": "/usr/bin/mpic++",
+        "CMAKE_CXX_COMPILER": "/lnm/programs64/llvm-18.1.8/bin/clang++",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_C_COMPILER": "/usr/bin/mpicc",
+        "CMAKE_C_COMPILER": "/lnm/programs64/llvm-18.1.8/bin/clang",
         "CMAKE_C_COMPILER_LAUNCHER": "ccache"
       }
     },


### PR DESCRIPTION
Makes LNM ready for #65, has slightly better compile times and more expressive error messages.