### PR TITLE
Only push docker images in workflows when they are run from the base repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
 
   tag-images-as-latest:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: ${{ github.ref == 'refs/heads/main' && github.repository == '4C-multiphysics/4C' }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ on:
       - '.github/workflows/docker.yml'
       - 'dependencies/current/'
       - 'dependencies/testing/'
+      - 'docker/dependencies/'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker_prebuilt_4c.yml
+++ b/.github/workflows/docker_prebuilt_4c.yml
@@ -16,7 +16,8 @@ env:
 jobs:
   build_4c_image:
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == '4C-multiphysics/4C'
+      }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Only push docker images in workflows when they are run from the base repo. Otherwise, the actions in forks will fail because forks are not allowed to push to our registry. 

Also, fix a missing path in the docker workflow trigger. When the `docker/dependencies/` folder contains changes the latest image should also be updated.