### PR TITLE
Update LNM default compiler to GCC 13.2

### DIFF
--- a/presets/lnm/workstation/CMakePresets.json
+++ b/presets/lnm/workstation/CMakePresets.json
@@ -15,9 +15,9 @@
         "FOUR_C_TRILINOS_ROOT": "/lnm/lib/packages/trilinos/16-1-0_v2/release-shared",
         "BUILD_SHARED_LIBS": "ON",
         "CMAKE_BUILD_TYPE": "RELEASE",
-        "CMAKE_CXX_COMPILER": "/usr/bin/mpic++",
+        "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_C_COMPILER": "/usr/bin/mpicc",
+        "CMAKE_C_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/gcc",
         "CMAKE_C_COMPILER_LAUNCHER": "ccache"
       }
     },


### PR DESCRIPTION
Alternative to #116 

Since the LLVM installation is not able to bring a new `libstdc++` required for newer C++ standards, @amgebauer and I decided to provide a newer GCC for now.

Related to #65 