### PR TITLE
Add a missing MPI include when ArborX is off

### DIFF
--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_utils.hpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_utils.hpp
@@ -12,6 +12,8 @@
 
 #include "4C_fem_geometric_search_bounding_volume.hpp"
 
+#include <mpi.h>
+
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN


### PR DESCRIPTION
Follows #117 