### PR TITLE
Add LLVM source-based coverage report generated every night

### DIFF
--- a/.github/actions/chunk_test_suite/action.yml
+++ b/.github/actions/chunk_test_suite/action.yml
@@ -11,8 +11,14 @@ inputs:
     description: Number of chunks
     required: true
   junit-report-artifact-name:
-    description: Name of the job that reports the junit summary
-    required: true
+    description: Name of the job that reports the junit summary (leave out if previous runtime should
+      not be used)
+    required: false
+    default: ''
+  base-workflow:
+    description: Name of the workflow file
+    required: false
+    default: nightly_tests.yml
 outputs:
   chunk-array:
     description: Array of chunks
@@ -24,8 +30,9 @@ runs:
       id: download-junit-reports
       continue-on-error: true
       uses: dawidd6/action-download-artifact@v6
+      if: ${{ inputs.junit-report-artifact-name != '' }}
       with:
-        workflow: nightly_tests.yml
+        workflow: ${{ inputs.base-workflow }}
         name: ${{ inputs.junit-report-artifact-name }}
         path: ${{ inputs.source-directory }}
         branch: ${{ github.event.repository.default_branch }}

--- a/.github/actions/download_4C_build/action.yml
+++ b/.github/actions/download_4C_build/action.yml
@@ -15,3 +15,4 @@ runs:
       shell: bash
       run: |
         tar -xf $GITHUB_WORKSPACE/4C_build.tar -C /
+        rm $GITHUB_WORKSPACE/4C_build.tar

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,162 @@
+name: coverage
+
+on:
+  schedule:
+    - cron: '0 1 * * *'
+
+jobs:
+  gcc13_coverage_build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:28cfb9d0
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      test-chunks: ${{ steps.set-matrix.outputs.chunk-array }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - uses: ./.github/actions/build_4C
+        with:
+          cmake-preset: docker_coverage
+          build-targets: full
+          build-directory: ${{ github.workspace }}/build
+          use-ccache: "false"
+      - uses: ./.github/actions/upload_4C_build
+        with:
+          build-directory: ${{ github.workspace }}/build
+          retention-days: 1
+      - uses: ./.github/actions/chunk_test_suite
+        id: set-matrix
+        # Note: We will not use previous runtimes for chunking to avoid running out of storage
+        with:
+          build-directory: ${{ github.workspace }}/build
+          source-directory: ${{ github.workspace }}
+          number-of-chunks: 40 # we need fine grained test chunks to avoid running out of storage
+
+  gcc13_coverage_test:
+    needs: gcc13_coverage_build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:28cfb9d0
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    strategy:
+      matrix:
+        test-chunk: ${{fromJson(needs.gcc13_coverage_build.outputs.test-chunks)}}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get upgrade -y
+          apt-get install -y llvm
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: gcc13_coverage_build
+      - name: Run all tests and collect raw coverage data
+        run: | # Note: Collect raw coverage data in a file distict for each process
+          cd $GITHUB_WORKSPACE/build
+          export LLVM_PROFILE_FILE="$GITHUB_WORKSPACE/4C-coverage-%m-%p.profraw"
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure  --output-junit $GITHUB_WORKSPACE/gcc13_coverage_test_report-$TEST_CHUNK.xml
+        env:
+          TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Collect coverage data
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          llvm-profdata merge -sparse $GITHUB_WORKSPACE/*.profraw -o $GITHUB_WORKSPACE/4C-coverage-data-$TEST_CHUNK.profdata
+        env:
+          TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload merged coverage data
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ github.job }}-4C-coverage-data-${{ matrix.test-chunk }}.profdata
+          path: |
+            ${{ github.workspace }}/4C-coverage-data-${{ matrix.test-chunk }}.profdata
+          retention-days: 1
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: gcc13_coverage_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/gcc13_coverage_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  gcc13_coverage_test_report:
+    needs: gcc13_coverage_test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: gcc13_coverage_test_report
+          retention-days: 2
+
+  report:
+    needs: [gcc13_coverage_test, gcc13_coverage_build]
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:28cfb9d0
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: gcc13_coverage_build
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+          ./utilities/set_up_dev_env.sh
+      - name: Download reports
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ github.workspace }}
+          merge-multiple: true
+          pattern: gcc13_coverage_test-4C-coverage-data-*.profdata
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y llvm
+      - name: Merge coverage data
+        run: |
+          cd $GITHUB_WORKSPACE
+          llvm-profdata merge -sparse *.profdata -o 4C-coverage-data.profdata
+      - name: Print of coverage report summary
+        run: |
+          cd $GITHUB_WORKSPACE
+          llvm-cov report --object ./build/lib4C.so --use-color --format=text --instr-profile=4C-coverage-data.profdata --show-branch-summary --show-instantiation-summary --show-region-summary --ignore-filename-regex=".*/build/.*"
+      - name: Generate coverage report
+        run: |
+          cd $GITHUB_WORKSPACE
+          llvm-cov show --object ./build/lib4C.so --use-color --output-dir=coverage_report --format=html --instr-profile=4C-coverage-data.profdata --show-branches=percent --show-directory-coverage --show-line-counts-or-regions -Xdemangler c++filt --project-title=4C --show-expansions --show-instantiations --ignore-filename-regex=".*/build/.*" --show-instantiation-summary
+      - name: Create coverage badge
+        run: |
+          cd $GITHUB_WORKSPACE
+          python -m venv venv
+          . venv/bin/activate
+          pip install anybadge
+          COVERAGE_PERCENT=`llvm-cov export --object ./build/lib4C.so --format=text --instr-profile=4C-coverage-data.profdata --summary-only --ignore-filename-regex=".*/build/.*" | python -c 'import json, sys; print(json.load(sys.stdin)["data"][0]["totals"]["lines"]["percent"])'`
+          anybadge -l coverage --suffix=" %" --value=$COVERAGE_PERCENT -m "%.2f" 65=red 90=orange 100=green > coverage_report/badge_coverage.svg
+      - name: Upload coverage html report
+        uses: actions/upload-artifact@v4
+        with:
+          name: 4C_coverage_report
+          path: ${{ github.workspace }}/coverage_report
+          retention-days: 2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: deploy
 
 on:
   workflow_run:
-    workflows: [documentation]
+    workflows: [documentation, coverage]
     types: [completed]
     branches: [main]
 
@@ -26,11 +26,19 @@ jobs:
           workflow: documentation.yml
           name: doxygen
           path: ${{ github.workspace }}/doxygen
+          branch: ${{ github.event.repository.default_branch }}
       - uses: dawidd6/action-download-artifact@v6
         with:
           workflow: documentation.yml
           name: readthedocs
           path: ${{ github.workspace }}/readthedocs
+          branch: ${{ github.event.repository.default_branch }}
+      - uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: coverage.yml
+          name: 4C_coverage_report
+          path: ${{ github.workspace }}/coverage_report
+          branch: ${{ github.event.repository.default_branch }}
       - uses: actions/upload-pages-artifact@v3
         id: deployment
         with:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - 'main'
+  schedule:
+    - cron: '0 22 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,7 +39,7 @@ jobs:
         with:
           name: doxygen
           path: ${{ github.workspace }}/build/doc/doxygen/html/
-          retention-days: 1
+          retention-days: 2
 
   readthedocs:
     runs-on: ubuntu-latest
@@ -62,4 +64,4 @@ jobs:
         with:
           name: readthedocs
           path: ${{ github.workspace }}/build/doc/readthedocs/html/
-          retention-days: 1
+          retention-days: 2

--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -100,17 +100,20 @@ if(FOUR_C_ENABLE_ADDRESS_SANITIZER)
 endif()
 
 four_c_process_global_option(
-  FOUR_C_ENABLE_COVERAGE "Set up a build to gather coverage information" OFF
+  FOUR_C_ENABLE_COVERAGE
+  "Set up a build to gather coverage information with LLVM source based coverage"
+  OFF
   )
 if(FOUR_C_ENABLE_COVERAGE)
   four_c_check_compiles(
     FOUR_C_COMPILER_SUPPORT_COVERAGE
     COMPILE_OPTIONS
-    "-fprofile-arcs"
-    "-ftest-coverage"
+    "-fprofile-instr-generate"
+    "-fcoverage-mapping"
     LINK_OPTIONS
-    "-fprofile-arcs"
-    "-ftest-coverage"
+    "-fprofile-instr-generate"
+    "-fcoverage-mapping"
+    "-Wl,--build-id=sha1"
     APPEND_ON_SUCCESS
     )
 

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -93,9 +93,10 @@
         ".docker_base"
       ],
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "DEBUG",
         "FOUR_C_ENABLE_COVERAGE": "ON",
-        "FOUR_C_TEST_TIMEOUT_SCALE": "50"
+        "FOUR_C_TEST_TIMEOUT_SCALE": "4",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_C_COMPILER": "clang"
       }
     }
   ]


### PR DESCRIPTION
This PR adds LLVM source based coverage (cf. https://clang.llvm.org/docs/SourceBasedCodeCoverage.html).

It is **much faster** than the coverage report that we used to have. In my fork, it finishes within 2h15m. I have a pro account with 40 parallel runners, so testing might take a bit longer within 4C-multiphysics, but I expect it to be below 3h.

The report itself is also a bit different:
 :heavy_check_mark:  Optimization does not affect coverage (we can use normal optimization)
 :heavy_check_mark: We see coverage for each instantiation of a template (i.e., we see which instantiations are covered, which not, optional, could be disabled if too much)
 :heavy_check_mark: For every execution branch bifurcation (e.g., an `if`-statement) we see the percentage how often a branch was taken
 :x: We don't yet have the option to sort by coverage statistics. Maybe a future version of llvm will be able to do so.
:information_source: Current bottleneck is the storage size of the Github runner (~14 GB). The build-folder already takes 4 GB + Ubuntu image etc., so there is not much storage left for testing and coverage raw output. That's why the test chunks are more fine-grained than during regular testing.
:information_source: Have a look at [the caveats according to exceptions](https://clang.llvm.org/docs/SourceBasedCodeCoverage.html#drawbacks-and-limitations).

Here is the generated report from my fork: https://amgebauer.github.io/4C/coverage_report/ (the deps-folder should now be excluded)

I will test the nightly generation and deployment in my fork this night and if it works, we can merge.

We also have to run doxygen and readthedocs generation every night to make sure it is available once we want to deploy.

:warning:  Note, I expect the deploy job to fail after merge until the first coverage pipeline ran successfully.