### PR TITLE
Quick fix for the material evaluate calls in the case of InelasticDefgradTransvIsotropElastViscoplast

### DIFF
--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -17,6 +17,7 @@
 #include "4C_mat_elast_couptransverselyisotropic.hpp"
 #include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_electrode.hpp"
+#include "4C_mat_inelastic_defgrad_factors_service.hpp"
 #include "4C_mat_multiplicative_split_defgrad_elasthyper.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_vplast_law.hpp"
@@ -29,6 +30,7 @@
 #include <map>
 #include <memory>
 #include <stdexcept>
+#include <string>
 #include <utility>
 
 FOUR_C_NAMESPACE_OPEN
@@ -2466,8 +2468,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_inverse_inelast
 
     // throw error if the Local Newton Loop cannot be evaluated with the given substepping
     // settings
-    if (err_status != Mat::ViscoplastErrorType::NoErrors)
-      FOUR_C_THROW(ViscoplastErrorMessages[err_status]);
+    if (err_status != Mat::ViscoplastErrorType::NoErrors) FOUR_C_THROW(Mat::to_string(err_status));
 
     // extract the inverse inelastic defgrad from the LNL solution
     iFinM = extract_inverse_inelastic_defgrad(sol);
@@ -3131,31 +3132,6 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
   // reset boolean for the history update
   update_hist_var_ = true;
 }
-
-/// map: error types to error messages in InelasticDefgradTransvIsotropElastViscoplast
-std::map<Mat::ViscoplastErrorType, std::string> Mat::ViscoplastErrorMessages = {
-    {ViscoplastErrorType::NegativePlasticStrain,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: negative plastic strain!"},
-    {ViscoplastErrorType::OverflowError,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: overflow error related to the "
-        "evaluation of the plastic strain increment!"},
-    {ViscoplastErrorType::NoPlasticIncompressibility,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: plastic incompressibility not "
-        "satisfied!"},
-    {ViscoplastErrorType::FailedSolLinSystLNL,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: solution of the linear system in "
-        "the Local Newton Loop failed!"},
-    {ViscoplastErrorType::NoConvergenceLNL,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: Local Newton Loop did not "
-        "converge for the given loop settings!"},
-    {ViscoplastErrorType::SingularJacobian,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: singular Jacobian after "
-        "converged Local Newton Loop, which does not allow for the analytical evaluation of the "
-        "linearization!"},
-    {ViscoplastErrorType::FailedSolAnalytLinearization,
-        "Error in InelasticDefgradTransvIsotropElastViscoplast: solution of the linear system in "
-        "the analytical linearization failed"},
-};
 
 
 

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -22,6 +22,7 @@
 #include <Teuchos_ParameterList.hpp>
 
 #include <memory>
+#include <vector>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -1482,6 +1483,11 @@ namespace Mat
       //! evaluation (used in order to update last_rightCG_ once outer NR converges) (for all Gauss
       //! points)
       std::vector<Core::LinAlg::Matrix<3, 3>> current_rightCG_;
+
+      //! current (reduced) deformation gradient: used to check whether the inverse inelastic
+      //! deformation gradient has already been evaluated (to improve the computation performance)
+      std::vector<Core::LinAlg::Matrix<3, 3>> current_defgrad_;
+
 
       //! current inverse plastic deformation gradient (for all Gauss points)
       std::vector<Core::LinAlg::Matrix<3, 3>> current_plastic_defgrd_inverse_;

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
@@ -47,36 +47,25 @@ namespace Mat
     {
       case Mat::ViscoplastErrorType::NegativePlasticStrain:
         return "Error in InelasticDefgradTransvIsotropElastViscoplast: negative plastic strain!";
-        break;
       case Mat::ViscoplastErrorType::OverflowError:
         return "Error in InelasticDefgradTransvIsotropElastViscoplast: overflow error related to "
-               "the "
-               "evaluation of the plastic strain increment!";
-        break;
+               "the evaluation of the plastic strain increment!";
       case Mat::ViscoplastErrorType::NoPlasticIncompressibility:
         return "Error in InelasticDefgradTransvIsotropElastViscoplast: plastic incompressibility "
-               "not "
-               "satisfied!";
-        break;
+               "not satisfied!";
       case Mat::ViscoplastErrorType::FailedSolLinSystLNL:
         return "Error in InelasticDefgradTransvIsotropElastViscoplast: solution of the linear "
-               "system "
-               "in the Local Newton Loop failed!";
-        break;
+               "system in the Local Newton Loop failed!";
       case Mat::ViscoplastErrorType::NoConvergenceLNL:
         return "Error in InelasticDefgradTransvIsotropElastViscoplast: Local Newton Loop did not "
                "converge for the given loop settings!";
-        break;
       case Mat::ViscoplastErrorType::SingularJacobian:
-        return "Error in InelasticDefgradTransvIsotropElastViscoplast: singular Jacobian after "
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: singular Jacobian after  "
                "converged Local Newton Loop, which does not allow for the analytical evaluation of "
                "the linearization!";
-        break;
       case Mat::ViscoplastErrorType::FailedSolAnalytLinearization:
         return "Error in InelasticDefgradTransvIsotropElastViscoplast: solution of the linear "
-               "system "
-               "in the analytical linearization failed";
-        break;
+               "system  in the analytical linearization failed";
       default:
         FOUR_C_THROW("to_string(Mat::ViscoplastErrorType): You should not be here!");
     }

--- a/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors_service.hpp
@@ -10,6 +10,8 @@
 
 #include "4C_config.hpp"
 
+#include "4C_utils_exceptions.hpp"
+
 #include <map>
 #include <string>
 
@@ -38,8 +40,47 @@ namespace Mat
                                    // failed
   };
 
-  /// map: error types to error messages in InelasticDefgradTransvIsotropElastViscoplast
-  extern std::map<Mat::ViscoplastErrorType, std::string> ViscoplastErrorMessages;
+  /// to_string: error types to error messages in InelasticDefgradTransvIsotropElastViscoplast
+  inline std::string to_string(Mat::ViscoplastErrorType err_type)
+  {
+    switch (err_type)
+    {
+      case Mat::ViscoplastErrorType::NegativePlasticStrain:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: negative plastic strain!";
+        break;
+      case Mat::ViscoplastErrorType::OverflowError:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: overflow error related to "
+               "the "
+               "evaluation of the plastic strain increment!";
+        break;
+      case Mat::ViscoplastErrorType::NoPlasticIncompressibility:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: plastic incompressibility "
+               "not "
+               "satisfied!";
+        break;
+      case Mat::ViscoplastErrorType::FailedSolLinSystLNL:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: solution of the linear "
+               "system "
+               "in the Local Newton Loop failed!";
+        break;
+      case Mat::ViscoplastErrorType::NoConvergenceLNL:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: Local Newton Loop did not "
+               "converge for the given loop settings!";
+        break;
+      case Mat::ViscoplastErrorType::SingularJacobian:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: singular Jacobian after "
+               "converged Local Newton Loop, which does not allow for the analytical evaluation of "
+               "the linearization!";
+        break;
+      case Mat::ViscoplastErrorType::FailedSolAnalytLinearization:
+        return "Error in InelasticDefgradTransvIsotropElastViscoplast: solution of the linear "
+               "system "
+               "in the analytical linearization failed";
+        break;
+      default:
+        FOUR_C_THROW("to_string(Mat::ViscoplastErrorType): You should not be here!");
+    }
+  }
 
 }  // namespace Mat
 


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This PR implements a quick fix for the redundant material evaluations issue #121, specifically for the transversely isotropic material `InelasticDefgradTransvIsotropElastViscoplast`. Concretely, the deformation gradient, which is the input of the material evaluations, is tracked continuously. If an inelastic deformation gradient has been previously computed for a specific deformation gradient, then the solution is simply returned, instead of repeating the substepping scheme (which would yield the exact same result). A performance speed up of approx. 2 was reached with this quick fix in the exemplary simulations performed. I am aware that this quick fix is not the optimal solution. However, it is IMO the best approach until we can find a consistent solution for all materials, see issue above. Moreover, the approach of converting error types to error messages was adapted as proposed [here](https://github.com/4C-multiphysics/4C/pull/102#discussion_r1873757244), by replacing the `std::map` with a `to_string(Mat::ViscoplastErrorType)` function.

## Related Issues and Merge Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to Issue #121 and PR #102. 