### PR TITLE
Add combined junit test report published as artifact

### DIFF
--- a/.github/actions/merge_junit_report_artifacts/action.yml
+++ b/.github/actions/merge_junit_report_artifacts/action.yml
@@ -1,0 +1,33 @@
+name: Merge junit report artifacts
+description: Merge junit reports from artifacts to a single artifact
+inputs:
+  retention-days:
+    description: Number of days to retain the artifact
+    required: false
+    default: "1"
+  junit-report-base-name:
+    description: Base name of the artifacts with the junit reports
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Download reports
+      uses: actions/download-artifact@v4
+      with:
+        path: ${{ github.workspace }}
+        merge-multiple: true
+        pattern: ${{ inputs.junit-report-base-name }}-*.xml
+    - name: Merge test reports
+      shell: bash
+      run: |
+        pip install junitparser==3.2.0
+        junitparser merge --glob $JUNIT_REPORT_BASE_NAME-*.xml $JUNIT_REPORT_BASE_NAME.xml
+      env:
+        JUNIT_REPORT_BASE_NAME: ${{ inputs.junit-report-base-name }}
+    - name: Upload test summary
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.junit-report-base-name }}.xml
+        path: |
+          ${{ github.workspace }}/${{ inputs.junit-report-base-name }}.xml
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -65,9 +65,30 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          ctest -I $TEST_CHUNK -j `nproc` --output-on-failure
+          ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/gcc13_assertions_test_report-$TEST_CHUNK.xml
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gcc13_assertions_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/gcc13_assertions_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  gcc13_assertions_test_report:
+    needs: gcc13_assertions_test
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main' && (success() || failure())
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: gcc13_assertions_test_report
+          retention-days: 1
 
   gcc9_build:
     runs-on: ubuntu-latest
@@ -169,8 +190,8 @@ jobs:
           ctest -L minimal -j `nproc` --output-on-failure
 
   ensure_all_tests_pass:
-    needs: [gcc9_build, gcc9_test_minimal, gcc13_assertions_test, gcc13_assertions_build, clang18_build,
-      clang18_test_minimal]
+    needs: [gcc9_build, gcc9_test_minimal, gcc13_assertions_test, gcc13_assertions_test_report, gcc13_assertions_build,
+      clang18_build, clang18_test_minimal]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -56,9 +56,30 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/gcc13_assertions_test_report-$TEST_CHUNK.xml
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: gcc13_assertions_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/gcc13_assertions_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  gcc13_assertions_test_report:
+    needs: gcc13_assertions_test
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: gcc13_assertions_test_report
+          retention-days: 2
 
   gcc9_build:
     runs-on: ubuntu-latest
@@ -111,9 +132,30 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/gcc9_test_report-$TEST_CHUNK.xml
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: gcc9_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/gcc9_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  gcc9_test_report:
+    needs: gcc9_test
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: gcc9_test_report
+          retention-days: 2
 
   clang18_build:
     runs-on: ubuntu-latest
@@ -166,9 +208,30 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/clang18_test_report-$TEST_CHUNK.xml
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: clang18_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/clang18_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  clang18_test_report:
+    needs: clang18_test
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: clang18_test_report
+          retention-days: 2
 
   gcc13_asan_build:
     runs-on: ubuntu-latest
@@ -221,6 +284,27 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/gcc13_asan_test_report-$TEST_CHUNK.xml
         env:
           TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: gcc13_asan_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/gcc13_asan_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  gcc13_asan_test_report:
+    needs: gcc13_asan_test
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: gcc13_asan_test_report
+          retention-days: 2


### PR DESCRIPTION
Export a combined junit test report after testing.

This lets us easily extract the runtime of the test suite. We can use this to automatically chunk the test suite (see #129).