### PR TITLE
Allow skipped gcc13_assertions_test_report

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -198,5 +198,5 @@ jobs:
       - name: Check for successful builds and tests
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: gcc13_assertions_test
+          allowed-skips: gcc13_assertions_test, gcc13_assertions_test_report
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
`gcc13_assertions_test_report` is skipped on the main branch. It should not be checked in `ensure_all_tests_pass`.

Follows #9.