### PR TITLE
Skip `ensure_all_tests_pass` on main

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -201,10 +201,9 @@ jobs:
     needs: [gcc9_build, gcc9_test_minimal, gcc13_assertions_test, gcc13_assertions_test_report, gcc13_assertions_build,
       clang18_build, clang18_test_minimal]
     runs-on: ubuntu-latest
-    if: always()
+    if: always() && github.ref != 'refs/heads/main'
     steps:
       - name: Check for successful builds and tests
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: gcc13_assertions_test, gcc13_assertions_test_report
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
Running this job on `main` comes with the burden that we need to maintain the list of jobs that might be skipped.

We only need this job in PRs, so we can skip in on main.