### PR TITLE
Add error on not supported output case

### DIFF
--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -166,11 +166,19 @@ namespace Core::IO
         }
         case OutputEntity::element:
         {
+          if (unique_names.size() != 1)
+            FOUR_C_THROW(
+                "For now, element based output can only be written if there is only one unique "
+                "entry in the context object");
           append_element_based_result_data_vector(result_data, context_map.count(name), name);
           break;
         }
         case OutputEntity::node:
         {
+          if (unique_names.size() != 1)
+            FOUR_C_THROW(
+                "For now, node based output can only be written if there is only one unique "
+                "entry in the context object");
           append_node_based_result_data_vector(result_data, context_map.count(name), name);
           break;
         }


### PR DESCRIPTION
## Description and Context

For now, the case that multiple unique strings are provided to `DiscretizationVisualizationWriterMesh::append_result_data_vector_with_context` via the context object is only supported for DOF based output. This PR adds an error if multiple unique strings are provided for element and node based output.