### PR TITLE
Remove unnamed components from LineDefinition

### DIFF
--- a/src/ale/4C_ale_ale2.cpp
+++ b/src/ale/4C_ale_ale2.cpp
@@ -82,20 +82,26 @@ void Discret::Elements::Ale2Type::setup_element_definition(
 {
   std::map<std::string, Input::LineDefinition>& defs = definitions["ALE2"];
 
-  defs["QUAD4"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD4", 4).add_named_int("MAT").build();
+  defs["QUAD4"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD4", 4)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD8"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD8", 8).add_named_int("MAT").build();
+  defs["QUAD8"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD8", 8)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD9"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD9", 9).add_named_int("MAT").build();
+  defs["QUAD9"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD9", 9)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["TRI3"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI3", 3).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI3", 3).add_named_int("MAT").build();
 
   defs["TRI6"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI6", 6).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI6", 6).add_named_int("MAT").build();
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/ale/4C_ale_ale3.cpp
+++ b/src/ale/4C_ale_ale3.cpp
@@ -82,28 +82,40 @@ void Discret::Elements::Ale3Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["ALE3"];
 
   defs["HEX8"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX8", 8).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("HEX8", 8).add_named_int("MAT").build();
 
-  defs["HEX20"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX20", 20).add_named_int("MAT").build();
+  defs["HEX20"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("HEX20", 20)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["HEX27"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX27", 27).add_named_int("MAT").build();
+  defs["HEX27"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("HEX27", 27)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["TET4"] =
-      Input::LineDefinition::Builder().add_int_vector("TET4", 4).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TET4", 4).add_named_int("MAT").build();
 
-  defs["TET10"] =
-      Input::LineDefinition::Builder().add_int_vector("TET10", 10).add_named_int("MAT").build();
+  defs["TET10"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("TET10", 10)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["WEDGE6"] =
-      Input::LineDefinition::Builder().add_int_vector("WEDGE6", 6).add_named_int("MAT").build();
+  defs["WEDGE6"] = Input::LineDefinition::Builder()
+                       .add_named_int_vector("WEDGE6", 6)
+                       .add_named_int("MAT")
+                       .build();
 
-  defs["WEDGE15"] =
-      Input::LineDefinition::Builder().add_int_vector("WEDGE15", 15).add_named_int("MAT").build();
+  defs["WEDGE15"] = Input::LineDefinition::Builder()
+                        .add_named_int_vector("WEDGE15", 15)
+                        .add_named_int("MAT")
+                        .build();
 
-  defs["PYRAMID5"] =
-      Input::LineDefinition::Builder().add_int_vector("PYRAMID5", 5).add_named_int("MAT").build();
+  defs["PYRAMID5"] = Input::LineDefinition::Builder()
+                         .add_named_int_vector("PYRAMID5", 5)
+                         .add_named_int("MAT")
+                         .build();
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/art_net/4C_art_net_artery.cpp
+++ b/src/art_net/4C_art_net_artery.cpp
@@ -57,7 +57,7 @@ void Discret::Elements::ArteryType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["ART"];
 
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("MAT")
                       .add_named_int("GP")
                       .add_named_string("TYPE")

--- a/src/beam3/4C_beam3_euler_bernoulli.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli.cpp
@@ -209,8 +209,10 @@ void Discret::Elements::Beam3ebType::setup_element_definition(
 {
   std::map<std::string, Input::LineDefinition>& defs = definitions["BEAM3EB"];
 
-  defs["LINE2"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE2", 2).add_named_int("MAT").build();
+  defs["LINE2"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE2", 2)
+                      .add_named_int("MAT")
+                      .build();
 }
 
 /*----------------------------------------------------------------------*

--- a/src/beam3/4C_beam3_kirchhoff.cpp
+++ b/src/beam3/4C_beam3_kirchhoff.cpp
@@ -97,7 +97,7 @@ void Discret::Elements::Beam3kType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["BEAM3K"];
 
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("WK")
                       .add_named_int("ROTVEC")
                       .add_named_int("MAT")
@@ -106,7 +106,7 @@ void Discret::Elements::Beam3kType::setup_element_definition(
                       .build();
 
   defs["LINE3"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE3", 3)
+                      .add_named_int_vector("LINE3", 3)
                       .add_named_int("WK")
                       .add_named_int("ROTVEC")
                       .add_named_int("MAT")
@@ -115,7 +115,7 @@ void Discret::Elements::Beam3kType::setup_element_definition(
                       .build();
 
   defs["LINE4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE4", 4)
+                      .add_named_int_vector("LINE4", 4)
                       .add_named_int("WK")
                       .add_named_int("ROTVEC")
                       .add_named_int("MAT")

--- a/src/beam3/4C_beam3_reissner.cpp
+++ b/src/beam3/4C_beam3_reissner.cpp
@@ -109,7 +109,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   // note: LINE2 refers to linear Lagrange interpolation of centerline AND triad field
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("MAT")
                       .add_named_double_vector("TRIADS", 6)
                       .add_optional_tag("FAD")
@@ -117,7 +117,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   // note: LINE3 refers to quadratic Lagrange interpolation of centerline AND triad field
   defs["LINE3"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE3", 3)
+                      .add_named_int_vector("LINE3", 3)
                       .add_named_int("MAT")
                       .add_named_double_vector("TRIADS", 9)
                       .add_optional_tag("FAD")
@@ -125,7 +125,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   // note: LINE4 refers to cubic Lagrange interpolation of centerline AND triad field
   defs["LINE4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE4", 4)
+                      .add_named_int_vector("LINE4", 4)
                       .add_named_int("MAT")
                       .add_named_double_vector("TRIADS", 12)
                       .add_optional_tag("FAD")
@@ -133,7 +133,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   // note: LINE5 refers to quartic Lagrange interpolation of centerline AND triad field
   defs["LINE5"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE5", 5)
+                      .add_named_int_vector("LINE5", 5)
                       .add_named_int("MAT")
                       .add_named_double_vector("TRIADS", 15)
                       .add_optional_tag("FAD")
@@ -142,7 +142,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   /* note: HERM2 refers to cubic Hermite interpolation of centerline (2 nodes)
    *       LINE2 refers to linear Lagrange interpolation of the triad field*/
   defs["HERM2LINE2"] = Input::LineDefinition::Builder()
-                           .add_int_vector("HERM2LINE2", 2)
+                           .add_named_int_vector("HERM2LINE2", 2)
                            .add_named_int("MAT")
                            .add_named_double_vector("TRIADS", 6)
                            .add_optional_tag("FAD")
@@ -151,7 +151,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   /* note: HERM2 refers to cubic order Hermite interpolation of centerline (2 nodes)
    *       LINE3 refers to quadratic Lagrange interpolation of the triad field*/
   defs["HERM2LINE3"] = Input::LineDefinition::Builder()
-                           .add_int_vector("HERM2LINE3", 3)
+                           .add_named_int_vector("HERM2LINE3", 3)
                            .add_named_int("MAT")
                            .add_named_double_vector("TRIADS", 9)
                            .add_optional_tag("FAD")
@@ -160,7 +160,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   /* note: HERM2 refers to cubic Hermite interpolation of centerline (2 nodes)
    *       LINE4 refers to cubic Lagrange interpolation of the triad field*/
   defs["HERM2LINE4"] = Input::LineDefinition::Builder()
-                           .add_int_vector("HERM2LINE4", 4)
+                           .add_named_int_vector("HERM2LINE4", 4)
                            .add_named_int("MAT")
                            .add_named_double_vector("TRIADS", 12)
                            .add_optional_tag("FAD")
@@ -169,7 +169,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   /* note: HERM2 refers to cubic Hermite interpolation of centerline (2 nodes)
    *       LINE5 refers to quartic Lagrange interpolation of the triad field*/
   defs["HERM2LINE5"] = Input::LineDefinition::Builder()
-                           .add_int_vector("HERM2LINE5", 5)
+                           .add_named_int_vector("HERM2LINE5", 5)
                            .add_named_int("MAT")
                            .add_named_double_vector("TRIADS", 15)
                            .add_optional_tag("FAD")

--- a/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
@@ -277,25 +277,25 @@ CONTACT::Beam3cmanager::Beam3cmanager(Core::FE::Discretization& discret, double 
     mi_->clear();
     // read potential law parameters from input and check
     {
-      std::istringstream pot_law_exponents_stream(
+      std::string pot_law_exponents_in(
           Teuchos::getNumericStringParameter(sbeampotential_, "POT_LAW_EXPONENT"));
 
       Core::IO::ValueParser pot_law_exponents_parser(
-          pot_law_exponents_stream, "While reading potential law exponents: ");
+          pot_law_exponents_in, "While reading potential law exponents: ");
 
-      while (!pot_law_exponents_parser.eof())
+      while (!pot_law_exponents_parser.at_end())
       {
         mi_->push_back(pot_law_exponents_parser.read<double>());
       }
     }
     {
-      std::istringstream pot_law_prefactors_stream(
+      std::string pot_law_prefactors_in(
           Teuchos::getNumericStringParameter(sbeampotential_, "POT_LAW_PREFACTOR"));
 
       Core::IO::ValueParser pot_law_prefactors_parser(
-          pot_law_prefactors_stream, "While reading potential law prefactors: ");
+          pot_law_prefactors_in, "While reading potential law prefactors: ");
 
-      while (!pot_law_prefactors_parser.eof())
+      while (!pot_law_prefactors_parser.at_end())
       {
         ki_->push_back(pot_law_prefactors_parser.read<double>());
       }

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -74,13 +74,12 @@ Beam3ContactOctTree::Beam3ContactOctTree(Teuchos::ParameterList& params,
     // COBB: 1. value for axial extrusion, 2. value for radial extrusion
     // SPBB: one value for radial extrusion
 
-    std::istringstream extrusion_value_stream(
-        Teuchos::getNumericStringParameter(params, "BEAMS_EXTVAL"));
+    std::string extrusion_value_in(Teuchos::getNumericStringParameter(params, "BEAMS_EXTVAL"));
 
     Core::IO::ValueParser extrusionvalue_parser(
-        extrusion_value_stream, "While reading extrusion values: ");
+        extrusion_value_in, "While reading extrusion values: ");
 
-    while (!extrusionvalue_parser.eof())
+    while (!extrusionvalue_parser.at_end())
     {
       extrusionvalue_->push_back(extrusionvalue_parser.read<double>());
     }

--- a/src/beaminteraction/4C_beaminteraction_beam_to_beam_contact_utils.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_beam_contact_utils.cpp
@@ -306,13 +306,13 @@ double BeamInteraction::determine_searchbox_inc(Teuchos::ParameterList& beamcont
   double searchboxinc = 0.0;
 
   std::vector<double> extval(0);
-  std::istringstream extrusion_value_stream(
+  std::string extrusion_value_in(
       Teuchos::getNumericStringParameter(beamcontactparams, "BEAMS_EXTVAL"));
 
   Core::IO::ValueParser extrusionvalue_parser(
-      extrusion_value_stream, "While reading extrusion values: ");
+      extrusion_value_in, "While reading extrusion values: ");
 
-  while (!extrusionvalue_parser.eof())
+  while (!extrusionvalue_parser.at_end())
   {
     extval.push_back(extrusionvalue_parser.read<double>());
   }

--- a/src/beaminteraction/4C_beaminteraction_crosslinking_params.cpp
+++ b/src/beaminteraction/4C_beaminteraction_crosslinking_params.cpp
@@ -113,13 +113,13 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // number of linker in simulation volume
   {
     numcrosslinkerpertype_.clear();
-    std::istringstream crosslinker_type_stream(
+    std::string crosslinker_type_in(
         Teuchos::getNumericStringParameter(crosslinking_params_list, "NUMCROSSLINKERPERTYPE"));
 
     Core::IO::ValueParser crosslinker_type_parser(
-        crosslinker_type_stream, "While reading crosslinker type: ");
+        crosslinker_type_in, "While reading crosslinker type: ");
 
-    while (!crosslinker_type_parser.eof())
+    while (!crosslinker_type_parser.at_end())
     {
       numcrosslinkerpertype_.push_back(crosslinker_type_parser.read<int>());
     }
@@ -133,13 +133,13 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // material numbers for crosslinker types
   {
     matcrosslinkerpertype_.clear();
-    std::istringstream crosslinker_material_stream(
+    std::string crosslinker_material_in(
         Teuchos::getNumericStringParameter(crosslinking_params_list, "MATCROSSLINKERPERTYPE"));
 
     Core::IO::ValueParser crosslinker_material_parser(
-        crosslinker_material_stream, "While reading crosslinker material: ");
+        crosslinker_material_in, "While reading crosslinker material: ");
 
-    while (!crosslinker_material_parser.eof())
+    while (!crosslinker_material_parser.at_end())
     {
       matcrosslinkerpertype_.push_back(crosslinker_material_parser.read<int>());
     }
@@ -171,13 +171,13 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   {
     maxnum_init_crosslinker_pertype_.clear();
     std::vector<int> maxnuminitcrosslinkerpertype;
-    std::istringstream num_crosslinker_per_type_stream(Teuchos::getNumericStringParameter(
+    std::string num_crosslinker_per_type_in(Teuchos::getNumericStringParameter(
         crosslinking_params_list, "MAXNUMINITCROSSLINKERPERTYPE"));
 
     Core::IO::ValueParser num_crosslinker_per_type_parser(
-        num_crosslinker_per_type_stream, "While reading number of initial crosslinker: ");
+        num_crosslinker_per_type_in, "While reading number of initial crosslinker: ");
 
-    while (!num_crosslinker_per_type_parser.eof())
+    while (!num_crosslinker_per_type_parser.at_end())
     {
       maxnuminitcrosslinkerpertype.push_back(num_crosslinker_per_type_parser.read<int>());
     }
@@ -201,15 +201,15 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // maximal number of bonds per filament binding spot
   {
     max_num_bonds_per_filament_bspot_.clear();
-    std::istringstream max_num_bonds_per_filament_bspot_stream(Teuchos::getNumericStringParameter(
+    std::string max_num_bonds_per_filament_bspot_in(Teuchos::getNumericStringParameter(
         crosslinking_params_list, "MAXNUMBONDSPERFILAMENTBSPOT"));
 
     Core::IO::ValueParser max_num_bonds_per_filament_bspot_parser(
-        max_num_bonds_per_filament_bspot_stream,
+        max_num_bonds_per_filament_bspot_in,
         "While reading max number of bonds per filament binding spot: ");
 
     int count = 0;
-    while (!max_num_bonds_per_filament_bspot_parser.eof())
+    while (!max_num_bonds_per_filament_bspot_parser.at_end())
     {
       max_num_bonds_per_filament_bspot_[linkertypes_[count]] =
           max_num_bonds_per_filament_bspot_parser.read<int>();
@@ -229,14 +229,14 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // distance between the two binding spots on each filament the same
   {
     filamentbspotintervalglobal_.clear();
-    std::istringstream filament_interval_bspot_stream(Teuchos::getNumericStringParameter(
+    std::string filament_interval_bspot_in(Teuchos::getNumericStringParameter(
         crosslinking_params_list, "FILAMENTBSPOTINTERVALGLOBAL"));
 
     Core::IO::ValueParser filament_interval_bspot_parser(
-        filament_interval_bspot_stream, "While reading filament binding spot interval global: ");
+        filament_interval_bspot_in, "While reading filament binding spot interval global: ");
 
     int count = 0;
-    while (!filament_interval_bspot_parser.eof())
+    while (!filament_interval_bspot_parser.at_end())
     {
       filamentbspotintervalglobal_[linkertypes_[count]] =
           filament_interval_bspot_parser.read<double>();
@@ -248,14 +248,14 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // reference length
   {
     filamentbspotintervallocal_.clear();
-    std::istringstream filament_bspot_interval_local_stream(
+    std::string filament_bspot_interval_local_in(
         Teuchos::getNumericStringParameter(crosslinking_params_list, "FILAMENTBSPOTINTERVALLOCAL"));
 
-    Core::IO::ValueParser filament_bspot_interval_local_parser(filament_bspot_interval_local_stream,
-        "While reading filament binding spot interval local: ");
+    Core::IO::ValueParser filament_bspot_interval_local_parser(
+        filament_bspot_interval_local_in, "While reading filament binding spot interval local: ");
 
     int count = 0;
-    while (!filament_bspot_interval_local_parser.eof())
+    while (!filament_bspot_interval_local_parser.at_end())
     {
       filamentbspotintervallocal_[linkertypes_[count]] =
           filament_bspot_interval_local_parser.read<double>();
@@ -286,18 +286,18 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // start and end arc parameter for binding spots on a filament
   {
     filamentbspotrangeglobal_.clear();
-    std::istringstream filament_bspot_range_global_stream(
+    std::string filament_bspot_range_global_in(
         Teuchos::getNumericStringParameter(crosslinking_params_list, "FILAMENTBSPOTRANGEGLOBAL"));
 
     Core::IO::ValueParser filament_bspot_range_global_parser(
-        filament_bspot_range_global_stream, "While reading filament binding spot range global: ");
+        filament_bspot_range_global_in, "While reading filament binding spot range global: ");
 
     int count = 0;
-    while (!filament_bspot_range_global_parser.eof())
+    while (!filament_bspot_range_global_parser.at_end())
     {
       std::pair<double, double> pair;
       pair.first = filament_bspot_range_global_parser.read<double>();
-      if (!filament_bspot_range_global_parser.eof())
+      if (!filament_bspot_range_global_parser.at_end())
         pair.second = filament_bspot_range_global_parser.read<double>();
       else
         FOUR_C_THROW("Filament binding spot range needs to be specified via two values");
@@ -313,18 +313,18 @@ void BeamInteraction::CrosslinkingParams::init(Solid::TimeInt::BaseDataGlobalSta
   // start and end arc parameter for binding spots on a filament
   {
     filamentbspotrangelocal_.clear();
-    std::istringstream filament_bspot_range_local_stream(
+    std::string filament_bspot_range_local_in(
         Teuchos::getNumericStringParameter(crosslinking_params_list, "FILAMENTBSPOTRANGELOCAL"));
 
     Core::IO::ValueParser filament_bspot_range_local_parser(
-        filament_bspot_range_local_stream, "While reading filament binding spot range local: ");
+        filament_bspot_range_local_in, "While reading filament binding spot range local: ");
 
     int count = 0;
-    while (!filament_bspot_range_local_parser.eof())
+    while (!filament_bspot_range_local_parser.at_end())
     {
       std::pair<double, double> pair;
       pair.first = filament_bspot_range_local_parser.read<double>();
-      if (!filament_bspot_range_local_parser.eof())
+      if (!filament_bspot_range_local_parser.at_end())
         pair.second = filament_bspot_range_local_parser.read<double>();
       else
         FOUR_C_THROW("Filament binding spot range needs to be specified via two values");

--- a/src/beaminteraction/4C_beaminteraction_potential_params.cpp
+++ b/src/beaminteraction/4C_beaminteraction_potential_params.cpp
@@ -60,25 +60,25 @@ void BeamInteraction::BeamPotentialParams::init(const double restart_time)
   pot_law_exponents_->clear();
   // read potential law parameters from input and check
   {
-    std::istringstream pot_law_exponents_stream(
-        Teuchos::getNumericStringParameter(beam_potential_params_list, "POT_LAW_EXPONENT"));
+    std::string pot_law_exponents_in =
+        Teuchos::getNumericStringParameter(beam_potential_params_list, "POT_LAW_EXPONENT");
 
     Core::IO::ValueParser pot_law_exponents_parser(
-        pot_law_exponents_stream, "While reading potential law exponents: ");
+        pot_law_exponents_in, "While reading potential law exponents: ");
 
-    while (!pot_law_exponents_parser.eof())
+    while (!pot_law_exponents_parser.at_end())
     {
       pot_law_exponents_->push_back(pot_law_exponents_parser.read<double>());
     }
   }
   {
-    std::istringstream pot_law_prefactors_stream(
-        Teuchos::getNumericStringParameter(beam_potential_params_list, "POT_LAW_PREFACTOR"));
+    std::string pot_law_prefactors_in =
+        Teuchos::getNumericStringParameter(beam_potential_params_list, "POT_LAW_PREFACTOR");
 
     Core::IO::ValueParser pot_law_prefactors_parser(
-        pot_law_prefactors_stream, "While reading potential law prefactors: ");
+        pot_law_prefactors_in, "While reading potential law prefactors: ");
 
-    while (!pot_law_prefactors_parser.eof())
+    while (!pot_law_prefactors_parser.at_end())
     {
       pot_law_prefactors_->push_back(pot_law_prefactors_parser.read<double>());
     }

--- a/src/beaminteraction/4C_beaminteraction_spherebeamlinking_params.cpp
+++ b/src/beaminteraction/4C_beaminteraction_spherebeamlinking_params.cpp
@@ -66,13 +66,13 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // number of linker in simulation volume
   {
     maxnumlinkerpertype_.clear();
-    std::istringstream max_num_linker_per_type_stream(
+    std::string max_num_linker_per_type_in(
         Teuchos::getNumericStringParameter(spherebeamlink_params_list, "MAXNUMLINKERPERTYPE"));
 
     Core::IO::ValueParser max_num_linker_per_type_parser(
-        max_num_linker_per_type_stream, "While reading max number of linker per type: ");
+        max_num_linker_per_type_in, "While reading max number of linker per type: ");
 
-    while (!max_num_linker_per_type_parser.eof())
+    while (!max_num_linker_per_type_parser.at_end())
     {
       maxnumlinkerpertype_.push_back(max_num_linker_per_type_parser.read<int>());
     }
@@ -86,13 +86,13 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // material numbers for crosslinker types
   {
     matlinkerpertype_.clear();
-    std::istringstream material_linker_per_type_stream(
+    std::string material_linker_per_type_in(
         Teuchos::getNumericStringParameter(spherebeamlink_params_list, "MATLINKERPERTYPE"));
 
     Core::IO::ValueParser material_linker_per_type_parser(
-        material_linker_per_type_stream, "While reading material number for linker type: ");
+        material_linker_per_type_in, "While reading material number for linker type: ");
 
-    while (!material_linker_per_type_parser.eof())
+    while (!material_linker_per_type_parser.at_end())
     {
       matlinkerpertype_.push_back(material_linker_per_type_parser.read<int>());
     }
@@ -129,14 +129,14 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // store contraction rate, each linker type (not material) can have its own
   {
     contractionrate_.clear();
-    std::istringstream contraction_rate_stream(
+    std::string contraction_rate_in(
         Teuchos::getNumericStringParameter(spherebeamlink_params_list, "CONTRACTIONRATE"));
 
     Core::IO::ValueParser contraction_rate_parser(
-        contraction_rate_stream, "While reading contraction rate: ");
+        contraction_rate_in, "While reading contraction rate: ");
 
     int count = 0;
-    while (!contraction_rate_parser.eof())
+    while (!contraction_rate_parser.at_end())
     {
       contractionrate_[linkertypes_[count]] = contraction_rate_parser.read<double>();
       ++count;
@@ -149,15 +149,14 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // distance between the two binding spots on each filament the same
   {
     filamentbspotintervalglobal_.clear();
-    std::istringstream filament_bspot_interval_global_stream(Teuchos::getNumericStringParameter(
+    std::string filament_bspot_interval_global_in(Teuchos::getNumericStringParameter(
         spherebeamlink_params_list, "FILAMENTBSPOTINTERVALGLOBAL"));
 
     Core::IO::ValueParser filament_bspot_interval_global_parser(
-        filament_bspot_interval_global_stream,
-        "While reading filament binding spot interval global: ");
+        filament_bspot_interval_global_in, "While reading filament binding spot interval global: ");
 
     int count = 0;
-    while (!filament_bspot_interval_global_parser.eof())
+    while (!filament_bspot_interval_global_parser.at_end())
     {
       filamentbspotintervalglobal_[linkertypes_[count]] =
           filament_bspot_interval_global_parser.read<double>();
@@ -169,14 +168,14 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // reference length
   {
     filamentbspotintervallocal_.clear();
-    std::istringstream filament_bspot_interval_local_stream(Teuchos::getNumericStringParameter(
+    std::string filament_bspot_interval_local_in(Teuchos::getNumericStringParameter(
         spherebeamlink_params_list, "FILAMENTBSPOTINTERVALLOCAL"));
 
-    Core::IO::ValueParser filament_bspot_interval_local_parser(filament_bspot_interval_local_stream,
-        "While reading filament binding spot interval local: ");
+    Core::IO::ValueParser filament_bspot_interval_local_parser(
+        filament_bspot_interval_local_in, "While reading filament binding spot interval local: ");
 
     int count = 0;
-    while (!filament_bspot_interval_local_parser.eof())
+    while (!filament_bspot_interval_local_parser.at_end())
     {
       filamentbspotintervallocal_[linkertypes_[count]] =
           filament_bspot_interval_local_parser.read<double>();
@@ -207,18 +206,18 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // start and end arc parameter for binding spots on a filament
   {
     filamentbspotrangeglobal_.clear();
-    std::istringstream filament_bspot_range_global_stream(
+    std::string filament_bspot_range_global_in(
         Teuchos::getNumericStringParameter(spherebeamlink_params_list, "FILAMENTBSPOTRANGEGLOBAL"));
 
     Core::IO::ValueParser filament_bspot_range_global_parser(
-        filament_bspot_range_global_stream, "While reading filament binding spot range global: ");
+        filament_bspot_range_global_in, "While reading filament binding spot range global: ");
 
     int count = 0;
-    while (!filament_bspot_range_global_parser.eof())
+    while (!filament_bspot_range_global_parser.at_end())
     {
       std::pair<double, double> pair;
       pair.first = filament_bspot_range_global_parser.read<double>();
-      if (!filament_bspot_range_global_parser.eof())
+      if (!filament_bspot_range_global_parser.at_end())
         pair.second = filament_bspot_range_global_parser.read<double>();
       else
         FOUR_C_THROW("Filament binding spot range needs to be specified via two values");
@@ -236,18 +235,18 @@ void BeamInteraction::SphereBeamLinkingParams::init(
   // start and end arc parameter for binding spots on a filament
   {
     filamentbspotrangelocal_.clear();
-    std::istringstream filament_bspot_range_local_stream(
+    std::string filament_bspot_range_local_in(
         Teuchos::getNumericStringParameter(spherebeamlink_params_list, "FILAMENTBSPOTRANGELOCAL"));
 
     Core::IO::ValueParser filament_bspot_range_local_parser(
-        filament_bspot_range_local_stream, "While reading filament binding spot range local: ");
+        filament_bspot_range_local_in, "While reading filament binding spot range local: ");
 
     int count = 0;
-    while (!filament_bspot_range_local_parser.eof())
+    while (!filament_bspot_range_local_parser.at_end())
     {
       std::pair<double, double> pair;
       pair.first = filament_bspot_range_local_parser.read<double>();
-      if (!filament_bspot_range_local_parser.eof())
+      if (!filament_bspot_range_local_parser.at_end())
         pair.second = filament_bspot_range_local_parser.read<double>();
       else
         FOUR_C_THROW("Filament binding spot range needs to be specified via two values");

--- a/src/bele/4C_bele_bele3.cpp
+++ b/src/bele/4C_bele_bele3.cpp
@@ -94,54 +94,54 @@ void Discret::Elements::Bele3Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs3 = definitions["BELE3_3"];
 
   defs3["TRI3"] = Input::LineDefinition::Builder()
-                      .add_int_vector("TRI3", 3)
+                      .add_named_int_vector("TRI3", 3)
                       .add_optional_named_int("MAT")
                       .build();
 
   defs3["TRI6"] = Input::LineDefinition::Builder()
-                      .add_int_vector("TRI6", 6)
+                      .add_named_int_vector("TRI6", 6)
                       .add_optional_named_int("MAT")
                       .build();
 
   defs3["QUAD4"] = Input::LineDefinition::Builder()
-                       .add_int_vector("QUAD4", 4)
+                       .add_named_int_vector("QUAD4", 4)
                        .add_optional_named_int("MAT")
                        .build();
 
   defs3["QUAD8"] = Input::LineDefinition::Builder()
-                       .add_int_vector("QUAD8", 8)
+                       .add_named_int_vector("QUAD8", 8)
                        .add_optional_named_int("MAT")
                        .build();
 
   defs3["QUAD9"] = Input::LineDefinition::Builder()
-                       .add_int_vector("QUAD9", 9)
+                       .add_named_int_vector("QUAD9", 9)
                        .add_optional_named_int("MAT")
                        .build();
 
   std::map<std::string, Input::LineDefinition>& defs4 = definitions["BELE3_4"];
 
   defs4["TRI3"] = Input::LineDefinition::Builder()
-                      .add_int_vector("TRI3", 3)
+                      .add_named_int_vector("TRI3", 3)
                       .add_optional_named_int("MAT")
                       .build();
 
   defs4["TRI6"] = Input::LineDefinition::Builder()
-                      .add_int_vector("TRI6", 6)
+                      .add_named_int_vector("TRI6", 6)
                       .add_optional_named_int("MAT")
                       .build();
 
   defs4["QUAD4"] = Input::LineDefinition::Builder()
-                       .add_int_vector("QUAD4", 4)
+                       .add_named_int_vector("QUAD4", 4)
                        .add_optional_named_int("MAT")
                        .build();
 
   defs4["QUAD8"] = Input::LineDefinition::Builder()
-                       .add_int_vector("QUAD8", 8)
+                       .add_named_int_vector("QUAD8", 8)
                        .add_optional_named_int("MAT")
                        .build();
 
   defs4["QUAD9"] = Input::LineDefinition::Builder()
-                       .add_int_vector("QUAD9", 9)
+                       .add_named_int_vector("QUAD9", 9)
                        .add_optional_named_int("MAT")
                        .build();
 }

--- a/src/bele/4C_bele_vele3.cpp
+++ b/src/bele/4C_bele_vele3.cpp
@@ -68,7 +68,7 @@ void Discret::Elements::Vele3Type::setup_element_definition(
 {
   std::map<std::string, Input::LineDefinition>& defs = definitions["VELE3"];
 
-  defs["HEX8"] = Input::LineDefinition::Builder().add_int_vector("HEX8", 8).build();
+  defs["HEX8"] = Input::LineDefinition::Builder().add_named_int_vector("HEX8", 8).build();
 }
 
 std::shared_ptr<Core::Elements::Element> Discret::Elements::Vele3SurfaceType::create(

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator_data.cpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator_data.cpp
@@ -62,7 +62,7 @@ void Solid::ModelEvaluator::BrownianDynData::init(
   // if input file is chosen, get the required values and check them for sanity
   if (beam_damping_coeff_specified_via_ == Inpar::BrownianDynamics::input_file)
   {
-    std::istringstream input_file_linecontent(Teuchos::getNumericStringParameter(
+    std::string input_file_linecontent(Teuchos::getNumericStringParameter(
         browndyn_params_list, "BEAMS_DAMPING_COEFF_PER_UNITLENGTH"));
 
     Core::IO::ValueParser beam_dampening_coefficients_parser(input_file_linecontent,
@@ -72,7 +72,7 @@ void Solid::ModelEvaluator::BrownianDynData::init(
     beams_damping_coefficient_prefactors_perunitlength_ =
         beam_dampening_coefficients_parser.read_array<double, 3>();
 
-    if (!beam_dampening_coefficients_parser.eof())
+    if (!beam_dampening_coefficients_parser.at_end())
     {
       FOUR_C_THROW(
           "Too many values for beam damping coefficients are provided within the input file!");

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_constitutivelaw_definition.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_constitutivelaw_definition.cpp
@@ -38,24 +38,11 @@ void CONTACT::CONSTITUTIVELAW::LawDefinition::read(const Global::Problem& proble
 {
   for (const auto& i : input.lines_in_section("CONTACT CONSTITUTIVE LAWS"))
   {
-    std::shared_ptr<std::stringstream> condline =
-        std::make_shared<std::stringstream>(std::string{i});
-
-    // add trailing white space to stringstream "condline" to avoid deletion of stringstream upon
-    // reading the last entry inside This is required since the material parameters can be
-    // specified in an arbitrary order in the input file. So it might happen that the last entry
-    // is extracted before all of the previous ones are.
-    condline->seekp(0, condline->end);
-    *condline << " ";
-
-    Core::IO::ValueParser parser(*condline, "While reading 'CONTACT CONSTITUTIVE LAWS' section: ");
+    Core::IO::ValueParser parser(i, "While reading 'CONTACT CONSTITUTIVE LAWS' section: ");
 
     parser.consume("LAW");
     const int id = parser.read<int>();
     const std::string name = parser.read<std::string>();
-
-    // Remove the parts that were already read.
-    condline->str(condline->str().erase(0, (size_t)condline->tellg()));
 
     if (name == coconstlawname_)
     {
@@ -70,6 +57,16 @@ void CONTACT::CONSTITUTIVELAW::LawDefinition::read(const Global::Problem& proble
           std::make_shared<CONTACT::CONSTITUTIVELAW::Container>(
               id, coconstlawtype_, coconstlawname_);
       // fill the latter
+
+      std::shared_ptr<std::stringstream> condline =
+          std::make_shared<std::stringstream>(std::string{parser.get_unparsed_remainder()});
+
+      // add trailing white space to stringstream "condline" to avoid deletion of stringstream upon
+      // reading the last entry inside This is required since the material parameters can be
+      // specified in an arbitrary order in the input file. So it might happen that the last entry
+      // is extracted before all of the previous ones are.
+      condline->seekp(0, condline->end);
+      *condline << " ";
 
       for (const auto& j : inputline_)
         condline = j->read(LawDefinition::name(), condline, *container);

--- a/src/core/fem/src/general/element/4C_fem_general_element_definition.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element_definition.cpp
@@ -139,7 +139,7 @@ void Core::Elements::ElementDefinition::print_element_lines(std::ostream& stream
     for (std::map<std::string, Input::LineDefinition>::iterator i = defs.begin(); i != defs.end();
          ++i)
     {
-      stream << "// 0 " << name << " " << i->first << " ";
+      stream << "// 0 " << name << " ";
       i->second.print(stream);
       stream << '\n';
     }

--- a/src/core/io/src/4C_io_gridgenerator.cpp
+++ b/src/core/io/src/4C_io_gridgenerator.cpp
@@ -158,7 +158,8 @@ namespace Core::IO::GridGenerator
     const std::string argument_line = std::invoke(
         [&]()
         {
-          std::stringstream eleargstream(inputData.distype_);
+          std::ostringstream eleargstream;
+          eleargstream << inputData.distype_;
           const int num_nodes = Core::FE::cell_type_switch(
               distype_enum, [](auto cell_type_t) { return Core::FE::num_nodes<cell_type_t()>; });
           for (int i = 0; i < num_nodes; ++i)
@@ -185,9 +186,7 @@ namespace Core::IO::GridGenerator
       std::istringstream eleargstream(argument_line);
       if (not linedef->read(eleargstream))
       {
-        Core::IO::cout << "\n"
-                       << eleid << " " << inputData.elementtype_ << " " << inputData.distype_
-                       << " ";
+        Core::IO::cout << "\n" << eleid << " " << inputData.elementtype_ << " ";
         linedef->print(Core::IO::cout.cout_replacement());
         Core::IO::cout << "\n";
         FOUR_C_THROW("failed to read element %d %s %s", eleid, inputData.elementtype_.c_str(),

--- a/src/core/io/src/4C_io_linedefinition.cpp
+++ b/src/core/io/src/4C_io_linedefinition.cpp
@@ -584,28 +584,10 @@ namespace Input
 
 
 
-  LineDefinition::Builder& LineDefinition::Builder::add_int(std::string name)
-  {
-    pimpl_->components_.emplace_back(
-        Internal::GenericComponent<int>{std::move(name), 0, Internal::Behavior::ignore_name});
-    return *this;
-  }
-
-
-
   LineDefinition::Builder& LineDefinition::Builder::add_int_vector(std::string name, int length)
   {
     pimpl_->components_.emplace_back(Internal::GenericComponent(
         std::move(name), std::vector<int>(length), Internal::Behavior::ignore_name));
-    return *this;
-  }
-
-
-
-  LineDefinition::Builder& LineDefinition::Builder::add_double_vector(std::string name, int length)
-  {
-    pimpl_->components_.emplace_back(Internal::GenericComponent(
-        std::move(name), std::vector<double>(length), Internal::Behavior::ignore_name));
     return *this;
   }
 

--- a/src/core/io/src/4C_io_linedefinition.cpp
+++ b/src/core/io/src/4C_io_linedefinition.cpp
@@ -575,15 +575,6 @@ namespace Input
 
 
 
-  LineDefinition::Builder& LineDefinition::Builder::add_int_vector(std::string name, int length)
-  {
-    pimpl_->components_.emplace_back(Internal::GenericComponent(
-        std::move(name), std::vector<int>(length), Internal::Behavior::ignore_name));
-    return *this;
-  }
-
-
-
   LineDefinition::Builder& LineDefinition::Builder::add_named_string(std::string name)
   {
     pimpl_->components_.emplace_back(

--- a/src/core/io/src/4C_io_linedefinition.cpp
+++ b/src/core/io/src/4C_io_linedefinition.cpp
@@ -575,15 +575,6 @@ namespace Input
 
 
 
-  LineDefinition::Builder& LineDefinition::Builder::add_string(std::string name)
-  {
-    pimpl_->components_.emplace_back(Internal::GenericComponent<std::string>{
-        std::move(name), "''", Internal::Behavior::ignore_name});
-    return *this;
-  }
-
-
-
   LineDefinition::Builder& LineDefinition::Builder::add_int_vector(std::string name, int length)
   {
     pimpl_->components_.emplace_back(Internal::GenericComponent(
@@ -633,6 +624,16 @@ namespace Input
   {
     pimpl_->components_.emplace_back(
         Internal::GenericComponent(std::move(name), std::vector<double>(length)));
+    return *this;
+  }
+
+
+
+  LineDefinition::Builder& LineDefinition::Builder::add_named_string_vector(
+      std::string name, int length)
+  {
+    pimpl_->components_.emplace_back(
+        Internal::GenericComponent(std::move(name), std::vector<std::string>(length)));
     return *this;
   }
 

--- a/src/core/io/src/4C_io_linedefinition.hpp
+++ b/src/core/io/src/4C_io_linedefinition.hpp
@@ -154,14 +154,8 @@ namespace Input
       /// Add a single string variable
       Builder& add_string(std::string name);
 
-      /// Add a single integer variable
-      Builder& add_int(std::string name);
-
       /// Add a vector of integer variables
       Builder& add_int_vector(std::string name, int length);
-
-      /// Add a vector of double variables
-      Builder& add_double_vector(std::string name, int length);
 
       /// Add a name followed by a variable string
       Builder& add_named_string(std::string name);

--- a/src/core/io/src/4C_io_linedefinition.hpp
+++ b/src/core/io/src/4C_io_linedefinition.hpp
@@ -151,9 +151,6 @@ namespace Input
       /// Add a single string definition without a value.
       Builder& add_tag(std::string name);
 
-      /// Add a vector of integer variables
-      Builder& add_int_vector(std::string name, int length);
-
       /// Add a name followed by a variable string
       Builder& add_named_string(std::string name);
 

--- a/src/core/io/src/4C_io_linedefinition.hpp
+++ b/src/core/io/src/4C_io_linedefinition.hpp
@@ -151,9 +151,6 @@ namespace Input
       /// Add a single string definition without a value.
       Builder& add_tag(std::string name);
 
-      /// Add a single string variable
-      Builder& add_string(std::string name);
-
       /// Add a vector of integer variables
       Builder& add_int_vector(std::string name, int length);
 
@@ -171,6 +168,9 @@ namespace Input
 
       /// Add a name followed by a vector of double variables
       Builder& add_named_double_vector(std::string name, int length);
+
+      /// Add a name followed by a vector of double variables
+      Builder& add_named_string_vector(std::string name, int length);
 
       /*!
        * Add a name followed by a vector of double variables.

--- a/src/core/io/src/4C_io_value_parser.cpp
+++ b/src/core/io/src/4C_io_value_parser.cpp
@@ -1,0 +1,94 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_io_value_parser.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  //! Helper to find the next token and update the given @p index into the line.
+  std::string_view advance_token_impl(std::string_view line, std::size_t& index)
+  {
+    // Skip whitespace
+    while (index < line.size() && std::isspace(line[index])) ++index;
+
+    // Find the end of the token
+    std::size_t start_of_token = index;
+    while (index < line.size() && !std::isspace(line[index])) ++index;
+
+    return line.substr(start_of_token, index - start_of_token);
+  }
+}  // namespace
+
+
+void Core::IO::Internal::parse(std::string_view string, int& value)
+{
+  std::string string_copy(string);
+  std::size_t end;
+  value = std::stoi(string_copy.data(), &end);
+  if (end != string_copy.size())
+    FOUR_C_THROW("Could not parse '%s' as an integer value.", string_copy.c_str());
+}
+
+void Core::IO::Internal::parse(std::string_view string, double& value)
+{
+  std::string string_copy(string);
+  std::size_t end;
+  value = std::stod(string_copy.data(), &end);
+  if (end != string_copy.size())
+    FOUR_C_THROW("Could not parse '%s' as a double value.", string_copy.c_str());
+}
+
+void Core::IO::Internal::parse(std::string_view string, std::string& value)
+{
+  value = std::string(string);
+}
+
+Core::IO::ValueParser::ValueParser(std::string_view line, std::string user_scope_message)
+    : line_(line), user_scope_(std::move(user_scope_message))
+{
+}
+
+
+void Core::IO::ValueParser::consume(const std::string& expected)
+{
+  std::string_view read_string = advance_token();
+  if (read_string != std::string_view(expected))
+    FOUR_C_THROW("%sCould not read expected string '%s'.", user_scope_.c_str(), expected.c_str());
+}
+
+
+std::string_view Core::IO::ValueParser::peek() const
+{
+  // Copy the current index to avoid modifying the parser state
+  std::size_t temp_index = current_index_;
+  return advance_token_impl(line_, temp_index);
+}
+
+
+bool Core::IO::ValueParser::at_end() const { return current_index_ == line_.size(); }
+
+
+std::string_view Core::IO::ValueParser::get_unparsed_remainder() const
+{
+  return line_.substr(current_index_);
+}
+
+
+std::string_view Core::IO::ValueParser::advance_token()
+{
+  auto token = advance_token_impl(line_, current_index_);
+
+  FOUR_C_ASSERT_ALWAYS(!token.empty(), "%sExpected more tokens, but reached the end of the line.",
+      user_scope_.c_str());
+
+  return token;
+}
+
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/tests/4C_io_linedefinition_test.cpp
+++ b/src/core/io/tests/4C_io_linedefinition_test.cpp
@@ -80,35 +80,6 @@ namespace
     EXPECT_FALSE(line_definition.read(input));
   }
 
-  // Int
-  TEST(LineDefinitionTest, add_int)
-  {
-    std::istringstream input("1");
-    auto line_definition = Input::LineDefinition::Builder().add_int("OMEGA").build();
-    EXPECT_TRUE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenIntRequiredButNothingGiven)
-  {
-    std::istringstream input("");
-    auto line_definition = Input::LineDefinition::Builder().add_int("OMEGA").build();
-    EXPECT_FALSE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenIntRequiredButDoubleGiven)
-  {
-    std::istringstream input("1.23");
-    auto line_definition = Input::LineDefinition::Builder().add_int("OMEGA").build();
-    EXPECT_ANY_THROW(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenIntConcatenatedWithSomething)
-  {
-    std::istringstream input("1*8e+2");
-    auto line_definition = Input::LineDefinition::Builder().add_int("OMEGA").build();
-    EXPECT_ANY_THROW(line_definition.read(input));
-  }
-
   // Int Vector
   TEST(LineDefinitionTest, add_int_vector)
   {
@@ -136,28 +107,6 @@ namespace
     std::istringstream input("1.23 2.34 3.45");
     auto line_definition = Input::LineDefinition::Builder().add_int_vector("OMEGA", 3).build();
     EXPECT_ANY_THROW(line_definition.read(input));
-  }
-
-  // Double Vector
-  TEST(LineDefinitionTest, add_double_vector)
-  {
-    std::istringstream input("1 2 3");
-    auto line_definition = Input::LineDefinition::Builder().add_double_vector("OMEGA", 3).build();
-    EXPECT_TRUE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenDoubleVectorRequiredButTooFewVectorEntriesGiven)
-  {
-    std::istringstream input("1 2");
-    auto line_definition = Input::LineDefinition::Builder().add_double_vector("OMEGA", 3).build();
-    EXPECT_FALSE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenDoubleVectorRequiredButTooManyVectorEntriesGiven)
-  {
-    std::istringstream input("1 2 3 4");
-    auto line_definition = Input::LineDefinition::Builder().add_double_vector("OMEGA", 3).build();
-    EXPECT_FALSE(line_definition.read(input));
   }
 
   // Named String
@@ -405,7 +354,6 @@ namespace
     std::ostringstream out;
     Input::LineDefinition::Builder()
         .add_tag("abc")
-        .add_int("i")
         .add_named_double("d")
         .add_named_int_vector("iv", 3)
         .add_optional_named_string_vector("s", 2)
@@ -414,6 +362,6 @@ namespace
         .build()
         .print(out);
 
-    EXPECT_EQ(out.str(), "abc 0 d 0 iv 0 0 0  [ pairs [...] s '' ''  ] ");
+    EXPECT_EQ(out.str(), "abc d 0 iv 0 0 0  [ pairs [...] s '' ''  ] ");
   }
 }  // namespace

--- a/src/core/io/tests/4C_io_linedefinition_test.cpp
+++ b/src/core/io/tests/4C_io_linedefinition_test.cpp
@@ -65,21 +65,6 @@ namespace
     EXPECT_FALSE(line_definition.read(input));
   }
 
-  // String
-  TEST(LineDefinitionTest, add_string)
-  {
-    std::istringstream input("OMEGA");
-    auto line_definition = Input::LineDefinition::Builder().add_string("OMEGA").build();
-    EXPECT_TRUE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenStringRequiredButNothingGiven)
-  {
-    std::istringstream input("");
-    auto line_definition = Input::LineDefinition::Builder().add_string("OMEGA").build();
-    EXPECT_FALSE(line_definition.read(input));
-  }
-
   // Int Vector
   TEST(LineDefinitionTest, add_int_vector)
   {
@@ -157,6 +142,22 @@ namespace
   {
     std::istringstream input("1");
     auto line_definition = Input::LineDefinition::Builder().add_named_int("OMEGA").build();
+    EXPECT_FALSE(line_definition.read(input));
+  }
+
+  TEST(LineDefinitionTest, add_named_string_vector)
+  {
+    std::istringstream input("OMEGA TEST1 TEST2 TEST3 TEST4 TEST5");
+    auto line_definition =
+        Input::LineDefinition::Builder().add_named_string_vector("OMEGA", 5).build();
+    EXPECT_TRUE(line_definition.read(input));
+  }
+
+  TEST(LineDefinitionTest, ReadFalseWhenNamedStringVectorRequiredButTooFewVectorEntriesGiven)
+  {
+    std::istringstream input("OMEGA TEST1 TEST2 TEST3 TEST4");
+    auto line_definition =
+        Input::LineDefinition::Builder().add_named_string_vector("OMEGA", 5).build();
     EXPECT_FALSE(line_definition.read(input));
   }
 

--- a/src/core/io/tests/4C_io_linedefinition_test.cpp
+++ b/src/core/io/tests/4C_io_linedefinition_test.cpp
@@ -65,35 +65,6 @@ namespace
     EXPECT_FALSE(line_definition.read(input));
   }
 
-  // Int Vector
-  TEST(LineDefinitionTest, add_int_vector)
-  {
-    std::istringstream input("1 2 3");
-    auto line_definition = Input::LineDefinition::Builder().add_int_vector("OMEGA", 3).build();
-    EXPECT_TRUE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenIntVectorRequiredButTooFewVectorEntriesGiven)
-  {
-    std::istringstream input("1 2");
-    auto line_definition = Input::LineDefinition::Builder().add_int_vector("OMEGA", 3).build();
-    EXPECT_FALSE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenIntVectorRequiredButTooManyVectorEntriesGiven)
-  {
-    std::istringstream input("1 2 3 4");
-    auto line_definition = Input::LineDefinition::Builder().add_int_vector("OMEGA", 3).build();
-    EXPECT_FALSE(line_definition.read(input));
-  }
-
-  TEST(LineDefinitionTest, ReadFalseWhenIntVectorRequiredButDoubleVectorEntriesGiven)
-  {
-    std::istringstream input("1.23 2.34 3.45");
-    auto line_definition = Input::LineDefinition::Builder().add_int_vector("OMEGA", 3).build();
-    EXPECT_ANY_THROW(line_definition.read(input));
-  }
-
   // Named String
   TEST(LineDefinitionTest, add_named_string)
   {

--- a/src/core/io/tests/4C_io_value_parser_test.cpp
+++ b/src/core/io/tests/4C_io_value_parser_test.cpp
@@ -15,109 +15,109 @@ namespace
 
   TEST(ValueParser, ConsumeSuccess)
   {
-    std::istringstream string_stream("expected");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("expected");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
     parser.consume("expected");
   }
 
   TEST(ValueParser, ConsumeFail)
   {
-    std::istringstream string_stream("unexpected");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("unexpected");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
     EXPECT_ANY_THROW(parser.consume("expected"));
   }
 
   TEST(ValueParser, ReadDoubleSuccess)
   {
-    std::istringstream string_stream("11.3");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("11.3");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_EQ(parser.read<double>(), 11.3);
   }
 
   TEST(ValueParser, ReadIntSuccess)
   {
-    std::istringstream string_stream("42");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("42");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_EQ(parser.read<int>(), 42);
   }
 
   TEST(ValueParser, ReadDoubleFromIntSuccess)
   {
-    std::istringstream string_stream("42");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("42");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_EQ(parser.read<double>(), 42);
   }
 
   TEST(ValueParser, ReadIntFromDoubleFail)
   {
-    std::istringstream string_stream("11.3");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("11.3");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_ANY_THROW(parser.read<int>());
   }
 
   TEST(ValueParser, ReadFailWithExtraCharacters)
   {
-    std::istringstream string_stream("11.3*2");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("11.3*2");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_ANY_THROW(parser.read<double>());
   }
 
   TEST(ValueParser, ReadExtraCharactersAfterWhitespaceCheckEOF)
   {
-    std::istringstream string_stream("11.3 3");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("11.3 3");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_EQ(parser.read<double>(), 11.3);
-    EXPECT_FALSE(parser.eof());
+    EXPECT_FALSE(parser.at_end());
   }
 
   TEST(ValueParser, ReadIntArraySuccess)
   {
-    std::istringstream string_stream("1 2 3");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("1 2 3");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     const auto array = parser.read_array<int, 3>();
 
     EXPECT_EQ(array[0], 1);
     EXPECT_EQ(array[1], 2);
     EXPECT_EQ(array[2], 3);
-    EXPECT_TRUE(parser.eof());
+    EXPECT_TRUE(parser.at_end());
   }
 
   TEST(ValueParser, ReadIntArrayFailTooLong)
   {
-    std::istringstream string_stream("1 2 3 4");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("1 2 3 4");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     parser.read_array<int, 3>();
-    EXPECT_FALSE(parser.eof());
+    EXPECT_FALSE(parser.at_end());
   }
 
   TEST(ValueParser, ReadIntArrayFailTooShort)
   {
-    std::istringstream string_stream("1 2");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("1 2");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_ANY_THROW((parser.read_array<int, 3>()));
   }
 
   TEST(ValueParser, ReadIntArrayFailOtherCharacters)
   {
-    std::istringstream string_stream("1 2 a");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("1 2 a");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     EXPECT_ANY_THROW((parser.read_array<int, 3>()));
   }
 
   TEST(ValueParser, ReadCombinedIntStringArraySuccess)
   {
-    std::istringstream string_stream("1 2 3 a b c");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("1 2 3 a b c");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     const auto ints = parser.read_array<int, 3>();
     const auto strings = parser.read_array<std::string, 3>();
@@ -128,18 +128,18 @@ namespace
     EXPECT_EQ(strings[0], "a");
     EXPECT_EQ(strings[1], "b");
     EXPECT_EQ(strings[2], "c");
-    EXPECT_TRUE(parser.eof());
+    EXPECT_TRUE(parser.at_end());
   }
 
   TEST(ValueParser, ReadDoubleVectorSuccess)
   {
     // read a vector of doubles with not specified size
-    std::istringstream string_stream("0.1 0.2 0.3 0.4 0.5 0.6");
-    Core::IO::ValueParser parser(string_stream, "While reading section MY PARAMETERS: ");
+    std::string_view in("0.1 0.2 0.3 0.4 0.5 0.6");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
 
     std::vector<double> vec;
 
-    while (!parser.eof())
+    while (!parser.at_end())
     {
       vec.push_back(parser.read<double>());
     }
@@ -148,6 +148,55 @@ namespace
     {
       EXPECT_DOUBLE_EQ(vec[i], 0.1 * (i + 1));
     }
+  }
+
+  TEST(ValueParser, Unparsed)
+  {
+    std::string_view in("a 1 b 2 c 3");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
+
+    parser.consume("a");
+    parser.read<int>();
+    parser.consume("b");
+
+    EXPECT_FALSE(parser.at_end());
+
+    std::string unparsed = std::string(parser.get_unparsed_remainder());
+
+    Core::IO::ValueParser parser2(unparsed, "While reading section MY PARAMETERS: ");
+
+    parser2.read<int>();
+    parser2.consume("c");
+    parser2.read<int>();
+
+    EXPECT_TRUE(parser2.at_end());
+  }
+
+  TEST(ValueParser, Peek)
+  {
+    std::string_view in("a 1");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
+
+    EXPECT_EQ(parser.peek(), "a");
+    parser.consume("a");
+    EXPECT_EQ(parser.peek(), "1");
+
+    // Peek should not consume the token.
+    EXPECT_EQ(parser.get_unparsed_remainder(), " 1");
+
+    // Now consume it.
+    EXPECT_EQ(parser.read<int>(), 1);
+  }
+
+  TEST(ValueParser, ParseEmpty)
+  {
+    std::string_view in("");
+    Core::IO::ValueParser parser(in, "While reading section MY PARAMETERS: ");
+
+    EXPECT_EQ(parser.peek(), "");
+    EXPECT_TRUE(parser.at_end());
+
+    EXPECT_ANY_THROW(parser.consume("a"));
   }
 
 

--- a/src/elemag/4C_elemag_diff_ele.cpp
+++ b/src/elemag/4C_elemag_diff_ele.cpp
@@ -98,14 +98,14 @@ void Discret::Elements::ElemagDiffType::setup_element_definition(
 
   // 3D elements
   defs["HEX8"] = Input::LineDefinition::Builder()
-                     .add_int_vector("HEX8", 8)
+                     .add_named_int_vector("HEX8", 8)
                      .add_named_int("MAT")
                      .add_named_int("DEG")
                      .add_named_int("SPC")
                      .build();
 
   defs["TET4"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TET4", 4)
+                     .add_named_int_vector("TET4", 4)
                      .add_named_int("MAT")
                      .add_named_int("DEG")
                      .add_named_int("SPC")
@@ -113,21 +113,21 @@ void Discret::Elements::ElemagDiffType::setup_element_definition(
 
   // 2D elements
   defs["QUAD4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD4", 4)
+                      .add_named_int_vector("QUAD4", 4)
                       .add_named_int("MAT")
                       .add_named_int("DEG")
                       .add_named_int("SPC")
                       .build();
 
   defs["QUAD9"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD9", 9)
+                      .add_named_int_vector("QUAD9", 9)
                       .add_named_int("MAT")
                       .add_named_int("DEG")
                       .add_named_int("SPC")
                       .build();
 
   defs["TRI3"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI3", 3)
+                     .add_named_int_vector("TRI3", 3)
                      .add_named_int("MAT")
                      .add_named_int("DEG")
                      .add_named_int("SPC")

--- a/src/elemag/4C_elemag_ele.cpp
+++ b/src/elemag/4C_elemag_ele.cpp
@@ -92,14 +92,14 @@ void Discret::Elements::ElemagType::setup_element_definition(
 
   // 3D elements
   defs["HEX8"] = Input::LineDefinition::Builder()
-                     .add_int_vector("HEX8", 8)
+                     .add_named_int_vector("HEX8", 8)
                      .add_named_int("MAT")
                      .add_named_int("DEG")
                      .add_named_int("SPC")
                      .build();
 
   defs["TET4"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TET4", 4)
+                     .add_named_int_vector("TET4", 4)
                      .add_named_int("MAT")
                      .add_named_int("DEG")
                      .add_named_int("SPC")
@@ -107,21 +107,21 @@ void Discret::Elements::ElemagType::setup_element_definition(
 
   // 2D elements
   defs["QUAD4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD4", 4)
+                      .add_named_int_vector("QUAD4", 4)
                       .add_named_int("MAT")
                       .add_named_int("DEG")
                       .add_named_int("SPC")
                       .build();
 
   defs["QUAD9"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD9", 9)
+                      .add_named_int_vector("QUAD9", 9)
                       .add_named_int("MAT")
                       .add_named_int("DEG")
                       .add_named_int("SPC")
                       .build();
 
   defs["TRI3"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI3", 3)
+                     .add_named_int_vector("TRI3", 3)
                      .add_named_int("MAT")
                      .add_named_int("DEG")
                      .add_named_int("SPC")

--- a/src/fluid_ele/4C_fluid_ele.cpp
+++ b/src/fluid_ele/4C_fluid_ele.cpp
@@ -74,104 +74,104 @@ void Discret::Elements::FluidType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defsgeneral = definitions["FLUID"];
 
   defsgeneral["HEX8"] = Input::LineDefinition::Builder()
-                            .add_int_vector("HEX8", 8)
+                            .add_named_int_vector("HEX8", 8)
                             .add_named_int("MAT")
                             .add_named_string("NA")
                             .build();
 
   defsgeneral["HEX20"] = Input::LineDefinition::Builder()
-                             .add_int_vector("HEX20", 20)
+                             .add_named_int_vector("HEX20", 20)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();
 
   defsgeneral["HEX27"] = Input::LineDefinition::Builder()
-                             .add_int_vector("HEX27", 27)
+                             .add_named_int_vector("HEX27", 27)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();
 
   defsgeneral["TET4"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TET4", 4)
+                            .add_named_int_vector("TET4", 4)
                             .add_named_int("MAT")
                             .add_named_string("NA")
                             .build();
 
   defsgeneral["TET10"] = Input::LineDefinition::Builder()
-                             .add_int_vector("TET10", 10)
+                             .add_named_int_vector("TET10", 10)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();
 
   defsgeneral["WEDGE6"] = Input::LineDefinition::Builder()
-                              .add_int_vector("WEDGE6", 6)
+                              .add_named_int_vector("WEDGE6", 6)
                               .add_named_int("MAT")
                               .add_named_string("NA")
                               .build();
 
   defsgeneral["WEDGE15"] = Input::LineDefinition::Builder()
-                               .add_int_vector("WEDGE15", 15)
+                               .add_named_int_vector("WEDGE15", 15)
                                .add_named_int("MAT")
                                .add_named_string("NA")
                                .build();
 
   defsgeneral["PYRAMID5"] = Input::LineDefinition::Builder()
-                                .add_int_vector("PYRAMID5", 5)
+                                .add_named_int_vector("PYRAMID5", 5)
                                 .add_named_int("MAT")
                                 .add_named_string("NA")
                                 .build();
 
   defsgeneral["NURBS8"] = Input::LineDefinition::Builder()
-                              .add_int_vector("NURBS8", 8)
+                              .add_named_int_vector("NURBS8", 8)
                               .add_named_int("MAT")
                               .add_named_string("NA")
                               .build();
 
   defsgeneral["NURBS27"] = Input::LineDefinition::Builder()
-                               .add_int_vector("NURBS27", 27)
+                               .add_named_int_vector("NURBS27", 27)
                                .add_named_int("MAT")
                                .add_named_string("NA")
                                .build();
 
   // 2D elements
   defsgeneral["QUAD4"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD4", 4)
+                             .add_named_int_vector("QUAD4", 4)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();
 
   defsgeneral["QUAD8"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD8", 8)
+                             .add_named_int_vector("QUAD8", 8)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();
 
   defsgeneral["QUAD9"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD9", 9)
+                             .add_named_int_vector("QUAD9", 9)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();
 
   defsgeneral["TRI3"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TRI3", 3)
+                            .add_named_int_vector("TRI3", 3)
                             .add_named_int("MAT")
                             .add_named_string("NA")
                             .build();
 
   defsgeneral["TRI6"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TRI6", 6)
+                            .add_named_int_vector("TRI6", 6)
                             .add_named_int("MAT")
                             .add_named_string("NA")
                             .build();
 
   defsgeneral["NURBS4"] = Input::LineDefinition::Builder()
-                              .add_int_vector("NURBS4", 4)
+                              .add_named_int_vector("NURBS4", 4)
                               .add_named_int("MAT")
                               .add_named_string("NA")
                               .build();
 
   defsgeneral["NURBS9"] = Input::LineDefinition::Builder()
-                              .add_int_vector("NURBS9", 9)
+                              .add_named_int_vector("NURBS9", 9)
                               .add_named_int("MAT")
                               .add_named_string("NA")
                               .build();

--- a/src/fluid_ele/4C_fluid_ele_immersed.cpp
+++ b/src/fluid_ele/4C_fluid_ele_immersed.cpp
@@ -40,7 +40,7 @@ void Discret::Elements::FluidTypeImmersed::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defsimmersed = definitions["FLUIDIMMERSED"];
 
   defsimmersed["HEX8"] = Input::LineDefinition::Builder()
-                             .add_int_vector("HEX8", 8)
+                             .add_named_int_vector("HEX8", 8)
                              .add_named_int("MAT")
                              .add_named_string("NA")
                              .build();

--- a/src/fluid_ele/4C_fluid_ele_xwall.cpp
+++ b/src/fluid_ele/4C_fluid_ele_xwall.cpp
@@ -69,12 +69,12 @@ void Discret::Elements::FluidXWallType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defsxwall = definitions["FLUIDXW"];
 
   defsxwall["HEX8"] = Input::LineDefinition::Builder()
-                          .add_int_vector("HEX8", 8)
+                          .add_named_int_vector("HEX8", 8)
                           .add_named_int("MAT")
                           .add_named_string("NA")
                           .build();
   defsxwall["TET4"] = Input::LineDefinition::Builder()
-                          .add_int_vector("TET4", 4)
+                          .add_named_int_vector("TET4", 4)
                           .add_named_int("MAT")
                           .add_named_string("NA")
                           .build();

--- a/src/lubrication/src/4C_lubrication_ele.cpp
+++ b/src/lubrication/src/4C_lubrication_ele.cpp
@@ -73,26 +73,36 @@ void Discret::Elements::LubricationType::setup_element_definition(
 {
   std::map<std::string, Input::LineDefinition>& defs = definitions["LUBRICATION"];
 
-  defs["QUAD4"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD4", 4).add_named_int("MAT").build();
+  defs["QUAD4"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD4", 4)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD8"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD8", 8).add_named_int("MAT").build();
+  defs["QUAD8"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD8", 8)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD9"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD9", 9).add_named_int("MAT").build();
+  defs["QUAD9"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD9", 9)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["TRI3"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI3", 3).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI3", 3).add_named_int("MAT").build();
 
   defs["TRI6"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI6", 6).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI6", 6).add_named_int("MAT").build();
 
-  defs["LINE2"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE2", 2).add_named_int("MAT").build();
+  defs["LINE2"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE2", 2)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["LINE3"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE3", 3).add_named_int("MAT").build();
+  defs["LINE3"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE3", 3)
+                      .add_named_int("MAT")
+                      .build();
 }
 
 /*----------------------------------------------------------------------*

--- a/src/mat/4C_mat_materialdefinition.cpp
+++ b/src/mat/4C_mat_materialdefinition.cpp
@@ -49,28 +49,25 @@ std::vector<std::pair<int, Core::IO::InputParameterContainer>> Mat::MaterialDefi
   std::vector<std::pair<int, Core::IO::InputParameterContainer>> found_materials;
   for (const auto& line : input.lines_in_section(name))
   {
-    std::shared_ptr<std::stringstream> condline =
-        std::make_shared<std::stringstream>(std::string(line));
-
-    // add trailing white space to stringstream "condline" to avoid deletion of stringstream upon
-    // reading the last entry inside This is required since the material parameters can be
-    // specified in an arbitrary order in the input file. So it might happen that the last entry
-    // is extracted before all of the previous ones are.
-    condline->seekp(0, condline->end);
-    *condline << " ";
-
-    Core::IO::ValueParser parser(*condline, "While reading 'MATERIALS' section: ");
+    Core::IO::ValueParser parser(line, "While reading 'MATERIALS' section: ");
 
     parser.consume("MAT");
     const int matid = parser.read<int>();
     const std::string name = parser.read<std::string>();
 
-    // Remove the parts that were already read.
-    condline->str(condline->str().erase(0, (size_t)condline->tellg()));
-
     if (name == materialname_)
     {
       if (matid <= -1) FOUR_C_THROW("Illegal negative ID provided");
+
+      std::shared_ptr<std::stringstream> condline =
+          std::make_shared<std::stringstream>(std::string(parser.get_unparsed_remainder()));
+
+      // add trailing white space to stringstream "condline" to avoid deletion of stringstream upon
+      // reading the last entry inside This is required since the material parameters can be
+      // specified in an arbitrary order in the input file. So it might happen that the last entry
+      // is extracted before all of the previous ones are.
+      condline->seekp(0, condline->end);
+      *condline << " ";
 
       Core::IO::InputParameterContainer input_data;
       for (auto& j : inputline_)

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -72,7 +72,7 @@ void Discret::Elements::MembraneTri3Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["MEMBRANE3"];
 
   defs["TRI3"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI3", 3)
+                     .add_named_int_vector("TRI3", 3)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_named_double("THICK")
@@ -145,7 +145,7 @@ void Discret::Elements::MembraneTri6Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["MEMBRANE6"];
 
   defs["TRI6"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI6", 6)
+                     .add_named_int_vector("TRI6", 6)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_named_double("THICK")
@@ -218,7 +218,7 @@ void Discret::Elements::MembraneQuad4Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["MEMBRANE4"];
 
   defs["QUAD4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD4", 4)
+                      .add_named_int_vector("QUAD4", 4)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_named_double("THICK")
@@ -291,7 +291,7 @@ void Discret::Elements::MembraneQuad9Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["MEMBRANE9"];
 
   defs["QUAD9"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD9", 9)
+                      .add_named_int_vector("QUAD9", 9)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_named_double("THICK")

--- a/src/particle_engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle_engine/4C_particle_engine_particlereader.cpp
@@ -36,12 +36,10 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
 
     double t1 = time.totalElapsedTime(true);
     {
-      std::istringstream linestream{std::string{particle_line}};
-
       PARTICLEENGINE::TypeEnum particletype;
       PARTICLEENGINE::ParticleStates particlestates;
 
-      Core::IO::ValueParser parser{linestream, "While reading particle data: "};
+      Core::IO::ValueParser parser{particle_line, "While reading particle data: "};
       parser.consume("TYPE");
       auto type = parser.read<std::string>();
       parser.consume("POS");
@@ -61,6 +59,8 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
         std::string statelabel;
         PARTICLEENGINE::StateEnum particlestate;
         std::vector<double> state;
+
+        std::istringstream linestream(std::string(parser.get_unparsed_remainder()));
 
         while (linestream >> statelabel)
         {

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
@@ -101,35 +101,47 @@ void Discret::Elements::PoroFluidMultiPhaseType::setup_element_definition(
 {
   std::map<std::string, Input::LineDefinition>& defs = definitions["POROFLUIDMULTIPHASE"];
 
-  defs["QUAD4"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD4", 4).add_named_int("MAT").build();
+  defs["QUAD4"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD4", 4)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD8"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD8", 8).add_named_int("MAT").build();
+  defs["QUAD8"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD8", 8)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD9"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD9", 9).add_named_int("MAT").build();
+  defs["QUAD9"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD9", 9)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["TRI3"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI3", 3).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI3", 3).add_named_int("MAT").build();
 
   defs["TRI6"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI6", 6).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI6", 6).add_named_int("MAT").build();
 
-  defs["LINE2"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE2", 2).add_named_int("MAT").build();
+  defs["LINE2"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE2", 2)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["LINE3"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE3", 3).add_named_int("MAT").build();
+  defs["LINE3"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE3", 3)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["HEX8"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX8", 8).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("HEX8", 8).add_named_int("MAT").build();
 
   defs["TET4"] =
-      Input::LineDefinition::Builder().add_int_vector("TET4", 4).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TET4", 4).add_named_int("MAT").build();
 
-  defs["TET10"] =
-      Input::LineDefinition::Builder().add_int_vector("TET10", 10).add_named_int("MAT").build();
+  defs["TET10"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("TET10", 10)
+                      .add_named_int("MAT")
+                      .build();
 }
 
 /*----------------------------------------------------------------------*

--- a/src/red_airways/4C_red_airways_acinus.cpp
+++ b/src/red_airways/4C_red_airways_acinus.cpp
@@ -63,7 +63,7 @@ void Discret::Elements::RedAcinusType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["RED_ACINUS"];
 
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_named_double("AcinusVolume")

--- a/src/red_airways/4C_red_airways_airway.cpp
+++ b/src/red_airways/4C_red_airways_airway.cpp
@@ -64,7 +64,7 @@ void Discret::Elements::RedAirwayType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["RED_AIRWAY"];
 
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("MAT")
                       .add_named_string("ElemSolvingType")
                       .add_named_string("TYPE")

--- a/src/red_airways/4C_red_airways_interacinardep.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep.cpp
@@ -70,8 +70,10 @@ void Discret::Elements::RedInterAcinarDepType::setup_element_definition(
 {
   std::map<std::string, Input::LineDefinition>& defs = definitions["RED_ACINAR_INTER_DEP"];
 
-  defs["LINE2"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE2", 2).add_named_int("MAT").build();
+  defs["LINE2"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE2", 2)
+                      .add_named_int("MAT")
+                      .build();
 }
 
 

--- a/src/rigidsphere/4C_rigidsphere.cpp
+++ b/src/rigidsphere/4C_rigidsphere.cpp
@@ -95,7 +95,7 @@ void Discret::Elements::RigidsphereType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["RIGIDSPHERE"];
 
   defs["POINT1"] = Input::LineDefinition::Builder()
-                       .add_int_vector("POINT1", 1)
+                       .add_named_int_vector("POINT1", 1)
                        .add_named_double("RADIUS")
                        .add_named_double("DENSITY")
                        .build();

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -93,147 +93,147 @@ void Discret::Elements::TransportType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["TRANSP"];
 
   defs["HEX8"] = Input::LineDefinition::Builder()
-                     .add_int_vector("HEX8", 8)
+                     .add_named_int_vector("HEX8", 8)
                      .add_named_int("MAT")
                      .add_named_string("TYPE")
                      .add_optional_named_double_vector("FIBER1", 3)
                      .build();
 
   defs["HEX20"] = Input::LineDefinition::Builder()
-                      .add_int_vector("HEX20", 20)
+                      .add_named_int_vector("HEX20", 20)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["HEX27"] = Input::LineDefinition::Builder()
-                      .add_int_vector("HEX27", 27)
+                      .add_named_int_vector("HEX27", 27)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["NURBS27"] = Input::LineDefinition::Builder()
-                        .add_int_vector("NURBS27", 27)
+                        .add_named_int_vector("NURBS27", 27)
                         .add_named_int("MAT")
                         .add_named_string("TYPE")
                         .add_optional_named_double_vector("FIBER1", 3)
                         .build();
 
   defs["NURBS8"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS8", 8)
+                       .add_named_int_vector("NURBS8", 8)
                        .add_named_int("MAT")
                        .add_named_string("TYPE")
                        .add_optional_named_double_vector("FIBER1", 3)
                        .build();
 
   defs["TET4"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TET4", 4)
+                     .add_named_int_vector("TET4", 4)
                      .add_named_int("MAT")
                      .add_named_string("TYPE")
                      .add_optional_named_double_vector("FIBER1", 3)
                      .build();
 
   defs["TET10"] = Input::LineDefinition::Builder()
-                      .add_int_vector("TET10", 10)
+                      .add_named_int_vector("TET10", 10)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["WEDGE6"] = Input::LineDefinition::Builder()
-                       .add_int_vector("WEDGE6", 6)
+                       .add_named_int_vector("WEDGE6", 6)
                        .add_named_int("MAT")
                        .add_named_string("TYPE")
                        .add_optional_named_double_vector("FIBER1", 3)
                        .build();
 
   defs["WEDGE15"] = Input::LineDefinition::Builder()
-                        .add_int_vector("WEDGE15", 15)
+                        .add_named_int_vector("WEDGE15", 15)
                         .add_named_int("MAT")
                         .add_named_string("TYPE")
                         .add_optional_named_double_vector("FIBER1", 3)
                         .build();
 
   defs["PYRAMID5"] = Input::LineDefinition::Builder()
-                         .add_int_vector("PYRAMID5", 5)
+                         .add_named_int_vector("PYRAMID5", 5)
                          .add_named_int("MAT")
                          .add_named_string("TYPE")
                          .add_optional_named_double_vector("FIBER1", 3)
                          .build();
 
   defs["QUAD4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD4", 4)
+                      .add_named_int_vector("QUAD4", 4)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["QUAD8"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD8", 8)
+                      .add_named_int_vector("QUAD8", 8)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["QUAD9"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD9", 9)
+                      .add_named_int_vector("QUAD9", 9)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["TRI3"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI3", 3)
+                     .add_named_int_vector("TRI3", 3)
                      .add_named_int("MAT")
                      .add_named_string("TYPE")
                      .add_optional_named_double_vector("FIBER1", 3)
                      .build();
 
   defs["TRI6"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI6", 6)
+                     .add_named_int_vector("TRI6", 6)
                      .add_named_int("MAT")
                      .add_named_string("TYPE")
                      .add_optional_named_double_vector("FIBER1", 3)
                      .build();
 
   defs["NURBS4"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS4", 4)
+                       .add_named_int_vector("NURBS4", 4)
                        .add_named_int("MAT")
                        .add_named_string("TYPE")
                        .add_optional_named_double_vector("FIBER1", 3)
                        .build();
 
   defs["NURBS9"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS9", 9)
+                       .add_named_int_vector("NURBS9", 9)
                        .add_named_int("MAT")
                        .add_named_string("TYPE")
                        .add_optional_named_double_vector("FIBER1", 3)
                        .build();
 
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["LINE3"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE3", 3)
+                      .add_named_int_vector("LINE3", 3)
                       .add_named_int("MAT")
                       .add_named_string("TYPE")
                       .add_optional_named_double_vector("FIBER1", 3)
                       .build();
 
   defs["NURBS2"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS2", 2)
+                       .add_named_int_vector("NURBS2", 2)
                        .add_named_int("MAT")
                        .add_named_string("TYPE")
                        .add_optional_named_double_vector("FIBER1", 3)
                        .build();
 
   defs["NURBS3"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS3", 3)
+                       .add_named_int_vector("NURBS3", 3)
                        .add_named_int("MAT")
                        .add_named_string("TYPE")
                        .add_optional_named_double_vector("FIBER1", 3)

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -81,7 +81,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defsgeneral = definitions["SHELL7P"];
 
   defsgeneral["QUAD4"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD4", 4)
+                             .add_named_int_vector("QUAD4", 4)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
                              .add_named_string_vector("EAS", 5)
@@ -96,7 +96,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                              .build();
 
   defsgeneral["QUAD8"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD8", 8)
+                             .add_named_int_vector("QUAD8", 8)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
                              .add_named_string_vector("EAS", 5)
@@ -111,7 +111,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                              .build();
 
   defsgeneral["QUAD9"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD9", 9)
+                             .add_named_int_vector("QUAD9", 9)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
                              .add_named_string_vector("EAS", 5)
@@ -126,7 +126,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                              .build();
 
   defsgeneral["TRI3"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TRI3", 3)
+                            .add_named_int_vector("TRI3", 3)
                             .add_named_int("MAT")
                             .add_named_double("THICK")
                             .add_named_double("SDC")
@@ -139,7 +139,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                             .build();
 
   defsgeneral["TRI6"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TRI6", 6)
+                            .add_named_int_vector("TRI6", 6)
                             .add_named_int("MAT")
                             .add_named_double("THICK")
                             .add_named_double("SDC")

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -84,11 +84,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                              .add_int_vector("QUAD4", 4)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
-                             .add_named_string("EAS")
-                             .add_string("EAS2")
-                             .add_string("EAS3")
-                             .add_string("EAS4")
-                             .add_string("EAS5")
+                             .add_named_string_vector("EAS", 5)
                              .add_named_double("SDC")
                              .add_optional_tag("ANS")
                              .add_optional_named_double_vector("RAD", 3)
@@ -103,11 +99,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                              .add_int_vector("QUAD8", 8)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
-                             .add_named_string("EAS")
-                             .add_string("EAS2")
-                             .add_string("EAS3")
-                             .add_string("EAS4")
-                             .add_string("EAS5")
+                             .add_named_string_vector("EAS", 5)
                              .add_named_double("SDC")
                              .add_optional_tag("ANS")
                              .add_optional_named_double_vector("RAD", 3)
@@ -122,11 +114,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
                              .add_int_vector("QUAD9", 9)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
-                             .add_named_string("EAS")
-                             .add_string("EAS2")
-                             .add_string("EAS3")
-                             .add_string("EAS4")
-                             .add_string("EAS5")
+                             .add_named_string_vector("EAS", 5)
                              .add_named_double("SDC")
                              .add_optional_tag("ANS")
                              .add_optional_named_double_vector("RAD", 3)
@@ -338,7 +326,7 @@ bool Discret::Elements::Shell7p::read_element(const std::string& eletype,
 
   // extract number of EAS parameters for different locking types
   Solid::Elements::ShellLockingTypes locking_types = {};
-  if (container.get_if<std::string>("EAS") != nullptr)
+  if (container.get_if<std::vector<std::string>>("EAS") != nullptr)
   {
     eletech_.insert(Inpar::Solid::EleTech::eas);
     Solid::Utils::Shell::ReadElement::read_and_set_locking_types(

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -80,11 +80,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                              .add_int_vector("QUAD4", 4)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
-                             .add_named_string("EAS")
-                             .add_string("EAS2")
-                             .add_string("EAS3")
-                             .add_string("EAS4")
-                             .add_string("EAS5")
+                             .add_named_string_vector("EAS", 5)
                              .add_named_double("SDC")
                              .add_optional_tag("ANS")
                              .add_optional_named_double_vector("RAD", 3)
@@ -100,11 +96,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                              .add_int_vector("QUAD8", 8)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
-                             .add_named_string("EAS")
-                             .add_string("EAS2")
-                             .add_string("EAS3")
-                             .add_string("EAS4")
-                             .add_string("EAS5")
+                             .add_named_string_vector("EAS", 5)
                              .add_named_double("SDC")
                              .add_optional_tag("ANS")
                              .add_optional_named_double_vector("RAD", 3)
@@ -120,11 +112,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                              .add_int_vector("QUAD9", 9)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
-                             .add_named_string("EAS")
-                             .add_string("EAS2")
-                             .add_string("EAS3")
-                             .add_string("EAS4")
-                             .add_string("EAS5")
+                             .add_named_string_vector("EAS", 5)
                              .add_named_double("SDC")
                              .add_optional_tag("ANS")
                              .add_optional_named_double_vector("RAD", 3)
@@ -368,7 +356,7 @@ bool Discret::Elements::Shell7pScatra::read_element(const std::string& eletype,
 
   // extract number of EAS parameters for different locking types
   Solid::Elements::ShellLockingTypes locking_types = {};
-  if (container.get_if<std::string>("EAS") != nullptr)
+  if (container.get_if<std::vector<std::string>>("EAS") != nullptr)
   {
     eletech_.insert(Inpar::Solid::EleTech::eas);
     Solid::Utils::Shell::ReadElement::read_and_set_locking_types(

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -77,7 +77,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defsgeneral = definitions["SHELL7PSCATRA"];
 
   defsgeneral["QUAD4"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD4", 4)
+                             .add_named_int_vector("QUAD4", 4)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
                              .add_named_string_vector("EAS", 5)
@@ -93,7 +93,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                              .build();
 
   defsgeneral["QUAD8"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD8", 8)
+                             .add_named_int_vector("QUAD8", 8)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
                              .add_named_string_vector("EAS", 5)
@@ -109,7 +109,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                              .build();
 
   defsgeneral["QUAD9"] = Input::LineDefinition::Builder()
-                             .add_int_vector("QUAD9", 9)
+                             .add_named_int_vector("QUAD9", 9)
                              .add_named_int("MAT")
                              .add_named_double("THICK")
                              .add_named_string_vector("EAS", 5)
@@ -125,7 +125,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                              .build();
 
   defsgeneral["TRI3"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TRI3", 3)
+                            .add_named_int_vector("TRI3", 3)
                             .add_named_int("MAT")
                             .add_named_double("THICK")
                             .add_named_double("SDC")
@@ -139,7 +139,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
                             .build();
 
   defsgeneral["TRI6"] = Input::LineDefinition::Builder()
-                            .add_int_vector("TRI6", 6)
+                            .add_named_int_vector("TRI6", 6)
                             .add_named_int("MAT")
                             .add_named_double("THICK")
                             .add_named_double("SDC")

--- a/src/shell7p/4C_shell7p_utils.cpp
+++ b/src/shell7p/4C_shell7p_utils.cpp
@@ -676,30 +676,22 @@ void Solid::Utils::Shell::ReadElement::read_and_set_locking_types(const Core::FE
   {
     case Core::FE::CellType::quad4:
     {
-      type = container.get<std::string>("EAS");
-      set_membrane_locking_size_quad4(locking_types.membrane, type);
-      type = container.get<std::string>("EAS2");
-      set_bending_locking_size_quad4(locking_types.bending, type);
-      type = container.get<std::string>("EAS3");
-      set_thickness_locking_size_quad4(locking_types.thickness, type);
-      type = container.get<std::string>("EAS4");
-      set_shear_strain_locking_size_quad4(locking_types.transverse_shear_strain_const, type);
-      type = container.get<std::string>("EAS5");
-      set_shear_strain_locking_size_quad4(locking_types.transverse_shear_strain_lin, type);
+      const auto& eas = container.get<std::vector<std::string>>("EAS");
+      set_membrane_locking_size_quad4(locking_types.membrane, eas[0]);
+      set_bending_locking_size_quad4(locking_types.bending, eas[1]);
+      set_thickness_locking_size_quad4(locking_types.thickness, eas[2]);
+      set_shear_strain_locking_size_quad4(locking_types.transverse_shear_strain_const, eas[3]);
+      set_shear_strain_locking_size_quad4(locking_types.transverse_shear_strain_lin, eas[4]);
       break;
     }
     case Core::FE::CellType::quad9:
     {
-      type = container.get<std::string>("EAS");
-      set_membrane_locking_size_quad9(locking_types.membrane, type);
-      type = container.get<std::string>("EAS2");
-      set_bending_locking_size_quad9(locking_types.bending, type);
-      type = container.get<std::string>("EAS3");
-      set_thickness_locking_size_quad9(locking_types.thickness, type);
-      type = container.get<std::string>("EAS4");
-      set_shear_strain_locking_size_quad9(locking_types.transverse_shear_strain_const, type);
-      type = container.get<std::string>("EAS5");
-      set_shear_strain_locking_size_quad9(locking_types.transverse_shear_strain_lin, type);
+      const auto& eas = container.get<std::vector<std::string>>("EAS");
+      set_membrane_locking_size_quad9(locking_types.membrane, eas[0]);
+      set_bending_locking_size_quad9(locking_types.bending, eas[1]);
+      set_thickness_locking_size_quad9(locking_types.thickness, eas[2]);
+      set_shear_strain_locking_size_quad9(locking_types.transverse_shear_strain_const, eas[3]);
+      set_shear_strain_locking_size_quad9(locking_types.transverse_shear_strain_lin, eas[4]);
       break;
     }
     default:

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
@@ -95,7 +95,7 @@ void Discret::Elements::KirchhoffLoveShellNurbsType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["SHELL_KIRCHHOFF_LOVE_NURBS"];
 
   defs["NURBS9"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS9", 9)
+                       .add_named_int_vector("NURBS9", 9)
                        .add_named_int("MAT")
                        .add_named_int_vector("GP", 2)
                        .build();

--- a/src/so3/4C_so3_hex18.cpp
+++ b/src/so3/4C_so3_hex18.cpp
@@ -77,7 +77,7 @@ void Discret::Elements::SoHex18Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["HEX18"] = Input::LineDefinition::Builder()
-                      .add_int_vector("HEX18", 18)
+                      .add_named_int_vector("HEX18", 18)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_optional_named_double_vector("RAD", 3)

--- a/src/so3/4C_so3_hex27.cpp
+++ b/src/so3/4C_so3_hex27.cpp
@@ -80,7 +80,7 @@ void Discret::Elements::SoHex27Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["HEX27"] = Input::LineDefinition::Builder()
-                      .add_int_vector("HEX27", 27)
+                      .add_named_int_vector("HEX27", 27)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_optional_named_double_vector("RAD", 3)

--- a/src/so3/4C_so3_hex8.cpp
+++ b/src/so3/4C_so3_hex8.cpp
@@ -91,7 +91,7 @@ void Discret::Elements::SoHex8Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["HEX8"] = Input::LineDefinition::Builder()
-                     .add_int_vector("HEX8", 8)
+                     .add_named_int_vector("HEX8", 8)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_named_string("EAS")

--- a/src/so3/4C_so3_nurbs27.cpp
+++ b/src/so3/4C_so3_nurbs27.cpp
@@ -78,7 +78,7 @@ void Discret::Elements::Nurbs::SoNurbs27Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["NURBS27"] = Input::LineDefinition::Builder()
-                        .add_int_vector("NURBS27", 27)
+                        .add_named_int_vector("NURBS27", 27)
                         .add_named_int("MAT")
                         .add_named_int_vector("GP", 3)
                         .build();

--- a/src/so3/4C_so3_sh18.cpp
+++ b/src/so3/4C_so3_sh18.cpp
@@ -63,7 +63,7 @@ void Discret::Elements::SoSh18Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["HEX18"] = Input::LineDefinition::Builder()
-                      .add_int_vector("HEX18", 18)
+                      .add_named_int_vector("HEX18", 18)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_named_string("TSL")

--- a/src/so3/4C_so3_sh8.cpp
+++ b/src/so3/4C_so3_sh8.cpp
@@ -73,7 +73,7 @@ void Discret::Elements::SoSh8Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["HEX8"] = Input::LineDefinition::Builder()
-                     .add_int_vector("HEX8", 8)
+                     .add_named_int_vector("HEX8", 8)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_named_string("EAS")

--- a/src/so3/4C_so3_shw6.cpp
+++ b/src/so3/4C_so3_shw6.cpp
@@ -72,7 +72,7 @@ void Discret::Elements::SoShw6Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["WEDGE6"] = Input::LineDefinition::Builder()
-                       .add_int_vector("WEDGE6", 6)
+                       .add_named_int_vector("WEDGE6", 6)
                        .add_named_int("MAT")
                        .add_named_string("KINEM")
                        .add_named_string("EAS")

--- a/src/so3/4C_so3_tet10.cpp
+++ b/src/so3/4C_so3_tet10.cpp
@@ -86,7 +86,7 @@ void Discret::Elements::SoTet10Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["TET10"] = Input::LineDefinition::Builder()
-                      .add_int_vector("TET10", 10)
+                      .add_named_int_vector("TET10", 10)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_optional_named_double_vector("RAD", 3)

--- a/src/so3/4C_so3_tet4.cpp
+++ b/src/so3/4C_so3_tet4.cpp
@@ -91,7 +91,7 @@ void Discret::Elements::SoTet4Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["TET4"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TET4", 4)
+                     .add_named_int_vector("TET4", 4)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_optional_named_double_vector("RAD", 3)

--- a/src/so3/4C_so3_weg6.cpp
+++ b/src/so3/4C_so3_weg6.cpp
@@ -81,7 +81,7 @@ void Discret::Elements::SoWeg6Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions[get_element_type_string()];
 
   defs["WEDGE6"] = Input::LineDefinition::Builder()
-                       .add_int_vector("WEDGE6", 6)
+                       .add_named_int_vector("WEDGE6", 6)
                        .add_named_int("MAT")
                        .add_named_string("KINEM")
                        .add_optional_named_double_vector("RAD", 3)

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -30,7 +30,8 @@ namespace
   Input::LineDefinition::Builder get_default_line_definition_builder()
   {
     return Input::LineDefinition::Builder()
-        .add_int_vector(Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
+        .add_named_int_vector(
+            Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
         .add_named_int("MAT")
         .add_named_string("KINEM")
         .add_optional_named_string("PRESTRESS_TECH")
@@ -85,7 +86,7 @@ void Discret::Elements::SolidType::setup_element_definition(
 
 
   defsgeneral["NURBS27"] = Input::LineDefinition::Builder()
-                               .add_int_vector("NURBS27", 27)
+                               .add_named_int_vector("NURBS27", 27)
                                .add_named_int("MAT")
                                .add_named_string("KINEM")
                                .build();

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -33,7 +33,8 @@ namespace Discret::Elements::SolidPoroPressureBasedInternal
     Input::LineDefinition::Builder get_default_line_definition_builder()
     {
       return Input::LineDefinition::Builder()
-          .add_int_vector(Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
+          .add_named_int_vector(
+              Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
           .add_named_int("MAT")
           .add_named_string("KINEM")
           .add_optional_named_string("TYPE");

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -32,7 +32,8 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
     Input::LineDefinition::Builder get_default_line_definition_builder()
     {
       return Input::LineDefinition::Builder()
-          .add_int_vector(Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
+          .add_named_int_vector(
+              Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
           .add_named_int("MAT")
           .add_named_string("KINEM")
           .add_optional_named_double_vector("POROANISODIR1", 3)

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -25,7 +25,8 @@ namespace
   Input::LineDefinition::Builder get_default_line_definition_builder()
   {
     return Input::LineDefinition::Builder()
-        .add_int_vector(Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
+        .add_named_int_vector(
+            Core::FE::cell_type_to_string(celltype), Core::FE::num_nodes<celltype>)
         .add_named_int("MAT")
         .add_named_string("KINEM")
         .add_named_string("TYPE")

--- a/src/thermo/4C_thermo_element.cpp
+++ b/src/thermo/4C_thermo_element.cpp
@@ -108,58 +108,86 @@ void Thermo::ElementType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["THERMO"];
 
   defs["HEX8"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX8", 8).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("HEX8", 8).add_named_int("MAT").build();
 
-  defs["HEX20"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX20", 20).add_named_int("MAT").build();
+  defs["HEX20"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("HEX20", 20)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["HEX27"] =
-      Input::LineDefinition::Builder().add_int_vector("HEX27", 27).add_named_int("MAT").build();
+  defs["HEX27"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("HEX27", 27)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["TET4"] =
-      Input::LineDefinition::Builder().add_int_vector("TET4", 4).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TET4", 4).add_named_int("MAT").build();
 
-  defs["TET10"] =
-      Input::LineDefinition::Builder().add_int_vector("TET10", 10).add_named_int("MAT").build();
+  defs["TET10"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("TET10", 10)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["WEDGE6"] =
-      Input::LineDefinition::Builder().add_int_vector("WEDGE6", 6).add_named_int("MAT").build();
+  defs["WEDGE6"] = Input::LineDefinition::Builder()
+                       .add_named_int_vector("WEDGE6", 6)
+                       .add_named_int("MAT")
+                       .build();
 
-  defs["WEDGE15"] =
-      Input::LineDefinition::Builder().add_int_vector("WEDGE15", 15).add_named_int("MAT").build();
+  defs["WEDGE15"] = Input::LineDefinition::Builder()
+                        .add_named_int_vector("WEDGE15", 15)
+                        .add_named_int("MAT")
+                        .build();
 
-  defs["PYRAMID5"] =
-      Input::LineDefinition::Builder().add_int_vector("PYRAMID5", 5).add_named_int("MAT").build();
+  defs["PYRAMID5"] = Input::LineDefinition::Builder()
+                         .add_named_int_vector("PYRAMID5", 5)
+                         .add_named_int("MAT")
+                         .build();
 
-  defs["NURBS27"] =
-      Input::LineDefinition::Builder().add_int_vector("NURBS27", 27).add_named_int("MAT").build();
+  defs["NURBS27"] = Input::LineDefinition::Builder()
+                        .add_named_int_vector("NURBS27", 27)
+                        .add_named_int("MAT")
+                        .build();
 
-  defs["QUAD4"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD4", 4).add_named_int("MAT").build();
+  defs["QUAD4"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD4", 4)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD8"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD8", 8).add_named_int("MAT").build();
+  defs["QUAD8"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD8", 8)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["QUAD9"] =
-      Input::LineDefinition::Builder().add_int_vector("QUAD9", 9).add_named_int("MAT").build();
+  defs["QUAD9"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("QUAD9", 9)
+                      .add_named_int("MAT")
+                      .build();
 
   defs["TRI3"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI3", 3).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI3", 3).add_named_int("MAT").build();
 
   defs["TRI6"] =
-      Input::LineDefinition::Builder().add_int_vector("TRI6", 6).add_named_int("MAT").build();
+      Input::LineDefinition::Builder().add_named_int_vector("TRI6", 6).add_named_int("MAT").build();
 
-  defs["NURBS4"] =
-      Input::LineDefinition::Builder().add_int_vector("NURBS4", 4).add_named_int("MAT").build();
+  defs["NURBS4"] = Input::LineDefinition::Builder()
+                       .add_named_int_vector("NURBS4", 4)
+                       .add_named_int("MAT")
+                       .build();
 
-  defs["NURBS9"] =
-      Input::LineDefinition::Builder().add_int_vector("NURBS9", 9).add_named_int("MAT").build();
+  defs["NURBS9"] = Input::LineDefinition::Builder()
+                       .add_named_int_vector("NURBS9", 9)
+                       .add_named_int("MAT")
+                       .build();
 
-  defs["LINE2"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE2", 2).add_named_int("MAT").build();
+  defs["LINE2"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE2", 2)
+                      .add_named_int("MAT")
+                      .build();
 
-  defs["LINE3"] =
-      Input::LineDefinition::Builder().add_int_vector("LINE3", 3).add_named_int("MAT").build();
+  defs["LINE3"] = Input::LineDefinition::Builder()
+                      .add_named_int_vector("LINE3", 3)
+                      .add_named_int("MAT")
+                      .build();
 }  // setup_element_definition()
 
 

--- a/src/torsion3/4C_torsion3.cpp
+++ b/src/torsion3/4C_torsion3.cpp
@@ -72,7 +72,7 @@ void Discret::Elements::Torsion3Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["TORSION3"];
 
   defs["LINE3"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE3", 3)
+                      .add_named_int_vector("LINE3", 3)
                       .add_named_int("MAT")
                       .add_named_string("BENDINGPOTENTIAL")
                       .build();

--- a/src/truss3/4C_truss3.cpp
+++ b/src/truss3/4C_truss3.cpp
@@ -73,7 +73,7 @@ void Discret::Elements::Truss3Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["TRUSS3"];
 
   defs["LINE2"] = Input::LineDefinition::Builder()
-                      .add_int_vector("LINE2", 2)
+                      .add_named_int_vector("LINE2", 2)
                       .add_named_int("MAT")
                       .add_named_double("CROSS")
                       .add_named_string("KINEM")

--- a/src/w1/4C_w1.cpp
+++ b/src/w1/4C_w1.cpp
@@ -70,7 +70,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["WALL"];
 
   defs["QUAD4"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD4", 4)
+                      .add_named_int_vector("QUAD4", 4)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_named_string("EAS")
@@ -80,7 +80,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
                       .build();
 
   defs["QUAD8"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD8", 8)
+                      .add_named_int_vector("QUAD8", 8)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_named_string("EAS")
@@ -90,7 +90,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
                       .build();
 
   defs["QUAD9"] = Input::LineDefinition::Builder()
-                      .add_int_vector("QUAD9", 9)
+                      .add_named_int_vector("QUAD9", 9)
                       .add_named_int("MAT")
                       .add_named_string("KINEM")
                       .add_named_string("EAS")
@@ -100,7 +100,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
                       .build();
 
   defs["TRI3"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI3", 3)
+                     .add_named_int_vector("TRI3", 3)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_named_string("EAS")
@@ -110,7 +110,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
                      .build();
 
   defs["TRI6"] = Input::LineDefinition::Builder()
-                     .add_int_vector("TRI6", 6)
+                     .add_named_int_vector("TRI6", 6)
                      .add_named_int("MAT")
                      .add_named_string("KINEM")
                      .add_named_string("EAS")
@@ -120,7 +120,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
                      .build();
 
   defs["NURBS4"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS4", 4)
+                       .add_named_int_vector("NURBS4", 4)
                        .add_named_int("MAT")
                        .add_named_string("KINEM")
                        .add_named_string("EAS")
@@ -130,7 +130,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
                        .build();
 
   defs["NURBS9"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS9", 9)
+                       .add_named_int_vector("NURBS9", 9)
                        .add_named_int("MAT")
                        .add_named_string("KINEM")
                        .add_named_string("EAS")

--- a/src/w1/4C_w1_nurbs.cpp
+++ b/src/w1/4C_w1_nurbs.cpp
@@ -69,7 +69,7 @@ void Discret::Elements::Nurbs::Wall1NurbsType::setup_element_definition(
   std::map<std::string, Input::LineDefinition>& defs = definitions["WALLNURBS"];
 
   defs["NURBS4"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS4", 4)
+                       .add_named_int_vector("NURBS4", 4)
                        .add_named_int("MAT")
                        .add_named_string("KINEM")
                        .add_named_string("EAS")
@@ -79,7 +79,7 @@ void Discret::Elements::Nurbs::Wall1NurbsType::setup_element_definition(
                        .build();
 
   defs["NURBS9"] = Input::LineDefinition::Builder()
-                       .add_int_vector("NURBS9", 9)
+                       .add_named_int_vector("NURBS9", 9)
                        .add_named_int("MAT")
                        .add_named_string("KINEM")
                        .add_named_string("EAS")


### PR DESCRIPTION
Part of #73 

The LineDefinition supported special components where the name was not required in the input line. @lauraengelhardt and I think this is confusing and not necessary. Thus, this PR removes these special cases. No changes to input files are necessary which kind of proves our point ;)

FYI @mairehenke I changed internals of the shell elements. You can now use a string vector.

