### PR TITLE
Increase number of chunks for coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           build-directory: ${{ github.workspace }}/build
           source-directory: ${{ github.workspace }}
-          number-of-chunks: 40 # we need fine grained test chunks to avoid running out of storage
+          number-of-chunks: 60 # we need fine grained test chunks to avoid running out of storage
 
   gcc13_coverage_test:
     needs: gcc13_coverage_build


### PR DESCRIPTION
## Description and Context
For the coverage workflow, we ran into problems concerning disk storage (see https://github.com/4C-multiphysics/4C/actions/runs/12308399500). Thus, the number of chunks is increased from 40 to 60, resulting in less output data per runner, which resolved the issue on my fork.

## Related Issues and Merge Requests
Closes #155 
Follows https://github.com/4C-multiphysics/4C/pull/128