### PR TITLE
Remove my_output_flag function from InputFile

### DIFF
--- a/apps/pre_exodus/4C_pre_exodus_validate.cpp
+++ b/apps/pre_exodus/4C_pre_exodus_validate.cpp
@@ -29,7 +29,7 @@ void EXODUS::validate_input_file(const MPI_Comm comm, const std::string datfile)
   Global::Problem* problem = Global::Problem::instance();
 
   // create a InputFile
-  Core::IO::InputFile reader(datfile, comm, 0);
+  Core::IO::InputFile reader(datfile, comm);
 
   // read and validate dynamic and solver sections
   std::cout << "...Read parameters" << std::endl;

--- a/src/core/io/src/4C_io_domainreader.cpp
+++ b/src/core/io/src/4C_io_domainreader.cpp
@@ -87,7 +87,7 @@ namespace Core::IO
 
     Teuchos::Time time("", true);
 
-    if (!input_.my_output_flag() && myrank == 0)
+    if (myrank == 0)
       Core::IO::cout << "Entering domain generation mode for " << name_
                      << " discretization ...\nCreate and partition elements      in...."
                      << Core::IO::endl;
@@ -96,10 +96,9 @@ namespace Core::IO
         DomainReader::read_rectangular_cuboid_input_data();
     inputData.node_gid_of_first_new_node_ = nodeGIdOfFirstNewNode;
 
-    Core::IO::GridGenerator::create_rectangular_cuboid_discretization(
-        *dis_, inputData, static_cast<bool>(input_.my_output_flag()));
+    Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*dis_, inputData, false);
 
-    if (!myrank && input_.my_output_flag() == 0)
+    if (!myrank)
       Core::IO::cout << "............................................... " << std::setw(10)
                      << std::setprecision(5) << std::scientific << time.totalElapsedTime(true)
                      << " secs" << Core::IO::endl;
@@ -182,15 +181,14 @@ namespace Core::IO
 
     Teuchos::Time time("", true);
 
-    if (!myrank && !input_.my_output_flag())
+    if (!myrank)
       Core::IO::cout << "Complete discretization " << std::left << std::setw(16) << name_
                      << " in...." << Core::IO::flush;
 
     int err = dis_->fill_complete(false, false, false);
     if (err) FOUR_C_THROW("dis_->fill_complete() returned %d", err);
 
-    if (!myrank && !input_.my_output_flag())
-      Core::IO::cout << time.totalElapsedTime(true) << " secs" << Core::IO::endl;
+    if (!myrank) Core::IO::cout << time.totalElapsedTime(true) << " secs" << Core::IO::endl;
 
     Core::Rebalance::Utils::print_parallel_distribution(*dis_);
   }

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -520,8 +520,8 @@ namespace Core::IO
 
   /*----------------------------------------------------------------------*/
   /*----------------------------------------------------------------------*/
-  InputFile::InputFile(std::string filename, MPI_Comm comm, int outflag)
-      : top_level_file_(std::move(filename)), comm_(std::move(comm)), outflag_(outflag)
+  InputFile::InputFile(std::string filename, MPI_Comm comm)
+      : top_level_file_(std::move(filename)), comm_(std::move(comm))
   {
     read_generic();
   }
@@ -530,11 +530,6 @@ namespace Core::IO
   /*----------------------------------------------------------------------*/
   /*----------------------------------------------------------------------*/
   std::string InputFile::my_inputfile_name() const { return top_level_file_.string(); }
-
-
-  /*----------------------------------------------------------------------*/
-  /*----------------------------------------------------------------------*/
-  int InputFile::my_output_flag() const { return outflag_; }
 
 
   /*----------------------------------------------------------------------*/
@@ -826,11 +821,8 @@ namespace Core::IO
 
     if (myrank == 0)
     {
-      if (!input.my_output_flag())
-      {
-        Core::IO::cout << "Reading knot vectors for " << name << " discretization :\n";
-        fflush(stdout);
-      }
+      Core::IO::cout << "Reading knot vectors for " << name << " discretization :\n";
+      fflush(stdout);
     }
 
     // number of patches to be determined
@@ -885,11 +877,8 @@ namespace Core::IO
 
     if (myrank == 0)
     {
-      if (!input.my_output_flag())
-      {
-        printf("                        %8d patches", npatches);
-        fflush(stdout);
-      }
+      printf("                        %8d patches", npatches);
+      fflush(stdout);
     }
 
 
@@ -1087,13 +1076,10 @@ namespace Core::IO
 
     if (myrank == 0)
     {
-      if (!input.my_output_flag())
-      {
-        Core::IO::cout << " in...." << time.totalElapsedTime(true) << " secs\n";
+      Core::IO::cout << " in...." << time.totalElapsedTime(true) << " secs\n";
 
-        time.reset();
-        fflush(stdout);
-      }
+      time.reset();
+      fflush(stdout);
     }
   }
 

--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -201,13 +201,10 @@ namespace Core::IO
     };
 
     /// construct a reader for a given file
-    InputFile(std::string filename, MPI_Comm comm, int outflag = 0);
+    InputFile(std::string filename, MPI_Comm comm);
 
     /// return my inputfile name
     [[nodiscard]] std::string my_inputfile_name() const;
-
-    /// return my output flag
-    [[nodiscard]] int my_output_flag() const;
 
     /**
      * Get a a range of lines inside a section that have actual content, i.e., they contain
@@ -271,9 +268,6 @@ namespace Core::IO
 
     /// The communicator associated with this object.
     MPI_Comm comm_;
-
-    /// Flag for output (default: output should be written)
-    int outflag_{};
 
     /// The whole input file.
     std::vector<char> inputfile_;

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1565,7 +1565,7 @@ void Global::read_micro_fields(Global::Problem& problem, const std::filesystem::
             (const_cast<char*>(micro_inputfile_name.c_str())), length, 0, subgroupcomm);
 
         // start with actual reading
-        Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm, 1);
+        Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm);
 
         std::shared_ptr<Core::FE::Discretization> dis_micro =
             std::make_shared<Core::FE::Discretization>(
@@ -1707,7 +1707,7 @@ void Global::read_microfields_np_support(Global::Problem& problem)
         (const_cast<char*>(micro_inputfile_name.c_str())), length, 0, subgroupcomm);
 
     // start with actual reading
-    Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm, 1);
+    Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm);
 
     std::shared_ptr<Core::FE::Discretization> structdis_micro =
         std::make_shared<Core::FE::Discretization>("structure", subgroupcomm, problem.n_dim());

--- a/src/particle_engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle_engine/4C_particle_engine_particlereader.cpp
@@ -30,8 +30,7 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
   bool any_particles_read = false;
   for (const auto& particle_line : input.lines_in_section(section_name))
   {
-    if (!any_particles_read && !input.my_output_flag())
-      Core::IO::cout << "Read and create particles\n" << Core::IO::flush;
+    if (!any_particles_read) Core::IO::cout << "Read and create particles\n" << Core::IO::flush;
     any_particles_read = true;
 
     double t1 = time.totalElapsedTime(true);
@@ -100,14 +99,14 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
     }
 
     double t2 = time.totalElapsedTime(true);
-    if (!myrank && !input.my_output_flag())
+    if (!myrank)
     {
       printf("reading %10.5e secs\n", t2 - t1);
       fflush(stdout);
     }
   }
 
-  if (any_particles_read && !input.my_output_flag())
+  if (any_particles_read)
     printf("in............................................. %10.5e secs\n",
         time.totalElapsedTime(true));
 }


### PR DESCRIPTION
This implementation was in the wrong place. I removed the flag. If output should be conditional, one may introduce a flag for that in the respective function in the future. I kept the same console output except for microscale simulations, which now print a few more lines.