### PR TITLE
Add FILE_PATH and FILE_DIR variable substitution in input files

### DIFF
--- a/apps/global_full/4C_global_full_control.cpp
+++ b/apps/global_full/4C_global_full_control.cpp
@@ -12,6 +12,7 @@
 #include "4C_global_full_inp_control.hpp"
 #include "4C_io_pstream.hpp"
 
+#include <chrono>
 
 namespace
 {

--- a/apps/pre_exodus/4C_pre_exodus_validate.cpp
+++ b/apps/pre_exodus/4C_pre_exodus_validate.cpp
@@ -29,7 +29,7 @@ void EXODUS::validate_input_file(const MPI_Comm comm, const std::string datfile)
   Global::Problem* problem = Global::Problem::instance();
 
   // create a InputFile
-  Core::IO::InputFile reader(datfile, comm, 0);
+  Core::IO::InputFile reader(datfile, comm);
 
   // read and validate dynamic and solver sections
   std::cout << "...Read parameters" << std::endl;

--- a/cmake/functions/four_c_add_googletest_executable.cmake
+++ b/cmake/functions/four_c_add_googletest_executable.cmake
@@ -136,7 +136,8 @@ function(four_c_add_google_test_executable TESTNAME)
       "Copying support file ${support_file} to ${FOUR_C_TEST_SUPPORT_FILE_DIR}/${support_file}"
       )
 
-    configure_file(${support_file} ${FOUR_C_TEST_SUPPORT_FILE_DIR}/${support_file})
+    # Only substitute CMake variables with @ syntax. The $ style variables we use internally are not substituted.
+    configure_file(${support_file} ${FOUR_C_TEST_SUPPORT_FILE_DIR}/${support_file} @ONLY)
   endforeach()
   target_compile_definitions(
     ${TESTNAME} PRIVATE -DFOUR_C_TEST_SUPPORT_FILE_DIR="${FOUR_C_TEST_SUPPORT_FILE_DIR}"

--- a/src/core/io/src/4C_io_domainreader.cpp
+++ b/src/core/io/src/4C_io_domainreader.cpp
@@ -87,7 +87,7 @@ namespace Core::IO
 
     Teuchos::Time time("", true);
 
-    if (!input_.my_output_flag() && myrank == 0)
+    if (myrank == 0)
       Core::IO::cout << "Entering domain generation mode for " << name_
                      << " discretization ...\nCreate and partition elements      in...."
                      << Core::IO::endl;
@@ -96,10 +96,9 @@ namespace Core::IO
         DomainReader::read_rectangular_cuboid_input_data();
     inputData.node_gid_of_first_new_node_ = nodeGIdOfFirstNewNode;
 
-    Core::IO::GridGenerator::create_rectangular_cuboid_discretization(
-        *dis_, inputData, static_cast<bool>(input_.my_output_flag()));
+    Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*dis_, inputData, false);
 
-    if (!myrank && input_.my_output_flag() == 0)
+    if (!myrank)
       Core::IO::cout << "............................................... " << std::setw(10)
                      << std::setprecision(5) << std::scientific << time.totalElapsedTime(true)
                      << " secs" << Core::IO::endl;
@@ -182,15 +181,14 @@ namespace Core::IO
 
     Teuchos::Time time("", true);
 
-    if (!myrank && !input_.my_output_flag())
+    if (!myrank)
       Core::IO::cout << "Complete discretization " << std::left << std::setw(16) << name_
                      << " in...." << Core::IO::flush;
 
     int err = dis_->fill_complete(false, false, false);
     if (err) FOUR_C_THROW("dis_->fill_complete() returned %d", err);
 
-    if (!myrank && !input_.my_output_flag())
-      Core::IO::cout << time.totalElapsedTime(true) << " secs" << Core::IO::endl;
+    if (!myrank) Core::IO::cout << time.totalElapsedTime(true) << " secs" << Core::IO::endl;
 
     Core::Rebalance::Utils::print_parallel_distribution(*dis_);
   }

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -520,8 +520,8 @@ namespace Core::IO
 
   /*----------------------------------------------------------------------*/
   /*----------------------------------------------------------------------*/
-  InputFile::InputFile(std::string filename, MPI_Comm comm, int outflag)
-      : top_level_file_(std::move(filename)), comm_(std::move(comm)), outflag_(outflag)
+  InputFile::InputFile(std::string filename, MPI_Comm comm)
+      : top_level_file_(std::move(filename)), comm_(std::move(comm))
   {
     read_generic();
   }
@@ -530,11 +530,6 @@ namespace Core::IO
   /*----------------------------------------------------------------------*/
   /*----------------------------------------------------------------------*/
   std::string InputFile::my_inputfile_name() const { return top_level_file_.string(); }
-
-
-  /*----------------------------------------------------------------------*/
-  /*----------------------------------------------------------------------*/
-  int InputFile::my_output_flag() const { return outflag_; }
 
 
   /*----------------------------------------------------------------------*/
@@ -826,11 +821,8 @@ namespace Core::IO
 
     if (myrank == 0)
     {
-      if (!input.my_output_flag())
-      {
-        Core::IO::cout << "Reading knot vectors for " << name << " discretization :\n";
-        fflush(stdout);
-      }
+      Core::IO::cout << "Reading knot vectors for " << name << " discretization :\n";
+      fflush(stdout);
     }
 
     // number of patches to be determined
@@ -885,11 +877,8 @@ namespace Core::IO
 
     if (myrank == 0)
     {
-      if (!input.my_output_flag())
-      {
-        printf("                        %8d patches", npatches);
-        fflush(stdout);
-      }
+      printf("                        %8d patches", npatches);
+      fflush(stdout);
     }
 
 
@@ -1087,13 +1076,10 @@ namespace Core::IO
 
     if (myrank == 0)
     {
-      if (!input.my_output_flag())
-      {
-        Core::IO::cout << " in...." << time.totalElapsedTime(true) << " secs\n";
+      Core::IO::cout << " in...." << time.totalElapsedTime(true) << " secs\n";
 
-        time.reset();
-        fflush(stdout);
-      }
+      time.reset();
+      fflush(stdout);
     }
   }
 

--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -201,13 +201,10 @@ namespace Core::IO
     };
 
     /// construct a reader for a given file
-    InputFile(std::string filename, MPI_Comm comm, int outflag = 0);
+    InputFile(std::string filename, MPI_Comm comm);
 
     /// return my inputfile name
     [[nodiscard]] std::string my_inputfile_name() const;
-
-    /// return my output flag
-    [[nodiscard]] int my_output_flag() const;
 
     /**
      * Get a a range of lines inside a section that have actual content, i.e., they contain
@@ -271,9 +268,6 @@ namespace Core::IO
 
     /// The communicator associated with this object.
     MPI_Comm comm_;
-
-    /// Flag for output (default: output should be written)
-    int outflag_{};
 
     /// The whole input file.
     std::vector<char> inputfile_;

--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -147,6 +147,13 @@ namespace Core::IO
    * and each section name must be unique. An exception is the special section named "INCLUDES"
    * which can contain a list of other files that should be read in addition to the current file.
    *
+   * The input file supports a few special variables which are substituted during reading of the
+   * file. Variables need to be surrounded by braces with a dollar sign prepended, e.g.,
+   * `${FILE_PATH}`. The following variables are supported:
+   *
+   *   - FILE_PATH: The absolute path to the input file containing this variable.
+   *   - FILE_DIR: The absolute path to the directory containing the file with this variable.
+   *
    * Three file formats are supported: the custom .dat file format and the standard .yaml (or .yml)
    * and .json formats. The format of a file is detected based on its ending. If the ending is not
    * one of the above mentioned, the file is assumed to be in the .dat format.

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -381,8 +381,6 @@ Core::IO::InputFileUtils::read_matching_lines_in_section(Core::IO::InputFile& in
   std::vector<std::string> unparsed_lines;
   std::vector<Input::LineDefinition> parsed_lines;
 
-  Input::LineDefinition::ReadContext context{.input_file = input.my_inputfile_name()};
-
   const auto process_line = [&](const std::string& input_line)
   {
     for (const auto& definition : possible_lines)
@@ -391,7 +389,7 @@ Core::IO::InputFileUtils::read_matching_lines_in_section(Core::IO::InputFile& in
 
       // Make a copy that potentially gets filled by the Read.
       auto parsed_definition = definition;
-      if (parsed_definition.read(l, context))
+      if (parsed_definition.read(l))
       {
         parsed_lines.emplace_back(std::move(parsed_definition));
         return;

--- a/src/core/io/src/4C_io_linedefinition.hpp
+++ b/src/core/io/src/4C_io_linedefinition.hpp
@@ -12,7 +12,6 @@
 
 #include "4C_io_input_parameter_container.hpp"
 
-#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -177,13 +176,6 @@ namespace Input
        */
       Builder& add_named_double_vector(std::string name, LengthDefinition length_definition);
 
-      /**
-       * Add a name followed by a file path. If the path is absolute, the path is not changed. If
-       * the path is relative, it is taken relative to the path passed in the context to the read()
-       * function.
-       */
-      Builder& add_named_path(std::string name);
-
       /// Add a name followed by a variable string
       Builder& add_optional_named_string(const std::string& name);
 
@@ -242,22 +234,9 @@ namespace Input
     void print(std::ostream& stream) const;
 
     /**
-     * Context information that may be passed to the read function of a LineDefinition.
+     * If reading succeeds, returns the data. Otherwise, returns an empty std::optional.
      */
-    struct ReadContext
-    {
-      /**
-       * The path of the input file that an input line belongs to.
-       */
-      std::filesystem::path input_file;
-    };
-
-    /**
-     * If reading succeeds, returns the data. Otherwise, returns an empty std::optional. The read
-     * may use additional @p context containing information such as the name of the input file.
-     */
-    std::optional<Core::IO::InputParameterContainer> read(
-        std::istream& stream, const ReadContext& context = {});
+    std::optional<Core::IO::InputParameterContainer> read(std::istream& stream);
 
     [[nodiscard]] const Core::IO::InputParameterContainer& container() const;
 

--- a/src/core/io/tests/4C_io_linedefinition_test.cpp
+++ b/src/core/io/tests/4C_io_linedefinition_test.cpp
@@ -265,55 +265,6 @@ namespace
     EXPECT_TRUE(line_definition.read(input));
   }
 
-  TEST(LineDefinitionTest, PathEmpty)
-  {
-    std::istringstream input("PATH");
-    auto line_definition = Input::LineDefinition::Builder().add_named_path("PATH").build();
-    auto container = line_definition.read(input);
-    EXPECT_FALSE(container.has_value());
-  }
-
-  TEST(LineDefinitionTest, PathNoContext)
-  {
-    std::istringstream input("PATH file.txt");
-    auto line_definition = Input::LineDefinition::Builder().add_named_path("PATH").build();
-    auto container = line_definition.read(input);
-    ASSERT_TRUE(container.has_value());
-    EXPECT_EQ(std::filesystem::path("file.txt"), container->get<std::filesystem::path>("PATH"));
-  }
-
-  TEST(LineDefinitionTest, PathAbsolute)
-  {
-    std::istringstream input("PATH /home/my/file.txt");
-    auto line_definition = Input::LineDefinition::Builder().add_named_path("PATH").build();
-    auto container = line_definition.read(
-        input, Input::LineDefinition::ReadContext{.input_file = {"/data/dummy/input.txt"}});
-    ASSERT_TRUE(container.has_value());
-    EXPECT_EQ(
-        std::filesystem::path("/home/my/file.txt"), container->get<std::filesystem::path>("PATH"));
-  }
-
-  TEST(LineDefinitionTest, PathRelativeWithContext)
-  {
-    std::istringstream input("PATH my/file.txt");
-    auto line_definition = Input::LineDefinition::Builder().add_named_path("PATH").build();
-    auto container = line_definition.read(
-        input, Input::LineDefinition::ReadContext{.input_file = {"/data/dummy/input.txt"}});
-    ASSERT_TRUE(container.has_value());
-    EXPECT_EQ(std::filesystem::path("/data/dummy/my/file.txt"),
-        container->get<std::filesystem::path>("PATH"));
-  }
-
-  TEST(LineDefinitionTest, PathRelativeWithSingleFileNameContext)
-  {
-    std::istringstream input("PATH my/file.txt");
-    auto line_definition = Input::LineDefinition::Builder().add_named_path("PATH").build();
-    auto container = line_definition.read(
-        input, Input::LineDefinition::ReadContext{.input_file = {"input.txt"}});
-    ASSERT_TRUE(container.has_value());
-    EXPECT_EQ(std::filesystem::path("my/file.txt"), container->get<std::filesystem::path>("PATH"));
-  }
-
   TEST(LineDefinitionPrinting, Empty)
   {
     std::ostringstream out;

--- a/src/core/io/tests/test_files/has_includes/folder3/include3.dat
+++ b/src/core/io/tests/test_files/has_includes/folder3/include3.dat
@@ -1,3 +1,5 @@
 -------INCLUDED SECTION 3
 line
 line
+-------INCLUDES
+${FILE_DIR}/../folder4/include4.dat

--- a/src/core/io/tests/test_files/has_includes/folder4/include4.dat
+++ b/src/core/io/tests/test_files/has_includes/folder4/include4.dat
@@ -1,0 +1,5 @@
+--VARIABLE SUBSTITUTION
+${FILE_PATH}
+// Check that multiple variable can be substituted. The result of the substitution does not make sense here.
+${FILE_DIR} + ${FILE_DIR}
+${FILE_DIR} + ${FILE_PATH}

--- a/src/core/io/tests/test_files/yaml_includes/main.yaml
+++ b/src/core/io/tests/test_files/yaml_includes/main.yaml
@@ -1,3 +1,5 @@
 INCLUDES: included.dat
 MAIN SECTION:
   - something
+  # a variable to substitute
+  - ${FILE_DIR}

--- a/src/core/utils/src/functions/4C_utils_function_library.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_library.cpp
@@ -41,13 +41,13 @@ namespace
     }
     else if (function_lin_def.container().get_or<bool>("CUBIC_SPLINE_FROM_CSV", false))
     {
-      const auto csv_file = function_lin_def.container().get<std::filesystem::path>("CSV");
+      const auto csv_file = function_lin_def.container().get<std::string>("CSV");
 
       // safety check
       if (csv_file.empty())
         FOUR_C_THROW("You forgot to specify the *.csv file for cubic spline interpolation!");
 
-      return std::make_shared<Core::Utils::CubicSplineFromCSV>(csv_file.string());
+      return std::make_shared<Core::Utils::CubicSplineFromCSV>(csv_file);
     }
     else
       return {nullptr};

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1565,7 +1565,7 @@ void Global::read_micro_fields(Global::Problem& problem, const std::filesystem::
             (const_cast<char*>(micro_inputfile_name.c_str())), length, 0, subgroupcomm);
 
         // start with actual reading
-        Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm, 1);
+        Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm);
 
         std::shared_ptr<Core::FE::Discretization> dis_micro =
             std::make_shared<Core::FE::Discretization>(
@@ -1707,7 +1707,7 @@ void Global::read_microfields_np_support(Global::Problem& problem)
         (const_cast<char*>(micro_inputfile_name.c_str())), length, 0, subgroupcomm);
 
     // start with actual reading
-    Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm, 1);
+    Core::IO::InputFile micro_reader(micro_inputfile_name, subgroupcomm);
 
     std::shared_ptr<Core::FE::Discretization> structdis_micro =
         std::make_shared<Core::FE::Discretization>("structure", subgroupcomm, problem.n_dim());

--- a/src/mat/4C_mat_anisotropy_extension.hpp
+++ b/src/mat/4C_mat_anisotropy_extension.hpp
@@ -18,6 +18,7 @@
 #include "4C_mat_anisotropy_fiber_provider.hpp"
 #include "4C_utils_exceptions.hpp"
 
+#include <cstdint>
 #include <functional>
 #include <utility>
 

--- a/src/particle_engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle_engine/4C_particle_engine_particlereader.cpp
@@ -30,8 +30,7 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
   bool any_particles_read = false;
   for (const auto& particle_line : input.lines_in_section(section_name))
   {
-    if (!any_particles_read && !input.my_output_flag())
-      Core::IO::cout << "Read and create particles\n" << Core::IO::flush;
+    if (!any_particles_read) Core::IO::cout << "Read and create particles\n" << Core::IO::flush;
     any_particles_read = true;
 
     double t1 = time.totalElapsedTime(true);
@@ -100,14 +99,14 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
     }
 
     double t2 = time.totalElapsedTime(true);
-    if (!myrank && !input.my_output_flag())
+    if (!myrank)
     {
       printf("reading %10.5e secs\n", t2 - t1);
       fflush(stdout);
     }
   }
 
-  if (any_particles_read && !input.my_output_flag())
+  if (any_particles_read)
     printf("in............................................. %10.5e secs\n",
         time.totalElapsedTime(true));
 }


### PR DESCRIPTION
Introduce variable substitutions for `${FILE_PATH}` and `${FILE_DIR}` inside input files. This allows me to drop another special case `LineDefinition::add_named_path`, which achieved something similar but the implementation feels misplaced. The old implementation would not have worked with included files. @c-p-schmidt This should have been used for the csv function, but seems to be broken. Do we even need this feature? 

@gilrrei @ppraegla @amgebauer Does this kind of variable substitution make sense? Or is this better done by external tools (e.g. jinja). I don't want to support a lot of variables, but it seems useful to be able to refer to the file location.

Depends on #157 

Related to #73 