### PR TITLE
Add coverage badge to README

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -153,7 +153,7 @@ jobs:
           . venv/bin/activate
           pip install anybadge
           COVERAGE_PERCENT=`llvm-cov export --object ./build/lib4C.so --format=text --instr-profile=4C-coverage-data.profdata --summary-only --ignore-filename-regex=".*/build/.*" | python -c 'import json, sys; print(json.load(sys.stdin)["data"][0]["totals"]["lines"]["percent"])'`
-          anybadge -l coverage --suffix=" %" --value=$COVERAGE_PERCENT -m "%.2f" 65=red 90=orange 100=green > coverage_report/badge_coverage.svg
+          anybadge -l coverage --suffix=" %" --value=$COVERAGE_PERCENT -m "%.2f" 75=red 90=orange 100=green > coverage_report/badge_coverage.svg
       - name: Upload coverage html report
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![website](./utilities/assets/badges/website_badge.svg)](https://4C-multiphysics.org)
 [![docs/rtd](./utilities/assets/badges/documentation_readthedocs.svg)](https://4c-multiphysics.github.io/4C/readthedocs/)
 [![docs/doxygen](./utilities/assets/badges/documentation_doxygen.svg)](https://4c-multiphysics.github.io/4C/doxygen/)
+[![coverage report](https://4c-multiphysics.github.io/4C/coverage_report/badge_coverage.svg)](https://4c-multiphysics.github.io/4C/coverage_report)
 
 </div>
 
@@ -16,6 +17,7 @@
 [![workflows/buildtest](https://github.com/4C-multiphysics/4C/actions/workflows/buildtest.yml/badge.svg?branch=main)](https://github.com/4C-multiphysics/4C/actions/workflows/buildtest.yml?query=branch%3Amain)
 [![workflows/nightly_tests](https://github.com/4C-multiphysics/4C/actions/workflows/nightly_tests.yml/badge.svg?branch=main)](https://github.com/4C-multiphysics/4C/actions/workflows/nightly_tests.yml?query=branch%3Amain)
 [![workflows/documentation](https://github.com/4C-multiphysics/4C/actions/workflows/documentation.yml/badge.svg?branch=main)](https://github.com/4C-multiphysics/4C/actions/workflows/documentation.yml?query=branch%3Amain)
+[![workflows/coverage](https://github.com/4C-multiphysics/4C/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/4C-multiphysics/4C/actions/workflows/coverage.yml?query=branch%3Amain)
 
 </div>
 


### PR DESCRIPTION
Adds the coverage badges to our README.

I also change the coverage color so that it is consistent with our previous colors.

 * 0-75: red
 * 75-90: orange
 * 90-100: green