### PR TITLE
Reimplement LineDefinition as a more powerful InputSpec

### DIFF
--- a/src/core/io/src/4C_io_input_parameter_container.cpp
+++ b/src/core/io/src/4C_io_input_parameter_container.cpp
@@ -73,4 +73,43 @@ void Core::IO::InputParameterContainer::print(std::ostream& os) const
 }
 
 
+Core::IO::InputParameterContainer& Core::IO::InputParameterContainer::group(const std::string& name)
+{
+  return groups_[name];
+}
+
+
+const Core::IO::InputParameterContainer& Core::IO::InputParameterContainer::group(
+    const std::string& name) const
+{
+  FOUR_C_ASSERT_ALWAYS(groups_.count(name) > 0, "Group '%s' not found in container.", name.c_str());
+  return groups_.at(name);
+}
+
+void Core::IO::InputParameterContainer::merge(const Core::IO::InputParameterContainer& other)
+{
+  const auto combine_maps = [](auto& map1, const auto& map2)
+  {
+    for (const auto& [key, value] : map2)
+    {
+      if (map1.count(key) > 0)
+      {
+        FOUR_C_THROW("Key %s already exists in the container!", key.c_str());
+      }
+      map1[key] = value;
+    }
+  };
+
+  combine_maps(intdata_, other.intdata_);
+  combine_maps(doubledata_, other.doubledata_);
+  combine_maps(booldata_, other.booldata_);
+  combine_maps(vecintdata_, other.vecintdata_);
+  combine_maps(vecdoubledata_, other.vecdoubledata_);
+  combine_maps(mapdata_, other.mapdata_);
+  combine_maps(stringdata_, other.stringdata_);
+  combine_maps(anydata_, other.anydata_);
+  combine_maps(groups_, other.groups_);
+}
+
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -46,16 +46,13 @@ namespace Core::IO
     }
   }  // namespace Internal
 
-  /*!
-  \brief A data storage container
-
-  You can store various types of data in this container and access the data by keys.
-
-  The intention of this class is to store rather 'small' units of data. Though possible,
-  it is not meant to be used at the system level to store huge data sets such as sparse matrices or
-  vectors of system length. It does therefore not support any Core::LinAlg::Vector<double>
-  or Epetra_CrsMatrix objects and is not supposed to in the future either.
-  */
+  /**
+   * A container to store dynamic input parameters. The container can store arbitrary types of
+   * parameters. Parameters can be grouped in sub-containers.
+   *
+   * This class is a core part of the input mechanism, as it contains the parsed data from the input
+   * file and grants access to it.
+   */
   class InputParameterContainer
   {
    public:
@@ -101,6 +98,21 @@ namespace Core::IO
         anydata_[name] = data;
     }
 
+    /**
+     * Access group @p name. If the group does not exist, it will be created.
+     */
+    InputParameterContainer& group(const std::string& name);
+
+    /**
+     * Access group @p name. This function throws an error if the group does not exist.
+     */
+    [[nodiscard]] const InputParameterContainer& group(const std::string& name) const;
+
+
+    /**
+     * Combine the data from another container with this one. Conflicting data will throw an error.
+     */
+    void merge(const InputParameterContainer& other);
 
     /*!
      * Get a const reference to the data stored at the key @p name from the container. An error
@@ -210,6 +222,9 @@ namespace Core::IO
 
     //! a map to store anything
     std::map<std::string, std::any> anydata_;
+
+    //! Groups present in this container. Groups are InputParameterContainers themselves.
+    std::map<std::string, InputParameterContainer> groups_;
   };  // class InputParameterContainer
 }  // namespace Core::IO
 

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -1,0 +1,23 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_io_input_spec.hpp"
+
+#include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_exceptions.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+void Core::IO::fully_parse(ValueParser& parser, const Core::IO::InputSpec& input_spec,
+    Core::IO::InputParameterContainer& container)
+{
+  input_spec.parse(parser, container);
+  FOUR_C_ASSERT_ALWAYS(parser.at_end(), "After parsing, the line still contains '%s'.",
+      std::string(parser.get_unparsed_remainder()).c_str());
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -1,0 +1,32 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_IO_INPUT_SPEC_HPP
+#define FOUR_C_IO_INPUT_SPEC_HPP
+
+#include "4C_config.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::IO
+{
+  class InputSpec;
+  class InputParameterContainer;
+  class ValueParser;
+
+  /**
+   * Use the @p parser to parse whatever @p input_spec expects. The results are stored in the
+   * @p container. If parsing fails, an exception is thrown.
+   */
+  void fully_parse(
+      ValueParser& parser, const InputSpec& input_spec, InputParameterContainer& container);
+
+}  // namespace Core::IO
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -1,0 +1,361 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_io_input_spec_builders.hpp"
+
+#include <set>
+#include <unordered_map>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  void parse_in_arbitrary_order(Core::IO::ValueParser& parser,
+      const std::vector<Core::IO::InputSpec>& line, Core::IO::InputParameterContainer& container)
+  {
+    std::unordered_map<std::string, const Core::IO::InputSpec*> name_to_entry_map;
+    std::set<const Core::IO::InputSpec*> unnamed_entries;
+    for (const auto& entry : line)
+    {
+      const auto& name = entry.name();
+      if (name.empty())
+      {
+        unnamed_entries.insert(&entry);
+      }
+      else
+      {
+        name_to_entry_map[name] = &entry;
+      }
+    }
+
+    const auto are_entries_left = [&]()
+    { return !name_to_entry_map.empty() || !unnamed_entries.empty(); };
+
+
+    // Parse as long as there are tokens and we expect more entries.
+    while (!parser.at_end() && are_entries_left())
+    {
+      // Only peek at the next value, do not consume it yet.
+      const std::string next(parser.peek());
+
+      if (next == "//")
+      {
+        parser.consume_comment(next);
+        break;
+      }
+
+      // The typical case: peeking reveals the key of the next value.
+      const auto it = name_to_entry_map.find(next);
+      if (it != name_to_entry_map.end())
+      {
+        // Will consume the name as well as the value.
+        it->second->parse(parser, container);
+
+        // Drop the entry from the map: we do not want to parse the same value twice. This also
+        // allows to check if all required values have been parsed.
+        name_to_entry_map.erase(it);
+        continue;
+      }
+
+      // We might find a parseable unnamed component.
+      if (!unnamed_entries.empty())
+      {
+        bool parsed = false;
+        Core::IO::ValueParser::BacktrackScope backtrack_scope(parser);
+        for (const auto& entry : unnamed_entries)
+        {
+          try
+          {
+            entry->parse(parser, container);
+          }
+          catch (const Core::Exception&)
+          {
+            // Try the next component.
+            parser.backtrack();
+          }
+
+          // Drop the entry from the set: we do not want to parse the same value twice.
+          unnamed_entries.erase(entry);
+          parsed = true;
+          break;
+        }
+
+        if (parsed) continue;
+      }
+
+      // If we reach this point, we could not parse the next value. What remains must therefore
+      // belong to other specs.
+      break;
+    }
+
+    // Consume a potential trailing comment
+    {
+      const auto next = parser.peek();
+      if (next == "//") parser.consume_comment("//");
+    }
+
+    for (const auto& entry : unnamed_entries)
+    {
+      // Unnamed entries contain a useful description, which indicates what is missing.
+      FOUR_C_ASSERT_ALWAYS(!entry->required(), "Required '%s' not found in input line",
+          entry->description().c_str());
+    }
+
+    // Check if all required values have been parsed, i.e., any remaining component must be optional
+    for (const auto& [name, entry] : name_to_entry_map)
+    {
+      if (entry->required())
+      {
+        FOUR_C_THROW("Required value '%s' not found in input line", name.c_str());
+      }
+      else if (entry->has_default_value())
+      {
+        entry->set_default_value(container);
+      }
+    }
+  }
+
+  void assert_unique_or_empty_names(const std::vector<Core::IO::InputSpec>& specs)
+  {
+    std::set<std::string> names;
+    for (const auto& component : specs)
+    {
+      if (!component.name().empty())
+        FOUR_C_ASSERT_ALWAYS(names.insert(component.name()).second,
+            "Duplicate component name '%s' found in input line.", component.name().c_str());
+    }
+  }
+
+  bool all_have_default_values(const std::vector<Core::IO::InputSpec>& specs)
+  {
+    return std::all_of(specs.begin(), specs.end(),
+        [](const Core::IO::InputSpec& component) { return component.has_default_value(); });
+  }
+
+  [[nodiscard]] const std::string& describe_for_error_handling(const Core::IO::InputSpec& spec)
+  {
+    return (spec.name().empty()) ? spec.description() : spec.name();
+  }
+
+  [[nodiscard]] std::string describe_for_error_handling(
+      const std::vector<Core::IO::InputSpec>& specs)
+  {
+    if (specs.empty()) return "{}";
+
+    std::string description = "{";
+    for (const auto& spec : specs)
+    {
+      // Unnamed InputSpecs are created internally and will have a description that is useful for
+      // error messages.
+      description += describe_for_error_handling(spec);
+      description += ", ";
+    }
+    description.pop_back();
+    description.pop_back();
+    description += "}";
+
+    return description;
+  }
+
+
+}  // namespace
+
+void Core::IO::InputSpecBuilders::Internal::GroupSpec::parse(
+    Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
+{
+  // Support the special case of unnamed groups.
+  if (!name.empty()) parser.consume(name);
+
+  // Parse into a separate container to avoid side effects if parsing fails.
+  Core::IO::InputParameterContainer subcontainer;
+  parse_in_arbitrary_order(parser, specs, subcontainer);
+
+  if (name.empty())
+    container.merge(subcontainer);
+  else
+    container.group(name) = subcontainer;
+}
+
+
+void Core::IO::InputSpecBuilders::Internal::GroupSpec::set_default_value(
+    Core::IO::InputParameterContainer& container) const
+{
+  auto& subcontainer = (name.empty()) ? container : container.group(name);
+  for (const auto& component : specs)
+  {
+    if (component.has_default_value()) component.set_default_value(subcontainer);
+  }
+}
+
+
+void Core::IO::InputSpecBuilders::Internal::GroupSpec::print(
+    std::ostream& stream, const Core::IO::InputParameterContainer& container) const
+{
+  if (!name.empty()) stream << name;
+
+  const auto& subcontainer = (name.empty()) ? container : container.group(name);
+  for (const auto& component : specs)
+  {
+    component.print(stream, subcontainer);
+    stream << " ";
+  }
+}
+
+void Core::IO::InputSpecBuilders::Internal::OneOfSpec::parse(
+    Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
+{
+  ValueParser::BacktrackScope backtrack_scope(parser);
+
+  // Try to parse a component and backtrack if it fails.
+  const auto try_parse = [&](const Core::IO::InputSpec& component) -> bool
+  {
+    try
+    {
+      component.parse(parser, container);
+      return true;
+    }
+    catch (const Core::Exception&)
+    {
+      parser.backtrack();
+      return false;
+    }
+  };
+
+  auto component = specs.begin();
+  for (; component != specs.end(); ++component)
+  {
+    const auto success = try_parse(*component);
+
+    // Now check that no other component can be parsed.
+    if (success)
+    {
+      ValueParser::BacktrackScope backtrack_scope_after_success(parser);
+      for (auto other = specs.begin(); other != specs.end(); ++other)
+      {
+        if (other == component) continue;
+        if (try_parse(*other))
+        {
+          // Backtrack to the original position.
+          parser.backtrack();
+          FOUR_C_THROW(
+              "Ambiguous input: both '%s' and '%s' could be parsed, but only one of them is "
+              "expected.",
+              describe_for_error_handling(*component).c_str(),
+              describe_for_error_handling(*other).c_str());
+        }
+      }
+
+      // If we reach this point, we have successfully parsed the input.
+      return;
+    }
+  }
+
+  // If we reach this point, none of the specs could be parsed.
+  FOUR_C_THROW("None of the specs fit the input. Expected %s", data.description.c_str());
+}
+
+
+void Core::IO::InputSpecBuilders::Internal::OneOfSpec::set_default_value(
+    Core::IO::InputParameterContainer& container) const
+{
+  FOUR_C_THROW("Implementation error: OneOfSpec cannot have a default value.");
+}
+
+
+void Core::IO::InputSpecBuilders::Internal::OneOfSpec::print(
+    std::ostream& stream, const Core::IO::InputParameterContainer& container) const
+{
+  stream << "<one_of {";
+  for (const auto& component : specs)
+  {
+    component.print(stream, container);
+    stream << ";";
+  }
+  stream << "}>";
+}
+
+
+Core::IO::InputSpec Core::IO::InputSpecBuilders::tag(std::string name, ScalarData<bool> data)
+{
+  return user_defined<bool>(
+      name, data,
+      // If we encounter the tag, we set the value to true.
+      [name](ValueParser& parser, InputParameterContainer& container)
+      {
+        parser.consume(name);
+        container.add(name, true);
+      },
+      [name](std::ostream& stream, const InputParameterContainer& container) { stream << name; });
+}
+
+
+Core::IO::InputSpec Core::IO::InputSpecBuilders::group(
+    std::string name, std::vector<InputSpec> specs, Core::IO::InputSpecBuilders::GroupData data)
+{
+  FOUR_C_ASSERT_ALWAYS(!specs.empty(), "A group must contain at least one entry.");
+
+  assert_unique_or_empty_names(specs);
+
+  InputSpec::CommonData common_data{
+      .name = name,
+      .description = data.description,
+      .required = data.required,
+      .has_default_value = all_have_default_values(specs),
+  };
+
+  return InputSpec(
+      Internal::GroupSpec{.name = name, .data = std::move(data), .specs = std::move(specs)},
+      common_data);
+}
+
+
+Core::IO::InputSpec Core::IO::InputSpecBuilders::group(std::vector<InputSpec> specs)
+{
+  assert_unique_or_empty_names(specs);
+
+  // Generate a description of the form "group {a, b, c}".
+  std::string description = "group " + describe_for_error_handling(specs);
+
+  InputSpec::CommonData common_data{
+      .name = "",
+      .description = description,
+      .required = true,
+      .has_default_value = all_have_default_values(specs),
+  };
+
+  return InputSpec(Internal::GroupSpec{.name = "",
+                       .data = {.description = description, .required = true},
+                       .specs = std::move(specs)},
+      common_data);
+}
+
+
+Core::IO::InputSpec Core::IO::InputSpecBuilders::one_of(std::vector<InputSpec> specs)
+{
+  FOUR_C_ASSERT_ALWAYS(!specs.empty(), "`one_of` must contain at least one entry.");
+
+  assert_unique_or_empty_names(specs);
+
+  std::string description = "one_of " + describe_for_error_handling(specs);
+  InputSpec::CommonData common_data{
+      .name = "",
+      .description = description,
+      .required = true,
+      .has_default_value = false,
+  };
+
+  GroupData group_data{
+      .description = description,
+      .required = true,
+  };
+
+  return InputSpec(Internal::OneOfSpec{.data = std::move(group_data), .specs = std::move(specs)},
+      std::move(common_data));
+}
+
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -1,0 +1,896 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_IO_INPUT_SPEC_BUILDERS_HPP
+#define FOUR_C_IO_INPUT_SPEC_BUILDERS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_io_input_parameter_container.hpp"
+#include "4C_io_input_spec.hpp"
+#include "4C_io_value_parser.hpp"
+
+#include <functional>
+#include <optional>
+#include <ostream>
+#include <variant>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::IO
+{
+  namespace Internal
+  {
+    /**
+     * Helper to print values in the format of a dat file.
+     */
+    struct DatPrinter
+    {
+      template <typename T>
+      void operator()(std::ostream& out, const T& val) const
+      {
+        out << " " << val;
+      }
+
+      void operator()(std::ostream& out, bool val) const { out << " " << (val ? "true" : "false"); }
+
+      template <typename T>
+      void operator()(std::ostream& out, const std::vector<T>& val) const
+      {
+        for (const auto& v : val)
+        {
+          (*this)(out, v);
+        }
+      }
+
+      template <typename T, typename U>
+      void operator()(std::ostream& out, const std::pair<T, U>& val) const
+      {
+        (*this)(out, val.first);
+        (*this)(out, val.second);
+      }
+    };
+
+    template <typename T, typename AlwaysVoid = void>
+    constexpr bool has_print = false;
+
+    template <typename T>
+    constexpr bool has_print<T, std::void_t<decltype(std::declval<const std::decay_t<T>>().print(
+                                    std::declval<std::ostream&>(),
+                                    std::declval<const Core::IO::InputParameterContainer&>()))>> =
+        true;
+
+    template <typename T, typename AlwaysVoid = void>
+    constexpr bool has_set_default_value = false;
+
+    template <typename T>
+    constexpr bool has_set_default_value<T,
+        std::void_t<decltype(std::declval<const std::decay_t<T>>().set_default_value(
+            std::declval<Core::IO::InputParameterContainer&>()))>> = true;
+
+
+    template <typename T, typename AlwaysVoid = void>
+    struct PrettyTypeName
+    {
+      std::string operator()() { return Utils::try_demangle(typeid(T).name()); }
+    };
+
+    template <>
+    struct PrettyTypeName<std::string>
+    {
+      std::string operator()() { return "string"; }
+    };
+
+    template <>
+    struct PrettyTypeName<std::filesystem::path>
+    {
+      std::string operator()() { return "char"; }
+    };
+
+    template <typename T>
+    struct PrettyTypeName<std::vector<T>>
+    {
+      std::string operator()() { return "vector<" + PrettyTypeName<T>{}() + ">"; }
+    };
+
+    template <typename T, typename U>
+    struct PrettyTypeName<std::pair<T, U>>
+    {
+      std::string operator()()
+      {
+        return "pair<" + PrettyTypeName<T>{}() + ", " + PrettyTypeName<U>{}() + ">";
+      }
+    };
+
+    template <typename T>
+    std::string get_pretty_type_name()
+    {
+      return PrettyTypeName<T>{}();
+    }
+
+    class InputSpecTypeErasedInterface
+    {
+     public:
+      virtual ~InputSpecTypeErasedInterface() = default;
+      virtual void parse(ValueParser& parser, InputParameterContainer& container) const = 0;
+      virtual void set_default_value(InputParameterContainer& container) const = 0;
+      virtual void print(std::ostream& stream, const InputParameterContainer& container) const = 0;
+      [[nodiscard]] virtual std::unique_ptr<InputSpecTypeErasedInterface> clone() const = 0;
+    };
+
+    template <typename T>
+    struct InputSpecTypeErasedImplementation : public InputSpecTypeErasedInterface
+    {
+      template <typename T2, std::enable_if_t<!std::is_same_v<std::decay_t<T>, InputSpec>, int> = 0>
+      explicit InputSpecTypeErasedImplementation(T2&& wrapped) : wrapped(std::forward<T2>(wrapped))
+      {
+      }
+
+      void parse(ValueParser& parser, InputParameterContainer& container) const override
+      {
+        wrapped.parse(parser, container);
+      }
+
+      void set_default_value(InputParameterContainer& container) const override
+      {
+        if constexpr (Internal::has_set_default_value<T>)
+        {
+          wrapped.set_default_value(container);
+        }
+        else
+        {
+          FOUR_C_ASSERT(wrapped.data.default_value.has_value(),
+              "Implementation error: this function should only be called if the wrapped type has "
+              "an optional default value.");
+
+          container.add(wrapped.name, *wrapped.data.default_value);
+        }
+      }
+
+      void print(std::ostream& stream, const InputParameterContainer& container) const override
+      {
+        if constexpr (Internal::has_print<T>)
+        {
+          wrapped.print(stream, container);
+        }
+        else
+        {
+          stream << wrapped.name;
+
+          const auto* value = container.get_if<typename T::DataType::StoredType>(wrapped.name);
+          if (value)
+          {
+            // Print the value if it is present in the container.
+            Internal::DatPrinter{}(stream, *value);
+          }
+          else
+          {
+            // Print the type of the value if it is not present in the container.
+            // This functionality is only required to print exemplary lines into a default
+            // dat file. When no default value, exists there is not much that we can let the
+            // user know except the type we expect.
+            stream << " <" << Internal::get_pretty_type_name<typename T::DataType::StoredType>()
+                   << ">";
+          }
+        }
+      }
+
+      [[nodiscard]] std::unique_ptr<InputSpecTypeErasedInterface> clone() const override
+      {
+        return std::make_unique<InputSpecTypeErasedImplementation<T>>(wrapped);
+      }
+
+      T wrapped;
+    };
+  }  // namespace Internal
+
+  /**
+   * Objects of this class encapsulate knowledge about the input. Users can create objects using
+   * the helper functions in the InputSpecBuilders namespace. See the function
+   * InputSpecBuilders::entry() for an explanation how to create InputSpecs. This class can be
+   * treated as an implementation detail from the user's perspective.
+   */
+  class InputSpec
+  {
+   public:
+    /**
+     * Store a reduced version of the common data entries.
+     */
+    struct CommonData
+    {
+      /**
+       * The name or key under which the value is found in the input. This name is also used to
+       * store the value in the container.
+       */
+      std::string name;
+
+      /**
+       * An optional description of the value.
+       */
+      std::string description;
+
+      /**
+       * Whether the value is required or optional.
+       */
+      bool required;
+
+      /**
+       * Whether the spec has a default value.
+       */
+      bool has_default_value;
+    };
+
+    /**
+     * A default-constructed spec. A value needs to be assigned to this object before it can
+     * be used.
+     */
+    InputSpec() = default;
+
+    /**
+     * Construct a InputSpec. This constructor is not intended to be used directly. Use the
+     * helper functions in the InputSpecBuilders namespace instead.
+     */
+    template <typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, InputSpec>, int> = 0>
+    InputSpec(T&& spec, CommonData data);
+
+    InputSpec(const InputSpec& other) : data_(other.data_), spec_(other.spec_->clone()) {}
+
+    InputSpec& operator=(const InputSpec& other)
+    {
+      spec_ = other.spec_->clone();
+      data_ = other.data_;
+      return *this;
+    }
+
+    InputSpec(InputSpec&&) noexcept = default;
+    InputSpec& operator=(InputSpec&&) noexcept = default;
+
+    /**
+     * Parse this spec from the input. This is often not the correct function to call, if you
+     * want to ensure that the input is fully parsed. Use the fully_parse() function instead.
+     *
+     * @note This function is an implementation detail and should not be called by users.
+     */
+    void parse(ValueParser& parser, InputParameterContainer& container) const
+    {
+      spec_->parse(parser, container);
+    }
+
+    /**
+     * Store the default value of this spec in the container. This likely only makes sense
+     * if the has_default_value() function returns true.
+     *
+     * @note This function is an implementation detail and should not be called by users.
+     */
+    void set_default_value(InputParameterContainer& container) const
+    {
+      spec_->set_default_value(container);
+    }
+
+    /**
+     * Legacy dat-style printing. This format is intended to be human-readable and is not used
+     * for further processing.
+     *
+     * @note This function is an implementation detail and should not be called by users.
+     */
+    void print(std::ostream& stream, const InputParameterContainer& container) const
+    {
+      if (!required()) stream << "[";
+      spec_->print(stream, container);
+      if (!required()) stream << "]";
+    }
+
+    [[nodiscard]] const std::string& name() const { return data_.name; }
+
+    [[nodiscard]] const std::string& description() const { return data_.description; }
+
+    [[nodiscard]] bool required() const { return data_.required; }
+
+    [[nodiscard]] bool has_default_value() const { return data_.has_default_value; }
+
+   private:
+    //! Common data entries.
+    CommonData data_;
+
+    //! Pointer to type-erased implementation.
+    std::unique_ptr<Internal::InputSpecTypeErasedInterface> spec_;
+  };
+
+  /**
+   * Helper functions to create InputSpec objects. When you want to create an InputSpec, you
+   * can "import" the functions from this namespace by using the following line:
+   *
+   * @code
+   * using namespace Core::IO::InputSpecBuilders;
+   * @endcode
+   *
+   * This allows you to create InputSpec objects in a concise notation like this:
+   *
+   * @code
+   * auto input = group("params",
+   *   {
+   *   entry<int>("a", {.description = "An integer value", .required = true}),
+   *   entry<std::vector<double>>("b", {.description = "A vector of doubles", .required = false,
+   *     .size = 4}),
+   *   }
+   * );
+   * @endcode
+   */
+  namespace InputSpecBuilders
+  {
+    //! Additional parameters for a scalar-valued entry().
+    template <typename StoredTypeIn>
+    struct ScalarData
+    {
+      using StoredType = StoredTypeIn;
+      /**
+       * An optional description of the value.
+       */
+      std::string description{};
+
+      /**
+       * Whether the value is required or optional.
+       */
+      std::optional<bool> required{};
+
+      /**
+       * The default value of the parameter. If this optional fields is set, the parameter is
+       * optional. If it is not set, the parameter is required.
+       */
+      std::optional<StoredType> default_value{};
+    };
+
+    //! Additional parameters for a vector-valued entry().
+    template <typename StoredTypeIn, typename ScalarTypeIn>
+    struct VectorData
+    {
+      using StoredType = StoredTypeIn;
+      using ScalarType = ScalarTypeIn;
+
+      /**
+       * A function that determines the size of the vector. This function is called with the
+       * already parsed content of the input line, which may be used to query the size as the
+       * value of another parameter.
+       */
+      using SizeCallback = std::function<int(const InputParameterContainer&)>;
+
+      /**
+       * An optional description of the value.
+       */
+      std::string description{};
+
+      /**
+       * Whether the value is required or optional.
+       */
+      std::optional<bool> required{};
+
+      /**
+       * The default value of the parameter. If this optional fields is set, the parameter is
+       * optional. If it is not set, the parameter is required.
+       */
+      std::optional<StoredType> default_value{};
+
+      /**
+       * The size of the data. This can either be a fixed size or a callback that determines the
+       * size based on the value of another parameter.
+       *
+       * @note We use `int` instead of `size_t` since this is what most users write. Template
+       *      argument deduction will work a lot better with `int` than with `size_t`.
+       */
+      std::variant<int, SizeCallback> size;
+    };
+
+    //! Additional parameters for a group().
+    struct GroupData
+    {
+      /**
+       * An optional description of the Group.
+       */
+      std::string description{};
+
+      /**
+       * Whether the Group is required or optional.
+       */
+      bool required{true};
+    };
+
+    namespace Internal
+    {
+      template <typename T>
+      struct DataForHelper
+      {
+        using type = ScalarData<T>;
+      };
+
+      template <typename T>
+      struct DataForHelper<std::vector<T>>
+      {
+        using type = VectorData<std::vector<T>, T>;
+      };
+
+      template <typename T>
+      using DataFor = typename DataForHelper<T>::type;
+
+
+      template <typename DataType>
+      static constexpr bool is_sized_data = false;
+
+      template <typename D, typename S>
+      static constexpr bool is_sized_data<VectorData<D, S>> = true;
+
+      //! Make .required field consistent with .default_value.
+      template <typename DataType>
+      void sanitize_required_default(DataType& data)
+      {
+        if (data.default_value.has_value())
+        {
+          if (data.required.has_value())
+          {
+            FOUR_C_ASSERT_ALWAYS(!data.required.value(),
+                "A parameter cannot be both required and have a default value.");
+          }
+          else
+          {
+            data.required = false;
+          }
+        }
+        else
+        {
+          if (!data.required.has_value()) data.required = true;
+        }
+        FOUR_C_ASSERT(data.required.has_value(), "Required field must now be set.");
+      }
+
+      template <typename DataTypeIn>
+      struct BasicSpec
+      {
+        std::string name;
+        using DataType = std::decay_t<DataTypeIn>;
+        using StoredType = typename DataType::StoredType;
+        DataType data;
+        void parse(ValueParser& parser, InputParameterContainer& container) const;
+      };
+
+
+      template <typename DataTypeIn>
+      struct UserDefinedSpec
+      {
+        std::string name;
+        using DataType = std::decay_t<DataTypeIn>;
+        using StoredType = typename DataType::StoredType;
+        DataType data;
+        std::function<void(ValueParser&, InputParameterContainer&)> parse;
+        std::function<void(std::ostream&, const InputParameterContainer&)> print;
+      };
+
+      struct GroupSpec
+      {
+        std::string name;
+        GroupData data;
+        std::vector<InputSpec> specs;
+
+        void parse(ValueParser& parser, InputParameterContainer& container) const;
+        void set_default_value(InputParameterContainer& container) const;
+        void print(std::ostream& stream, const InputParameterContainer& container) const;
+      };
+
+      struct OneOfSpec
+      {
+        // A one_of spec is essentially an unnamed group with additional logic to ensure that
+        // exactly one of the contained specs is present.
+        GroupData data;
+        std::vector<InputSpec> specs;
+
+        void parse(ValueParser& parser, InputParameterContainer& container) const;
+
+        void set_default_value(InputParameterContainer& container) const;
+
+        void print(std::ostream& stream, const InputParameterContainer& container) const;
+      };
+    }  // namespace Internal
+
+    /**
+     * Create a normal entry. All entries are parameterized by a struct which contains the optional
+     * `description`, `required` and `default_value` fields. The following examples demonstrate how
+     * entries can be created:
+     *
+     * @code
+     * // An entry with name and description. By default, the entry is required.
+     * entry<int>("my_int", {.description = "An integer value."});
+     *
+     * // An entry with a default value. This entry is implicitly optional because a default value
+     * // is given.
+     * entry<double>("my_double", {.default_value = 3.14});
+     * // This is equivalent to:
+     * entry<double>("my_double", {.required = false, .default_value = 3.14});
+     *
+     * // An optional entry. This value does not have a default value.
+     * entry<std::string>("my_string", {.required = false});
+     *
+     * // A vector entry with a fixed size of 3.
+     * entry<std::vector<double>>("my_vector", {.size = 3});
+     *
+     * // A vector entry with a size that is determined by the value of another parameter. The
+     * // size is given as a callback.
+     * entry<int>("N");
+     * entry<std::vector<double>>("my_vector", {.size = from_parameter<int>("N")});
+     * @endcode
+     *
+     * After parsing an InputSpec with fully_parse(), the value of the entry can be retrieved from
+     * an InputParameterContainer. The details depend on the `required` and `default_value` fields:
+     *
+     *   - `required` is used to determine whether the parameter is required in the input file. Note
+     *     that by default, if `required` is not set, the parameter is implicitly required. Failing
+     *     to read a required parameter will result in an exception.  If successfully parsed, the
+     *     container that is filled by the fully_parse() function will contain the parameter and its
+     *     value. On the other hand, if a parameter is not required, it is optional and can be left
+     *     out in the input file. The container that is filled by the fully_parse() function will
+     *     not contain the optional parameter.
+     *
+     *   - `default_value` is used to provide a value that is used if the parameter is not present
+     *     in the input file. If `default_value` is set, the parameter is implicitly optional. If
+     *     the parameter is not present in the input file, the default value will be stored in the
+     *     container that is filled by the fully_parse() function.
+     *
+     *   - Setting both `required = true` and a `default_value` is a logical error and will result
+     *     in an exception.
+     *
+     * When you decide how to set the `required` and `default_value` fields, consider the following
+     * three cases:
+     *
+     *   - If you always require a parameter and there is no reasonable default value, do not set
+     *     `required` or `default_value`. This will make the parameter required by default. Parsing
+     *     will fail if the parameter is not present, but after parsing you can be sure that the
+     *     parameter can safely be retrieved with InputParameterContainer::get(). A good example is
+     *     the time step size in a time integration scheme: this parameter is always required and
+     *     taking an arbitrary default value is not a good idea.
+     *
+     *   - Is there a reasonable default value for the parameter, which works in most situations? If
+     *     yes, set `default_value` to this value (`required` implicitly is `false` then). This
+     *     guarantees that you can always read the a value from the container with
+     *     InputParameterContainer::get(). A good example is a parameter that activates or
+     *     deactivates a feature, e.g., defaulting the EAS element technology to off might be
+     *     reasonable.
+     *
+     *   - If the parameter is not required, but there is no reasonable default value, set
+     *     `required = false`. This makes the parameter optional and the container might not contain
+     *     the parameter if it is not present in the input file. Use
+     *     InputParameterContainer::get_if() or InputParameterContainer::get_or() to safely retrieve
+     *     the value from the container. Since this complicates retrieval of input data, this case
+     *     should be used with caution. Try to formulate your input requirements in a way that one
+     *     of the cases above applies. To still give an example, the present case may be useful for
+     *     a damping parameter that, when present, activates damping using the provided value. This
+     *     example demonstrates that the parameter has a double role: its presence activates
+     *     damping and its value determines the damping strength. An often better way to selectively
+     *     activate parameters can be achieved with the group() function, especially if a set of
+     *     parameters is always required together.
+     *
+     * @tparam T The data type of the entry.
+     */
+    template <typename T, typename DataType = Internal::DataFor<T>>
+    [[nodiscard]] InputSpec entry(std::string name, DataType&& data = {});
+
+    /**
+     * Create a callback that returns the value of the parameter with the given @p name. Such a
+     * callback can, e.g., be used to determine the size of a vector parameter based on the value
+     * of another parameter. Of course, the parameter with the given @p name must be read before
+     * the parameter that uses this callback. Example:
+     *
+     * @code
+     *   auto input_spec = group({
+     *    entry<int>("N"),
+     *    entry<std::vector<double>>("data", {.size = read_from_parameter<int>("N")}),
+     *    });
+     * @endcode
+     *
+     * @tparam T The type of the parameter of given @p name.
+     */
+    template <typename T>
+    [[nodiscard]] auto from_parameter(const std::string& name);
+
+    /**
+     * Create a special "tag" entry. A tag is essentially a `bool` parameter that is `true` if the
+     * tag is present in the input and `false` otherwise.
+     *
+     * @note Tags are always optional. If not present in the input, the value is `false`.
+     *
+     * @deprecated Use `entry<bool>` instead, to be more explicit in input files. A "tag" cannot
+     * explicitly be set to `false` in the input file, as this requires leaving out the tag.
+     */
+    [[nodiscard]] InputSpec tag(std::string name, ScalarData<bool> data = {});
+
+    /**
+     * A user-defined entry. This is a more flexible version of the `entry` function. It takes
+     * a custom function to parse and store the value. The function must take a `ValueParser` and an
+     * `InputParameterContainer` as arguments. You can also provide a custom function to print the
+     * value. If no print function is provided, a default print function fitting the data type is
+     * used. The struct that parameterizes the entry follows the same rules as for the entry()
+     * function.
+     *
+     * @note This function is a last resort. If what you are parsing is so special that it
+     *       is not covered by the other functions, you can use this function. Please consider,
+     *       enhancing the library with a new function if you think what you are doing is a
+     *       missing common use case.
+     */
+    template <typename T, typename DataType = Internal::DataFor<T>>
+    [[nodiscard]] InputSpec user_defined(std::string name, DataType&& data = {},
+        const std::function<void(ValueParser&, InputParameterContainer&)>& parse = nullptr,
+        const std::function<void(std::ostream&, const Core::IO::InputParameterContainer&)>& print =
+            nullptr);
+
+    /**
+     * An entry whose value is a a selection from a list of choices. For example:
+     *
+     * @code
+     * selection<int>("my_selection", {{"a", 1}, {"b", 2}, {"c", 3}});
+     * @endcode
+     *
+     * The choices are given as a vector of pairs. The first element of the pair is the string
+     * that is expected in the input file. The second element is the value that is stored and may be
+     * any type. This function is for convenience, as you do not need to convert parsed string
+     * values to another type yourself. A frequent use case is to map strings to enum constants.
+     *
+     * The remaining parameterization options follow the same rules as for the entry() function.
+     */
+    template <typename T, typename DataType = Internal::DataFor<T>>
+    [[nodiscard]] InputSpec selection(
+        std::string name, std::vector<std::pair<std::string, T>> choices, DataType data = {});
+
+    /**
+     * A group of InputSpecs. This groups one or more InputSpecs under a name. A group can be
+     * required (default) or optional. If the group is optional and not present in the input, all
+     * InputSpecs in the group are implicitly optional. Examples:
+     *
+     * @code
+     * // A required group.
+     * group("group",
+     *    {
+     *      entry<double>("a"),
+     *      entry<int>("b"),
+     *    });
+     *
+     * // An optional group. If the group is not present in the input, none of the entries are
+     * // required. This is useful to require a group of parameters together.
+     * group("GenAlpha",
+     *   {
+     *      entry<double>("alpha_f"),
+     *      entry<double>("alpha_m"),
+     *      entry<double>("gamma"),
+     *   },
+     *   {.required = false}
+     *   );
+     *
+     * //Groups may be nested
+     * group("outer",
+     *  {
+     *    entry<int>("a"),
+     *    group("inner",
+     *    {
+     *      entry<double>("b"),
+     *      entry<std::string>("c"),
+     *    }
+     *    ),
+     *  });
+     *
+     * @endcode
+     *
+     * A group introduces a new scope in the input. This group scope is not only useful for
+     * structuring the input file, but also to selectively activate a set of parameters, as
+     * demonstrated in the second example. If an optional group is not present in the input, none of
+     * the entries are required. If the group is present, all entries are required. This is often
+     * exactly what you need: a group activates a feature which requires certain parameters to
+     * be present.
+     *
+     * Whether a group has a default value is determined by the default values of its entries. If
+     * all entries have default values, the group implicitly has a default value. In this case, if
+     * the group is optional and not present in the input, the default values of the entries are
+     * stored under the group name in the container.
+     *
+     * @note If you want to group multiple InputSpecs without creating a new scope, use the other
+     * group() function which does not take a name.
+     *
+     */
+    [[nodiscard]] InputSpec group(
+        std::string name, std::vector<InputSpec> specs, GroupData data = {});
+
+    /**
+     * A group of multiple InputSpecs. In contrast to the other group() function, this function
+     * produces a group without a name and, consequently, no scope is created in the input.
+     * Example:
+     *
+     * @code
+     * group({
+     *   entry<int>("a"),
+     *   entry<double>("b"),
+     *   entry<std::string>("c"),
+     *   });
+     * @endcode
+     *
+     * This functions gathers multiple InputSpecs on the same level and treats them as a single
+     * InputSpec.
+     */
+    [[nodiscard]] InputSpec group(std::vector<InputSpec> specs);
+
+    /**
+     * Exactly one of the given InputSpecs is expected. There is no support for default values and
+     * one of the InputSpecs is always required. For example, the example shown for the group()
+     * function may be enhanced to require exactly one of two groups:
+     *
+     * @code
+     * one_of({
+     *  group("OneStepTheta",
+     *  {
+     *    entry<double>("theta"),
+     *  }),
+     *  group("GenAlpha",
+     *  {
+     *    entry<double>("alpha_f"),
+     *    entry<double>("alpha_m"),
+     *    entry<double>("gamma"),
+     *  }),
+     *  });
+     * @endcode
+     *
+     * This InputSpecs requires either the "OneStepTheta" group or the "GenAlpha" group to be
+     * present in the input. If both or none of them are present, an exception is thrown.
+     */
+    [[nodiscard]] InputSpec one_of(std::vector<InputSpec> specs);
+  }  // namespace InputSpecBuilders
+}  // namespace Core::IO
+
+
+// --- template definitions --- //
+
+template <typename DataType>
+void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataType>::parse(
+    ValueParser& parser, InputParameterContainer& container) const
+{
+  parser.consume(name);
+
+  if constexpr (InputSpecBuilders::Internal::is_sized_data<DataType>)
+  {
+    struct SizeVisitor
+    {
+      std::size_t operator()(std::size_t size) const { return size; }
+      std::size_t operator()(const typename DataType::SizeCallback& callback) const
+      {
+        return callback(container);
+      }
+      InputParameterContainer& container;
+    };
+
+    std::size_t size = std::visit(SizeVisitor{container}, data.size);
+    FOUR_C_ASSERT(size > 0, "Size must be greater than 0.");
+    auto parsed = parser.read<typename DataType::StoredType>(size);
+    container.add(name, parsed);
+  }
+  else
+  {
+    container.add(name, parser.read<typename DataType::StoredType>());
+  }
+}
+
+
+template <typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, Core::IO::InputSpec>, int>>
+Core::IO::InputSpec::InputSpec(T&& spec, CommonData data)
+    : data_(std::move(data)),
+      spec_(std::make_unique<Internal::InputSpecTypeErasedImplementation<std::decay_t<T>>>(
+          std::forward<T>(spec)))
+{
+}
+
+
+template <typename T>
+auto Core::IO::InputSpecBuilders::from_parameter(const std::string& name)
+{
+  return [name](const InputParameterContainer& container) -> T
+  {
+    const T* val = container.get_if<T>(name);
+    FOUR_C_ASSERT_ALWAYS(val, "Parameter '%s' not found in container.", name.c_str());
+    return *val;
+  };
+}
+
+
+template <typename T, typename DataType>
+Core::IO::InputSpec Core::IO::InputSpecBuilders::entry(std::string name, DataType&& data)
+{
+  Internal::sanitize_required_default(data);
+  return InputSpec(Internal::BasicSpec<DataType>{.name = name, .data = data},
+      {
+          .name = name,
+          .description = data.description,
+          .required = data.required.value(),
+          .has_default_value = data.default_value.has_value(),
+      });
+}
+
+
+template <typename T, typename DataType>
+Core::IO::InputSpec Core::IO::InputSpecBuilders::user_defined(std::string name, DataType&& data,
+    const std::function<void(ValueParser&, InputParameterContainer&)>& parse,
+    const std::function<void(std::ostream&, const Core::IO::InputParameterContainer&)>& print)
+{
+  Internal::sanitize_required_default(data);
+  return InputSpec(
+      Internal::UserDefinedSpec<DataType>{
+          .name = name,
+          .data = std::forward<DataType>(data),
+          .parse = parse,
+          .print = print ? print : [](std::ostream&, const InputParameterContainer&) {},
+      },
+      {
+          .name = name,
+          .description = data.description,
+          .required = data.required.value(),
+          .has_default_value = data.default_value.has_value(),
+      });
+}
+
+
+template <typename T, typename DataType>
+Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
+    std::string name, std::vector<std::pair<std::string, T>> choices, DataType data)
+{
+  FOUR_C_ASSERT_ALWAYS(!choices.empty(), "Selection must have at least one choice.");
+
+  if (data.default_value.has_value())
+  {
+    auto default_value_it = std::find_if(choices.begin(), choices.end(),
+        [&](const auto& choice) { return choice.second == data.default_value.value(); });
+
+    FOUR_C_ASSERT_ALWAYS(
+        default_value_it != choices.end(), "Default value of selection not found in choices.");
+  }
+
+  return user_defined<T, DataType>(
+      name, std::move(data),
+      [name, data, choices](ValueParser& parser, InputParameterContainer& container)
+      {
+        parser.consume(name);
+        auto value = parser.read<std::string>();
+        for (const auto& choice : choices)
+        {
+          if (choice.first == value)
+          {
+            container.add(name, choice.second);
+            return;
+          }
+        }
+        FOUR_C_THROW("Invalid value '%s'", value.c_str());
+      },
+      [name, data, choices](std::ostream& stream, const InputParameterContainer& container)
+      {
+        stream << name;
+        auto* val = container.get_if<T>(name);
+        if (val)
+        {
+          for (const auto& choice : choices)
+          {
+            if (choice.second == *val)
+            {
+              stream << " " << choice.first;
+              return;
+            }
+          }
+          FOUR_C_ASSERT(false, "Invalid value.");
+        }
+        else
+        {
+          stream << " (";
+          for (const auto& choice : choices)
+          {
+            stream << choice.first << "|";
+          }
+          stream << ")";
+        }
+      });
+}
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -1,0 +1,430 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_io_input_spec_builders.hpp"
+#include "4C_io_value_parser.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+
+namespace
+{
+  using namespace FourC;
+  using namespace FourC::Core::IO;
+  using namespace FourC::Core::IO::InputSpecBuilders;
+
+  TEST(InputSpecTest, Simple)
+  {
+    auto line = group({
+        tag("marker"),
+        entry<int>("a", {.description = "An integer", .default_value = 1}),
+        entry<double>("b", {.required = true}),
+        entry<std::string>("c", {.required = false}),
+        entry<bool>("d"),
+    });
+    InputParameterContainer container;
+    std::string stream("marker b 2.0 d true // trailing comment");
+    ValueParser parser(stream);
+    fully_parse(parser, line, container);
+    EXPECT_EQ(container.get<int>("a"), 1);
+    EXPECT_EQ(container.get<double>("b"), 2.0);
+    EXPECT_EQ(container.get_if<std::string>("c"), nullptr);
+    EXPECT_EQ(container.get<bool>("d"), true);
+  }
+
+  TEST(InputSpecTest, OutofOrder)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<double>("b"),
+        entry<std::string>("c"),
+    });
+    InputParameterContainer container;
+    std::string stream("b 2.0 c string a 1");
+    ValueParser parser(stream);
+    fully_parse(parser, line, container);
+    EXPECT_EQ(container.get<int>("a"), 1);
+    EXPECT_EQ(container.get<double>("b"), 2.0);
+    EXPECT_EQ(container.get<std::string>("c"), "string");
+  }
+
+  TEST(InputSpecTest, OptionalLeftOut)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<double>("b"),
+        entry<std::string>("c", {.default_value = "default"}),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2.0 // c 1");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 1);
+      EXPECT_EQ(container.get<double>("b"), 2.0);
+      EXPECT_EQ(container.get<std::string>("c"), "default");
+    }
+  }
+
+  TEST(InputSpecTest, RequiredLeftOut)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<double>("b"),
+        entry<std::string>("c"),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2.0");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+          "Required value 'c' not found in input line");
+    }
+  }
+
+  TEST(InputSpecTest, Vector)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<std::vector<double>>("b", {.size = 3}),
+        entry<std::string>("c"),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 1.0 2.0 3.0 c string");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 1);
+      const auto& b = container.get<std::vector<double>>("b");
+      EXPECT_EQ(b.size(), 3);
+      EXPECT_EQ(b[0], 1.0);
+      EXPECT_EQ(b[1], 2.0);
+      EXPECT_EQ(b[2], 3.0);
+      EXPECT_EQ(container.get<std::string>("c"), "string");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 1.0 2.0 c string");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+          "Could not parse 'c' as a double value");
+    }
+  }
+
+  TEST(InputSpecTest, VectorWithParsedLength)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<std::vector<double>>("b", {.size = from_parameter<int>("a")}),
+        entry<std::string>("c"),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 3 b 1.0 2.0 3.0 c string");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 3);
+      const auto& b = container.get<std::vector<double>>("b");
+      EXPECT_EQ(b.size(), 3);
+      EXPECT_EQ(b[0], 1.0);
+      EXPECT_EQ(b[1], 2.0);
+      EXPECT_EQ(b[2], 3.0);
+      EXPECT_EQ(container.get<std::string>("c"), "string");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 3 b 1.0 2.0 c string");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+          "Could not parse 'c' as a double value");
+    }
+  }
+
+  TEST(InputSpecTest, UserDefined)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<double>("b"),
+        user_defined<std::string>(
+            "c", {.description = "A string", .default_value = "Not found"},
+            [name = "c"](ValueParser& parser, InputParameterContainer& container)
+            {
+              parser.consume(name);
+              // Some special parsing logic
+              parser.consume("_");
+              parser.consume("_");
+
+              container.add<std::string>("c", "I found c");
+            },
+            [](std::ostream& out, const Core::IO::InputParameterContainer&) { out << "_ _"; }),
+        entry<std::string>("s"),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2.0 c _ _ s hello");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 1);
+      EXPECT_EQ(container.get<double>("b"), 2.0);
+      EXPECT_EQ(container.get<std::string>("c"), "I found c");
+      EXPECT_EQ(container.get<std::string>("s"), "hello");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2.0 c _ s hello");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+          fully_parse(parser, line, container), Core::Exception, "expected string '_'");
+    }
+  }
+
+  TEST(InputSpecTest, Selection)
+  {
+    auto line = group({
+        entry<int>("a"),
+        selection<int>("b", {{"b1", 1}, {"b2", 2}}, {.default_value = 1}),
+        selection<std::string>("c", {{"c1", "1"}, {"c2", "2"}}, {.default_value = "2"}),
+        entry<std::string>("d"),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b b2 d string c c1");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 1);
+      EXPECT_EQ(container.get<int>("b"), 2);
+      EXPECT_EQ(container.get<std::string>("c"), "1");
+      EXPECT_EQ(container.get<std::string>("d"), "string");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b b4 c string");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+          fully_parse(parser, line, container), Core::Exception, "Invalid value 'b4'");
+    }
+  }
+
+  TEST(InputSpecTest, Unparsed)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<int>("optional", {.default_value = 42}),
+        entry<double>("b"),
+        entry<std::string>("c"),
+    });
+    InputParameterContainer container;
+    std::string stream("a 1 b 2.0 c string unparsed unparsed");
+    ValueParser parser(stream);
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+        "line still contains 'unparsed unparsed'");
+  }
+
+
+  TEST(InputSpecTest, Groups)
+  {
+    auto line = group({
+        entry<int>("a"),
+        group("group1",
+            {
+                entry<double>("b"),
+            }),
+        group("group2",
+            {
+                entry<double>("b", {.default_value = 3.0}),
+                entry<std::string>("c"),
+            },
+            {
+                .required = false,
+            }),
+        group("group3",
+            {
+                entry<std::string>("c", {.default_value = "default"}),
+            },
+            {
+                .required = false,
+            }),
+        entry<std::string>("c"),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 group1 b 2.0 c string");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      const auto& const_container = container;
+      EXPECT_EQ(const_container.get<int>("a"), 1);
+      EXPECT_EQ(const_container.group("group1").get<double>("b"), 2.0);
+      EXPECT_ANY_THROW([[maybe_unused]] const auto& c = const_container.group("group2"));
+      // Group 3 only contains entries that have default values, so it implicitly has a default
+      // value.
+      EXPECT_EQ(const_container.group("group3").get<std::string>("c"), "default");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 group2 b 2.0 c string group1 b 4.0 c string");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      const auto& const_container = container;
+      EXPECT_EQ(const_container.get<int>("a"), 1);
+      EXPECT_EQ(const_container.group("group2").get<double>("b"), 2.0);
+      EXPECT_EQ(const_container.group("group1").get<double>("b"), 4.0);
+      EXPECT_EQ(const_container.get<std::string>("c"), "string");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 group1 b 4.0 c string");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      const auto& const_container = container;
+      EXPECT_EQ(const_container.get<int>("a"), 1);
+      EXPECT_ANY_THROW([[maybe_unused]] const auto& c = const_container.group("group2"));
+      EXPECT_EQ(const_container.group("group1").get<double>("b"), 4.0);
+      EXPECT_EQ(const_container.get<std::string>("c"), "string");
+    }
+  }
+
+  TEST(InputSpecTest, OneOf)
+  {
+    auto line = group({
+        entry<int>("a", {.default_value = 42}),
+        one_of({
+            entry<double>("b"),
+            group("group",
+                {
+                    entry<std::string>("c"),
+                    entry<double>("d"),
+                }),
+        }),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 1);
+      EXPECT_EQ(container.get<double>("b"), 2);
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("group c string d 2.0");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 42);
+      EXPECT_EQ(container.group("group").get<std::string>("c"), "string");
+      EXPECT_EQ(container.group("group").get<double>("d"), 2);
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 group c string d 2.0 b 3.0");
+      ValueParser parser(stream);
+      // More than one of the one_of entries is present. Refuse to parse any of them.
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+          "still contains 'group c string d 2.0 b 3.0'");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 group c string");
+      // Note: we start to parse the group, but the entries are not complete, so we backtrack.
+      // The result is that the parts of the group remain unparsed.
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+          fully_parse(parser, line, container), Core::Exception, "still contains 'group c string'");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(
+          fully_parse(parser, line, container), Core::Exception, "Required 'one_of {b, group}'");
+    }
+  }
+
+  TEST(InputSpecTest, OneOfTopLevel)
+  {
+    auto line = one_of({
+        group({
+            entry<int>("a"),
+            entry<double>("b"),
+        }),
+        group({
+            entry<std::string>("c"),
+            entry<double>("d"),
+        }),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<int>("a"), 1);
+      EXPECT_EQ(container.get<double>("b"), 2);
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("c string d 2.0");
+      ValueParser parser(stream);
+      fully_parse(parser, line, container);
+      EXPECT_EQ(container.get<std::string>("c"), "string");
+      EXPECT_EQ(container.get<double>("d"), 2);
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 b 2 c string d 2.0");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+          "both 'group {a, b}' and 'group {c, d}'");
+    }
+
+    {
+      InputParameterContainer container;
+      std::string stream("a 1 c string");
+      ValueParser parser(stream);
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+          "one_of {group {a, b}, group {c, d}}");
+    }
+  }
+
+  TEST(InputSpecTest, Print)
+  {
+    auto line = group({
+        entry<int>("a"),
+        entry<std::string>("b"),
+        selection<int>("c", {{"c1", 1}, {"c2", 2}}, {.default_value = 1}),
+    });
+
+    {
+      InputParameterContainer container;
+      container.add("a", 1);
+      container.add("b", std::string("s"));
+      std::ostringstream out;
+      line.print(out, container);
+      EXPECT_EQ(out.str(), "a 1 b s [c (c1|c2|)] ");
+    }
+  }
+}  // namespace

--- a/src/core/io/tests/4C_io_linedefinition_test.cpp
+++ b/src/core/io/tests/4C_io_linedefinition_test.cpp
@@ -106,7 +106,7 @@ namespace
   {
     std::istringstream input("OMEGA 1.23");
     auto line_definition = Input::LineDefinition::Builder().add_named_int("OMEGA").build();
-    EXPECT_ANY_THROW(line_definition.read(input));
+    EXPECT_FALSE(line_definition.read(input));
   }
 
   TEST(LineDefinitionTest, ReadFalseWhenNamedIntRequiredButNoNameGiven)
@@ -162,7 +162,7 @@ namespace
     std::istringstream input("OMEGA 1.23 2.34 3.45");
     auto line_definition =
         Input::LineDefinition::Builder().add_named_int_vector("OMEGA", 3).build();
-    EXPECT_ANY_THROW(line_definition.read(input));
+    EXPECT_FALSE(line_definition.read(input));
   }
 
   TEST(LineDefinitionTest, ReadFalseWhenNamedIntVectorRequiredButNoNameGiven)
@@ -192,7 +192,7 @@ namespace
   {
     std::istringstream input("OMEGA 123.45*893");
     auto line_definition = Input::LineDefinition::Builder().add_named_double("OMEGA").build();
-    EXPECT_ANY_THROW(line_definition.read(input));
+    EXPECT_FALSE(line_definition.read(input));
   }
 
   TEST(LineDefinitionTest, ReadFalseWhenNamedDoubleRequiredButNoNameGiven)
@@ -334,6 +334,8 @@ namespace
         .build()
         .print(out);
 
-    EXPECT_EQ(out.str(), "abc d 0 iv 0 0 0  [ pairs [...] s '' ''  ] ");
+    EXPECT_EQ(out.str(),
+        "abc d <double> iv <vector<int>> [s <vector<string>>] [pairs <vector<pair<string, "
+        "double>>>] ");
   }
 }  // namespace


### PR DESCRIPTION
### Description

To progress with #73 and merge our two input definitions, we need an implementation that can handle all the cases the two competing implementations have. This PR proposes this implementation. The main design goal is to have an easily readable and flexible way to construct input lines (as known from .dat format), while keeping in mind that we also want to support other formats soon (mainly yaml). In its most concise form, a line may now be written like this (see also the unit tests):

```cpp
  auto input = group({
        entry<int>("a", {.default_value = 42}),
        one_of({
            entry<double>("b"),
            group("nested",
                    {
                        entry<std::string>("c"),
                        entry<double>("d"),
                    }),
        }),
    });
```

This is a very concise style without any unnecessary clutter. Of course, this is still C++ and you can also name all the types very explicitly. The single parts that make up the line may also be stored separately and you are not forced to spell out a complete input line at once. For instance, in the `LineDefinition` we add the entries incrementally. Overall, this value-based design is a lot more flexible and, IMO, readable than the pointer-laden design of `LineComponent` which will soon also be replaced by the new implementation. We can generate emitters for yaml that work on the new implementation, so that we should be able to tackle #113 soon :tada: 

To demonstrate that this works, and to not have a third implementation, I replaced the internals of `LineDefinition` with the new class `InputSpec`. In the future, the `InputSpec` will be used directly instead of `LineDefinition`, but let's take one step at a time.


Related to #73 , ~~Depends on #161~~, Depends on #170 