### PR TITLE
Introduce typos hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -72,6 +72,15 @@ repos:
           # Allow the first line to be a shebang separated by a newline.
           - --detect-license-in-X-top-lines=3
 
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.28.4
+    hooks:
+      - id: typos
+        name: Check for typos
+        types_or: [c++, c]
+        files: '^apps/'
+        exclude: 'mm$'
+
   - repo: local
     hooks:
       - id: check-venv-up-to-date

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,8 @@
+[default.extend-words]
+thr = "thermo"
+
+# Special abbreviations we would like to keep as is.
+ele = "ele" # "element"
+eles = "eles" # "elements"
+nd = "nd"  # "number of dimensions"
+mor = "mor" # "model order reduction"

--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.hpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.hpp
@@ -193,7 +193,7 @@ namespace RTD
    *  \brief write all parameters of the header sections for readthedocs
    *
    *  \param[in] stream: stream for the restructuredText file
-   *  \param[in] list: vector containing all paramters in the current section
+   *  \param[in] list: vector containing all parameters in the current section
    *  \param[in] parentname: name of the parent section (initially empty string)
    */
   /// print flag sections of dat file with given list

--- a/apps/global_full/4C_global_full_cal_control.cpp
+++ b/apps/global_full/4C_global_full_cal_control.cpp
@@ -105,7 +105,7 @@ void ntacal()
       break;
 
     case Core::ProblemType::thermo:
-      thr_dyn_drt();
+      thermo_dyn_drt();
       break;
 
     case Core::ProblemType::tsi:

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -219,7 +219,7 @@ int main(int argc, char *argv[])
     ~CleanUpMPI() { MPI_Finalize(); }
   } cleanup_mpi;
 
-  // Kokkos should be initilized right after MPI.
+  // Kokkos should be initialized right after MPI.
   Kokkos::ScopeGuard kokkos_guard{};
 
   // Initialize our own singleton registry to ensure we clean up all singletons properly.

--- a/apps/post_monitor/4C_post_monitor.cpp
+++ b/apps/post_monitor/4C_post_monitor.cpp
@@ -313,7 +313,7 @@ void MonWriter::write_mon_str_file(const std::string& filename, PostProblem& pro
   // The call is handed to _all_ processors, because the extrapolation of the
   // stresses/strains from Gauss points to nodes is done by Core::FE::Discretization
   // utilising an assembly call. The assembly is parallel and thus all processors
-  // have to be incoporated --- at least I think so.
+  // have to be incorporated --- at least I think so.
   // (culpit: bborn, 07/09)
   for (std::vector<std::string>::iterator gn = groupnames.begin(); gn != groupnames.end(); ++gn)
     write_str_results(outfile, problem, result, gdof, dim, strtype, *gn, node);
@@ -342,7 +342,8 @@ void MonWriter::write_mon_heatflux_file(
     groupnames.push_back("gauss_initial_heatfluxes_xyz");
 
     // write it, now
-    write_mon_thr_file(filename, problem, infieldtype, "heatflux", heatfluxtype, groupnames, node);
+    write_mon_thermo_file(
+        filename, problem, infieldtype, "heatflux", heatfluxtype, groupnames, node);
   }
 
   return;
@@ -369,7 +370,8 @@ void MonWriter::write_mon_tempgrad_file(
     groupnames.push_back("gauss_current_tempgrad_xyz");
 
     // write, now
-    write_mon_thr_file(filename, problem, infieldtype, "tempgrad", tempgradtype, groupnames, node);
+    write_mon_thermo_file(
+        filename, problem, infieldtype, "tempgrad", tempgradtype, groupnames, node);
   }
 
   return;
@@ -377,7 +379,7 @@ void MonWriter::write_mon_tempgrad_file(
 
 
 /*----------------------------------------------------------------------*/
-void MonWriter::write_mon_thr_file(const std::string& filename, PostProblem& problem,
+void MonWriter::write_mon_thermo_file(const std::string& filename, PostProblem& problem,
     std::string& infieldtype, const std::string thrname, const std::string thrtype,
     std::vector<std::string> groupnames, int node)
 {
@@ -444,7 +446,7 @@ void MonWriter::write_mon_thr_file(const std::string& filename, PostProblem& pro
     outfile << "\n";
     outfile << "#\n";
 
-    write_thr_table_head(outfile, thrname, thrtype, dim);
+    write_thermo_table_head(outfile, thrname, thrtype, dim);
   }
   else  // this proc is not the node owner
   {
@@ -459,13 +461,13 @@ void MonWriter::write_mon_thr_file(const std::string& filename, PostProblem& pro
   // (called groupnames).The call is handed to _all_ processors, because the
   // extrapolation of the heatfluxes/temperature gradients from Gauss points to
   // nodes is done by Core::FE::Discretization utilising an assembly call. The
-  // assembly is parallel and thus all processors have to be incoporated
+  // assembly is parallel and thus all processors have to be incorporated
   // --- at least I think so. (culpit: bborn, 07/09)
   for (std::vector<std::string>::iterator gn = groupnames.begin(); gn != groupnames.end(); ++gn)
-    write_thr_results(outfile, problem, result, gdof, dim, thrtype, *gn, node);
+    write_thermo_results(outfile, problem, result, gdof, dim, thrtype, *gn, node);
 
   if (outfile.is_open()) outfile.close();
-}  // write_mon_thr_file()
+}  // write_mon_thermo_file()
 
 
 /*----------------------------------------------------------------------*/
@@ -1437,7 +1439,7 @@ void ThermoMonWriter::write_result(
 }
 
 /*----------------------------------------------------------------------*/
-void ThermoMonWriter::write_thr_table_head(
+void ThermoMonWriter::write_thermo_table_head(
     std::ofstream& outfile, const std::string thrname, const std::string thrtype, const int dim)
 {
   switch (dim)
@@ -1466,7 +1468,7 @@ void ThermoMonWriter::write_thr_table_head(
 }
 
 /*----------------------------------------------------------------------*/
-void ThermoMonWriter::write_thr_results(std::ofstream& outfile, PostProblem& problem,
+void ThermoMonWriter::write_thermo_results(std::ofstream& outfile, PostProblem& problem,
     PostResult& result, std::vector<int>& gdof, int dim, std::string thrtype, std::string groupname,
     const int node)
 {
@@ -1512,7 +1514,7 @@ void ThermoMonWriter::write_thr_results(std::ofstream& outfile, PostProblem& pro
     // bottom control here, because first set has been read already
     do
     {
-      write_thr_result(outfile, field, result, groupname, name, dim, node);
+      write_thermo_result(outfile, field, result, groupname, name, dim, node);
     } while (result.next_result());
   }
 
@@ -1520,7 +1522,7 @@ void ThermoMonWriter::write_thr_results(std::ofstream& outfile, PostProblem& pro
 }
 
 /*----------------------------------------------------------------------*/
-void ThermoMonWriter::write_thr_result(std::ofstream& outfile, PostField*& field,
+void ThermoMonWriter::write_thermo_result(std::ofstream& outfile, PostField*& field,
     PostResult& result, const std::string groupname, const std::string name, const int dim,
     const int node) const
 {

--- a/apps/post_monitor/4C_post_monitor.hpp
+++ b/apps/post_monitor/4C_post_monitor.hpp
@@ -86,18 +86,19 @@ class MonWriter
     FOUR_C_THROW("Not impl.");
   }
 
-  void write_mon_thr_file(const std::string& filename, PostProblem& problem,
+  void write_mon_thermo_file(const std::string& filename, PostProblem& problem,
       std::string& infieldtype, const std::string thrname, const std::string thrtype,
       std::vector<std::string> groupnames, int node);
 
-  virtual void write_thr_table_head(
+  virtual void write_thermo_table_head(
       std::ofstream& outfile, const std::string thrname, const std::string thrtype, const int dim)
   {
     FOUR_C_THROW("Not impl.");
   }
 
-  virtual void write_thr_results(std::ofstream& outfile, PostProblem& problem, PostResult& result,
-      std::vector<int>& gdof, int dim, std::string thrtype, std::string groupname, const int node)
+  virtual void write_thermo_results(std::ofstream& outfile, PostProblem& problem,
+      PostResult& result, std::vector<int>& gdof, int dim, std::string thrtype,
+      std::string groupname, const int node)
   {
     FOUR_C_THROW("Not impl.");
   }
@@ -312,14 +313,14 @@ class ThermoMonWriter : public FieldMonWriter
   void write_result(
       std::ofstream& outfile, PostResult& result, std::vector<int>& gdof, int dim) override;
 
-  void write_thr_table_head(std::ofstream& outfile, const std::string thrname,
+  void write_thermo_table_head(std::ofstream& outfile, const std::string thrname,
       const std::string thrtype, const int dim) override;
 
-  void write_thr_results(std::ofstream& outfile, PostProblem& problem, PostResult& result,
+  void write_thermo_results(std::ofstream& outfile, PostProblem& problem, PostResult& result,
       std::vector<int>& gdof, int dim, std::string thrtype, std::string groupname,
       const int node) override;
 
-  void write_thr_result(std::ofstream& file, PostField*& field, PostResult& result,
+  void write_thermo_result(std::ofstream& file, PostField*& field, PostResult& result,
       const std::string groupname, const std::string name, const int dim, const int node) const;
 
  private:

--- a/apps/post_processor/4C_post_processor_single_field_writers.cpp
+++ b/apps/post_processor/4C_post_processor_single_field_writers.cpp
@@ -397,7 +397,7 @@ void ThermoFilter::write_all_results(PostField* field)
   // write displacement field
   writer_->write_result("displacement", "displacement", nodebased, field->problem()->num_dim());
 
-  // special infomation for SLM
+  // special information for SLM
   writer_->write_result("phase", "phase", dofbased, numdofpernode);
   writer_->write_result("conductivity", "conductivity", dofbased, numdofpernode);
   writer_->write_result("capacity", "capacity", dofbased, numdofpernode);

--- a/apps/pre_exodus/4C_pre_exodus.cpp
+++ b/apps/pre_exodus/4C_pre_exodus.cpp
@@ -197,7 +197,7 @@ int main(int argc, char** argv)
     My_CLP.setOption("head", &headfile, "4C header file to open");
     My_CLP.setOption("dat", &datfile, "output .dat file name [defaults to exodus file name]");
 
-    // switch for genarating a 2d .dat - file
+    // switch for generating a 2d .dat - file
     My_CLP.setOption("d2", "d3", &twodim, "space dimensions in .dat-file: d2: 2D, d3: 3D");
 
     // check for quad->tri conversion

--- a/apps/pre_exodus/4C_pre_exodus_readbc.cpp
+++ b/apps/pre_exodus/4C_pre_exodus_readbc.cpp
@@ -123,7 +123,7 @@ void EXODUS::read_bc_file(const std::string& bcfile, std::vector<EXODUS::ElemDef
 
     if (mesh_entity.compare(ebmarker) == 0)
     {
-      // in case of eb we differntiate between 'element' or 'condition'
+      // in case of eb we differentiate between 'element' or 'condition'
       if (type.compare("ELEMENT") == 0)
       {
         EXODUS::ElemDef edef = EXODUS::read_edef(mesh_entity, id, actcond);

--- a/apps/pre_exodus/4C_pre_exodus_readbc.hpp
+++ b/apps/pre_exodus/4C_pre_exodus_readbc.hpp
@@ -46,8 +46,8 @@ namespace EXODUS
   //! this is what fully defines a 4C element
   struct ElemDef
   {
-    int id;             ///< refering to mesh_entity id of eb,ns,ss
-    MeshEntity me;      ///< refering to underlying mesh entity
+    int id;             ///< referring to mesh_entity id of eb,ns,ss
+    MeshEntity me;      ///< referring to underlying mesh entity
     std::string sec;    ///< FLUID,STRUCTURE,ALE,etc.
     std::string desc;   ///< like "MAT 1 EAS full"
     std::string ename;  ///< FLUID,SOLIDSH8,etc
@@ -56,8 +56,8 @@ namespace EXODUS
   //! this is what fully defines a 4C condition
   struct CondDef
   {
-    int id;            ///< refering to mesh_entity id of eb,ns,ss
-    MeshEntity me;     ///< refering to underlying mesh entity
+    int id;            ///< referring to mesh_entity id of eb,ns,ss
+    MeshEntity me;     ///< referring to underlying mesh entity
     std::string sec;   ///< see valid_condition 'sectionname'
     std::string desc;  ///< see valid_condition 'description'
     int e_id;          ///< refers to datfile 'E num -'

--- a/apps/pre_exodus/4C_pre_exodus_reader.hpp
+++ b/apps/pre_exodus/4C_pre_exodus_reader.hpp
@@ -55,7 +55,7 @@ namespace EXODUS
     //! Print Nodes and Coords
     void print_nodes(std::ostream& os, bool storeid = false) const;
 
-    //! Get numer of nodes in mesh
+    //! Get number of nodes in mesh
     int get_num_nodes() const { return nodes_->size(); }
 
     //! Get number of elements in mesh
@@ -114,7 +114,7 @@ namespace EXODUS
     std::vector<int> outside_oriented_side(
         const std::vector<int> parentele, const std::vector<int> sidemap) const;
 
-    //! Get egde Normal at node
+    //! Get edge Normal at node
     std::vector<double> normal(const int head1, const int origin, const int head2) const;
 
     //! Get normalized Vector between 2 nodes
@@ -289,7 +289,7 @@ namespace EXODUS
    private:
     std::set<int> nodeids_;  // nodids in NodeSet
     std::string name_;       // NodeSet name
-    std::string propname_;   // Icem assignes part names as property names
+    std::string propname_;   // Icem assigns part names as property names
   };
 
   class SideSet

--- a/apps/pre_locsys/4C_pre_locsys.cpp
+++ b/apps/pre_locsys/4C_pre_locsys.cpp
@@ -69,11 +69,11 @@ int main(int argc, char** argv)
     rotmatrix(i, 2) = vector3(i);
   }
 
-  // Compute rotation angle via quaterion
-  Core::LinAlg::Matrix<4, 1> quaterion;
-  Core::LargeRotations::triadtoquaternion(rotmatrix, quaterion);
+  // Compute rotation angle via quaternion
+  Core::LinAlg::Matrix<4, 1> quaternion;
+  Core::LargeRotations::triadtoquaternion(rotmatrix, quaternion);
   Core::LinAlg::Matrix<3, 1> rotangle;
-  Core::LargeRotations::quaterniontoangle(quaterion, rotangle);
+  Core::LargeRotations::quaterniontoangle(quaternion, rotangle);
 
   std::cout << std::endl << std::setprecision(10) << "Rotation vector: " << rotangle << std::endl;
 

--- a/src/thermo/4C_thermo_dyn.cpp
+++ b/src/thermo/4C_thermo_dyn.cpp
@@ -19,7 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | main control routine for (in)stationary heat conduction              |
  *----------------------------------------------------------------------*/
-void thr_dyn_drt()
+void thermo_dyn_drt()
 {
   // access the discretization
   std::shared_ptr<Core::FE::Discretization> thermodis = nullptr;
@@ -50,8 +50,7 @@ void thr_dyn_drt()
 
   // done
   return;
-
-}  // thr_dyn_drt()
+}
 
 
 /*----------------------------------------------------------------------*/

--- a/src/thermo/4C_thermo_dyn.hpp
+++ b/src/thermo/4C_thermo_dyn.hpp
@@ -13,7 +13,7 @@
 FOUR_C_NAMESPACE_OPEN
 
 /*! entry point for the solution of temperature problems */
-void thr_dyn_drt();
+void thermo_dyn_drt();
 
 /*----------------------------------------------------------------------*/
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
Typos are annoying to fix during review (if they are even detected there). Luckily, there is [typos](https://github.com/crate-ci/typos), a configurable and fast spell checker specifically written for code bases. This PR enables `typos` in the pre-commit hooks. I suggest going over the different file types we have and start enforcing the check.

Special words that we do not want to be corrected are listed in `.typos.toml`. For now, I only applied the check to parts of the C++ sources to find the special cases we need to ignore. Of course, we could also fix some of these cases in the future.