### PR TITLE
Add link to Discussions for issue template chooser

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+contact_links:
+  - name: Questions/Help/Support
+    url: https://github.com/4C-multiphysics/4C/discussions
+    about: Please ask and answer questions here


### PR DESCRIPTION
Following #166 , this PR adds a new option people see when creating an issue. With the [template chooser](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser) config, a link to the Github Discussions is added for questions, help or support requests. See for example, [numpy](https://github.com/numpy/numpy/issues/new/choose) how this looks like.

Thanks, @gilrrei, for telling me about this feature.