### PR TITLE
Replace SFINAE in core with C++20 concepts

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -30,6 +30,8 @@ Checks: >-
   -bugprone-assert-side-effect,
   -bugprone-multiple-statement-macro
 CheckOptions:
+  - key: readability-identifier-naming.ConceptCase
+    value: CamelCase
   - key: readability-identifier-naming.StructCase
     value: CamelCase
   - key: readability-identifier-naming.ClassCase

--- a/src/core/comm/src/4C_comm_pack_buffer.hpp
+++ b/src/core/comm/src/4C_comm_pack_buffer.hpp
@@ -13,6 +13,7 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <cstring>
+#include <type_traits>
 #include <typeinfo>
 #include <vector>
 
@@ -41,7 +42,8 @@ namespace Core::Communication
     const std::vector<char>& operator()() const { return buf_; }
 
     /// Add a trivially copyable object, i.e., an object of a type that can be copied with memcpy.
-    template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
+    template <typename T>
+      requires std::is_trivially_copyable_v<T>
     void add_to_pack(const T& stuff)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -57,7 +59,8 @@ namespace Core::Communication
 
     /// Add an array of trivially copyable objects, i.e., objects of a type that can be copied with
     /// memcpy.
-    template <typename T, typename = std::enable_if_t<std::is_trivially_copyable_v<T>>>
+    template <typename T>
+      requires std::is_trivially_copyable_v<T>
     void add_to_pack(const T* stuff, std::size_t stuff_size)
     {
       FOUR_C_ASSERT(stuff_size % sizeof(T) == 0, "Size of stuff must be a multiple of sizeof(T).");
@@ -102,7 +105,8 @@ namespace Core::Communication
      * type T.
      */
     template <typename T>
-    std::enable_if_t<std::is_trivially_copyable_v<T>, void> extract_from_pack(T& stuff)
+      requires std::is_trivially_copyable_v<T>
+    void extract_from_pack(T& stuff)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       // Check that the type matches the type that was packed.
@@ -123,6 +127,7 @@ namespace Core::Communication
      * Same as the other method but extracts @p stuff_size entries into the array @p stuff.
      */
     template <typename T>
+      requires std::is_trivially_copyable_v<T>
     void extract_from_pack(T* stuff, const std::size_t stuff_size)
     {
       FOUR_C_ASSERT(stuff_size % sizeof(T) == 0, "Size of stuff must be a multiple of sizeof(T).");
@@ -145,7 +150,8 @@ namespace Core::Communication
      * Get @p stuff but also leave it in the buffer for the next extraction.
      */
     template <typename T>
-    std::enable_if_t<std::is_trivially_copyable_v<T>, void> peek(T& stuff) const
+      requires std::is_trivially_copyable_v<T>
+    void peek(T& stuff) const
     {
       std::size_t position = position_;
 

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_gauss_point_extrapolation.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_gauss_point_extrapolation.cpp
@@ -24,7 +24,8 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace
 {
-  template <Core::FE::CellType distype, std::enable_if_t<Core::FE::is_tet<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_tet<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 4) return Core::FE::CellType::point1;
@@ -32,7 +33,8 @@ namespace
     return Core::FE::CellType::tet10;
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<Core::FE::is_hex<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_hex<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 8) return Core::FE::CellType::point1;
@@ -41,14 +43,16 @@ namespace
     return Core::FE::CellType::hex27;
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<Core::FE::is_nurbs<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_nurbs<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 8) return Core::FE::CellType::point1;
     return Core::FE::CellType::nurbs27;
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<Core::FE::is_quad<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_quad<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 4) return Core::FE::CellType::point1;
@@ -57,7 +61,8 @@ namespace
     return Core::FE::CellType::quad9;
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<Core::FE::is_tri<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_tri<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 3) return Core::FE::CellType::point1;
@@ -65,7 +70,8 @@ namespace
     return Core::FE::CellType::tri6;
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<Core::FE::is_wedge<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_wedge<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 6) return Core::FE::CellType::point1;
@@ -73,8 +79,8 @@ namespace
     return Core::FE::CellType::wedge15;
   }
 
-  template <Core::FE::CellType distype,
-      std::enable_if_t<Core::FE::is_pyramid<distype>, bool> = true>
+  template <Core::FE::CellType distype>
+    requires(Core::FE::is_pyramid<distype>)
   inline Core::FE::CellType get_gauss_point_extrapolation_base_distype(unsigned numgp)
   {
     if (numgp < 5) return Core::FE::CellType::point1;

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_integration.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_integration.hpp
@@ -81,7 +81,8 @@ namespace Core::FE
    * @return GaussRule1D / GaussRule2D / GaussRule3D depending on the dimension of the
    * discretization
    */
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_hex<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_hex<distype>)
   GaussRule3D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -113,7 +114,8 @@ namespace Core::FE
     }
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_nurbs<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_nurbs<distype>)
   GaussRule3D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -125,7 +127,8 @@ namespace Core::FE
     }
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_tet<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_tet<distype>)
   GaussRule3D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -146,7 +149,8 @@ namespace Core::FE
     }
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_wedge<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_wedge<distype>)
   GaussRule3D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -162,7 +166,8 @@ namespace Core::FE
     }
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_pyramid<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_pyramid<distype>)
   GaussRule3D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -381,7 +386,8 @@ namespace Core::FE
   };
 
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_quad<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_quad<distype>)
   GaussRule2D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -417,7 +423,8 @@ namespace Core::FE
     }
   }
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_tri<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_tri<distype>)
   GaussRule2D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)
@@ -479,7 +486,8 @@ namespace Core::FE
     line_lobatto14point   ///< degree of precision: 25 (closed)
   };
 
-  template <Core::FE::CellType distype, std::enable_if_t<FE::is_line<distype>, int> = 0>
+  template <Core::FE::CellType distype>
+    requires(FE::is_line<distype>)
   GaussRule1D num_gauss_points_to_gauss_rule(unsigned numgp)
   {
     switch (numgp)

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -125,7 +125,8 @@ namespace Core::IO
     template <typename T>
     struct InputSpecTypeErasedImplementation : public InputSpecTypeErasedInterface
     {
-      template <typename T2, std::enable_if_t<!std::is_same_v<std::decay_t<T>, InputSpec>, int> = 0>
+      template <typename T2>
+        requires(!std::common_with<InputSpec, T2>)
       explicit InputSpecTypeErasedImplementation(T2&& wrapped) : wrapped(std::forward<T2>(wrapped))
       {
       }
@@ -234,7 +235,8 @@ namespace Core::IO
      * Construct a InputSpec. This constructor is not intended to be used directly. Use the
      * helper functions in the InputSpecBuilders namespace instead.
      */
-    template <typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, InputSpec>, int> = 0>
+    template <typename T>
+      requires(!std::common_with<InputSpec, T>)
     InputSpec(T&& spec, CommonData data);
 
     InputSpec(const InputSpec& other) : data_(other.data_), spec_(other.spec_->clone()) {}
@@ -791,7 +793,8 @@ void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataType>::parse(
 }
 
 
-template <typename T, std::enable_if_t<!std::is_same_v<std::decay_t<T>, Core::IO::InputSpec>, int>>
+template <typename T>
+  requires(!std::common_with<Core::IO::InputSpec, T>)
 Core::IO::InputSpec::InputSpec(T&& spec, CommonData data)
     : data_(std::move(data)),
       spec_(std::make_unique<Internal::InputSpecTypeErasedImplementation<std::decay_t<T>>>(

--- a/src/core/io/src/4C_io_string_converter.hpp
+++ b/src/core/io/src/4C_io_string_converter.hpp
@@ -76,7 +76,7 @@ namespace Core::IO
    *
    * @note More supported types may be added via template specialisation.
    */
-  template <typename T, class Enable = void>
+  template <typename T>
   struct StringConverter
   {
     static T Parse(const std::string& str) = delete;
@@ -113,11 +113,8 @@ namespace Core::IO
     /**
      * A helper struct to figure out whether a type behaves like a list or a map and determine
      * the associated rank.
-     *
-     * @tparam T The relevant type.
-     * @tparam Enable A parameter to leverage SFINAE and selectively enable specializations.
      */
-    template <typename T, typename Enable = void>
+    template <typename T>
     struct StringPatternTraits;
 
     /**
@@ -168,7 +165,8 @@ namespace Core::IO
      * Arithmetic types are neither lists nor maps and have no associated rank.
      */
     template <typename T>
-    struct StringPatternTraits<T, std::enable_if_t<std::is_arithmetic_v<T>>>
+      requires std::is_arithmetic_v<T>
+    struct StringPatternTraits<T>
     {
       static constexpr int list_rank = 0;
       static constexpr int map_rank = 0;
@@ -220,8 +218,8 @@ namespace Core::IO
     /**
      * @brief Parse the split string into an std::vector or std::list.
      */
-    template <class T,
-        std::enable_if_t<Internal::StringPatternTraits<T>::is_list_compatible, int> = 0>
+    template <class T>
+      requires Internal::StringPatternTraits<T>::is_list_compatible
     void parse_split_string(T& t, const std::vector<std::string>& split_str)
     {
       for (const auto& str : split_str)
@@ -354,7 +352,8 @@ namespace Core::IO
    * T (std::array, std::pair, std::tuple).
    */
   template <class T>
-  struct StringConverter<T, std::enable_if_t<Internal::StringPatternTraits<T>::is_list_compatible>>
+    requires Internal::StringPatternTraits<T>::is_list_compatible
+  struct StringConverter<T>
   {
     static T parse(const std::string& str)
     {
@@ -379,7 +378,8 @@ namespace Core::IO
    * definition.
    */
   template <class T>
-  struct StringConverter<T, std::enable_if_t<Internal::StringPatternTraits<T>::is_map_compatible>>
+    requires Internal::StringPatternTraits<T>::is_map_compatible
+  struct StringConverter<T>
   {
     static T parse(const std::string& str)
     {

--- a/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
+++ b/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
@@ -218,7 +218,8 @@ namespace Core::Utils::SymbolicExpressionDetails
      * to evaluate the parsed expression
      * @return  Derivative of the parsed expression with respect to the variables
      */
-    template <typename T2, std::enable_if_t<IsFAD<T2>::value, void*> = nullptr>
+    template <typename T2>
+      requires IsFAD<T2>::value
     T evaluate_derivative(const std::map<std::string, T2>& variable_values,
         const std::map<std::string, double>& constants = {}) const;
 
@@ -475,7 +476,8 @@ namespace Core::Utils::SymbolicExpressionDetails
 
 
   template <class T>
-  template <typename T2, std::enable_if_t<IsFAD<T2>::value, void*>>
+  template <typename T2>
+    requires IsFAD<T2>::value
   T Parser<T>::evaluate_derivative(const std::map<std::string, T2>& variable_values,
       const std::map<std::string, double>& constants) const
   {

--- a/src/core/utils/src/numerics/4C_utils_fad.hpp
+++ b/src/core/utils/src/numerics/4C_utils_fad.hpp
@@ -17,21 +17,15 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::FADUtils
 {
-  namespace Internal
-  {
-    template <typename T, typename AlwaysVoid = void>
-    constexpr bool is_double_convertible = false;
-
-    template <typename T>
-    constexpr bool is_double_convertible<T,
-        std::void_t<decltype(static_cast<double>(std::declval<std::remove_cv_t<T>>()))>> = true;
-  }  // namespace Internal
+  template <typename T>
+  concept ExplicitlyConvertibleToDouble = requires(T a) {
+    { static_cast<double>(a) };
+  };
 
   /*!
    * \brief Overload of CastToDouble() for any type that is convertible to double.
    */
-  template <typename ScalarType,
-      std::enable_if_t<Internal::is_double_convertible<ScalarType>, bool> = true>
+  template <ExplicitlyConvertibleToDouble ScalarType>
   inline double cast_to_double(ScalarType a)
   {
     return static_cast<double>(a);
@@ -46,9 +40,8 @@ namespace Core::FADUtils
    * @note We recursively call this function with the value of the FAD variable @p a until we reach
    * the innermost double value.
    */
-  template <typename FADType,
-      typename =
-          std::enable_if_t<Sacado::IsFad<FADType>::value || Sacado::IsExpr<FADType>::value, void*>>
+  template <typename FADType>
+    requires(Sacado::IsFad<FADType>::value || Sacado::IsExpr<FADType>::value)
   inline double cast_to_double(FADType a)
   {
     return cast_to_double(a.val());

--- a/src/core/utils/src/numerics/4C_utils_mathoperations.hpp
+++ b/src/core/utils/src/numerics/4C_utils_mathoperations.hpp
@@ -22,7 +22,7 @@ namespace Core
    * implementations are within the specializations for the different @p NumberType.
    * @tparam Enable This template parameter exists to allow SFINAE
    */
-  template <typename NumberType, typename Enable = void>
+  template <typename NumberType>
   struct MathOperations
   {
     // Defer evaluation of static_assert until user tries an instantiation.
@@ -38,7 +38,8 @@ namespace Core
   };
 
   template <typename T>
-  struct MathOperations<T, std::enable_if_t<std::is_arithmetic_v<T>>>
+    requires std::is_arithmetic_v<T>
+  struct MathOperations<T>
   {
     static constexpr T abs(T t) { return std::abs(t); }
     static constexpr T sqrt(T t) { return std::sqrt(t); }

--- a/src/core/utils/src/numerics/4C_utils_mathoperations_cln.hpp
+++ b/src/core/utils/src/numerics/4C_utils_mathoperations_cln.hpp
@@ -21,7 +21,8 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core
 {
   template <typename T>
-  struct MathOperations<T, std::enable_if_t<std::is_same_v<std::decay_t<T>, Core::CLN::ClnWrapper>>>
+    requires std::is_same_v<std::decay_t<T>, Core::CLN::ClnWrapper>
+  struct MathOperations<T>
   {
     static constexpr T abs(const T& t) { return cln::abs(t.Value()); }
     static constexpr T sqrt(const T& t) { return cln::sqrt(t.Value()); }

--- a/src/core/utils/src/numerics/4C_utils_mathoperations_sacado.hpp
+++ b/src/core/utils/src/numerics/4C_utils_mathoperations_sacado.hpp
@@ -19,7 +19,8 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core
 {
   template <typename T>
-  struct MathOperations<T, std::enable_if_t<Sacado::IsFad<std::decay_t<T>>::value>>
+    requires(Sacado::IsFad<T>::value || Sacado::IsExpr<T>::value)
+  struct MathOperations<T>
   {
     template <typename T2>
     static constexpr std::decay_t<T2> abs(T2&& t)

--- a/src/core/utils/src/stl_extension/4C_utils_singleton_owner.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_singleton_owner.hpp
@@ -129,8 +129,9 @@ namespace Core::Utils
      * @param [in] creator  Function (object) that can create the singleton instance and return a
      * unique_ptr to it. The function's signature must be `std::unique_ptr<T>(creation_args_...)`.
      */
-    template <typename Fn, typename E = std::enable_if_t<!std::is_same_v<Fn, SingletonOwner>, Fn>>
-    SingletonOwner(Fn&& creator);
+    template <typename Fn>
+    SingletonOwner(Fn&& creator)
+      requires std::is_invocable_r_v<std::unique_ptr<T>, Fn, CreationArgs...>;
 
     //! Deleted copy constructor. Only one object can own the singleton.
     SingletonOwner(const SingletonOwner& other) = delete;
@@ -199,8 +200,9 @@ namespace Core::Utils
      * @param [in] creator  Function (object) that can create the singleton instance and return a
      * unique_ptr to it. The function's signature must be `std::unique_ptr<T>(creation_args_...)`.
      */
-    template <typename Fn, typename E = std::enable_if_t<!std::is_same_v<Fn, SingletonMap>, Fn>>
-    SingletonMap(Fn&& creator);
+    template <typename Fn>
+    SingletonMap(Fn&& creator)
+      requires std::is_invocable_r_v<std::unique_ptr<T>, Fn, CreationArgs...>;
 
     /**
      * Return a SingletonOwner for the given @p key. If it does not exist, one is created the first
@@ -278,8 +280,9 @@ namespace Core::Utils
 
 
   template <typename T, typename... CreationArgs>
-  template <typename Fn, typename E>
+  template <typename Fn>
   SingletonOwner<T, CreationArgs...>::SingletonOwner(Fn&& creator)
+    requires std::is_invocable_r_v<std::unique_ptr<T>, Fn, CreationArgs...>
       : creator_(std::forward<Fn>(creator))
   {
     SingletonOwnerRegistry::register_deleter(this, [this]() { destroy_instance(); });
@@ -315,8 +318,9 @@ namespace Core::Utils
 
 
   template <typename Key, typename T, typename... CreationArgs>
-  template <typename Fn, typename E>
+  template <typename Fn>
   SingletonMap<Key, T, CreationArgs...>::SingletonMap(Fn&& creator)
+    requires std::is_invocable_r_v<std::unique_ptr<T>, Fn, CreationArgs...>
       : creator_(std::forward<Fn>(creator))
   {
   }

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc.cpp
@@ -532,12 +532,12 @@ template <Core::FE::CellType... celltypes>
 struct VerifyPackable
 {
   static constexpr bool are_all_packable =
-      (Core::Communication::is_packable<Discret::Elements::SolidEleCalc<celltypes,
+      (Core::Communication::Packable<Discret::Elements::SolidEleCalc<celltypes,
               Discret::Elements::DisplacementBasedFormulation<celltypes>>> &&
           ...);
 
   static constexpr bool are_all_unpackable =
-      (Core::Communication::is_unpackable<Discret::Elements::SolidEleCalc<celltypes,
+      (Core::Communication::Unpackable<Discret::Elements::SolidEleCalc<celltypes,
               Discret::Elements::DisplacementBasedFormulation<celltypes>>> &&
           ...);
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_interface_serializable.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_interface_serializable.hpp
@@ -29,30 +29,28 @@ namespace Discret::Elements
 
     /*!
      * @brief This struct should be used to serialize an item within a sum type (e.g.
-     *std::variant).
+     * std::variant).
      *
      * The pack(Core::Communication::PackBuffer&) is called for those types that provide the method.
-     *Nothing is done for types that don't provide a Pack-method.
+     * Nothing is done for types that don't provide a Pack-method.
      *
      * @note If you have a type that needs to be serialized during execution, you could verify that
      * the Pack-member function is correct by asserting it with
-     *static_assert(Core::Communication::is_packable<T>); in your cpp file
+     * static_assert(Core::Communication::Packable<T>); in your cpp file
      */
     struct PackAction
     {
       PackAction(Core::Communication::PackBuffer& buffer) : data(buffer) {}
 
-      template <typename T,
-          std::enable_if_t<Core::Communication::is_packable<const VariantItemInternalType<T>>,
-              bool> = true>
+      template <typename T>
+        requires(Core::Communication::Packable<const VariantItemInternalType<T>>)
       void operator()(const T& packable)
       {
         packable->pack(data);
       }
 
-      template <typename T,
-          std::enable_if_t<!Core::Communication::is_packable<const VariantItemInternalType<T>>,
-              bool> = true>
+      template <typename T>
+        requires(!Core::Communication::Packable<const VariantItemInternalType<T>>)
       void operator()(const T& other)
       {
         // do nothing if it is not packable
@@ -76,17 +74,15 @@ namespace Discret::Elements
     {
       UnpackAction(Core::Communication::UnpackBuffer& buffer) : buffer_(buffer) {}
 
-      template <typename T,
-          std::enable_if_t<Core::Communication::is_unpackable<VariantItemInternalType<T>>, bool> =
-              true>
+      template <typename T>
+        requires(Core::Communication::Unpackable<VariantItemInternalType<T>>)
       void operator()(T& unpackable)
       {
         unpackable->unpack(buffer_);
       }
 
-      template <typename T,
-          std::enable_if_t<!Core::Communication::is_unpackable<VariantItemInternalType<T>>, bool> =
-              true>
+      template <typename T>
+        requires(!Core::Communication::Unpackable<VariantItemInternalType<T>>)
       void operator()(T& other)
       {
         // do nothing if it is not unpackable

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.cpp
@@ -796,12 +796,12 @@ template <Core::FE::CellType... celltypes>
 struct VerifyPackable
 {
   static constexpr bool are_all_packable =
-      (Core::Communication::is_packable<Discret::Elements::SolidScatraEleCalc<celltypes,
+      (Core::Communication::Packable<Discret::Elements::SolidScatraEleCalc<celltypes,
               Discret::Elements::DisplacementBasedFormulation<celltypes>>> &&
           ...);
 
   static constexpr bool are_all_unpackable =
-      (Core::Communication::is_unpackable<Discret::Elements::SolidScatraEleCalc<celltypes,
+      (Core::Communication::Unpackable<Discret::Elements::SolidScatraEleCalc<celltypes,
               Discret::Elements::DisplacementBasedFormulation<celltypes>>> &&
           ...);
 


### PR DESCRIPTION
Use the more expressive and powerful C++ 20 `requires` syntax instead of `std::enable_if`. I applied it to all code in the core module and some places that use the same concepts. I also added the case style for concepts to our `clang-tidy` config.