### PR TITLE
Fix unit tests for transversely isotropic viscoplastic material

### DIFF
--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -1832,7 +1832,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
   // calculate equivalent plastic strain rate using the viscoplastic law
   state_quantities.curr_equiv_plastic_strain_rate_ =
       viscoplastic_law_->evaluate_plastic_strain_rate(state_quantities.curr_equiv_stress_,
-          plastic_strain, check_dt, parameter()->bool_log_substepping(), err_status,
+          plastic_strain, int_dt, parameter()->bool_log_substepping(), err_status,
           update_hist_var_);
 
   // return if we get an error, all other calculations are useless since substepping is triggered
@@ -1936,7 +1936,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   if (eval_state)
   {
     relevant_state_quantities =
-        evaluate_state_quantities(CM, iFinM, plastic_strain, err_status, int_dt, check_dt);
+        evaluate_state_quantities(CM, iFinM, plastic_strain, err_status, int_dt, int_dt);
   }
 
   // get the state quantities
@@ -2199,7 +2199,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   // compute the relevant derivatives of the plastic strain rate
   Core::LinAlg::Matrix<2, 1> evoEqFunctionDers =
       viscoplastic_law_->evaluate_derivatives_of_plastic_strain_rate(
-          equiv_stress, plastic_strain, check_dt, parameter()->bool_log_substepping(), err_status);
+          equiv_stress, plastic_strain, int_dt, parameter()->bool_log_substepping(), err_status);
 
   // return if we get an error, all other calculations are useless since substepping is triggered
   if (err_status != Mat::ViscoplastErrorType::NoErrors)
@@ -2658,7 +2658,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::calculate_local_newton_loop_r
 
   // evaluate state variables
   state_quantities_ =
-      evaluate_state_quantities(CM, iFinM, plastic_strain, err_status, int_dt, check_dt);
+      evaluate_state_quantities(CM, iFinM, plastic_strain, err_status, int_dt, int_dt);
 
   // declare residuals of the LNL
   Core::LinAlg::Matrix<3, 3> resFM(true);
@@ -2728,8 +2728,8 @@ Core::LinAlg::Matrix<10, 10> Mat::InelasticDefgradTransvIsotropElastViscoplast::
 
   // evaluate state derivatives
   state_quantity_derivatives_ = evaluate_state_quantity_derivatives(CM, iFinM, plastic_strain,
-      err_status, int_dt, check_dt);  // we do not reevaluate the state quantities, this
-                                      // was done in the residual computation already
+      err_status, int_dt, int_dt);  // we do not reevaluate the state quantities, this
+                                    // was done in the residual computation already
 
   // get derivative of update tensor wrt inverse inelastic defgrad (in FourTensor form)
   Core::LinAlg::FourTensor<3> dEpdiFin_FourTensor(true);

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -1370,12 +1370,11 @@ namespace Mat
      *                  \f[ \boldsymbol{F}_{\text{in}}^{-1} \f] in matrix form
      * @param[in] plastic_strain plastic strain  \f$ \varepsilon_{\text{p}} \f$
      * @param[out] err_status error status
-     * @param[in] int_dt time step (or substep) length used for time integration
-     * @param[in] check_dt time step (or substep) length used for overflow checking
+     * @param[in] dt time step (or substep) length used for time integration
      */
     StateQuantities evaluate_state_quantities(const Core::LinAlg::Matrix<3, 3>& CM,
         const Core::LinAlg::Matrix<3, 3>& iFinM, const double plastic_strain,
-        Mat::ViscoplastErrorType& err_status, const double int_dt, const double check_dt);
+        Mat::ViscoplastErrorType& err_status, const double dt);
 
     /*! @brief Evaluate the current state variable derivatives with respect to the right
      * Cauchy-Green deformation tensor, the inverse plastic deformation gradient and the equivalent
@@ -1386,16 +1385,15 @@ namespace Mat
      *                  \f$ in matrix form
      * @param[in] plastic_strain plastic strain  \f$ \varepsilon_{\text{p}} \f$
      * @param[out] err_status error status
-     * @param[in] int_dt time step length  \f$ \Delta t
+     * @param[in] dt time step length  \f$ \Delta t
      * \f$ (used for the integration)
-     * @param[in] check_dt time step (or substep) length used for overflow checking
      * @param[in] eval_state boolean: do we want to also evaluate the current state first (true)
      *                       or is this already available from the current state variables (false)
      */
     StateQuantityDerivatives evaluate_state_quantity_derivatives(
         const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<3, 3>& iFinM,
-        const double plastic_strain, Mat::ViscoplastErrorType& err_status, const double int_dt,
-        const double check_dt, const bool eval_state = false);
+        const double plastic_strain, Mat::ViscoplastErrorType& err_status, const double dt,
+        const bool eval_state = false);
 
     //! return the fiber direction of transverse isotropy for the considered element
     Core::LinAlg::Matrix<3, 1> get_fiber_direction() { return m_; }
@@ -1580,15 +1578,14 @@ namespace Mat
      * @param[in] last_iFpM last inverse plastic deformation gradient
      *                      \f$ \boldsymbol{F}_{\text{in}, n}^{-1} \f$ in matrix form
      * @param[in] last_plastic_strain last plastic strain \f$ \varepsilon_{\text{p}, n}\f$
-     * @param[in] int_dt time step (or substep) length used for time integration
-     * @param[in] check_dt time step (or substep) length used for overflow checking
+     * @param[in] dt time step (or substep) length used for time integration
      * @param[out] err_status error status
      * @return  residual of the LNL equations
      */
     Core::LinAlg::Matrix<10, 1> calculate_local_newton_loop_residual(
         const Core::LinAlg::Matrix<3, 3>& CM, const Core::LinAlg::Matrix<10, 1>& x,
         const Core::LinAlg::Matrix<3, 3>& last_iFinM, const double last_plastic_strain,
-        const double int_dt, const double check_dt, Mat::ViscoplastErrorType& err_status);
+        const double dt, Mat::ViscoplastErrorType& err_status);
 
 
     /*!
@@ -1603,16 +1600,14 @@ namespace Mat
      * @param[in] last_iFpM last inverse plastic deformation gradient
      *                      \f$ \boldsymbol{F}_{\text{in}, n}^{-1} \f$ in matrix form
      * @param[in] last_plastic_strain last plastic strain \f$ \varepsilon_{\text{p}, n}\f$
-     * @param[in] int_dt time step (or substep) length used for time integration
-     * @param[in] check_dt time step (or substep) length used for overflow checking
+     * @param[in] dt time step (or substep) length used for time integration
      * @param[out] err_status error status
      * @return 10x10 jacobian matrix of the Local Newton Loop and of the linearization
      *         \f$ \boldsymbol{J} \f$
      */
     Core::LinAlg::Matrix<10, 10> calculate_jacobian(const Core::LinAlg::Matrix<3, 3>& CM,
         const Core::LinAlg::Matrix<10, 1>& x, const Core::LinAlg::Matrix<3, 3>& last_iFinM,
-        const double last_plastic_strain, const double int_dt, const double check_dt,
-        Mat::ViscoplastErrorType& err_status);
+        const double last_plastic_strain, const double dt, Mat::ViscoplastErrorType& err_status);
 
 
     /*!

--- a/src/mat/vplast/4C_mat_vplast_reform_johnsoncook.cpp
+++ b/src/mat/vplast/4C_mat_vplast_reform_johnsoncook.cpp
@@ -88,7 +88,7 @@ double Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_plastic_strain_rate(
 
     // check if characteristic term too large, throw error overflow error if so
     if (((!log_substep) && (std::log(dt) + log_temp > std::log(10.0 + const_pars_.p * dt))) ||
-        ((log_substep) && (std::log(dt) + log_temp > std::log(2.0e4 + const_pars_.p * dt))))
+        ((log_substep) && (std::log(dt) + log_temp > std::log(2.0e30 + const_pars_.p * dt))))
     {
       err_status = Mat::ViscoplastErrorType::OverflowError;
       return -1;
@@ -161,7 +161,7 @@ Mat::Viscoplastic::ReformulatedJohnsonCook::evaluate_derivatives_of_plastic_stra
 
     // check overflow error using these logarithms
     if ((!log_substep && (log_dt + log_deriv_sigma > 10.0) && (log_dt + log_deriv_eps > 10.0)) &&
-        (log_substep && (log_dt + log_deriv_sigma > 2.0e4) && (log_dt + log_deriv_eps > 2.0e4)))
+        (log_substep && (log_dt + log_deriv_sigma > 2.0e30) && (log_dt + log_deriv_eps > 2.0e30)))
     {
       err_status = Mat::ViscoplastErrorType::OverflowError;
       return Core::LinAlg::Matrix<2, 1>{true};

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -1552,11 +1552,11 @@ namespace
         computed_state_quantities_transv_isotrop =
             transv_isotrop_elast_viscoplast_->evaluate_state_quantities(CM,
                 iFin_transv_isotrop_elast_viscoplast_solution_,
-                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0);
+                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0);
     Mat::InelasticDefgradTransvIsotropElastViscoplast::StateQuantities
         computed_state_quantities_isotrop = isotrop_elast_viscoplast_->evaluate_state_quantities(CM,
             iFin_transv_isotrop_elast_viscoplast_solution_,
-            plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0);
+            plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0);
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
     {
       FOUR_C_THROW("Error encountered during testing of TestEvaluateStateQuantities");
@@ -1616,15 +1616,13 @@ namespace
         computed_state_quantity_derivatives_transv_isotrop =
             transv_isotrop_elast_viscoplast_->evaluate_state_quantity_derivatives(CM,
                 iFin_transv_isotrop_elast_viscoplast_solution_,
-                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0,
-                true);
+                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, true);
 
     Mat::InelasticDefgradTransvIsotropElastViscoplast::StateQuantityDerivatives
         computed_state_quantity_derivatives_isotrop =
             isotrop_elast_viscoplast_->evaluate_state_quantity_derivatives(CM,
                 iFin_transv_isotrop_elast_viscoplast_solution_,
-                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0,
-                true);
+                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, true);
 
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
     {

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -1552,11 +1552,11 @@ namespace
         computed_state_quantities_transv_isotrop =
             transv_isotrop_elast_viscoplast_->evaluate_state_quantities(CM,
                 iFin_transv_isotrop_elast_viscoplast_solution_,
-                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 10.0, 0.0);
+                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0);
     Mat::InelasticDefgradTransvIsotropElastViscoplast::StateQuantities
         computed_state_quantities_isotrop = isotrop_elast_viscoplast_->evaluate_state_quantities(CM,
             iFin_transv_isotrop_elast_viscoplast_solution_,
-            plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 10.0, 0.0);
+            plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0);
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
     {
       FOUR_C_THROW("Error encountered during testing of TestEvaluateStateQuantities");
@@ -1616,14 +1616,14 @@ namespace
         computed_state_quantity_derivatives_transv_isotrop =
             transv_isotrop_elast_viscoplast_->evaluate_state_quantity_derivatives(CM,
                 iFin_transv_isotrop_elast_viscoplast_solution_,
-                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0e100, 0.0,
+                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0,
                 true);
 
     Mat::InelasticDefgradTransvIsotropElastViscoplast::StateQuantityDerivatives
         computed_state_quantity_derivatives_isotrop =
             isotrop_elast_viscoplast_->evaluate_state_quantity_derivatives(CM,
                 iFin_transv_isotrop_elast_viscoplast_solution_,
-                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0e100, 0.0,
+                plastic_strain_transv_isotrop_elast_viscoplast_solution_, err_status, 1.0, 1.0,
                 true);
 
     if (err_status != Mat::ViscoplastErrorType::NoErrors)

--- a/unittests/mat/vplast/4C_vplast_reform_johnsoncook_test.cpp
+++ b/unittests/mat/vplast/4C_vplast_reform_johnsoncook_test.cpp
@@ -94,14 +94,14 @@ namespace
     // set reference solution
     plastic_strain_rate_reformulated_JC_solution_ = 23188.7161986626;
 
-    // declare error status and overflow check boolean
+    // declare error status and logarithmic substepping
     Mat::ViscoplastErrorType err_status = Mat::ViscoplastErrorType::NoErrors;
-    const bool check_overflow = false;
+    const bool log_substep = true;
 
     // compute solution from the viscoplasticity law
     double plastic_strain_rate_reformulated_JC =
         vplast_law_reformulated_JC_->evaluate_plastic_strain_rate(
-            equiv_stress_, equiv_plastic_strain_, 1.0, !check_overflow, err_status, false);
+            equiv_stress_, equiv_plastic_strain_, 1.0, log_substep, err_status, false);
 
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
       FOUR_C_THROW("Error encountered during testing of TestEvaluatePlasticStrainRate");
@@ -119,14 +119,14 @@ namespace
     deriv_plastic_strain_rate_reformulated_JC_solution_(1, 0) = -47431778.9968811;
 
 
-    // declare error status and overflow check boolean
+    // declare error status and logarithmic substepping
     Mat::ViscoplastErrorType err_status = Mat::ViscoplastErrorType::NoErrors;
-    const bool check_overflow = false;
+    const bool log_substep = true;
 
     // compute solution from the viscoplasticity law
     Core::LinAlg::Matrix<2, 1> deriv_plastic_strain_rate_reformulated_JC =
         vplast_law_reformulated_JC_->evaluate_derivatives_of_plastic_strain_rate(
-            equiv_stress_, equiv_plastic_strain_, 1.0, !check_overflow, err_status, false);
+            equiv_stress_, equiv_plastic_strain_, 1.0, log_substep, err_status, false);
 
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
       FOUR_C_THROW("Error encountered during testing of TestEvaluatePlasticStrainRateDerivatives");

--- a/unittests/mat/vplast/4C_vplast_reform_johnsoncook_test.cpp
+++ b/unittests/mat/vplast/4C_vplast_reform_johnsoncook_test.cpp
@@ -101,7 +101,7 @@ namespace
     // compute solution from the viscoplasticity law
     double plastic_strain_rate_reformulated_JC =
         vplast_law_reformulated_JC_->evaluate_plastic_strain_rate(
-            equiv_stress_, equiv_plastic_strain_, 0.0, check_overflow, err_status, false);
+            equiv_stress_, equiv_plastic_strain_, 1.0, !check_overflow, err_status, false);
 
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
       FOUR_C_THROW("Error encountered during testing of TestEvaluatePlasticStrainRate");
@@ -126,7 +126,7 @@ namespace
     // compute solution from the viscoplasticity law
     Core::LinAlg::Matrix<2, 1> deriv_plastic_strain_rate_reformulated_JC =
         vplast_law_reformulated_JC_->evaluate_derivatives_of_plastic_strain_rate(
-            equiv_stress_, equiv_plastic_strain_, 0.0, check_overflow, err_status, false);
+            equiv_stress_, equiv_plastic_strain_, 1.0, !check_overflow, err_status, false);
 
     if (err_status != Mat::ViscoplastErrorType::NoErrors)
       FOUR_C_THROW("Error encountered during testing of TestEvaluatePlasticStrainRateDerivatives");


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
The PR fixes a previously undetected error related to the utilized time step in the unit tests of `InelasticDefgradTransvIsotropElastViscoplast` and `ReformulatedJohnsonCook`. Specifically, it avoids the evaluation of log(0.0), as was previously the case. The failing unit tests were detected by  @c-p-schmidt while working on other files, not associated to the mentioned classes. @c-p-schmidt : thanks for reporting them! Moreover, the variable `check_dt` was removed, as it is not necessary in the updated overflow error checking anymore.

## Related Issues and Merge Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
