### PR TITLE
Remove warning about migration to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,6 @@
 
 </div>
 
-> [!WARNING]
-> We are currently migrating the project from GitLab. Links might be out-dated.
-
 4C ("Comprehensive Computational Community Code") is a parallel multiphysics research code
 to address a plethora of physical problems by means of _computational mechanics_.
 


### PR DESCRIPTION
## Description and Context

Remove a warning, that is more or less outdated.
