### PR TITLE
Use InputParameterContainer instead of LineDefinition to pass input parameters

### DIFF
--- a/src/core/io/src/4C_io_elementreader.cpp
+++ b/src/core/io/src/4C_io_elementreader.cpp
@@ -206,8 +206,9 @@ void Core::IO::ElementReader::get_and_distribute_elements(const int nblock, cons
         {
           std::istringstream element_specific_remainder{
               std::string(parser.get_unparsed_remainder())};
+          auto data = linedef->read(element_specific_remainder);
 
-          if (not linedef->read(element_specific_remainder))
+          if (!data.has_value())
           {
             std::cout << "\n" << elenumber << " " << eletype << " ";
             linedef->print(std::cout);
@@ -217,8 +218,8 @@ void Core::IO::ElementReader::get_and_distribute_elements(const int nblock, cons
                 "failed to read element %d %s %s", elenumber, eletype.c_str(), distype.c_str());
           }
 
-          ele->set_node_ids(distype, linedef->container());
-          ele->read_element(eletype, distype, linedef->container());
+          ele->set_node_ids(distype, *data);
+          ele->read_element(eletype, distype, *data);
         }
         else
         {

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -344,7 +344,7 @@ bool Core::IO::InputFileUtils::need_to_print_equal_sign(const Teuchos::Parameter
 }
 
 
-std::vector<Input::LineDefinition> Core::IO::InputFileUtils::read_all_lines_in_section(
+std::vector<Core::IO::InputParameterContainer> Core::IO::InputFileUtils::read_all_lines_in_section(
     Core::IO::InputFile& input, const std::string& section,
     const std::vector<Input::LineDefinition>& possible_lines)
 {
@@ -374,12 +374,12 @@ std::vector<Input::LineDefinition> Core::IO::InputFileUtils::read_all_lines_in_s
 }
 
 
-std::pair<std::vector<Input::LineDefinition>, std::vector<std::string>>
+std::pair<std::vector<Core::IO::InputParameterContainer>, std::vector<std::string>>
 Core::IO::InputFileUtils::read_matching_lines_in_section(Core::IO::InputFile& input,
     const std::string& section, const std::vector<Input::LineDefinition>& possible_lines)
 {
   std::vector<std::string> unparsed_lines;
-  std::vector<Input::LineDefinition> parsed_lines;
+  std::vector<Core::IO::InputParameterContainer> parsed_lines;
 
   Input::LineDefinition::ReadContext context{.input_file = input.file_for_section(section)};
 
@@ -389,11 +389,10 @@ Core::IO::InputFileUtils::read_matching_lines_in_section(Core::IO::InputFile& in
     {
       std::stringstream l{input_line};
 
-      // Make a copy that potentially gets filled by the Read.
-      auto parsed_definition = definition;
-      if (parsed_definition.read(l, context))
+      auto data = definition.read(l, context);
+      if (data.has_value())
       {
-        parsed_lines.emplace_back(std::move(parsed_definition));
+        parsed_lines.emplace_back(std::move(data.value()));
         return;
       }
     }

--- a/src/core/io/src/4C_io_input_file_utils.hpp
+++ b/src/core/io/src/4C_io_input_file_utils.hpp
@@ -66,8 +66,9 @@ namespace Core::IO::InputFileUtils
    *
    * @see read_matching_lines_in_section()
    */
-  std::vector<Input::LineDefinition> read_all_lines_in_section(Core::IO::InputFile& input,
-      const std::string& section, const std::vector<Input::LineDefinition>& possible_lines);
+  std::vector<Core::IO::InputParameterContainer> read_all_lines_in_section(
+      Core::IO::InputFile& input, const std::string& section,
+      const std::vector<Input::LineDefinition>& possible_lines);
 
 
   /**
@@ -78,7 +79,7 @@ namespace Core::IO::InputFileUtils
    *
    * @see read_all_lines_in_section()
    */
-  std::pair<std::vector<Input::LineDefinition>, std::vector<std::string>>
+  std::pair<std::vector<Core::IO::InputParameterContainer>, std::vector<std::string>>
   read_matching_lines_in_section(Core::IO::InputFile& input, const std::string& section,
       const std::vector<Input::LineDefinition>& possible_lines);
 

--- a/src/core/io/src/4C_io_linedefinition.cpp
+++ b/src/core/io/src/4C_io_linedefinition.cpp
@@ -33,9 +33,6 @@ namespace Input
      public:
       /// Components that make up an InputLine.
       std::vector<Core::IO::InputSpec> components_;
-
-      /// Store the read data.
-      Core::IO::InputParameterContainer container_;
     };
   }  // namespace Internal
 
@@ -297,9 +294,9 @@ namespace Input
 
 
   std::optional<Core::IO::InputParameterContainer> LineDefinition::read(
-      std::istream& stream, const ReadContext& context)
+      std::istream& stream, const ReadContext& context) const
   {
-    pimpl_->container_ = Core::IO::InputParameterContainer();
+    Core::IO::InputParameterContainer container;
 
     // extract everything from the stream into a string
     std::stringstream ss;
@@ -310,19 +307,14 @@ namespace Input
     {
       auto input_line = Core::IO::InputSpecBuilders::group(pimpl_->components_);
       Core::IO::ValueParser parser(line, {.base_path = context.input_file.parent_path()});
-      Core::IO::fully_parse(parser, input_line, pimpl_->container_);
+      Core::IO::fully_parse(parser, input_line, container);
     }
     catch (const Core::Exception& e)
     {
       return std::nullopt;
     }
 
-    return pimpl_->container_;
-  }
-
-  const Core::IO::InputParameterContainer& LineDefinition::container() const
-  {
-    return pimpl_->container_;
+    return container;
   }
 
 

--- a/src/core/io/src/4C_io_linedefinition.hpp
+++ b/src/core/io/src/4C_io_linedefinition.hpp
@@ -257,9 +257,7 @@ namespace Input
      * may use additional @p context containing information such as the name of the input file.
      */
     std::optional<Core::IO::InputParameterContainer> read(
-        std::istream& stream, const ReadContext& context = {});
-
-    [[nodiscard]] const Core::IO::InputParameterContainer& container() const;
+        std::istream& stream, const ReadContext& context = {}) const;
 
     //@}
 

--- a/src/core/utils/src/functions/4C_utils_function.hpp
+++ b/src/core/utils/src/functions/4C_utils_function.hpp
@@ -251,11 +251,11 @@ namespace Core::Utils
 
   /// try to create SymbolicFunctionOfAnything from a given line definition
   std::shared_ptr<FunctionOfAnything> try_create_symbolic_function_of_anything(
-      const std::vector<Input::LineDefinition>& function_line_defs);
+      const std::vector<Core::IO::InputParameterContainer>& parameters);
 
   /// create a vector function from multiple expressions
   std::shared_ptr<FunctionOfSpaceTime> try_create_symbolic_function_of_space_time(
-      const std::vector<Input::LineDefinition>& function_line_defs);
+      const std::vector<Core::IO::InputParameterContainer>& parameters);
 }  // namespace Core::Utils
 
 

--- a/src/core/utils/src/functions/4C_utils_function_library.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_library.cpp
@@ -26,22 +26,21 @@ namespace
 {
 
   std::shared_ptr<Core::Utils::FunctionOfScalar> create_library_function_scalar(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
-    if (function_line_defs.size() != 1) return nullptr;
+    if (parameters.size() != 1) return nullptr;
 
-    const auto& function_lin_def = function_line_defs.front();
+    const auto& function_lin_def = parameters.front();
 
-    if (function_lin_def.container().get_or<bool>("FASTPOLYNOMIAL", false))
+    if (function_lin_def.get_or<bool>("FASTPOLYNOMIAL", false))
     {
-      std::vector<double> coefficients =
-          function_lin_def.container().get<std::vector<double>>("COEFF");
+      std::vector<double> coefficients = function_lin_def.get<std::vector<double>>("COEFF");
 
       return std::make_shared<Core::Utils::FastPolynomialFunction>(std::move(coefficients));
     }
-    else if (function_lin_def.container().get_or<bool>("CUBIC_SPLINE_FROM_CSV", false))
+    else if (function_lin_def.get_or<bool>("CUBIC_SPLINE_FROM_CSV", false))
     {
-      const auto csv_file = function_lin_def.container().get<std::filesystem::path>("CSV");
+      const auto csv_file = function_lin_def.get<std::filesystem::path>("CSV");
 
       // safety check
       if (csv_file.empty())

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -18,12 +18,12 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace
 {
-  using LineDefinitionVector = std::vector<Input::LineDefinition>;
+  using InputParameters = std::vector<Core::IO::InputParameterContainer>;
 
-  using TypeErasedFunctionCreator = std::function<std::any(const LineDefinitionVector&)>;
+  using TypeErasedFunctionCreator = std::function<std::any(const InputParameters&)>;
 
   template <typename T>
-  using FunctionCreator = std::shared_ptr<T> (*)(const LineDefinitionVector&);
+  using FunctionCreator = std::shared_ptr<T> (*)(const InputParameters&);
 
   /**
    * Utility function that takes a function object returning a std::shared_ptr<T> and erases its
@@ -33,7 +33,7 @@ namespace
   template <typename T>
   TypeErasedFunctionCreator wrap_function(FunctionCreator<T> fun)
   {
-    return [fun](const LineDefinitionVector& linedefs) -> std::any
+    return [fun](const InputParameters& linedefs) -> std::any
     {
       std::shared_ptr<T> created = fun(linedefs);
       if (created == nullptr)
@@ -44,7 +44,7 @@ namespace
   }
 
 
-  std::any create_builtin_function(const std::vector<Input::LineDefinition>& function_line_defs)
+  std::any create_builtin_function(const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
     // List all known TryCreate functions in a vector, so they can be called with a unified
     // syntax below. Also, erase their exact return type, since we can only store std::any.
@@ -55,7 +55,7 @@ namespace
 
     for (const auto& try_create_function : try_create_function_vector)
     {
-      auto maybe_function = try_create_function(function_line_defs);
+      auto maybe_function = try_create_function(parameters);
       if (maybe_function.has_value()) return maybe_function;
     }
 
@@ -168,7 +168,10 @@ void Core::Utils::FunctionManager::read_input(Core::IO::InputFile& input)
 
             if (parsed_lines.size() > 0 && unparsed_lines.size() == 0)
             {
-              functions_.emplace_back(function_factory(parsed_lines));
+              std::vector<Core::IO::InputParameterContainer> parsed_lines_data(parsed_lines.size());
+              std::ranges::transform(parsed_lines, parsed_lines_data.begin(),
+                  [](const auto& line) { return line.container(); });
+              functions_.emplace_back(function_factory(parsed_lines_data));
               return false;
             }
           }

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -154,24 +154,21 @@ void Core::Utils::FunctionManager::read_input(Core::IO::InputFile& input)
         {
           for (auto& [possible_lines, function_factory] : attached_function_data_)
           {
-            auto [parsed_lines, unparsed_lines] =
+            auto [parsed_parameters, unparsed_lines] =
                 Core::IO::InputFileUtils::read_matching_lines_in_section(
                     input, "FUNCT" + std::to_string(funct_suffix), possible_lines);
 
             // A convoluted way of saying that there are no lines in the section, thus, stop
             // parsing. This can only be refactored if the reading mechanism is overhauled in
             // general.
-            if (parsed_lines.size() + unparsed_lines.size() == 0)
+            if (parsed_parameters.size() + unparsed_lines.size() == 0)
             {
               return true;
             }
 
-            if (parsed_lines.size() > 0 && unparsed_lines.size() == 0)
+            if (parsed_parameters.size() > 0 && unparsed_lines.size() == 0)
             {
-              std::vector<Core::IO::InputParameterContainer> parsed_lines_data(parsed_lines.size());
-              std::ranges::transform(parsed_lines, parsed_lines_data.begin(),
-                  [](const auto& line) { return line.container(); });
-              functions_.emplace_back(function_factory(parsed_lines_data));
+              functions_.emplace_back(function_factory(parsed_parameters));
               return false;
             }
           }

--- a/src/core/utils/src/functions/4C_utils_function_manager.hpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.hpp
@@ -43,7 +43,8 @@ namespace Core::Utils
     /**
      * Type used to pass functions that create 4C Functions from a number of parsed lines.
      */
-    using FunctionFactory = std::function<std::any(const std::vector<Input::LineDefinition>&)>;
+    using FunctionFactory =
+        std::function<std::any(const std::vector<Core::IO::InputParameterContainer>& lines)>;
 
     /// Return all known input lines that define a Function.
     std::vector<Input::LineDefinition> valid_function_lines();

--- a/src/core/utils/src/functions/4C_utils_function_of_time.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_of_time.cpp
@@ -89,7 +89,7 @@ double Core::Utils::SymbolicFunctionOfTime::evaluate_derivative(
 }
 
 std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of_time(
-    const std::vector<Input::LineDefinition>& function_line_defs)
+    const std::vector<Core::IO::InputParameterContainer>& parameters)
 {
   // Work around a design flaw in the input line for SymbolicFunctionOfTime.
   // This line accepts optional components in the beginning although this is not directly supported
@@ -110,19 +110,18 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
   int maxcomp = 0;
   int maxvar = -1;
   bool found_function_of_time(false);
-  for (const auto& ith_function_lin_def : function_line_defs)
+  for (const auto& ith_function_lin_def : parameters)
   {
-    ignore_errors_in([&]() { maxcomp = ith_function_lin_def.container().get<int>("COMPONENT"); });
-    ignore_errors_in([&]() { maxvar = ith_function_lin_def.container().get<int>("VARIABLE"); });
-    if (ith_function_lin_def.container().get_if<std::string>("SYMBOLIC_FUNCTION_OF_TIME") !=
-        nullptr)
+    ignore_errors_in([&]() { maxcomp = ith_function_lin_def.get<int>("COMPONENT"); });
+    ignore_errors_in([&]() { maxvar = ith_function_lin_def.get<int>("VARIABLE"); });
+    if (ith_function_lin_def.get_if<std::string>("SYMBOLIC_FUNCTION_OF_TIME") != nullptr)
       found_function_of_time = true;
   }
 
   if (!found_function_of_time) return nullptr;
 
   // evaluate the number of rows used for the definition of the variables
-  std::size_t numrowsvar = function_line_defs.size() - maxcomp - 1;
+  std::size_t numrowsvar = parameters.size() - maxcomp - 1;
 
   // define a vector of strings
   std::vector<std::string> functstring(maxcomp + 1);
@@ -131,15 +130,15 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
   for (int n = 0; n <= maxcomp; ++n)
   {
     // update the current row
-    const Input::LineDefinition& functcomp = function_line_defs[n];
+    const auto& functcomp = parameters[n];
 
     // check the validity of the n-th component
     int compid = 0;
-    ignore_errors_in([&]() { compid = functcomp.container().get<int>("COMPONENT"); });
+    ignore_errors_in([&]() { compid = functcomp.get<int>("COMPONENT"); });
     if (compid != n) FOUR_C_THROW("expected COMPONENT %d but got COMPONENT %d", n, compid);
 
     // read the expression of the n-th component of the i-th function
-    functstring[n] = functcomp.container().get<std::string>("SYMBOLIC_FUNCTION_OF_TIME");
+    functstring[n] = functcomp.get<std::string>("SYMBOLIC_FUNCTION_OF_TIME");
   }
 
   std::map<int, std::vector<std::shared_ptr<FunctionVariable>>> variable_pieces;
@@ -148,29 +147,29 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
   for (std::size_t j = 1; j <= numrowsvar; ++j)
   {
     // update the current row
-    const Input::LineDefinition& line = function_line_defs[maxcomp + j];
+    const auto& line = parameters[maxcomp + j];
 
     // read the number of the variable
     int varid;
-    ignore_errors_in([&]() { varid = line.container().get<int>("VARIABLE"); });
+    ignore_errors_in([&]() { varid = line.get<int>("VARIABLE"); });
 
     const auto variable = std::invoke(
         [&line]() -> std::shared_ptr<Core::Utils::FunctionVariable>
         {
           // read the name of the variable
-          std::string varname = line.container().get<std::string>("NAME");
+          std::string varname = line.get<std::string>("NAME");
 
           // read the type of the variable
-          std::string vartype = line.container().get<std::string>("TYPE");
+          std::string vartype = line.get<std::string>("TYPE");
 
           // read periodicity data
           Periodicstruct periodicdata{};
 
-          periodicdata.periodic = line.container().get<bool>("PERIODIC");
+          periodicdata.periodic = line.get<bool>("PERIODIC");
           if (periodicdata.periodic)
           {
-            periodicdata.t1 = line.container().get<double>("T1");
-            periodicdata.t2 = line.container().get<double>("T2");
+            periodicdata.t1 = line.get<double>("T1");
+            periodicdata.t2 = line.get<double>("T2");
           }
           else
           {
@@ -181,7 +180,7 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
           // distinguish the type of the variable
           if (vartype == "expression")
           {
-            auto description_vec = line.container().get<std::vector<std::string>>("DESCRIPTION");
+            auto description_vec = line.get<std::vector<std::string>>("DESCRIPTION");
 
             if (description_vec.size() != 1)
             {
@@ -199,7 +198,7 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
             std::vector<double> times = Internal::extract_time_vector(line);
 
             // read values
-            auto values = line.container().get<std::vector<double>>("VALUES");
+            auto values = line.get<std::vector<double>>("VALUES");
 
             return std::make_shared<LinearInterpolationVariable>(
                 varname, times, values, periodicdata);
@@ -210,7 +209,7 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
             std::vector<double> times = Internal::extract_time_vector(line);
 
             // read descriptions (strings separated with spaces)
-            auto description_vec = line.container().get<std::vector<std::string>>("DESCRIPTION");
+            auto description_vec = line.get<std::vector<std::string>>("DESCRIPTION");
 
             // check if the number of times = number of descriptions + 1
             std::size_t numtimes = times.size();
@@ -228,7 +227,7 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
             std::vector<double> times = Internal::extract_time_vector(line);
 
             // read values
-            auto values = line.container().get<std::vector<double>>("VALUES");
+            auto values = line.get<std::vector<double>>("VALUES");
 
             return std::make_shared<FourierInterpolationVariable>(
                 varname, times, values, periodicdata);
@@ -236,7 +235,6 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
           else
           {
             FOUR_C_THROW("unknown variable type");
-            return nullptr;
           }
         });
 

--- a/src/core/utils/src/functions/4C_utils_function_of_time.hpp
+++ b/src/core/utils/src/functions/4C_utils_function_of_time.hpp
@@ -82,7 +82,7 @@ namespace Core::Utils
 
   //! create a vector function of time from multiple expressions
   std::shared_ptr<FunctionOfTime> try_create_function_of_time(
-      const std::vector<Input::LineDefinition>& function_line_defs);
+      const std::vector<Core::IO::InputParameterContainer>& parameters);
 
 }  // namespace Core::Utils
 

--- a/src/core/utils/src/functions/4C_utils_functionvariables.cpp
+++ b/src/core/utils/src/functions/4C_utils_functionvariables.cpp
@@ -528,13 +528,14 @@ Core::Utils::FunctionVariable& Core::Utils::PiecewiseVariable::find_piece_for_ti
   return **active_piece;
 }
 
-std::vector<double> Core::Utils::Internal::extract_time_vector(const Input::LineDefinition& timevar)
+std::vector<double> Core::Utils::Internal::extract_time_vector(
+    const Core::IO::InputParameterContainer& timevar)
 {
   // read the number of points
-  int numpoints = timevar.container().get<int>("NUMPOINTS");
+  int numpoints = timevar.get<int>("NUMPOINTS");
 
   // read whether times are defined by number of points or by vector
-  bool bynum = timevar.container().get<bool>("BYNUM");
+  bool bynum = timevar.get<bool>("BYNUM");
 
   // read respectively create times vector
   std::vector<double> times = std::invoke(
@@ -543,7 +544,7 @@ std::vector<double> Core::Utils::Internal::extract_time_vector(const Input::Line
         if (bynum)  // times defined by number of points
         {
           // read the time range
-          auto timerange = timevar.container().get<std::vector<double>>("TIMERANGE");
+          auto timerange = timevar.get<std::vector<double>>("TIMERANGE");
 
           std::vector<double> times;
 
@@ -571,7 +572,7 @@ std::vector<double> Core::Utils::Internal::extract_time_vector(const Input::Line
         }
         else  // times defined by vector
         {
-          auto times = timevar.container().get<std::vector<double>>("TIMES");
+          auto times = timevar.get<std::vector<double>>("TIMES");
 
           return times;
         }

--- a/src/core/utils/src/functions/4C_utils_functionvariables.hpp
+++ b/src/core/utils/src/functions/4C_utils_functionvariables.hpp
@@ -226,7 +226,7 @@ namespace Core::Utils
   namespace Internal
   {
     //! Internal helper to figure out the correct time points from input.
-    std::vector<double> extract_time_vector(const Input::LineDefinition& timevar);
+    std::vector<double> extract_time_vector(const Core::IO::InputParameterContainer& timevar);
   }  // namespace Internal
 }  // namespace Core::Utils
 

--- a/src/core/utils/src/result_test/4C_utils_result_test.cpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.cpp
@@ -146,22 +146,22 @@ void Core::Utils::ResultTestManager::test_all(MPI_Comm comm)
   if (Core::Communication::my_mpi_rank(comm) == 0)
     Core::IO::cout << "\nChecking results of " << size << " tests:\n";
 
-  for (auto& result : results_)
+  for (const auto& result : results_)
   {
     for (const auto& fieldtest : fieldtest_)
     {
-      if (fieldtest->match(result.container()))
+      if (fieldtest->match(result))
       {
-        if (result.container().get_if<int>("ELEMENT") != nullptr)
-          fieldtest->test_element(result.container(), nerr, test_count);
-        else if (result.container().get_if<int>("NODE") != nullptr)
-          fieldtest->test_node(result.container(), nerr, test_count);
-        else if (result.container().get_if<int>("LINE") != nullptr ||
-                 result.container().get_if<int>("SURFACE") != nullptr ||
-                 result.container().get_if<int>("VOLUME") != nullptr)
-          fieldtest->test_node_on_geometry(result.container(), nerr, test_count, get_node_set());
+        if (result.get_if<int>("ELEMENT") != nullptr)
+          fieldtest->test_element(result, nerr, test_count);
+        else if (result.get_if<int>("NODE") != nullptr)
+          fieldtest->test_node(result, nerr, test_count);
+        else if (result.get_if<int>("LINE") != nullptr ||
+                 result.get_if<int>("SURFACE") != nullptr ||
+                 result.get_if<int>("VOLUME") != nullptr)
+          fieldtest->test_node_on_geometry(result, nerr, test_count, get_node_set());
         else
-          fieldtest->test_special(result.container(), nerr, test_count, uneval_test_count);
+          fieldtest->test_special(result, nerr, test_count, uneval_test_count);
       }
     }
   }
@@ -204,7 +204,8 @@ void Core::Utils::ResultTestManager::test_all(MPI_Comm comm)
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::Utils::ResultTestManager::set_parsed_lines(std::vector<Input::LineDefinition> results)
+void Core::Utils::ResultTestManager::set_parsed_lines(
+    std::vector<Core::IO::InputParameterContainer> results)
 {
   results_ = std::move(results);
 }

--- a/src/core/utils/src/result_test/4C_utils_result_test.hpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.hpp
@@ -130,7 +130,7 @@ namespace Core::Utils
     void test_all(MPI_Comm comm);
 
     /// Store the parsed @p results.
-    void set_parsed_lines(std::vector<Input::LineDefinition> results);
+    void set_parsed_lines(std::vector<Core::IO::InputParameterContainer> results);
 
     /// Store the node set
     void set_node_set(const std::vector<std::vector<std::vector<int>>>& nodeset);
@@ -146,7 +146,7 @@ namespace Core::Utils
     std::vector<std::shared_ptr<ResultTest>> fieldtest_;
 
     /// expected results
-    std::vector<Input::LineDefinition> results_;
+    std::vector<Core::IO::InputParameterContainer> results_;
 
     /// node set for values extraction
     std::vector<std::vector<std::vector<int>>> nodeset_;

--- a/src/fluid/4C_fluid_functions.cpp
+++ b/src/fluid/4C_fluid_functions.cpp
@@ -56,33 +56,33 @@ namespace
 
 
   std::shared_ptr<Core::Utils::FunctionOfSpaceTime> create_fluid_function(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
-    if (function_line_defs.size() != 1) return nullptr;
+    if (parameters.size() != 1) return nullptr;
 
-    const auto& function_lin_def = function_line_defs.front();
+    const auto& function_lin_def = parameters.front();
 
-    if (function_lin_def.container().get_or("BELTRAMI", false))
+    if (function_lin_def.get_or("BELTRAMI", false))
     {
-      double c1 = function_lin_def.container().get<double>("c1");
+      double c1 = function_lin_def.get<double>("c1");
 
       return std::make_shared<FLD::BeltramiFunction>(c1);
     }
-    else if (function_lin_def.container().get_or("CHANNELWEAKLYCOMPRESSIBLE", false))
+    else if (function_lin_def.get_or("CHANNELWEAKLYCOMPRESSIBLE", false))
     {
       return std::make_shared<FLD::ChannelWeaklyCompressibleFunction>();
     }
-    else if (function_lin_def.container().get_or("CORRECTIONTERMCHANNELWEAKLYCOMPRESSIBLE", false))
+    else if (function_lin_def.get_or("CORRECTIONTERMCHANNELWEAKLYCOMPRESSIBLE", false))
     {
       return std::make_shared<FLD::CorrectionTermChannelWeaklyCompressibleFunction>();
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_POISEUILLE", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_POISEUILLE", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
-      auto L = function_lin_def.container().get_or<double>("L", 0);
-      auto R = function_lin_def.container().get_or<double>("R", 0);
-      auto U = function_lin_def.container().get_or<double>("U", 0);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
+      auto L = function_lin_def.get_or<double>("L", 0);
+      auto R = function_lin_def.get_or<double>("R", 0);
+      auto U = function_lin_def.get_or<double>("U", 0);
 
       if (mat_id <= 0)
         FOUR_C_THROW("Please give a (reasonable) 'MAT' in WEAKLYCOMPRESSIBLE_POISEUILLE");
@@ -95,13 +95,13 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressiblePoiseuilleFunction>(fparams, L, R, U);
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE", false))
     {
       // read data
-      auto mat_id = function_lin_def.container().get_or<int>("MAT", -1);
-      auto L = function_lin_def.container().get_or<double>("L", 0);
-      auto R = function_lin_def.container().get_or<double>("R", 0);
-      auto U = function_lin_def.container().get_or<double>("U", 0);
+      auto mat_id = function_lin_def.get_or<int>("MAT", -1);
+      auto L = function_lin_def.get_or<double>("L", 0);
+      auto R = function_lin_def.get_or<double>("R", 0);
+      auto U = function_lin_def.get_or<double>("U", 0);
 
       if (mat_id <= 0)
         FOUR_C_THROW("Please give a (reasonable) 'MAT' in WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE");
@@ -117,10 +117,10 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressiblePoiseuilleForceFunction>(fparams, L, R, U);
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
 
       if (mat_id <= 0)
         FOUR_C_THROW("Please give a (reasonable) 'MAT' in WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW");
@@ -130,11 +130,10 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressibleManufacturedFlowFunction>(fparams);
     }
-    else if (function_lin_def.container().get_or(
-                 "WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW_FORCE", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW_FORCE", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
 
       if (mat_id <= 0)
         FOUR_C_THROW(
@@ -145,10 +144,10 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressibleManufacturedFlowForceFunction>(fparams);
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_ETIENNE_CFD", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_CFD", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
 
       if (mat_id <= 0)
         FOUR_C_THROW("Please give a (reasonable) 'MAT' in WEAKLYCOMPRESSIBLE_ETIENNE_CFD");
@@ -158,10 +157,10 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressibleEtienneCFDFunction>(fparams);
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
 
       if (mat_id <= 0)
         FOUR_C_THROW("Please give a (reasonable) 'MAT' in WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE");
@@ -171,10 +170,10 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressibleEtienneCFDForceFunction>(fparams);
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_VISCOSITY", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_VISCOSITY", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
 
       if (mat_id <= 0)
         FOUR_C_THROW(
@@ -185,11 +184,11 @@ namespace
 
       return std::make_shared<FLD::WeaklyCompressibleEtienneCFDViscosityFunction>(fparams);
     }
-    else if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID", false))
     {
       // read data
-      int mat_id_fluid = function_lin_def.container().get_or<int>("MAT_FLUID", -1);
-      int mat_id_struct = function_lin_def.container().get_or<int>("MAT_STRUCT", -1);
+      int mat_id_fluid = function_lin_def.get_or<int>("MAT_FLUID", -1);
+      int mat_id_struct = function_lin_def.get_or<int>("MAT_STRUCT", -1);
 
       if (mat_id_fluid <= 0)
         FOUR_C_THROW(
@@ -205,12 +204,11 @@ namespace
       return std::make_shared<FLD::WeaklyCompressibleEtienneFSIFluidFunction>(
           fparams_fluid, fparams_struct);
     }
-    else if (function_lin_def.container().get_or(
-                 "WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_FORCE", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_FORCE", false))
     {
       // read data
-      int mat_id_fluid = function_lin_def.container().get_or<int>("MAT_FLUID", -1);
-      int mat_id_struct = function_lin_def.container().get_or<int>("MAT_STRUCT", -1);
+      int mat_id_fluid = function_lin_def.get_or<int>("MAT_FLUID", -1);
+      int mat_id_struct = function_lin_def.get_or<int>("MAT_STRUCT", -1);
 
       if (mat_id_fluid <= 0)
       {
@@ -232,12 +230,11 @@ namespace
       return std::make_shared<FLD::WeaklyCompressibleEtienneFSIFluidForceFunction>(
           fparams_fluid, fparams_struct);
     }
-    else if (function_lin_def.container().get_or(
-                 "WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_VISCOSITY", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_VISCOSITY", false))
     {
       // read data
-      int mat_id_fluid = function_lin_def.container().get_or<int>("MAT_FLUID", -1);
-      int mat_id_struct = function_lin_def.container().get_or<int>("MAT_STRUCT", -1);
+      int mat_id_fluid = function_lin_def.get_or<int>("MAT_FLUID", -1);
+      int mat_id_struct = function_lin_def.get_or<int>("MAT_STRUCT", -1);
 
       if (mat_id_fluid <= 0)
       {
@@ -259,10 +256,10 @@ namespace
       return std::make_shared<FLD::WeaklyCompressibleEtienneFSIFluidViscosityFunction>(
           fparams_fluid, fparams_struct);
     }
-    else if (function_lin_def.container().get_or("BELTRAMI-UP", false))
+    else if (function_lin_def.get_or("BELTRAMI-UP", false))
     {
       // read data
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
 
       if (mat_id <= 0) FOUR_C_THROW("Please give a (reasonable) 'MAT'/material in BELTRAMI-UP");
 
@@ -271,11 +268,11 @@ namespace
 
       return std::make_shared<FLD::BeltramiUP>(fparams);
     }
-    else if (function_lin_def.container().get_or("BELTRAMI-RHS", false))
+    else if (function_lin_def.get_or("BELTRAMI-RHS", false))
     {
       // read material
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
-      int is_stokes = function_lin_def.container().get_or<int>("ISSTOKES", 0);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
+      int is_stokes = function_lin_def.get_or<int>("ISSTOKES", 0);
 
       if (mat_id <= 0) FOUR_C_THROW("Please give a (reasonable) 'MAT'/material in BELTRAMI-RHS");
 
@@ -284,11 +281,11 @@ namespace
 
       return std::make_shared<FLD::BeltramiRHS>(fparams, (bool)is_stokes);
     }
-    else if (function_lin_def.container().get_or("KIMMOIN-UP", false))
+    else if (function_lin_def.get_or("KIMMOIN-UP", false))
     {
       // read material
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
-      int is_stationary = function_lin_def.container().get_or<int>("ISSTAT", 0);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
+      int is_stationary = function_lin_def.get_or<int>("ISSTAT", 0);
 
       if (mat_id <= 0) FOUR_C_THROW("Please give a (reasonable) 'MAT'/material in KIMMOIN-UP");
 
@@ -297,12 +294,12 @@ namespace
 
       return std::make_shared<FLD::KimMoinUP>(fparams, (bool)is_stationary);
     }
-    else if (function_lin_def.container().get_or("KIMMOIN-RHS", false))
+    else if (function_lin_def.get_or("KIMMOIN-RHS", false))
     {
       // read material
-      int mat_id = function_lin_def.container().get_or<int>("MAT", -1);
-      int is_stationary = function_lin_def.container().get_or<int>("ISSTAT", 0);
-      int is_stokes = function_lin_def.container().get_or<int>("ISSTOKES", 0);
+      int mat_id = function_lin_def.get_or<int>("MAT", -1);
+      int is_stationary = function_lin_def.get_or<int>("ISSTAT", 0);
+      int is_stokes = function_lin_def.get_or<int>("ISSTOKES", 0);
 
       if (mat_id <= 0) FOUR_C_THROW("Please give a (reasonable) 'MAT'/material in KIMMOIN-RHS");
 
@@ -311,12 +308,12 @@ namespace
 
       return std::make_shared<FLD::KimMoinRHS>(fparams, (bool)is_stationary, (bool)is_stokes);
     }
-    else if (function_lin_def.container().get_or("KIMMOIN-STRESS", false))
+    else if (function_lin_def.get_or("KIMMOIN-STRESS", false))
     {
       // read material
-      auto mat_id = function_lin_def.container().get_or<int>("MAT", -1);
-      auto is_stationary = function_lin_def.container().get_or<int>("ISSTAT", 0);
-      auto amplitude = function_lin_def.container().get_or<double>("AMPLITUDE", 1.0);
+      auto mat_id = function_lin_def.get_or<int>("MAT", -1);
+      auto is_stationary = function_lin_def.get_or<int>("ISSTAT", 0);
+      auto amplitude = function_lin_def.get_or<double>("AMPLITUDE", 1.0);
 
       if (mat_id <= 0) FOUR_C_THROW("Please give a (reasonable) 'MAT'/material in KIMMOIN-STRESS");
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
@@ -21,67 +21,65 @@ namespace
   using namespace Discret::Utils;
 
   std::shared_ptr<Core::Utils::FunctionOfSpaceTime> create_xfluid_function(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
-    if (function_line_defs.size() != 1) return nullptr;
+    if (parameters.size() != 1) return nullptr;
 
-    const auto& function_lin_def = function_line_defs.front();
+    const auto& function_lin_def = parameters.front();
 
-    if (function_lin_def.container().get_or<bool>("FORWARDFACINGSTEP", false))
+    if (function_lin_def.get_or<bool>("FORWARDFACINGSTEP", false))
     {
       return std::make_shared<GerstenbergerForwardfacingStep>();
     }
-    else if (function_lin_def.container().get_or<bool>("MOVINGLEVELSETCYLINDER", false))
+    else if (function_lin_def.get_or<bool>("MOVINGLEVELSETCYLINDER", false))
     {
-      auto origin = function_lin_def.container().get<std::vector<double>>("ORIGIN");
+      auto origin = function_lin_def.get<std::vector<double>>("ORIGIN");
 
-      auto radius = function_lin_def.container().get<double>("RADIUS");
+      auto radius = function_lin_def.get<double>("RADIUS");
 
-      auto direction = function_lin_def.container().get<std::vector<double>>("DIRECTION");
+      auto direction = function_lin_def.get<std::vector<double>>("DIRECTION");
 
-      auto distance = function_lin_def.container().get<double>("DISTANCE");
+      auto distance = function_lin_def.get<double>("DISTANCE");
 
-      auto maxspeed = function_lin_def.container().get<double>("MAXSPEED");
+      auto maxspeed = function_lin_def.get<double>("MAXSPEED");
 
       return std::make_shared<MovingLevelSetCylinder>(
           &origin, radius, &direction, distance, maxspeed);
     }
-    else if (function_lin_def.container().get_or<bool>("MOVINGLEVELSETTORUS", false) or
-             function_lin_def.container().get_or<bool>("MOVINGLEVELSETTORUSVELOCITY", false) or
-             function_lin_def.container().get_or<bool>("MOVINGLEVELSETTORUSSLIPLENGTH", false))
+    else if (function_lin_def.get_or<bool>("MOVINGLEVELSETTORUS", false) or
+             function_lin_def.get_or<bool>("MOVINGLEVELSETTORUSVELOCITY", false) or
+             function_lin_def.get_or<bool>("MOVINGLEVELSETTORUSSLIPLENGTH", false))
     {
-      auto origin = function_lin_def.container().get<std::vector<double>>("ORIGIN");
+      auto origin = function_lin_def.get<std::vector<double>>("ORIGIN");
 
-      auto orient_vec_torus =
-          function_lin_def.container().get<std::vector<double>>("ORIENTVEC_TORUS");
+      auto orient_vec_torus = function_lin_def.get<std::vector<double>>("ORIENTVEC_TORUS");
 
-      auto radius = function_lin_def.container().get<double>("RADIUS");
+      auto radius = function_lin_def.get<double>("RADIUS");
 
-      auto radius_tube = function_lin_def.container().get<double>("RADIUS_TUBE");
+      auto radius_tube = function_lin_def.get<double>("RADIUS_TUBE");
 
-      auto direction = function_lin_def.container().get<std::vector<double>>("DIRECTION");
+      auto direction = function_lin_def.get<std::vector<double>>("DIRECTION");
 
-      auto distance = function_lin_def.container().get<double>("DISTANCE");
+      auto distance = function_lin_def.get<double>("DISTANCE");
 
-      auto maxspeed = function_lin_def.container().get<double>("MAXSPEED");
+      auto maxspeed = function_lin_def.get<double>("MAXSPEED");
 
-      auto rot_vec_torus = function_lin_def.container().get<std::vector<double>>("ROTATION_VEC");
+      auto rot_vec_torus = function_lin_def.get<std::vector<double>>("ROTATION_VEC");
 
-      auto rotspeed =
-          function_lin_def.container().get<double>("ROTATION_SPEED");  // revolutions per second
+      auto rotspeed = function_lin_def.get<double>("ROTATION_SPEED");  // revolutions per second
 
       auto rotramptime =
-          function_lin_def.container().get<double>("ROTATION_RAMPTIME");  // revolutions per second
+          function_lin_def.get<double>("ROTATION_RAMPTIME");  // revolutions per second
 
-      if (function_lin_def.container().get_or<bool>("MOVINGLEVELSETTORUS", false))
+      if (function_lin_def.get_or<bool>("MOVINGLEVELSETTORUS", false))
         return std::make_shared<MovingLevelSetTorus>(&origin, &orient_vec_torus, radius,
             radius_tube, &direction, distance, maxspeed, &rot_vec_torus, rotspeed, rotramptime);
-      else if (function_lin_def.container().get_or<bool>("MOVINGLEVELSETTORUSVELOCITY", false))
+      else if (function_lin_def.get_or<bool>("MOVINGLEVELSETTORUSVELOCITY", false))
         return std::make_shared<MovingLevelSetTorusVelocity>(&origin, &orient_vec_torus, radius,
             radius_tube, &direction, distance, maxspeed, &rot_vec_torus, rotspeed, rotramptime);
-      else if (function_lin_def.container().get_or<bool>("MOVINGLEVELSETTORUSSLIPLENGTH", false))
+      else if (function_lin_def.get_or<bool>("MOVINGLEVELSETTORUSSLIPLENGTH", false))
       {
-        auto slipfunct = function_lin_def.container().get<int>("SLIP_FUNCT");
+        auto slipfunct = function_lin_def.get<int>("SLIP_FUNCT");
         return std::make_shared<MovingLevelSetTorusSliplength>(&origin, &orient_vec_torus, radius,
             radius_tube, &direction, distance, maxspeed, &rot_vec_torus, rotspeed, rotramptime,
             slipfunct);
@@ -92,40 +90,40 @@ namespace
         return std::shared_ptr<Core::Utils::FunctionOfSpaceTime>(nullptr);
       }
     }
-    else if (function_lin_def.container().get_or<bool>("TAYLORCOUETTEFLOW", false))
+    else if (function_lin_def.get_or<bool>("TAYLORCOUETTEFLOW", false))
     {
-      auto radius_i = function_lin_def.container().get<double>("RADIUS_I");
-      auto radius_o = function_lin_def.container().get<double>("RADIUS_O");
+      auto radius_i = function_lin_def.get<double>("RADIUS_I");
+      auto radius_o = function_lin_def.get<double>("RADIUS_O");
 
-      auto vel_theta_i = function_lin_def.container().get<double>("VEL_THETA_I");
-      auto vel_theta_o = function_lin_def.container().get<double>("VEL_THETA_O");
+      auto vel_theta_i = function_lin_def.get<double>("VEL_THETA_I");
+      auto vel_theta_o = function_lin_def.get<double>("VEL_THETA_O");
 
-      auto sliplength_i = function_lin_def.container().get<double>("SLIPLENGTH_I");
-      auto sliplength_o = function_lin_def.container().get<double>("SLIPLENGTH_O");
+      auto sliplength_i = function_lin_def.get<double>("SLIPLENGTH_I");
+      auto sliplength_o = function_lin_def.get<double>("SLIPLENGTH_O");
 
-      auto traction_theta_i = function_lin_def.container().get<double>("TRACTION_THETA_I");
-      auto traction_theta_o = function_lin_def.container().get<double>("TRACTION_THETA_O");
+      auto traction_theta_i = function_lin_def.get<double>("TRACTION_THETA_I");
+      auto traction_theta_o = function_lin_def.get<double>("TRACTION_THETA_O");
 
-      auto viscosity = function_lin_def.container().get<double>("VISCOSITY");
+      auto viscosity = function_lin_def.get<double>("VISCOSITY");
 
       return std::make_shared<TaylorCouetteFlow>(radius_i, radius_o, vel_theta_i, vel_theta_o,
           sliplength_i, sliplength_o, traction_theta_i, traction_theta_o, viscosity);
     }
-    else if (function_lin_def.container().get_or<bool>("URQUIZABOXFLOW", false))
+    else if (function_lin_def.get_or<bool>("URQUIZABOXFLOW", false))
     {
-      auto lengthx = function_lin_def.container().get<double>("LENGTHX");
-      auto lengthy = function_lin_def.container().get<double>("LENGTHY");
+      auto lengthx = function_lin_def.get<double>("LENGTHX");
+      auto lengthy = function_lin_def.get<double>("LENGTHY");
 
-      auto rotation = function_lin_def.container().get<double>("ROTATION");
-      auto viscosity = function_lin_def.container().get<double>("VISCOSITY");
-      auto density = function_lin_def.container().get<double>("DENSITY");
+      auto rotation = function_lin_def.get<double>("ROTATION");
+      auto viscosity = function_lin_def.get<double>("VISCOSITY");
+      auto density = function_lin_def.get<double>("DENSITY");
 
-      auto functno = function_lin_def.container().get<int>("CASE");
+      auto functno = function_lin_def.get<int>("CASE");
 
       std::vector<double> lin_comb(2, 0.0);
-      if (function_lin_def.container().get_if<std::vector<double>>("COMBINATION") != nullptr)
+      if (function_lin_def.get_if<std::vector<double>>("COMBINATION") != nullptr)
       {
-        lin_comb = function_lin_def.container().get<std::vector<double>>("COMBINATION");
+        lin_comb = function_lin_def.get<std::vector<double>>("COMBINATION");
       }
       else if (functno == 3)
         FOUR_C_THROW(
@@ -135,21 +133,21 @@ namespace
       return std::make_shared<UrquizaBoxFlow>(
           lengthx, lengthy, rotation, viscosity, density, functno, lin_comb);
     }
-    else if (function_lin_def.container().get_or<bool>("URQUIZABOXFLOW_FORCE", false))
+    else if (function_lin_def.get_or<bool>("URQUIZABOXFLOW_FORCE", false))
     {
-      auto lengthx = function_lin_def.container().get<double>("LENGTHX");
-      auto lengthy = function_lin_def.container().get<double>("LENGTHY");
+      auto lengthx = function_lin_def.get<double>("LENGTHX");
+      auto lengthy = function_lin_def.get<double>("LENGTHY");
 
-      auto rotation = function_lin_def.container().get<double>("ROTATION");
-      auto viscosity = function_lin_def.container().get<double>("VISCOSITY");
-      auto density = function_lin_def.container().get<double>("DENSITY");
+      auto rotation = function_lin_def.get<double>("ROTATION");
+      auto viscosity = function_lin_def.get<double>("VISCOSITY");
+      auto density = function_lin_def.get<double>("DENSITY");
 
-      auto functno = function_lin_def.container().get<int>("CASE");
+      auto functno = function_lin_def.get<int>("CASE");
 
       std::vector<double> lin_comb(2, 0.0);
-      if (function_lin_def.container().get_if<std::vector<double>>("COMBINATION") != nullptr)
+      if (function_lin_def.get_if<std::vector<double>>("COMBINATION") != nullptr)
       {
-        lin_comb = function_lin_def.container().get<std::vector<double>>("COMBINATION");
+        lin_comb = function_lin_def.get<std::vector<double>>("COMBINATION");
       }
       else if (functno == 3)
         FOUR_C_THROW(
@@ -159,21 +157,21 @@ namespace
       return std::make_shared<UrquizaBoxFlowForce>(
           lengthx, lengthy, rotation, viscosity, density, functno, lin_comb);
     }
-    else if (function_lin_def.container().get_or<bool>("URQUIZABOXFLOW_TRACTION", false))
+    else if (function_lin_def.get_or<bool>("URQUIZABOXFLOW_TRACTION", false))
     {
-      auto lengthx = function_lin_def.container().get<double>("LENGTHX");
-      auto lengthy = function_lin_def.container().get<double>("LENGTHY");
+      auto lengthx = function_lin_def.get<double>("LENGTHX");
+      auto lengthy = function_lin_def.get<double>("LENGTHY");
 
-      auto rotation = function_lin_def.container().get<double>("ROTATION");
-      auto viscosity = function_lin_def.container().get<double>("VISCOSITY");
-      auto density = function_lin_def.container().get<double>("DENSITY");
+      auto rotation = function_lin_def.get<double>("ROTATION");
+      auto viscosity = function_lin_def.get<double>("VISCOSITY");
+      auto density = function_lin_def.get<double>("DENSITY");
 
-      auto functno = function_lin_def.container().get<int>("CASE");
+      auto functno = function_lin_def.get<int>("CASE");
 
       std::vector<double> lin_comb(2, 0.0);
-      if (function_lin_def.container().get_if<std::vector<double>>("COMBINATION") != nullptr)
+      if (function_lin_def.get_if<std::vector<double>>("COMBINATION") != nullptr)
       {
-        lin_comb = function_lin_def.container().get<std::vector<double>>("COMBINATION");
+        lin_comb = function_lin_def.get<std::vector<double>>("COMBINATION");
       }
       else if (functno == 3)
         FOUR_C_THROW(

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
@@ -17,15 +17,15 @@ FOUR_C_NAMESPACE_OPEN
 namespace
 {
   std::shared_ptr<Core::Utils::FunctionOfSpaceTime> create_combust_function(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
-    if (function_line_defs.size() != 1) return nullptr;
+    if (parameters.size() != 1) return nullptr;
 
-    if (function_line_defs.front().container().get_or("ZALESAKSDISK", false))
+    if (parameters.front().get_or("ZALESAKSDISK", false))
     {
       return std::make_shared<Discret::Utils::ZalesaksDiskFunction>();
     }
-    else if (function_line_defs.front().container().get_or("COLLAPSINGWATERCOLUMN", false))
+    else if (parameters.front().get_or("COLLAPSINGWATERCOLUMN", false))
     {
       return std::make_shared<Discret::Utils::CollapsingWaterColumnFunction>();
     }

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -2117,15 +2117,15 @@ void Global::read_cloning_material_map(Global::Problem& problem, Core::IO::Input
   const std::vector<Input::LineDefinition> lines = Core::FE::valid_cloning_material_map_lines();
 
   // perform the actual reading and extract the input parameters
-  std::vector<Input::LineDefinition> input_line_vec =
+  auto parameters =
       Core::IO::InputFileUtils::read_all_lines_in_section(input, "CLONING MATERIAL MAP", lines);
-  for (const auto& input_line : input_line_vec)
+  for (const auto& input_line : parameters)
   {
     // extract what was read from the input file
-    std::string src_field = input_line.container().get<std::string>("SRC_FIELD");
-    int src_matid = input_line.container().get_or<int>("SRC_MAT", -1);
-    std::string tar_field = input_line.container().get<std::string>("TAR_FIELD");
-    int tar_matid = input_line.container().get_or<int>("TAR_MAT", -1);
+    std::string src_field = input_line.get<std::string>("SRC_FIELD");
+    int src_matid = input_line.get_or<int>("SRC_MAT", -1);
+    std::string tar_field = input_line.get<std::string>("TAR_FIELD");
+    int tar_matid = input_line.get_or<int>("TAR_MAT", -1);
 
     // create the key pair
     std::pair<std::string, std::string> fields(src_field, tar_field);

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
@@ -64,20 +64,17 @@ namespace
 
   template <int dim>
   std::shared_ptr<Core::Utils::FunctionOfAnything> try_create_poro_function(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
-    if (function_line_defs.size() != 1) return nullptr;
+    if (parameters.size() != 1) return nullptr;
 
-    const auto& function_lin_def = function_line_defs.front();
+    const auto& function_lin_def = parameters.front();
 
-    if (function_lin_def.container().get_if<std::string>("POROMULTIPHASESCATRA_FUNCTION") !=
-        nullptr)
+    if (function_lin_def.get_if<std::string>("POROMULTIPHASESCATRA_FUNCTION") != nullptr)
     {
-      std::string type =
-          function_lin_def.container().get<std::string>("POROMULTIPHASESCATRA_FUNCTION");
+      std::string type = function_lin_def.get<std::string>("POROMULTIPHASESCATRA_FUNCTION");
 
-      auto params =
-          function_lin_def.container().get<std::vector<std::pair<std::string, double>>>("PARAMS");
+      auto params = function_lin_def.get<std::vector<std::pair<std::string, double>>>("PARAMS");
 
       return create_poro_function<dim>(type, params);
     }
@@ -88,16 +85,16 @@ namespace
   }
 
   auto try_create_poro_function_dispatch(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
     switch (Global::Problem::instance()->n_dim())
     {
       case 1:
-        return try_create_poro_function<1>(function_line_defs);
+        return try_create_poro_function<1>(parameters);
       case 2:
-        return try_create_poro_function<2>(function_line_defs);
+        return try_create_poro_function<2>(parameters);
       case 3:
-        return try_create_poro_function<3>(function_line_defs);
+        return try_create_poro_function<3>(parameters);
       default:
         FOUR_C_THROW("Unsupported dimension %d.", Global::Problem::instance()->n_dim());
     }

--- a/src/structure_new/src/utils/4C_structure_new_functions.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_functions.cpp
@@ -30,16 +30,16 @@ namespace
   /*----------------------------------------------------------------------*/
   /*----------------------------------------------------------------------*/
   std::shared_ptr<Core::Utils::FunctionOfSpaceTime> create_structure_function(
-      const std::vector<Input::LineDefinition>& function_line_defs)
+      const std::vector<Core::IO::InputParameterContainer>& parameters)
   {
-    if (function_line_defs.size() != 1) return nullptr;
+    if (parameters.size() != 1) return nullptr;
 
-    const auto& function_lin_def = function_line_defs.front();
+    const auto& function_lin_def = parameters.front();
 
-    if (function_lin_def.container().get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE", false))
+    if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE", false))
     {
       // read data
-      int mat_id_struct = function_lin_def.container().get_or<int>("MAT_STRUCT", -1);
+      int mat_id_struct = function_lin_def.get_or<int>("MAT_STRUCT", -1);
 
       if (mat_id_struct <= 0)
         FOUR_C_THROW(
@@ -50,11 +50,10 @@ namespace
 
       return std::make_shared<Solid::WeaklyCompressibleEtienneFSIStructureFunction>(fparams);
     }
-    else if (function_lin_def.container().get_or(
-                 "WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE_FORCE", false))
+    else if (function_lin_def.get_or("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE_FORCE", false))
     {
       // read data
-      int mat_id_struct = function_lin_def.container().get_or<int>("MAT_STRUCT", -1);
+      int mat_id_struct = function_lin_def.get_or<int>("MAT_STRUCT", -1);
 
       if (mat_id_struct <= 0)
       {


### PR DESCRIPTION
Further unifies the different input mechanisms #73. `LineDefinition` could be replaced by `InputSpec` now.