### PR TITLE
Automatically tag docker images on release

### DIFF
--- a/.github/actions/tag_docker_image/action.yml
+++ b/.github/actions/tag_docker_image/action.yml
@@ -1,0 +1,52 @@
+name: Add tags to docker image
+description: Automatically detect and add tags based on branch name, commit hash and version
+inputs:
+  image-name:
+    description: Name of the docker image
+    required: true
+  source-tag:
+    description: Source tag of the image (if not set, it will be determined based on the git sha)
+    required: false
+    default: ''
+  tag-types:
+    description: Type of tags to add based on the syntax of docker/metadata-action@v5
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Detect docker image
+      if: ${{ inputs.source-tag == '' }}
+      id: detect-sha
+      uses: docker/metadata-action@v5
+      with:
+        images:
+        tags: |
+          type=sha
+    - shell: bash
+      name: Pull docker image
+      run: docker pull $IMAGE_NAME:$SOURCE_TAG
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SOURCE_TAG: ${{ inputs.source-tag == '' && steps.detect-sha.outputs.tags || inputs.source-tag
+          }}
+    # automatically detect tags
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.image-name }}
+        tags: ${{ inputs.tag-types }}
+    - shell: bash
+      name: Add tag
+      run: |
+        for TARGET_TAG in $TARGET_TAGS; do
+          echo "Adding $TARGET_TAG to $IMAGE_NAME:$SOURCE_TAG"
+          docker image tag $IMAGE_NAME:$SOURCE_TAG $IMAGE_NAME:$TARGET_TAG
+          docker push $IMAGE_NAME:$TARGET_TAG
+        done
+      env:
+        IMAGE_NAME: ${{ inputs.image-name }}
+        SOURCE_TAG: ${{ inputs.source-tag == '' && steps.detect-sha.outputs.tags || inputs.source-tag
+          }}
+        TARGET_TAGS: ${{ steps.meta.outputs.tags }}
+

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,7 +64,7 @@ jobs:
             }}
           ubuntu-version: "24.04"
 
-  tag-images-as-latest:
+  tag-images-as-main:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' && github.repository == '4C-multiphysics/4C' }}
     permissions:
@@ -82,9 +82,10 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Pull current Ubuntu 24.04 dependencies image and tag it with latest
-        run: |
-          IMAGE_NAME="${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-dependencies-ubuntu24.04"
-          docker pull $IMAGE_NAME:${{ steps.compute-dependencies-hash.outputs.computed_dependencies_hash }}
-          docker image tag $IMAGE_NAME:${{ steps.compute-dependencies-hash.outputs.computed_dependencies_hash }} $IMAGE_NAME:latest
-          docker push $IMAGE_NAME:latest
+      - name: Add tags to docker dependencies image
+        uses: ./.github/actions/tag_docker_image
+        with:
+          image-name: ${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-dependencies-ubuntu24.04
+          source-tag: ${{ steps.compute-dependencies-hash.outputs.computed_dependencies_hash }}
+          tag-types: |
+            type=ref,event=branch

--- a/.github/workflows/docker_prebuilt_4c.yml
+++ b/.github/workflows/docker_prebuilt_4c.yml
@@ -40,6 +40,14 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           labels: |
             org.opencontainers.image.description=Image containing the built 4C code
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha
+      - name: Extract short git hash
+        id: extract-git-hash
+        shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
@@ -50,8 +58,7 @@ jobs:
           context: .
           file: docker/prebuilt_4C/Dockerfile
           push: true
-          tags: ${{ env.IMAGE_NAME }}:latest
-          # tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       # This step generates an artifact attestation for the image, which is an unforgeable statement about where and how it was built. It increases supply chain security for people who consume the image. For more information, see "[AUTOTITLE](/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds)."

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -1,0 +1,44 @@
+name: publish_release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+
+env:
+  REGISTRY: ghcr.io
+  PROJECT_NAMESPACE: 4c-multiphysics
+
+jobs:
+  publish_release:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: compute-dependencies-hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+        with:
+          skip-check: 'true'
+      - name: Add tag to docker dependencies image
+        uses: ./.github/actions/tag_docker_image
+        with:
+          image-name: ${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-dependencies-ubuntu24.04
+          source-tag: ${{ steps.compute-dependencies-hash.outputs.computed_dependencies_hash }}
+          tag-types: |
+            type=semver,pattern={{version}}
+      - name: Add tag to docker image
+        uses: ./.github/actions/tag_docker_image
+        with:
+          image-name: ${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c
+          tag-types: |
+            type=semver,pattern={{version}}


### PR DESCRIPTION
This PR adds automatically tags to the docker images `4c` and `4c-dependencies-ubuntu24-04`.

The following tags are added:
 * `latest`
 * `2025.1.0` for the git tag name `v2025.1.0`.
 * branch-name
 * sha-hash (only for `4c`)

Note additionally,

* `latest` will now refer to the latest release
* `main` is now what used to be `latest` before