### PR TITLE
Reorganize InputSpec headers

### DIFF
--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
@@ -11,6 +11,7 @@
 #include "4C_fem_general_utils_createdis.hpp"
 #include "4C_global_legacy_module.hpp"
 #include "4C_io_input_file_utils.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_linedefinition.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_string.hpp"
@@ -329,9 +330,9 @@ namespace RTD
     for (const auto& spec : material->specs())
     {
       std::vector<std::string> table_row;
-      table_row.push_back(spec.name());
-      table_row.emplace_back((spec.required() ? "" : "yes"));
-      table_row.push_back(spec.description());
+      table_row.push_back(spec.impl().name());
+      table_row.emplace_back((spec.impl().required() ? "" : "yes"));
+      table_row.push_back(spec.impl().description());
 
       parametertable.add_row(table_row);
 
@@ -344,7 +345,7 @@ namespace RTD
 
       std::ostringstream parameterstream;
       Core::IO::InputParameterContainer container;
-      spec.print(parameterstream, container);
+      spec.print_as_dat(parameterstream, container);
       parameter += " " + parameterstream.str();
     }
 
@@ -624,7 +625,7 @@ namespace RTD
     write_code(stream, contactlawsectionstring);
 
     std::stringstream specs_string;
-    specs.print(specs_string, Core::IO::InputParameterContainer{});
+    specs.print_as_dat(specs_string, Core::IO::InputParameterContainer{});
     write_code(stream, {specs_string.str()});
   }
 

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char* argv[])
         auto valid_co_laws = CONTACT::CONSTITUTIVELAW::valid_contact_constitutive_laws();
         Core::IO::InputFileUtils::print_section_header(std::cout, "CONTACT CONSTITUTIVE LAWS");
         std::cout << "//";
-        valid_co_laws.print(std::cout, Core::IO::InputParameterContainer{});
+        valid_co_laws.print_as_dat(std::cout, Core::IO::InputParameterContainer{});
         std::cout << '\n';
       }
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.cpp
@@ -10,6 +10,7 @@
 #include "4C_contact_constitutivelaw_bundle.hpp"
 #include "4C_contact_constitutivelaw_contactconstitutivelaw_parameter.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_spec_builders.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.hpp
@@ -11,7 +11,7 @@
 /*----------------------------------------------------------------------*/
 #include "4C_config.hpp"
 
-#include "4C_io_input_spec_builders.hpp"
+#include "4C_io_input_spec.hpp"
 
 #include <iostream>
 #include <memory>

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -12,12 +12,40 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-void Core::IO::fully_parse(ValueParser& parser, const Core::IO::InputSpec& input_spec,
-    Core::IO::InputParameterContainer& container)
+Core::IO::InputSpec::InputSpec(std::unique_ptr<Internal::InputSpecTypeErasedBase> pimpl)
+    : pimpl_(std::move(pimpl))
 {
-  input_spec.parse(parser, container);
+}
+
+Core::IO::InputSpec::~InputSpec() = default;
+
+Core::IO::InputSpec::InputSpec(const InputSpec& other) : pimpl_(other.pimpl_->clone()) {}
+
+Core::IO::InputSpec& Core::IO::InputSpec::operator=(const InputSpec& other)
+{
+  pimpl_ = other.pimpl_->clone();
+  return *this;
+}
+
+void Core::IO::InputSpec::fully_parse(
+    ValueParser& parser, Core::IO::InputParameterContainer& container) const
+{
+  pimpl_->parse(parser, container);
   FOUR_C_ASSERT_ALWAYS(parser.at_end(), "After parsing, the line still contains '%s'.",
       std::string(parser.get_unparsed_remainder()).c_str());
+}
+
+void Core::IO::InputSpec::print_as_dat(
+    std::ostream& stream, const Core::IO::InputParameterContainer& container) const
+{
+  pimpl_->print(stream, container);
+}
+
+Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl() { return *pimpl_; }
+
+const Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl() const
+{
+  return *pimpl_;
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -10,21 +10,70 @@
 
 #include "4C_config.hpp"
 
+#include <memory>
+
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::IO
 {
-  class InputSpec;
   class InputParameterContainer;
   class ValueParser;
 
-  /**
-   * Use the @p parser to parse whatever @p input_spec expects. The results are stored in the
-   * @p container. If parsing fails, an exception is thrown.
-   */
-  void fully_parse(
-      ValueParser& parser, const InputSpec& input_spec, InputParameterContainer& container);
+  namespace Internal
+  {
+    class InputSpecTypeErasedBase;
+  }  // namespace Internal
 
+  /**
+   * Objects of this class encapsulate knowledge about the input. You can create objects using the
+   * helper functions in the InputSpecBuilders namespace. See the function
+   * InputSpecBuilders::entry() for more information on how to create InputSpecs.
+   */
+  class InputSpec
+  {
+   public:
+    InputSpec() = default;
+
+    ~InputSpec();
+
+    InputSpec(std::unique_ptr<Internal::InputSpecTypeErasedBase> pimpl);
+
+    InputSpec(const InputSpec& other);
+    InputSpec& operator=(const InputSpec& other);
+
+    InputSpec(InputSpec&&) noexcept = default;
+    InputSpec& operator=(InputSpec&&) noexcept = default;
+
+    /**
+     * Use the @p parser to parse whatever this InputSpec expects. The results are stored in the
+     * @p container. If parsing fails, an exception is thrown.
+     */
+    void fully_parse(ValueParser& parser, InputParameterContainer& container) const;
+
+    /**
+     * Print the expected input format of this InputSpec to @p stream in dat format. The @p
+     * container is used to print the default values of the input. If a value is not present in the
+     * container, the type of the value is printed instead.
+     */
+    void print_as_dat(std::ostream& stream, const InputParameterContainer& container) const;
+
+    /**
+     * Access the opaque implementation class. This is used in the implementation files where the
+     * definition is known. There is nothing you can or should do with this function in the user
+     * code.
+     */
+    Internal::InputSpecTypeErasedBase& impl();
+
+    /**
+     * Access the opaque implementation class. This is used in the implementation files where the
+     * definition is known. There is nothing you can or should do with this function in the user
+     * code.
+     */
+    [[nodiscard]] const Internal::InputSpecTypeErasedBase& impl() const;
+
+   private:
+    std::unique_ptr<Internal::InputSpecTypeErasedBase> pimpl_;
+  };
 }  // namespace Core::IO
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_linedefinition.cpp
+++ b/src/core/io/src/4C_io_linedefinition.cpp
@@ -287,8 +287,7 @@ namespace Input
   {
     auto line = Core::IO::InputSpecBuilders::group(pimpl_->components_);
     Core::IO::InputParameterContainer container;
-    line.set_default_value(container);
-    line.print(stream, container);
+    line.print_as_dat(stream, container);
   }
 
 
@@ -307,7 +306,7 @@ namespace Input
     {
       auto input_line = Core::IO::InputSpecBuilders::group(pimpl_->components_);
       Core::IO::ValueParser parser(line, {.base_path = context.input_file.parent_path()});
-      Core::IO::fully_parse(parser, input_line, container);
+      input_line.fully_parse(parser, container);
     }
     catch (const Core::Exception& e)
     {

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -30,7 +30,7 @@ namespace
     InputParameterContainer container;
     std::string stream("marker b 2.0 d true // trailing comment");
     ValueParser parser(stream);
-    fully_parse(parser, line, container);
+    line.fully_parse(parser, container);
     EXPECT_EQ(container.get<int>("a"), 1);
     EXPECT_EQ(container.get<double>("b"), 2.0);
     EXPECT_EQ(container.get_if<std::string>("c"), nullptr);
@@ -47,7 +47,7 @@ namespace
     InputParameterContainer container;
     std::string stream("b 2.0 c string a 1");
     ValueParser parser(stream);
-    fully_parse(parser, line, container);
+    line.fully_parse(parser, container);
     EXPECT_EQ(container.get<int>("a"), 1);
     EXPECT_EQ(container.get<double>("b"), 2.0);
     EXPECT_EQ(container.get<std::string>("c"), "string");
@@ -65,7 +65,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 2.0 // c 1");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<double>("b"), 2.0);
       EXPECT_EQ(container.get<std::string>("c"), "default");
@@ -84,7 +84,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 2.0");
       ValueParser parser(stream);
-      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
           "Required value 'c' not found in input line");
     }
   }
@@ -101,7 +101,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 1.0 2.0 3.0 c string");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 1);
       const auto& b = container.get<std::vector<double>>("b");
       EXPECT_EQ(b.size(), 3);
@@ -115,7 +115,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 1.0 2.0 c string");
       ValueParser parser(stream);
-      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
           "Could not parse 'c' as a double value");
     }
   }
@@ -132,7 +132,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 3 b 1.0 2.0 3.0 c string");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 3);
       const auto& b = container.get<std::vector<double>>("b");
       EXPECT_EQ(b.size(), 3);
@@ -146,7 +146,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 3 b 1.0 2.0 c string");
       ValueParser parser(stream);
-      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
           "Could not parse 'c' as a double value");
     }
   }
@@ -175,7 +175,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 2.0 c _ _ s hello");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<double>("b"), 2.0);
       EXPECT_EQ(container.get<std::string>("c"), "I found c");
@@ -187,7 +187,7 @@ namespace
       std::string stream("a 1 b 2.0 c _ s hello");
       ValueParser parser(stream);
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(
-          fully_parse(parser, line, container), Core::Exception, "expected string '_'");
+          line.fully_parse(parser, container), Core::Exception, "expected string '_'");
     }
   }
 
@@ -204,7 +204,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b b2 d string c c1");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<int>("b"), 2);
       EXPECT_EQ(container.get<std::string>("c"), "1");
@@ -216,7 +216,7 @@ namespace
       std::string stream("a 1 b b4 c string");
       ValueParser parser(stream);
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(
-          fully_parse(parser, line, container), Core::Exception, "Invalid value 'b4'");
+          line.fully_parse(parser, container), Core::Exception, "Invalid value 'b4'");
     }
   }
 
@@ -231,7 +231,7 @@ namespace
     InputParameterContainer container;
     std::string stream("a 1 b 2.0 c string unparsed unparsed");
     ValueParser parser(stream);
-    FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+    FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
         "line still contains 'unparsed unparsed'");
   }
 
@@ -266,7 +266,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 group1 b 2.0 c string");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       const auto& const_container = container;
       EXPECT_EQ(const_container.get<int>("a"), 1);
       EXPECT_EQ(const_container.group("group1").get<double>("b"), 2.0);
@@ -280,7 +280,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 group2 b 2.0 c string group1 b 4.0 c string");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       const auto& const_container = container;
       EXPECT_EQ(const_container.get<int>("a"), 1);
       EXPECT_EQ(const_container.group("group2").get<double>("b"), 2.0);
@@ -292,7 +292,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 group1 b 4.0 c string");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       const auto& const_container = container;
       EXPECT_EQ(const_container.get<int>("a"), 1);
       EXPECT_ANY_THROW([[maybe_unused]] const auto& c = const_container.group("group2"));
@@ -319,7 +319,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 2");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<double>("b"), 2);
     }
@@ -328,7 +328,7 @@ namespace
       InputParameterContainer container;
       std::string stream("group c string d 2.0");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 42);
       EXPECT_EQ(container.group("group").get<std::string>("c"), "string");
       EXPECT_EQ(container.group("group").get<double>("d"), 2);
@@ -339,7 +339,7 @@ namespace
       std::string stream("a 1 group c string d 2.0 b 3.0");
       ValueParser parser(stream);
       // More than one of the one_of entries is present. Refuse to parse any of them.
-      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
           "still contains 'group c string d 2.0 b 3.0'");
     }
 
@@ -350,7 +350,7 @@ namespace
       // The result is that the parts of the group remain unparsed.
       ValueParser parser(stream);
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(
-          fully_parse(parser, line, container), Core::Exception, "still contains 'group c string'");
+          line.fully_parse(parser, container), Core::Exception, "still contains 'group c string'");
     }
 
     {
@@ -358,7 +358,7 @@ namespace
       std::string stream("a 1");
       ValueParser parser(stream);
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(
-          fully_parse(parser, line, container), Core::Exception, "Required 'one_of {b, group}'");
+          line.fully_parse(parser, container), Core::Exception, "Required 'one_of {b, group}'");
     }
   }
 
@@ -382,7 +382,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 2");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<double>("b"), 2);
       EXPECT_EQ(container.get<int>("index"), 1);
@@ -392,7 +392,7 @@ namespace
       InputParameterContainer container;
       std::string stream("c string d 2.0");
       ValueParser parser(stream);
-      fully_parse(parser, line, container);
+      line.fully_parse(parser, container);
       EXPECT_EQ(container.get<std::string>("c"), "string");
       EXPECT_EQ(container.get<double>("d"), 2);
       EXPECT_EQ(container.get<int>("index"), 10);
@@ -402,7 +402,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 b 2 c string d 2.0");
       ValueParser parser(stream);
-      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
           "both 'group {a, b}' and 'group {c, d}'");
     }
 
@@ -410,7 +410,7 @@ namespace
       InputParameterContainer container;
       std::string stream("a 1 c string");
       ValueParser parser(stream);
-      FOUR_C_EXPECT_THROW_WITH_MESSAGE(fully_parse(parser, line, container), Core::Exception,
+      FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
           "one_of {group {a, b}, group {c, d}}");
     }
   }
@@ -428,7 +428,7 @@ namespace
       container.add("a", 1);
       container.add("b", std::string("s"));
       std::ostringstream out;
-      line.print(out, container);
+      line.print_as_dat(out, container);
       EXPECT_EQ(out.str(), "a 1 b s [c (c1|c2|)] ");
     }
   }

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -23,6 +23,7 @@
 #include "4C_io_geometry_type.hpp"
 #include "4C_io_input_file.hpp"
 #include "4C_io_input_file_utils.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_linedefinition.hpp"
 #include "4C_io_meshreader.hpp"
 #include "4C_mat_elchmat.hpp"
@@ -2070,12 +2071,12 @@ void Global::read_materials(Global::Problem& problem, Core::IO::InputFile& input
     if (problem.materials()->id_exists(mat_id))
       FOUR_C_THROW("More than one material with 'MAT %d'", mat_id);
 
-    Core::IO::fully_parse(parser, all_materials, container);
+    all_materials.fully_parse(parser, container);
 
     problem.materials()->insert(
         mat_id, Core::Utils::LazyPtr<Core::Mat::PAR::Parameter>(
                     [mat_id, mat_type = all_types[current_index],
-                        container = container.group(all_specs[current_index].name())]()
+                        container = container.group(all_specs[current_index].impl().name())]()
                     { return Mat::make_parameter(mat_id, mat_type, container); }));
   }
 
@@ -2105,7 +2106,7 @@ void Global::read_contact_constitutive_laws(Global::Problem& problem, Core::IO::
         section_i, {.user_scope_message = "While reading 'CONTACT CONSTITUTIVE LAWS' section: "});
 
     Core::IO::InputParameterContainer container;
-    Core::IO::fully_parse(parser, valid_law_spec, container);
+    valid_law_spec.fully_parse(parser, container);
     CONTACT::CONSTITUTIVELAW::create_contact_constitutive_law_from_input(container);
   }
 }

--- a/src/mat/4C_mat_materialdefinition.cpp
+++ b/src/mat/4C_mat_materialdefinition.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_io_input_file.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_value_parser.hpp"
 #include "4C_mat_par_bundle.hpp"
 
@@ -52,8 +53,8 @@ std::ostream& Mat::MaterialDefinition::print(
   stream << comment << " " << description_ << '\n';
   for (const auto& c : components_)
   {
-    stream << comment << " " << c.name() << (c.required() ? " " : " (optional) ") << c.description()
-           << '\n';
+    stream << comment << " " << c.impl().name() << (c.impl().required() ? " " : " (optional) ")
+           << c.impl().description() << '\n';
   }
 
   // the default line
@@ -61,8 +62,8 @@ std::ostream& Mat::MaterialDefinition::print(
   auto input_line = Core::IO::InputSpecBuilders::group(components_);
 
   Core::IO::InputParameterContainer container;
-  input_line.set_default_value(container);
-  input_line.print(stream, container);
+  input_line.impl().set_default_value(container);
+  input_line.impl().print(stream, container);
 
   stream << '\n';
 

--- a/src/mat/4C_mat_materialdefinition.hpp
+++ b/src/mat/4C_mat_materialdefinition.hpp
@@ -12,7 +12,7 @@
 /* headers */
 #include "4C_config.hpp"
 
-#include "4C_io_input_spec_builders.hpp"
+#include "4C_io_input_spec.hpp"
 #include "4C_io_linecomponent.hpp"
 #include "4C_mat_par_bundle.hpp"
 


### PR DESCRIPTION
This PR shuffles code around such that the `4C_io_input_spec.hpp` header contains barely enough information to pass `InputSpec` around by value and call a few central functions. All implementation details that are necessary for construction are still hidden in `4C_io_input_spec_builders.hpp`. It is now obvious when code uses the implementation details because it calls `impl()`. This is currently required when interfacing with the legacy input mechanism and the rtd emitter.