### PR TITLE
Emit metadata for InputSpec

### DIFF
--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.cpp
@@ -134,7 +134,7 @@ Core::IO::InputSpec CONTACT::CONSTITUTIVELAW::valid_contact_constitutive_laws()
     group_index_to_type.push_back(Inpar::CONTACT::ConstitutiveLawType::colaw_mirco);
   }
 
-  auto valid_law = group({
+  auto valid_law = anonymous_group({
       entry<int>("LAW"),
       one_of(specs, store_index_as("LAW_TYPE", group_index_to_type)),
   });

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -41,6 +41,13 @@ void Core::IO::InputSpec::print_as_dat(
   pimpl_->print(stream, container);
 }
 
+void Core::IO::InputSpec::emit_metadata(YAML::Emitter& yaml) const
+{
+  yaml << YAML::BeginMap;
+  pimpl_->emit_metadata(yaml);
+  yaml << YAML::EndMap;
+}
+
 Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl() { return *pimpl_; }
 
 const Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl() const

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -10,6 +10,8 @@
 
 #include "4C_config.hpp"
 
+#include <yaml-cpp/emitter.h>
+
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN
@@ -56,6 +58,11 @@ namespace Core::IO
      * container, the type of the value is printed instead.
      */
     void print_as_dat(std::ostream& stream, const InputParameterContainer& container) const;
+
+    /**
+     * Emit metadata about the InputSpec to the @p yaml emitter.
+     */
+    void emit_metadata(YAML::Emitter& yaml) const;
 
     /**
      * Access the opaque implementation class. This is used in the implementation files where the

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -214,7 +214,7 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::emit_metadata(YAML::Emitt
     yaml << YAML::Key << (name.empty() ? data.description : name);
     yaml << YAML::Value << YAML::BeginMap;
     {
-      yaml << YAML::Key << "type" << YAML::Value << (name.empty() ? "anonymous_group" : "scope");
+      yaml << YAML::Key << "type" << YAML::Value << (name.empty() ? "anonymous_group" : "group");
       yaml << YAML::Key << "description" << YAML::Value << data.description;
       yaml << YAML::Key << "required" << YAML::Value << data.required;
 
@@ -357,12 +357,12 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::group(
 }
 
 
-Core::IO::InputSpec Core::IO::InputSpecBuilders::group(std::vector<InputSpec> specs)
+Core::IO::InputSpec Core::IO::InputSpecBuilders::anonymous_group(std::vector<InputSpec> specs)
 {
   assert_unique_or_empty_names(specs);
 
   // Generate a description of the form "group {a, b, c}".
-  std::string description = "group " + describe(specs);
+  std::string description = "anonymous_group " + describe(specs);
 
   IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
       .name = "",

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -711,7 +711,7 @@ namespace Core::IO
      * Example:
      *
      * @code
-     * group({
+     * anonymous_group({
      *   entry<int>("a"),
      *   entry<double>("b"),
      *   entry<std::string>("c"),
@@ -721,7 +721,7 @@ namespace Core::IO
      * This functions gathers multiple InputSpecs on the same level and treats them as a single
      * InputSpec.
      */
-    [[nodiscard]] InputSpec group(std::vector<InputSpec> specs);
+    [[nodiscard]] InputSpec anonymous_group(std::vector<InputSpec> specs);
 
     /**
      * Exactly one of the given InputSpecs is expected. There is no support for default values and

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -14,6 +14,8 @@
 #include "4C_io_input_spec.hpp"
 #include "4C_io_value_parser.hpp"
 
+#include <yaml-cpp/emitter.h>
+
 #include <functional>
 #include <optional>
 #include <ostream>
@@ -112,6 +114,34 @@ namespace Core::IO
       return PrettyTypeName<T>{}();
     }
 
+    template <typename T>
+    concept YamlCppSupportedType = requires(YAML::Emitter& yaml, const T& value) {
+      { yaml << value };
+    };
+
+    template <YamlCppSupportedType T>
+    void emit_value_as_yaml(YAML::Emitter& yaml, const T& value)
+    {
+      yaml << value;
+    }
+
+    template <typename T, typename U>
+    void emit_value_as_yaml(YAML::Emitter& yaml, const std::pair<T, U>& value)
+    {
+      yaml << YAML::Flow << YAML::BeginSeq;
+      emit_value_as_yaml(yaml, value.first);
+      emit_value_as_yaml(yaml, value.second);
+      yaml << YAML::EndSeq;
+    }
+
+    template <typename T>
+    void emit_value_as_yaml(YAML::Emitter& yaml, const std::vector<T>& value)
+    {
+      yaml << YAML::Flow << YAML::BeginSeq;
+      for (const auto& v : value) emit_value_as_yaml(yaml, v);
+      yaml << YAML::EndSeq;
+    }
+
     class InputSpecTypeErasedBase
     {
      public:
@@ -148,6 +178,11 @@ namespace Core::IO
 
       virtual void parse(ValueParser& parser, InputParameterContainer& container) const = 0;
       virtual void set_default_value(InputParameterContainer& container) const = 0;
+
+      //! Emit metadata. This function always emits into a map, i.e., the implementation must
+      //! insert keys and values into the yaml emitter.
+      virtual void emit_metadata(YAML::Emitter& yaml) const = 0;
+
       [[nodiscard]] virtual std::unique_ptr<InputSpecTypeErasedBase> clone() const = 0;
 
       void print(std::ostream& stream, const InputParameterContainer& container) const
@@ -201,6 +236,8 @@ namespace Core::IO
           container.add(wrapped.name, *wrapped.data.default_value);
         }
       }
+
+      void emit_metadata(YAML::Emitter& yaml) const override { wrapped.emit_metadata(yaml); }
 
       void do_print(std::ostream& stream, const InputParameterContainer& container) const override
       {
@@ -399,6 +436,7 @@ namespace Core::IO
         using StoredType = typename DataType::StoredType;
         DataType data;
         void parse(ValueParser& parser, InputParameterContainer& container) const;
+        void emit_metadata(YAML::Emitter& yaml) const;
       };
 
 
@@ -411,6 +449,20 @@ namespace Core::IO
         DataType data;
         std::function<void(ValueParser&, InputParameterContainer&)> parse;
         std::function<void(std::ostream&, const InputParameterContainer&)> print;
+        std::function<void(YAML::Emitter&)> emit_metadata;
+      };
+
+      template <typename DataTypeIn>
+      struct SelectionSpec
+      {
+        std::string name;
+        using DataType = std::decay_t<DataTypeIn>;
+        using StoredType = typename DataType::StoredType;
+        DataType data;
+        std::vector<std::pair<std::string, StoredType>> choices;
+        void parse(ValueParser& parser, InputParameterContainer& container) const;
+        void print(std::ostream& stream, const InputParameterContainer& container) const;
+        void emit_metadata(YAML::Emitter& yaml) const;
       };
 
       struct GroupSpec
@@ -422,6 +474,7 @@ namespace Core::IO
         void parse(ValueParser& parser, InputParameterContainer& container) const;
         void set_default_value(InputParameterContainer& container) const;
         void print(std::ostream& stream, const InputParameterContainer& container) const;
+        void emit_metadata(YAML::Emitter& yaml) const;
       };
 
       struct OneOfSpec
@@ -442,6 +495,8 @@ namespace Core::IO
         void set_default_value(InputParameterContainer& container) const;
 
         void print(std::ostream& stream, const InputParameterContainer& container) const;
+
+        void emit_metadata(YAML::Emitter& yaml) const;
       };
     }  // namespace Internal
 
@@ -572,7 +627,8 @@ namespace Core::IO
     [[nodiscard]] InputSpec user_defined(std::string name, DataType&& data = {},
         const std::function<void(ValueParser&, InputParameterContainer&)>& parse = nullptr,
         const std::function<void(std::ostream&, const Core::IO::InputParameterContainer&)>& print =
-            nullptr);
+            nullptr,
+        const std::function<void(YAML::Emitter&)>& emit_metadata = nullptr);
 
     /**
      * An entry whose value is a a selection from a list of choices. For example:
@@ -778,6 +834,99 @@ void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataType>::parse(
 }
 
 
+template <typename DataTypeIn>
+void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataTypeIn>::emit_metadata(
+    YAML::Emitter& yaml) const
+{
+  {
+    yaml << YAML::Key << name;
+    yaml << YAML::Value << YAML::BeginMap;
+    {
+      yaml << YAML::Key << "type" << YAML::Value
+           << IO::Internal::get_pretty_type_name<StoredType>();
+      yaml << YAML::Key << "description" << YAML::Value << data.description;
+      yaml << YAML::Key << "required" << YAML::Value << data.required.value();
+      if (data.default_value.has_value())
+      {
+        yaml << YAML::Key << "default" << YAML::Value;
+        IO::Internal::emit_value_as_yaml(yaml, data.default_value.value());
+      }
+    }
+    yaml << YAML::EndMap;
+  }
+}
+
+
+template <typename DataTypeIn>
+void Core::IO::InputSpecBuilders::Internal::SelectionSpec<DataTypeIn>::parse(
+    ValueParser& parser, InputParameterContainer& container) const
+{
+  parser.consume(name);
+  auto value = parser.read<std::string>();
+  for (const auto& choice : choices)
+  {
+    if (choice.first == value)
+    {
+      container.add(name, choice.second);
+      return;
+    }
+  }
+  FOUR_C_THROW("Invalid value '%s'", value.c_str());
+}
+
+template <typename DataTypeIn>
+void Core::IO::InputSpecBuilders::Internal::SelectionSpec<DataTypeIn>::print(
+    std::ostream& stream, const InputParameterContainer& container) const
+{
+  stream << name;
+  auto* val = container.get_if<StoredType>(name);
+  if (val)
+  {
+    for (const auto& choice : choices)
+    {
+      if (choice.second == *val)
+      {
+        stream << " " << choice.first;
+        return;
+      }
+    }
+    FOUR_C_ASSERT(false, "Invalid value.");
+  }
+  else
+  {
+    stream << " (";
+    for (const auto& choice : choices)
+    {
+      stream << choice.first << "|";
+    }
+    stream << ")";
+  }
+}
+
+template <typename DataTypeIn>
+void Core::IO::InputSpecBuilders::Internal::SelectionSpec<DataTypeIn>::emit_metadata(
+    YAML::Emitter& yaml) const
+{
+  yaml << YAML::Key << name << YAML::BeginMap;
+  {
+    yaml << YAML::Key << "type" << YAML::Value << "selection";
+    yaml << YAML::Key << "description" << YAML::Value << data.description;
+    yaml << YAML::Key << "required" << YAML::Value << data.required.value();
+    if (data.default_value.has_value())
+    {
+      yaml << YAML::Key << "default" << YAML::Value;
+      IO::Internal::emit_value_as_yaml(yaml, data.default_value.value());
+    }
+    yaml << YAML::Key << "choices" << YAML::Value << YAML::BeginMap;
+    for (const auto& choice : choices)
+    {
+      yaml << YAML::Key << choice.first << YAML::Value;
+      IO::Internal::emit_value_as_yaml(yaml, choice.second);
+    }
+    yaml << YAML::EndMap;
+  }
+  yaml << YAML::EndMap;
+}
 
 template <typename T>
 auto Core::IO::InputSpecBuilders::from_parameter(const std::string& name)
@@ -808,7 +957,8 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::entry(std::string name, DataTyp
 template <typename T, typename DataType>
 Core::IO::InputSpec Core::IO::InputSpecBuilders::user_defined(std::string name, DataType&& data,
     const std::function<void(ValueParser&, InputParameterContainer&)>& parse,
-    const std::function<void(std::ostream&, const Core::IO::InputParameterContainer&)>& print)
+    const std::function<void(std::ostream&, const Core::IO::InputParameterContainer&)>& print,
+    const std::function<void(YAML::Emitter&)>& emit_metadata)
 {
   Internal::sanitize_required_default(data);
   return IO::Internal::make_spec(
@@ -817,6 +967,12 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::user_defined(std::string name, 
           .data = std::forward<DataType>(data),
           .parse = parse,
           .print = print ? print : [](std::ostream&, const InputParameterContainer&) {},
+          .emit_metadata = emit_metadata ? emit_metadata
+                                         : [name](YAML::Emitter& yaml)
+                               {
+      yaml << YAML::Key << name << YAML::BeginMap;
+      yaml << YAML::Key << "type" << YAML::Value << "user_defined" <<
+                                     YAML::EndMap; },
       },
       {
           .name = name,
@@ -832,6 +988,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
     std::string name, std::vector<std::pair<std::string, T>> choices, DataType data)
 {
   FOUR_C_ASSERT_ALWAYS(!choices.empty(), "Selection must have at least one choice.");
+  Internal::sanitize_required_default(data);
 
   if (data.default_value.has_value())
   {
@@ -842,47 +999,13 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
         default_value_it != choices.end(), "Default value of selection not found in choices.");
   }
 
-  return user_defined<T, DataType>(
-      name, std::move(data),
-      [name, data, choices](ValueParser& parser, InputParameterContainer& container)
+  return IO::Internal::make_spec(
+      Internal::SelectionSpec<DataType>{.name = name, .data = data, .choices = choices},
       {
-        parser.consume(name);
-        auto value = parser.read<std::string>();
-        for (const auto& choice : choices)
-        {
-          if (choice.first == value)
-          {
-            container.add(name, choice.second);
-            return;
-          }
-        }
-        FOUR_C_THROW("Invalid value '%s'", value.c_str());
-      },
-      [name, data, choices](std::ostream& stream, const InputParameterContainer& container)
-      {
-        stream << name;
-        auto* val = container.get_if<T>(name);
-        if (val)
-        {
-          for (const auto& choice : choices)
-          {
-            if (choice.second == *val)
-            {
-              stream << " " << choice.first;
-              return;
-            }
-          }
-          FOUR_C_ASSERT(false, "Invalid value.");
-        }
-        else
-        {
-          stream << " (";
-          for (const auto& choice : choices)
-          {
-            stream << choice.first << "|";
-          }
-          stream << ")";
-        }
+          .name = name,
+          .description = data.description,
+          .required = data.required.value(),
+          .has_default_value = data.default_value.has_value(),
       });
 }
 

--- a/src/core/io/src/4C_io_linedefinition.cpp
+++ b/src/core/io/src/4C_io_linedefinition.cpp
@@ -285,7 +285,7 @@ namespace Input
 
   void LineDefinition::print(std::ostream& stream) const
   {
-    auto line = Core::IO::InputSpecBuilders::group(pimpl_->components_);
+    auto line = Core::IO::InputSpecBuilders::anonymous_group(pimpl_->components_);
     Core::IO::InputParameterContainer container;
     line.print_as_dat(stream, container);
   }
@@ -304,7 +304,7 @@ namespace Input
 
     try
     {
-      auto input_line = Core::IO::InputSpecBuilders::group(pimpl_->components_);
+      auto input_line = Core::IO::InputSpecBuilders::anonymous_group(pimpl_->components_);
       Core::IO::ValueParser parser(line, {.base_path = context.input_file.parent_path()});
       input_line.fully_parse(parser, container);
     }

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -20,7 +20,7 @@ namespace
 
   TEST(InputSpecTest, Simple)
   {
-    auto line = group({
+    auto line = anonymous_group({
         tag("marker"),
         entry<int>("a", {.description = "An integer", .default_value = 1}),
         entry<double>("b", {.required = true}),
@@ -39,7 +39,7 @@ namespace
 
   TEST(InputSpecTest, OutofOrder)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<double>("b"),
         entry<std::string>("c"),
@@ -55,7 +55,7 @@ namespace
 
   TEST(InputSpecTest, OptionalLeftOut)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<double>("b"),
         entry<std::string>("c", {.default_value = "default"}),
@@ -74,7 +74,7 @@ namespace
 
   TEST(InputSpecTest, RequiredLeftOut)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<double>("b"),
         entry<std::string>("c"),
@@ -91,7 +91,7 @@ namespace
 
   TEST(InputSpecTest, Vector)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<std::vector<double>>("b", {.size = 3}),
         entry<std::string>("c"),
@@ -122,7 +122,7 @@ namespace
 
   TEST(InputSpecTest, VectorWithParsedLength)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<std::vector<double>>("b", {.size = from_parameter<int>("a")}),
         entry<std::string>("c"),
@@ -153,7 +153,7 @@ namespace
 
   TEST(InputSpecTest, UserDefined)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<double>("b"),
         user_defined<std::string>(
@@ -193,7 +193,7 @@ namespace
 
   TEST(InputSpecTest, Selection)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         selection<int>("b", {{"b1", 1}, {"b2", 2}}, {.default_value = 1}),
         selection<std::string>("c", {{"c1", "1"}, {"c2", "2"}}, {.default_value = "2"}),
@@ -222,7 +222,7 @@ namespace
 
   TEST(InputSpecTest, Unparsed)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<int>("optional", {.default_value = 42}),
         entry<double>("b"),
@@ -238,7 +238,7 @@ namespace
 
   TEST(InputSpecTest, Groups)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         group("group1",
             {
@@ -303,7 +303,7 @@ namespace
 
   TEST(InputSpecTest, OneOf)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a", {.default_value = 42}),
         one_of({
             entry<double>("b"),
@@ -366,11 +366,11 @@ namespace
   {
     auto line = one_of(
         {
-            group({
+            anonymous_group({
                 entry<int>("a"),
                 entry<double>("b"),
             }),
-            group({
+            anonymous_group({
                 entry<std::string>("c"),
                 entry<double>("d"),
             }),
@@ -403,7 +403,7 @@ namespace
       std::string stream("a 1 b 2 c string d 2.0");
       ValueParser parser(stream);
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
-          "both 'group {a, b}' and 'group {c, d}'");
+          "both 'anonymous_group {a, b}' and 'anonymous_group {c, d}'");
     }
 
     {
@@ -411,13 +411,13 @@ namespace
       std::string stream("a 1 c string");
       ValueParser parser(stream);
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(line.fully_parse(parser, container), Core::Exception,
-          "one_of {group {a, b}, group {c, d}}");
+          "one_of {anonymous_group {a, b}, anonymous_group {c, d}}");
     }
   }
 
   TEST(InputSpecTest, Print)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a"),
         entry<std::string>("b"),
         selection<int>("c", {{"c1", 1}, {"c2", 2}}, {.default_value = 1}),
@@ -435,7 +435,7 @@ namespace
 
   TEST(InputSpecTest, EmitMetadata)
   {
-    auto line = group({
+    auto line = anonymous_group({
         entry<int>("a", {.default_value = 42}),
         entry<std::vector<double>>("b", {.default_value = std::vector{1., 2., 3.}, .size = 3}),
         one_of({
@@ -455,9 +455,9 @@ namespace
       YAML::Emitter yaml(out);
       line.emit_metadata(yaml);
 
-      std::string expected = R"(group {a, b, one_of {b, group}, e}:
+      std::string expected = R"(anonymous_group {a, b, one_of {b, group}, e}:
   type: anonymous_group
-  description: group {a, b, one_of {b, group}, e}
+  description: anonymous_group {a, b, one_of {b, group}, e}
   required: true
   specs:
     a:
@@ -481,7 +481,7 @@ namespace
           required: false
           default: [1, abc]
         group:
-          type: scope
+          type: group
           description: ""
           required: true
           specs:

--- a/src/mat/4C_mat_materialdefinition.cpp
+++ b/src/mat/4C_mat_materialdefinition.cpp
@@ -59,7 +59,7 @@ std::ostream& Mat::MaterialDefinition::print(
 
   // the default line
   stream << comment << "MAT 0   " << materialname_ << "   ";
-  auto input_line = Core::IO::InputSpecBuilders::group(components_);
+  auto input_line = Core::IO::InputSpecBuilders::anonymous_group(components_);
 
   Core::IO::InputParameterContainer container;
   input_line.impl().set_default_value(container);


### PR DESCRIPTION
This PR allows to call `emit_metadata` for an `InputSpec` which will write all the knowledge we have about that spec into a yaml file. We do not yet use it for the `4C_metadata.yaml` file but this can follow soon if we agree this format looks sensible in general.

Part of #113, Depends on #237 

FYI @gilrrei 