### PR TITLE
Consistently use separators in MORTAR input conditions (Part III)

### DIFF
--- a/doc/readthedocs/boundaryconditions.rst
+++ b/doc/readthedocs/boundaryconditions.rst
@@ -383,10 +383,10 @@ is necessary:
 
    ---------------------------DESIGN LINE|SURF MORTAR CONTACT CONDITIONS 2D|3D
    DLINE              <numtotal>
-   //E <num> - <interfaceID> [Master|Slave|Selfcontact] [Inactive|Active] [FrCoeffOrBound 0.0] [AdhesionBound 0.0] [Solidcontact|Beamtosolidcontact|Beamtosolidmeshtying]     [DoNothing|RemoveDBCSlaveNodes] [TwoHalfPass 0.0]  [RefConfCheckNonSmoothSelfContactSurface 0.0] [ConstitutiveLawID 0]
+   //E <num> - InterfaceID <interfaceID> Side <Master|Slave|Selfcontact> Initialization <Inactive|Active> [FrCoeffOrBound 0.0] [AdhesionBound 0.0] [Application <Solidcontact|Beamtosolidcontact|Beamtosolidmeshtying>] [DbcHandling <DoNothing|RemoveDBCSlaveNodes>] [TwoHalfPass 0.0] [RefConfCheckNonSmoothSelfContactSurface 0.0] [ConstitutiveLawID 0]
 
 The parameters
-``FrCoeffOrBound, AdhesionBound, Solidcontact, DoNothing, TwoHalfPass, RefConfCheckNonSmoothSelfContactSurface``
+``FrCoeffOrBound, AdhesionBound, Application, DbcHandling, TwoHalfPass, RefConfCheckNonSmoothSelfContactSurface and ConstitutiveLawID``
 are optional. You'll find more information about contact in the
 :ref:`contact and meshtying <contactandmeshtying>` section.
 

--- a/doc/readthedocs/contact.rst
+++ b/doc/readthedocs/contact.rst
@@ -17,8 +17,8 @@ or surfaces (3D). Two types of contact can be defined: Master/Slave contact and 
 
      ---------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
      DLINE 2
-     E 1 - 1 Master <further parameters>
-     E 2 - 1 Slave <further parameters>
+     E 1 - InterfaceID 1 Side Master <further parameters>
+     E 2 - InterfaceID 1 Side Slave <further parameters>
 
 for master/slave contact, or
 
@@ -26,7 +26,7 @@ for master/slave contact, or
 
      ---------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
      DLINE 1
-     E 1 - 1 Selfcontact <further parameters>
+     E 1 - InterfaceID 1 Side Selfcontact <further parameters>
 
 for self contact, see also :ref:`DESIGN MORTAR CONTACT CONDITIONS 2D<designlinemortarcontactconditions2d>`.
 
@@ -39,8 +39,8 @@ for self contact, see also :ref:`DESIGN MORTAR CONTACT CONDITIONS 2D<designlinem
 
      ---------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
      DSURF 2
-     E 1 - 1 Master <further parameters>
-     E 2 - 1 Slave <further parameters>
+     E 1 - InterfaceID 1 Side Master <further parameters>
+     E 2 - InterfaceID 1 Side Slave <further parameters>
 
   and for self contact:
 
@@ -48,7 +48,7 @@ for self contact, see also :ref:`DESIGN MORTAR CONTACT CONDITIONS 2D<designlinem
 
      ---------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
      DSURF 1
-     E 1 - 1 Selfcontact <further parameters>
+     E 1 - InterfaceID 1 Side Selfcontact <further parameters>
 
 
   see see :ref:`DESIGN MORTAR CONTACT CONDITIONS 3D<designsurfmortarcontactconditions3d>`.
@@ -57,14 +57,14 @@ The further parameters are:
 
 ::
 
-   [Inactive|Active] \
+   Initialization [Inactive|Active] \
    FrCoeffOrBound 0.0 \
    AdhesionBound 0.0  \
-   [Solidcontact | Beamtosolidcontact | Beamtosolidmeshtying]  \
-   [DoNothing | RemoveDBCSlaveNodes]  \
+   Application [Solidcontact | Beamtosolidcontact | Beamtosolidmeshtying]  \
+   DbcHandling [DoNothing | RemoveDBCSlaveNodes]  \
    Twohalfpass 0|1  \
    RefConfCheckNonSmoothSelfContactSurface 0|1  \
-   ConstitutiveLawID  <num>
+   ConstitutiveLawID <num>
 
 Remarks:
 
@@ -142,15 +142,15 @@ Different meshes can be connected with the `MORTAR COUPLING` definition. Two dif
 
    --------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
    DLINE                           0
-   //E num - 0 Master Inactive
+   //E num - InterfaceID 0 Side Master Initialization Inactive
    --------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
    DSURF                           0
-   //E num - 0 Master Inactive
+   //E num - InterfaceID 0 Side Master Initialization Inactive
    --------------------DESIGN LINE MORTAR MULTI-COUPLING CONDITIONS 2D
    DLINE                           0
-   //E num - 0 Master Inactive
+   //E num - InterfaceID 0 Side Master Initialization Inactive
    --------------------DESIGN SURF MORTAR MULTI-COUPLING CONDITIONS 3D
    DSURF                           0
-   //E num - 0 Master Inactive
+   //E num - InterfaceID 0 Side Master Initialization Inactive
 
 See the reference :ref:`DESIGN MORTAR COUPLING CONDITIONS 3D<designsurfmortarcouplingconditions3d>`, :ref:`DESIGN MORTAR COUPLING CONDITIONS 2D<designlinemortarcouplingconditions2d>`, :ref:`DESIGN MORTAR MULTI-COUPLING CONDITIONS 3D<designsurfmortarmulti-couplingconditions3d>`, :ref:`DESIGN MORTAR MULTI-COUPLING CONDITIONS 2D<designlinemortarmulti-couplingconditions2d>`

--- a/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
@@ -82,7 +82,7 @@ void Adapter::CouplingEhlMortar::setup(std::shared_ptr<Core::FE::Discretization>
   double fr_coeff = -1.;
   for (int i = 0; i < (int)ehl_conditions.size(); ++i)
   {
-    [[maybe_unused]] const int group1id = ehl_conditions[i]->parameters().get<int>("Interface ID");
+    [[maybe_unused]] const int group1id = ehl_conditions[i]->parameters().get<int>("InterfaceID");
     const auto fr = ehl_conditions[i]->parameters().get<double>("FrCoeffOrBound");
     if (fr != ehl_conditions[0]->parameters().get<double>("FrCoeffOrBound"))
       FOUR_C_THROW("inconsistency in friction coefficients");

--- a/src/contact/4C_contact_manager.cpp
+++ b/src/contact/4C_contact_manager.cpp
@@ -137,7 +137,7 @@ CONTACT::Manager::Manager(Core::FE::Discretization& discret, double alphaf)
 
     // try to build contact group around this condition
     currentgroup.push_back(contactconditions[i]);
-    const int groupid1 = currentgroup[0]->parameters().get<int>("Interface ID");
+    const int groupid1 = currentgroup[0]->parameters().get<int>("InterfaceID");
 
     // In case of MultiScale contact this is the id of the interface's constitutive contact law
     int contactconstitutivelawid = currentgroup[0]->parameters().get<int>("ConstitutiveLawID");
@@ -152,7 +152,7 @@ CONTACT::Manager::Manager(Core::FE::Discretization& discret, double alphaf)
     {
       if (j == i) continue;  // do not detect contactconditions[i] again
       tempcond = contactconditions[j];
-      const int groupid2 = tempcond->parameters().get<int>("Interface ID");
+      const int groupid2 = tempcond->parameters().get<int>("InterfaceID");
       if (groupid1 != groupid2) continue;  // not in the group
       foundit = true;                      // found a group entry
       currentgroup.push_back(tempcond);    // store it in currentgroup

--- a/src/contact/4C_contact_meshtying_manager.cpp
+++ b/src/contact/4C_contact_meshtying_manager.cpp
@@ -85,14 +85,14 @@ CONTACT::MtManager::MtManager(Core::FE::Discretization& discret, double alphaf)
 
     // try to build meshtying group around this condition
     currentgroup.push_back(contactconditions[i]);
-    const auto groupid1 = currentgroup[0]->parameters().get<int>("Interface ID");
+    const auto groupid1 = currentgroup[0]->parameters().get<int>("InterfaceID");
     bool foundit = false;
 
     for (unsigned j = 0; j < contactconditions.size(); ++j)
     {
       if (j == i) continue;  // do not detect contactconditions[i] again
       tempcond = contactconditions[j];
-      const auto groupid2 = tempcond->parameters().get<int>("Interface ID");
+      const auto groupid2 = tempcond->parameters().get<int>("InterfaceID");
       if (groupid1 != groupid2) continue;  // not in the group
       foundit = true;                      // found a group entry
       currentgroup.push_back(tempcond);    // store it in currentgroup

--- a/src/contact/4C_contact_meshtying_strategy_factory.cpp
+++ b/src/contact/4C_contact_meshtying_strategy_factory.cpp
@@ -349,14 +349,14 @@ void Mortar::STRATEGY::FactoryMT::build_interfaces(const Teuchos::ParameterList&
 
     // try to build meshtying group around this condition
     currentgroup.push_back(contactconditions[i]);
-    const int groupid1 = currentgroup[0]->parameters().get<int>("Interface ID");
+    const int groupid1 = currentgroup[0]->parameters().get<int>("InterfaceID");
     bool foundit = false;
 
     for (int j = 0; j < (int)contactconditions.size(); ++j)
     {
       if (j == i) continue;  // do not detect contactconditions[i] again
       tempcond = contactconditions[j];
-      const int groupid2 = tempcond->parameters().get<int>("Interface ID");
+      const int groupid2 = tempcond->parameters().get<int>("InterfaceID");
 
       if (groupid1 != groupid2) continue;  // not in the group
       foundit = true;                      // found a group entry

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -682,7 +682,7 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
   for (auto& currentgroup : ccond_grps)
   {
     // initialize a reference to the i-th contact condition group
-    const auto groupid1 = currentgroup[0]->parameters().get<int>("Interface ID");
+    const auto groupid1 = currentgroup[0]->parameters().get<int>("InterfaceID");
 
     // In case of MultiScale contact this is the id of the interface's constitutive contact law
     int contactconstitutivelaw_id = currentgroup[0]->parameters().get<int>("ConstitutiveLawID");

--- a/src/contact/4C_contact_utils.cpp
+++ b/src/contact/4C_contact_utils.cpp
@@ -118,7 +118,7 @@ void CONTACT::Utils::get_contact_condition_groups(
 
     // try to build contact group around this condition
     current_grp.push_back(cconds[i]);
-    const auto groupid1 = current_grp[0]->parameters().get<int>("Interface ID");
+    const auto groupid1 = current_grp[0]->parameters().get<int>("InterfaceID");
     bool foundit = false;
 
     // only one surface per group is ok for self contact
@@ -130,7 +130,7 @@ void CONTACT::Utils::get_contact_condition_groups(
       // do not compare ids of one and the same contact condition
       if (j == i) continue;
       tempcond = cconds[j];
-      const auto groupid2 = tempcond->parameters().get<int>("Interface ID");
+      const auto groupid2 = tempcond->parameters().get<int>("InterfaceID");
 
       // Do the IDs coincide?
       if (groupid1 != groupid2) continue;  // not in the group

--- a/src/contact/4C_contact_utils.cpp
+++ b/src/contact/4C_contact_utils.cpp
@@ -456,7 +456,7 @@ void CONTACT::Utils::DbcHandler::detect_dbc_slave_nodes_and_elements(
 
       const Core::Conditions::Condition* sl_cond = ccond_grp[i];
 
-      const int dbc_handling_id = sl_cond->parameters().get<int>("dbc_handling");
+      const int dbc_handling_id = sl_cond->parameters().get<int>("DbcHandling");
       const auto dbc_handling = static_cast<Inpar::Mortar::DBCHandling>(dbc_handling_id);
 
       switch (dbc_handling)

--- a/src/contact/4C_contact_utils.hpp
+++ b/src/contact/4C_contact_utils.hpp
@@ -125,7 +125,8 @@ namespace CONTACT
      *  sets.
      *
      *  A possible condition line can look like
-     *  E 7 - 1 Slave Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact RemoveDBCSlaveNodes
+     *  E 7 - InterfaceID 1 Side Slave Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+     * RemoveDBCSlaveNodes
      *
      *  \author hiermeier \date 01/18 */
     class DbcHandler

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -153,7 +153,7 @@ void Inpar::EHL::set_valid_conditions(
 
   for (const auto& cond : {lineehl, surfehl})
   {
-    cond->add_component(std::make_shared<Input::IntComponent>("Interface ID"));
+    cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
     cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
         Teuchos::tuple<std::string>("Master", "Slave"),
         Teuchos::tuple<std::string>("Master", "Slave")));

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -8,6 +8,7 @@
 #include "4C_inpar_ehl.hpp"
 
 #include "4C_fem_condition_definition.hpp"
+#include "4C_io_linecomponent.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -153,13 +154,13 @@ void Inpar::EHL::set_valid_conditions(
 
   for (const auto& cond : {lineehl, surfehl})
   {
-    cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
+    add_named_int(cond, "InterfaceID");
+    add_named_selection_component(cond, "Side", "interface side", "Master",
         Teuchos::tuple<std::string>("Master", "Slave"),
-        Teuchos::tuple<std::string>("Master", "Slave")));
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Initialization", "Active",
+        Teuchos::tuple<std::string>("Master", "Slave"));
+    add_named_selection_component(cond, "Initialization", "initialization", "Active",
         Teuchos::tuple<std::string>("Inactive", "Active"),
-        Teuchos::tuple<std::string>("Inactive", "Active"), true));
+        Teuchos::tuple<std::string>("Inactive", "Active"), true);
     add_named_real(cond, "FrCoeffOrBound", "", 0.0, true);
 
     condlist.push_back(cond);

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -180,29 +180,28 @@ void Inpar::Mortar::set_valid_conditions(
 
   for (const auto& cond : {linecontact, surfcontact})
   {
-    cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
+    add_named_int(cond, "InterfaceID");
+    add_named_selection_component(cond, "Side", "interface side", "Master",
         Teuchos::tuple<std::string>("Master", "Slave", "Selfcontact"),
-        Teuchos::tuple<std::string>("Master", "Slave", "Selfcontact")));
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Initialization", "Inactive",
+        Teuchos::tuple<std::string>("Master", "Slave", "Selfcontact"));
+    add_named_selection_component(cond, "Initialization", "initialization", "Inactive",
         Teuchos::tuple<std::string>("Inactive", "Active"),
-        Teuchos::tuple<std::string>("Inactive", "Active"), true));
+        Teuchos::tuple<std::string>("Inactive", "Active"), true);
 
     add_named_real(cond, "FrCoeffOrBound", "friction coefficient bound", 0.0, true);
     add_named_real(cond, "AdhesionBound", "adhesion bound", 0.0, true);
 
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Application", "Solidcontact",
+    add_named_selection_component(cond, "Application", "application", "Solidcontact",
         Teuchos::tuple<std::string>("Solidcontact", "Beamtosolidcontact", "Beamtosolidmeshtying"),
         Teuchos::tuple<std::string>("Solidcontact", "Beamtosolidcontact", "Beamtosolidmeshtying"),
-        true));
+        true);
 
     // optional DBC handling
-    cond->add_component(std::make_shared<Input::SelectionComponent>("DbcHandling", "DoNothing",
+    add_named_selection_component(cond, "DbcHandling", "DbcHandling", "DoNothing",
         Teuchos::tuple<std::string>("DoNothing", "RemoveDBCSlaveNodes"),
         Teuchos::tuple<int>(static_cast<int>(DBCHandling::do_nothing),
             static_cast<int>(DBCHandling::remove_dbc_nodes_from_slave_side)),
-        true));
-
+        true);
     add_named_real(cond, "TwoHalfPass", "optional two half pass approach", 0.0, true);
     add_named_real(cond, "RefConfCheckNonSmoothSelfContactSurface",
         "optional reference configuration check for non-smooth self contact surfaces", 0.0, true);
@@ -225,13 +224,13 @@ void Inpar::Mortar::set_valid_conditions(
 
   for (const auto& cond : {linemortar, surfmortar})
   {
-    cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
+    add_named_int(cond, "InterfaceID");
+    add_named_selection_component(cond, "Side", "interface side", "Master",
         Teuchos::tuple<std::string>("Master", "Slave"),
-        Teuchos::tuple<std::string>("Master", "Slave")));
-    cond->add_component(std::make_shared<Input::SelectionComponent>("Initialization", "Inactive",
+        Teuchos::tuple<std::string>("Master", "Slave"));
+    add_named_selection_component(cond, "Initialization", "initialization", "Inactive",
         Teuchos::tuple<std::string>("Inactive", "Active"),
-        Teuchos::tuple<std::string>("Inactive", "Active"), true));
+        Teuchos::tuple<std::string>("Inactive", "Active"), true);
 
     condlist.push_back(cond);
   }
@@ -294,13 +293,13 @@ void Inpar::Mortar::set_valid_conditions(
 
     for (const auto& cond : {linemortar, surfmortar})
     {
-      cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
-      cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
+      add_named_int(cond, "InterfaceID");
+      add_named_selection_component(cond, "Side", "interface side", "Master",
           Teuchos::tuple<std::string>("Master", "Slave"),
-          Teuchos::tuple<std::string>("Master", "Slave")));
-      cond->add_component(std::make_shared<Input::SelectionComponent>("Initialization", "Inactive",
+          Teuchos::tuple<std::string>("Master", "Slave"));
+      add_named_selection_component(cond, "Initialization", "initialization", "Inactive",
           Teuchos::tuple<std::string>("Inactive", "Active"),
-          Teuchos::tuple<std::string>("Inactive", "Active"), true));
+          Teuchos::tuple<std::string>("Inactive", "Active"), true);
 
       condlist.push_back(cond);
     }

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -180,7 +180,7 @@ void Inpar::Mortar::set_valid_conditions(
 
   for (const auto& cond : {linecontact, surfcontact})
   {
-    cond->add_component(std::make_shared<Input::IntComponent>("Interface ID"));
+    cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
     cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
         Teuchos::tuple<std::string>("Master", "Slave", "Selfcontact"),
         Teuchos::tuple<std::string>("Master", "Slave", "Selfcontact")));
@@ -225,7 +225,7 @@ void Inpar::Mortar::set_valid_conditions(
 
   for (const auto& cond : {linemortar, surfmortar})
   {
-    cond->add_component(std::make_shared<Input::IntComponent>("Interface ID"));
+    cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
     cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
         Teuchos::tuple<std::string>("Master", "Slave"),
         Teuchos::tuple<std::string>("Master", "Slave")));
@@ -294,7 +294,7 @@ void Inpar::Mortar::set_valid_conditions(
 
     for (const auto& cond : {linemortar, surfmortar})
     {
-      cond->add_component(std::make_shared<Input::IntComponent>("Interface ID"));
+      cond->add_component(std::make_shared<Input::IntComponent>("InterfaceID"));
       cond->add_component(std::make_shared<Input::SelectionComponent>("Side", "Master",
           Teuchos::tuple<std::string>("Master", "Slave"),
           Teuchos::tuple<std::string>("Master", "Slave")));

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -197,7 +197,7 @@ void Inpar::Mortar::set_valid_conditions(
         true));
 
     // optional DBC handling
-    cond->add_component(std::make_shared<Input::SelectionComponent>("dbc_handling", "DoNothing",
+    cond->add_component(std::make_shared<Input::SelectionComponent>("DbcHandling", "DoNothing",
         Teuchos::tuple<std::string>("DoNothing", "RemoveDBCSlaveNodes"),
         Teuchos::tuple<int>(static_cast<int>(DBCHandling::do_nothing),
             static_cast<int>(DBCHandling::remove_dbc_nodes_from_slave_side)),

--- a/src/ssi/4C_ssi_utils.cpp
+++ b/src/ssi/4C_ssi_utils.cpp
@@ -854,7 +854,7 @@ void SSI::Utils::check_consistency_of_ssi_interface_contact_condition(
     // loop over all contact conditions and add them to the vector, if IDs match
     for (auto* contactcondition : contactconditions)
     {
-      if (contactcondition->parameters().get<int>("Interface ID") != contactconditionID) continue;
+      if (contactcondition->parameters().get<int>("InterfaceID") != contactconditionID) continue;
 
       InterfaceContactConditions.push_back(contactcondition);
     }

--- a/tests/framework-test/tutorial_contact_3d.bc
+++ b/tests/framework-test/tutorial_contact_3d.bc
@@ -22,14 +22,14 @@ Property Name: none
 has 36 Nodes
 *ns1="CONDITION"
 sectionname="DESIGN SURF MORTAR CONTACT CONDITIONS 3D"
-description="1 Slave"
+description="InterfaceID 1 Side Slave"
 
 Node Set, named: master
 Property Name: none
 has 121 Nodes
 *ns2="CONDITION"
 sectionname="DESIGN SURF MORTAR CONTACT CONDITIONS 3D"
-description="1 Master"
+description="InterfaceID 1 Side Master"
 
 $$ Assign the Dirichlet Boundary Conditions
 Node Set, named: pushing

--- a/tests/input_files/ale2d_solid_nln_large_rot_mshs.dat
+++ b/tests/input_files/ale2d_solid_nln_large_rot_mshs.dat
@@ -56,11 +56,11 @@ E 5 - NUMDOF 2 ONOFF 1 1 VAL 1.0 1.0 FUNCT 1 2
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  3
 // outer_domain_inner_boundary
-E 2 - 1 Master
+E 2 - InterfaceID 1 Side Master
 // main_domain_outer_boundary_xcurs
-E 3 - 1 Slave
+E 3 - InterfaceID 1 Side Slave
 // main_domain_outer_boundary_ycurs
-E 4 - 1 Slave
+E 4 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    1 DLINE 1
 NODE    2 DLINE 1

--- a/tests/input_files/ale2d_solid_nln_large_rot_msht.dat
+++ b/tests/input_files/ale2d_solid_nln_large_rot_msht.dat
@@ -62,9 +62,9 @@ E 5 - NUMDOF 2 ONOFF 1 1 VAL 1.0 1.0 FUNCT 1 2
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // main_domain_inner_boundary
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 // inner_domain_outer_boundary
-E 4 - 1 Master
+E 4 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    112 DNODE 1
 NODE    1317 DNODE 1

--- a/tests/input_files/beam3eb_static_contact_beamtosolidcontact_solidcontact.dat
+++ b/tests/input_files/beam3eb_static_contact_beamtosolidcontact_solidcontact.dat
@@ -101,11 +101,11 @@ E 2 - NUMDOF 3  ONOFF 1 1 1  VAL 0.4 0.0 -0.4 FUNCT 1  0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  3
 // stscontact_solid1
-E 3 - 1 Master Inactive FrCoeffOrBound 0.5 AdhesionBound 0.0 Solidcontact
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.5 AdhesionBound 0.0 Application Solidcontact
 // stscontact_solid2
-E 4 - 1 Slave Inactive FrCoeffOrBound 0.5 AdhesionBound 0.0 Solidcontact
+E 4 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.5 AdhesionBound 0.0 Application Solidcontact
 // btscontact_beam1
-E 5 - 2 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Beamtosolidcontact
+E 5 - InterfaceID 2 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Beamtosolidcontact
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    55 DNODE 1
 NODE    59 DNODE 1

--- a/tests/input_files/cardiovascular0d_syspulcirculation_2chamber_structurecontactpenalty_direct_genalpha.dat
+++ b/tests/input_files/cardiovascular0d_syspulcirculation_2chamber_structurecontactpenalty_direct_genalpha.dat
@@ -204,14 +204,14 @@ E 10 - NUMDOF 3 ONOFF 0 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 E 11 - NUMDOF 3 ONOFF 0 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  8
-E 12 - 1 Master Inactive FrCoeffOrBound 0.0
-E 13 - 1 Slave Inactive FrCoeffOrBound 0.0
-E 14 - 2 Master Inactive FrCoeffOrBound 0.0
-E 15 - 2 Slave Inactive FrCoeffOrBound 0.0
-E 16 - 3 Master Inactive FrCoeffOrBound 0.0
-E 17 - 3 Slave Inactive FrCoeffOrBound 0.0
-E 18 - 4 Master Inactive FrCoeffOrBound 0.0
-E 19 - 4 Slave Inactive FrCoeffOrBound 0.0
+E 12 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.0
+E 13 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.0
+E 14 - InterfaceID 2 Side Master Initialization Inactive FrCoeffOrBound 0.0
+E 15 - InterfaceID 2 Side Slave Initialization Inactive FrCoeffOrBound 0.0
+E 16 - InterfaceID 3 Side Master Initialization Inactive FrCoeffOrBound 0.0
+E 17 - InterfaceID 3 Side Slave Initialization Inactive FrCoeffOrBound 0.0
+E 18 - InterfaceID 4 Side Master Initialization Inactive FrCoeffOrBound 0.0
+E 19 - InterfaceID 4 Side Slave Initialization Inactive FrCoeffOrBound 0.0
 -----DESIGN SURF CARDIOVASCULAR 0D SYS-PUL CIRCULATION CONDITIONS
 DSURF                           2
 E 6 - id 0 TYPE ventricle_left

--- a/tests/input_files/contact2D_adhesion_fixedbound_new_struc.dat
+++ b/tests/input_files/contact2D_adhesion_fixedbound_new_struc.dat
@@ -80,9 +80,9 @@ E 2 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 2 1
 -------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // slave
-E 3 - 1 Slave Inactive FrCoeffOrBound 0 AdhesionBound 150
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0 AdhesionBound 150
 // master
-E 4 - 1 Master Inactive FrCoeffOrBound 0 AdhesionBound 150
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0 AdhesionBound 150
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    68 DNODE 1
 -----------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/contact2D_binning_redist_dynamic.dat
+++ b/tests/input_files/contact2D_binning_redist_dynamic.dat
@@ -123,9 +123,9 @@ E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // block_bottom_curve
-E 2 - 0 Slave Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Slave Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // table_top_curve
-E 3 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 3 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    9 DLINE 1
 NODE    10 DLINE 1

--- a/tests/input_files/contact2D_binning_redist_none.dat
+++ b/tests/input_files/contact2D_binning_redist_none.dat
@@ -123,9 +123,9 @@ E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // block_bottom_curve
-E 2 - 0 Slave Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Slave Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // table_top_curve
-E 3 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 3 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    9 DLINE 1
 NODE    10 DLINE 1

--- a/tests/input_files/contact2D_binning_redist_static.dat
+++ b/tests/input_files/contact2D_binning_redist_static.dat
@@ -123,9 +123,9 @@ E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // block_bottom_curve
-E 2 - 0 Slave Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Slave Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // table_top_curve
-E 3 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 3 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    9 DLINE 1
 NODE    10 DLINE 1

--- a/tests/input_files/contact2D_centrdiff.dat
+++ b/tests/input_files/contact2D_centrdiff.dat
@@ -71,8 +71,8 @@ E 7 - FIELD Velocity FUNCT 1
 E 8 - FIELD Velocity FUNCT 1
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 10 - 1 Master Inactive
-E 23 - 1 Slave Inactive
+E 10 - InterfaceID 1 Side Master Initialization Inactive
+E 23 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 618 DNODE 3
 NODE 583 DNODE 4

--- a/tests/input_files/contact2D_cpp_normal_new_struc.dat
+++ b/tests/input_files/contact2D_cpp_normal_new_struc.dat
@@ -70,8 +70,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_cpp_vertex_on_vertex_new_struc.dat
+++ b/tests/input_files/contact2D_cpp_vertex_on_vertex_new_struc.dat
@@ -108,9 +108,9 @@ E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // slave
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.3
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.3
 // master
-E 3 - 1 Master Inactive FrCoeffOrBound 0.3
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.3
 -----------------------DESIGN POINT MORTAR CORNER CONDITIONS 2D/3D
 DPOINT 1
 // corner

--- a/tests/input_files/contact2D_ele_based_new_struc.dat
+++ b/tests/input_files/contact2D_ele_based_new_struc.dat
@@ -77,8 +77,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_hertz_linstatic.dat
+++ b/tests/input_files/contact2D_hertz_linstatic.dat
@@ -79,8 +79,8 @@ E 3 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -1.0 0.0 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 
 E 4 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -1.0 0.0 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 11 - 1 Slave Inactive
-E 13 - 1 Master
+E 11 - InterfaceID 1 Side Slave Initialization Inactive
+E 13 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 288 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_hertz_linstatic_new_struct.dat
+++ b/tests/input_files/contact2D_hertz_linstatic_new_struct.dat
@@ -77,8 +77,8 @@ E 3 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -1.0 0.0 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 
 E 4 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -1.0 0.0 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 11 - 1 Slave Inactive
-E 13 - 1 Master
+E 11 - InterfaceID 1 Side Slave Initialization Inactive
+E 13 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 288 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_initfield.dat
+++ b/tests/input_files/contact2D_initfield.dat
@@ -72,8 +72,8 @@ E 7 - FIELD Velocity FUNCT 1
 E 8 - FIELD Velocity FUNCT 1
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 10 - 1 Master Inactive
-E 23 - 1 Slave Inactive
+E 10 - InterfaceID 1 Side Master Initialization Inactive
+E 23 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 618 DNODE 3
 NODE 583 DNODE 4

--- a/tests/input_files/contact2D_initfield_new_struct.dat
+++ b/tests/input_files/contact2D_initfield_new_struct.dat
@@ -69,8 +69,8 @@ E 7 - FIELD Velocity FUNCT 1
 E 8 - FIELD Velocity FUNCT 1
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 10 - 1 Master Inactive
-E 23 - 1 Slave Inactive
+E 10 - InterfaceID 1 Side Master Initialization Inactive
+E 23 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 618 DNODE 3
 NODE 583 DNODE 4

--- a/tests/input_files/contact2D_lin_duallagr.dat
+++ b/tests/input_files/contact2D_lin_duallagr.dat
@@ -71,8 +71,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_lin_penalty.dat
+++ b/tests/input_files/contact2D_lin_penalty.dat
@@ -67,8 +67,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_lin_petrovgalerkin.dat
+++ b/tests/input_files/contact2D_lin_petrovgalerkin.dat
@@ -73,8 +73,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_lin_petrovgalerkin_new_struct.dat
+++ b/tests/input_files/contact2D_lin_petrovgalerkin_new_struct.dat
@@ -73,8 +73,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_lin_stdlagr_new_struc.dat
+++ b/tests/input_files/contact2D_lin_stdlagr_new_struc.dat
@@ -68,8 +68,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_lin_uzawa.dat
+++ b/tests/input_files/contact2D_lin_uzawa.dat
@@ -70,8 +70,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 90 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_meshtying.dat
+++ b/tests/input_files/contact2D_meshtying.dat
@@ -82,15 +82,15 @@ E 2 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 2 1
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // slave_c
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // master_c
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // slave_m
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 // master_m
-E 6 - 1 Master Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    171 DNODE 1
 -----------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/contact2D_multibody.dat
+++ b/tests/input_files/contact2D_multibody.dat
@@ -104,7 +104,7 @@ E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           1
 //                              selfonctact
-E 2 - 1 Selfcontact
+E 2 - InterfaceID 1 Side Selfcontact
 ---------------------------------------------------------DLINE-NODE TOPOLOGY
 NODE 673 DLINE 1
 NODE 674 DLINE 1

--- a/tests/input_files/contact2D_nurbs9_dual_consistent.dat
+++ b/tests/input_files/contact2D_nurbs9_dual_consistent.dat
@@ -66,9 +66,9 @@ E 2 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 2 1
 -------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 1 - 1 Slave Inactive
+E 1 - InterfaceID 1 Side Slave Initialization Inactive
 // mrtr_2
-E 8 - 1 Master Inactive
+E 8 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------------------------------DLINE-NODE TOPOLOGY
 //patch coupling BC 1 (begin)
 NODE       1 DLINE   1

--- a/tests/input_files/contact2D_nurbs9_dual_consistent_new_struct.dat
+++ b/tests/input_files/contact2D_nurbs9_dual_consistent_new_struct.dat
@@ -67,9 +67,9 @@ E 2 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 2 1
 -------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 1 - 1 Slave Inactive
+E 1 - InterfaceID 1 Side Slave Initialization Inactive
 // mrtr_2
-E 8 - 1 Master Inactive
+E 8 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------------------------------DLINE-NODE TOPOLOGY
 //patch coupling BC 1 (begin)
 NODE       1 DLINE   1

--- a/tests/input_files/contact2D_nurbs9_pg_frict.dat
+++ b/tests/input_files/contact2D_nurbs9_pg_frict.dat
@@ -71,8 +71,8 @@ E 12 - NUMDOF 2 ONOFF 1 1 VAL 6.0 0.12 FUNCT 2 1
 E 13 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 5 - 1 Slave Inactive FrCoeffOrBound 0.4
-E 14 - 1 Master Inactive FrCoeffOrBound 0.4
+E 5 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.4
+E 14 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.4
 -----------------------------------------------------------STRUCTURE KNOTVECTORS
 NURBS_DIMENSION                       2
 BEGIN NURBSPATCH

--- a/tests/input_files/contact2D_nurbs9_std_new_struc.dat
+++ b/tests/input_files/contact2D_nurbs9_std_new_struc.dat
@@ -88,10 +88,10 @@ E 6 - NUMDOF 2 ONOFF 1 1 VAL -0.3 -0.31 FUNCT 2 1
 E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-//E 2 - 1 Slave Inactive FrCoeffOrBound 0.1
-//E 5 - 1 Master Inactive FrCoeffOrBound 0.1
-E 2 - 1 Slave
-E 5 - 1 Master
+//E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.1
+//E 5 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
+E 2 - InterfaceID 1 Side Slave
+E 5 - InterfaceID 1 Side Master
 -----------------------------------------------------------STRUCTURE KNOTVECTORS
 NURBS_DIMENSION                       2
 BEGIN                           NURBSPATCH

--- a/tests/input_files/contact2D_onlylin_stdlagr.dat
+++ b/tests/input_files/contact2D_onlylin_stdlagr.dat
@@ -67,8 +67,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave
-E 6 - 1 Master
+E 4 - InterfaceID 1 Side Slave
+E 6 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 978 DNODE 1
 NODE 694 DNODE 2

--- a/tests/input_files/contact2D_parredist.dat
+++ b/tests/input_files/contact2D_parredist.dat
@@ -66,8 +66,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave
-E 6 - 1 Master
+E 4 - InterfaceID 1 Side Slave
+E 6 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 296 DNODE 1
 NODE 215 DNODE 2

--- a/tests/input_files/contact2D_parredist_mineleproc.dat
+++ b/tests/input_files/contact2D_parredist_mineleproc.dat
@@ -66,8 +66,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave
-E 6 - 1 Master
+E 4 - InterfaceID 1 Side Slave
+E 6 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 296 DNODE 1
 NODE 215 DNODE 2

--- a/tests/input_files/contact2D_parredist_new_struct.dat
+++ b/tests/input_files/contact2D_parredist_new_struct.dat
@@ -70,8 +70,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave
-E 6 - 1 Master
+E 4 - InterfaceID 1 Side Slave
+E 6 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 296 DNODE 1
 NODE 215 DNODE 2

--- a/tests/input_files/contact2D_patch_bound.dat
+++ b/tests/input_files/contact2D_patch_bound.dat
@@ -91,14 +91,14 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Master
-E 15 - 1 Master
-E 16 - 1 Master
-E 17 - 1 Master
-E 18 - 1 Master
-E 24 - 1 Master
-E 25 - 1 Master
-E 28 - 1 Slave Active
+E 14 - InterfaceID 1 Side Master
+E 15 - InterfaceID 1 Side Master
+E 16 - InterfaceID 1 Side Master
+E 17 - InterfaceID 1 Side Master
+E 18 - InterfaceID 1 Side Master
+E 24 - InterfaceID 1 Side Master
+E 25 - InterfaceID 1 Side Master
+E 28 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1  DNODE 1
 NODE 10 DNODE 2

--- a/tests/input_files/contact2D_patch_bound_new_struct.dat
+++ b/tests/input_files/contact2D_patch_bound_new_struct.dat
@@ -94,22 +94,22 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Master
-E 15 - 1 Master
-E 16 - 1 Master
-E 17 - 1 Master
-E 18 - 1 Master
-E 24 - 1 Master
-E 25 - 1 Master
-E 28 - 1 Slave Active
-//E 14 - 1 Slave Inactive
-//E 15 - 1 Slave Inactive
-//E 16 - 1 Slave Active
-//E 17 - 1 Slave Inactive
-//E 18 - 1 Slave Inactive
-//E 24 - 1 Slave Inactive
-//E 25 - 1 Slave Inactive
-//E 28 - 1 Master
+E 14 - InterfaceID 1 Side Master
+E 15 - InterfaceID 1 Side Master
+E 16 - InterfaceID 1 Side Master
+E 17 - InterfaceID 1 Side Master
+E 18 - InterfaceID 1 Side Master
+E 24 - InterfaceID 1 Side Master
+E 25 - InterfaceID 1 Side Master
+E 28 - InterfaceID 1 Side Slave Initialization Active
+//E 14 - InterfaceID 1 Side Slave Initialization Inactive
+//E 15 - InterfaceID 1 Side Slave Initialization Inactive
+//E 16 - InterfaceID 1 Side Slave Initialization Active
+//E 17 - InterfaceID 1 Side Slave Initialization Inactive
+//E 18 - InterfaceID 1 Side Slave Initialization Inactive
+//E 24 - InterfaceID 1 Side Slave Initialization Inactive
+//E 25 - InterfaceID 1 Side Slave Initialization Inactive
+//E 28 - InterfaceID 1 Side Master
 -----------------------DESIGN POINT MORTAR CORNER CONDITIONS 2D/3D
 DPOINT 1
 // nonsmooth

--- a/tests/input_files/contact2D_patch_linstatic.dat
+++ b/tests/input_files/contact2D_patch_linstatic.dat
@@ -85,14 +85,14 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Master
-E 15 - 1 Master
-E 16 - 1 Master
-E 17 - 1 Master
-E 18 - 1 Master
-E 24 - 1 Master
-E 25 - 1 Master
-E 28 - 1 Slave Active
+E 14 - InterfaceID 1 Side Master
+E 15 - InterfaceID 1 Side Master
+E 16 - InterfaceID 1 Side Master
+E 17 - InterfaceID 1 Side Master
+E 18 - InterfaceID 1 Side Master
+E 24 - InterfaceID 1 Side Master
+E 25 - InterfaceID 1 Side Master
+E 28 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 10 DNODE 2

--- a/tests/input_files/contact2D_patch_linstatic_new_struct.dat
+++ b/tests/input_files/contact2D_patch_linstatic_new_struct.dat
@@ -87,14 +87,14 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Master
-E 15 - 1 Master
-E 16 - 1 Master
-E 17 - 1 Master
-E 18 - 1 Master
-E 24 - 1 Master
-E 25 - 1 Master
-E 28 - 1 Slave Active
+E 14 - InterfaceID 1 Side Master
+E 15 - InterfaceID 1 Side Master
+E 16 - InterfaceID 1 Side Master
+E 17 - InterfaceID 1 Side Master
+E 18 - InterfaceID 1 Side Master
+E 24 - InterfaceID 1 Side Master
+E 25 - InterfaceID 1 Side Master
+E 28 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 10 DNODE 2

--- a/tests/input_files/contact2D_quad.dat
+++ b/tests/input_files/contact2D_quad.dat
@@ -71,8 +71,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 434 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_quad_const.dat
+++ b/tests/input_files/contact2D_quad_const.dat
@@ -70,8 +70,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 434 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_quad_new_struct.dat
+++ b/tests/input_files/contact2D_quad_new_struct.dat
@@ -70,8 +70,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 1 2
 E 2 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave
-E 4 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 4 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 434 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact2D_self.dat
+++ b/tests/input_files/contact2D_self.dat
@@ -71,40 +71,40 @@ E 21 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 49 - NUMDOF 2 ONOFF 1 1 VAL 0.0 -1.0 FUNCT 0 1
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           34
-E 3 - 3 Selfcontact
-E 4 - 2 Selfcontact
-E 6 - 2 Selfcontact
-E 7 - 3 Selfcontact
-E 9 - 2 Selfcontact
-E 10 - 3 Selfcontact
-E 13 - 1 Selfcontact
-E 14 - 2 Selfcontact
-E 16 - 2 Selfcontact
-E 17 - 1 Selfcontact
-E 19 - 2 Selfcontact
-E 20 - 1 Selfcontact
-E 22 - 2 Selfcontact
-E 25 - 3 Selfcontact
-E 26 - 2 Selfcontact
-E 27 - 1 Selfcontact
-E 28 - 2 Selfcontact
-E 31 - 3 Selfcontact
-E 32 - 2 Selfcontact
-E 34 - 2 Selfcontact
-E 35 - 3 Selfcontact
-E 37 - 2 Selfcontact
-E 38 - 3 Selfcontact
-E 41 - 1 Selfcontact
-E 42 - 2 Selfcontact
-E 44 - 2 Selfcontact
-E 45 - 1 Selfcontact
-E 47 - 2 Selfcontact
-E 48 - 1 Selfcontact
-E 50 - 2 Selfcontact
-E 51 - 3 Selfcontact
-E 52 - 2 Selfcontact
-E 53 - 1 Selfcontact
-E 54 - 2 Selfcontact
+E 3 - InterfaceID 3 Side Selfcontact
+E 4 - InterfaceID 2 Side Selfcontact
+E 6 - InterfaceID 2 Side Selfcontact
+E 7 - InterfaceID 3 Side Selfcontact
+E 9 - InterfaceID 2 Side Selfcontact
+E 10 - InterfaceID 3 Side Selfcontact
+E 13 - InterfaceID 1 Side Selfcontact
+E 14 - InterfaceID 2 Side Selfcontact
+E 16 - InterfaceID 2 Side Selfcontact
+E 17 - InterfaceID 1 Side Selfcontact
+E 19 - InterfaceID 2 Side Selfcontact
+E 20 - InterfaceID 1 Side Selfcontact
+E 22 - InterfaceID 2 Side Selfcontact
+E 25 - InterfaceID 3 Side Selfcontact
+E 26 - InterfaceID 2 Side Selfcontact
+E 27 - InterfaceID 1 Side Selfcontact
+E 28 - InterfaceID 2 Side Selfcontact
+E 31 - InterfaceID 3 Side Selfcontact
+E 32 - InterfaceID 2 Side Selfcontact
+E 34 - InterfaceID 2 Side Selfcontact
+E 35 - InterfaceID 3 Side Selfcontact
+E 37 - InterfaceID 2 Side Selfcontact
+E 38 - InterfaceID 3 Side Selfcontact
+E 41 - InterfaceID 1 Side Selfcontact
+E 42 - InterfaceID 2 Side Selfcontact
+E 44 - InterfaceID 2 Side Selfcontact
+E 45 - InterfaceID 1 Side Selfcontact
+E 47 - InterfaceID 2 Side Selfcontact
+E 48 - InterfaceID 1 Side Selfcontact
+E 50 - InterfaceID 2 Side Selfcontact
+E 51 - InterfaceID 3 Side Selfcontact
+E 52 - InterfaceID 2 Side Selfcontact
+E 53 - InterfaceID 1 Side Selfcontact
+E 54 - InterfaceID 2 Side Selfcontact
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1429 DNODE 1
 NODE 1379 DNODE 2

--- a/tests/input_files/contact2D_self_new_struct.dat
+++ b/tests/input_files/contact2D_self_new_struct.dat
@@ -71,40 +71,40 @@ E 21 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 49 - NUMDOF 2 ONOFF 1 1 VAL 0.0 -1.0 FUNCT 0 1
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           34
-E 3 - 3 Selfcontact
-E 4 - 2 Selfcontact
-E 6 - 2 Selfcontact
-E 7 - 3 Selfcontact
-E 9 - 2 Selfcontact
-E 10 - 3 Selfcontact
-E 13 - 1 Selfcontact
-E 14 - 2 Selfcontact
-E 16 - 2 Selfcontact
-E 17 - 1 Selfcontact
-E 19 - 2 Selfcontact
-E 20 - 1 Selfcontact
-E 22 - 2 Selfcontact
-E 25 - 3 Selfcontact
-E 26 - 2 Selfcontact
-E 27 - 1 Selfcontact
-E 28 - 2 Selfcontact
-E 31 - 3 Selfcontact
-E 32 - 2 Selfcontact
-E 34 - 2 Selfcontact
-E 35 - 3 Selfcontact
-E 37 - 2 Selfcontact
-E 38 - 3 Selfcontact
-E 41 - 1 Selfcontact
-E 42 - 2 Selfcontact
-E 44 - 2 Selfcontact
-E 45 - 1 Selfcontact
-E 47 - 2 Selfcontact
-E 48 - 1 Selfcontact
-E 50 - 2 Selfcontact
-E 51 - 3 Selfcontact
-E 52 - 2 Selfcontact
-E 53 - 1 Selfcontact
-E 54 - 2 Selfcontact
+E 3 - InterfaceID 3 Side Selfcontact
+E 4 - InterfaceID 2 Side Selfcontact
+E 6 - InterfaceID 2 Side Selfcontact
+E 7 - InterfaceID 3 Side Selfcontact
+E 9 - InterfaceID 2 Side Selfcontact
+E 10 - InterfaceID 3 Side Selfcontact
+E 13 - InterfaceID 1 Side Selfcontact
+E 14 - InterfaceID 2 Side Selfcontact
+E 16 - InterfaceID 2 Side Selfcontact
+E 17 - InterfaceID 1 Side Selfcontact
+E 19 - InterfaceID 2 Side Selfcontact
+E 20 - InterfaceID 1 Side Selfcontact
+E 22 - InterfaceID 2 Side Selfcontact
+E 25 - InterfaceID 3 Side Selfcontact
+E 26 - InterfaceID 2 Side Selfcontact
+E 27 - InterfaceID 1 Side Selfcontact
+E 28 - InterfaceID 2 Side Selfcontact
+E 31 - InterfaceID 3 Side Selfcontact
+E 32 - InterfaceID 2 Side Selfcontact
+E 34 - InterfaceID 2 Side Selfcontact
+E 35 - InterfaceID 3 Side Selfcontact
+E 37 - InterfaceID 2 Side Selfcontact
+E 38 - InterfaceID 3 Side Selfcontact
+E 41 - InterfaceID 1 Side Selfcontact
+E 42 - InterfaceID 2 Side Selfcontact
+E 44 - InterfaceID 2 Side Selfcontact
+E 45 - InterfaceID 1 Side Selfcontact
+E 47 - InterfaceID 2 Side Selfcontact
+E 48 - InterfaceID 1 Side Selfcontact
+E 50 - InterfaceID 2 Side Selfcontact
+E 51 - InterfaceID 3 Side Selfcontact
+E 52 - InterfaceID 2 Side Selfcontact
+E 53 - InterfaceID 1 Side Selfcontact
+E 54 - InterfaceID 2 Side Selfcontact
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1429 DNODE 1
 NODE 1379 DNODE 2

--- a/tests/input_files/contact2D_self_saddlepoint.dat
+++ b/tests/input_files/contact2D_self_saddlepoint.dat
@@ -89,40 +89,40 @@ E 21 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 49 - NUMDOF 2 ONOFF 1 1 VAL 0.0 -1.0 FUNCT 0 1
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           34
-E 3 - 3 Selfcontact
-E 4 - 2 Selfcontact
-E 6 - 2 Selfcontact
-E 7 - 3 Selfcontact
-E 9 - 2 Selfcontact
-E 10 - 3 Selfcontact
-E 13 - 1 Selfcontact
-E 14 - 2 Selfcontact
-E 16 - 2 Selfcontact
-E 17 - 1 Selfcontact
-E 19 - 2 Selfcontact
-E 20 - 1 Selfcontact
-E 22 - 2 Selfcontact
-E 25 - 3 Selfcontact
-E 26 - 2 Selfcontact
-E 27 - 1 Selfcontact
-E 28 - 2 Selfcontact
-E 31 - 3 Selfcontact
-E 32 - 2 Selfcontact
-E 34 - 2 Selfcontact
-E 35 - 3 Selfcontact
-E 37 - 2 Selfcontact
-E 38 - 3 Selfcontact
-E 41 - 1 Selfcontact
-E 42 - 2 Selfcontact
-E 44 - 2 Selfcontact
-E 45 - 1 Selfcontact
-E 47 - 2 Selfcontact
-E 48 - 1 Selfcontact
-E 50 - 2 Selfcontact
-E 51 - 3 Selfcontact
-E 52 - 2 Selfcontact
-E 53 - 1 Selfcontact
-E 54 - 2 Selfcontact
+E 3 - InterfaceID 3 Side Selfcontact
+E 4 - InterfaceID 2 Side Selfcontact
+E 6 - InterfaceID 2 Side Selfcontact
+E 7 - InterfaceID 3 Side Selfcontact
+E 9 - InterfaceID 2 Side Selfcontact
+E 10 - InterfaceID 3 Side Selfcontact
+E 13 - InterfaceID 1 Side Selfcontact
+E 14 - InterfaceID 2 Side Selfcontact
+E 16 - InterfaceID 2 Side Selfcontact
+E 17 - InterfaceID 1 Side Selfcontact
+E 19 - InterfaceID 2 Side Selfcontact
+E 20 - InterfaceID 1 Side Selfcontact
+E 22 - InterfaceID 2 Side Selfcontact
+E 25 - InterfaceID 3 Side Selfcontact
+E 26 - InterfaceID 2 Side Selfcontact
+E 27 - InterfaceID 1 Side Selfcontact
+E 28 - InterfaceID 2 Side Selfcontact
+E 31 - InterfaceID 3 Side Selfcontact
+E 32 - InterfaceID 2 Side Selfcontact
+E 34 - InterfaceID 2 Side Selfcontact
+E 35 - InterfaceID 3 Side Selfcontact
+E 37 - InterfaceID 2 Side Selfcontact
+E 38 - InterfaceID 3 Side Selfcontact
+E 41 - InterfaceID 1 Side Selfcontact
+E 42 - InterfaceID 2 Side Selfcontact
+E 44 - InterfaceID 2 Side Selfcontact
+E 45 - InterfaceID 1 Side Selfcontact
+E 47 - InterfaceID 2 Side Selfcontact
+E 48 - InterfaceID 1 Side Selfcontact
+E 50 - InterfaceID 2 Side Selfcontact
+E 51 - InterfaceID 3 Side Selfcontact
+E 52 - InterfaceID 2 Side Selfcontact
+E 53 - InterfaceID 1 Side Selfcontact
+E 54 - InterfaceID 2 Side Selfcontact
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1429 DNODE 1
 NODE 1379 DNODE 2

--- a/tests/input_files/contact2D_simpler.dat
+++ b/tests/input_files/contact2D_simpler.dat
@@ -117,7 +117,7 @@ E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           1
 //                              selfonctact
-E 2 - 1 Selfcontact
+E 2 - InterfaceID 1 Side Selfcontact
 ---------------------------------------------------------DLINE-NODE TOPOLOGY
 NODE 673 DLINE 1
 NODE 674 DLINE 1

--- a/tests/input_files/contact2D_slidingblock_coulomb.dat
+++ b/tests/input_files/contact2D_slidingblock_coulomb.dat
@@ -85,8 +85,8 @@ DSURF                           1
 E 1 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -10 0.0 0.0 0.0 0.0 FUNCT 0 0 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave Active FrCoeffOrBound 0.1
-E 7 - 1 Master Inactive FrCoeffOrBound 0.1
+E 1 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
+E 7 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 415 DNODE 1
 NODE 343 DNODE 2

--- a/tests/input_files/contact2D_slidingblock_lin_duallagr.dat
+++ b/tests/input_files/contact2D_slidingblock_lin_duallagr.dat
@@ -85,9 +85,9 @@ E 4 - NUMDOF 2 ONOFF 1 1 VAL 1.0 -1.0 FUNCT 3 2
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
 //                              contact_bottom
-E 2 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Master Initialization Inactive
 //                              contact_top
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 ---------------------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/contact2D_slidingblock_tresca.dat
+++ b/tests/input_files/contact2D_slidingblock_tresca.dat
@@ -90,8 +90,8 @@ DSURF                           1
 E 1 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -15 0.0 0.0 0.0 0.0  FUNCT 0 0 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave Active FrCoeffOrBound 1.0
-E 7 - 1 Master Inactive FrCoeffOrBound 1.0
+E 1 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 1.0
+E 7 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 1.0
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 415 DNODE 1
 NODE 343 DNODE 2

--- a/tests/input_files/contact2D_slidingblock_tresca_new_struct.dat
+++ b/tests/input_files/contact2D_slidingblock_tresca_new_struct.dat
@@ -85,8 +85,8 @@ DSURF                           1
 E 1 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -15 0.0 0.0 0.0 0.0  FUNCT 0 0 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave Active FrCoeffOrBound 1.0
-E 7 - 1 Master Inactive FrCoeffOrBound 1.0
+E 1 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 1.0
+E 7 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 1.0
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 415 DNODE 1
 NODE 343 DNODE 2

--- a/tests/input_files/contact2D_twobeamshorizontal.dat
+++ b/tests/input_files/contact2D_twobeamshorizontal.dat
@@ -64,8 +64,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0  FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0  FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave Inactive FrCoeffOrBound 0.2
-E 6 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
+E 6 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 296 DNODE 1
 NODE 210 DNODE 2

--- a/tests/input_files/contact2D_twobeamshorizontal_new_struct.dat
+++ b/tests/input_files/contact2D_twobeamshorizontal_new_struct.dat
@@ -64,8 +64,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0  FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0  FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave Inactive FrCoeffOrBound 0.2
-E 6 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
+E 6 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 296 DNODE 1
 NODE 210 DNODE 2

--- a/tests/input_files/contact2D_twobeamsvertical.dat
+++ b/tests/input_files/contact2D_twobeamsvertical.dat
@@ -72,8 +72,8 @@ E 7 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 E 8 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 4 - 1 Slave Inactive FrCoeffOrBound 0.9
-E 6 - 1 Master Inactive FrCoeffOrBound 0.9
+E 4 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.9
+E 6 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.9
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 301 DNODE 1
 NODE 261 DNODE 2

--- a/tests/input_files/contact3D_adhesion_fixedbound_new_struc.dat
+++ b/tests/input_files/contact3D_adhesion_fixedbound_new_struc.dat
@@ -74,8 +74,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 1.0 FUNCT 0 0 1
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive FrCoeffOrBound 0 AdhesionBound 120
-E 7 - 1 Slave Inactive FrCoeffOrBound 0 AdhesionBound 120
+E 6 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0 AdhesionBound 120
+E 7 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0 AdhesionBound 120
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_bin_strat.dat
+++ b/tests/input_files/contact3D_bin_strat.dat
@@ -80,8 +80,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_bin_strat_new_struct.dat
+++ b/tests/input_files/contact3D_bin_strat_new_struct.dat
@@ -80,8 +80,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_blocked_system_ilu_precon.dat
+++ b/tests/input_files/contact3D_blocked_system_ilu_precon.dat
@@ -123,9 +123,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // contact_surf_small
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/contact3D_cpp_normal_new_struc.dat
+++ b/tests/input_files/contact3D_cpp_normal_new_struc.dat
@@ -76,8 +76,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_dual_lts.dat
+++ b/tests/input_files/contact3D_dual_lts.dat
@@ -73,9 +73,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    17 DSURFACE 1
 NODE    18 DSURFACE 1

--- a/tests/input_files/contact3D_dual_lts_new_struct.dat
+++ b/tests/input_files/contact3D_dual_lts_new_struct.dat
@@ -73,9 +73,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    17 DSURFACE 1
 NODE    18 DSURFACE 1

--- a/tests/input_files/contact3D_ele_based_new_struc.dat
+++ b/tests/input_files/contact3D_ele_based_new_struc.dat
@@ -76,8 +76,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_GPTSpenalty.dat
+++ b/tests/input_files/contact3D_lin_GPTSpenalty.dat
@@ -69,8 +69,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_GPTSpenalty_new_struct.dat
+++ b/tests/input_files/contact3D_lin_GPTSpenalty_new_struct.dat
@@ -73,8 +73,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_ElastHyper NUMMAT 1 MATIDS 3 DENS 7.8e-6
 MAT 3 ELAST_CoupNeoHooke YOUNG 210.0 NUE 0.3

--- a/tests/input_files/contact3D_lin_duallagr.dat
+++ b/tests/input_files/contact3D_lin_duallagr.dat
@@ -76,8 +76,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_ltl_new_struc.dat
+++ b/tests/input_files/contact3D_lin_ltl_new_struc.dat
@@ -81,9 +81,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 2 2 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.9
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.9
 // master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.9
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.9
 -----------------------------DESIGN LINE MORTAR EDGE CONDITIONS 3D
 DLINE  1
 // line

--- a/tests/input_files/contact3D_lin_nts_new_struc.dat
+++ b/tests/input_files/contact3D_lin_nts_new_struc.dat
@@ -87,8 +87,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_penalty.dat
+++ b/tests/input_files/contact3D_lin_penalty.dat
@@ -77,8 +77,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_penalty_genalphaliegroup.dat
+++ b/tests/input_files/contact3D_lin_penalty_genalphaliegroup.dat
@@ -78,8 +78,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_stdlagr.dat
+++ b/tests/input_files/contact3D_lin_stdlagr.dat
@@ -72,8 +72,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_lin_uzawa.dat
+++ b/tests/input_files/contact3D_lin_uzawa.dat
@@ -79,8 +79,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_ltl_patch.dat
+++ b/tests/input_files/contact3D_ltl_patch.dat
@@ -82,9 +82,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact_surf
-E 3 - 0 Slave Inactive
+E 3 - InterfaceID 0 Side Slave Initialization Inactive
 // bottom_contact_surf
-E 4 - 0 Master Inactive
+E 4 - InterfaceID 0 Side Master Initialization Inactive
 -----------------------------DESIGN LINE MORTAR EDGE CONDITIONS 3D
 DLINE  1
 // top_contact_edge

--- a/tests/input_files/contact3D_lts_ll_new_struc.dat
+++ b/tests/input_files/contact3D_lts_ll_new_struc.dat
@@ -85,9 +85,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 0.0 -1.0 FUNCT 2 0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------DESIGN LINE MORTAR EDGE CONDITIONS 3D
 DLINE  1
 // line

--- a/tests/input_files/contact3D_nitsche_hex8_nonsym_coulomb.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_nonsym_coulomb.dat
@@ -72,9 +72,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // bottom_contact
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    226 DSURFACE 1
 NODE    229 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_nonsym_coulomb_new_struct.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_nonsym_coulomb_new_struct.dat
@@ -73,9 +73,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // bottom_contact
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    226 DSURFACE 1
 NODE    229 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_nonsym_ele.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_nonsym_ele.dat
@@ -72,9 +72,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // c_twist
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // c_block
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    84 DSURFACE 1
 NODE    85 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_nonsym_ele_new_struct.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_nonsym_ele_new_struct.dat
@@ -75,9 +75,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // c_twist
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // c_block
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    84 DSURFACE 1
 NODE    85 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_skew_segm.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_segm.dat
@@ -71,9 +71,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // c_twist
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // c_block
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    84 DSURFACE 1
 NODE    85 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_skew_segm_new_struct.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_segm_new_struct.dat
@@ -74,9 +74,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // c_twist
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // c_block
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    84 DSURFACE 1
 NODE    85 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_skew_segm_newtonLS_new_struc.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_segm_newtonLS_new_struc.dat
@@ -91,9 +91,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // c_twist
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // c_block
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    84 DSURFACE 1
 NODE    85 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_skew_tresca.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_tresca.dat
@@ -72,9 +72,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // bottom_contact
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    226 DSURFACE 1
 NODE    229 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_skew_tresca_new_struct.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_tresca_new_struct.dat
@@ -72,9 +72,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 // bottom_contact
-E 4 - 1 Master Inactive FrCoeffOrBound 0.2
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    226 DSURFACE 1
 NODE    229 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_sym_coulomb.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_sym_coulomb.dat
@@ -72,9 +72,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.5
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.5
 // bottom_contact
-E 4 - 1 Master Inactive FrCoeffOrBound 0.5
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.5
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    226 DSURFACE 1
 NODE    229 DSURFACE 1

--- a/tests/input_files/contact3D_nitsche_hex8_sym_coulomb_new_struc.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_sym_coulomb_new_struc.dat
@@ -79,9 +79,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Inactive FrCoeffOrBound 0.5
+E 3 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.5
 // bottom_contact
-E 4 - 1 Master Inactive FrCoeffOrBound 0.5
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.5
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    226 DSURFACE 1
 NODE    229 DSURFACE 1

--- a/tests/input_files/contact3D_nurbs27_pg.dat
+++ b/tests/input_files/contact3D_nurbs27_pg.dat
@@ -73,8 +73,8 @@ MAT 2 MAT_ElastHyper NUMMAT 1 MATIDS 4 DENS 0.01
 MAT 4 ELAST_CoupNeoHooke YOUNG 1.0 NUE 0.3
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 2 - 1 Master Inactive FrCoeffOrBound 0.2
-E 7 - 1 Slave Inactive FrCoeffOrBound 0.2
+E 2 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
+E 7 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.2
 -----------------------------------------------DESIGN SURF DIRICH CONDITIONS
 DSURF                           1
 E 8 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 0.0 FUNCT 2 1 0

--- a/tests/input_files/contact3D_nurbs27_segm_pg.dat
+++ b/tests/input_files/contact3D_nurbs27_segm_pg.dat
@@ -72,8 +72,8 @@ E 11 - NUMDOF 3 ONOFF 1 1 1 VAL 0 0 0 FUNCT 0 0 0
 E 6  - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
-E 5 - 1 Slave Inactive
-E 12 - 1 Master Inactive
+E 5 - InterfaceID 1 Side Slave Initialization Inactive
+E 12 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------------------------------DNODE-NODE TOPOLOGY
 //
 // structure: patch 1, (0,0,0)

--- a/tests/input_files/contact3D_onlylin_penalty_hex27.dat
+++ b/tests/input_files/contact3D_onlylin_penalty_hex27.dat
@@ -65,8 +65,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_onlylin_penalty_hex27_new_struct.dat
+++ b/tests/input_files/contact3D_onlylin_penalty_hex27_new_struct.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_patch_linstatic.dat
+++ b/tests/input_files/contact3D_patch_linstatic.dat
@@ -92,8 +92,8 @@ E 24 - NUMDOF 6 ONOFF 0 0 1 0 0 0 VAL 0.0 0.0 -100 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1
 E 25 - NUMDOF 6 ONOFF 0 0 1 0 0 0 VAL 0.0 0.0 -100 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 TYPE Live
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 9 - 1 Slave Active
-E 29 - 1 Master Inactive
+E 9 - InterfaceID 1 Side Slave Initialization Active
+E 29 - InterfaceID 1 Side Master Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1224 DNODE 1
 NODE 741 DNODE 2

--- a/tests/input_files/contact3D_patch_linstatic_new_struct.dat
+++ b/tests/input_files/contact3D_patch_linstatic_new_struct.dat
@@ -93,8 +93,8 @@ E 24 - NUMDOF 6 ONOFF 0 0 1 0 0 0 VAL 0.0 0.0 -100 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1
 E 25 - NUMDOF 6 ONOFF 0 0 1 0 0 0 VAL 0.0 0.0 -100 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 TYPE Live
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 9 - 1 Slave Active
-E 29 - 1 Master Inactive
+E 9 - InterfaceID 1 Side Slave Initialization Active
+E 29 - InterfaceID 1 Side Master Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1224 DNODE 1
 NODE 741 DNODE 2

--- a/tests/input_files/contact3D_patch_unbiased_self_nitsche_skew.dat
+++ b/tests/input_files/contact3D_patch_unbiased_self_nitsche_skew.dat
@@ -60,9 +60,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 3 - InterfaceID 1 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 // bottom_contact
-E 4 - 1 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 4 - InterfaceID 1 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    65 DSURFACE 1
 NODE    68 DSURFACE 1

--- a/tests/input_files/contact3D_pwlin_penalty_hex20.dat
+++ b/tests/input_files/contact3D_pwlin_penalty_hex20.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 613 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact3D_pwlin_penalty_hex27.dat
+++ b/tests/input_files/contact3D_pwlin_penalty_hex27.dat
@@ -65,8 +65,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_pwlin_penalty_hex27_new_struct.dat
+++ b/tests/input_files/contact3D_pwlin_penalty_hex27_new_struct.dat
@@ -65,8 +65,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_pwlin_penalty_tet10.dat
+++ b/tests/input_files/contact3D_pwlin_penalty_tet10.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 620 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact3D_pwlin_penalty_tet10_new_struct.dat
+++ b/tests/input_files/contact3D_pwlin_penalty_tet10_new_struct.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 620 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact3D_quad_const_hex27.dat
+++ b/tests/input_files/contact3D_quad_const_hex27.dat
@@ -60,8 +60,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_quad_lin_tet10.dat
+++ b/tests/input_files/contact3D_quad_lin_tet10.dat
@@ -64,8 +64,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 620 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact3D_quad_lin_tet10_new_struct.dat
+++ b/tests/input_files/contact3D_quad_lin_tet10_new_struct.dat
@@ -64,8 +64,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 620 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact3D_quad_penalty_hex27.dat
+++ b/tests/input_files/contact3D_quad_penalty_hex27.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_quad_penalty_hex27_new_struct.dat
+++ b/tests/input_files/contact3D_quad_penalty_hex27_new_struct.dat
@@ -65,8 +65,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 1082 DNODE 2

--- a/tests/input_files/contact3D_quad_tet10.dat
+++ b/tests/input_files/contact3D_quad_tet10.dat
@@ -65,8 +65,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 620 DNODE 1
 NODE 1 DNODE 2

--- a/tests/input_files/contact3D_roundrobin_ghost.dat
+++ b/tests/input_files/contact3D_roundrobin_ghost.dat
@@ -75,8 +75,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_roundrobin_ghost_new_struc.dat
+++ b/tests/input_files/contact3D_roundrobin_ghost_new_struc.dat
@@ -75,8 +75,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1  1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master
-E 7 - 1 Slave
+E 6 - InterfaceID 1 Side Master
+E 7 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/contact3D_slidingblock_coulomb.dat
+++ b/tests/input_files/contact3D_slidingblock_coulomb.dat
@@ -92,9 +92,9 @@ E 6 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 243 DSURFACE 1
 NODE 244 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_coulomb_new_struct.dat
+++ b/tests/input_files/contact3D_slidingblock_coulomb_new_struct.dat
@@ -89,9 +89,9 @@ E 6 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 243 DSURFACE 1
 NODE 244 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_duallagr.dat
+++ b/tests/input_files/contact3D_slidingblock_duallagr.dat
@@ -80,9 +80,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              top_contact
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 //                              bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 65 DSURFACE 1
 NODE 68 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_duallagr_new_struct.dat
+++ b/tests/input_files/contact3D_slidingblock_duallagr_new_struct.dat
@@ -78,9 +78,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              top_contact
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 //                              bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 65 DSURFACE 1
 NODE 68 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_lagrange_hex20.dat
+++ b/tests/input_files/contact3D_slidingblock_lagrange_hex20.dat
@@ -79,9 +79,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              slavesurface
-E 3 - 1 Slave Active FrCoeffOrBound 0.8
+E 3 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.8
 //                              mastersurface
-E 4 - 1 Master Inactive FrCoeffOrBound 0.8
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.8
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 4 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_lagrange_tet10.dat
+++ b/tests/input_files/contact3D_slidingblock_lagrange_tet10.dat
@@ -98,9 +98,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1455 DSURFACE 1
 NODE 1458 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_lagrange_tet10_new_struct.dat
+++ b/tests/input_files/contact3D_slidingblock_lagrange_tet10_new_struct.dat
@@ -98,9 +98,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1455 DSURFACE 1
 NODE 1458 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_penalty.dat
+++ b/tests/input_files/contact3D_slidingblock_penalty.dat
@@ -98,9 +98,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 243 DSURFACE 1
 NODE 244 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_penalty_new_struct.dat
+++ b/tests/input_files/contact3D_slidingblock_penalty_new_struct.dat
@@ -96,9 +96,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 243 DSURFACE 1
 NODE 244 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_uzawa.dat
+++ b/tests/input_files/contact3D_slidingblock_uzawa.dat
@@ -100,9 +100,9 @@ E 6 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 243 DSURFACE 1
 NODE 244 DSURFACE 1

--- a/tests/input_files/contact3D_slidingblock_uzawa_tet10.dat
+++ b/tests/input_files/contact3D_slidingblock_uzawa_tet10.dat
@@ -97,9 +97,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0  FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              master
-E 4 - 1 Master Inactive FrCoeffOrBound 0.1
+E 4 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 //                              slave
-E 5 - 1 Slave Active FrCoeffOrBound 0.1
+E 5 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1455 DSURFACE 1
 NODE 1458 DSURFACE 1

--- a/tests/input_files/contact3D_sp_dual_simple.dat
+++ b/tests/input_files/contact3D_sp_dual_simple.dat
@@ -118,9 +118,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // contact_surf_small
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/contact3D_sp_std_braess_sarazin.dat
+++ b/tests/input_files/contact3D_sp_std_braess_sarazin.dat
@@ -123,9 +123,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // contact_surf_small
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/contact3D_sp_std_simple.dat
+++ b/tests/input_files/contact3D_sp_std_simple.dat
@@ -125,9 +125,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // contact_surf_small
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/contact3D_sp_std_uzawa.dat
+++ b/tests/input_files/contact3D_sp_std_uzawa.dat
@@ -125,9 +125,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 2 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 // contact_surf_small
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/contact3D_symmetry_LM_cond.dat
+++ b/tests/input_files/contact3D_symmetry_LM_cond.dat
@@ -88,9 +88,9 @@ E 2 - NUMDOF 3 ONOFF 0 1 0 VAL 0 -1 0 FUNCT 0 1 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // master
-E 1 - 1 Master Inactive FrCoeffOrBound 0.5
+E 1 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.5
 // slave
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.5
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.5
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // sy_z

--- a/tests/input_files/contact3D_symmetry_LM_sp.dat
+++ b/tests/input_files/contact3D_symmetry_LM_sp.dat
@@ -88,9 +88,9 @@ E 2 - NUMDOF 3 ONOFF 0 1 0 VAL 0 -1 0 FUNCT 0 1 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // master
-E 1 - 1 Master Inactive FrCoeffOrBound 0.5
+E 1 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.5
 // slave
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.5
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.5
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // sy_z

--- a/tests/input_files/contact3D_symmetry_penalty.dat
+++ b/tests/input_files/contact3D_symmetry_penalty.dat
@@ -88,9 +88,9 @@ E 6 - NUMDOF 3 ONOFF 0 1 0 VAL 0 0 0 FUNCT none none none
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 1 - 1 Slave Active  FrCoeffOrBound 0.03
+E 1 - InterfaceID 1 Side Slave Initialization Active  FrCoeffOrBound 0.03
 // master
-E 2 - 1 Master Inactive FrCoeffOrBound 0.03
+E 2 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.03
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // LineMrtrSym_x

--- a/tests/input_files/contact3D_symmetry_penalty_new_struct.dat
+++ b/tests/input_files/contact3D_symmetry_penalty_new_struct.dat
@@ -85,9 +85,9 @@ E 6 - NUMDOF 3 ONOFF 0 1 0 VAL 0 0 0 FUNCT none none none
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 1 - 1 Slave Active  FrCoeffOrBound 0.03
+E 1 - InterfaceID 1 Side Slave Initialization Active  FrCoeffOrBound 0.03
 // master
-E 2 - 1 Master Inactive FrCoeffOrBound 0.03
+E 2 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.03
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // LineMrtrSym_x

--- a/tests/input_files/contact3D_tet4_hex8.dat
+++ b/tests/input_files/contact3D_tet4_hex8.dat
@@ -86,9 +86,9 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1  1 2
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.1
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.1
 // master
-E 3 - 1 Master Inactive FrCoeffOrBound 0.1
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    2 DLINE 1
 NODE    3 DLINE 1

--- a/tests/input_files/contact3D_tet4_hex8_new_struct.dat
+++ b/tests/input_files/contact3D_tet4_hex8_new_struct.dat
@@ -83,9 +83,9 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1  1 2
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // slave
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.1
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.1
 // master
-E 3 - 1 Master Inactive FrCoeffOrBound 0.1
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    2 DLINE 1
 NODE    3 DLINE 1

--- a/tests/input_files/contact3D_unbiased_self_hex8_nitsche.dat
+++ b/tests/input_files/contact3D_unbiased_self_hex8_nitsche.dat
@@ -90,9 +90,9 @@ E 4 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT none none none
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // cyl_side_of_cyl-bl_interface
-E 5 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 5 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 // block_side_of_cyl-bl_interface
-E 6 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 6 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // lines_mrtr_sym_normal_z

--- a/tests/input_files/contact3D_unbiased_self_hex8_nitsche_new_struct.dat
+++ b/tests/input_files/contact3D_unbiased_self_hex8_nitsche_new_struct.dat
@@ -99,9 +99,9 @@ E 4 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT none none none
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // cyl_side_of_cyl-bl_interface
-E 5 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 5 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 // block_side_of_cyl-bl_interface
-E 6 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 6 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // lines_mrtr_sym_normal_z

--- a/tests/input_files/contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
+++ b/tests/input_files/contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
@@ -98,9 +98,9 @@ E 4 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT none none none
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // cyl_side_of_cyl-bl_interface
-E 5 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 5 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 // block_side_of_cyl-bl_interface
-E 6 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 6 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // lines_mrtr_sym_normal_z

--- a/tests/input_files/ehl2D_block_sqz.dat
+++ b/tests/input_files/ehl2D_block_sqz.dat
@@ -128,8 +128,8 @@ DVOL   1
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0 0 0 FUNCT 0 0 0
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 1 - 1 Slave
-E 2 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 2 - InterfaceID 1 Side Master
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    171 DLINE 1
 NODE    172 DLINE 1

--- a/tests/input_files/ehl3D_block_sqz.dat
+++ b/tests/input_files/ehl3D_block_sqz.dat
@@ -128,8 +128,8 @@ DVOL   1
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0 0 0 FUNCT 0 0 0
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 1 - 1 Slave
-E 2 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 2 - InterfaceID 1 Side Master
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    414 DLINE 1
 NODE    415 DLINE 1

--- a/tests/input_files/ehl3d_cyl_mono.dat
+++ b/tests/input_files/ehl3d_cyl_mono.dat
@@ -131,8 +131,8 @@ E 1 - NUMDOF 3 ONOFF 0 0 0 VAL 0 0 0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1 0 0 FUNCT 1 0 0
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 1 - 1 Slave
-E 2 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 2 - InterfaceID 1 Side Master
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    741 DLINE 1
 NODE    742 DLINE 1

--- a/tests/input_files/ehl3d_cyl_mono_averaged.dat
+++ b/tests/input_files/ehl3d_cyl_mono_averaged.dat
@@ -132,8 +132,8 @@ E 1 - NUMDOF 3 ONOFF 0 0 0 VAL 0 0 0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1 0 0 FUNCT 1 0 0
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 1 - 1 Slave
-E 2 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 2 - InterfaceID 1 Side Master
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    741 DLINE 1
 NODE    742 DLINE 1

--- a/tests/input_files/ehl3d_cyl_part.dat
+++ b/tests/input_files/ehl3d_cyl_part.dat
@@ -130,8 +130,8 @@ E 1 - NUMDOF 3 ONOFF 0 0 0 VAL 0 0 0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1 0 0 FUNCT 1 0 0
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 1 - 1 Slave
-E 2 - 1 Master
+E 1 - InterfaceID 1 Side Slave
+E 2 - InterfaceID 1 Side Master
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    741 DLINE 1
 NODE    742 DLINE 1

--- a/tests/input_files/ehl3d_mixed.dat
+++ b/tests/input_files/ehl3d_mixed.dat
@@ -131,8 +131,8 @@ DVOL   1
 E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 1 0 0 FUNCT 1 0 0
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.3
-E 3 - 1 Master Inactive FrCoeffOrBound 0.3
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.3
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.3
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    99 DLINE 1
 NODE    102 DLINE 1

--- a/tests/input_files/ehl_bearing_barus.dat
+++ b/tests/input_files/ehl_bearing_barus.dat
@@ -99,8 +99,8 @@ DVOL   1
 E 1 - FIELD Velocity FUNCT 2
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave
-E 3 - 1 Master
+E 2 - InterfaceID 1 Side Slave
+E 3 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    413 DNODE 1
 NODE    414 DNODE 1

--- a/tests/input_files/ehl_bearing_roeland.dat
+++ b/tests/input_files/ehl_bearing_roeland.dat
@@ -99,8 +99,8 @@ DVOL   1
 E 1 - FIELD Velocity FUNCT 2
 ---------------------DESIGN SURF EHL MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave
-E 3 - 1 Master
+E 2 - InterfaceID 1 Side Slave
+E 3 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    413 DNODE 1
 NODE    414 DNODE 1

--- a/tests/input_files/elch_NonMatchingMesh_20x80.dat
+++ b/tests/input_files/elch_NonMatchingMesh_20x80.dat
@@ -77,9 +77,9 @@ E 2 - ID 1 POT 25.0 FUNCT 4 NUMSCAL 2 STOICH -1 0  E- 1 EPSILON -1 ZERO_CUR 0 Bu
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
 // left internal boundary
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // right internal boundary
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE 1 DLINE 1
 NODE 2 DLINE 1

--- a/tests/input_files/elch_NonMatchingMesh_20x80_pdeElim_ionTransport_Laplace.dat
+++ b/tests/input_files/elch_NonMatchingMesh_20x80_pdeElim_ionTransport_Laplace.dat
@@ -85,9 +85,9 @@ E 4 - ID 1 POT 25.0 FUNCT 3 NUMSCAL 1 STOICH -1  E- 1 EPSILON -1 ZERO_CUR 0 Butl
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE 2
 // quad
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // lin
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    1 DLINE 1
 NODE    2 DLINE 1

--- a/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Bmat.dat
+++ b/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Bmat.dat
@@ -112,9 +112,9 @@ E 4 - ID 1 MASTER_OR_SLAVE Slave PLANE yz LAYER 0 ANGLE 0.0 ABSTREETOL 1e-9
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
 // left internal boundary
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // right internal boundary
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 5 DNODE 1
 ---------------------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Smat.dat
+++ b/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Smat.dat
@@ -118,9 +118,9 @@ E 4 - ID 1 MASTER_OR_SLAVE Slave PLANE yz LAYER 0 ANGLE 0.0 ABSTREETOL 1e-9
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
 // left internal boundary
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // right internal boundary
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 5 DNODE 1
 ---------------------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/f3_beltrami_8x8_meshtying_ale.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_ale.dat
@@ -151,9 +151,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 2.0 3.0 FUNCT 3 3 3
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // outer_domain_inner_boundary
-E 3 - 1 Master
+E 3 - InterfaceID 1 Side Master
 // inner_domain_outer_boundary
-E 4 - 1 Slave
+E 4 - InterfaceID 1 Side Slave
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/f3_beltrami_8x8_meshtying_ale_euler.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_ale_euler.dat
@@ -148,9 +148,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 2.0 3.0 FUNCT 3 3 3
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // outer_domain_inner_boundary
-E 4 - 1 Master
+E 4 - InterfaceID 1 Side Master
 // inner_domain_outer_boundary
-E 2 - 1 Slave
+E 2 - InterfaceID 1 Side Slave
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/f3_beltrami_8x8_meshtying_bmat.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_bmat.dat
@@ -129,9 +129,9 @@ E 6 - NUMDOF 4 ONOFF 1 1 1 1 VAL 1.0 1.0 1.0 1.0 FUNCT 1 1 1 2
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // inside meshtying
-E 7 - 1 Slave
+E 7 - InterfaceID 1 Side Slave
 // outside meshtying
-E 8 - 1 Master
+E 8 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    51 DNODE 1
 -----------------------------------------------DSURF-NODE TOPOLOGY

--- a/tests/input_files/f3_beltrami_8x8_meshtying_bmat_merged.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_bmat_merged.dat
@@ -139,9 +139,9 @@ E 6 - NUMDOF 4 ONOFF 1 1 1 1 VAL 1.0 1.0 1.0 1.0 FUNCT 1 1 1 2
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // inside meshtying
-E 7 - 1 Slave
+E 7 - InterfaceID 1 Side Slave
 // outside meshtying
-E 8 - 1 Master
+E 8 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    51 DNODE 1
 -----------------------------------------------DSURF-NODE TOPOLOGY

--- a/tests/input_files/f3_beltrami_8x8_meshtying_smat.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_smat.dat
@@ -146,9 +146,9 @@ E 6 - NUMDOF 4 ONOFF 1 1 1 1 VAL 1.0 1.0 1.0 1.0 FUNCT 1 1 1 2
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // inside meshtying
-E 7 - 1 Slave
+E 7 - InterfaceID 1 Side Slave
 // outside meshtying
-E 8 - 1 Master
+E 8 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    51 DNODE 1
 -----------------------------------------------DSURF-NODE TOPOLOGY

--- a/tests/input_files/f3_beltrami_8x8_meshtying_smat_velcoupled.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_smat_velcoupled.dat
@@ -140,9 +140,9 @@ E 6 - NUMDOF 4 ONOFF 1 1 1 1 VAL 1.0 1.0 1.0 1.0 FUNCT 1 1 1 2
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // inside meshtying
-E 7 - 1 Slave
+E 7 - InterfaceID 1 Side Slave
 // outside meshtying
-E 8 - 1 Master
+E 8 - InterfaceID 1 Side Master
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    51 DNODE 1
 -----------------------------------------------DSURF-NODE TOPOLOGY

--- a/tests/input_files/f3_channel_meshtying_DCmaster.dat
+++ b/tests/input_files/f3_channel_meshtying_DCmaster.dat
@@ -141,9 +141,9 @@ E 5 - NUMDOF 4  ONOFF 1 1 0 0  VAL 0.0 0.0 0.0 0.0 FUNCT 0 0 0 0
 ------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // internal interface fluid boundary layer
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 // internal interface fluid inner
-E 7 - 1 Master
+E 7 - InterfaceID 1 Side Master
 ---------------------------------DESIGN FLOW RATE SURF CONDITIONS
 DSURF    7
 E 1 - 1

--- a/tests/input_files/fbi_meshtying_bmat.dat
+++ b/tests/input_files/fbi_meshtying_bmat.dat
@@ -147,9 +147,9 @@ E 7 - NUMDOF 4 ONOFF 1 1 0 0 VAL 0.0 0.0 0.0 0.0 FUNCT 0 0 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // fluid_coupling_surf
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // randschicht_coupling_surf
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    27 DLINE 1
 NODE    28 DLINE 1

--- a/tests/input_files/fbi_meshtying_smat.dat
+++ b/tests/input_files/fbi_meshtying_smat.dat
@@ -155,9 +155,9 @@ E 7 - NUMDOF 4 ONOFF 1 1 0 0 VAL 0.0 0.0 0.0 0.0 FUNCT 0 0 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // fluid_coupling_surf
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // randschicht_coupling_surf
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    27 DLINE 1
 NODE    28 DLINE 1

--- a/tests/input_files/fsci_simp_salz_syst.dat
+++ b/tests/input_files/fsci_simp_salz_syst.dat
@@ -225,10 +225,10 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // contacting_outer_bag_surface
-E 8 - 1 Master
+E 8 - InterfaceID 1 Side Master
 // contacting_inner_tube_surface
-E 9 - 1 Slave
-//E 9 - 1 Slave Active
+E 9 - InterfaceID 1 Side Slave
+//E 9 - InterfaceID 1 Side Slave Initialization Active
 -----------------DESIGN SURFACE FLOW-DEPENDENT PRESSURE CONDITIONS
 DSURF  1
 // outflow

--- a/tests/input_files/fsi_dc_mono_slfs_msht.dat
+++ b/tests/input_files/fsi_dc_mono_slfs_msht.dat
@@ -140,9 +140,9 @@ E 6 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // hole_interface
-E 7 - 1 Slave
+E 7 - InterfaceID 1 Side Slave
 // cavity_interface
-E 9 - 1 Master
+E 9 - InterfaceID 1 Side Master
 -------------------------------DESIGN FSI COUPLING LINE CONDITIONS
 DLINE  2
 // structure_fsi_curve

--- a/tests/input_files/fsi_dc_mono_slss_msht.dat
+++ b/tests/input_files/fsi_dc_mono_slss_msht.dat
@@ -140,9 +140,9 @@ E 6 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // hole_interface
-E 7 - 1 Slave
+E 7 - InterfaceID 1 Side Slave
 // cavity_interface
-E 9 - 1 Master
+E 9 - InterfaceID 1 Side Master
 -------------------------------DESIGN FSI COUPLING LINE CONDITIONS
 DLINE  2
 // structure_fsi_curve

--- a/tests/input_files/fsi_pw_mono_fs_ga_ga_contact.dat
+++ b/tests/input_files/fsi_pw_mono_fs_ga_ga_contact.dat
@@ -149,8 +149,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 ------------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 1 Master Inactive
-E 7 - 1 Slave Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
+E 7 - InterfaceID 1 Side Slave Initialization Inactive
 -----------------------------------------DESIGN FSI COUPLING SURF CONDITIONS
 DSURF                           2
 //                              fluid_fsi_surf

--- a/tests/input_files/meshtying2D_inf_plate.dat
+++ b/tests/input_files/meshtying2D_inf_plate.dat
@@ -67,9 +67,9 @@ E 2 - NUMDOF 2 ONOFF 1 0 VAL 0.0 0.0 FUNCT none none
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 // mrtr_2
-E 6 - 1 Master Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    28 DLINE 1
 NODE    29 DLINE 1

--- a/tests/input_files/meshtying2D_inf_plate_new_struct.dat
+++ b/tests/input_files/meshtying2D_inf_plate_new_struct.dat
@@ -68,9 +68,9 @@ E 2 - NUMDOF 2 ONOFF 1 0 VAL 0.0 0.0 FUNCT none none
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 // mrtr_2
-E 6 - 1 Master Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    28 DLINE 1
 NODE    29 DLINE 1

--- a/tests/input_files/meshtying2D_inf_plate_quad_const.dat
+++ b/tests/input_files/meshtying2D_inf_plate_quad_const.dat
@@ -74,9 +74,9 @@ E 2 - NUMDOF 2 ONOFF 1 0 VAL 0.0 0.0 FUNCT none none
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 // mrtr_2
-E 6 - 1 Master Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    24 DLINE 1
 NODE    25 DLINE 1

--- a/tests/input_files/meshtying2D_inf_plate_quad_lin.dat
+++ b/tests/input_files/meshtying2D_inf_plate_quad_lin.dat
@@ -76,9 +76,9 @@ E 2 - NUMDOF 2 ONOFF 1 0 VAL 0.0 0.0 FUNCT none none
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 // mrtr_2
-E 6 - 1 Master Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    24 DLINE 1
 NODE    25 DLINE 1

--- a/tests/input_files/meshtying2D_inf_plate_quad_lin_new_struct.dat
+++ b/tests/input_files/meshtying2D_inf_plate_quad_lin_new_struct.dat
@@ -69,9 +69,9 @@ E 2 - NUMDOF 2 ONOFF 1 0 VAL 0.0 0.0 FUNCT none none
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // mrtr_1
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 // mrtr_2
-E 6 - 1 Master Inactive
+E 6 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    24 DLINE 1
 NODE    25 DLINE 1

--- a/tests/input_files/meshtying2D_nurbs9_dual.dat
+++ b/tests/input_files/meshtying2D_nurbs9_dual.dat
@@ -86,8 +86,8 @@ E 6 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.31 FUNCT 0 1
 E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
-E 2 - 1 Slave Active
-E 5 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 5 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------------------STRUCTURE KNOTVECTORS
 NURBS_DIMENSION                       2
 BEGIN                           NURBSPATCH

--- a/tests/input_files/meshtying2D_nurbs9_dual_new_struct.dat
+++ b/tests/input_files/meshtying2D_nurbs9_dual_new_struct.dat
@@ -87,8 +87,8 @@ E 6 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.31 FUNCT 0 1
 E 1 - NUMDOF 2 ONOFF 1 1 VAL 0.0 0.0 FUNCT 0 0
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
-E 2 - 1 Slave Active
-E 5 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 5 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------------------STRUCTURE KNOTVECTORS
 NURBS_DIMENSION                       2
 BEGIN                           NURBSPATCH

--- a/tests/input_files/meshtying2D_patch_linstatic.dat
+++ b/tests/input_files/meshtying2D_patch_linstatic.dat
@@ -77,14 +77,14 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Slave Active
-E 15 - 1 Slave Active
-E 16 - 1 Slave Active
-E 17 - 1 Slave Active
-E 18 - 1 Slave Active
-E 24 - 1 Slave Active
-E 25 - 1 Slave Active
-E 28 - 1 Master
+E 14 - InterfaceID 1 Side Slave Initialization Active
+E 15 - InterfaceID 1 Side Slave Initialization Active
+E 16 - InterfaceID 1 Side Slave Initialization Active
+E 17 - InterfaceID 1 Side Slave Initialization Active
+E 18 - InterfaceID 1 Side Slave Initialization Active
+E 24 - InterfaceID 1 Side Slave Initialization Active
+E 25 - InterfaceID 1 Side Slave Initialization Active
+E 28 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 10 DNODE 2

--- a/tests/input_files/meshtying2D_patch_linstatic_2.dat
+++ b/tests/input_files/meshtying2D_patch_linstatic_2.dat
@@ -83,22 +83,22 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Slave Active
-E 15 - 1 Slave Active
-E 16 - 1 Slave Active
-E 17 - 1 Slave Active
-E 18 - 1 Slave Active
-E 24 - 1 Slave Active
-E 25 - 1 Slave Active
-E 28 - 1 Master
-// E 14 - 1 Master
-// E 15 - 1 Master
-// E 16 - 1 Master
-// E 17 - 1 Master
-// E 18 - 1 Master
-// E 24 - 1 Master
-// E 25 - 1 Master
-// E 28 - 1 Slave Inactive
+E 14 - InterfaceID 1 Side Slave Initialization Active
+E 15 - InterfaceID 1 Side Slave Initialization Active
+E 16 - InterfaceID 1 Side Slave Initialization Active
+E 17 - InterfaceID 1 Side Slave Initialization Active
+E 18 - InterfaceID 1 Side Slave Initialization Active
+E 24 - InterfaceID 1 Side Slave Initialization Active
+E 25 - InterfaceID 1 Side Slave Initialization Active
+E 28 - InterfaceID 1 Side Master
+// E 14 - InterfaceID 1 Side Master
+// E 15 - InterfaceID 1 Side Master
+// E 16 - InterfaceID 1 Side Master
+// E 17 - InterfaceID 1 Side Master
+// E 18 - InterfaceID 1 Side Master
+// E 24 - InterfaceID 1 Side Master
+// E 25 - InterfaceID 1 Side Master
+// E 28 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 10 DNODE 2

--- a/tests/input_files/meshtying2D_patch_linstatic_2_new_struct.dat
+++ b/tests/input_files/meshtying2D_patch_linstatic_2_new_struct.dat
@@ -80,22 +80,22 @@ DLINE                           1
 E 30 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -100 0.0 0.0 0.0 0.0 FUNCT 0 1 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           8
-E 14 - 1 Slave Active
-E 15 - 1 Slave Active
-E 16 - 1 Slave Active
-E 17 - 1 Slave Active
-E 18 - 1 Slave Active
-E 24 - 1 Slave Active
-E 25 - 1 Slave Active
-E 28 - 1 Master
-// E 14 - 1 Master
-// E 15 - 1 Master
-// E 16 - 1 Master
-// E 17 - 1 Master
-// E 18 - 1 Master
-// E 24 - 1 Master
-// E 25 - 1 Master
-// E 28 - 1 Slave Inactive
+E 14 - InterfaceID 1 Side Slave Initialization Active
+E 15 - InterfaceID 1 Side Slave Initialization Active
+E 16 - InterfaceID 1 Side Slave Initialization Active
+E 17 - InterfaceID 1 Side Slave Initialization Active
+E 18 - InterfaceID 1 Side Slave Initialization Active
+E 24 - InterfaceID 1 Side Slave Initialization Active
+E 25 - InterfaceID 1 Side Slave Initialization Active
+E 28 - InterfaceID 1 Side Master
+// E 14 - InterfaceID 1 Side Master
+// E 15 - InterfaceID 1 Side Master
+// E 16 - InterfaceID 1 Side Master
+// E 17 - InterfaceID 1 Side Master
+// E 18 - InterfaceID 1 Side Master
+// E 24 - InterfaceID 1 Side Master
+// E 25 - InterfaceID 1 Side Master
+// E 28 - InterfaceID 1 Side Slave Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 10 DNODE 2

--- a/tests/input_files/meshtying2D_structure.dat
+++ b/tests/input_files/meshtying2D_structure.dat
@@ -57,8 +57,8 @@ DLINE                           1
 E 6 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 1.0 0.0 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 TYPE Live
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
-E 2 - 1 Slave Active
-E 8 - 1 Master
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 8 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 60 DNODE 2

--- a/tests/input_files/meshtying2D_structure_crosspoints.dat
+++ b/tests/input_files/meshtying2D_structure_crosspoints.dat
@@ -68,18 +68,18 @@ DLINE                           1
 E 1 - NUMDOF 2 ONOFF 0 1 VAL 0 0 FUNCT none none
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           12
-E 3 - 1 Slave Active
-E 4 - 1 Master Inactive
-E 5 - 2 Slave Active
-E 6 - 2 Master Inactive
-E 7 - 3 Slave Active
-E 8 - 3 Master Inactive
-E 9 - 4 Slave Active
-E 10 - 4 Master Inactive
-E 11 - 5 Slave Active
-E 12 - 5 Master Inactive
-E 13 - 6 Slave Active
-E 14 - 6 Master Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Active
+E 4 - InterfaceID 1 Side Master Initialization Inactive
+E 5 - InterfaceID 2 Side Slave Initialization Active
+E 6 - InterfaceID 2 Side Master Initialization Inactive
+E 7 - InterfaceID 3 Side Slave Initialization Active
+E 8 - InterfaceID 3 Side Master Initialization Inactive
+E 9 - InterfaceID 4 Side Slave Initialization Active
+E 10 - InterfaceID 4 Side Master Initialization Inactive
+E 11 - InterfaceID 5 Side Slave Initialization Active
+E 12 - InterfaceID 5 Side Master Initialization Inactive
+E 13 - InterfaceID 6 Side Slave Initialization Active
+E 14 - InterfaceID 6 Side Master Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1662 DNODE 1
 ---------------------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/meshtying2D_structure_crosspoints_new_struct.dat
+++ b/tests/input_files/meshtying2D_structure_crosspoints_new_struct.dat
@@ -67,18 +67,18 @@ DLINE                           1
 E 1 - NUMDOF 2 ONOFF 0 1 VAL 0 0 FUNCT none none
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           12
-E 3 - 1 Slave Active
-E 4 - 1 Master Inactive
-E 5 - 2 Slave Active
-E 6 - 2 Master Inactive
-E 7 - 3 Slave Active
-E 8 - 3 Master Inactive
-E 9 - 4 Slave Active
-E 10 - 4 Master Inactive
-E 11 - 5 Slave Active
-E 12 - 5 Master Inactive
-E 13 - 6 Slave Active
-E 14 - 6 Master Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Active
+E 4 - InterfaceID 1 Side Master Initialization Inactive
+E 5 - InterfaceID 2 Side Slave Initialization Active
+E 6 - InterfaceID 2 Side Master Initialization Inactive
+E 7 - InterfaceID 3 Side Slave Initialization Active
+E 8 - InterfaceID 3 Side Master Initialization Inactive
+E 9 - InterfaceID 4 Side Slave Initialization Active
+E 10 - InterfaceID 4 Side Master Initialization Inactive
+E 11 - InterfaceID 5 Side Slave Initialization Active
+E 12 - InterfaceID 5 Side Master Initialization Inactive
+E 13 - InterfaceID 6 Side Slave Initialization Active
+E 14 - InterfaceID 6 Side Master Initialization Inactive
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1662 DNODE 1
 ---------------------------------------------------------DLINE-NODE TOPOLOGY

--- a/tests/input_files/meshtying2D_structure_new_struct.dat
+++ b/tests/input_files/meshtying2D_structure_new_struct.dat
@@ -57,8 +57,8 @@ DLINE                           1
 E 6 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 1.0 0.0 0.0 0.0 0.0 FUNCT 1 1 1 1 1 1 TYPE Live
 -----------------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
-E 2 - 1 Slave Active
-E 8 - 1 Master
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 8 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 60 DNODE 2

--- a/tests/input_files/meshtying3D_elebased.dat
+++ b/tests/input_files/meshtying3D_elebased.dat
@@ -77,8 +77,8 @@ DSURF  1
 E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave Active
-E 3 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    2 DLINE 1
 NODE    3 DLINE 1

--- a/tests/input_files/meshtying3D_elebased_new_struct.dat
+++ b/tests/input_files/meshtying3D_elebased_new_struct.dat
@@ -78,8 +78,8 @@ DSURF  1
 E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave Active
-E 3 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    2 DLINE 1
 NODE    3 DLINE 1

--- a/tests/input_files/meshtying3D_nts.dat
+++ b/tests/input_files/meshtying3D_nts.dat
@@ -77,8 +77,8 @@ DSURF  1
 E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave Active
-E 3 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    2 DLINE 1
 NODE    3 DLINE 1

--- a/tests/input_files/meshtying3D_nurbs_dual.dat
+++ b/tests/input_files/meshtying3D_nurbs_dual.dat
@@ -68,8 +68,8 @@ COMPONENT 0 SYMBOLIC_FUNCTION_OF_SPACE_TIME 2e-1
 COMPONENT 0 SYMBOLIC_FUNCTION_OF_SPACE_TIME 3e-1
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 5 - 1 Slave Active
-E 12 - 1 Master Inactive
+E 5 - InterfaceID 1 Side Slave Initialization Active
+E 12 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------------------------------DNODE-NODE TOPOLOGY
 //
 // structure: patch 1, (0,0,0)

--- a/tests/input_files/meshtying3D_patch_bound.dat
+++ b/tests/input_files/meshtying3D_patch_bound.dat
@@ -79,20 +79,20 @@ DSURF  1
 E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  14
-E 3 - 1 Slave Active
-E 4 - 1 Master Inactive
-E 5 - 2 Slave Active
-E 6 - 2 Master Inactive
-E 7 - 3 Slave Active
-E 8 - 3 Master Inactive
-E 9 - 4 Slave Active
-E 10 - 4 Master Inactive
-E 11 - 5 Slave Active
-E 12 - 5 Master Inactive
-E 13 - 6 Slave Active
-E 14 - 6 Master Inactive
-E 15 - 7 Slave Active
-E 16 - 7 Master Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Active
+E 4 - InterfaceID 1 Side Master Initialization Inactive
+E 5 - InterfaceID 2 Side Slave Initialization Active
+E 6 - InterfaceID 2 Side Master Initialization Inactive
+E 7 - InterfaceID 3 Side Slave Initialization Active
+E 8 - InterfaceID 3 Side Master Initialization Inactive
+E 9 - InterfaceID 4 Side Slave Initialization Active
+E 10 - InterfaceID 4 Side Master Initialization Inactive
+E 11 - InterfaceID 5 Side Slave Initialization Active
+E 12 - InterfaceID 5 Side Master Initialization Inactive
+E 13 - InterfaceID 6 Side Slave Initialization Active
+E 14 - InterfaceID 6 Side Master Initialization Inactive
+E 15 - InterfaceID 7 Side Slave Initialization Active
+E 16 - InterfaceID 7 Side Master Initialization Inactive
 -----------------------------DESIGN LINE MORTAR EDGE CONDITIONS 3D
 DLINE  1
 // edge

--- a/tests/input_files/meshtying3D_patch_lin_duallagr.dat
+++ b/tests/input_files/meshtying3D_patch_lin_duallagr.dat
@@ -89,8 +89,8 @@ E 8 - NUMDOF 3 ONOFF 0 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 9 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 2 - 1 Slave Active
-E 3 - 1 Master
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 3 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 42 DNODE 1

--- a/tests/input_files/meshtying3D_patch_lin_duallagr_new_struct.dat
+++ b/tests/input_files/meshtying3D_patch_lin_duallagr_new_struct.dat
@@ -90,8 +90,8 @@ E 8 - NUMDOF 3 ONOFF 0 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 9 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 2 - 1 Slave Active
-E 3 - 1 Master
+E 2 - InterfaceID 1 Side Slave Initialization Active
+E 3 - InterfaceID 1 Side Master
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 1 DNODE 1
 NODE 42 DNODE 1

--- a/tests/input_files/meshtying3D_sp_dual_simple.dat
+++ b/tests/input_files/meshtying3D_sp_dual_simple.dat
@@ -120,9 +120,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL -1.0 0.0 0.0 FUNCT 1 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive
+E 2 - InterfaceID 0 Side Master Initialization Inactive
 // contact_surf_small
-E 4 - 0 Slave Active
+E 4 - InterfaceID 0 Side Slave Initialization Active
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/meshtying3D_sp_ost.dat
+++ b/tests/input_files/meshtying3D_sp_ost.dat
@@ -61,9 +61,9 @@ COMPONENT 2 SYMBOLIC_FUNCTION_OF_SPACE_TIME y
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
 //                              top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 //                              bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------DESIGN VOL INITIAL FIELD CONDITIONS
 DVOL   1
 E 1 - FIELD Velocity FUNCT 2

--- a/tests/input_files/meshtying3D_sp_ost_new_struct.dat
+++ b/tests/input_files/meshtying3D_sp_ost_new_struct.dat
@@ -62,9 +62,9 @@ COMPONENT 2 SYMBOLIC_FUNCTION_OF_SPACE_TIME y
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
 //                              top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 //                              bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------DESIGN VOL INITIAL FIELD CONDITIONS
 DVOL   1
 E 1 - FIELD Velocity FUNCT 2

--- a/tests/input_files/meshtying3D_sp_std_braess_sarazin.dat
+++ b/tests/input_files/meshtying3D_sp_std_braess_sarazin.dat
@@ -118,9 +118,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL -1.0 0.0 0.0 FUNCT 1 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive
+E 2 - InterfaceID 0 Side Master Initialization Inactive
 // contact_surf_small
-E 4 - 0 Slave Active
+E 4 - InterfaceID 0 Side Slave Initialization Active
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/meshtying3D_sp_std_simple.dat
+++ b/tests/input_files/meshtying3D_sp_std_simple.dat
@@ -120,9 +120,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL -1.0 0.0 0.0 FUNCT 1 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive
+E 2 - InterfaceID 0 Side Master Initialization Inactive
 // contact_surf_small
-E 4 - 0 Slave Active
+E 4 - InterfaceID 0 Side Slave Initialization Active
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/meshtying3D_sp_std_uzawa.dat
+++ b/tests/input_files/meshtying3D_sp_std_uzawa.dat
@@ -120,9 +120,9 @@ E 3 - NUMDOF 3 ONOFF 1 1 1 VAL -1.0 0.0 0.0 FUNCT 1 0 0
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // contact_surf_large
-E 2 - 0 Master Inactive
+E 2 - InterfaceID 0 Side Master Initialization Inactive
 // contact_surf_small
-E 4 - 0 Slave Active
+E 4 - InterfaceID 0 Side Slave Initialization Active
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_duallagr.dat
+++ b/tests/input_files/meshtying3D_structure_duallagr.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_duallagr_binning.dat
+++ b/tests/input_files/meshtying3D_structure_duallagr_binning.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_duallagr_new_struct_condensed_redist_none.dat
+++ b/tests/input_files/meshtying3D_structure_duallagr_new_struct_condensed_redist_none.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_duallagr_new_struct_condensed_redist_static.dat
+++ b/tests/input_files/meshtying3D_structure_duallagr_new_struct_condensed_redist_static.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_duallagr_new_struct_saddlepoint_redist_none.dat
+++ b/tests/input_files/meshtying3D_structure_duallagr_new_struct_saddlepoint_redist_none.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_duallagr_new_struct_saddlepoint_redist_static.dat
+++ b/tests/input_files/meshtying3D_structure_duallagr_new_struct_saddlepoint_redist_static.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_penalty_redist_none.dat
+++ b/tests/input_files/meshtying3D_structure_penalty_redist_none.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_penalty_redist_static.dat
+++ b/tests/input_files/meshtying3D_structure_penalty_redist_static.dat
@@ -68,8 +68,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_quad_const.dat
+++ b/tests/input_files/meshtying3D_structure_quad_const.dat
@@ -62,9 +62,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 // bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    344 DSURFACE 1
 NODE    347 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_quad_const_new_struct.dat
+++ b/tests/input_files/meshtying3D_structure_quad_const_new_struct.dat
@@ -60,9 +60,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 // bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    344 DSURFACE 1
 NODE    347 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_quad_lin.dat
+++ b/tests/input_files/meshtying3D_structure_quad_lin.dat
@@ -63,9 +63,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 // bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    344 DSURFACE 1
 NODE    347 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_quad_lin_new_struct.dat
+++ b/tests/input_files/meshtying3D_structure_quad_lin_new_struct.dat
@@ -60,9 +60,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 // bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    344 DSURFACE 1
 NODE    347 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_simpler.dat
+++ b/tests/input_files/meshtying3D_structure_simpler.dat
@@ -80,8 +80,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_simpler_new_struct.dat
+++ b/tests/input_files/meshtying3D_structure_simpler_new_struct.dat
@@ -81,8 +81,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_stdlagr.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_initial.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_initial.dat
@@ -63,8 +63,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 2.0 2.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_no.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_no.dat
@@ -63,8 +63,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 2.0 2.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_stdlagr_new_struct.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_new_struct.dat
@@ -67,8 +67,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_initial.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_initial.dat
@@ -64,8 +64,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 2.0 2.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_no.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_no.dat
@@ -64,8 +64,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 2.0 2.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_tet10.dat
+++ b/tests/input_files/meshtying3D_structure_tet10.dat
@@ -64,8 +64,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 360 DSURFACE 1
 NODE 365 DSURFACE 1

--- a/tests/input_files/meshtying3D_structure_uzawa.dat
+++ b/tests/input_files/meshtying3D_structure_uzawa.dat
@@ -66,8 +66,8 @@ E 1 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 1.0 FUNCT 1 1 1
 -----------------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF                           2
-E 3 - 1 Master Inactive
-E 4 - 1 Slave Active
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 1 Side Slave Initialization Active
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 1 DSURFACE 1
 NODE 2 DSURFACE 1

--- a/tests/input_files/old_solid_ele_contact3D_nitsche_hex8_skew_segm_new_struct.dat
+++ b/tests/input_files/old_solid_ele_contact3D_nitsche_hex8_skew_segm_new_struct.dat
@@ -74,9 +74,9 @@ E 2 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // c_twist
-E 3 - 1 Slave Inactive
+E 3 - InterfaceID 1 Side Slave Initialization Inactive
 // c_block
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    84 DSURFACE 1
 NODE    85 DSURFACE 1

--- a/tests/input_files/old_solid_ele_contact3D_unbiased_self_hex8_nitsche_new_struct.dat
+++ b/tests/input_files/old_solid_ele_contact3D_unbiased_self_hex8_nitsche_new_struct.dat
@@ -99,9 +99,9 @@ E 4 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT none none none
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // cyl_side_of_cyl-bl_interface
-E 5 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 5 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 // block_side_of_cyl-bl_interface
-E 6 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 6 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // lines_mrtr_sym_normal_z

--- a/tests/input_files/old_solid_ele_contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
+++ b/tests/input_files/old_solid_ele_contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
@@ -98,9 +98,9 @@ E 4 - NUMDOF 3 ONOFF 0 0 1 VAL 0.0 0.0 0.0 FUNCT none none none
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // cyl_side_of_cyl-bl_interface
-E 5 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 5 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 // block_side_of_cyl-bl_interface
-E 6 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
+E 6 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 1
 -------------------------DESIGN LINE MORTAR SYMMETRY CONDITIONS 3D
 DLINE  2
 // lines_mrtr_sym_normal_z

--- a/tests/input_files/poro_2D_contact_closed_bound.dat
+++ b/tests/input_files/poro_2D_contact_closed_bound.dat
@@ -166,9 +166,9 @@ E 4 - NUMDOF 3 ONOFF 0 1 0 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // solid_contact_interface
-E 1 - 1 Slave Inactive FrCoeffOrBound 0.3
+E 1 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.3
 // poro_contact_interface
-E 2 - 1 Master Inactive FrCoeffOrBound 0.3
+E 2 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.3
 -----------------------------DESIGN SURFACE POROCOUPLING CONDITION
 DSURF  1
 // poro

--- a/tests/input_files/poro_2D_quad4_meshtying.dat
+++ b/tests/input_files/poro_2D_quad4_meshtying.dat
@@ -154,9 +154,9 @@ E 8 - NUMDOF 2 ONOFF 0 1 VAL 0.0 0.0 FUNCT 0 0
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // bottom_line
-E 4 - 1 Master
+E 4 - InterfaceID 1 Side Master
 // top_line_bottom
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 -----------------------------DESIGN SURFACE POROCOUPLING CONDITION
 DSURF  2
 // surf

--- a/tests/input_files/poro_2D_quad4_poroporocontact.dat
+++ b/tests/input_files/poro_2D_quad4_poroporocontact.dat
@@ -281,9 +281,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 0 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // edge_semicircle
-E 1 - 1 Slave Inactive FrCoeffOrBound 0.3
+E 1 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.3
 // top_line
-E 3 - 1 Master Inactive FrCoeffOrBound 0.3
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.3
 -----------------------------DESIGN SURFACE POROCOUPLING CONDITION
 DSURF  2
 // semicircle

--- a/tests/input_files/poro_2D_quad4_porosolid_mt_patchtest.dat
+++ b/tests/input_files/poro_2D_quad4_porosolid_mt_patchtest.dat
@@ -148,9 +148,9 @@ E 8 - NUMDOF 2 ONOFF 0 1 VAL 0.0 0.0 FUNCT 0 0
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE  2
 // bottom_line
-E 4 - 1 Master
+E 4 - InterfaceID 1 Side Master
 // top_line_bottom
-E 5 - 1 Slave Active
+E 5 - InterfaceID 1 Side Slave Initialization Active
 -----------------------------DESIGN SURFACE POROCOUPLING CONDITION
 DSURF  1
 // surf

--- a/tests/input_files/poro_new_solid_nitsche_contact3D_twoelem.dat
+++ b/tests/input_files/poro_new_solid_nitsche_contact3D_twoelem.dat
@@ -211,9 +211,9 @@ E 5 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 1 Slave
+E 2 - InterfaceID 1 Side Slave
 // s_contact
-E 3 - 1 Master
+E 3 - InterfaceID 1 Side Master
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/poro_scatra_contact3D_two_cubes.dat
+++ b/tests/input_files/poro_scatra_contact3D_two_cubes.dat
@@ -228,8 +228,8 @@ DSURF  1
 E 5 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
-E 2 - 1 Slave Inactive
-E 3 - 1 Master Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------------DESIGN VOL TRANSPORT DIRICH CONDITIONS
 DVOL                           1
 E 2 - NUMDOF 1 ONOFF 1 VAL 1.0 FUNCT 0

--- a/tests/input_files/poro_solid_contact3D_twoelem.dat
+++ b/tests/input_files/poro_solid_contact3D_twoelem.dat
@@ -210,9 +210,9 @@ E 5 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.3
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.3
 // s_contact
-E 3 - 1 Master Inactive FrCoeffOrBound 0.3
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.3
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/poro_solid_contact3D_twoelem_wonopen.dat
+++ b/tests/input_files/poro_solid_contact3D_twoelem_wonopen.dat
@@ -209,9 +209,9 @@ E 5 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 1 Slave Inactive FrCoeffOrBound 0.3
+E 2 - InterfaceID 1 Side Slave Initialization Inactive FrCoeffOrBound 0.3
 // s_contact
-E 3 - 1 Master Inactive FrCoeffOrBound 0.3
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.3
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem.dat
@@ -211,9 +211,9 @@ E 5 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 1 Slave
+E 2 - InterfaceID 1 Side Slave
 // s_contact
-E 3 - 1 Master
+E 3 - InterfaceID 1 Side Master
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem_twosided.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem_twosided.dat
@@ -217,9 +217,9 @@ E 2 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 1 Master
+E 2 - InterfaceID 1 Side Master
 // s_contact
-E 3 - 1 Slave
+E 3 - InterfaceID 1 Side Slave
 ---------------------------DESIGN SURFACE PORO PARTIAL INTEGRATION
 DSURF 1
 // all

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem_wonopen.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem_wonopen.dat
@@ -212,9 +212,9 @@ E 5 -
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 1 Slave
+E 2 - InterfaceID 1 Side Slave
 // s_contact
-E 3 - 1 Master
+E 3 - InterfaceID 1 Side Master
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    1 DSURFACE 1
 NODE    2 DSURFACE 1

--- a/tests/input_files/roughcontact2d_brokenrational_patchtest.dat
+++ b/tests/input_files/roughcontact2d_brokenrational_patchtest.dat
@@ -78,9 +78,9 @@ E 6 - NUMDOF 2 ONOFF 0 1 VAL 0.0 1.0 FUNCT 0 1
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // bottomcontact
-E 1 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 1 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 // topcontact
-E 2 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 2 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 -----------------------------------------------DNODE-NODE TOPOLOGY
 NODE    21 DNODE 1
 NODE    242 DNODE 2

--- a/tests/input_files/roughcontact2d_mirco_patchtest.dat
+++ b/tests/input_files/roughcontact2d_mirco_patchtest.dat
@@ -81,9 +81,9 @@ E 6 - NUMDOF 2 ONOFF 0 1 VAL 0.0 1.0 FUNCT 0 1
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // bottom_contact
-E 3 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 3 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 // top_contact
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    73 DLINE 1
 NODE    74 DLINE 1

--- a/tests/input_files/roughcontact2d_mirco_varying_roughness.dat
+++ b/tests/input_files/roughcontact2d_mirco_varying_roughness.dat
@@ -81,9 +81,9 @@ E 6 - NUMDOF 2 ONOFF 0 1 VAL 0.0 1.0 FUNCT 0 1
 --------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE  2
 // bottom_contact
-E 3 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 3 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 // top_contact
-E 4 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 4 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE    73 DLINE 1
 NODE    74 DLINE 1

--- a/tests/input_files/roughcontact3d_lin.dat
+++ b/tests/input_files/roughcontact3d_lin.dat
@@ -74,8 +74,8 @@ DSURF                           1
 E 12 - NUMDOF 3 ONOFF 1 1 1 VAL 1.0 1.0 -1.0 FUNCT 1 1 2
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
-E 6 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
-E 7 - 0 Slave Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 6 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 7 - InterfaceID 0 Side Slave Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 249 DNODE 1
 NODE 175 DNODE 2

--- a/tests/input_files/roughcontact3d_multipatch.dat
+++ b/tests/input_files/roughcontact3d_multipatch.dat
@@ -59,13 +59,13 @@ E 6 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  4
 // master_left
-E 1 - 0 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 1 - InterfaceID 0 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 // master_right
-E 2 - 1 Master Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 2
+E 2 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 2
 // slave_left
-E 3 - 0 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
+E 3 - InterfaceID 0 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 1
 // slave_right
-E 4 - 1 Slave Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 2
+E 4 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 0 RefConfCheckNonSmoothSelfContactSurface 0.0 ConstitutiveLawID 2
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    157 DSURFACE 1
 NODE    158 DSURFACE 1

--- a/tests/input_files/scatra_NonMatchingMesh_20x80_linear_bmat_merged.dat
+++ b/tests/input_files/scatra_NonMatchingMesh_20x80_linear_bmat_merged.dat
@@ -71,9 +71,9 @@ E 2 - NUMDOF 1 ONOFF 1 VAL 0.9 FUNCT 0
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
 // left internal boundary
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // right internal boundary
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE 1 DLINE 1
 NODE 2 DLINE 1

--- a/tests/input_files/scatra_NonMatchingMesh_20x80_smat.dat
+++ b/tests/input_files/scatra_NonMatchingMesh_20x80_smat.dat
@@ -71,9 +71,9 @@ E 2 - NUMDOF 1 ONOFF 1 VAL 0.9 FUNCT 0
 -------------------------DESIGN LINE MORTAR COUPLING CONDITIONS 2D
 DLINE                           2
 // left internal boundary
-E 5 - 1 Master
+E 5 - InterfaceID 1 Side Master
 // right internal boundary
-E 6 - 1 Slave
+E 6 - InterfaceID 1 Side Slave
 -----------------------------------------------DLINE-NODE TOPOLOGY
 NODE 1 DLINE 1
 NODE 2 DLINE 1

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
@@ -104,9 +104,9 @@ E 3 - 0 Master S2I_KINETICS_ID 1 CONTACT_CONDITION_ID 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // left_block_side_of_interface
-E 2 - 1 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
 // right_block_side_of_interface
-E 3 - 1 Master Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  2
 // left_block_side_of_interface

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_2x2.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_2x2.dat
@@ -109,9 +109,9 @@ E 3 - 0 Master S2I_KINETICS_ID 1 CONTACT_CONDITION_ID 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // left_block_side_of_interface
-E 2 - 1 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
 // right_block_side_of_interface
-E 3 - 1 Master Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  2
 // left_block_side_of_interface

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_3x3.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_3x3.dat
@@ -119,9 +119,9 @@ E 3 - 0 Master S2I_KINETICS_ID 1 CONTACT_CONDITION_ID 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // left_block_side_of_interface
-E 2 - 1 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
 // right_block_side_of_interface
-E 3 - 1 Master Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  2
 // left_block_side_of_interface

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
@@ -104,9 +104,9 @@ E 3 - 0 Master S2I_KINETICS_ID 1 CONTACT_CONDITION_ID 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // left_block_side_of_interface
-E 2 - 1 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
 // right_block_side_of_interface
-E 3 - 1 Master Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  2
 // left_block_side_of_interface

--- a/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_and_meshtying_elch_s2i_butlervolmer.dat
+++ b/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_and_meshtying_elch_s2i_butlervolmer.dat
@@ -160,8 +160,8 @@ E 2 - FIELD ScaTra FUNCT 2
 E 3 - FIELD ScaTra FUNCT 3
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
-E 4 - 1 Master Inactive
-E 5 - 1 Slave Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
+E 5 - InterfaceID 1 Side Slave Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  4
 E 2 - 0 Slave KINETIC_MODEL Butler-VolmerReduced NUMSCAL 1 STOICHIOMETRIES -1  E- 1  K_R  1.036426957e-3 ALPHA_A 0.5 ALPHA_C 0.5 IS_PSEUDO_CONTACT False

--- a/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
+++ b/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
@@ -157,10 +157,10 @@ E 2 - FIELD ScaTra FUNCT 2
 E 3 - FIELD ScaTra FUNCT 3
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  4
-E 2 - 1 Slave Inactive
-E 3 - 1 Master Inactive
-E 4 - 2 Master Inactive
-E 5 - 2 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
+E 4 - InterfaceID 2 Side Master Initialization Inactive
+E 5 - InterfaceID 2 Side Slave Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  4
 E 2 - 1 Slave KINETIC_MODEL Butler-VolmerReduced NUMSCAL 1 STOICHIOMETRIES -1  E- 1  K_R  1.0e-3 ALPHA_A 0.5 ALPHA_C 0.5 IS_PSEUDO_CONTACT False

--- a/tests/input_files/ssi_mono_3D_3blocks_nitsche_unbiased_selfcontact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
+++ b/tests/input_files/ssi_mono_3D_3blocks_nitsche_unbiased_selfcontact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
@@ -160,10 +160,10 @@ E 2 - FIELD ScaTra FUNCT 2
 E 3 - FIELD ScaTra FUNCT 3
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  4
-E 2 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
-E 3 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
-E 4 - 1 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
-E 5 - 1 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 2 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 3 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 4 - InterfaceID 1 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 5 - InterfaceID 1 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  4
 E 2 - 0 Slave KINETIC_MODEL Butler-VolmerReduced NUMSCAL 1 STOICHIOMETRIES -1  E- 1  K_R  1.0e-3 ALPHA_A 0.5 ALPHA_C 0.5 IS_PSEUDO_CONTACT False

--- a/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
+++ b/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
@@ -108,9 +108,9 @@ E 3 - 0 Master S2I_KINETICS_ID 1 CONTACT_CONDITION_ID 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // left_block_side_of_interface
-E 2 - 1 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
 // right_block_side_of_interface
-E 3 - 1 Master Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  2
 // left_block_side_of_interface

--- a/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
+++ b/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
@@ -108,9 +108,9 @@ E 3 - 0 Master S2I_KINETICS_ID 1 CONTACT_CONDITION_ID 1
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // left_block_side_of_interface
-E 2 - 1 Slave Inactive
+E 2 - InterfaceID 1 Side Slave Initialization Inactive
 // right_block_side_of_interface
-E 3 - 1 Master Inactive
+E 3 - InterfaceID 1 Side Master Initialization Inactive
 -------------------------------DESIGN S2I KINETICS SURF CONDITIONS
 DSURF  2
 // left_block_side_of_interface

--- a/tests/input_files/thermo3D_meshtying_nurbs.dat
+++ b/tests/input_files/thermo3D_meshtying_nurbs.dat
@@ -62,8 +62,8 @@ DVOL 1
 E 1 - NUMDOF 1 ONOFF 1 VAL 1 FUNCT 1
 -------------------------DESIGN SURF MORTAR COUPLING CONDITIONS 3D
 DSURF  2
-E 5 - 1 Slave Active
-E 12 - 1 Master Inactive
+E 5 - InterfaceID 1 Side Slave Initialization Active
+E 12 - InterfaceID 1 Side Master Initialization Inactive
 --------------------------------------------------------FUNCT1
 COMPONENT 0 SYMBOLIC_FUNCTION_OF_SPACE_TIME x+10*x*y+y*y
 -------------------------------------------------------DNODE-NODE TOPOLOGY

--- a/tests/input_files/tsi_contact3D_conduction.dat
+++ b/tests/input_files/tsi_contact3D_conduction.dat
@@ -115,9 +115,9 @@ E 2 - NUMDOF 1 ONOFF 1 VAL 20 FUNCT 0
 --------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // top_contact
-E 3 - 1 Slave Active
+E 3 - InterfaceID 1 Side Slave Initialization Active
 // bottom_contact
-E 4 - 1 Master Inactive
+E 4 - InterfaceID 1 Side Master Initialization Inactive
 -----------------------------------------------DSURF-NODE TOPOLOGY
 NODE    65 DSURFACE 1
 NODE    68 DSURFACE 1

--- a/tests/input_files/tsi_meshtying_nurbs.dat
+++ b/tests/input_files/tsi_meshtying_nurbs.dat
@@ -108,8 +108,8 @@ DSURF                           1
 E 6 - NUMDOF 1 ONOFF 1 VAL 1 FUNCT 1
 -------------------------DESIGN SURF MORTAR MULTI-COUPLING CONDITIONS 3D
 DSURF  2
-E 5 - 1 Slave Active
-E 12 - 1 Master Inactive
+E 5 - InterfaceID 1 Side Slave Initialization Active
+E 12 - InterfaceID 1 Side Master Initialization Inactive
 --------------------------------------------------------FUNCT1
 COMPONENT 0 SYMBOLIC_FUNCTION_OF_SPACE_TIME x+10*x*y+y*y
 --------------------------------------------------------FUNCT2

--- a/tests/input_files/wear2D_modgap.dat
+++ b/tests/input_files/wear2D_modgap.dat
@@ -92,8 +92,8 @@ DSURF                           1
 E 1 - NUMDOF 6 ONOFF 0 1 0 0 0 0 VAL 0.0 -10 0.0 0.0 0.0 0.0 FUNCT 0 0 0 0 0 0 TYPE Live
 -----------------------------------DESIGN LINE MORTAR CONTACT CONDITIONS 2D
 DLINE                           2
-E 1 - 1 Slave Active FrCoeffOrBound 0.1
-E 7 - 1 Master Inactive FrCoeffOrBound 0.1
+E 1 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.1
+E 7 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.1
 ---------------------------------------------------------DNODE-NODE TOPOLOGY
 NODE 415 DNODE 1
 NODE 343 DNODE 2

--- a/tests/input_files/wear3D_modgap.dat
+++ b/tests/input_files/wear3D_modgap.dat
@@ -76,9 +76,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 0.0 FUNCT 0 0 0
 -----------------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF                           2
 //                              slave
-E 2 - 1 Slave Active FrCoeffOrBound 0.2
+E 2 - InterfaceID 1 Side Slave Initialization Active FrCoeffOrBound 0.2
 //                              master
-E 3 - 1 Master Inactive FrCoeffOrBound 0.2
+E 3 - InterfaceID 1 Side Master Initialization Inactive FrCoeffOrBound 0.2
 ---------------------------------------------------------DSURF-NODE TOPOLOGY
 NODE 3 DSURFACE 1
 NODE 4 DSURFACE 1

--- a/tests/input_files/xfpsci_twoelem_pp.dat
+++ b/tests/input_files/xfpsci_twoelem_pp.dat
@@ -211,9 +211,9 @@ E 2 -
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 2 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 // s_contact
-E 3 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 3 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 ------------------------DESIGN XFEM FPI MONOLITHIC SURF CONDITIONS
 DSURF  2
 // all solid red

--- a/tests/input_files/xfpsci_twoelem_ps.dat
+++ b/tests/input_files/xfpsci_twoelem_ps.dat
@@ -210,9 +210,9 @@ E 1 -
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 2 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 // s_contact
-E 3 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 3 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 ------------------------DESIGN XFEM FSI MONOLITHIC SURF CONDITIONS
 DSURF  1
 // all solid red

--- a/tests/input_files/xfsci_twoelem.dat
+++ b/tests/input_files/xfsci_twoelem.dat
@@ -175,9 +175,9 @@ E 4 - NUMDOF 3 ONOFF 1 1 1 VAL 0.0 0.0 -1.0 FUNCT 0 0 1
 -------------------------DESIGN SURF MORTAR CONTACT CONDITIONS 3D
 DSURF  2
 // zp
-E 2 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 2 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 // s_contact
-E 3 - 0 Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Solidcontact DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
+E 3 - InterfaceID 0 Side Selfcontact Inactive FrCoeffOrBound 0.0 AdhesionBound 0.0 Application Solidcontact DbcHandling DoNothing TwoHalfPass 1 RefConfCheckNonSmoothSelfContactSurface 0
 ------------------------DESIGN XFEM FSI MONOLITHIC SURF CONDITIONS
 DSURF  2
 // all solid red


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
This PR adds separators to all conditions in `4C_inpar_mortar.cpp` and another coupling condition in `4C_inpar_ehl.cpp`.
See https://github.com/4C-multiphysics/4C/pull/224 for a detailed explanation.

## Related Issues and Merge Requests
Follows https://github.com/4C-multiphysics/4C/pull/224
Follows https://github.com/4C-multiphysics/4C/pull/238
Part of https://github.com/4C-multiphysics/4C/issues/73