### PR TITLE
Reuse ccache from clang18_build for clang18_install_test

### DIFF
--- a/.github/actions/build_4C/action.yml
+++ b/.github/actions/build_4C/action.yml
@@ -15,21 +15,35 @@ inputs:
     description: Use ccache to speed up the build
     required: false
     default: "true"
+  cache-key:
+    description: Key to restore the cache for ccache (default <job-name>-<preset-name>)
+    required: false
+    default: ""
   additional-cmake-flags:
     description: Additional flags to pass to CMake
     required: false
     default: ""
+outputs:
+  cache-key:
+    description: Key to restore the cache for ccache
+    value: ${{ steps.prepare-cache-key.outputs.cache_key }}
 runs:
   using: composite
   steps:
     - shell: bash
       if: ${{ inputs.use-ccache == 'true' }}
       run: apt-get update
+    - name: Prepare ccache cache key
+      id: prepare-cache-key
+      shell: bash
+      run: |
+        CACHE_KEY=${{ inputs.cache-key == '' && format('{0}-{1}', github.job, inputs.cmake-preset) || inputs.cache-key }}
+        echo "cache_key=$CACHE_KEY" >> $GITHUB_OUTPUT
     - name: Setup ccache
       if: ${{ inputs.use-ccache == 'true' }}
       uses: hendrikmuhs/ccache-action@v1.2
       with:
-        key: ${{ github.job }}-${{ inputs.cmake-preset }}
+        key: ${{ steps.prepare-cache-key.outputs.cache_key }}
     - uses: ./.github/actions/configure_4C
       with:
         cmake-preset: ${{ inputs.cmake-preset }}

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -106,6 +106,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    outputs:
+      cache-key: ${{ steps.build-4C.outputs.cache-key }}
     steps:
       # Due to a bug in runner action the variables $GITHUB_WORKSPACE and ${{ github.workspace }} are different inside a container. https://github.com/actions/runner/issues/2058
       # The repo gets cloned to `/__w/4C/4C` ($GITHUB_WORKSPACE) while ${{ github.workspace }} points to `/home/runner/work/4C/4C`.`
@@ -114,6 +116,7 @@ jobs:
       - name: Check docker hash
         uses: ./.github/actions/compute-and-check-dependencies-hash
       - uses: ./.github/actions/build_4C
+        id: build-4C
         with:
           cmake-preset: docker_clang
           build-targets: full
@@ -166,15 +169,13 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           git config --global --add safe.directory $GITHUB_WORKSPACE
-      - uses: ./.github/actions/download_4C_build
-        with:
-          build-job: clang18_build
       - uses: ./.github/actions/build_4C
         with:
           cmake-preset: docker_clang
           build-targets: install
           build-directory: ${{ github.workspace }}/build
           use-ccache: "true"
+          cache-key: ${{needs.clang18_build.outputs.cache-key}}
       - name: Test the installation
         run: |
           cd $GITHUB_WORKSPACE/build/tests/install_test


### PR DESCRIPTION
We only have limited amount of storage available for our cache. Since we build clang18 anyway in the stage before, we can reuse the cache from that stage and don't need our own.

fyi @vryy