### PR TITLE
Remove fortran_style option from LineComponent (+ some small clean ups related to input)

### DIFF
--- a/src/adapter/4C_adapter_coupling_nonlin_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_nonlin_mortar.cpp
@@ -616,9 +616,7 @@ void Adapter::CouplingNonLinMortar::setup_spring_dashpot(
   // find master surface: loop all coupling conditions
   for (int i = 0; i < n_coup_conds; i++)
   {
-    // add one, since read in of COUPLING parameter in DESIGN SURF SPRING DASHPOT CONDITIONS
-    // subtracts one
-    if (coup_conds[i]->parameters().get<int>("COUPLING") == (coupling_id + 1))
+    if (coup_conds[i]->parameters().get<int>("COUPLING") == (coupling_id))
       conds_master.push_back(coup_conds[i]);
   }
   if (!conds_master.size()) FOUR_C_THROW("Coupling ID not found.");

--- a/src/art_net/4C_art_net_art_terminal_bc.cpp
+++ b/src/art_net/4C_art_net_art_terminal_bc.cpp
@@ -79,10 +79,10 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     else if (Type == "forced")  // => with Reflection
     {
       // If forced curve exists => Rf = curve
-      if (curve[1] >= 0)
+      if (curve[1] > 0)
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1] - 1)
                        .evaluate(time);
         Rf = vals[1] * curvefac;
       }
@@ -106,10 +106,10 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     // -----------------------------------------------------------------
     // Read in the value of the applied BC
     // -----------------------------------------------------------------
-    if (curve[0] >= 0)
+    if (curve[0] > 0)
     {
       curvefac = Global::Problem::instance()
-                     ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
+                     ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
                      .evaluate(time);
       BCin = vals[0] * curvefac;
     }
@@ -550,12 +550,12 @@ void Arteries::Utils::solve_reflective_terminal(Core::FE::Discretization& actdis
   const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 
   // if the curve exist => Rf = val*curve(time)
-  if (curve[0] >= 0)
+  if (curve[0] > 0)
   {
     double time = params.get<double>("total time");
-    curvefac =
-        Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(curve[0]).evaluate(
-            time);
+    curvefac = Global::Problem::instance()
+                   ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                   .evaluate(time);
     Rf = vals[0] * curvefac;
   }
   // else Rf = val

--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
@@ -1505,7 +1505,7 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate_scatra_bc(Artery*
       if (curvenum > 0)
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
       }
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_arterialproxdist.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_arterialproxdist.cpp
@@ -114,10 +114,11 @@ void Utils::Cardiovascular0DArterialProxDist::evaluate(Teuchos::ParameterList& p
     const int curvenum = cardiovascular0dcond_[condID]->parameters().get<int>("p_at_crv");
     double curvefac_np = 1.0;
 
-    if (curvenum >= 0 && usetime)
+    if (curvenum > 0 && usetime)
     {
+      // function_by_id takes a zero based index
       curvefac_np = Global::Problem::instance()
-                        ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                        ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                         .evaluate(tim);
     }
 

--- a/src/constraint/4C_constraint.cpp
+++ b/src/constraint/4C_constraint.cpp
@@ -41,17 +41,10 @@ CONSTRAINTS::Constraint::Constraint(std::shared_ptr<Core::FE::Discretization> di
         minID = condID;
       }
 
-      auto* const myinittime = i->parameters().get_if<double>("activeTime");
-      if (myinittime)
-      {
-        inittimes_.insert(std::pair<int, double>(condID, *myinittime));
-        activecons_.insert(std::pair<int, bool>(condID, false));
-      }
-      else
-      {
-        inittimes_.insert(std::pair<int, double>(condID, 0.0));
-        activecons_.insert(std::pair<int, bool>(condID, false));
-      }
+      auto const myinittime = i->parameters().get<double>("activeTime");
+
+      inittimes_.insert(std::pair<int, double>(condID, myinittime));
+      activecons_.insert(std::pair<int, bool>(condID, false));
     }
   }
   else
@@ -76,17 +69,10 @@ CONSTRAINTS::Constraint::Constraint(
     for (auto& i : constrcond_)
     {
       int condID = i->parameters().get<int>("ConditionID");
-      auto* const myinittime = i->parameters().get_if<double>("activeTime");
-      if (myinittime)
-      {
-        inittimes_.insert(std::pair<int, double>(condID, *myinittime));
-        activecons_.insert(std::pair<int, bool>(condID, false));
-      }
-      else
-      {
-        inittimes_.insert(std::pair<int, double>(condID, 0.0));
-        activecons_.insert(std::pair<int, bool>(condID, false));
-      }
+      auto const myinittime = i->parameters().get<double>("activeTime");
+
+      inittimes_.insert(std::pair<int, double>(condID, myinittime));
+      activecons_.insert(std::pair<int, bool>(condID, false));
     }
   }
   else
@@ -254,9 +240,7 @@ void CONSTRAINTS::Constraint::evaluate_constraint(Teuchos::ParameterList& params
       }
 
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
-      const auto* curve = cond->parameters().get_if<int>("curve");
-      int curvenum = -1;
-      if (curve) curvenum = *curve;
+      const int curvenum = cond->parameters().get_or<int>("curve", -1);
       double curvefac = 1.0;
       if (curvenum >= 0)
         curvefac = Global::Problem::instance()

--- a/src/constraint/4C_constraint.cpp
+++ b/src/constraint/4C_constraint.cpp
@@ -242,10 +242,13 @@ void CONSTRAINTS::Constraint::evaluate_constraint(Teuchos::ParameterList& params
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
       const int curvenum = cond->parameters().get_or<int>("curve", -1);
       double curvefac = 1.0;
-      if (curvenum >= 0)
+      if (curvenum > 0)
+      {
+        // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
+      }
 
       // global and local ID of this bc in the redundant vectors
       const int offsetID = params.get<int>("OffsetID");

--- a/src/constraint/4C_constraint_multipointconstraint2.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint2.cpp
@@ -369,16 +369,18 @@ void CONSTRAINTS::MPConstraint2::evaluate_constraint(std::shared_ptr<Core::FE::D
       }
 
       // Load curve business
-      const auto* curve = cond.parameters().get_if<int>("curve");
-      int curvenum = -1;
-      if (curve) curvenum = *curve;
+      const int curvenum = cond.parameters().get_or<int>("curve", -1);
       double curvefac = 1.0;
       bool usetime = true;
       if (time < 0.0) usetime = false;
-      if (curvenum >= 0 && usetime)
+      if (curvenum > 0 && usetime)
+      {
+        // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
+      }
+
       std::shared_ptr<Core::LinAlg::Vector<double>> timefact =
           params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("vector curve factors");
       timefact->ReplaceGlobalValues(1, &curvefac, &gindex);

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -456,16 +456,18 @@ void CONSTRAINTS::MPConstraint3::evaluate_constraint(std::shared_ptr<Core::FE::D
       }
 
       // loadcurve business
-      const auto* curve = cond->parameters().get_if<int>("curve");
-      int curvenum = -1;
-      if (curve) curvenum = (*curve);
+      const int curvenum = cond->parameters().get_or<int>("curve", -1);
       double curvefac = 1.0;
       bool usetime = true;
       if (time < 0.0) usetime = false;
-      if (curvenum >= 0 && usetime)
+      if (curvenum > 0 && usetime)
+      {
+        // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
+      }
+
       std::shared_ptr<Core::LinAlg::Vector<double>> timefact =
           params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("vector curve factors");
       timefact->ReplaceGlobalValues(1, &curvefac, &gindex);
@@ -533,16 +535,17 @@ void CONSTRAINTS::MPConstraint3::initialize_constraint(Core::FE::Discretization&
     Core::LinAlg::assemble(systemvector, elevector3, constrlm, constrowner);
 
     // loadcurve business
-    const auto* curve = cond->parameters().get_if<int>("curve");
-    int curvenum = -1;
-    if (curve) curvenum = (*curve);
+    const int curvenum = cond->parameters().get_or<int>("curve", -1);
     double curvefac = 1.0;
     bool usetime = true;
     if (time < 0.0) usetime = false;
-    if (curvenum >= 0 && usetime)
+    if (curvenum > 0 && usetime)
+    {
+      // function_by_id takes a zero-based index
       curvefac = Global::Problem::instance()
-                     ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                     ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                      .evaluate(time);
+    }
 
     // Get ConditionID of current condition if defined and write value in parameterlist
     constexpr unsigned character_length = 30;

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -411,16 +411,17 @@ void CONSTRAINTS::MPConstraint3Penalty::evaluate_constraint(
             Core::Communication::my_mpi_rank(disc->get_comm()), eid, err);
 
       // loadcurve business
-      const auto* curve = cond->parameters().get_if<int>("curve");
-      int curvenum = -1;
-      if (curve) curvenum = (*curve);
+      const int curvenum = cond->parameters().get_or<int>("curve", -1);
       double curvefac = 1.0;
       bool usetime = true;
       if (time < 0.0) usetime = false;
-      if (curvenum >= 0 && usetime)
+      if (curvenum > 0 && usetime)
+      {
+        // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
+      }
 
 
       double diff = (curvefac * (*initerror_)[eid] - (*acterror_)[eid]);

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -29,20 +29,12 @@ CONSTRAINTS::ConstraintPenalty::ConstraintPenalty(
   {
     for (auto* i : constrcond_)
     {
-      const double* mypenalty = i->parameters().get_if<double>("penalty");
-      const double* myrho = i->parameters().get_if<double>("rho");
+      const double mypenalty = i->parameters().get<double>("penalty");
+      const double myrho = i->parameters().get<double>("rho");
       int condID = i->parameters().get<int>("ConditionID");
-      if (mypenalty and myrho)
-      {
-        penalties_.insert(std::pair<int, double>(condID, *mypenalty));
-        rho_.insert(std::pair<int, double>(condID, *myrho));
-      }
-      else
-      {
-        FOUR_C_THROW(
-            "you should not turn up in penalty controlled constraint without penalty parameter and "
-            "rho!");
-      }
+
+      penalties_.insert(std::pair<int, double>(condID, mypenalty));
+      rho_.insert(std::pair<int, double>(condID, myrho));
     }
     int nummyele = 0;
     int numele = penalties_.size();

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -204,14 +204,15 @@ void CONSTRAINTS::ConstraintPenalty::evaluate_constraint(Teuchos::ParameterList&
       }
 
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
-      const auto* curve = cond->parameters().get_if<int>("curve");
-      int curvenum = -1;
-      if (curve) curvenum = *curve;
+      const int curvenum = cond->parameters().get_or<int>("curve", -1);
       double curvefac = 1.0;
-      if (curvenum >= 0)
+      if (curvenum > 0)
+      {
+        // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
+      }
 
       double diff = (curvefac * (*initerror_)[condID - 1] - (*acterror_)[condID - 1]);
 

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -303,11 +303,11 @@ void Core::Conditions::PeriodicBoundaryConditions::put_all_slaves_to_masters_pro
 
           for (auto& mysurfpbc : mysurfpbcs_)
           {
-            const int myid = mysurfpbc->parameters().get<int>("ID");
-            const int mylayer = mysurfpbc->parameters().get<int>("LAYER");
+            const int id_zero_based = mysurfpbc->parameters().get<int>("ID") - 1;
+            const int layer = mysurfpbc->parameters().get<int>("LAYER");
             // yes, I am the condition with id pbcid and in the desired layer
 
-            if (myid == pbcid && (mylayer + 1) == nlayer)
+            if (id_zero_based == pbcid && layer == nlayer)
             {
               const auto& mymasterslavetoggle =
                   mysurfpbc->parameters().get<std::string>("MASTER_OR_SLAVE");

--- a/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
@@ -412,9 +412,8 @@ void Core::FE::Discretization::evaluate_condition(Teuchos::ParameterList& params
         {
           const auto& function_manager =
               params.get<const Core::Utils::FunctionManager*>("function_manager");
-          curvefac =
-              function_manager->function_by_id<Core::Utils::FunctionOfTime>(curvenum).evaluate(
-                  time);
+          curvefac = function_manager->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                         .evaluate(time);
         }
 
         // Get ConditionID of current condition if defined and write value in parameter list

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
@@ -280,7 +280,7 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
         std::map<int, std::set<int>> slavetopbcset;
         for (auto& mypbc : mypbcs)
         {
-          const int myid = mypbc->parameters().get<int>("ID");
+          const int zero_based_id = mypbc->parameters().get<int>("ID") - 1;
 
           const auto mymasterslavetoggle = mypbc->parameters().get<std::string>("MASTER_OR_SLAVE");
 
@@ -292,7 +292,7 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
             // store them in list depending on the pbc id
             for (int idtoadd : *masteridstoadd)
             {
-              (mastertopbcset[myid]).insert(idtoadd);
+              (mastertopbcset[zero_based_id]).insert(idtoadd);
             }
           }
           else if (mymasterslavetoggle == "Slave")
@@ -303,7 +303,7 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
             // store them in list depending on the pbc id
             for (int idtoadd : *slaveidstoadd)
             {
-              (slavetopbcset[myid]).insert(idtoadd);
+              (slavetopbcset[zero_based_id]).insert(idtoadd);
             }
           }
           else

--- a/src/core/io/src/4C_io_linecomponent.cpp
+++ b/src/core/io/src/4C_io_linecomponent.cpp
@@ -366,10 +366,6 @@ namespace Input
               snumber, name(), section_name, 1, optional_);
         }
       }
-      if (data_.fortran_style)
-      {
-        if (not data_.none_allowed or number != -1) number -= 1;
-      }
 
       // remove parameter value from stringstream "condline"
       condline->str(
@@ -415,9 +411,8 @@ namespace Input
     const std::string default_value = std::invoke(
         [&]()
         {
-          if (data_.none_allowed) return "none "s;
-          if (data_.fortran_style)
-            return "-1 "s;
+          if (data_.none_allowed)
+            return "none "s;
           else
             return std::to_string(data_.default_value) + " ";
         });
@@ -447,7 +442,7 @@ namespace Input
   std::shared_ptr<std::stringstream> IntVectorComponent::read(const std::string& section_name,
       std::shared_ptr<std::stringstream> condline, Core::IO::InputParameterContainer& container)
   {
-    const int initialize_value = data_.default_value + (data_.fortran_style ? -1 : 0);
+    const int initialize_value = data_.default_value;
     const int dynamic_length = std::visit(LengthVisitor{container}, length_);
     // initialize integer parameter vector to be read
     std::vector<int> nnumbers(dynamic_length, initialize_value);
@@ -481,11 +476,6 @@ namespace Input
         {
           current_number = convert_and_validate_string_to_number<int>(
               snumber, name(), section_name, dynamic_length, optional_);
-        }
-
-        if (data_.fortran_style)
-        {
-          if (not data_.none_allowed or current_number != -1) current_number -= 1;
         }
 
         // remove parameter value from stringstream "condline"

--- a/src/core/io/src/4C_io_linecomponent.hpp
+++ b/src/core/io/src/4C_io_linecomponent.hpp
@@ -197,7 +197,6 @@ namespace Input
   struct IntComponentData
   {
     int default_value{0};
-    bool fortran_style{false};
     bool none_allowed{false};
     bool optional{false};
   };
@@ -444,8 +443,7 @@ namespace Input
   template <typename DefinitionType>
   inline void add_named_int(const std::shared_ptr<DefinitionType>& definition,
       const std::string& name, const std::string& description = {}, const int defaultvalue = 0,
-      const bool optional = false, const bool none_allowed = false,
-      const bool fortran_style = false)
+      const bool optional = false, const bool none_allowed = false)
   {
     definition->add_component(
         std::make_shared<Input::SeparatorComponent>(name, description, optional));
@@ -453,7 +451,6 @@ namespace Input
     data.default_value = defaultvalue;
     data.optional = optional;
     data.none_allowed = none_allowed;
-    data.fortran_style = fortran_style;
     definition->add_component(std::make_shared<Input::IntComponent>(name, data));
   }
 
@@ -464,8 +461,7 @@ namespace Input
   template <typename DefinitionType>
   inline void add_named_int_vector(const std::shared_ptr<DefinitionType>& definition,
       const std::string& name, const std::string& description, const int size,
-      const int defaultvalue = 0, const bool optional = false, const bool none_allowed = false,
-      const bool fortran_style = false)
+      const int defaultvalue = 0, const bool optional = false, const bool none_allowed = false)
   {
     definition->add_component(
         std::make_shared<Input::SeparatorComponent>(name, description, optional));
@@ -473,7 +469,6 @@ namespace Input
     data.default_value = defaultvalue;
     data.optional = optional;
     data.none_allowed = none_allowed;
-    data.fortran_style = fortran_style;
     definition->add_component(std::make_shared<Input::IntVectorComponent>(name, size, data));
   }
 

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
@@ -527,14 +527,12 @@ void Discret::Elements::FluidBoundaryParent<distype>::flow_dep_pressure_bc(
   const double time =
       fldparatimint_->time() + (1 - fldparatimint_->alpha_f()) * fldparatimint_->dt();
   if (time < 0.0) usetime = false;
-  const int curve = fdp_cond->parameters().get<int>("curve");
-  int curvenum = -1;
-  if (curve) curvenum = curve;
+  const int curvenum = fdp_cond->parameters().get<int>("curve");
   double curvefac = 1.0;
-  if (curvenum >= 0 and usetime)
-    curvefac =
-        Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(curvenum).evaluate(
-            time);
+  if (curvenum > 0 and usetime)
+    curvefac = Global::Problem::instance()
+                   ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                   .evaluate(time);
 
   // (temporarily) switch off any flow-dependent pressure condition in case of zero
   // time-curve factor

--- a/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
@@ -80,7 +80,7 @@ FLD::TransferTurbulentInflowCondition::TransferTurbulentInflowCondition(
         }
       }
 
-      if (id != 0)
+      if (id != 1)
       {
         FOUR_C_THROW("expecting only one group of coupling surfaces (up to now), its %d", id);
       }
@@ -319,23 +319,7 @@ void FLD::TransferTurbulentInflowCondition::get_data(
 {
   id = cond->parameters().get<int>("ID");
 
-  const auto mydirection = cond->parameters().get<std::string>("DIRECTION");
-  if (mydirection == "x")
-  {
-    direction = 0;
-  }
-  else if (mydirection == "y")
-  {
-    direction = 1;
-  }
-  else if (mydirection == "z")
-  {
-    direction = 2;
-  }
-  else
-  {
-    FOUR_C_THROW("unknown direction");
-  }
+  direction = cond->parameters().get<int>("DIRECTION");
 
   const auto mytoggle = cond->parameters().get<std::string>("toggle");
   if (mytoggle == "master")
@@ -354,10 +338,10 @@ void FLD::TransferTurbulentInflowCondition::get_data(
   // find out whether we will use a time curve
   if (curve_ == -1)
   {
-    const auto* curve = cond->parameters().get_if<int>("curve");
+    const auto curve = cond->parameters().get<int>("curve");
 
-    // set curve number
-    if (curve) curve_ = *curve;
+    // set zero based curve number
+    curve_ = curve - 1;
   }
 }
 

--- a/src/immersed_problem/4C_immersed_problem_immersed_base.cpp
+++ b/src/immersed_problem/4C_immersed_problem_immersed_base.cpp
@@ -431,7 +431,7 @@ void Immersed::ImmersedBase::evaluate_interpolation_condition(Core::FE::Discreti
       if (curvenum >= 0 && usetime)
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                        .evaluate(time);
       }
 

--- a/src/immersed_problem/4C_immersed_problem_immersed_base.hpp
+++ b/src/immersed_problem/4C_immersed_problem_immersed_base.hpp
@@ -236,7 +236,7 @@ namespace Immersed
     */
     void evaluate_interpolation_condition(Core::FE::Discretization& evaldis,
         Teuchos::ParameterList& params, Core::FE::AssembleStrategy& strategy,
-        const std::string& condstring, const int condid);
+        const std::string& condstring);
 
 
     /*!

--- a/src/immersed_problem/4C_immersed_problem_immersed_partitioned_fsi_dirichletneumann.cpp
+++ b/src/immersed_problem/4C_immersed_problem_immersed_partitioned_fsi_dirichletneumann.cpp
@@ -869,7 +869,7 @@ void Immersed::ImmersedPartitionedFSIDirichletNeumann::calc_fluid_tractions_on_s
               << std::endl;
   }
   evaluate_interpolation_condition(
-      *immersedstructure_->discretization(), params, struct_bdry_strategy, "IMMERSEDCoupling", -1);
+      *immersedstructure_->discretization(), params, struct_bdry_strategy, "IMMERSEDCoupling");
 
   // we just validate the boundary tractions
   boundary_traction_isvalid_ = true;

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -114,7 +114,7 @@ void Inpar::ArteryNetwork::set_valid_conditions(
       Teuchos::tuple<std::string>("forced", "absorbing"), true);
 
   add_named_real_vector(art_in_bc, "VAL", "values", 2);
-  add_named_int_vector(art_in_bc, "curve", "curve ids", 2, 0.0, false, true, true);
+  add_named_int_vector(art_in_bc, "curve", "curve ids", 2, 0.0, false, true);
 
   condlist.push_back(art_in_bc);
 
@@ -126,7 +126,7 @@ void Inpar::ArteryNetwork::set_valid_conditions(
           Core::Conditions::ArtRfCond, true, Core::Conditions::geometry_type_point);
 
   add_named_real_vector(art_rf_bc, "VAL", "value", 1);
-  add_named_int_vector(art_rf_bc, "curve", "curve", 1, 0, false, true, true);
+  add_named_int_vector(art_rf_bc, "curve", "curve", 1, 0, false, true);
   condlist.push_back(art_rf_bc);
 
 
@@ -395,8 +395,8 @@ void Inpar::ReducedLung::set_valid_conditions(
 
   // reduced airway inlet components
   add_named_real_vector(raw_in_bc, "VAL", "value", 1);
-  add_named_int_vector(raw_in_bc, "curve", "curve", 2, 0, false, true, true);
-  add_named_int_vector(raw_in_bc, "funct", "function id", 1, 0, true, true, false);
+  add_named_int_vector(raw_in_bc, "curve", "curve", 2, 0, false, true);
+  add_named_int_vector(raw_in_bc, "funct", "function id", 1, 0, true, true);
 
   condlist.push_back(raw_in_bc);
 
@@ -446,7 +446,7 @@ void Inpar::ReducedLung::set_valid_conditions(
 
   // raw_volPpl_bc_components
   Input::add_named_real_vector(raw_volPpl_bc, "VAL", "value", 1);
-  Input::add_named_int_vector(raw_volPpl_bc, "curve", "curve", 1, 0, false, true, true);
+  Input::add_named_int_vector(raw_volPpl_bc, "curve", "curve", 1, 0, false, true);
 
   condlist.push_back(raw_volPpl_bc);
 

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -577,8 +577,7 @@ void Inpar::Cardiovascular0D::set_valid_conditions(
   Input::add_named_real(cardiovascular0darterialproxdistcond, "y_arp_0");
   Input::add_named_real(cardiovascular0darterialproxdistcond, "p_ard_0");
   Input::add_named_real(cardiovascular0darterialproxdistcond, "p_at_fac");
-  Input::add_named_int(
-      cardiovascular0darterialproxdistcond, "p_at_crv", "curve", 0, false, true, false);
+  Input::add_named_int(cardiovascular0darterialproxdistcond, "p_at_crv", "curve", 0, false, true);
   condlist.push_back(cardiovascular0darterialproxdistcond);
 
   /*--------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -578,7 +578,7 @@ void Inpar::Cardiovascular0D::set_valid_conditions(
   Input::add_named_real(cardiovascular0darterialproxdistcond, "p_ard_0");
   Input::add_named_real(cardiovascular0darterialproxdistcond, "p_at_fac");
   Input::add_named_int(
-      cardiovascular0darterialproxdistcond, "p_at_crv", "curve", 0, false, true, true);
+      cardiovascular0darterialproxdistcond, "p_at_crv", "curve", 0, false, true, false);
   condlist.push_back(cardiovascular0darterialproxdistcond);
 
   /*--------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -362,7 +362,7 @@ void Inpar::ElCh::set_valid_conditions(
       cond->add_component(std::make_shared<Input::SeparatorComponent>("ID"));
       cond->add_component(std::make_shared<Input::IntComponent>("ConditionID"));
       add_named_real(cond, "POT");
-      add_named_int(cond, "FUNCT", "", 0, false, true, true);
+      add_named_int(cond, "FUNCT", "", 0, false, true);
       add_named_int(cond, "NUMSCAL");
       add_named_int_vector(cond, "STOICH", "", "NUMSCAL");
       add_named_int(cond, "E-");
@@ -408,7 +408,7 @@ void Inpar::ElCh::set_valid_conditions(
       electrodedomainkineticscomponents.emplace_back(
           std::make_shared<Input::SeparatorComponent>("FUNCT"));
       electrodedomainkineticscomponents.emplace_back(
-          std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, true, true, false}));
+          std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, false, true, false}));
       electrodedomainkineticscomponents.emplace_back(
           std::make_shared<Input::SeparatorComponent>("NUMSCAL"));
 

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -408,7 +408,7 @@ void Inpar::ElCh::set_valid_conditions(
       electrodedomainkineticscomponents.emplace_back(
           std::make_shared<Input::SeparatorComponent>("FUNCT"));
       electrodedomainkineticscomponents.emplace_back(
-          std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, false, true, false}));
+          std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, true, false}));
       electrodedomainkineticscomponents.emplace_back(
           std::make_shared<Input::SeparatorComponent>("NUMSCAL"));
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1381,13 +1381,13 @@ void Inpar::FLUID::set_valid_conditions(
           "TransferTurbulentInflow", Core::Conditions::TransferTurbulentInflow, true,
           Core::Conditions::geometry_type_surface);
 
-  add_named_int(tbc_turb_inflow, "ID", "", 0, false, false, false);
+  add_named_int(tbc_turb_inflow, "ID", "", 0, false, false);
   add_named_selection_component(tbc_turb_inflow, "toggle", "toggle", "master",
       Teuchos::tuple<std::string>("master", "slave"),
       Teuchos::tuple<std::string>("master", "slave"));
   add_named_selection_component(tbc_turb_inflow, "DIRECTION", "transfer direction", "x",
       Teuchos::tuple<std::string>("x", "y", "z"), Teuchos::tuple<int>(0, 1, 2));
-  add_named_int(tbc_turb_inflow, "curve", "curve id", 0, false, true, false);
+  add_named_int(tbc_turb_inflow, "curve", "curve id", 0, false, true);
 
   condlist.push_back(tbc_turb_inflow);
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1381,13 +1381,13 @@ void Inpar::FLUID::set_valid_conditions(
           "TransferTurbulentInflow", Core::Conditions::TransferTurbulentInflow, true,
           Core::Conditions::geometry_type_surface);
 
-  add_named_int(tbc_turb_inflow, "ID", "", 0, false, false, true);
+  add_named_int(tbc_turb_inflow, "ID", "", 0, false, false, false);
   add_named_selection_component(tbc_turb_inflow, "toggle", "toggle", "master",
       Teuchos::tuple<std::string>("master", "slave"),
       Teuchos::tuple<std::string>("master", "slave"));
   add_named_selection_component(tbc_turb_inflow, "DIRECTION", "transfer direction", "x",
-      Teuchos::tuple<std::string>("x", "y", "z"), Teuchos::tuple<std::string>("x", "y", "z"));
-  add_named_int(tbc_turb_inflow, "curve", "curve id", 0, false, true, true);
+      Teuchos::tuple<std::string>("x", "y", "z"), Teuchos::tuple<int>(0, 1, 2));
+  add_named_int(tbc_turb_inflow, "curve", "curve id", 0, false, true, false);
 
   condlist.push_back(tbc_turb_inflow);
 
@@ -1426,7 +1426,7 @@ void Inpar::FLUID::set_valid_conditions(
   add_named_real(
       surfflowdeppressure, "ReferencePressure", " reference pressure outside of boundary");
   add_named_real(surfflowdeppressure, "AdiabaticExponent", "adiabatic exponent");
-  add_named_int(surfflowdeppressure, "curve", "curve id", 0, false, true, true);
+  add_named_int(surfflowdeppressure, "curve", "curve id", 0, false, true);
 
   condlist.emplace_back(surfflowdeppressure);
 
@@ -1522,7 +1522,7 @@ void Inpar::FLUID::set_valid_conditions(
     add_named_real_vector(cond, "val", "velocity", 3);
 
     // and optional spatial functions
-    add_named_int_vector(cond, "funct", "spatial function", 3, 0, true, false, false);
+    add_named_int_vector(cond, "funct", "spatial function", 3, 0, true, false);
 
     // characteristic velocity
     add_named_real(cond, "u_C");

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -644,11 +644,10 @@ void Inpar::ScaTra::set_valid_conditions(
     add_named_real(cond, "coeff", "heat transfer coefficient h");
     add_named_real(cond, "surtemp", "surrounding (fluid) temperature T_oo");
     add_named_int(cond, "surtempfunct",
-        "time curve to increase the surrounding (fluid) temperature T_oo in time", 0, false, true,
-        true);
+        "time curve to increase the surrounding (fluid) temperature T_oo in time", 0, false, true);
     add_named_int(cond, "funct",
         "time curve to increase the complete boundary condition, i.e., the heat flux", 0, false,
-        true, true);
+        true);
 
     condlist.emplace_back(cond);
   }

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -425,7 +425,7 @@ namespace Inpar
         add_named_selection_component(cond, "DIRECTION", "", "xyz",
             Teuchos::tuple<std::string>("xyz", "refsurfnormal", "cursurfnormal"),
             Teuchos::tuple<std::string>("xyz", "refsurfnormal", "cursurfnormal"), false);
-        add_named_int(cond, "COUPLING", "", 0, false, true, false);
+        add_named_int(cond, "COUPLING", "", 0, false, true);
         condlist.emplace_back(cond);
       }
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -425,7 +425,7 @@ namespace Inpar
         add_named_selection_component(cond, "DIRECTION", "", "xyz",
             Teuchos::tuple<std::string>("xyz", "refsurfnormal", "cursurfnormal"),
             Teuchos::tuple<std::string>("xyz", "refsurfnormal", "cursurfnormal"), false);
-        add_named_int(cond, "COUPLING", "", 0, false, true, true);
+        add_named_int(cond, "COUPLING", "", 0, false, true, false);
         condlist.emplace_back(cond);
       }
 

--- a/src/inpar/4C_inpar_thermo.cpp
+++ b/src/inpar/4C_inpar_thermo.cpp
@@ -180,11 +180,10 @@ void Inpar::Thermo::set_valid_conditions(
     add_named_real(cond, "coeff", "heat transfer coefficient h");
     add_named_real(cond, "surtemp", "surrounding (fluid) temperature T_oo");
     add_named_int(cond, "surtempfunct",
-        "time curve to increase the surrounding (fluid) temperature T_oo in time", 0, false, true,
-        true);
+        "time curve to increase the surrounding (fluid) temperature T_oo in time", 0, false, true);
     add_named_int(cond, "funct",
         "time curve to increase the complete boundary condition, i.e., the heat flux", 0, false,
-        true, true);
+        true);
 
     condlist.push_back(cond);
   }

--- a/src/inpar/4C_inpar_validconditions.cpp
+++ b/src/inpar/4C_inpar_validconditions.cpp
@@ -536,14 +536,14 @@ Input::valid_conditions()
 
   for (const auto& cond : {lineperiodic, surfperiodic})
   {
-    add_named_int(cond, "ID", "periodic boundary condition id", 0, false, false, true);
+    add_named_int(cond, "ID", "periodic boundary condition id", 0, false, false);
     add_named_selection_component(cond, "MASTER_OR_SLAVE", "master-slave toggle", "Master",
         Teuchos::tuple<std::string>("Master", "Slave"),
         Teuchos::tuple<std::string>("Master", "Slave"));
     add_named_selection_component(cond, "PLANE", "degrees of freedom for the pbc plane", "xy",
         Teuchos::tuple<std::string>("xy", "yx", "yz", "zy", "xz", "zx", "xyz"),
         Teuchos::tuple<std::string>("xy", "xy", "yz", "yz", "xz", "xz", "xyz"));
-    add_named_int(cond, "LAYER", "layer of periodic boundary condition", 0, false, false, true);
+    add_named_int(cond, "LAYER", "layer of periodic boundary condition", 0, false, false);
     add_named_real(cond, "ANGLE", "angle of rotation");
     add_named_real(cond, "ABSTREETOL", "tolerance for nodematching in octree");
 

--- a/src/inpar/4C_inpar_validconditions.cpp
+++ b/src/inpar/4C_inpar_validconditions.cpp
@@ -631,7 +631,7 @@ Input::valid_conditions()
           true, Core::Conditions::geometry_type_surface);
 
   add_named_int(volumeconstraint, "ConditionID");
-  add_named_int(volumeconstraint, "curve", "id of the curve", 0, false, true, true);
+  add_named_int(volumeconstraint, "curve", "id of the curve", 0, false, true);
   add_named_real(volumeconstraint, "activeTime");
   add_named_selection_component(volumeconstraint, "projection", "projection", "none",
       Teuchos::tuple<std::string>("none", "xy", "yz", "xz"),
@@ -650,7 +650,7 @@ Input::valid_conditions()
           Core::Conditions::geometry_type_surface);
 
   add_named_int(volumeconstraintpen, "ConditionID");
-  add_named_int(volumeconstraintpen, "curve", "id of the curve", 0, false, true, true);
+  add_named_int(volumeconstraintpen, "curve", "id of the curve", 0, false, true);
   add_named_real(volumeconstraintpen, "activeTime");
   add_named_real(volumeconstraintpen, "penalty");
   add_named_real(volumeconstraintpen, "rho");
@@ -669,7 +669,7 @@ Input::valid_conditions()
           Core::Conditions::geometry_type_surface);
 
   add_named_int(areaconstraint, "ConditionID");
-  add_named_int(areaconstraint, "curve", "id of the curve", 0, false, true, true);
+  add_named_int(areaconstraint, "curve", "id of the curve", 0, false, true);
   add_named_real(areaconstraint, "activeTime");
 
   condlist.push_back(areaconstraint);
@@ -711,7 +711,7 @@ Input::valid_conditions()
           Core::Conditions::geometry_type_line);
 
   add_named_int(areaconstraint2D, "ConditionID");
-  add_named_int(areaconstraint2D, "curve", {}, 0, false, true, true);
+  add_named_int(areaconstraint2D, "curve", {}, 0, false, true);
   add_named_real(areaconstraint2D, "activeTime");
 
   condlist.push_back(areaconstraint2D);
@@ -738,7 +738,7 @@ Input::valid_conditions()
 
   add_named_int(nodeonplaneconst3D, "ConditionID");
   add_named_real(nodeonplaneconst3D, "amplitude");
-  add_named_int(nodeonplaneconst3D, "curve", {}, 0, false, true, true);
+  add_named_int(nodeonplaneconst3D, "curve", {}, 0, false, true);
   add_named_real(nodeonplaneconst3D, "activeTime");
   add_named_int_vector(nodeonplaneconst3D, "planeNodes", "ids of the nodes spanning the plane", 3);
   add_named_selection_component(nodeonplaneconst3D, "control", "relative or absolute control",
@@ -758,7 +758,7 @@ Input::valid_conditions()
 
   add_named_int(nodemasterconst3D, "ConditionID");
   add_named_real(nodemasterconst3D, "amplitude");
-  add_named_int(nodemasterconst3D, "curve", {}, 0, false, true, true);
+  add_named_int(nodemasterconst3D, "curve", {}, 0, false, true);
   add_named_real(nodemasterconst3D, "activeTime");
   add_named_int(nodemasterconst3D, "masterNode");
   add_named_real_vector(nodemasterconst3D, "direction", "direction", 3);
@@ -781,7 +781,7 @@ Input::valid_conditions()
 
   add_named_int(nodemasterconst3Dpen, "ConditionID");
   add_named_real(nodemasterconst3Dpen, "amplitude");
-  add_named_int(nodemasterconst3Dpen, "curve", {}, 0, false, true, true);
+  add_named_int(nodemasterconst3Dpen, "curve", {}, 0, false, true);
   add_named_real(nodemasterconst3Dpen, "activeTime");
   add_named_real(nodemasterconst3Dpen, "penalty");
   add_named_int(nodemasterconst3Dpen, "masterNode");
@@ -802,7 +802,7 @@ Input::valid_conditions()
 
   add_named_int(nodeonlineconst2D, "ConditionID");
   add_named_real(nodeonlineconst2D, "amplitude");
-  add_named_int(nodeonlineconst2D, "curve", {}, 0, false, true, true);
+  add_named_int(nodeonlineconst2D, "curve", {}, 0, false, true);
   add_named_int(nodeonlineconst2D, "constrNode1");
   add_named_int(nodeonlineconst2D, "constrNode2");
   add_named_int(nodeonlineconst2D, "constrNode3");

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -569,9 +569,9 @@ void Inpar::XFEM::set_valid_conditions(
       Teuchos::tuple<int>(Inpar::XFEM::Proj_normal, Inpar::XFEM::Proj_smoothed,
           Inpar::XFEM::Proj_normal_smoothed_comb, Inpar::XFEM::Proj_normal_phi),
       true);
-  add_named_int(xfem_levelset_navier_slip, "L2_PROJECTION_SOLVER", "", 0, false, true, true);
-  add_named_int(xfem_levelset_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true, true);
-  add_named_int(xfem_levelset_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true, true);
+  add_named_int(xfem_levelset_navier_slip, "L2_PROJECTION_SOLVER", "", 0, false, true, false);
+  add_named_int(xfem_levelset_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true, false);
+  add_named_int(xfem_levelset_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true, false);
   add_named_real(xfem_levelset_navier_slip, "SLIPCOEFFICIENT");
   xfem_levelset_navier_slip->add_component(
       std::make_shared<Input::SeparatorComponent>("SLIP_FUNCT", "", true));
@@ -592,7 +592,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_dirch->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_DIRICHLET_ID"));
   xfem_navier_slip_robin_dirch->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
 
   for (unsigned i = 0; i < dirichletbundcomponents.size(); ++i)
   {
@@ -610,7 +610,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_neumann->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_NEUMANN_ID"));
   xfem_navier_slip_robin_neumann->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
 
   for (unsigned i = 0; i < neumanncomponents.size(); ++i)
   {
@@ -785,8 +785,8 @@ void Inpar::XFEM::set_valid_conditions(
           "displacement_1storder_wo_initfunct", "displacement_2ndorder_wo_initfunct",
           "displacement_1storder_with_initfunct", "displacement_2ndorder_with_initfunct"),
       true);
-  add_named_int(xfem_surf_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true, true);
-  add_named_int(xfem_surf_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true, true);
+  add_named_int(xfem_surf_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true, false);
+  add_named_int(xfem_surf_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true, false);
   add_named_real(xfem_surf_navier_slip, "SLIPCOEFFICIENT");
   xfem_surf_navier_slip->add_component(
       std::make_shared<Input::SeparatorComponent>("SLIP_FUNCT", "", true));
@@ -809,7 +809,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_dirch_surf->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_DIRICHLET_ID"));
   xfem_navier_slip_robin_dirch_surf->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
 
   // Likely, not necessary. But needed for the current structure.
   add_named_selection_component(xfem_navier_slip_robin_dirch_surf, "EVALTYPE", "",
@@ -842,7 +842,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_neumann_surf->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_NEUMANN_ID"));
   xfem_navier_slip_robin_neumann_surf->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
 
   for (unsigned i = 0; i < neumanncomponents.size(); ++i)
   {

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -398,7 +398,7 @@ void Inpar::XFEM::set_valid_conditions(
       std::make_shared<RealVectorComponent>("VAL", LengthFromInt("NUMDOF")));
   dirichletbundcomponents.emplace_back(std::make_shared<SeparatorComponent>("FUNCT"));
   dirichletbundcomponents.emplace_back(std::shared_ptr<LineComponent>(
-      new IntVectorComponent("FUNCT", LengthFromInt("NUMDOF"), {0, false, true, false})));
+      new IntVectorComponent("FUNCT", LengthFromInt("NUMDOF"), {0, true, false})));
 
   // optional
   dirichletbundcomponents.emplace_back(std::make_shared<SeparatorComponent>("TAG", "", true));
@@ -420,7 +420,7 @@ void Inpar::XFEM::set_valid_conditions(
       std::make_shared<RealVectorComponent>("VAL", LengthFromInt("NUMDOF")));
   neumanncomponents.emplace_back(std::make_shared<SeparatorComponent>("FUNCT"));
   neumanncomponents.emplace_back(std::shared_ptr<LineComponent>(
-      new IntVectorComponent("FUNCT", LengthFromInt("NUMDOF"), {0, false, true, false})));
+      new IntVectorComponent("FUNCT", LengthFromInt("NUMDOF"), {0, true, false})));
 
   // optional
   neumanncomponents.emplace_back(std::make_shared<SeparatorComponent>("TYPE", "", true));
@@ -569,14 +569,14 @@ void Inpar::XFEM::set_valid_conditions(
       Teuchos::tuple<int>(Inpar::XFEM::Proj_normal, Inpar::XFEM::Proj_smoothed,
           Inpar::XFEM::Proj_normal_smoothed_comb, Inpar::XFEM::Proj_normal_phi),
       true);
-  add_named_int(xfem_levelset_navier_slip, "L2_PROJECTION_SOLVER", "", 0, false, true, false);
-  add_named_int(xfem_levelset_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true, false);
-  add_named_int(xfem_levelset_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true, false);
+  add_named_int(xfem_levelset_navier_slip, "L2_PROJECTION_SOLVER", "", 0, false, true);
+  add_named_int(xfem_levelset_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true);
+  add_named_int(xfem_levelset_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true);
   add_named_real(xfem_levelset_navier_slip, "SLIPCOEFFICIENT");
   xfem_levelset_navier_slip->add_component(
       std::make_shared<Input::SeparatorComponent>("SLIP_FUNCT", "", true));
   xfem_levelset_navier_slip->add_component(
-      std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, false, false, true}));
+      std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, false, true}));
   add_named_bool(xfem_levelset_navier_slip, "FORCE_ONLY_TANG_VEL", "", false, true);
 
   condlist.push_back(xfem_levelset_navier_slip);
@@ -592,7 +592,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_dirch->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_DIRICHLET_ID"));
   xfem_navier_slip_robin_dirch->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, false}));
 
   for (unsigned i = 0; i < dirichletbundcomponents.size(); ++i)
   {
@@ -610,7 +610,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_neumann->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_NEUMANN_ID"));
   xfem_navier_slip_robin_neumann->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, false}));
 
   for (unsigned i = 0; i < neumanncomponents.size(); ++i)
   {
@@ -669,7 +669,7 @@ void Inpar::XFEM::set_valid_conditions(
           Inpar::XFEM::navierslip),
       true);
   add_named_real(xfem_surf_fsi_part, "SLIPCOEFFICIENT", "", 0.0, true);
-  add_named_int(xfem_surf_fsi_part, "SLIP_FUNCT", "slip function id", 0, true, false, false);
+  add_named_int(xfem_surf_fsi_part, "SLIP_FUNCT", "slip function id", 0, true, false);
 
   condlist.push_back(xfem_surf_fsi_part);
 
@@ -694,7 +694,7 @@ void Inpar::XFEM::set_valid_conditions(
           Inpar::XFEM::navierslip, Inpar::XFEM::navierslip_contact),
       true);
   add_named_real(xfem_surf_fsi_mono, "SLIPCOEFFICIENT", "", 0.0, true);
-  add_named_int(xfem_surf_fsi_mono, "SLIP_FUNCT", "slip function id", 0, true, false, false);
+  add_named_int(xfem_surf_fsi_mono, "SLIP_FUNCT", "slip function id", 0, true, false);
 
   condlist.push_back(xfem_surf_fsi_mono);
 
@@ -785,13 +785,13 @@ void Inpar::XFEM::set_valid_conditions(
           "displacement_1storder_wo_initfunct", "displacement_2ndorder_wo_initfunct",
           "displacement_1storder_with_initfunct", "displacement_2ndorder_with_initfunct"),
       true);
-  add_named_int(xfem_surf_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true, false);
-  add_named_int(xfem_surf_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true, false);
+  add_named_int(xfem_surf_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true);
+  add_named_int(xfem_surf_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true);
   add_named_real(xfem_surf_navier_slip, "SLIPCOEFFICIENT");
   xfem_surf_navier_slip->add_component(
       std::make_shared<Input::SeparatorComponent>("SLIP_FUNCT", "", true));
   xfem_surf_navier_slip->add_component(
-      std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, false, false, true}));
+      std::make_shared<Input::IntComponent>("FUNCT", IntComponentData{0, false, true}));
   add_named_bool(xfem_surf_navier_slip, "FORCE_ONLY_TANG_VEL", "", false, true);
 
   condlist.push_back(xfem_surf_navier_slip);
@@ -809,7 +809,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_dirch_surf->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_DIRICHLET_ID"));
   xfem_navier_slip_robin_dirch_surf->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, false}));
 
   // Likely, not necessary. But needed for the current structure.
   add_named_selection_component(xfem_navier_slip_robin_dirch_surf, "EVALTYPE", "",
@@ -842,7 +842,7 @@ void Inpar::XFEM::set_valid_conditions(
   xfem_navier_slip_robin_neumann_surf->add_component(
       std::make_shared<Input::SeparatorComponent>("ROBIN_NEUMANN_ID"));
   xfem_navier_slip_robin_neumann_surf->add_component(
-      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, false, true, false}));
+      std::make_shared<Input::IntComponent>("robin_id", IntComponentData{0, true, false}));
 
   for (unsigned i = 0; i < neumanncomponents.size(); ++i)
   {

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -742,7 +742,8 @@ void Inpar::XFEM::set_valid_conditions(
   }
 
   // optional: allow for random noise, set percentage used in uniform random distribution
-  add_named_real(xfem_surf_wdbc, "RANDNOISE", "", 0.0, true);
+  add_named_real(xfem_surf_wdbc, "RANDNOISE",
+      "set percentage of random noise used in uniform random distribution", 0.0, true);
 
   condlist.push_back(xfem_surf_wdbc);
 

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -326,19 +326,19 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           // Get the type of prescribed bc
           Bc = (condition->parameters().get<std::string>("boundarycond"));
 
-          const auto* vals = &condition->parameters().get<std::vector<double>>("VAL");
-          const auto* curve = &condition->parameters().get<std::vector<int>>("curve");
-          const auto* functions = &condition->parameters().get<std::vector<int>>("funct");
+          const auto vals = condition->parameters().get<std::vector<double>>("VAL");
+          const auto curve = condition->parameters().get<std::vector<int>>("curve");
+          const auto functions = condition->parameters().get<std::vector<int>>("funct");
 
           // Read in the value of the applied BC
           // Get factor of first CURVE
           double curvefac = 1.0;
-          if ((*curve)[0] >= 0)
+          if (curve[0] > 0)
           {
             curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>((*curve)[0])
+                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
                            .evaluate(time);
-            BCin = (*vals)[0] * curvefac;
+            BCin = vals[0] * curvefac;
           }
           else
           {
@@ -347,11 +347,7 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           }
 
           // Get factor of FUNCT
-          int functnum = -1;
-          if (functions)
-            functnum = (*functions)[0];
-          else
-            functnum = -1;
+          int functnum = functions[0];
 
           double functionfac = 0.0;
           if (functnum > 0)
@@ -364,10 +360,10 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           // Get factor of second CURVE
           int curve2num = -1;
           double curve2fac = 1.0;
-          if (curve) curve2num = (*curve)[1];
-          if (curve2num >= 0)
+          curve2num = curve[1];
+          if (curve2num > 0)
             curve2fac = Global::Problem::instance()
-                            ->function_by_id<Core::Utils::FunctionOfTime>(curve2num)
+                            ->function_by_id<Core::Utils::FunctionOfTime>(curve2num - 1)
                             .evaluate(time);
 
           // Add first_CURVE + FUNCTION * second_CURVE
@@ -470,17 +466,17 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             Bc = (condition->parameters().get<std::string>("phase2"));
           }
 
-          const auto* curve = &condition->parameters().get<std::vector<int>>("curve");
+          const auto curve = condition->parameters().get<std::vector<int>>("curve");
           double curvefac = 1.0;
-          const auto* vals = &condition->parameters().get<std::vector<double>>("VAL");
+          const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
           // Read in the value of the applied BC
-          if ((*curve)[phase_number] >= 0)
+          if (curve[phase_number] > 0)
           {
             curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>((*curve)[phase_number])
+                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[phase_number] - 1)
                            .evaluate(time);
-            BCin = (*vals)[phase_number] * curvefac;
+            BCin = vals[phase_number] * curvefac;
           }
           else
           {
@@ -513,15 +509,15 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             double Pp_np = 0.0;
             if (pplCond)
             {
-              const auto* curve = &pplCond->parameters().get<std::vector<int>>("curve");
+              const auto curve = pplCond->parameters().get<std::vector<int>>("curve");
               double curvefac = 1.0;
-              const auto* vals = &pplCond->parameters().get<std::vector<double>>("VAL");
+              const auto vals = pplCond->parameters().get<std::vector<double>>("VAL");
 
               // Read in the value of the applied BC
-              if ((*curve)[0] >= 0)
+              if (curve[0] > 0)
               {
                 curvefac = Global::Problem::instance()
-                               ->function_by_id<Core::Utils::FunctionOfTime>((*curve)[0])
+                               ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
                                .evaluate(time);
               }
 
@@ -592,7 +588,7 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
               {
                 FOUR_C_THROW("Unknown volume pleural pressure type: %s", ppl_Type.c_str());
               }
-              Pp_np *= curvefac * ((*vals)[0]);
+              Pp_np *= curvefac * (vals[0]);
             }
             else
             {

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -100,10 +100,7 @@ namespace
         bcVal = (*vals)[0] * curvefac;
 
         // get funct 1
-        const int* function = condition->parameters().get_if<int>("VAL");
-        int functnum = -1;
-        if (function) functnum = (*function);
-
+        const int functnum = condition->parameters().get_or<int>("VAL", -1);
         double functionfac = 0.0;
         if (functnum > 0)
         {

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -83,7 +83,7 @@ namespace
       {
         const auto* curve = condition->parameters().get_if<std::vector<int>>("curve");
         double curvefac = 1.0;
-        const auto* vals = &condition->parameters().get<std::vector<double>>("VAL");
+        const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
         // -----------------------------------------------------------------
         // Read in the value of the applied BC
@@ -92,12 +92,12 @@ namespace
         // get curve1 and val1
         int curvenum = -1;
         if (curve) curvenum = (*curve)[0];
-        if (curvenum >= 0)
+        if (curvenum > 0)
           curvefac = Global::Problem::instance()
-                         ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                         ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                          .evaluate(time);
 
-        bcVal = (*vals)[0] * curvefac;
+        bcVal = vals[0] * curvefac;
 
         // get funct 1
         const int functnum = condition->parameters().get_or<int>("VAL", -1);
@@ -112,9 +112,9 @@ namespace
         int curve2num = -1;
         double curve2fac = 1.0;
         if (curve) curve2num = (*curve)[1];
-        if (curve2num >= 0)
+        if (curve2num > 0)
           curve2fac = Global::Problem::instance()
-                          ->function_by_id<Core::Utils::FunctionOfTime>(curve2num)
+                          ->function_by_id<Core::Utils::FunctionOfTime>(curve2num - 1)
                           .evaluate(time);
 
         bcVal += functionfac * curve2fac;
@@ -955,7 +955,7 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
             //  Val = curve1*val1 + curve2*func
             // -----------------------------------------------------------------
             const auto* curve = condition->parameters().get_if<std::vector<int>>("curve");
-            const auto* vals = &condition->parameters().get<std::vector<double>>("VAL");
+            const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
             // get factor of curve1 or curve2
             const auto curvefac = [&](unsigned id)
@@ -963,9 +963,9 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
               int curvenum = -1;
               if (curve)
               {
-                if ((curvenum = (*curve)[id]) >= 0)
+                if ((curvenum = (*curve)[id]) > 0)
                   return Global::Problem::instance()
-                      ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                      ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                       .evaluate(time);
                 else
                   return 1.0;
@@ -992,7 +992,7 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
                     return 0.0;
                 });
 
-            BCin = (*vals)[0] * curvefac(0) + functfac * curvefac(1);
+            BCin = vals[0] * curvefac(0) + functfac * curvefac(1);
           }
           // -----------------------------------------------------------------------------
           // get the local id of the node to whom the bc is prescribed
@@ -1094,21 +1094,20 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
             Bc = (condition->parameters().get<std::string>("phase2"));
           }
 
-          const auto* curve = condition->parameters().get_if<std::vector<int>>("curve");
+          const auto curve = condition->parameters().get<std::vector<int>>("curve");
           double curvefac = 1.0;
-          const auto* vals = &condition->parameters().get<std::vector<double>>("VAL");
+          const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
           // -----------------------------------------------------------------
           // Read in the value of the applied BC
           // -----------------------------------------------------------------
-          int curvenum = -1;
-          if (curve) curvenum = (*curve)[phase_number];
-          if (curvenum >= 0)
+          int curvenum = curve[phase_number];
+          if (curvenum > 0)
             curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                           ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                            .evaluate(time);
 
-          BCin = (*vals)[phase_number] * curvefac;
+          BCin = vals[phase_number] * curvefac;
 
           // -----------------------------------------------------------------
           // Compute flow value in case a volume is prescribed in the RedAirwayVentilatorCond
@@ -1118,9 +1117,9 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
             if (fmod(time, period) < period1)
             {
               double Vnp = BCin;
-              double Vn = (*vals)[phase_number] *
+              double Vn = vals[phase_number] *
                           Global::Problem::instance()
-                              ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                              ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                               .evaluate(time - dt);
               BCin = (Vnp - Vn) / dt;
               Bc = "flow";

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -200,19 +200,19 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           // Get the type of prescribed bc
           Bc = (condition->parameters().get<std::string>("boundarycond"));
 
-          const auto* curve = &condition->parameters().get<std::vector<int>>("curve");
+          const auto curve = condition->parameters().get<std::vector<int>>("curve");
           double curvefac = 1.0;
-          const auto* vals = &condition->parameters().get<std::vector<double>>("VAL");
-          const auto* functions = &condition->parameters().get<std::vector<int>>("funct");
+          const auto vals = condition->parameters().get<std::vector<double>>("VAL");
+          const auto functions = condition->parameters().get<std::vector<int>>("funct");
 
           // Read in the value of the applied BC
           // Get factor of first CURVE
-          if ((*curve)[0] >= 0)
+          if (curve[0] > 0)
           {
             curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>((*curve)[0])
+                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
                            .evaluate(time);
-            BCin = (*vals)[0] * curvefac;
+            BCin = vals[0] * curvefac;
           }
           else
           {
@@ -220,11 +220,7 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
             exit(1);
           }
           // Get factor of FUNCT
-          int functnum = -1;
-          if (functions)
-            functnum = (*functions)[0];
-          else
-            functnum = -1;
+          int functnum = functions[0];
 
           double functionfac = 0.0;
           if (functnum > 0)
@@ -237,10 +233,10 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           // Get factor of second CURVE
           int curve2num = -1;
           double curve2fac = 1.0;
-          if (curve) curve2num = (*curve)[1];
-          if (curve2num >= 0)
+          curve2num = curve[1];
+          if (curve2num > 0)
             curve2fac = Global::Problem::instance()
-                            ->function_by_id<Core::Utils::FunctionOfTime>(curve2num)
+                            ->function_by_id<Core::Utils::FunctionOfTime>(curve2num - 1)
                             .evaluate(time);
 
           // Add first_CURVE + FUNCTION * second_CURVE
@@ -270,15 +266,15 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
             double Pp_np = 0.0;
             if (pplCond)
             {
-              const auto* curve = &pplCond->parameters().get<std::vector<int>>("curve");
+              const auto curve = pplCond->parameters().get<std::vector<int>>("curve");
               double curvefac = 1.0;
-              const auto* vals = &pplCond->parameters().get<std::vector<double>>("VAL");
+              const auto vals = pplCond->parameters().get<std::vector<double>>("VAL");
 
               // Read in the value of the applied BC
-              if ((*curve)[0] >= 0)
+              if (curve[0] > 0)
               {
                 curvefac = Global::Problem::instance()
-                               ->function_by_id<Core::Utils::FunctionOfTime>((*curve)[0])
+                               ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
                                .evaluate(time);
               }
 
@@ -348,7 +344,7 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
               {
                 FOUR_C_THROW("Unknown volume pleural pressure type: %s", ppl_Type.c_str());
               }
-              Pp_np *= curvefac * ((*vals)[0]);
+              Pp_np *= curvefac * (vals[0]);
             }
             else
             {

--- a/src/scatra/4C_scatra_timint_elch_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scheme.cpp
@@ -283,10 +283,11 @@ void ScaTra::ScaTraTimIntElchOST::compute_time_deriv_pot0(const bool init)
     else
     {
       // compute time derivative of applied potential
-      if (functnum >= 0)
+      if (functnum > 0)
       {
+        // function_by_id takes a zero-based index
         const double functfac =
-            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum).evaluate(time_);
+            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum - 1).evaluate(time_);
 
         // adjust potential at metal side accordingly
         pot0np *= functfac;
@@ -852,10 +853,11 @@ void ScaTra::ScaTraTimIntElchGenAlpha::compute_time_deriv_pot0(const bool init)
     {
       // these values are not used without double layer charging
       // compute time derivative of applied potential
-      if (functnum >= 0)
+      if (functnum > 0)
       {
+        // function_by_id takes a zero-based index
         const double functfac =
-            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum).evaluate(time_);
+            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum - 1).evaluate(time_);
         // adjust potential at metal side accordingly
 
         pot0np *= functfac;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
@@ -153,11 +153,12 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
   double rhsfac = 1.0;
   // find out whether we shell use a time curve and get the factor
   // this feature can be also used for stationary "pseudo time loops"
-  if (curvenum >= 0)
+  if (curvenum > 0)
   {
-    const double curvefac =
-        Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(curvenum).evaluate(
-            time);
+    // function_by_id takes a zero-based index
+    const double curvefac = Global::Problem::instance()
+                                ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                                .evaluate(time);
     // adjust potential at metal side accordingly
     pot0 *= curvefac;
   }
@@ -258,10 +259,11 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
 
     const double time = my::scatraparamstimint_->time();
 
-    if (curvenum >= 0)
+    if (curvenum > 0)
     {
+      // function_by_id takes a zero-based index
       const double curvefac = Global::Problem::instance()
-                                  ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                                  ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                                   .evaluate(time);
       // adjust potential at metal side accordingly
       pot0 *= curvefac;

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
@@ -405,11 +405,11 @@ void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::calc_elch_boundary_
   double rhsfac = 1.0;
   // find out whether we shell use a time curve and get the factor
   // this feature can be also used for stationary "pseudo time loops"
-  if (functnum >= 0)
+  if (functnum > 0)
   {
-    const double functfac =
-        Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(functnum).evaluate(
-            time);
+    const double functfac = Global::Problem::instance()
+                                ->function_by_id<Core::Utils::FunctionOfTime>(functnum - 1)
+                                .evaluate(time);
 
     // adjust potential at metal side accordingly
     pot0 *= functfac;

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
@@ -313,11 +313,12 @@ void Discret::Elements::ScaTraEleCalcElchDiffCond<distype, probdim>::calc_elch_d
   double rhsfac = 1.0;
   // find out whether we shell use a time curve and get the factor
   // this feature can be also used for stationary "pseudo time loops"
-  if (curvenum >= 0)
+  if (curvenum > 0)
   {
-    const double curvefac =
-        Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfTime>(curvenum).evaluate(
-            time);
+    // function_by_id takes a zero-based index
+    const double curvefac = Global::Problem::instance()
+                                ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                                .evaluate(time);
     // adjust potential at metal side accordingly
     pot0 *= curvefac;
   }

--- a/src/thermo/4C_thermo_ele_boundary_impl.cpp
+++ b/src/thermo/4C_thermo_ele_boundary_impl.cpp
@@ -156,10 +156,10 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
 
     // find out whether we shall use a time curve for q^_c and get the factor
     double curvefac = 1.0;
-    if (curvenum >= 0)
+    if (curvenum > 0)
     {
       curvefac = Global::Problem::instance()
-                     ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                     ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                      .evaluate(time);
     }
     // multiply heat convection coefficient with the timecurve factor
@@ -169,10 +169,10 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
     // enabling for instance a load cycle due to combustion of a fluid
     double surtempcurvefac = 1.0;
     // find out whether we shall use a time curve for T_oo and get the factor
-    if (surtempcurvenum >= 0)
+    if (surtempcurvenum > 0)
     {
       surtempcurvefac = Global::Problem::instance()
-                            ->function_by_id<Core::Utils::FunctionOfTime>(surtempcurvenum)
+                            ->function_by_id<Core::Utils::FunctionOfTime>(surtempcurvenum - 1)
                             .evaluate(time);
     }
     // complete surrounding temperatures T_oo: multiply with the timecurve factor
@@ -375,10 +375,10 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
 
         // find out whether we shall use a time curve for q^_c and get the factor
         double curvefac = 1.0;
-        if (curvenum >= 0)
+        if (curvenum > 0)
         {
           curvefac = Global::Problem::instance()
-                         ->function_by_id<Core::Utils::FunctionOfTime>(curvenum)
+                         ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
                          .evaluate(time);
         }
         // multiply heat convection coefficient with the timecurve factor
@@ -388,10 +388,10 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
         // enabling for instance a load cycle due to combustion of a fluid
         double surtempcurvefac = 1.0;
         // find out whether we shall use a time curve for T_oo and get the factor
-        if (surtempcurvenum >= 0)
+        if (surtempcurvenum > 0)
         {
           surtempcurvefac = Global::Problem::instance()
-                                ->function_by_id<Core::Utils::FunctionOfTime>(surtempcurvenum)
+                                ->function_by_id<Core::Utils::FunctionOfTime>(surtempcurvenum - 1)
                                 .evaluate(time);
         }
         // complete surrounding temperatures T_oo: multiply with the timecurve factor

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -432,7 +432,7 @@ bool XFEM::LevelSetCoupling::set_level_set_field(const double time)
     if (projtosurf_ != Inpar::XFEM::Proj_normal)  // and projtosurf_!=Inpar::XFEM::Proj_normal_phi
     {
       // check for potential L2_Projection smoothing
-      const int l2_proj_num = (cond->parameters().get<int>("L2_PROJECTION_SOLVER") + 1);
+      const int l2_proj_num = (cond->parameters().get<int>("L2_PROJECTION_SOLVER"));
       if (l2_proj_num < 1) FOUR_C_THROW("Issue with L2_PROJECTION_SOLVER, smaller than 1!!!");
 
       // SMOOTHED GRAD PHI!!!!!! (Create from nodal map on Xfluid discretization)
@@ -1240,8 +1240,8 @@ void XFEM::LevelSetCouplingNavierSlip::set_element_conditions()
   Core::Conditions::Condition* cond = cutterele_conds_[0].second;  // get condition of first element
 
   // Get robin coupling IDs
-  robin_dirichlet_id_ = cond->parameters().get<int>("ROBIN_DIRICHLET_ID");
-  robin_neumann_id_ = cond->parameters().get<int>("ROBIN_NEUMANN_ID");
+  robin_dirichlet_id_ = cond->parameters().get<int>("ROBIN_DIRICHLET_ID") - 1;
+  robin_neumann_id_ = cond->parameters().get<int>("ROBIN_NEUMANN_ID") - 1;
 
   has_neumann_jump_ = (robin_neumann_id_ < 0) ? false : true;
 
@@ -1309,7 +1309,7 @@ void XFEM::LevelSetCouplingNavierSlip::set_element_specific_conditions(
       FOUR_C_THROW(
           "%i conditions of the same name with robin id %i, for element %i! %s coupling-condition "
           "not unique!",
-          mynewcond.size(), (robin_id + 1), cutele->id(), cond_name.c_str());
+          mynewcond.size(), robin_id, cutele->id(), cond_name.c_str());
     }
     else if (mynewcond.size() == 1)  // unique condition found
     {
@@ -1419,7 +1419,7 @@ void XFEM::LevelSetCouplingNavierSlip::get_condition_by_robin_id(
   for (size_t i = 0; i < mycond.size(); ++i)
   {
     Core::Conditions::Condition* cond = mycond[i];
-    const int id = cond->parameters().get<int>("robin_id");
+    const int id = cond->parameters().get<int>("robin_id") - 1;
 
     if (id == coupling_id) mynewcond.push_back(cond);
   }

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -1415,7 +1415,7 @@ void XFEM::LevelSetCouplingNavierSlip::get_condition_by_robin_id(
 {
   mynewcond.clear();
 
-  // select the conditions with specified "couplingID"
+  // select the conditions with specified "robin_id"
   for (size_t i = 0; i < mycond.size(); ++i)
   {
     Core::Conditions::Condition* cond = mycond[i];

--- a/src/xfem/4C_xfem_coupling_levelset.hpp
+++ b/src/xfem/4C_xfem_coupling_levelset.hpp
@@ -487,8 +487,6 @@ namespace XFEM
         gradphi.put_scalar(0.0);  // This to catch the cases when gradphi \approx 0
 
       setup_projection_matrix(projection_matrix, gradphi);
-
-      return;
     }
 
    protected:
@@ -530,8 +528,8 @@ namespace XFEM
     bool has_neumann_jump_;
     double sliplength_;
 
-    // ID given the Robin Dirichlet/-Neumann conditions (need to match the one given in the "MAIN
-    // condition")
+    // ID given the Robin Dirichlet/-Neumann conditions
+    // (need to match the one given in the "MAIN condition")
     int robin_dirichlet_id_;
     int robin_neumann_id_;
 

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1497,7 +1497,7 @@ void XFEM::MeshCouplingNavierSlip::get_condition_by_robin_id(
 {
   mynewcond.clear();
 
-  // select the conditions with specified "couplingID"
+  // select the conditions with specified "robin_id"
   for (auto* cond : mycond)
   {
     const int id = cond->parameters().get<int>("robin_id");

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1248,7 +1248,7 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions(Core::LinAlg::Ma
   if (eval_dirich_at_gp)
   {
     // evaluate interface velocity (given by weak Dirichlet condition)
-    robin_id_dirch = cond->parameters().get<int>("ROBIN_DIRICHLET_ID");
+    robin_id_dirch = cond->parameters().get<int>("ROBIN_DIRICHLET_ID") - 1;
     // Check if int is negative (signbit(x) -> x<0 true, x=>0 false)
     if (!std::signbit(static_cast<double>(robin_id_dirch)))
       evaluate_dirichlet_function(
@@ -1265,7 +1265,7 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions(Core::LinAlg::Ma
   }
 
   // evaluate interface traction (given by Neumann condition)
-  robin_id_dirch = cond->parameters().get<int>("ROBIN_NEUMANN_ID");
+  robin_id_dirch = cond->parameters().get<int>("ROBIN_NEUMANN_ID") - 1;
   if (!std::signbit(static_cast<double>(robin_id_dirch)))
   {
     // This is maybe not the most efficient implementation as we evaluate dynvisc as well as the
@@ -1338,14 +1338,14 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions_old_state(
   //  }
 
   // evaluate interface velocity (given by weak Dirichlet condition)
-  int robin_id_dirch = cond->parameters().get<int>("ROBIN_DIRICHLET_ID");
+  int robin_id_dirch = cond->parameters().get<int>("ROBIN_DIRICHLET_ID") - 1;
   // Check if int is negative (signbit(x) -> x<0 true, x=>0 false)
   if (!std::signbit(static_cast<double>(robin_id_dirch)))
     evaluate_dirichlet_function(
         ivel, x, conditionsmap_robin_dirch_.find(robin_id_dirch)->second, time_ - dt_);
 
   // evaluate interface traction (given by Neumann condition)
-  robin_id_dirch = cond->parameters().get<int>("ROBIN_NEUMANN_ID");
+  robin_id_dirch = cond->parameters().get<int>("ROBIN_NEUMANN_ID") - 1;
   if (!std::signbit(static_cast<double>(robin_id_dirch)))
     evaluate_neumann_function(
         itraction, x, conditionsmap_robin_neumann_.find(robin_id_dirch)->second, time_ - dt_);
@@ -1384,10 +1384,10 @@ void XFEM::MeshCouplingNavierSlip::create_robin_id_map(
   for (unsigned i = 0; i < conditions_NS.size(); ++i)
   {
     // Extract its robin id (either dirichlet or neumann)
-    const int tmp_robin_id = conditions_NS[i]->parameters().get<int>(robin_id_name);
+    const int tmp_robin_id = conditions_NS[i]->parameters().get<int>(robin_id_name) - 1;
 
     // Is this robin id active? I.e. is it not 0 or negative?
-    if (!(tmp_robin_id < 0))
+    if (tmp_robin_id >= 0)
     {
       std::vector<Core::Conditions::Condition*> mynewcond;
       get_condition_by_robin_id(conditions_robin, tmp_robin_id, mynewcond);
@@ -1479,7 +1479,7 @@ void XFEM::MeshCouplingNavierSlip::set_condition_specific_parameters()
   //       Robin Dirichlet section (Safety check! (not beautiful structure but could be worse..))
   for (auto* tmp_cond : conditions_NS)
   {
-    const int tmp_robin_id = tmp_cond->parameters().get<int>("ROBIN_DIRICHLET_ID");
+    const int tmp_robin_id = tmp_cond->parameters().get<int>("ROBIN_DIRICHLET_ID") - 1;
     if (!std::signbit(static_cast<double>(tmp_robin_id)))
     {
       if ((conditionsmap_robin_dirch_.find(tmp_robin_id)
@@ -1500,9 +1500,9 @@ void XFEM::MeshCouplingNavierSlip::get_condition_by_robin_id(
   // select the conditions with specified "robin_id"
   for (auto* cond : mycond)
   {
-    const int id = cond->parameters().get<int>("robin_id");
+    const int id_zero_based = cond->parameters().get<int>("robin_id") - 1;
 
-    if (id == coupling_id) mynewcond.push_back(cond);
+    if (id_zero_based == coupling_id) mynewcond.push_back(cond);
   }
 }
 

--- a/src/xfem/4C_xfem_coupling_mesh_coupled_levelset.hpp
+++ b/src/xfem/4C_xfem_coupling_mesh_coupled_levelset.hpp
@@ -69,7 +69,7 @@ namespace XFEM
       if (eval_dirich_at_gp)
       {
         // evaluate interface velocity (given by weak Dirichlet condition)
-        robin_id_dirch = cond->parameters().get<int>("ROBIN_DIRICHLET_ID");
+        robin_id_dirch = cond->parameters().get<int>("ROBIN_DIRICHLET_ID") - 1;
         // Check if int is negative (signbit(x) -> x<0 true, x=>0 false)
         if (!std::signbit(static_cast<double>(robin_id_dirch)))
           evaluate_dirichlet_function(
@@ -86,7 +86,7 @@ namespace XFEM
       }
 
       // evaluate interface traction (given by Neumann condition)
-      robin_id_dirch = cond->parameters().get<int>("ROBIN_NEUMANN_ID");
+      robin_id_dirch = cond->parameters().get<int>("ROBIN_NEUMANN_ID") - 1;
       if (!std::signbit(static_cast<double>(robin_id_dirch)))
       {
         // This is maybe not the most efficient implementation as we evaluate dynvisc as well as the

--- a/tests/input_files/fsci_simp_salz_syst.dat
+++ b/tests/input_files/fsci_simp_salz_syst.dat
@@ -232,7 +232,7 @@ E 9 - InterfaceID 1 Side Slave
 -----------------DESIGN SURFACE FLOW-DEPENDENT PRESSURE CONDITIONS
 DSURF  1
 // outflow
-E 2 - TYPE_OF_FLOW_DEPENDENCE flow_rate ConstCoeff 0.0 LinCoeff 343.0 InitialVolume 0.0 ReferencePressure 0.0 AdiabaticExponent 0.0 curve 0
+E 2 - TYPE_OF_FLOW_DEPENDENCE flow_rate ConstCoeff 0.0 LinCoeff 343.0 InitialVolume 0.0 ReferencePressure 0.0 AdiabaticExponent 0.0 curve none
 -------------------------------DESIGN FSI COUPLING SURF CONDITIONS
 DSURF  2
 // fluid-bag_surface


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
Remove the `fortran_style` option from `LineComponent`.
Now, all integer values are read as they are (without modifying to a zero-based representation).
Any modification is done explicitly after the input has been read. 

Additionally I simplified some loops and applied some clang-tidy suggestions.

## Related Issues and Merge Requests
Related to https://github.com/4C-multiphysics/4C/issues/73
Follows https://github.com/4C-multiphysics/4C/pull/238, see https://github.com/4C-multiphysics/4C/pull/238#discussion_r1913064591