### PR TITLE
Fix bug in default.head creation by pre_exodus

### DIFF
--- a/apps/pre_exodus/4C_pre_exodus.cpp
+++ b/apps/pre_exodus/4C_pre_exodus.cpp
@@ -313,13 +313,13 @@ int main(int argc, char** argv)
       std::stringstream prelimhead;
       Core::IO::InputFileUtils::print_dat(prelimhead, *list);
       std::string headstring = prelimhead.str();
-      size_t size_section =
-          headstring.find("-------------------------------------------------------PROBLEM SIZE");
+      size_t size_section = headstring.find("--PROBLEM SIZE");
       if (size_section != std::string::npos)
       {
-        size_t typ_section =
-            headstring.find("--------------------------------------------------------PROBLEM TYPE");
-        headstring.erase(size_section, typ_section - size_section);
+        size_t size_section_start = headstring.substr(0, size_section).rfind("\n");
+        size_t type_section = headstring.find("--PROBLEM TYPE");
+        size_t type_section_start = headstring.substr(0, type_section).rfind("\n");
+        headstring.erase(size_section_start, type_section_start - size_section_start);
       }
       defaulthead << headstring;
 


### PR DESCRIPTION
## Description and Context
Probably since the change in keywords (renaming PROBLEM TYP to PROBLEM TYPE), `pre_exodus` did not procude a correct `default.head` for the case that the option `--head` is missing. (The complete part after `PROBLEM SIZE` was skipped).

I changed a few lines, so that now the complete `default.head` is printed as it should. In addition, now the correct output does not depend on the number of dashes in front of the section keyword anymore ;-)

## Related Issues and Merge Requests
Follow up to https://gitlab.lrz.de/baci/baci/-/merge_requests/2645

