### PR TITLE
Add administrative tasks for releasing 4C

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,57 @@
+---
+name: Release
+about: Create a new release.
+title: "Release 4C version YYYY.MINOR.PATCH"
+type: Task
+assignees: ''
+
+---
+
+## Steps for a new 4C release
+> [!NOTE]
+> For a PATCH-release, only some of the steps below are necessary. Commits are typically added to the
+> ``main`` branch and cherry-picked to the release branch. That ensures that the main branch is fixed
+> and the PATCH itself is still compatible with all projects consuming a specific version of |FOURC|.
+
+- [ ] Check whether all changes that should be part of the release are merged into the ``main``-branch.
+- [ ] Draft the release notes and post them as a comment to this issue (See notes below on release notes)
+- [ ] Update the version number in the ``VERSION`` file in the repo. The version scheme is ``YYYY.MINOR.PATCH``, where ``YYYY`` is the year of the release, ``MINOR`` is the number of the release in the year starting at ``1``, and ``PATCH`` is the patch number. ``PATCH`` is typically ``0`` and incremented on demand. Typically, this step only involves removing the ``-dev`` suffix from the version.
+- [ ] Pick a commit from ``main``-branch where all nightly tests have passed and the above points are satisfied. Commit: ``<insert the commit sha>``
+- [ ] Create a new branch from the commit chosen in the previous step. The branch should be named ``release/YYYY.MINOR.x``. Note, since all patches are maintained on this branch, the name does not contain the respective patch number.
+- [ ] Create a new release on GitHub. The tag name should be ``vYYYY.MINOR.PATCH`` and the release title should be ``4C version vYYYY.MINOR.PATCH``. Tick 'Set as latest release' and 'Create a discussion for this release'
+- [ ] Upload the `4C_metadata.yaml` and `4C_schema.yaml` to the release. You can download them as artifact from the nightly pipeline.
+- [ ] Update the tags of all Docker images, e.g., ``4c`` and ``4c-dependencies-ubuntu24.04``. Add the tag ``YYYY.MINOR.PATCH`` to the images, and ``latest`` if it is the latest release. You can run the script `./utilities/tag_images_for_release.sh`.
+- [ ] Prepare the next release in the `VERSION` file in the repo by incrementing the number of the release, resetting the patch number to `0`, and adding the suffix `-dev`.
+
+
+### Release notes
+The release notes might contain a summary of the changes since the last release or a description of the fixed bugs in a PATCH release.
+
+We do not yet have an automated way to collect the changelog. So, this requires some manual work. You can get a draft of the release notes from GitHub (Releases -> Draft a new release -> Generate release notes).
+
+<details><summary>Changelog template</summary>
+<p>
+
+## What's Changed
+<!-- Usually the commit message with pull request id, as provided by GitHub's generated release notes, is enough -->
+
+### Breaking Changes
+<!-- List of breaking changes: Filter issues with `breaking change` label -->
+
+### Major changes
+<!-- Any major changes. This can also contain self-written text on some major change -->
+
+### Dependency changes
+<!-- Any changes to our dependencies, e.g., Trilinos update, a new dependency -->
+
+### Miscellaneous
+<!-- Any other noteworthy changes -->
+
+## New Contributors
+<!-- GitHub's generated release notes contain a list of new contributors since the last release -->
+
+
+<!-- link to full changelog provided by GitHub's generated release notes -->
+**Full Changelog**: https://github.com/4C-multiphysics/4C/compare/v2025.1.0...v2025.2.0
+</p>
+</details>

--- a/doc/documentation/src/developer_guide/developer_release.rst
+++ b/doc/documentation/src/developer_guide/developer_release.rst
@@ -1,0 +1,9 @@
+How to release |FOURC|
+----------------------
+
+.. note::
+   This section is only relevant for the maintainers of the repository.
+
+|FOURC| is released regularly on GitHub. Releases are managed and created by the @4C-multiphysics/maintainer.
+
+Create an issue with the release template on GitHub and follow the administrative tasks that need to be performed to publish a release on GitHub.

--- a/doc/documentation/src/developer_guide/developmentguide.rst
+++ b/doc/documentation/src/developer_guide/developmentguide.rst
@@ -17,3 +17,4 @@ Developer guide
     developer_cluster
     petra_object_model
     development_parts
+    developer_release

--- a/utilities/tag_images_for_release.sh
+++ b/utilities/tag_images_for_release.sh
@@ -1,0 +1,105 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# The script requires the following variables to be set, e.g., with
+# export RELEASE="2025.2.0"
+# export COMMIT_SHA="87550fd36f7d057a47b67dba2226ed6cb6a8985b"
+# export VERSION_DEPENDENCIES="49ffc8b8" # The dependencies hash
+# export IMAGE_PREBUILT_4C="4c@sha256:8c313acdd3c1f96a5cc943b4239e63dd8557417c1c3f5fe85144a63bc4ed67ab"
+# export IMAGE_PREBUILT_4C_MINIMAL="4c-minimal@sha256:170306ee11ca9f403dd8248949b748aba22180e8532a035c02a43f923217c22b"
+#
+# For the prebuilt 4C images it is better to use the digest `4c@sha256:...` instead of the `main` tag.
+# The main tag can already point to a newer commit than the desired commit.
+#
+# Note: you need a working docker installation
+set -e
+
+echo "This script pushes images to the public 4C repository for a release."
+read -sp "Have you checked that the script is up-to-date? Do you know what you are doing? (y/N): " REPLY
+echo ""
+
+if [ "$REPLY" != "y" ]; then
+echo "Abort."
+  exit 1
+fi
+
+REQUIRED_INPUT=(
+  "RELEASE"
+  "COMMIT_SHA"
+  "VERSION_DEPENDENCIES"
+  "IMAGE_PREBUILT_4C"
+  "IMAGE_PREBUILT_4C_MINIMAL"
+)
+
+echo "Input:"
+for VAR in ${REQUIRED_INPUT[@]};
+do
+  echo "${VAR}=${!VAR}"
+  if [ "${!VAR}" = "" ]; then
+    echo "Required input is empty!"
+    exit 1
+  fi
+done
+echo ""
+
+
+# Dependencies image
+docker pull ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:${VERSION_DEPENDENCIES}
+docker tag ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:${VERSION_DEPENDENCIES} ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:${RELEASE}
+docker tag ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:${VERSION_DEPENDENCIES} ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:latest
+
+
+# Prebuilt 4C
+docker pull ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C}
+# Check if the 4C build in the image matches the commit for the release
+IMAGE_PREBUILT_4C_REVISION=`docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision"}}' ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C}`
+if [ "$COMMIT_SHA" != "$IMAGE_PREBUILT_4C_REVISION" ]; then
+  echo "The prebuilt 4C is based on commit $IMAGE_PREBUILT_4C_REVISION. But you provided commit $COMMIT_SHA for the release."
+  echo "The provided docker image might be wrong!"
+  exit 1
+fi
+# Check if the dependencies hash matches the provided dependencies version
+IMAGE_PREBUILT_4C_DEPENDENCIES_HASH=`docker inspect --format '{{ index .Config.Labels "org.4c-multiphysics.dependencies_hash"}}' ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C}`
+if [ "$VERSION_DEPENDENCIES" != "$IMAGE_PREBUILT_4C_DEPENDENCIES_HASH" ]; then
+  echo "The prebuilt 4C is based on the dependencies image $IMAGE_PREBUILT_4C_DEPENDENCIES_HASH. But you provided $VERSION_DEPENDENCIES for the dependencies image for the release."
+  echo "The provided docker image might be wrong!"
+  exit 1
+fi
+docker tag ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C} ghcr.io/4c-multiphysics/4c:${RELEASE}
+docker tag ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C} ghcr.io/4c-multiphysics/4c:latest
+
+
+# Prebuilt 4C minimal
+docker pull ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C_MINIMAL}
+IMAGE_PREBUILT_4C_MINIMAL_REVISION=`docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision"}}' ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C_MINIMAL}`
+if [ "$COMMIT_SHA" != "$IMAGE_PREBUILT_4C_MINIMAL_REVISION" ]; then
+  echo "The prebuilt 4C is based on commit $IMAGE_PREBUILT_4C_MINIMAL_REVISION. But you provided commit $COMMIT_SHA for the release."
+  echo "The provided docker image might be wrong!"
+  exit 1
+fi
+docker tag ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C_MINIMAL} ghcr.io/4c-multiphysics/4c-minimal:${RELEASE}
+docker tag ghcr.io/4c-multiphysics/${IMAGE_PREBUILT_4C_MINIMAL} ghcr.io/4c-multiphysics/4c-minimal:latest
+
+
+read -sp "You are about to push to the 4C repository. Continue? (y/N): " REPLY
+echo ""
+if [ "$REPLY" != "y" ]; then
+  echo "Abort."
+  exit 1
+fi
+
+# Push the images
+docker push ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:${RELEASE}
+docker push ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:latest
+
+docker push ghcr.io/4c-multiphysics/4c:${RELEASE}
+docker push ghcr.io/4c-multiphysics/4c:latest
+
+docker push ghcr.io/4c-multiphysics/4c-minimal:${RELEASE}
+docker push ghcr.io/4c-multiphysics/4c-minimal:latest
+
+echo "You have released the images for 4C version $VERSION"


### PR DESCRIPTION
Currently draft, since the exact procedure might not be final.

We might want to automate step 6.

@4C-multiphysics/maintainer 