### PR TITLE
Don't reset step in explicit central difference scheme

### DIFF
--- a/src/structure_new/src/explicit/4C_structure_new_expl_centrdiff.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_centrdiff.cpp
@@ -74,8 +74,6 @@ void Solid::EXPLICIT::CentrDiff::set_state(const Core::LinAlg::Vector<double>& x
   const double dt = (*global_state().get_delta_time())[0];
   const double dthalf = dt / 2.0;
 
-  model_eval().reset_step_state();
-
   // ---------------------------------------------------------------------------
   // new end-point acceleration
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
Resetting the step should only be done if the timestep will be recomuted again (e.g. for time adaptivity) and not in the general case when setting the state.