### PR TITLE
Replace most LineDefinitions with InputSpecs

### DIFF
--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
@@ -640,13 +640,13 @@ namespace RTD
       write_linktarget(stream, "restultdescriptionreference");
       write_header(stream, 0, "Result description reference");
 
-      std::vector<Input::LineDefinition> lines =
-          global_legacy_module_callbacks().valid_result_description_lines();
+      auto result_spec = global_legacy_module_callbacks().valid_result_description_lines();
       write_paragraph(stream,
           "The result of the simulation with respect to specific quantities at concrete points "
           "can be tested against particular values with a given tolerance.");
       std::stringstream resultDescriptionStream;
-      Core::IO::InputFileUtils::print_section(resultDescriptionStream, "RESULT DESCRIPTION", lines);
+      Core::IO::InputFileUtils::print_section(
+          resultDescriptionStream, "RESULT DESCRIPTION", result_spec);
       const std::vector<std::string> resultDescriptionList =
           Core::Utils::split(resultDescriptionStream.str(), "\n");
       write_code(stream, resultDescriptionList);

--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
@@ -287,9 +287,9 @@ namespace RTD
         "This discretization is then cloned/duplicated such that the resulting discretization "
         "is assigned the material TAR_MAT.");
 
-    const std::vector<Input::LineDefinition> lines = Core::FE::valid_cloning_material_map_lines();
+    const auto spec = Core::FE::valid_cloning_material_map();
     std::stringstream cloningMatStream;
-    Core::IO::InputFileUtils::print_section(cloningMatStream, "CLONING MATERIAL MAP", lines);
+    Core::IO::InputFileUtils::print_section(cloningMatStream, "CLONING MATERIAL MAP", spec);
     const std::vector<std::string> cloningMatList =
         Core::Utils::split(cloningMatStream.str(), "\n");
 

--- a/apps/global_full/4C_global_full_control.cpp
+++ b/apps/global_full/4C_global_full_control.cpp
@@ -12,6 +12,8 @@
 #include "4C_global_full_inp_control.hpp"
 #include "4C_io_pstream.hpp"
 
+#include <chrono>
+
 
 namespace
 {

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -289,7 +289,7 @@ int main(int argc, char* argv[])
         std::cout << '\n';
       }
 
-      const auto lines = Core::FE::valid_cloning_material_map_lines();
+      const auto lines = Core::FE::valid_cloning_material_map();
       Core::IO::InputFileUtils::print_section(std::cout, "CLONING MATERIAL MAP", lines);
 
       print_element_dat_header();

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -294,9 +294,8 @@ int main(int argc, char* argv[])
 
       print_element_dat_header();
 
-      const std::vector<Input::LineDefinition> result_lines =
-          global_legacy_module_callbacks().valid_result_description_lines();
-      Core::IO::InputFileUtils::print_section(std::cout, "RESULT DESCRIPTION", result_lines);
+      const auto result_spec = global_legacy_module_callbacks().valid_result_description_lines();
+      Core::IO::InputFileUtils::print_section(std::cout, "RESULT DESCRIPTION", result_spec);
 
       printf("\n\n");
     }

--- a/apps/pre_exodus/4C_pre_exodus.cpp
+++ b/apps/pre_exodus/4C_pre_exodus.cpp
@@ -347,7 +347,7 @@ int main(int argc, char** argv)
         std::stringstream tmp;
         Core::Utils::FunctionManager functionmanager;
         global_legacy_module_callbacks().AttachFunctionDefinitions(functionmanager);
-        const std::vector<Input::LineDefinition> flines = functionmanager.valid_function_lines();
+        const auto flines = functionmanager.valid_function_lines();
         Core::IO::InputFileUtils::print_section(tmp, "FUNCT", flines);
         std::string tmpstring = tmp.str();
         std::string removeit =

--- a/apps/pre_exodus/4C_pre_exodus.cpp
+++ b/apps/pre_exodus/4C_pre_exodus.cpp
@@ -331,7 +331,7 @@ int main(int argc, char** argv)
       }
 
       // print cloning material map default lines (right after the materials)
-      const auto lines = Core::FE::valid_cloning_material_map_lines();
+      const auto lines = Core::FE::valid_cloning_material_map();
       Core::IO::InputFileUtils::print_section(defaulthead, "CLONING MATERIAL MAP", lines);
 
       // print spatial functions

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -8,6 +8,7 @@
 #include "4C_fem_general_utils_createdis.hpp"
 
 #include "4C_fem_dofset_transparent_independent.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_linedefinition.hpp"
 #include "4C_rebalance_binning_based.hpp"
 
@@ -253,14 +254,16 @@ void Core::FE::DiscretizationCreatorBase::finalize(
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<Input::LineDefinition> Core::FE::valid_cloning_material_map_lines()
+Core::IO::InputSpec Core::FE::valid_cloning_material_map()
 {
-  return {Input::LineDefinition::Builder()
-          .add_named_string("SRC_FIELD")
-          .add_named_int("SRC_MAT")
-          .add_named_string("TAR_FIELD")
-          .add_named_int("TAR_MAT")
-          .build()};
+  using namespace Core::IO::InputSpecBuilders;
+  return anonymous_group({
+      entry<std::string>("SRC_FIELD"),
+      entry<int>("SRC_MAT"),
+      entry<std::string>("TAR_FIELD"),
+      entry<int>("TAR_MAT"),
+
+  });
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.hpp
@@ -17,6 +17,7 @@
 #include "4C_fem_general_immersed_node.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_fem_nurbs_discretization.hpp"
+#include "4C_io_input_spec.hpp"
 #include "4C_io_linedefinition.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_material_base.hpp"
@@ -941,7 +942,7 @@ namespace Core::FE
   };  // clone_discretization_from_condition
 
   //! Return valid cloning material map input lines.
-  std::vector<Input::LineDefinition> valid_cloning_material_map_lines();
+  IO::InputSpec valid_cloning_material_map();
 
 }  // namespace Core::FE
 

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -10,6 +10,7 @@
 #include "4C_io_input_file_utils.hpp"
 
 #include "4C_io_input_file.hpp"
+#include "4C_io_value_parser.hpp"
 
 #include <ryml.hpp>
 #include <ryml_std.hpp>
@@ -291,6 +292,17 @@ void Core::IO::InputFileUtils::print_section(std::ostream& out, const std::strin
 }
 
 
+void Core::IO::InputFileUtils::print_section(
+    std::ostream& out, const std::string& header, const InputSpec& spec)
+{
+  print_section_header(out, header);
+
+  out << "// ";
+  spec.print_as_dat(out, Core::IO::InputParameterContainer{});
+  out << '\n';
+}
+
+
 void Core::IO::InputFileUtils::print_dat(
     std::ostream& stream, const Teuchos::ParameterList& list, bool comment)
 {
@@ -373,6 +385,23 @@ std::vector<Core::IO::InputParameterContainer> Core::IO::InputFileUtils::read_al
           out << '\n';
         });
     FOUR_C_THROW(out.str().c_str());
+  }
+
+  return parsed_lines;
+}
+
+
+std::vector<Core::IO::InputParameterContainer> Core::IO::InputFileUtils::read_all_lines_in_section(
+    Core::IO::InputFile& input, const std::string& section, const InputSpec& spec)
+{
+  std::vector<Core::IO::InputParameterContainer> parsed_lines;
+
+  for (const auto& line : input.lines_in_section(section))
+  {
+    ValueParser parser{line};
+    Core::IO::InputParameterContainer container;
+    spec.fully_parse(parser, container);
+    parsed_lines.emplace_back(std::move(container));
   }
 
   return parsed_lines;

--- a/src/core/io/src/4C_io_input_file_utils.hpp
+++ b/src/core/io/src/4C_io_input_file_utils.hpp
@@ -65,17 +65,6 @@ namespace Core::IO::InputFileUtils
    */
   void print_section(std::ostream& out, const std::string& header, const InputSpec& spec);
 
-  /**
-   * Read all lines in a @p section of @p input that match the @p possible_lines.
-   * Every line in the @p section must be readable as one of the @p possible_lines. Otherwise, an
-   * exception is thrown.
-   *
-   * @see read_matching_lines_in_section()
-   */
-  std::vector<Core::IO::InputParameterContainer> read_all_lines_in_section(
-      Core::IO::InputFile& input, const std::string& section,
-      const std::vector<Input::LineDefinition>& possible_lines);
-
 
   /**
    * Read all lines in a @p section of @p input that match the @p spec. Every line in the @p section
@@ -86,7 +75,7 @@ namespace Core::IO::InputFileUtils
 
 
   /**
-   * Read only lines in a @p section of @p input that match the @p possible_lines. This implies
+   * Read only lines in a @p section of @p input that match the @p spec. This implies
    * that, potentially, no lines are read at all, resulting in an empty returned vector. In
    * addition to the vector of parsed lines, the second returned value contains all unparsed input
    * lines.
@@ -94,8 +83,8 @@ namespace Core::IO::InputFileUtils
    * @see read_all_lines_in_section()
    */
   std::pair<std::vector<Core::IO::InputParameterContainer>, std::vector<std::string>>
-  read_matching_lines_in_section(Core::IO::InputFile& input, const std::string& section,
-      const std::vector<Input::LineDefinition>& possible_lines);
+  read_matching_lines_in_section(
+      Core::IO::InputFile& input, const std::string& section, const InputSpec& spec);
 
 }  // namespace Core::IO::InputFileUtils
 

--- a/src/core/io/src/4C_io_input_file_utils.hpp
+++ b/src/core/io/src/4C_io_input_file_utils.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_input_spec.hpp"
 #include "4C_io_linedefinition.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
@@ -60,6 +61,11 @@ namespace Core::IO::InputFileUtils
       const std::vector<Input::LineDefinition>& possible_lines);
 
   /**
+   * Print @p spec into a dat file section with given @p header.
+   */
+  void print_section(std::ostream& out, const std::string& header, const InputSpec& spec);
+
+  /**
    * Read all lines in a @p section of @p input that match the @p possible_lines.
    * Every line in the @p section must be readable as one of the @p possible_lines. Otherwise, an
    * exception is thrown.
@@ -69,6 +75,14 @@ namespace Core::IO::InputFileUtils
   std::vector<Core::IO::InputParameterContainer> read_all_lines_in_section(
       Core::IO::InputFile& input, const std::string& section,
       const std::vector<Input::LineDefinition>& possible_lines);
+
+
+  /**
+   * Read all lines in a @p section of @p input that match the @p spec. Every line in the @p section
+   * must match the @p spec. Otherwise, an exception is thrown.
+   */
+  std::vector<Core::IO::InputParameterContainer> read_all_lines_in_section(
+      Core::IO::InputFile& input, const std::string& section, const InputSpec& spec);
 
 
   /**

--- a/src/core/utils/src/functions/4C_utils_function_library.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_library.cpp
@@ -9,7 +9,7 @@
 
 #include "4C_io_control.hpp"
 #include "4C_io_file_reader.hpp"
-#include "4C_io_linedefinition.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_utils_cubic_spline_interpolation.hpp"
 #include "4C_utils_function_manager.hpp"
 
@@ -59,21 +59,21 @@ namespace
 /*----------------------------------------------------------------------*/
 void Core::Utils::add_valid_library_functions(Core::Utils::FunctionManager& function_manager)
 {
-  using namespace Input;
+  using namespace IO::InputSpecBuilders;
 
-  LineDefinition fast_polynomial_funct =
-      LineDefinition::Builder()
-          .add_tag("FASTPOLYNOMIAL")
-          .add_named_int("NUMCOEFF")
-          .add_named_double_vector("COEFF", LengthFromIntNamed("NUMCOEFF"))
-          .build();
+  auto spec = one_of({
+      anonymous_group({
+          tag("FASTPOLYNOMIAL"),
+          entry<int>("NUMCOEFF"),
+          entry<std::vector<double>>("COEFF", {.size = from_parameter<int>("NUMCOEFF")}),
+      }),
+      anonymous_group({
+          tag("CUBIC_SPLINE_FROM_CSV"),
+          entry<std::filesystem::path>("CSV"),
+      }),
+  });
 
-  LineDefinition cubic_spline_from_csv_funct =
-      LineDefinition::Builder().add_tag("CUBIC_SPLINE_FROM_CSV").add_named_path("CSV").build();
-
-  function_manager.add_function_definition(
-      {std::move(fast_polynomial_funct), std::move(cubic_spline_from_csv_funct)},
-      create_library_function_scalar);
+  function_manager.add_function_definition(spec, create_library_function_scalar);
 }
 
 

--- a/src/core/utils/src/functions/4C_utils_function_manager.hpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.hpp
@@ -11,7 +11,7 @@
 
 #include "4C_config.hpp"
 
-#include "4C_io_linedefinition.hpp"
+#include "4C_io_input_spec.hpp"
 #include "4C_utils_demangle.hpp"
 #include "4C_utils_exceptions.hpp"
 
@@ -47,21 +47,20 @@ namespace Core::Utils
         std::function<std::any(const std::vector<Core::IO::InputParameterContainer>& lines)>;
 
     /// Return all known input lines that define a Function.
-    std::vector<Input::LineDefinition> valid_function_lines();
+    IO::InputSpec valid_function_lines();
 
     /// Read the 4C input file and set up all Functions.
     void read_input(Core::IO::InputFile& input);
 
     /**
-     * Tell the FunctionManager how to parse a set of @p possible_lines into a Function object.
-     * When the ReadInput() function is called, this class will try to read lines encountered in
-     * the input file according to the @p possible_lines that were previously passed in this
-     * function. If one or more of these lines match, they are parsed and the @p function_factory
-     * that was passed alongside these lines is called with the parsed data. @p function_factory
-     * needs to return the actual function object wrapped in a std::shared_ptr.
+     * Tell the FunctionManager how to parse a @p spec into a Function object. When the ReadInput()
+     * function is called, this class will try to read lines encountered in the input file according
+     * to the @p spec that were previously passed in this function. If one or more of these lines
+     * match, they are parsed and the @p function_factory that was passed alongside these lines is
+     * called with the parsed data. @p function_factory needs to return the actual function object
+     * wrapped in a std::shared_ptr.
      */
-    void add_function_definition(
-        std::vector<Input::LineDefinition> possible_lines, FunctionFactory function_factory);
+    void add_function_definition(IO::InputSpec spec, FunctionFactory function_factory);
 
     /**
      * Get a Function by its @p id in the input file. In addition, you need to specify the type of
@@ -87,12 +86,10 @@ namespace Core::Utils
     /// Function objects belonging to distinct interfaces.
     std::vector<std::any> functions_;
 
-
     /**
      * Store the lines we can read and how to convert them into a 4C Function.
      */
-    std::vector<std::pair<std::vector<Input::LineDefinition>, FunctionFactory>>
-        attached_function_data_;
+    std::vector<std::pair<IO::InputSpec, FunctionFactory>> attached_function_data_;
   };
 
   /**

--- a/src/core/utils/src/result_test/4C_utils_result_test.cpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.cpp
@@ -121,7 +121,7 @@ int Core::Utils::ResultTest::compare_values(
 /*----------------------------------------------------------------------*/
 bool Core::Utils::ResultTest::match(const Core::IO::InputParameterContainer& container)
 {
-  return container.get_or<bool>(myname_, false);
+  return container.has_group(myname_);
 }
 
 
@@ -152,16 +152,17 @@ void Core::Utils::ResultTestManager::test_all(MPI_Comm comm)
     {
       if (fieldtest->match(result))
       {
-        if (result.get_if<int>("ELEMENT") != nullptr)
-          fieldtest->test_element(result, nerr, test_count);
-        else if (result.get_if<int>("NODE") != nullptr)
-          fieldtest->test_node(result, nerr, test_count);
-        else if (result.get_if<int>("LINE") != nullptr ||
-                 result.get_if<int>("SURFACE") != nullptr ||
-                 result.get_if<int>("VOLUME") != nullptr)
-          fieldtest->test_node_on_geometry(result, nerr, test_count, get_node_set());
+        const auto& group = result.group(fieldtest->name());
+
+        if (group.get_if<int>("ELEMENT") != nullptr)
+          fieldtest->test_element(group, nerr, test_count);
+        else if (group.get_if<int>("NODE") != nullptr)
+          fieldtest->test_node(group, nerr, test_count);
+        else if (group.get_if<int>("LINE") != nullptr || group.get_if<int>("SURFACE") != nullptr ||
+                 group.get_if<int>("VOLUME") != nullptr)
+          fieldtest->test_node_on_geometry(group, nerr, test_count, get_node_set());
         else
-          fieldtest->test_special(result, nerr, test_count, uneval_test_count);
+          fieldtest->test_special(group, nerr, test_count, uneval_test_count);
       }
     }
   }

--- a/src/core/utils/src/result_test/4C_utils_result_test.hpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.hpp
@@ -20,11 +20,6 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace Input
-{
-  class LineDefinition;
-}  // namespace Input
-
 namespace Core::IO
 {
   class InputFile;
@@ -96,6 +91,12 @@ namespace Core::Utils
 
     /// tell whether this field test matches to a given line
     virtual bool match(const Core::IO::InputParameterContainer& container);
+
+    /**
+     * The name of the field test. This name matches the top-level group of the input for a result
+     * test.
+     */
+    [[nodiscard]] const std::string& name() const { return myname_; }
 
    protected:
     //! compare a calculated @param actresult with the expected one stored in the @param container

--- a/src/fluid/4C_fluid_functions.cpp
+++ b/src/fluid/4C_fluid_functions.cpp
@@ -8,6 +8,7 @@
 #include "4C_fluid_functions.hpp"
 
 #include "4C_global_data.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_mat_fluid_linear_density_viscosity.hpp"
 #include "4C_mat_fluid_murnaghantait.hpp"
 #include "4C_mat_fluid_weakly_compressible.hpp"
@@ -331,146 +332,104 @@ namespace
 
 void FLD::add_valid_fluid_functions(Core::Utils::FunctionManager& function_manager)
 {
-  auto beltrami =
-      Input::LineDefinition::Builder().add_tag("BELTRAMI").add_named_double("c1").build();
+  using namespace Core::IO::InputSpecBuilders;
+  auto spec = one_of({
+      anonymous_group({
+          tag("BELTRAMI"),
+          entry<double>("c1"),
+      }),
+      tag("CHANNELWEAKLYCOMPRESSIBLE"),
+      tag("CORRECTIONTERMCHANNELWEAKLYCOMPRESSIBLE"),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_POISEUILLE"),
+          entry<int>("MAT"),
+          entry<double>("L"),
+          entry<double>("R"),
+          entry<double>("U"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE"),
+          entry<int>("MAT"),
+          entry<double>("L"),
+          entry<double>("R"),
+          entry<double>("U"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW"),
+          entry<int>("MAT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW_FORCE"),
+          entry<int>("MAT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD"),
+          entry<int>("MAT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE"),
+          entry<int>("MAT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_VISCOSITY"),
+          entry<int>("MAT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID"),
+          entry<int>("MAT_FLUID"),
+          entry<int>("MAT_STRUCT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_FORCE"),
+          entry<int>("MAT_FLUID"),
+          entry<int>("MAT_STRUCT"),
+      }),
+      anonymous_group({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_VISCOSITY"),
+          entry<int>("MAT_FLUID"),
+          entry<int>("MAT_STRUCT"),
+      }),
+      anonymous_group({
+          tag("BELTRAMI-UP"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+      }),
+      anonymous_group({
+          tag("BELTRAMI-GRADU"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+      }),
+      anonymous_group({
+          tag("BELTRAMI-RHS"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+          entry<int>("ISSTOKES"),
+      }),
+      anonymous_group({
+          tag("KIMMOIN-UP"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+      }),
+      anonymous_group({
+          tag("KIMMOIN-GRADU"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+      }),
+      anonymous_group({
+          tag("KIMMOIN-RHS"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+          entry<int>("ISSTOKES"),
+      }),
+      anonymous_group({
+          tag("KIMMOIN-STRESS"),
+          entry<int>("MAT"),
+          entry<int>("ISSTAT"),
+          entry<double>("AMPLITUDE"),
+      }),
+  });
 
-  auto channelweaklycompressible =
-      Input::LineDefinition::Builder().add_tag("CHANNELWEAKLYCOMPRESSIBLE").build();
-
-  auto correctiontermchannelweaklycompressible =
-      Input::LineDefinition::Builder().add_tag("CORRECTIONTERMCHANNELWEAKLYCOMPRESSIBLE").build();
-
-  auto weaklycompressiblepoiseuille = Input::LineDefinition::Builder()
-                                          .add_tag("WEAKLYCOMPRESSIBLE_POISEUILLE")
-                                          .add_named_int("MAT")
-                                          .add_named_double("L")
-                                          .add_named_double("R")
-                                          .add_named_double("U")
-                                          .build();
-
-  auto weaklycompressiblepoiseuilleforce = Input::LineDefinition::Builder()
-                                               .add_tag("WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE")
-                                               .add_named_int("MAT")
-                                               .add_named_double("L")
-                                               .add_named_double("R")
-                                               .add_named_double("U")
-                                               .build();
-
-  auto weaklycompressiblemanufacturedflow = Input::LineDefinition::Builder()
-                                                .add_tag("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW")
-                                                .add_named_int("MAT")
-                                                .build();
-
-  auto weaklycompressiblemanufacturedflowforce =
-      Input::LineDefinition::Builder()
-          .add_tag("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW_FORCE")
-          .add_named_int("MAT")
-          .build();
-
-  auto weaklycompressibleetiennecfd = Input::LineDefinition::Builder()
-                                          .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD")
-                                          .add_named_int("MAT")
-                                          .build();
-
-  auto weaklycompressibleetiennecfdforce = Input::LineDefinition::Builder()
-                                               .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE")
-                                               .add_named_int("MAT")
-                                               .build();
-
-  auto weaklycompressibleetiennecfdviscosity =
-      Input::LineDefinition::Builder()
-          .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_VISCOSITY")
-          .add_named_int("MAT")
-          .build();
-
-  auto weaklycompressibleetiennefsifluid = Input::LineDefinition::Builder()
-                                               .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID")
-                                               .add_named_int("MAT_FLUID")
-                                               .add_named_int("MAT_STRUCT")
-                                               .build();
-
-  auto weaklycompressibleetiennefsifluidforce =
-      Input::LineDefinition::Builder()
-          .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_FORCE")
-          .add_named_int("MAT_FLUID")
-          .add_named_int("MAT_STRUCT")
-          .build();
-
-  auto weaklycompressibleetiennefsifluidviscosity =
-      Input::LineDefinition::Builder()
-          .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_VISCOSITY")
-          .add_named_int("MAT_FLUID")
-          .add_named_int("MAT_STRUCT")
-          .build();
-
-  auto beltramiup = Input::LineDefinition::Builder()
-                        .add_tag("BELTRAMI-UP")
-                        .add_named_int("MAT")
-                        .add_named_int("ISSTAT")
-                        .build();
-
-  auto beltramigradu = Input::LineDefinition::Builder()
-                           .add_tag("BELTRAMI-GRADU")
-                           .add_named_int("MAT")
-                           .add_named_int("ISSTAT")
-                           .build();
-
-  auto beltramirhs = Input::LineDefinition::Builder()
-                         .add_tag("BELTRAMI-RHS")
-                         .add_named_int("MAT")
-                         .add_named_int("ISSTAT")
-                         .add_named_int("ISSTOKES")
-                         .build();
-
-  auto kimmoinup = Input::LineDefinition::Builder()
-                       .add_tag("KIMMOIN-UP")
-                       .add_named_int("MAT")
-                       .add_named_int("ISSTAT")
-                       .build();
-
-  auto kimmoingradu = Input::LineDefinition::Builder()
-                          .add_tag("KIMMOIN-GRADU")
-                          .add_named_int("MAT")
-                          .add_named_int("ISSTAT")
-                          .build();
-
-  auto kimmoinrhs = Input::LineDefinition::Builder()
-                        .add_tag("KIMMOIN-RHS")
-                        .add_named_int("MAT")
-                        .add_named_int("ISSTAT")
-                        .add_named_int("ISSTOKES")
-                        .build();
-
-  auto kimmoinstress = Input::LineDefinition::Builder()
-                           .add_tag("KIMMOIN-STRESS")
-                           .add_named_int("MAT")
-                           .add_named_int("ISSTAT")
-                           .add_named_double("AMPLITUDE")
-                           .build();
-
-  std::vector<Input::LineDefinition> lines;
-  lines.emplace_back(std::move(beltrami));
-  lines.emplace_back(std::move(channelweaklycompressible));
-  lines.emplace_back(std::move(correctiontermchannelweaklycompressible));
-  lines.emplace_back(std::move(weaklycompressiblepoiseuille));
-  lines.emplace_back(std::move(weaklycompressiblepoiseuilleforce));
-  lines.emplace_back(std::move(weaklycompressiblemanufacturedflow));
-  lines.emplace_back(std::move(weaklycompressiblemanufacturedflowforce));
-  lines.emplace_back(std::move(weaklycompressibleetiennecfd));
-  lines.emplace_back(std::move(weaklycompressibleetiennecfdforce));
-  lines.emplace_back(std::move(weaklycompressibleetiennecfdviscosity));
-  lines.emplace_back(std::move(weaklycompressibleetiennefsifluid));
-  lines.emplace_back(std::move(weaklycompressibleetiennefsifluidforce));
-  lines.emplace_back(std::move(weaklycompressibleetiennefsifluidviscosity));
-  lines.emplace_back(std::move(beltramiup));
-  lines.emplace_back(std::move(beltramigradu));
-  lines.emplace_back(std::move(beltramirhs));
-  lines.emplace_back(std::move(kimmoinup));
-  lines.emplace_back(std::move(kimmoingradu));
-  lines.emplace_back(std::move(kimmoinrhs));
-  lines.emplace_back(std::move(kimmoinstress));
-
-  function_manager.add_function_definition(std::move(lines), create_fluid_function);
+  function_manager.add_function_definition(std::move(spec), create_fluid_function);
 }
 
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
@@ -7,7 +7,7 @@
 
 #include "4C_fluid_xfluid_functions.hpp"
 
-#include "4C_io_linedefinition.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_utils_function_manager.hpp"
 
 #include <cmath>
@@ -190,124 +190,103 @@ namespace
 
 void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& function_manager)
 {
-  Input::LineDefinition gerstenbergerforwardfacingstep =
-      Input::LineDefinition::Builder().add_tag("FORWARDFACINGSTEP").build();
+  using namespace Core::IO::InputSpecBuilders;
 
-  Input::LineDefinition movinglevelsetcylinder = Input::LineDefinition::Builder()
-                                                     .add_tag("MOVINGLEVELSETCYLINDER")
-                                                     .add_named_double_vector("ORIGIN", 3)
-                                                     .add_named_double("RADIUS")
-                                                     .add_named_double_vector("DIRECTION", 3)
-                                                     .add_named_double("DISTANCE")
-                                                     .add_named_double("MAXSPEED")
-                                                     .build();
+  auto spec = one_of({
+      tag("FORWARDFACINGSTEP"),
+      anonymous_group({
+          tag("MOVINGLEVELSETCYLINDER"),
+          entry<std::vector<double>>("ORIGIN", {.size = 3}),
+          entry<double>("RADIUS"),
+          entry<std::vector<double>>("DIRECTION", {.size = 3}),
+          entry<double>("DISTANCE"),
+          entry<double>("MAXSPEED"),
+      }),
+      anonymous_group({
+          tag("MOVINGLEVELSETTORUS"),
+          entry<std::vector<double>>("ORIGIN", {.size = 3}),
+          entry<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
+          entry<double>("RADIUS"),
+          entry<double>("RADIUS_TUBE"),
+          entry<std::vector<double>>("DIRECTION", {.size = 3}),
+          entry<double>("DISTANCE"),
+          entry<double>("MAXSPEED"),
+          entry<std::vector<double>>("ROTATION_VEC", {.size = 3}),
+          entry<double>("ROTATION_SPEED"),
+          entry<double>("ROTATION_RAMPTIME"),
+      }),
+      anonymous_group({
+          tag("MOVINGLEVELSETTORUSVELOCITY"),
+          entry<std::vector<double>>("ORIGIN", {.size = 3}),
+          entry<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
+          entry<double>("RADIUS"),
+          entry<double>("RADIUS_TUBE"),
+          entry<std::vector<double>>("DIRECTION", {.size = 3}),
+          entry<double>("DISTANCE"),
+          entry<double>("MAXSPEED"),
+          entry<std::vector<double>>("ROTATION_VEC", {.size = 3}),
+          entry<double>("ROTATION_SPEED"),
+          entry<double>("ROTATION_RAMPTIME"),
+      }),
+      anonymous_group({
+          tag("MOVINGLEVELSETTORUSSLIPLENGTH"),
+          entry<std::vector<double>>("ORIGIN", {.size = 3}),
+          entry<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
+          entry<double>("RADIUS"),
+          entry<double>("RADIUS_TUBE"),
+          entry<std::vector<double>>("DIRECTION", {.size = 3}),
+          entry<double>("DISTANCE"),
+          entry<double>("MAXSPEED"),
+          entry<std::vector<double>>("ROTATION_VEC", {.size = 3}),
+          entry<double>("ROTATION_SPEED"),
+          entry<double>("ROTATION_RAMPTIME"),
+          entry<int>("SLIP_FUNCT"),
+      }),
+      anonymous_group({
+          tag("TAYLORCOUETTEFLOW"),
+          entry<double>("RADIUS_I"),
+          entry<double>("RADIUS_O"),
+          entry<double>("VEL_THETA_I"),
+          entry<double>("VEL_THETA_O"),
+          entry<double>("SLIPLENGTH_I"),
+          entry<double>("SLIPLENGTH_O"),
+          entry<double>("TRACTION_THETA_I"),
+          entry<double>("TRACTION_THETA_O"),
+          entry<double>("VISCOSITY"),
+      }),
+      anonymous_group({
+          tag("URQUIZABOXFLOW"),
+          entry<double>("LENGTHX"),
+          entry<double>("LENGTHY"),
+          entry<double>("ROTATION"),
+          entry<double>("VISCOSITY"),
+          entry<double>("DENSITY"),
+          entry<int>("CASE"),
+          entry<std::vector<double>>("COMBINATION", {.size = 2}),
+      }),
+      anonymous_group({
+          tag("URQUIZABOXFLOW_TRACTION"),
+          entry<double>("LENGTHX"),
+          entry<double>("LENGTHY"),
+          entry<double>("ROTATION"),
+          entry<double>("VISCOSITY"),
+          entry<double>("DENSITY"),
+          entry<int>("CASE"),
+          entry<std::vector<double>>("COMBINATION", {.size = 2}),
+      }),
+      anonymous_group({
+          tag("URQUIZABOXFLOW_FORCE"),
+          entry<double>("LENGTHX"),
+          entry<double>("LENGTHY"),
+          entry<double>("ROTATION"),
+          entry<double>("VISCOSITY"),
+          entry<double>("DENSITY"),
+          entry<int>("CASE"),
+          entry<std::vector<double>>("COMBINATION", {.size = 2}),
+      }),
+  });
 
-  Input::LineDefinition movinglevelsettorus = Input::LineDefinition::Builder()
-                                                  .add_tag("MOVINGLEVELSETTORUS")
-                                                  .add_named_double_vector("ORIGIN", 3)
-                                                  .add_named_double_vector("ORIENTVEC_TORUS", 3)
-                                                  .add_named_double("RADIUS")
-                                                  .add_named_double("RADIUS_TUBE")
-                                                  .add_named_double_vector("DIRECTION", 3)
-                                                  .add_named_double("DISTANCE")
-                                                  .add_named_double("MAXSPEED")
-                                                  .add_named_double_vector("ROTATION_VEC", 3)
-                                                  .add_named_double("ROTATION_SPEED")
-                                                  .add_named_double("ROTATION_RAMPTIME")
-                                                  .build();
-
-  Input::LineDefinition movinglevelsettorusvelocity =
-      Input::LineDefinition::Builder()
-          .add_tag("MOVINGLEVELSETTORUSVELOCITY")
-          .add_named_double_vector("ORIGIN", 3)
-          .add_named_double_vector("ORIENTVEC_TORUS", 3)
-          .add_named_double("RADIUS")
-          .add_named_double("RADIUS_TUBE")
-          .add_named_double_vector("DIRECTION", 3)
-          .add_named_double("DISTANCE")
-          .add_named_double("MAXSPEED")
-          .add_named_double_vector("ROTATION_VEC", 3)
-          .add_named_double("ROTATION_SPEED")
-          .add_named_double("ROTATION_RAMPTIME")
-          .build();
-
-  Input::LineDefinition movinglevelsettorussliplength =
-      Input::LineDefinition::Builder()
-          .add_tag("MOVINGLEVELSETTORUSSLIPLENGTH")
-          .add_named_double_vector("ORIGIN", 3)
-          .add_named_double_vector("ORIENTVEC_TORUS", 3)
-          .add_named_double("RADIUS")
-          .add_named_double("RADIUS_TUBE")
-          .add_named_double_vector("DIRECTION", 3)
-          .add_named_double("DISTANCE")
-          .add_named_double("MAXSPEED")
-          .add_named_double_vector("ROTATION_VEC", 3)
-          .add_named_double("ROTATION_SPEED")
-          .add_named_double("ROTATION_RAMPTIME")
-          .add_named_int("SLIP_FUNCT")
-          .build();
-
-  Input::LineDefinition taylorcouetteflow = Input::LineDefinition::Builder()
-                                                .add_tag("TAYLORCOUETTEFLOW")
-                                                .add_named_double("RADIUS_I")
-                                                .add_named_double("RADIUS_O")
-                                                .add_named_double("VEL_THETA_I")
-                                                .add_named_double("VEL_THETA_O")
-                                                .add_named_double("SLIPLENGTH_I")
-                                                .add_named_double("SLIPLENGTH_O")
-                                                .add_named_double("TRACTION_THETA_I")
-                                                .add_named_double("TRACTION_THETA_O")
-                                                .add_named_double("VISCOSITY")
-                                                .build();
-
-  Input::LineDefinition urquizaboxflow = Input::LineDefinition::Builder()
-                                             .add_tag("URQUIZABOXFLOW")
-                                             .add_named_double("LENGTHX")
-                                             .add_named_double("LENGTHY")
-                                             .add_named_double("ROTATION")
-                                             .add_named_double("VISCOSITY")
-                                             .add_named_double("DENSITY")
-                                             .add_named_int("CASE")
-                                             .add_optional_named_double_vector("COMBINATION", 2)
-                                             .build();
-
-  Input::LineDefinition urquizaboxflowtraction =
-      Input::LineDefinition::Builder()
-          .add_tag("URQUIZABOXFLOW_TRACTION")
-          .add_named_double("LENGTHX")
-          .add_named_double("LENGTHY")
-          .add_named_double("ROTATION")
-          .add_named_double("VISCOSITY")
-          .add_named_double("DENSITY")
-          .add_named_int("CASE")
-          .add_optional_named_double_vector("COMBINATION", 2)
-          .build();
-
-  Input::LineDefinition urquizaboxflowforce =
-      Input::LineDefinition::Builder()
-          .add_tag("URQUIZABOXFLOW_FORCE")
-          .add_named_double("LENGTHX")
-          .add_named_double("LENGTHY")
-          .add_named_double("ROTATION")
-          .add_named_double("VISCOSITY")
-          .add_named_double("DENSITY")
-          .add_named_int("CASE")
-          .add_optional_named_double_vector("COMBINATION", 2)
-          .build();
-
-  std::vector<Input::LineDefinition> lines;
-
-  lines.emplace_back(std::move(gerstenbergerforwardfacingstep));
-  lines.emplace_back(std::move(movinglevelsetcylinder));
-  lines.emplace_back(std::move(movinglevelsettorus));
-  lines.emplace_back(std::move(movinglevelsettorusvelocity));
-  lines.emplace_back(std::move(movinglevelsettorussliplength));
-  lines.emplace_back(std::move(taylorcouetteflow));
-  lines.emplace_back(std::move(urquizaboxflow));
-  lines.emplace_back(std::move(urquizaboxflowforce));
-  lines.emplace_back(std::move(urquizaboxflowtraction));
-
-  function_manager.add_function_definition(std::move(lines), create_xfluid_function);
+  function_manager.add_function_definition(std::move(spec), create_xfluid_function);
 }
 
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_fluid_xfluid_functions_combust.hpp"
 
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_linedefinition.hpp"
 #include "4C_utils_function_manager.hpp"
 
@@ -38,14 +39,14 @@ namespace
 
 void Discret::Utils::add_valid_combust_functions(Core::Utils::FunctionManager& function_manager)
 {
-  Input::LineDefinition zalesaksdisk =
-      Input::LineDefinition::Builder().add_tag("ZALESAKSDISK").build();
+  using namespace Core::IO::InputSpecBuilders;
 
-  Input::LineDefinition collapsingwatercolumn =
-      Input::LineDefinition::Builder().add_tag("COLLAPSINGWATERCOLUMN").build();
+  auto spec = one_of({
+      tag("ZALESAKSDISK"),
+      tag("COLLAPSINGWATERCOLUMN"),
+  });
 
-  function_manager.add_function_definition(
-      {std::move(zalesaksdisk), std::move(collapsingwatercolumn)}, create_combust_function);
+  function_manager.add_function_definition(spec, create_combust_function);
 }
 
 

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -2122,11 +2122,11 @@ void Global::read_contact_constitutive_laws(Global::Problem& problem, Core::IO::
 /*----------------------------------------------------------------------*/
 void Global::read_cloning_material_map(Global::Problem& problem, Core::IO::InputFile& input)
 {
-  const std::vector<Input::LineDefinition> lines = Core::FE::valid_cloning_material_map_lines();
+  auto spec = Core::FE::valid_cloning_material_map();
 
   // perform the actual reading and extract the input parameters
   auto parameters =
-      Core::IO::InputFileUtils::read_all_lines_in_section(input, "CLONING MATERIAL MAP", lines);
+      Core::IO::InputFileUtils::read_all_lines_in_section(input, "CLONING MATERIAL MAP", spec);
   for (const auto& input_line : parameters)
   {
     // extract what was read from the input file

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -40,6 +40,7 @@
 #include "4C_fluid_functions.hpp"
 #include "4C_fluid_xfluid_functions.hpp"
 #include "4C_fluid_xfluid_functions_combust.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_lubrication_ele.hpp"
 #include "4C_mat_aaaneohooke.hpp"
 #include "4C_mat_beam_elasthyper.hpp"
@@ -322,357 +323,212 @@ namespace
     PoroMultiPhaseScaTra::add_valid_poro_functions(function_manager);
   }
 
-  std::vector<Input::LineDefinition> valid_result_lines()
+  Core::IO::InputSpec valid_result_lines()
   {
-    return {//
-        Input::LineDefinition::Builder()
-            .add_tag("STRUCTURE")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
+    using namespace Core::IO::InputSpecBuilders;
 
-        Input::LineDefinition::Builder()
-            .add_tag("STRUCTURE")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("OP")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("STRUCTURE")
-            .add_named_string("DIS")
-            .add_named_int("LINE")
-            .add_named_string("OP")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("STRUCTURE")
-            .add_named_string("DIS")
-            .add_named_int("SURFACE")
-            .add_named_string("OP")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("STRUCTURE")
-            .add_named_string("DIS")
-            .add_named_int("VOLUME")
-            .add_named_string("OP")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("STRUCTURE")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("FLUID")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("FLUID")
-            .add_named_string("DIS")
-            .add_named_int("ELEMENT")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("XFLUID")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("ALE")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("THERMAL")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("LUBRICATION")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("POROFLUIDMULTIPHASE")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("POROFLUIDMULTIPHASE")
-            .add_named_string("DIS")
-            .add_named_int("ELEMENT")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("POROFLUIDMULTIPHASE")
-            .add_named_string("DIS")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("SCATRA")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("SCATRA")
-            .add_named_string("DIS")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("SSI")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("SSI")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("SSTI")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("STI")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("RED_AIRWAY")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("RED_AIRWAY")
-            .add_named_string("DIS")
-            .add_named_int("ELEMENT")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("ARTNET")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("ARTNET")
-            .add_named_string("DIS")
-            .add_named_int("ELEMENT")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("ADJOINT")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("OPTI")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("OPTI")
-            .add_named_string("DIS")
-            .add_named_int("ELEMENT")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("FSI")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("FSI")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("PARTICLE")
-            .add_named_int("ID")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("PARTICLEWALL")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("PARTICLEWALL")
-            .add_named_string("DIS")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("RIGIDBODY")
-            .add_named_int("ID")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("ELECTROMAGNETIC")
-            .add_named_string("DIS")
-            .add_named_int("NODE")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build(),
-
-        Input::LineDefinition::Builder()
-            .add_tag("CARDIOVASCULAR0D")
-            .add_named_string("DIS")
-            .add_tag("SPECIAL")
-            .add_named_string("QUANTITY")
-            .add_named_double("VALUE")
-            .add_named_double("TOLERANCE")
-            .add_optional_named_string("NAME")
-            .build()};
+    return one_of({
+        group("STRUCTURE",
+            {
+                one_of({
+                    anonymous_group({
+                        entry<std::string>("DIS"),
+                        one_of({
+                            entry<int>("NODE"),
+                            entry<int>("LINE"),
+                            entry<int>("SURFACE"),
+                            entry<int>("VOLUME"),
+                        }),
+                    }),
+                    tag("SPECIAL"),
+                }),
+                entry<std::string>("OP", {.required = false}),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("FLUID",
+            {
+                entry<std::string>("DIS"),
+                one_of({
+                    entry<int>("NODE"),
+                    entry<int>("ELEMENT"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("XFLUID",
+            {
+                entry<std::string>("DIS"),
+                entry<int>("NODE"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("ALE",
+            {
+                entry<std::string>("DIS"),
+                entry<int>("NODE"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("THERMAL",
+            {
+                entry<std::string>("DIS"),
+                entry<int>("NODE"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("LUBRICATION",
+            {
+                entry<std::string>("DIS"),
+                entry<int>("NODE"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("POROFLUIDMULTIPHASE",
+            {
+                entry<std::string>("DIS"),
+                one_of({
+                    entry<int>("NODE"),
+                    entry<int>("ELEMENT"),
+                    tag("SPECIAL"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("SCATRA",
+            {
+                entry<std::string>("DIS"),
+                one_of({
+                    entry<int>("NODE"),
+                    tag("SPECIAL"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("SSI",
+            {
+                one_of({
+                    anonymous_group({
+                        entry<std::string>("DIS"),
+                        entry<int>("NODE"),
+                    }),
+                    tag("SPECIAL"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("SSTI",
+            {
+                tag("SPECIAL"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+            }),
+        group("STI",
+            {
+                tag("SPECIAL"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+            }),
+        group("RED_AIRWAY",
+            {
+                entry<std::string>("DIS"),
+                one_of({
+                    entry<int>("NODE"),
+                    entry<int>("ELEMENT"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("ARTNET",
+            {
+                entry<std::string>("DIS"),
+                one_of({
+                    entry<int>("NODE"),
+                    entry<int>("ELEMENT"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("FSI",
+            {
+                one_of({
+                    entry<int>("NODE"),
+                    tag("SPECIAL"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("PARTICLE",
+            {
+                entry<int>("ID"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+            }),
+        group("PARTICLEWALL",
+            {
+                entry<std::string>("DIS"),
+                one_of({
+                    entry<int>("NODE"),
+                    tag("SPECIAL"),
+                }),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("RIGIDBODY",
+            {
+                entry<int>("ID"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+            }),
+        group("ELECTROMAGNETIC",
+            {
+                entry<std::string>("DIS"),
+                entry<int>("NODE"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+        group("CARDIOVASCULAR0D",
+            {
+                entry<std::string>("DIS"),
+                tag("SPECIAL"),
+                entry<std::string>("QUANTITY"),
+                entry<double>("VALUE"),
+                entry<double>("TOLERANCE"),
+                entry<std::string>("NAME", {.required = false}),
+            }),
+    });
   }
 
 }  // namespace

--- a/src/module_registry/4C_module_registry_callbacks.hpp
+++ b/src/module_registry/4C_module_registry_callbacks.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_input_spec.hpp"
 #include "4C_utils_function_manager.hpp"
 
 #include <functional>
@@ -43,7 +44,7 @@ struct ModuleCallbacks
   /**
    * A callback to return valid result description lines.
    */
-  std::function<std::vector<Input::LineDefinition>()> valid_result_description_lines;
+  std::function<Core::IO::InputSpec()> valid_result_description_lines;
 };
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
@@ -8,7 +8,7 @@
 #include "4C_poromultiphase_scatra_function.hpp"
 
 #include "4C_global_data.hpp"
-#include "4C_io_linedefinition.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_poromultiphase_scatra_utils.hpp"
 #include "4C_utils_fad.hpp"
 #include "4C_utils_function_manager.hpp"
@@ -113,13 +113,15 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraFunction<dim>::PoroMultiPhaseScaTraFun
 /*----------------------------------------------------------------------*/
 void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager& function_manager)
 {
+  using namespace Core::IO::InputSpecBuilders;
+
   function_manager.add_function_definition(
-      {Input::LineDefinition::Builder()
-              .add_named_string("POROMULTIPHASESCATRA_FUNCTION")
-              .add_optional_named_int("NUMPARAMS")
-              .add_optional_named_pair_of_string_and_double_vector(
-                  "PARAMS", Input::LengthFromIntNamed("NUMPARAMS"))
-              .build()},
+      anonymous_group({
+          entry<std::string>("POROMULTIPHASESCATRA_FUNCTION"),
+          entry<int>("NUMPARAMS", {.required = false}),
+          entry<std::vector<std::pair<std::string, double>>>(
+              "PARAMS", {.required = false, .size = from_parameter<int>("NUMPARAMS")}),
+      }),
       try_create_poro_function_dispatch);
 }
 

--- a/src/structure_new/src/utils/4C_structure_new_functions.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_functions.cpp
@@ -8,6 +8,7 @@
 #include "4C_structure_new_functions.hpp"
 
 #include "4C_global_data.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_stvenantkirchhoff.hpp"
 #include "4C_utils_function_manager.hpp"
@@ -79,17 +80,17 @@ namespace
 /*----------------------------------------------------------------------*/
 void Solid::add_valid_structure_functions(Core::Utils::FunctionManager& function_manager)
 {
-  std::vector<Input::LineDefinition> lines;
-  lines.emplace_back(Input::LineDefinition::Builder()
-          .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE")
-          .add_named_int("MAT_STRUCT")
-          .build());
-  lines.emplace_back(Input::LineDefinition::Builder()
-          .add_tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE_FORCE")
-          .add_named_int("MAT_STRUCT")
-          .build());
+  using namespace Core::IO::InputSpecBuilders;
 
-  function_manager.add_function_definition(std::move(lines), create_structure_function);
+  auto spec = anonymous_group({
+      one_of({
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE"),
+          tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE_FORCE"),
+      }),
+      entry<int>("MAT_STRUCT"),
+  });
+
+  function_manager.add_function_definition(std::move(spec), create_structure_function);
 }
 
 


### PR DESCRIPTION
`LineDefinition` is only a wrapper around `InputSpec` with reduced functionality. This PR replaces its use for

- cloning material map
- result description
- functions

I will replace the element definition in another PR.

Part of #73 