### PR TITLE
Remove dependencies to so3_utils in other modules

### DIFF
--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode.cpp
@@ -14,7 +14,6 @@
 #include "4C_scatra_ele_parameter_elch.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
-#include "4C_so3_utils.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
@@ -15,7 +15,6 @@
 #include "4C_scatra_ele_parameter_elch.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
-#include "4C_so3_utils.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
@@ -18,7 +18,6 @@
 #include "4C_scatra_ele_parameter_elch.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
-#include "4C_so3_utils.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN


### PR DESCRIPTION
Now, `so3_utils` can be removed with `so3`.