### PR TITLE
Store none_allowed components as Noneables in the InputParameterContainer

### DIFF
--- a/src/art_net/4C_art_net_art_terminal_bc.cpp
+++ b/src/art_net/4C_art_net_art_terminal_bc.cpp
@@ -10,6 +10,7 @@
 #include "4C_fem_condition_utils.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 
@@ -65,7 +66,7 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     // -----------------------------------------------------------------
     // Read in the bc curve information
     // -----------------------------------------------------------------
-    const auto& curve = condition->parameters().get<std::vector<int>>("curve");
+    const auto& curve = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
     double curvefac = 1.0;
     const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 
@@ -79,10 +80,10 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     else if (Type == "forced")  // => with Reflection
     {
       // If forced curve exists => Rf = curve
-      if (curve[1] > 0)
+      if (curve[1].has_value() && curve[1].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1] - 1)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value() - 1)
                        .evaluate(time);
         Rf = vals[1] * curvefac;
       }
@@ -106,10 +107,10 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     // -----------------------------------------------------------------
     // Read in the value of the applied BC
     // -----------------------------------------------------------------
-    if (curve[0] > 0)
+    if (curve[0].has_value() && curve[0].value())
     {
       curvefac = Global::Problem::instance()
-                     ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                     ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value() - 1)
                      .evaluate(time);
       BCin = vals[0] * curvefac;
     }
@@ -545,16 +546,16 @@ void Arteries::Utils::solve_reflective_terminal(Core::FE::Discretization& actdis
   // -------------------------------------------------------------------
   // Read in the bc curve information
   // -------------------------------------------------------------------
-  const auto& curve = condition->parameters().get<std::vector<int>>("curve");
+  const auto& curve = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
   double curvefac = 1.0;
   const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 
   // if the curve exist => Rf = val*curve(time)
-  if (curve[0] > 0)
+  if (curve[0].has_value() && curve[0].value())
   {
     double time = params.get<double>("total time");
     curvefac = Global::Problem::instance()
-                   ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                   ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value() - 1)
                    .evaluate(time);
     Rf = vals[0] * curvefac;
   }
@@ -624,7 +625,7 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
   // -------------------------------------------------------------------
   // Read in the bc curve information
   // -------------------------------------------------------------------
-  const auto& curve = condition->parameters().get<std::vector<int>>("curve");
+  const auto& curve = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
   double curvefac = 1.0;
   const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 
@@ -661,10 +662,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       double Pout = 0.0;
       double dFdA = 0.0;
       // read in the reflection value
-      if (curve[1] >= 0)
+      if (curve[1].has_value() && curve[1].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value())
                        .evaluate(time);
         R = vals[1] * curvefac;
       }
@@ -679,10 +680,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         exit(1);
       }
 
-      if (curve[0] >= 0)
+      if (curve[0].has_value() && curve[0].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value())
                        .evaluate(time);
         Pout = vals[0] * curvefac;
       }
@@ -736,10 +737,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       double C = 0.0;
 
       // Read in the periferal pressure of the wind kessel model
-      if (curve[0] >= 0)
+      if (curve[0].has_value() && curve[0].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value())
                        .evaluate(time);
         //        Pout = vals[0]*curvefac;
       }
@@ -748,10 +749,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         //        Pout = vals[0];
       }
       // read in the resistance value
-      if (curve[1] >= 0)
+      if (curve[1].has_value() && curve[1].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value())
                        .evaluate(time);
         R = vals[1] * curvefac;
       }
@@ -760,10 +761,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         R = vals[1];
       }
       // Read in the capacitance value
-      if (curve[2] >= 0)
+      if (curve[2].has_value() && curve[2].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[2])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[2].value())
                        .evaluate(time);
         C = vals[2] * curvefac;
       }
@@ -796,22 +797,8 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       double Poutnm = 0.0;
 
       // Read in the periferal pressure of the windkessel model
-      if (curve[0] >= 0)
-      {
-        curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
-                       .evaluate(time);
-        //        Pout = vals[0]*curvefac;
-        curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
-                       .evaluate(time - dt);
-      }
-      else
-      {
-        //        Pout = vals[2];
-      }
       // Read in Pout at time step n-1
-      if (curve[0] >= 0)
+      if (curve[0].has_value() && curve[0].value())
       {
         double t;
         if (time <= dt)
@@ -819,7 +806,7 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         else
           t = time - dt;
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value())
                        .evaluate(t);
         Poutnm = vals[0] * curvefac;
       }
@@ -828,10 +815,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         Poutnm = vals[2];
       }
       // read in the source resistance value
-      if (curve[1] >= 0)
+      if (curve[1].has_value() && curve[1].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value())
                        .evaluate(time);
         R1 = vals[1] * curvefac;
       }
@@ -840,10 +827,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         R1 = vals[1];
       }
       // Read in the capacitance value
-      if (curve[2] >= 0)
+      if (curve[2].has_value() && curve[2].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[2])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[2].value())
                        .evaluate(time);
         C = vals[2] * curvefac;
       }
@@ -852,10 +839,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         C = vals[2];
       }
       // read in the periferal resistance value
-      if (curve[3] >= 0)
+      if (curve[3].has_value() && curve[3].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[3])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[3].value())
                        .evaluate(time);
         R2 = vals[3] * curvefac;
       }
@@ -932,10 +919,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       double L = 0.0;
 
       // Read in the periferal pressure of the wind kessel model
-      if (curve[0] >= 0)
+      if (curve[0].has_value() && curve[0].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value())
                        .evaluate(time);
         //        Pout = vals[0]*curvefac;
       }
@@ -944,10 +931,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         //        Pout = vals[2];
       }
       // read in the source resistance value
-      if (curve[1] >= 0)
+      if (curve[1].has_value() && curve[1].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value())
                        .evaluate(time);
         R1 = vals[1] * curvefac;
       }
@@ -956,10 +943,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         R1 = vals[1];
       }
       // Read in the capacitance value
-      if (curve[2] >= 0)
+      if (curve[2].has_value() && curve[2].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[2])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[2].value())
                        .evaluate(time);
         C = vals[2] * curvefac;
       }
@@ -968,10 +955,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         C = vals[2];
       }
       // read in the periferal resistance value
-      if (curve[3] >= 0)
+      if (curve[3].has_value() && curve[3].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[3])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[3].value())
                        .evaluate(time);
         R2 = vals[3] * curvefac;
       }
@@ -980,10 +967,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         R2 = vals[3];
       }
       // read in the inductance value
-      if (curve[4] >= 0)
+      if (curve[4].has_value() && curve[4].value())
       {
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[4])
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curve[4].value())
                        .evaluate(time);
         L = vals[4] * curvefac;
       }

--- a/src/beam3/4C_beam3_kirchhoff.hpp
+++ b/src/beam3/4C_beam3_kirchhoff.hpp
@@ -891,7 +891,7 @@ namespace Discret
           const Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, double>&
               disp_totlag,
           const Core::LinAlg::Matrix<6, 1, double>& load_vector_neumann,
-          const std::vector<int>* function_numbers, double time) const;
+          const std::vector<Core::IO::Noneable<int>>& function_numbers, double time) const;
 
       /** \brief evaluate contributions to element residual vector from line Neumann condition
        *
@@ -901,7 +901,7 @@ namespace Discret
       void evaluate_line_neumann_forces(
           Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, T>& force_ext,
           const Core::LinAlg::Matrix<6, 1, double>& load_vector_neumann,
-          const std::vector<int>* function_numbers, double time) const;
+          const std::vector<Core::IO::Noneable<int>>& function_numbers, double time) const;
 
       /** \brief evaluate all contributions from brownian dynamics (thermal & viscous
        * forces/moments)

--- a/src/beaminteraction/4C_beaminteraction_beam_to_beam_potential_pair.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_beam_potential_pair.cpp
@@ -15,6 +15,7 @@
 #include "4C_fem_general_utils_integration.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_beampotential.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
@@ -237,18 +238,18 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  int function_number = linechargeconds_[0]->parameters().get<int>("FUNCT");
+  auto function_number = linechargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
 
-  if (function_number != -1)
+  if (function_number.has_value() && function_number.value() > 0)
     q1 *= Global::Problem::instance()
-              ->function_by_id<Core::Utils::FunctionOfTime>(function_number - 1)
+              ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value() - 1)
               .evaluate(time_);
 
-  function_number = linechargeconds_[1]->parameters().get<int>("FUNCT");
+  function_number = linechargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
 
-  if (function_number != -1)
+  if (function_number.has_value() && function_number.value() > 0)
     q2 *= Global::Problem::instance()
-              ->function_by_id<Core::Utils::FunctionOfTime>(function_number - 1)
+              ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value() - 1)
               .evaluate(time_);
 
 
@@ -618,18 +619,18 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  int function_number = linechargeconds_[0]->parameters().get<int>("FUNCT");
+  auto function_number = linechargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
 
-  if (function_number != -1)
+  if (function_number.has_value() && function_number.value() > 0)
     q1 *= Global::Problem::instance()
-              ->function_by_id<Core::Utils::FunctionOfTime>(function_number - 1)
+              ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value() - 1)
               .evaluate(time_);
 
-  function_number = linechargeconds_[1]->parameters().get<int>("FUNCT");
+  function_number = linechargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
 
-  if (function_number != -1)
+  if (function_number.has_value() && function_number.value() > 0)
     q2 *= Global::Problem::instance()
-              ->function_by_id<Core::Utils::FunctionOfTime>(function_number - 1)
+              ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value() - 1)
               .evaluate(time_);
 
 
@@ -1203,18 +1204,18 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  int function_number = linechargeconds_[0]->parameters().get<int>("FUNCT");
+  auto function_number = linechargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
 
-  if (function_number != -1)
+  if (function_number.has_value() && function_number.value() > 0)
     rho1 *= Global::Problem::instance()
-                ->function_by_id<Core::Utils::FunctionOfTime>(function_number - 1)
+                ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value() - 1)
                 .evaluate(time_);
 
-  function_number = linechargeconds_[1]->parameters().get<int>("FUNCT");
+  function_number = linechargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
 
-  if (function_number != -1)
+  if (function_number.has_value() && function_number.value() > 0)
     rho2 *= Global::Problem::instance()
-                ->function_by_id<Core::Utils::FunctionOfTime>(function_number - 1)
+                ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value() - 1)
                 .evaluate(time_);
 
 

--- a/src/constraint/4C_constraint.cpp
+++ b/src/constraint/4C_constraint.cpp
@@ -240,13 +240,13 @@ void CONSTRAINTS::Constraint::evaluate_constraint(Teuchos::ParameterList& params
       }
 
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
-      const int curvenum = cond->parameters().get_or<int>("curve", -1);
+      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
       double curvefac = 1.0;
-      if (curvenum > 0)
+      if (curvenum.has_value() && curvenum.value() > 0)
       {
         // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                        .evaluate(time);
       }
 

--- a/src/constraint/4C_constraint_multipointconstraint2.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint2.cpp
@@ -11,6 +11,7 @@
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_dofset_transparent.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_rebalance_binning_based.hpp"
 #include "4C_utils_function_of_time.hpp"
@@ -369,15 +370,13 @@ void CONSTRAINTS::MPConstraint2::evaluate_constraint(std::shared_ptr<Core::FE::D
       }
 
       // Load curve business
-      const int curvenum = cond.parameters().get_or<int>("curve", -1);
+      const auto curvenum = cond.parameters().get<Core::IO::Noneable<int>>("curve");
       double curvefac = 1.0;
-      bool usetime = true;
-      if (time < 0.0) usetime = false;
-      if (curvenum > 0 && usetime)
+      if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
       {
         // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                        .evaluate(time);
       }
 

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -456,15 +456,13 @@ void CONSTRAINTS::MPConstraint3::evaluate_constraint(std::shared_ptr<Core::FE::D
       }
 
       // loadcurve business
-      const int curvenum = cond->parameters().get_or<int>("curve", -1);
+      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
       double curvefac = 1.0;
-      bool usetime = true;
-      if (time < 0.0) usetime = false;
-      if (curvenum > 0 && usetime)
+      if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
       {
         // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                        .evaluate(time);
       }
 
@@ -535,15 +533,13 @@ void CONSTRAINTS::MPConstraint3::initialize_constraint(Core::FE::Discretization&
     Core::LinAlg::assemble(systemvector, elevector3, constrlm, constrowner);
 
     // loadcurve business
-    const int curvenum = cond->parameters().get_or<int>("curve", -1);
+    const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
     double curvefac = 1.0;
-    bool usetime = true;
-    if (time < 0.0) usetime = false;
-    if (curvenum > 0 && usetime)
+    if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
     {
       // function_by_id takes a zero-based index
       curvefac = Global::Problem::instance()
-                     ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                     ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                      .evaluate(time);
     }
 

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -411,18 +411,15 @@ void CONSTRAINTS::MPConstraint3Penalty::evaluate_constraint(
             Core::Communication::my_mpi_rank(disc->get_comm()), eid, err);
 
       // loadcurve business
-      const int curvenum = cond->parameters().get_or<int>("curve", -1);
+      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
       double curvefac = 1.0;
-      bool usetime = true;
-      if (time < 0.0) usetime = false;
-      if (curvenum > 0 && usetime)
+      if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
       {
         // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                        .evaluate(time);
       }
-
 
       double diff = (curvefac * (*initerror_)[eid] - (*acterror_)[eid]);
       elematrix1.scale(diff);

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -204,13 +204,13 @@ void CONSTRAINTS::ConstraintPenalty::evaluate_constraint(Teuchos::ParameterList&
       }
 
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
-      const int curvenum = cond->parameters().get_or<int>("curve", -1);
+      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
       double curvefac = 1.0;
-      if (curvenum > 0)
+      if (curvenum.has_value() && curvenum.value() > 0)
       {
         // function_by_id takes a zero-based index
         curvefac = Global::Problem::instance()
-                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                       ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                        .evaluate(time);
       }
 

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -36,7 +36,7 @@ CONSTRAINTS::SpringDashpot::SpringDashpot(std::shared_ptr<Core::FE::Discretizati
       stiff_comp_((spring_->parameters().get<std::vector<double>>("STIFF"))[0]),
       offset_((spring_->parameters().get<std::vector<double>>("DISPLOFFSET"))[0]),
       viscosity_((spring_->parameters().get<std::vector<double>>("VISCO"))[0]),
-      coupling_(spring_->parameters().get<int>("COUPLING")),
+      coupling_(spring_->parameters().get<Core::IO::Noneable<int>>("COUPLING").value_or(-1)),
       nodes_(spring_->get_nodes()),
       area_(),
       gap0_(),

--- a/src/contact/4C_contact_manager.cpp
+++ b/src/contact/4C_contact_manager.cpp
@@ -31,6 +31,7 @@
 #include "4C_inpar_wear.hpp"
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_mortar_utils.hpp"
 
@@ -140,7 +141,9 @@ CONTACT::Manager::Manager(Core::FE::Discretization& discret, double alphaf)
     const int groupid1 = currentgroup[0]->parameters().get<int>("InterfaceID");
 
     // In case of MultiScale contact this is the id of the interface's constitutive contact law
-    int contactconstitutivelawid = currentgroup[0]->parameters().get<int>("ConstitutiveLawID");
+    auto maybe_contactconstitutivelawid =
+        currentgroup[0]->parameters().get<Core::IO::Noneable<int>>("ConstitutiveLawID");
+    auto contactconstitutivelawid = maybe_contactconstitutivelawid.value_or(-1);
 
     bool foundit = false;
 

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -685,7 +685,8 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
     const auto groupid1 = currentgroup[0]->parameters().get<int>("InterfaceID");
 
     // In case of MultiScale contact this is the id of the interface's constitutive contact law
-    int contactconstitutivelaw_id = currentgroup[0]->parameters().get<int>("ConstitutiveLawID");
+    auto contactconstitutivelaw_id =
+        currentgroup[0]->parameters().get<Core::IO::Noneable<int>>("ConstitutiveLawID");
 
     // Initialize a flag to check for MIRCO contact consitutive law
     bool mircolaw = false;
@@ -698,12 +699,12 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
     int hurstexponentfunction = 0;
     int initialtopologystddeviationfunction = 0;
 
-    if (contactconstitutivelaw_id != 0)
+    if (contactconstitutivelaw_id.has_value() && contactconstitutivelaw_id.value() > 0)
     {
       const int probinst =
           Global::Problem::instance()->contact_constitutive_laws()->get_read_from_problem();
       auto coconstlaw = Global::Problem::instance(probinst)->contact_constitutive_laws()->by_id(
-          contactconstitutivelaw_id);
+          contactconstitutivelaw_id.value());
       // Set the variables if MIRCO contact constitutive law is found
       if (coconstlaw.get<Inpar::CONTACT::ConstitutiveLawType>("LAW_TYPE") ==
           Inpar::CONTACT::ConstitutiveLawType::colaw_mirco)
@@ -820,8 +821,8 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
     // ------------------------------------------------------------------------
     const auto& non_owning_discret = Core::Utils::shared_ptr_from_ref(discret());
 
-    std::shared_ptr<CONTACT::Interface> newinterface = create_interface(
-        groupid1, get_comm(), n_dim(), icparams, isself[0], nullptr, contactconstitutivelaw_id);
+    std::shared_ptr<CONTACT::Interface> newinterface = create_interface(groupid1, get_comm(),
+        n_dim(), icparams, isself[0], nullptr, contactconstitutivelaw_id.value_or(-1));
     interfaces.push_back(newinterface);
 
     // get it again

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
@@ -15,6 +15,7 @@
 #include "4C_fem_general_cell_type.hpp"
 #include "4C_fem_nurbs_discretization_control_point.hpp"
 #include "4C_fem_nurbs_discretization_knotvector.hpp"
+#include "4C_io_input_parameter_container.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -196,8 +197,8 @@ namespace Core::FE
       template <Core::FE::CellType distype>
       void fill_matrix_and_rhs_for_ls_dirichlet_boundary(Core::Elements::Element& ele,
           const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
-          const std::vector<int>* funct, const std::vector<double>* val, const unsigned deg,
-          const double time, Core::LinAlg::SerialDenseMatrix& elemass,
+          const std::vector<Core::IO::Noneable<int>>& funct, const std::vector<double>& val,
+          const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
           std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
           const Core::Utils::FunctionManager& function_manager) const;
 
@@ -218,8 +219,8 @@ namespace Core::FE
       template <Core::FE::CellType distype>
       void fill_matrix_and_rhs_for_ls_dirichlet_domain(Core::Elements::Element& ele,
           const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
-          const std::vector<int>* funct, const std::vector<double>* val, const unsigned deg,
-          const double time, Core::LinAlg::SerialDenseMatrix& elemass,
+          const std::vector<Core::IO::Noneable<int>>& funct, const std::vector<double>& val,
+          const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
           std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
           const Core::Utils::FunctionManager& function_manager) const;
 

--- a/src/elemag/4C_elemag_diff_ele_calc.cpp
+++ b/src/elemag/4C_elemag_diff_ele_calc.cpp
@@ -1831,8 +1831,7 @@ funct = (cond)->get<std::vector<int>>("funct"); const double time = params.get<d
       // magnetic field. If there is only one component all the components will
       // be initialized to the same value.
       Core::LinAlg::SerialDenseVector intVal(2 * nsd_);
-      FOUR_C_ASSERT(funct != nullptr, "funct not set for initial value");
-      evaluate_all((*funct)[0], time, xyz, intVal);
+      evaluate_all(funct[0], time, xyz, intVal);
       // now fill the components in the one-sided mass matrix and the right hand side
       for (unsigned int i = 0; i < shapesface_->nfdofs_; ++i)
       {

--- a/src/elemag/4C_elemag_ele_calc.cpp
+++ b/src/elemag/4C_elemag_ele_calc.cpp
@@ -1418,7 +1418,7 @@ void Discret::Elements::ElemagEleCalc<distype>::LocalSolver::compute_absorbing_b
   {
     // Get the user defined functions
     auto* cond = params.getPtr<std::shared_ptr<Core::Conditions::Condition>>("condition");
-    const auto& funct = (*cond)->parameters().get<std::vector<int>>("FUNCT");
+    const auto& funct = (*cond)->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
     const double time = params.get<double>("time");
 
     Core::LinAlg::SerialDenseVector tempVec1(shapesface_->nfdofs_ * nsd_);
@@ -1448,7 +1448,7 @@ void Discret::Elements::ElemagEleCalc<distype>::LocalSolver::compute_absorbing_b
         // magnetic field. If there is only one component all the components will
         // be initialized to the same value.
         Core::LinAlg::SerialDenseVector intVal(2 * nsd_);
-        evaluate_all(funct[0], time, xyz, intVal);
+        evaluate_all(funct[0].value_or(-1), time, xyz, intVal);
         // now fill the components in the one-sided mass matrix and the right hand side
         for (unsigned int i = 0; i < shapesface_->nfdofs_; ++i)
         {

--- a/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
@@ -12,6 +12,7 @@
 #include "4C_fem_general_node.hpp"
 #include "4C_fem_geometric_search_matchingoctree.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_utils_function_of_time.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -338,10 +339,10 @@ void FLD::TransferTurbulentInflowCondition::get_data(
   // find out whether we will use a time curve
   if (curve_ == -1)
   {
-    const auto curve = cond->parameters().get<int>("curve");
+    const auto curve = cond->parameters().get<Core::IO::Noneable<int>>("curve");
 
     // set zero based curve number
-    curve_ = curve - 1;
+    curve_ = curve.value_or(-1) - 1;
   }
 }
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1522,7 +1522,7 @@ void Inpar::FLUID::set_valid_conditions(
     add_named_real_vector(cond, "val", "velocity", 3);
 
     // and optional spatial functions
-    add_named_int_vector(cond, "funct", "spatial function", 3, 0, true, false);
+    add_named_int_vector(cond, "funct", "spatial function", 3, 0, true, true);
 
     // characteristic velocity
     add_named_real(cond, "u_C");

--- a/src/inpar/4C_inpar_validconditions.cpp
+++ b/src/inpar/4C_inpar_validconditions.cpp
@@ -506,7 +506,7 @@ Input::valid_conditions()
   for (const auto& cond : {pointlocsys, linelocsys, surflocsys, vollocsys})
   {
     add_named_real_vector(cond, "ROTANGLE", "", 3);
-    add_named_int_vector(cond, "FUNCT", "", 3);
+    add_named_int_vector(cond, "FUNCT", "", 3, {}, false, true);
     add_named_int(cond, "USEUPDATEDNODEPOS");
   }
 

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -569,7 +569,7 @@ void Inpar::XFEM::set_valid_conditions(
       Teuchos::tuple<int>(Inpar::XFEM::Proj_normal, Inpar::XFEM::Proj_smoothed,
           Inpar::XFEM::Proj_normal_smoothed_comb, Inpar::XFEM::Proj_normal_phi),
       true);
-  add_named_int(xfem_levelset_navier_slip, "L2_PROJECTION_SOLVER", "", 0, false, true);
+  add_named_int(xfem_levelset_navier_slip, "L2_PROJECTION_SOLVER", "", 0, false, false);
   add_named_int(xfem_levelset_navier_slip, "ROBIN_DIRICHLET_ID", "", 0, false, true);
   add_named_int(xfem_levelset_navier_slip, "ROBIN_NEUMANN_ID", "", 0, false, true);
   add_named_real(xfem_levelset_navier_slip, "SLIPCOEFFICIENT");

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -13,6 +13,7 @@
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_fem_general_utils_gder2.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_mat_maxwell_0d_acinus.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
@@ -327,16 +328,18 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           Bc = (condition->parameters().get<std::string>("boundarycond"));
 
           const auto vals = condition->parameters().get<std::vector<double>>("VAL");
-          const auto curve = condition->parameters().get<std::vector<int>>("curve");
-          const auto functions = condition->parameters().get<std::vector<int>>("funct");
+          const auto curve =
+              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+          const auto functions =
+              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("funct");
 
           // Read in the value of the applied BC
           // Get factor of first CURVE
           double curvefac = 1.0;
-          if (curve[0] > 0)
+          if (curve[0].has_value() && curve[0].value() > 0)
           {
             curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value() - 1)
                            .evaluate(time);
             BCin = vals[0] * curvefac;
           }
@@ -347,23 +350,20 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           }
 
           // Get factor of FUNCT
-          int functnum = functions[0];
-
           double functionfac = 0.0;
-          if (functnum > 0)
+          if (functions[0].has_value() && functions[0].value() > 0)
           {
-            functionfac = Global::Problem::instance()
-                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
-                              .evaluate((ele->nodes()[i])->x().data(), time, 0);
+            functionfac =
+                Global::Problem::instance()
+                    ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[0].value() - 1)
+                    .evaluate((ele->nodes()[i])->x().data(), time, 0);
           }
 
           // Get factor of second CURVE
-          int curve2num = -1;
           double curve2fac = 1.0;
-          curve2num = curve[1];
-          if (curve2num > 0)
+          if (curve[1].has_value() && curve[1].value() > 0)
             curve2fac = Global::Problem::instance()
-                            ->function_by_id<Core::Utils::FunctionOfTime>(curve2num - 1)
+                            ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value() - 1)
                             .evaluate(time);
 
           // Add first_CURVE + FUNCTION * second_CURVE
@@ -466,16 +466,18 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             Bc = (condition->parameters().get<std::string>("phase2"));
           }
 
-          const auto curve = condition->parameters().get<std::vector<int>>("curve");
+          const auto curve =
+              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
           double curvefac = 1.0;
           const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
           // Read in the value of the applied BC
-          if (curve[phase_number] > 0)
+          if (curve[phase_number].has_value() && curve[phase_number].value() > 0)
           {
-            curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[phase_number] - 1)
-                           .evaluate(time);
+            curvefac =
+                Global::Problem::instance()
+                    ->function_by_id<Core::Utils::FunctionOfTime>(curve[phase_number].value() - 1)
+                    .evaluate(time);
             BCin = vals[phase_number] * curvefac;
           }
           else
@@ -509,15 +511,16 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             double Pp_np = 0.0;
             if (pplCond)
             {
-              const auto curve = pplCond->parameters().get<std::vector<int>>("curve");
+              const auto curve =
+                  pplCond->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
               double curvefac = 1.0;
               const auto vals = pplCond->parameters().get<std::vector<double>>("VAL");
 
               // Read in the value of the applied BC
-              if (curve[0] > 0)
+              if (curve[0].has_value() && curve[0].value() > 0)
               {
                 curvefac = Global::Problem::instance()
-                               ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                               ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value() - 1)
                                .evaluate(time);
               }
 

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -12,6 +12,7 @@
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_mat_newtonianfluid.hpp"
 #include "4C_red_airways_evaluation_data.hpp"
@@ -200,17 +201,19 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           // Get the type of prescribed bc
           Bc = (condition->parameters().get<std::string>("boundarycond"));
 
-          const auto curve = condition->parameters().get<std::vector<int>>("curve");
+          const auto curve =
+              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
           double curvefac = 1.0;
           const auto vals = condition->parameters().get<std::vector<double>>("VAL");
-          const auto functions = condition->parameters().get<std::vector<int>>("funct");
+          const auto functions =
+              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("funct");
 
           // Read in the value of the applied BC
           // Get factor of first CURVE
-          if (curve[0] > 0)
+          if (curve[0].has_value() && curve[0].value() > 0)
           {
             curvefac = Global::Problem::instance()
-                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                           ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value() - 1)
                            .evaluate(time);
             BCin = vals[0] * curvefac;
           }
@@ -220,23 +223,20 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
             exit(1);
           }
           // Get factor of FUNCT
-          int functnum = functions[0];
-
           double functionfac = 0.0;
-          if (functnum > 0)
+          if (functions[0].has_value() && functions[0].value() > 0)
           {
-            functionfac = Global::Problem::instance()
-                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
-                              .evaluate((ele->nodes()[i])->x().data(), time, 0);
+            functionfac =
+                Global::Problem::instance()
+                    ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[0].value() - 1)
+                    .evaluate((ele->nodes()[i])->x().data(), time, 0);
           }
 
           // Get factor of second CURVE
-          int curve2num = -1;
           double curve2fac = 1.0;
-          curve2num = curve[1];
-          if (curve2num > 0)
+          if (curve[1].has_value() && curve[1].value() > 0)
             curve2fac = Global::Problem::instance()
-                            ->function_by_id<Core::Utils::FunctionOfTime>(curve2num - 1)
+                            ->function_by_id<Core::Utils::FunctionOfTime>(curve[1].value() - 1)
                             .evaluate(time);
 
           // Add first_CURVE + FUNCTION * second_CURVE
@@ -266,15 +266,16 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
             double Pp_np = 0.0;
             if (pplCond)
             {
-              const auto curve = pplCond->parameters().get<std::vector<int>>("curve");
+              const auto curve =
+                  pplCond->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
               double curvefac = 1.0;
               const auto vals = pplCond->parameters().get<std::vector<double>>("VAL");
 
               // Read in the value of the applied BC
-              if (curve[0] > 0)
+              if (curve[0].has_value() && curve[0].value() > 0)
               {
                 curvefac = Global::Problem::instance()
-                               ->function_by_id<Core::Utils::FunctionOfTime>(curve[0] - 1)
+                               ->function_by_id<Core::Utils::FunctionOfTime>(curve[0].value() - 1)
                                .evaluate(time);
               }
 

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_io_control.hpp"
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_krylov_projector.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
@@ -306,8 +307,12 @@ void ScaTra::ScaTraTimIntElch::setup()
             "Found constant-current constant-voltage (CCCV) cell cycling boundary condition, but "
             "no CCCV half-cycle boundary conditions!");
       }
-      if (cccvcyclingcondition.parameters().get<int>("CONDITION_ID_FOR_CHARGE") < 0 or
-          cccvcyclingcondition.parameters().get<int>("CONDITION_ID_FOR_DISCHARGE") < 0)
+      if (!cccvcyclingcondition.parameters()
+              .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_CHARGE")
+              .has_value() or
+          !cccvcyclingcondition.parameters()
+              .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_DISCHARGE")
+              .has_value())
       {
         FOUR_C_THROW(
             "Invalid ID of constant-current constant-voltage (CCCV) half-cycle boundary condition "
@@ -2971,7 +2976,7 @@ void ScaTra::ScaTraTimIntElch::apply_neumann_bc(
             // condition.
             const std::vector<int> onoff = {0, 1};
             const std::vector<double> val = {0.0, condition->parameters().get<double>("CURRENT")};
-            const std::vector<int> funct = {0, 0};
+            const std::vector<Core::IO::Noneable<int>> funct = {0, 0};
             condition->parameters().add("NUMDOF", 2);
             condition->parameters().add("FUNCT", funct);
             condition->parameters().add("ONOFF", onoff);

--- a/src/scatra/4C_scatra_timint_elch_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scheme.cpp
@@ -266,7 +266,7 @@ void ScaTra::ScaTraTimIntElchOST::compute_time_deriv_pot0(const bool init)
   for (int icond = 0; icond < numcond; icond++)
   {
     auto pot0np = cond[icond]->parameters().get<double>("POT");
-    const auto functnum = cond[icond]->parameters().get<int>("FUNCT");
+    const auto functnum = cond[icond]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
     auto dlcap = cond[icond]->parameters().get<double>("DL_SPEC_CAP");
 
     if (init)
@@ -283,11 +283,12 @@ void ScaTra::ScaTraTimIntElchOST::compute_time_deriv_pot0(const bool init)
     else
     {
       // compute time derivative of applied potential
-      if (functnum > 0)
+      if (functnum.has_value() && functnum.value() > 0)
       {
         // function_by_id takes a zero-based index
         const double functfac =
-            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum - 1).evaluate(time_);
+            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum.value() - 1)
+                .evaluate(time_);
 
         // adjust potential at metal side accordingly
         pot0np *= functfac;
@@ -827,7 +828,7 @@ void ScaTra::ScaTraTimIntElchGenAlpha::compute_time_deriv_pot0(const bool init)
   for (int icond = 0; icond < numcond; icond++)
   {
     double pot0np = cond[icond]->parameters().get<double>("POT");
-    const int functnum = cond[icond]->parameters().get<int>("FUNCT");
+    const auto functnum = cond[icond]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
     double dlcap = cond[icond]->parameters().get<double>("DL_SPEC_CAP");
 
     if (init)
@@ -853,11 +854,12 @@ void ScaTra::ScaTraTimIntElchGenAlpha::compute_time_deriv_pot0(const bool init)
     {
       // these values are not used without double layer charging
       // compute time derivative of applied potential
-      if (functnum > 0)
+      if (functnum.has_value() && functnum.value() > 0)
       {
         // function_by_id takes a zero-based index
         const double functfac =
-            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum - 1).evaluate(time_);
+            problem_->function_by_id<Core::Utils::FunctionOfTime>(functnum.value() - 1)
+                .evaluate(time_);
         // adjust potential at metal side accordingly
 
         pot0np *= functfac;

--- a/src/scatra/4C_scatra_timint_elch_service.cpp
+++ b/src/scatra/4C_scatra_timint_elch_service.cpp
@@ -8,6 +8,7 @@
 #include "4C_scatra_timint_elch_service.hpp"
 
 #include "4C_io.hpp"
+#include "4C_io_input_parameter_container.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -23,11 +24,13 @@ ScaTra::CCCVCondition::CCCVCondition(const Core::Conditions::Condition& cccvcycl
       charging_(false),
       ihalfcycle_(-1),
       initrelaxtime_(cccvcyclingcondition.parameters().get<double>("INIT_RELAX_TIME")),
-      min_time_steps_during_init_relax_(
-          cccvcyclingcondition.parameters().get<int>("MIN_TIME_STEPS_DURING_INIT_RELAX")),
+      min_time_steps_during_init_relax_(cccvcyclingcondition.parameters()
+              .get<Core::IO::Noneable<int>>("MIN_TIME_STEPS_DURING_INIT_RELAX")
+              .value_or(-1)),
       nhalfcycles_(cccvcyclingcondition.parameters().get<int>("NUMBER_OF_HALF_CYCLES")),
-      num_add_adapt_timesteps_(
-          cccvcyclingcondition.parameters().get<int>("NUM_ADD_ADAPT_TIME_STEPS")),
+      num_add_adapt_timesteps_(cccvcyclingcondition.parameters()
+              .get<Core::IO::Noneable<int>>("NUM_ADD_ADAPT_TIME_STEPS")
+              .value_or(-1)),
       num_dofs_(num_dofs),
       phasechanged_(false),
       phaseinitialrelaxation_(false),
@@ -58,11 +61,15 @@ ScaTra::CCCVCondition::CCCVCondition(const Core::Conditions::Condition& cccvcycl
     }
 
     if (condition->parameters().get<int>("ConditionID") ==
-        cccvcyclingcondition.parameters().get<int>("CONDITION_ID_FOR_CHARGE"))
+        cccvcyclingcondition.parameters()
+            .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_CHARGE")
+            .value_or(-1))
       halfcycle_charge_ =
           std::make_shared<ScaTra::CCCVHalfCycleCondition>(*condition, adaptivetimestepping);
     if (condition->parameters().get<int>("ConditionID") ==
-        cccvcyclingcondition.parameters().get<int>("CONDITION_ID_FOR_DISCHARGE"))
+        cccvcyclingcondition.parameters()
+            .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_DISCHARGE")
+            .value_or(-1))
       halfcycle_discharge_ =
           std::make_shared<ScaTra::CCCVHalfCycleCondition>(*condition, adaptivetimestepping);
   }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
@@ -109,7 +109,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
   // access parameters of the condition
   const auto kinetics = cond->parameters().get<int>("KINETIC_MODEL");
   auto pot0 = cond->parameters().get<double>("POT");
-  const auto curvenum = cond->parameters().get<int>("FUNCT");
+  const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
   const auto nume = cond->parameters().get<int>("E-");
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated
@@ -153,11 +153,11 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
   double rhsfac = 1.0;
   // find out whether we shell use a time curve and get the factor
   // this feature can be also used for stationary "pseudo time loops"
-  if (curvenum > 0)
+  if (curvenum.has_value() && curvenum.value() > 0)
   {
     // function_by_id takes a zero-based index
     const double curvefac = Global::Problem::instance()
-                                ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                                ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                                 .evaluate(time);
     // adjust potential at metal side accordingly
     pot0 *= curvefac;
@@ -237,7 +237,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
 
     // access parameters of the condition
     auto pot0 = cond->parameters().get<double>("POT");
-    const auto curvenum = cond->parameters().get<int>("FUNCT");
+    const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
     const auto nume = cond->parameters().get<int>("E-");
     const auto e0 = cond->parameters().get<double>("e0");
     const auto c0 = cond->parameters().get<double>("c0");
@@ -259,12 +259,13 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
 
     const double time = my::scatraparamstimint_->time();
 
-    if (curvenum > 0)
+    if (curvenum.has_value() && curvenum.value() > 0)
     {
       // function_by_id takes a zero-based index
-      const double curvefac = Global::Problem::instance()
-                                  ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
-                                  .evaluate(time);
+      const double curvefac =
+          Global::Problem::instance()
+              ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
+              .evaluate(time);
       // adjust potential at metal side accordingly
       pot0 *= curvefac;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
@@ -11,6 +11,7 @@
 #include "4C_fem_nurbs_discretization_utils.hpp"
 #include "4C_fluid_rotsym_periodicbc.hpp"
 #include "4C_global_data.hpp"  // consistency check of formulation and material
+#include "4C_io_input_parameter_container.hpp"
 #include "4C_mat_elchmat.hpp"
 #include "4C_scatra_ele.hpp"
 #include "4C_scatra_ele_action.hpp"
@@ -354,7 +355,7 @@ void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::calc_elch_boundary_
   // access parameters of the condition
   const int kinetics = cond->parameters().get<int>("KINETIC_MODEL");
   double pot0 = cond->parameters().get<double>("POT");
-  const int functnum = cond->parameters().get<int>("FUNCT");
+  const auto functnum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
   const int nume = cond->parameters().get<int>("E-");
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated
@@ -405,10 +406,10 @@ void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::calc_elch_boundary_
   double rhsfac = 1.0;
   // find out whether we shell use a time curve and get the factor
   // this feature can be also used for stationary "pseudo time loops"
-  if (functnum > 0)
+  if (functnum.has_value() && functnum.value() > 0)
   {
     const double functfac = Global::Problem::instance()
-                                ->function_by_id<Core::Utils::FunctionOfTime>(functnum - 1)
+                                ->function_by_id<Core::Utils::FunctionOfTime>(functnum.value() - 1)
                                 .evaluate(time);
 
     // adjust potential at metal side accordingly

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
@@ -266,7 +266,7 @@ void Discret::Elements::ScaTraEleCalcElchDiffCond<distype, probdim>::calc_elch_d
   // access parameters of the condition
   const int kinetics = cond->parameters().get<int>("KINETIC_MODEL");
   double pot0 = cond->parameters().get<double>("POT");
-  const int curvenum = cond->parameters().get<int>("FUNCT");
+  const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
   const int nume = cond->parameters().get<int>("E-");
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated
@@ -313,11 +313,11 @@ void Discret::Elements::ScaTraEleCalcElchDiffCond<distype, probdim>::calc_elch_d
   double rhsfac = 1.0;
   // find out whether we shell use a time curve and get the factor
   // this feature can be also used for stationary "pseudo time loops"
-  if (curvenum > 0)
+  if (curvenum.has_value() && curvenum.value() > 0)
   {
     // function_by_id takes a zero-based index
     const double curvefac = Global::Problem::instance()
-                                ->function_by_id<Core::Utils::FunctionOfTime>(curvenum - 1)
+                                ->function_by_id<Core::Utils::FunctionOfTime>(curvenum.value() - 1)
                                 .evaluate(time);
     // adjust potential at metal side accordingly
     pot0 *= curvefac;

--- a/src/scatra_ele/4C_scatra_ele_calc_service_stabilization.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_stabilization.cpp
@@ -962,31 +962,22 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::calc_subgr_velocity(
     const std::string* condtype = &myfluidneumcond[0]->parameters().get<std::string>("TYPE");
 
     // get values and switches from the condition
-    const std::vector<int>* onoff =
-        &myfluidneumcond[0]->parameters().get<std::vector<int>>("ONOFF");
-    const std::vector<double>* val =
-        &myfluidneumcond[0]->parameters().get<std::vector<double>>("VAL");
-    const std::vector<int>* funct =
-        &myfluidneumcond[0]->parameters().get<std::vector<int>>("FUNCT");
+    const auto onoff = myfluidneumcond[0]->parameters().get<std::vector<int>>("ONOFF");
+    const auto val = myfluidneumcond[0]->parameters().get<std::vector<double>>("VAL");
+    const auto funct =
+        myfluidneumcond[0]->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
 
     // factor given by spatial function
     double functfac = 1.0;
-    int functnum = -1;
 
     // set this condition to the body-force array
     for (unsigned isd = 0; isd < nsd_; isd++)
     {
-      // get factor given by spatial function
-      if (funct)
-        functnum = (*funct)[isd];
-      else
-        functnum = -1;
-
-      double num = (*onoff)[isd] * (*val)[isd];
+      double num = onoff[isd] * val[isd];
 
       for (unsigned jnode = 0; jnode < nen_; ++jnode)
       {
-        if (functnum > 0)
+        if (funct[isd].has_value() && funct[isd].value() > 0)
         {
           // time factor for the intermediate step
           // (negative time value indicates error)
@@ -1000,7 +991,7 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::calc_subgr_velocity(
             // in some fancy turbulance stuff.
             functfac =
                 Global::Problem::instance()
-                    ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
+                    ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[isd].value() - 1)
                     .evaluate((ele->nodes()[jnode])->x().data(), scatraparatimint_->time(), isd);
           }
           else

--- a/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
+++ b/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
@@ -128,7 +128,8 @@ void Discret::Elements::Shell::evaluate_neumann(Core::Elements::Element& ele,
     }
   }
   // get ids of functions of space and time
-  const auto* function_ids = &condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto function_ids =
+      condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
 
   // integration loops
   std::array<double, 2> xi_gp;
@@ -219,13 +220,13 @@ void Discret::Elements::Shell::evaluate_neumann(Core::Elements::Element& ele,
       if (onoff[dim])
       {
         // function evaluation
-        const int function_number = (function_ids != nullptr) ? (*function_ids)[dim] : -1;
-        function_scale_factors[dim] =
-            (function_number > 0)
-                ? Global::Problem::instance()
-                      ->function_by_id<Core::Utils::FunctionOfSpaceTime>(function_number - 1)
-                      .evaluate(gauss_point_reference_coordinates.data(), total_time, dim)
-                : 1.0;
+        if (function_ids[dim].has_value() && function_ids[dim].value() > 0)
+        {
+          function_scale_factors[dim] =
+              Global::Problem::instance()
+                  ->function_by_id<Core::Utils::FunctionOfSpaceTime>(function_ids[dim].value() - 1)
+                  .evaluate(gauss_point_reference_coordinates.data(), total_time, dim);
+        }
       }
     }
 

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
@@ -143,7 +143,7 @@ int Discret::Elements::KirchhoffLoveShellNurbs::evaluate_neumann(Teuchos::Parame
   // get values and switches from the condition
   const auto& onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto& val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto& funct_id = condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto& funct_id = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
 
   // ensure that the boundary condition has the correct size
   if (onoff.size() != n_nodal_dof)
@@ -153,11 +153,11 @@ int Discret::Elements::KirchhoffLoveShellNurbs::evaluate_neumann(Teuchos::Parame
   std::array<const Core::Utils::FunctionOfSpaceTime*, n_nodal_dof> functions;
   for (int i_dof = 0; i_dof < n_nodal_dof; ++i_dof)
   {
-    if (onoff[i_dof] == 1 and funct_id[i_dof] > 0)
+    if (onoff[i_dof] == 1 and funct_id[i_dof].has_value() and funct_id[i_dof].value() > 0)
     {
       functions[i_dof] =
           &(Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(
-              funct_id[i_dof] - 1));
+              funct_id[i_dof].value() - 1));
     }
   }
 

--- a/src/so3/4C_so3_hex27_evaluate.cpp
+++ b/src/so3/4C_so3_hex27_evaluate.cpp
@@ -535,8 +535,8 @@ int Discret::Elements::SoHex27::evaluate_neumann(Teuchos::ParameterList& params,
     Core::LinAlg::SerialDenseMatrix* elemat1)
 {
   // get values and switches from the condition
-  const auto* onoff = &condition.parameters().get<std::vector<int>>("ONOFF");
-  const auto* val = &condition.parameters().get<std::vector<double>>("VAL");
+  const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
+  const auto val = condition.parameters().get<std::vector<double>>("VAL");
 
   /*
   **    TIME CURVE BUSINESS
@@ -552,23 +552,19 @@ int Discret::Elements::SoHex27::evaluate_neumann(Teuchos::ParameterList& params,
       });
 
   // ensure that at least as many curves/functs as dofs are available
-  if (int(onoff->size()) < NUMDIM_SOH27)
+  if (int(onoff.size()) < NUMDIM_SOH27)
     FOUR_C_THROW("Fewer functions or curves defined than the element has dofs.");
 
-  for (int checkdof = NUMDIM_SOH27; checkdof < int(onoff->size()); ++checkdof)
+  for (int checkdof = NUMDIM_SOH27; checkdof < int(onoff.size()); ++checkdof)
   {
-    if ((*onoff)[checkdof] != 0)
+    if (onoff[checkdof] != 0)
       FOUR_C_THROW(
           "Number of Dimensions in Neumann_Evaluation is 3. Further DoFs are not considered.");
   }
 
   // (SPATIAL) FUNCTION BUSINESS
-  const auto* funct = &condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOH27, 1> xrefegp(false);
-  bool havefunct = false;
-  if (funct)
-    for (int dim = 0; dim < NUMDIM_SOH27; dim++)
-      if ((*funct)[dim] > 0) havefunct = havefunct or true;
 
   /* ============================================================================*
   ** CONST SHAPE FUNCTIONS, DERIVATIVES and WEIGHTS for HEX_27 with 27 GAUSS POINTS*
@@ -603,14 +599,11 @@ int Discret::Elements::SoHex27::evaluate_neumann(Teuchos::ParameterList& params,
       FOUR_C_THROW("NEGATIVE JACOBIAN DETERMINANT");
 
     // material/reference co-ordinates of Gauss point
-    if (havefunct)
+    for (int dim = 0; dim < NUMDIM_SOH27; dim++)
     {
-      for (int dim = 0; dim < NUMDIM_SOH27; dim++)
-      {
-        xrefegp(dim) = 0.0;
-        for (int nodid = 0; nodid < NUMNOD_SOH27; ++nodid)
-          xrefegp(dim) += shapefcts[gp](nodid) * xrefe(nodid, dim);
-      }
+      xrefegp(dim) = 0.0;
+      for (int nodid = 0; nodid < NUMNOD_SOH27; ++nodid)
+        xrefegp(dim) += shapefcts[gp](nodid) * xrefe(nodid, dim);
     }
 
     // integration factor
@@ -618,16 +611,18 @@ int Discret::Elements::SoHex27::evaluate_neumann(Teuchos::ParameterList& params,
     // distribute/add over element load vector
     for (int dim = 0; dim < NUMDIM_SOH27; dim++)
     {
-      if ((*onoff)[dim])
+      if (onoff[dim])
       {
         // function evaluation
-        const int functnum = (funct) ? (*funct)[dim] : -1;
-        const double functfac =
-            (functnum > 0) ? Global::Problem::instance()
-                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
-                                 .evaluate(xrefegp.data(), time, dim)
-                           : 1.0;
-        double dim_fac = (*val)[dim] * fac * functfac;
+        double functfac = 1.0;
+        if (funct[dim].has_value() && funct[dim].value() > 0)
+        {
+          functfac = Global::Problem::instance()
+                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[dim].value() - 1)
+                         .evaluate(xrefegp.data(), time, dim);
+        }
+
+        double dim_fac = val[dim] * fac * functfac;
         for (int nodid = 0; nodid < NUMNOD_SOH27; ++nodid)
         {
           elevec1[nodid * NUMDIM_SOH27 + dim] += shapefcts[gp](nodid) * dim_fac;

--- a/src/so3/4C_so3_hex8_evaluate.cpp
+++ b/src/so3/4C_so3_hex8_evaluate.cpp
@@ -1186,8 +1186,8 @@ int Discret::Elements::SoHex8::evaluate_neumann(Teuchos::ParameterList& params,
 {
   set_params_interface_ptr(params);
   // get values and switches from the condition
-  const auto* onoff = &condition.parameters().get<std::vector<int>>("ONOFF");
-  const auto* val = &condition.parameters().get<std::vector<double>>("VAL");
+  const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
+  const auto val = condition.parameters().get<std::vector<double>>("VAL");
 
   /*
   **    TIME CURVE BUSINESS
@@ -1200,24 +1200,19 @@ int Discret::Elements::SoHex8::evaluate_neumann(Teuchos::ParameterList& params,
     time = params.get("total time", -1.0);
 
   // ensure that at least as many curves/functs as dofs are available
-  if (int(onoff->size()) < NUMDIM_SOH8)
+  if (int(onoff.size()) < NUMDIM_SOH8)
     FOUR_C_THROW("Fewer functions or curves defined than the element has dofs.");
 
-  for (int checkdof = NUMDIM_SOH8; checkdof < int(onoff->size()); ++checkdof)
+  for (int checkdof = NUMDIM_SOH8; checkdof < int(onoff.size()); ++checkdof)
   {
-    if ((*onoff)[checkdof] != 0)
+    if (onoff[checkdof] != 0)
       FOUR_C_THROW(
           "Number of Dimensions in Neumann_Evaluation is 3. Further DoFs are not considered.");
   }
 
   // (SPATIAL) FUNCTION BUSINESS
-  const auto* funct = &condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOH8, 1> xrefegp(false);
-  bool havefunct = false;
-  if (funct)
-    for (int dim = 0; dim < NUMDIM_SOH8; dim++)
-      if ((*funct)[dim] > 0) havefunct = havefunct or true;
-
 
   /* ============================================================================*
   ** CONST SHAPE FUNCTIONS, DERIVATIVES and WEIGHTS for HEX_8 with 8 GAUSS POINTS*
@@ -1245,14 +1240,11 @@ int Discret::Elements::SoHex8::evaluate_neumann(Teuchos::ParameterList& params,
       FOUR_C_THROW("NEGATIVE JACOBIAN DETERMINANT");
 
     // material/reference co-ordinates of Gauss point
-    if (havefunct)
+    for (int dim = 0; dim < NUMDIM_SOH8; dim++)
     {
-      for (int dim = 0; dim < NUMDIM_SOH8; dim++)
-      {
-        xrefegp(dim) = 0.0;
-        for (int nodid = 0; nodid < NUMNOD_SOH8; ++nodid)
-          xrefegp(dim) += shapefcts[gp](nodid) * xrefe(nodid, dim);
-      }
+      xrefegp(dim) = 0.0;
+      for (int nodid = 0; nodid < NUMNOD_SOH8; ++nodid)
+        xrefegp(dim) += shapefcts[gp](nodid) * xrefe(nodid, dim);
     }
 
     // integration factor
@@ -1260,16 +1252,18 @@ int Discret::Elements::SoHex8::evaluate_neumann(Teuchos::ParameterList& params,
     // distribute/add over element load vector
     for (int dim = 0; dim < NUMDIM_SOH8; dim++)
     {
-      if ((*onoff)[dim])
+      if (onoff[dim])
       {
         // function evaluation
-        const int functnum = (funct) ? (*funct)[dim] : -1;
-        const double functfac =
-            (functnum > 0) ? Global::Problem::instance()
-                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
-                                 .evaluate(xrefegp.data(), time, dim)
-                           : 1.0;
-        const double dim_fac = (*val)[dim] * fac * functfac;
+        double functfac = 1.0;
+        if (funct[dim].has_value() && funct[dim].value() > 0)
+        {
+          functfac = Global::Problem::instance()
+                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[dim].value() - 1)
+                         .evaluate(xrefegp.data(), time, dim);
+        }
+
+        const double dim_fac = val[dim] * fac * functfac;
         for (int nodid = 0; nodid < NUMNOD_SOH8; ++nodid)
         {
           elevec1[nodid * NUMDIM_SOH8 + dim] += shapefcts[gp](nodid) * dim_fac;

--- a/src/so3/4C_so3_tet4_evaluate.cpp
+++ b/src/so3/4C_so3_tet4_evaluate.cpp
@@ -686,8 +686,8 @@ int Discret::Elements::SoTet4::evaluate_neumann(Teuchos::ParameterList& params,
     Core::LinAlg::SerialDenseMatrix* elemat1)
 {
   // get values and switches from the condition
-  const auto* onoff = &condition.parameters().get<std::vector<int>>("ONOFF");
-  const auto* val = &condition.parameters().get<std::vector<double>>("VAL");
+  const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
+  const auto val = condition.parameters().get<std::vector<double>>("VAL");
 
   /*
   **    TIME CURVE BUSINESS
@@ -703,29 +703,20 @@ int Discret::Elements::SoTet4::evaluate_neumann(Teuchos::ParameterList& params,
       });
 
   // ensure that at least as many curves/functs as dofs are available
-  if (int(onoff->size()) < NUMDIM_SOTET4)
+  if (int(onoff.size()) < NUMDIM_SOTET4)
     FOUR_C_THROW("Fewer functions or curves defined than the element has dofs.");
 
-  for (int checkdof = NUMDIM_SOTET4; checkdof < int(onoff->size()); ++checkdof)
+  for (int checkdof = NUMDIM_SOTET4; checkdof < int(onoff.size()); ++checkdof)
   {
-    if ((*onoff)[checkdof] != 0)
+    if (onoff[checkdof] != 0)
       FOUR_C_THROW(
           "Number of Dimensions in Neumann_Evaluation is 3. Further DoFs are not considered.");
   }
 
   // (SPATIAL) FUNCTION BUSINESS
   static_assert((NUMGPT_SOTET4 == 1));
-  const auto* funct = &condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOTET4, 1> xrefegp(false);
-  bool havefunct = false;
-  if (funct)
-    for (int dim = 0; dim < NUMDIM_SOTET4; dim++)
-      if ((*funct)[dim] > 0)
-      {
-        havefunct = true;
-        break;
-      }
-
 
   /* =============================================================================*
    * CONST SHAPE FUNCTIONS and WEIGHTS for TET_4 with 1 GAUSS POINTS              *
@@ -771,14 +762,11 @@ int Discret::Elements::SoTet4::evaluate_neumann(Teuchos::ParameterList& params,
   for (int gp = 0; gp < NUMGPT_SOTET4; gp++)
   {
     // material/reference co-ordinates of Gauss point
-    if (havefunct)
+    for (int dim = 0; dim < NUMDIM_SOTET4; dim++)
     {
-      for (int dim = 0; dim < NUMDIM_SOTET4; dim++)
-      {
-        xrefegp(dim) = 0.0;
-        for (int nodid = 0; nodid < NUMNOD_SOTET4; ++nodid)
-          xrefegp(dim) += shapefcts[gp](nodid) * xrefe(nodid, dim);
-      }
+      xrefegp(dim) = 0.0;
+      for (int nodid = 0; nodid < NUMNOD_SOTET4; ++nodid)
+        xrefegp(dim) += shapefcts[gp](nodid) * xrefe(nodid, dim);
     }
 
     // integration factor
@@ -786,16 +774,18 @@ int Discret::Elements::SoTet4::evaluate_neumann(Teuchos::ParameterList& params,
     // distribute/add over element load vector
     for (int dim = 0; dim < NUMDIM_SOTET4; dim++)
     {
-      if ((*onoff)[dim])
+      if (onoff[dim])
       {
         // function evaluation
-        const int functnum = (funct) ? (*funct)[dim] : -1;
-        const double functfac =
-            (functnum > 0) ? Global::Problem::instance()
-                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
-                                 .evaluate(xrefegp.data(), time, dim)
-                           : 1.0;
-        const double dim_fac = (*val)[dim] * fac * functfac;
+        double functfac = 1.0;
+        if (funct[dim].has_value() && funct[dim].value() > 0)
+        {
+          functfac = Global::Problem::instance()
+                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[dim].value() - 1)
+                         .evaluate(xrefegp.data(), time, dim);
+        }
+
+        const double dim_fac = val[dim] * fac * functfac;
         for (int nodid = 0; nodid < NUMNOD_SOTET4; ++nodid)
         {
           elevec1[nodid * NUMDIM_SOTET4 + dim] += shapefcts[gp](nodid) * dim_fac;

--- a/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
@@ -99,7 +99,8 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
   }
 
   // get ids of functions of space and time
-  const auto& function_ids = condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto& function_ids =
+      condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
 
   const ElementNodes<celltype> nodal_coordinates =
       evaluate_element_nodes<celltype>(element, discretization, dof_index_array);
@@ -126,11 +127,11 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
           if (onoff[dim])
           {
             // function evaluation
-            const int function_number = function_ids[dim];
             const double function_scale_factor =
-                (function_number > 0)
+                (function_ids[dim].has_value() && function_ids[dim].value() > 0)
                     ? Global::Problem::instance()
-                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(function_number - 1)
+                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
+                              function_ids[dim].value() - 1)
                           .evaluate(gauss_point_reference_coordinates.data(), total_time, dim)
                     : 1.0;
 

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -186,11 +186,11 @@ void Solid::MonitorDbc::setup()
 void Solid::MonitorDbc::create_reaction_maps(const Core::FE::Discretization& discret,
     const Core::Conditions::Condition& rcond, std::shared_ptr<Epetra_Map>* react_maps) const
 {
-  const auto* onoff = &rcond.parameters().get<std::vector<int>>("ONOFF");
+  const auto onoff = rcond.parameters().get<std::vector<int>>("ONOFF");
   const auto* nids = rcond.get_nodes();
   std::vector<int> my_dofs[DIM];
   int ndof = 0;
-  for (int i : *onoff) ndof += i;
+  for (int i : onoff) ndof += i;
 
   for (auto& my_dof : my_dofs) my_dof.reserve(nids->size() * ndof);
 
@@ -203,7 +203,7 @@ void Solid::MonitorDbc::create_reaction_maps(const Core::FE::Discretization& dis
     const Core::Nodes::Node* node = discret.l_row_node(rlid);
 
     for (unsigned i = 0; i < DIM; ++i)
-      if ((*onoff)[i] == 1) my_dofs[i].push_back(discret.dof(node, i));
+      if (onoff[i] == 1) my_dofs[i].push_back(discret.dof(node, i));
   }
 
   for (unsigned i = 0; i < DIM; ++i)
@@ -543,11 +543,11 @@ double Solid::MonitorDbc::get_reaction_moment(Core::LinAlg::Matrix<DIM, 1>& rmom
   Core::LinAlg::Matrix<DIM, 1> node_reaction_moment(true);
   std::vector<int> node_gid(3);
 
-  const auto* onoff = &rcond->parameters().get<std::vector<int>>("ONOFF");
+  const auto onoff = rcond->parameters().get<std::vector<int>>("ONOFF");
   const std::vector<int>* nids = rcond->get_nodes();
   std::vector<int> my_dofs[DIM];
   int ndof = 0;
-  for (int i : *onoff) ndof += i;
+  for (int i : onoff) ndof += i;
 
   for (unsigned i = 0; i < DIM; ++i) my_dofs[i].reserve(nids->size() * ndof);
 
@@ -570,7 +570,7 @@ double Solid::MonitorDbc::get_reaction_moment(Core::LinAlg::Matrix<DIM, 1>& rmom
     node_reaction_force.put_scalar(0.0);
     for (unsigned i = 0; i < DIM; ++i)
     {
-      if ((*onoff)[i] == 1)
+      if (onoff[i] == 1)
       {
         const int lid = complete_freact.Map().LID(node_gid[i]);
         if (lid < 0)

--- a/src/w1/4C_w1_poro_p1_evaluate.cpp
+++ b/src/w1/4C_w1_poro_p1_evaluate.cpp
@@ -906,9 +906,9 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate_neumann(Teuchos::Parameter
 
 
   // get values and switches from the condition
-  const auto* onoff = &condition.parameters().get<std::vector<int>>("ONOFF");
-  const auto* val = &condition.parameters().get<std::vector<double>>("VAL");
-  const auto* funct = &condition.parameters().get<std::vector<int>>("FUNCT");
+  const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
+  const auto val = condition.parameters().get<std::vector<double>>("VAL");
+  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
 
 
   Core::LinAlg::Matrix<Base::numdim_, Base::numnod_> N_XYZ;
@@ -937,12 +937,12 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate_neumann(Teuchos::Parameter
     // loop the dofs of a node
     for (int i = 0; i < Base::numdim_; ++i)
     {
-      if ((*onoff)[i])
+      if (onoff[i])
       {
-        // factor given by spatial function
-        const int functnum = (funct) ? (*funct)[i] : -1;
         double functfac = 1.0;
-        if (functnum > 0)
+
+        // factor given by spatial function
+        if (funct[i].has_value() && funct[i].value() > 0)
         {
           // calculate reference position of GP
           Core::LinAlg::Matrix<1, Base::numdim_> gp_coord;
@@ -958,11 +958,11 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate_neumann(Teuchos::Parameter
 
           // evaluate function at current gauss point
           functfac = Global::Problem::instance()
-                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum - 1)
+                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[i].value() - 1)
                          .evaluate(coordgpref, time, i);
         }
 
-        ar[i] = fac * (*val)[i] * functfac;
+        ar[i] = fac * val[i] * functfac;
       }
     }
 

--- a/src/xfem/4C_xfem_coupling_levelset.hpp
+++ b/src/xfem/4C_xfem_coupling_levelset.hpp
@@ -358,7 +358,7 @@ namespace XFEM
       eval_projection_matrix<distype>(projection_matrix, eid, funct, derxy, normal);
       evaluate_coupling_conditions(ivel, itraction, x, cond);
 
-      if (has_neumann_jump_)
+      if (robin_neumann_id_ >= 0)
       {
         // This is maybe not the most efficient implementation as we evaluate dynvisc as well as the
         // sliplenght twice evaluate interface traction (given by Neumann condition) Add this to the
@@ -525,7 +525,6 @@ namespace XFEM
    private:
     bool forcetangvel_;
     bool is_constant_sliplength_;
-    bool has_neumann_jump_;
     double sliplength_;
 
     // ID given the Robin Dirichlet/-Neumann conditions

--- a/src/xfem/4C_xfem_neumann.cpp
+++ b/src/xfem/4C_xfem_neumann.cpp
@@ -115,17 +115,16 @@ void XFEM::evaluate_neumann_standard(
     const std::vector<int>* nodeids = cond.get_nodes();
     if (!nodeids) FOUR_C_THROW("PointNeumann condition does not have nodal cloud");
     const int nnode = (*nodeids).size();
-    const auto* funct = cond.parameters().get_if<std::vector<int>>("FUNCT");
-    const auto* onoff = cond.parameters().get_if<std::vector<int>>("ONOFF");
-    const auto* val = cond.parameters().get_if<std::vector<double>>("VAL");
+    const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto onoff = cond.parameters().get<std::vector<int>>("ONOFF");
+    const auto val = cond.parameters().get<std::vector<double>>("VAL");
+
     // Neumann BCs for some historic reason only have one curve
-    int functnum = -1;
-    if (funct) functnum = (*funct)[0];
     double functfac = 1.0;
-    if (functnum >= 0)
+    if (funct[0].has_value() && funct[0].value() >= 0)
     {
       functfac = Global::Problem::instance()
-                     ->function_by_id<Core::Utils::FunctionOfTime>(functnum)
+                     ->function_by_id<Core::Utils::FunctionOfTime>(funct[0].value())
                      .evaluate(time);
     }
     for (int i = 0; i < nnode; ++i)
@@ -139,9 +138,9 @@ void XFEM::evaluate_neumann_standard(
       const unsigned numdf = dofs.size();
       for (unsigned j = 0; j < numdf; ++j)
       {
-        if ((*onoff)[j] == 0) continue;
+        if (onoff[j] == 0) continue;
         const int gid = dofs[j];
-        double value = (*val)[j];
+        double value = val[j];
         value *= functfac;
         const int lid = systemvector.Map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Global id %d not on this proc in system vector", gid);


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
Currently, components with the option `none_allowed` set to true, are stored as `-1` in the `InputParameterContainer`.
Using the `Noneable` type introduced in #258, we now store such component values as optionals in the container.

This PR adapts the read functionalities of the `LineComponent` accordingly and adapts the getting and checking of the component values in the code base.

Please see the preceding discussion in #255.

## Related Issues and Merge Requests
Follows https://github.com/4C-multiphysics/4C/pull/238
Follows https://github.com/4C-multiphysics/4C/pull/258
Related to https://github.com/4C-multiphysics/4C/issues/73