### PR TITLE
Null-terminate a string for C-style print

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -277,9 +277,10 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::parse(
     }
   }
 
-  // If we reach this point, none of the specs could be parsed.
+  // Convert remainder into a null-terminated string for the error message.
+  std::string remainder(parser.get_unparsed_remainder());
   FOUR_C_THROW("While parsing '%s'.\nNone of the specs fit the input. Expected %s",
-      parser.get_unparsed_remainder().data(), data.description.c_str());
+      remainder.c_str(), data.description.c_str());
 }
 
 


### PR DESCRIPTION
Fixes failing ASAN pipeline https://github.com/4C-multiphysics/4C/actions/runs/12876423054/attempts/1.

Side note: we could think about switching the C-style formatting to C++20 `std::format`, which would avoid such mistakes and get rid of all the `c_str()` calls in `FOUR_C_THROW.`