### PR TITLE
Extract valid materials to global legacy module and streamline input

### DIFF
--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
@@ -343,8 +343,7 @@ namespace RTD
       }
 
       std::ostringstream parameterstream;
-      Core::IO::InputParameterContainer container;
-      spec.print_as_dat(parameterstream, container);
+      spec.print_as_dat(parameterstream);
       parameter += " " + parameterstream.str();
     }
 
@@ -624,7 +623,7 @@ namespace RTD
     write_code(stream, contactlawsectionstring);
 
     std::stringstream specs_string;
-    specs.print_as_dat(specs_string, Core::IO::InputParameterContainer{});
+    specs.print_as_dat(specs_string);
     write_code(stream, {specs_string.str()});
   }
 

--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
@@ -313,12 +313,7 @@ namespace RTD
     std::string materialDescription = material->description();
     write_paragraph(stream, materialDescription);
 
-    // the material line as it occurs in the dat file
-    std::string parameter = "   MAT <matID>  " + material->name();
-    std::vector<std::string> materialcode;
-    //
-    // Also: create the table from the parameter descriptions (based on the so-called
-    // separatorComponents) table header
+    // Also: create the table from the parameter descriptions
     const unsigned tablesize = 3;
     Table parametertable(tablesize);
     std::vector<std::string> tablerow(tablesize);
@@ -334,21 +329,8 @@ namespace RTD
       table_row.push_back(spec.impl().description());
 
       parametertable.add_row(table_row);
-
-      if (parameter.length() > 60)
-      {
-        parameter += " \\";
-        materialcode.push_back(parameter);
-        parameter = "   ";
-      }
-
-      std::ostringstream parameterstream;
-      spec.print_as_dat(parameterstream);
-      parameter += " " + parameterstream.str();
     }
 
-    materialcode.push_back(parameter);
-    write_code(stream, materialcode);
     //
     // Now printing the parameter table
     parametertable.set_widths({10, 10, 50});
@@ -576,6 +558,7 @@ namespace RTD
     }
     // Now write the complete code of this condition to the readthedocs file
     conditioncode.push_back(conditioncodeline);
+    conditioncode.push_back("");
     write_code(stream, conditioncode);
 
     /*------ PART 4 -------------------------
@@ -624,7 +607,11 @@ namespace RTD
 
     std::stringstream specs_string;
     specs.print_as_dat(specs_string);
-    write_code(stream, {specs_string.str()});
+
+    // Split on newline because this is what the write_code function expects
+    std::vector<std::string> specs_list = Core::Utils::split(specs_string.str(), "\n");
+
+    write_code(stream, specs_list);
   }
 
 

--- a/apps/create_rtdfiles/4C_create_rtdfiles_wrapper.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_wrapper.cpp
@@ -15,8 +15,8 @@
 #include "4C_fem_general_element_definition.hpp"
 #include "4C_fem_general_utils_createdis.hpp"
 #include "4C_global_data.hpp"
+#include "4C_global_legacy_module_validmaterials.hpp"
 #include "4C_inpar_validconditions.hpp"
-#include "4C_inpar_validmaterials.hpp"
 #include "4C_inpar_validparameters.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"
@@ -83,7 +83,7 @@ namespace RTD
       FOUR_C_THROW("failed to open file: %s", materialdocumentationfilename.c_str());
     materialdocumentationfile << "..\n   Created using 4C version (git SHA1):\n";
     materialdocumentationfile << "   " << VersionControl::git_hash << "\n\n";
-    write_material_reference(materialdocumentationfile, *Input::valid_materials());
+    write_material_reference(materialdocumentationfile, *Global::valid_materials());
   }
 
   /*----------------------------------------------------------------------*/

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -285,7 +285,7 @@ int main(int argc, char* argv[])
         auto valid_co_laws = CONTACT::CONSTITUTIVELAW::valid_contact_constitutive_laws();
         Core::IO::InputFileUtils::print_section_header(std::cout, "CONTACT CONSTITUTIVE LAWS");
         std::cout << "//";
-        valid_co_laws.print_as_dat(std::cout, Core::IO::InputParameterContainer{});
+        valid_co_laws.print_as_dat(std::cout);
         std::cout << '\n';
       }
 

--- a/src/core/fem/src/general/element/4C_fem_general_element_definition.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element_definition.cpp
@@ -123,11 +123,10 @@ void Core::Elements::ElementDefinition::print_element_lines(std::ostream& stream
   FOUR_C_ASSERT(definitions_.contains(name), "Element type not found: " + name);
   auto& defs = definitions_[name];
 
-  const Core::IO::InputParameterContainer container;
   for (const auto& [cell_type, spec] : defs)
   {
     stream << "// 0 " << name << " ";
-    spec.print_as_dat(stream, container);
+    spec.print_as_dat(stream);
     stream << '\n';
   }
 }

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -286,7 +286,7 @@ void Core::IO::InputFileUtils::print_section(
   print_section_header(out, header);
 
   out << "// ";
-  spec.print_as_dat(out, Core::IO::InputParameterContainer{});
+  spec.print_as_dat(out);
   out << '\n';
 }
 

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -284,10 +284,7 @@ void Core::IO::InputFileUtils::print_section(
     std::ostream& out, const std::string& header, const InputSpec& spec)
 {
   print_section_header(out, header);
-
-  out << "// ";
   spec.print_as_dat(out);
-  out << '\n';
 }
 
 

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -44,12 +44,11 @@ void Core::IO::InputSpec::fully_parse(
       std::string(parser.get_unparsed_remainder()).c_str());
 }
 
-void Core::IO::InputSpec::print_as_dat(
-    std::ostream& stream, const Core::IO::InputParameterContainer& container) const
+void Core::IO::InputSpec::print_as_dat(std::ostream& stream) const
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
 
-  pimpl_->print(stream, container);
+  pimpl_->print(stream, 0u);
 }
 
 void Core::IO::InputSpec::emit_metadata(YamlEmitter& yaml) const

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -52,11 +52,9 @@ namespace Core::IO
     void fully_parse(ValueParser& parser, InputParameterContainer& container) const;
 
     /**
-     * Print the expected input format of this InputSpec to @p stream in dat format. The @p
-     * container is used to print the default values of the input. If a value is not present in the
-     * container, the type of the value is printed instead.
+     * Print the expected input format of this InputSpec to @p stream in dat format.
      */
-    void print_as_dat(std::ostream& stream, const InputParameterContainer& container) const;
+    void print_as_dat(std::ostream& stream) const;
 
     /**
      * Emit metadata about the InputSpec to the @p yaml emitter.

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -193,18 +193,23 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::set_default_value(
 
 
 void Core::IO::InputSpecBuilders::Internal::GroupSpec::print(
-    std::ostream& stream, const Core::IO::InputParameterContainer& container) const
+    std::ostream& stream, std::size_t indent) const
 {
-  if (!name.empty()) stream << name;
+  if (!name.empty())
+  {
+    stream << "// " << std::string(indent, ' ') << name << ":\n";
+    indent += 2;
+  }
+  // Only print an anonymous group if it is not present at the top-level.
+  else if (indent > 0)
+  {
+    stream << "// " << std::string(indent, ' ') << "<anonymous_group>:\n";
+    indent += 2;
+  }
 
-  const auto& subcontainer =
-      (name.empty()) ? container
-                     : (container.has_group(name) ? container.group(name)
-                                                  : Core::IO::InputParameterContainer{});
   for (const auto& spec : specs)
   {
-    spec.impl().print(stream, subcontainer);
-    stream << " ";
+    spec.impl().print(stream, indent);
   }
 }
 
@@ -291,15 +296,13 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::set_default_value(
 
 
 void Core::IO::InputSpecBuilders::Internal::OneOfSpec::print(
-    std::ostream& stream, const Core::IO::InputParameterContainer& container) const
+    std::ostream& stream, std::size_t indent) const
 {
-  stream << "<one_of {";
+  stream << "// " << std::string(indent, ' ') << "<one_of>:\n";
   for (const auto& spec : specs)
   {
-    spec.impl().print(stream, container);
-    stream << ";";
+    spec.impl().print(stream, indent + 2);
   }
-  stream << "}>";
 }
 
 void Core::IO::InputSpecBuilders::Internal::OneOfSpec::emit_metadata(ryml::NodeRef node) const
@@ -321,6 +324,7 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::emit_metadata(ryml::NodeR
 
 Core::IO::InputSpec Core::IO::InputSpecBuilders::tag(std::string name, ScalarData<bool> data)
 {
+  Internal::sanitize_required_default(data);
   return user_defined<bool>(
       name, data,
       // If we encounter the tag, we set the value to true.
@@ -329,48 +333,72 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::tag(std::string name, ScalarDat
         parser.consume(name);
         container.add(name, true);
       },
-      [name](std::ostream& stream, const InputParameterContainer& container) { stream << name; });
+      // Print the tag as a comment.
+      [name, data](std::ostream& out, std::size_t indent)
+      {
+        out << "// " << std::string(indent, ' ') << name;
+        out << " <tag>";
+        if (!data.required.value()) out << " (optional)";
+        if (!data.description.empty()) out << " " << std::quoted(data.description);
+        out << "\n";
+      });
 }
+
+namespace
+{
+  // An anonymous groups is only used for grouping purposes and does not have a name. If it is
+  // used inside another group, it can be flattened by stealing its specs and adding them to the
+  // parent group.
+  std::vector<Core::IO::InputSpec> flatten_anonymous_group(std::vector<Core::IO::InputSpec> specs)
+  {
+    std::vector<Core::IO::InputSpec> flattened_specs;
+    for (auto&& spec : specs)
+    {
+      if (auto* group = dynamic_cast<Core::IO::Internal::InputSpecTypeErasedImplementation<
+              Core::IO::InputSpecBuilders::Internal::GroupSpec>*>(&spec.impl());
+          // must be an anonymous group to steal the specs
+          group && group->wrapped.name.empty())
+      {
+        for (auto&& sub_spec : group->wrapped.specs)
+        {
+          flattened_specs.emplace_back(std::move(sub_spec));
+        }
+      }
+      else
+      {
+        flattened_specs.emplace_back(std::move(spec));
+      }
+    }
+
+    return flattened_specs;
+  }
+}  // namespace
 
 
 Core::IO::InputSpec Core::IO::InputSpecBuilders::group(
     std::string name, std::vector<InputSpec> specs, Core::IO::InputSpecBuilders::GroupData data)
 {
-  assert_unique_or_empty_names(specs);
+  auto flattened_specs = flatten_anonymous_group(std::move(specs));
+
+  assert_unique_or_empty_names(flattened_specs);
 
   IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
       .name = name,
       .description = data.description,
       .required = data.required,
-      .has_default_value = all_have_default_values(specs),
+      .has_default_value = all_have_default_values(flattened_specs),
   };
 
   return IO::Internal::make_spec(
-      Internal::GroupSpec{.name = name, .data = std::move(data), .specs = std::move(specs)},
+      Internal::GroupSpec{
+          .name = name, .data = std::move(data), .specs = std::move(flattened_specs)},
       common_data);
 }
 
 
 Core::IO::InputSpec Core::IO::InputSpecBuilders::anonymous_group(std::vector<InputSpec> specs)
 {
-  // Flatten any other anonymous groups.
-  std::vector<InputSpec> flattened_specs;
-  for (auto&& spec : specs)
-  {
-    if (auto* group = dynamic_cast<IO::Internal::InputSpecTypeErasedImplementation<
-            InputSpecBuilders::Internal::GroupSpec>*>(&spec.impl());
-        group && group->wrapped.name.empty())
-    {
-      for (auto&& sub_spec : group->wrapped.specs)
-      {
-        flattened_specs.emplace_back(std::move(sub_spec));
-      }
-    }
-    else
-    {
-      flattened_specs.emplace_back(std::move(spec));
-    }
-  }
+  auto flattened_specs = flatten_anonymous_group(std::move(specs));
 
   assert_unique_or_empty_names(flattened_specs);
 

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -40,6 +40,7 @@
 #include "4C_fluid_functions.hpp"
 #include "4C_fluid_xfluid_functions.hpp"
 #include "4C_fluid_xfluid_functions_combust.hpp"
+#include "4C_global_legacy_module_validmaterials.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_lubrication_ele.hpp"
 #include "4C_mat_aaaneohooke.hpp"
@@ -70,6 +71,7 @@
 #include "4C_mat_list_chemoreac.hpp"
 #include "4C_mat_list_chemotaxis.hpp"
 #include "4C_mat_list_reactions.hpp"
+#include "4C_mat_materialdefinition.hpp"
 #include "4C_mat_maxwell_0d_acinus.hpp"
 #include "4C_mat_maxwell_0d_acinus_DoubleExponential.hpp"
 #include "4C_mat_maxwell_0d_acinus_Exponential.hpp"
@@ -531,6 +533,19 @@ namespace
     });
   }
 
+  std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> materials()
+  {
+    std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> mat;
+
+    auto mat_definitions = Global::valid_materials();
+    for (const auto& d : *mat_definitions)
+    {
+      mat[d->type()] = Core::IO::InputSpecBuilders::group(d->name(), d->specs());
+    }
+    return mat;
+  }
+
+
 }  // namespace
 
 ModuleCallbacks global_legacy_module_callbacks()
@@ -539,6 +554,8 @@ ModuleCallbacks global_legacy_module_callbacks()
   callbacks.RegisterParObjectTypes = register_par_object_types;
   callbacks.AttachFunctionDefinitions = attach_function_definitions;
   callbacks.valid_result_description_lines = valid_result_lines;
+  callbacks.materials = materials;
+
   return callbacks;
 }
 

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include "4C_inpar_validmaterials.hpp"
+#include "4C_global_legacy_module_validmaterials.hpp"
 
 #include "4C_global_data.hpp"
 #include "4C_inpar_material.hpp"
@@ -24,35 +24,8 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Input::print_empty_material_definitions(
-    std::ostream& stream, std::vector<std::shared_ptr<Mat::MaterialDefinition>>& matlist)
+std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::valid_materials()
 {
-  const std::string sectionname = "MATERIALS";
-  const unsigned l = sectionname.length();
-  stream << "--" << std::string(std::max<int>(65 - l, 0), '-');
-  stream << sectionname << '\n';
-
-  for (auto& i : matlist)
-  {
-    i->print(stream, nullptr);
-  }
-}
-
-/*----------------------------------------------------------------------*/
-/*----------------------------------------------------------------------*/
-void print_material_dat_header()
-{
-  std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> matlist =
-      Input::valid_materials();
-  Input::print_empty_material_definitions(std::cout, *matlist);
-}
-
-
-/*----------------------------------------------------------------------*/
-/*----------------------------------------------------------------------*/
-std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Input::valid_materials()
-{
-  using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
   // a list containing all valid materials

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.hpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.hpp
@@ -5,11 +5,9 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#ifndef FOUR_C_INPAR_VALIDMATERIALS_HPP
-#define FOUR_C_INPAR_VALIDMATERIALS_HPP
+#ifndef FOUR_C_GLOBAL_LEGACY_MODULE_VALIDMATERIALS_HPP
+#define FOUR_C_GLOBAL_LEGACY_MODULE_VALIDMATERIALS_HPP
 
-/*----------------------------------------------------------------------*/
-/* headers */
 #include "4C_config.hpp"
 
 #include <Teuchos_Array.hpp>
@@ -26,18 +24,11 @@ namespace Mat
   class MaterialDefinition;
 }
 
-namespace Input
+namespace Global
 {
   /// construct list with all materials and documentation
   std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> valid_materials();
-
-  /// print all known material sections without contents
-  void print_empty_material_definitions(
-      std::ostream& stream, std::vector<std::shared_ptr<Mat::MaterialDefinition>>& matlist);
-}  // namespace Input
-
-/// print empty material sections
-void print_material_dat_header();
+}  // namespace Global
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mat/4C_mat_materialdefinition.cpp
+++ b/src/mat/4C_mat_materialdefinition.cpp
@@ -45,27 +45,9 @@ void Mat::MaterialDefinition::add_component(Core::IO::InputSpec&& c)
 std::ostream& Mat::MaterialDefinition::print(
     std::ostream& stream, const Core::FE::Discretization* dis)
 {
-  // a string holding the comment indicating symbols for DAT input file
-  const std::string comment = "//";
-
-  // the descriptive lines (comments)
-  stream << comment << '\n';
-  stream << comment << " " << description_ << '\n';
-  for (const auto& c : components_)
-  {
-    stream << comment << " " << c.impl().name() << (c.impl().required() ? " " : " (optional) ")
-           << c.impl().description() << '\n';
-  }
-
-  // the default line
-  stream << comment << "MAT 0   " << materialname_ << "   ";
   auto input_line = Core::IO::InputSpecBuilders::anonymous_group(components_);
 
-  Core::IO::InputParameterContainer container;
-  input_line.impl().set_default_value(container);
-  input_line.impl().print(stream, container);
-
-  stream << '\n';
+  input_line.print_as_dat(stream);
 
   return stream;
 }

--- a/src/module_registry/4C_module_registry_callbacks.hpp
+++ b/src/module_registry/4C_module_registry_callbacks.hpp
@@ -11,9 +11,11 @@
 #include "4C_config.hpp"
 
 #include "4C_io_input_spec.hpp"
+#include "4C_legacy_enum_definitions_materials.hpp"
 #include "4C_utils_function_manager.hpp"
 
 #include <functional>
+#include <unordered_map>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -45,6 +47,19 @@ struct ModuleCallbacks
    * A callback to return valid result description lines.
    */
   std::function<Core::IO::InputSpec()> valid_result_description_lines;
+
+  /**
+   * A callback to return materials known by the module.
+   *
+   * @return A map from material type to corresponding InputSpec. Every InputSpec should contain a
+   * top-level group with the material name to easily identify the material and ensure it cannot be
+   * confused with other materials. All other necessary parameters can be added inside this group.
+   * Nested groups are allowed.
+   *
+   * @note The materials from various modules are gathered in a shared section. The input mechanism
+   * automatically adds an `entry<int>("MAT")` to the InputSpec to allow enumeration of materials.
+   */
+  std::function<std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec>()> materials;
 };
 
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
This PR uses `InputSpec` for  the possible materials on a higher level than before. My goal is to only use InputSpec for all input parameter related tasks, see #73. While there, I improved the dat comments. The valid materials are extracted to the global legacy module. 

Part of #59 