### PR TITLE
Don't allow additional parameters in yaml schema

### DIFF
--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -143,6 +143,7 @@ def create_json_schema(fourc_metadata: dict) -> dict:
             "title": section_name,
             "description": description,
             "type": "object",  # this type is required by the JSON schema template
+            "additionalProperties": False,
             "properties": create_properties_dict(section_options),
         }
 


### PR DESCRIPTION
Only accept parameters that are defined and accepted by 4C

fyi @gilrrei