### PR TITLE
InputFile::Fragment to access input file content independent of underlying format

### DIFF
--- a/src/core/fem/src/condition/4C_fem_condition_definition.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_definition.cpp
@@ -53,8 +53,8 @@ void Core::Conditions::ConditionDefinition::read(Core::IO::InputFile& input,
     std::multimap<int, std::shared_ptr<Core::Conditions::Condition>>& cmap)
 {
   // read the range into a vector
-  std::vector<std::string_view> section_vec;
-  std::ranges::copy(input.lines_in_section(section_name()), std::back_inserter(section_vec));
+  std::vector<IO::InputFile::Fragment> section_vec;
+  std::ranges::copy(input.in_section(section_name()), std::back_inserter(section_vec));
 
   if (section_vec.empty()) return;
 
@@ -63,7 +63,7 @@ void Core::Conditions::ConditionDefinition::read(Core::IO::InputFile& input,
   //
   // ("DPOINT" | "DLINE" | "DSURF" | "DVOL" ) <number>
 
-  Core::IO::ValueParser parser_header(section_vec[0],
+  Core::IO::ValueParser parser_header(section_vec[0].get_as_dat_style_string(),
       {.user_scope_message = "While reading header of condition section '" + sectionname_ + "': "});
 
   const std::string expected_geometry_type = std::invoke(
@@ -95,9 +95,9 @@ void Core::Conditions::ConditionDefinition::read(Core::IO::InputFile& input,
 
   for (auto i = section_vec.begin() + 1; i != section_vec.end(); ++i)
   {
-    Core::IO::ValueParser parser_content(
-        *i, {.user_scope_message =
-                    "While reading content of condition section '" + sectionname_ + "': "});
+    Core::IO::ValueParser parser_content(i->get_as_dat_style_string(),
+        {.user_scope_message =
+                "While reading content of condition section '" + sectionname_ + "': "});
 
     parser_content.consume("E");
     // Read a one-based condition number but convert it to zero-based for internal use.

--- a/src/core/io/src/4C_io_domainreader.cpp
+++ b/src/core/io/src/4C_io_domainreader.cpp
@@ -116,10 +116,10 @@ namespace Core::IO
     {
       bool any_lines_read = false;
       // read domain info
-      for (const auto& line : input_.lines_in_section_rank_0_only(sectionname_))
+      for (const auto& line : input_.in_section_rank_0_only(sectionname_))
       {
         any_lines_read = true;
-        std::istringstream t{std::string{line}};
+        std::istringstream t{std::string{line.get_as_dat_style_string()}};
         std::string key;
         t >> key;
         if (key == "LOWER_BOUND")

--- a/src/core/io/src/4C_io_elementreader.cpp
+++ b/src/core/io/src/4C_io_elementreader.cpp
@@ -128,9 +128,9 @@ std::pair<int, std::vector<int>> Core::IO::ElementReader::get_element_size_and_i
   // all reading is done on proc 0
   if (Core::Communication::my_mpi_rank(comm_) == 0)
   {
-    for (const auto& element_line : input_.lines_in_section_rank_0_only(sectionname_))
+    for (const auto& element_line : input_.in_section_rank_0_only(sectionname_))
     {
-      std::istringstream t{std::string{element_line}};
+      std::istringstream t{std::string{element_line.get_as_dat_style_string()}};
       int elenumber;
       std::string eletype;
       t >> elenumber >> eletype;
@@ -178,9 +178,10 @@ void Core::IO::ElementReader::get_and_distribute_elements(const int nblock, cons
     int bcount = 0;
     int block = 0;
 
-    for (const auto& element_line : input_.lines_in_section_rank_0_only(sectionname_))
+    for (const auto& element_line : input_.in_section_rank_0_only(sectionname_))
     {
-      ValueParser parser{element_line, {.user_scope_message = "While reading element line: "}};
+      ValueParser parser{element_line.get_as_dat_style_string(),
+          {.user_scope_message = "While reading element line: "}};
       const int elenumber = parser.read<int>() - 1;
       gidlist.push_back(elenumber);
 

--- a/src/core/io/src/4C_io_nodereader.cpp
+++ b/src/core/io/src/4C_io_nodereader.cpp
@@ -45,9 +45,9 @@ void Core::IO::read_nodes(Core::IO::InputFile& input, const std::string& node_se
   std::string tmp2;
 
   int line_count = 0;
-  for (const auto& node_line : input.lines_in_section_rank_0_only(node_section_name))
+  for (const auto& node_line : input.in_section_rank_0_only(node_section_name))
   {
-    std::istringstream linestream{std::string{node_line}};
+    std::istringstream linestream{std::string{node_line.get_as_dat_style_string()}};
     linestream >> tmp;
 
     if (tmp == "NODE")

--- a/src/core/io/tests/4C_io_input_file_test.cpp
+++ b/src/core/io/tests/4C_io_input_file_test.cpp
@@ -27,10 +27,10 @@ namespace
   {
     SCOPED_TRACE("Checking section " + section);
     ASSERT_TRUE(input.has_section(section));
-    auto section_lines = input.lines_in_section(section);
+    auto section_lines = input.in_section(section);
     std::vector<std::string> section_lines_str;
-    std::ranges::copy(section_lines | std::views::transform([](const std::string_view& line)
-                                          { return std::string{line}; }),
+    std::ranges::copy(section_lines | std::views::transform([](const auto& line)
+                                          { return std::string{line.get_as_dat_style_string()}; }),
         std::back_inserter(section_lines_str));
     EXPECT_EQ(lines.size(), section_lines_str.size());
     for (std::size_t i = 0; i < lines.size(); ++i)

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -174,9 +174,9 @@ void Core::Utils::FunctionManager::read_input(Core::IO::InputFile& input)
           // If we end up here, the current sections function definition could not be parsed.
           {
             std::stringstream ss;
-            for (const auto& line : input.lines_in_section("FUNCT" + std::to_string(funct_suffix)))
+            for (const auto& line : input.in_section("FUNCT" + std::to_string(funct_suffix)))
             {
-              ss << '\n' << line;
+              ss << '\n' << line.get_as_dat_style_string();
             }
 
             FOUR_C_THROW("Could not parse the following lines into a Function known to 4C:\n%s",

--- a/src/particle_engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle_engine/4C_particle_engine_particlereader.cpp
@@ -28,7 +28,7 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
   Teuchos::Time time("", true);
 
   bool any_particles_read = false;
-  for (const auto& particle_line : input.lines_in_section_rank_0_only(section_name))
+  for (const auto& particle_line : input.in_section_rank_0_only(section_name))
   {
     if (!any_particles_read) Core::IO::cout << "Read and create particles\n" << Core::IO::flush;
     any_particles_read = true;
@@ -38,8 +38,8 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
       PARTICLEENGINE::TypeEnum particletype;
       PARTICLEENGINE::ParticleStates particlestates;
 
-      Core::IO::ValueParser parser{
-          particle_line, {.user_scope_message = "While reading particle data: "}};
+      Core::IO::ValueParser parser{particle_line.get_as_dat_style_string(),
+          {.user_scope_message = "While reading particle data: "}};
       parser.consume("TYPE");
       auto type = parser.read<std::string>();
       parser.consume("POS");


### PR DESCRIPTION
We used to convert every input fragment into a dat-style string, even if it came from yaml. This PR prepares for a change in the internals of the input mechanism, such that we always match our expectation (InputSpec) against the content (InputFile::Fragment) and receive the parameters (InputParameterContainer) without doing unnecessary conversion to a format that is less powerful. We can still read both formats. This PR does not change the timings for a 1e6 element input file for .dat or .yaml.

My overall vision is to have the following two functions which all (parameter) input/output will be going through:

```
// reading input (added in this PR)
InputFile::Fragment::match(InputSpec) -> InputParameterContainer

// wrtiting into an input file
InputFile::append(InputSpec, InputParameterContainer) -> InputFile::Fragment
```