### PR TITLE
Check for and fix typos in remaining code and documentation files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,6 +79,9 @@ repos:
         name: Check for typos in code
         types_or: [c++, c, python, cmake, shell]
         exclude: '(mm$|list_of_tests.cmake)'
+      - id: typos
+        name: Check for typos in documentation
+        types_or: [markdown, rst]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,9 +76,9 @@ repos:
     rev: v1.28.4
     hooks:
       - id: typos
-        name: Check for typos
-        types_or: [c++, c]
-        exclude: 'mm$'
+        name: Check for typos in code
+        types_or: [c++, c, python, cmake, shell]
+        exclude: '(mm$|list_of_tests.cmake)'
 
   - repo: local
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ the [user documentation](https://baci.pages.gitlab.lrz.de/baci/readthedocs/4Cset
 
 ### Setup your Integrated Development Environment
 
-We recommend to use an Integrated Develoment Environment (IDE) for code development because it provides many convenient
+We recommend to use an Integrated Development Environment (IDE) for code development because it provides many convenient
 features and also eases to comply with our mandatory code style.
 Set-up instructions for various IDEs can be found in
 the [user documentation](https://baci.pages.gitlab.lrz.de/baci/readthedocs/4Csetup.html#set-up-your-ide).

--- a/cmake/functions/four_c_add_dependency.cmake
+++ b/cmake/functions/four_c_add_dependency.cmake
@@ -24,12 +24,12 @@ function(four_c_add_dependency target)
         _four_c_internal_link_with_debug_message(${target} INTERFACE ${_dep}_deps)
       endforeach()
     elseif(${_target_type} STREQUAL EXECUTABLE)
-      # Currently the code base is not able to link without cycles. When linking an executable to a libary, the
+      # Currently the code base is not able to link without cycles. When linking an executable to a library, the
       # transitive dependencies must not contain any cycles. For static libraries this can be ignored when the
       # libraries are repeated on the link line. However, for shared libraries there is no such workaround.
       # For this reason, we issue an error here (for now).
       message(
-        FATAL_ERROR "Trying to link parts of the library to ${target} which is an exectuable. "
+        FATAL_ERROR "Trying to link parts of the library to ${target} which is an executable. "
                     "Please link against the whole library."
         )
     else()

--- a/cmake/functions/four_c_testing_functions.cmake
+++ b/cmake/functions/four_c_testing_functions.cmake
@@ -128,7 +128,7 @@ endfunction()
 #                                 For two input files two NP's are required.
 # RESTART_STEP:                   Number of restart step; not defined indicates no restart
 # TIMEOUT:                        Manually defined duration for test timeout; defaults to global timeout if not specified
-# OMP_THREADS:                    Number of OpenMP threads per proccessor the test should use; defaults to deactivated
+# OMP_THREADS:                    Number of OpenMP threads per processor the test should use; defaults to deactivated
 # POST_ENSIGHT_STRUCTURE:         Test post_ensight options in serial and parallel (for structure simulation only!)
 # LABELS:                         Add labels to the test
 # CSV_COMPARISON_RESULT_FILE:     Arbitrary .csv result files to be compared (see `utilites/diff_with_tolerance.py`)

--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -47,7 +47,7 @@ enable_compiler_flag_if_supported("-Wno-overloaded-virtual")
 enable_linker_flag_if_supported("-rdynamic")
 
 # Enable position-independent code. This flag is necessary to build shared libraries. Since our internal targets are not
-# real libaries but object libraries, this property needs to be set explicitly.
+# real libraries but object libraries, this property needs to be set explicitly.
 if(BUILD_SHARED_LIBS)
   message(VERBOSE "Enabling POSITION_INDEPENDENT_CODE on internal targets.")
   set_target_properties(

--- a/doc/readthedocs/4Csetup.rst
+++ b/doc/readthedocs/4Csetup.rst
@@ -64,7 +64,7 @@ Graph and domain partitioner:
 Miscellaneous:
 
 - Qhull (recommended version: 2012.1, :download:`install script <qhull/install.sh>`
-- CLN (recommened version: 1.3.4),
+- CLN (recommended version: 1.3.4),
 - FFTW
 - HDF5
 - ArborX (optional)
@@ -178,7 +178,7 @@ are available from the up-right corner menu bar (look for the user's avatar) -->
 or under `your profile <https://gitlab.lrz.de/profile>`_.
 
 #. Under 'Main Settings' please enter your full name, i.e., first name followed by last name, in the 'Name' field.
-#. You may want to add a foto of you as a 'Public Avatar' so people can recognize you more easily.
+#. You may want to add a photo of you as a 'Public Avatar' so people can recognize you more easily.
 #. Hit 'Update profile settings'.
 
 
@@ -269,7 +269,7 @@ To add a SSH key to your GitLab account please follow the instructions below
 
 #. Test your setup
 
-    To test wether you have added your SSH key correctly, run the following command:
+    To test whether you have added your SSH key correctly, run the following command:
 
     .. code-block:: bash
 

--- a/doc/readthedocs/4Ctesting.rst
+++ b/doc/readthedocs/4Ctesting.rst
@@ -63,7 +63,7 @@ Thorough
 
 .. Note::
 
-    following test driven developement (TDD) (refer to Robert C. Martin [Martin08]_ ) this can also be interpreted as:
+    following test driven development (TDD) (refer to Robert C. Martin [Martin08]_ ) this can also be interpreted as:
 
     **Timely**
 

--- a/doc/readthedocs/boundaryconditions.rst
+++ b/doc/readthedocs/boundaryconditions.rst
@@ -21,9 +21,9 @@ The number to be entered in ``num`` is the number of conditions to follow.
 
 Each subsequent line starts with an ``E <set> -``, where ``set`` is the number of the TOPOLOGY set defined in terms of points, lines, surfaces and volumes, respectively.
 
-Note that all boundary conditions are given in terms of node sets
-Boundary conditions of a vector tye may be applied in arbitrary coordinate directions,
-which are not necessarily the original coordinate system, in which the system is defined.
+Note that all boundary conditions are given in terms of node sets.
+Boundary conditions may be applied in arbitrary coordinate directions,
+which do not need to coincide with the original coordinate system of the geometry.
 For this aspect one may define a local (rotated) coordinate system.
 
 .. `locsysconditions`:
@@ -36,7 +36,7 @@ The coordinate system is given by an axis :math:`\mathbf{n}` and an angle :math:
 around which the coordinate is rotated **clockwise**.
 
 Since the axis is a unit vector, the angle is given as the length of the vector,
-so that the complete roation can be entered in three values:
+so that the complete rotation can be entered in three values:
 :math:`[\alpha \cdot n_x, \, \alpha \cdot n_y, \, \alpha \cdot n_z]`.
 
 The complete definition of a local coordinate system writes:
@@ -205,7 +205,7 @@ A spring-dashpot condition, also called a Robin boundary condition,
 is used to give a surface boundary (and only surface boundaries!)
 a stiffness and/or viscosity with respect to its displacement.
 For each degree of freedom the stiffness and/or viscosity may be considered or not.
-Also, both stiffness and viscosity may depend on a function defintion.
+Also, both stiffness and viscosity may depend on a function definition.
 The Direction can be given in the global coordinate system or with respect to the surface normal.
 The input looks like this:
 
@@ -268,7 +268,7 @@ Some applications (typically in structural / solid mechanics) require the coupli
 nodes shall remain independent (e.g. joints and hinges in frames).
 While it is very easy to couple all(!) DoFs of several nodes at the same geometrical position (by simply merging the nodes into one node), things are more complicated if only certain DoFs are to be coupled.
 While it would always be possible to introduce this coupling as a Dirichlet condition / Multipoint
-Constraint into the final system of equations, we have decided to implement this at a more fundamental level by changing the assigment of DoFs according to the existing coupling
+Constraint into the final system of equations, we have decided to implement this at a more fundamental level by changing the assignment of DoFs according to the existing coupling
 conditions.
 Thus, if a point coupling condition is introduced for a set of nodes, the DoFs to be coupled are identified and the same(!) DoFs are then assigned to all participating nodes,
 while the remaining uncoupled DoFs are created and assigned independently for each node. This required some changes in the way nodal DoFs are assigned and handled in |FOURC|.

--- a/doc/readthedocs/debugging_profiling.rst
+++ b/doc/readthedocs/debugging_profiling.rst
@@ -10,7 +10,7 @@ However, not only software developers, also users of software written by others 
 Overview of debugging and profiling tools
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In the following various debugging and profiling tools are desribed that may be of help when developing or working with |FOURC|.
+In the following various debugging and profiling tools are described that may be of help when developing or working with |FOURC|.
 
 - Get MPI collective timer statistics with a :ref:`time monitor <Teuchos-Time-Monitor>` from ``Trilinos`` package ``Teuchos``
 - Code profiling of |FOURC| with :ref:`callgrind <profiling_callgrind>`

--- a/doc/readthedocs/developer_cmake.rst
+++ b/doc/readthedocs/developer_cmake.rst
@@ -11,7 +11,7 @@ If you find a nice one, feel free to tell your colleagues (via issue, Slack or T
 
 CMake presets are available since cmake 3.19 and have been improved in the following versions.
 We are currently using CMake preset version 5, which requires at least cmake 3.24.
-Make sure to have a sufficient cmake-version in your path or use the provided onces on the institute's server.
+Make sure to have a sufficient cmake-version in your path or use the provided ones on the institute's server.
 
 Configuration from a terminal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/readthedocs/functions.rst
+++ b/doc/readthedocs/functions.rst
@@ -42,7 +42,7 @@ If the function cannot easily be given as a symbolic expression, the function ma
 
 where
 
-- **expression** is simply a symoblic expression similar to the function definition itself.
+- **expression** is simply a symbolic expression similar to the function definition itself.
   That is,
 
   ::

--- a/doc/readthedocs/howto_document.rst
+++ b/doc/readthedocs/howto_document.rst
@@ -43,7 +43,7 @@ I also like `this doc <https://books.dehlia.in/writing-with-ratatouille/toc/>`_.
 
 - **Lists** (as the one addressing the features of reStructuredText here) can be numbered or unsorted.
   Any list must be surrounded by blank lines.
-  An unordered list with bullet points is created by dashs like this one::
+  An unordered list with bullet points is created by dashes like this one::
 
      Here, we'll start a list
 
@@ -136,7 +136,7 @@ I also like `this doc <https://books.dehlia.in/writing-with-ratatouille/toc/>`_.
 
 - **Math** can be inserted either within the text or as separate equations.
   For inline math one may use the ``math`` rule like ``:math:`f(x) = x^2```.
-  Separate equations are writen as a directive ``.. math::``, for example:
+  Separate equations are written as a directive ``.. math::``, for example:
 
   ::
 

--- a/doc/readthedocs/index.rst
+++ b/doc/readthedocs/index.rst
@@ -59,7 +59,7 @@ This guide to |FOURC| is structured as follows:
    A collection of useful scripts for working with |FOURC|
 
 :ref:`Appendix<appendix>`
-   Information on contributing to this documentation as well as seleceted topics of interest
+   Information on contributing to this documentation as well as selected topics of interest
 
 .. toctree::
    :maxdepth: 2

--- a/doc/readthedocs/materialdevelopment.rst
+++ b/doc/readthedocs/materialdevelopment.rst
@@ -111,7 +111,7 @@ The base classes of the material models representing a single physics environmen
      - ``Mat::ElchSingleMat``
    * - Electromagnetics
      - ``Mat::``
-   * - Sclar transport
+   * - Scalar transport
      - ``Mat::Material``
 
 Note that not all existing materials use a physics-specific base class,

--- a/doc/readthedocs/postprocessing.rst
+++ b/doc/readthedocs/postprocessing.rst
@@ -1,4 +1,3 @@
-
 .. _postprocessing:
 
 Postprocessing
@@ -44,7 +43,7 @@ As per default, running this script on the result (.control) file of the simulat
 
 The ``post_processor`` script has a lot of options to specify the post processing details.
 A complete list of these options is printed to the screen when executing ``./post_processor --help`` .
-Most of these options are self-explanatory. Other ouput format filters are available via the ``--filter`` option.
+Most of these options are self-explanatory. Other output format filters are available via the ``--filter`` option.
 Here the vtu filter is of particular interest when you want to convert the results to VTK file format,
 and did not provide the direct vtk output (see :ref:`above <directvtkoutput>`).
 
@@ -163,7 +162,7 @@ Movies should be playable across platforms (at least Linux/windows/macOS)
 and embeddable inside MS Powerpoint presentations
 without the need of having different movie versions in different formats.
 
-Since the tools to create videos is vast, here we will simply give ony a rough overview of a few tools that are used frequently.
+Since the tools to create videos is vast, here we will simply give a rough overview of a few tools that are used frequently.
 
 **Recoding videos**
 
@@ -178,7 +177,7 @@ Command line based:
 With GUI (freeware):
 
 - Blender (all OS)
-- Shotcut (Windows)
+- Shortcut (Windows)
 
 **Video editing**
 
@@ -186,7 +185,7 @@ If you want to join, cut or render videos in a fancy way, add subtitles, or prov
 you might want to use a tool with more features, which then comes with a graphical user interface:
 
 - Blender (all OS)
-- Shotcut (Windows)
+- Shortcut (Windows)
 
 **Videos from Pictures**
 

--- a/doc/readthedocs/preprocessing.rst
+++ b/doc/readthedocs/preprocessing.rst
@@ -28,7 +28,7 @@ additional information is needed, which is given by two additional files:
 
 #. for the global system parameters (solver, material, step information, etc.), called the *headerfile*, and
 
-#. a file for the correlation between element sets and type declatations, as well as boundary conditions definitions.
+#. a file for the correlation between element sets and type declarations, as well as boundary conditions definitions.
    This is the so-called the *bcfile*.
 
 These three files are merged into an input file for |FOURC| by the program ``pre_exodus``.
@@ -160,7 +160,7 @@ Unlike ``meshio.read``, the command ``abaqus_meshio.read`` will return a model, 
 - ``model`` has attributes materials (from MATERIAL), parts (from PART/END PART) and steps (from STEP)
 - ``model.parts[part_name].mesh`` is again a ``BMesh``, ``model.rootAssembly.instances[instance_name].mesh`` is a transformation of this mesh.
 
-``BModel`` is designed to mimick the way Abaqus systematically stores its data. To access the original ``meshio.Mesh`` one has to use ``model.parts[part_name].mesh``.
+``BModel`` is designed to mimic the way Abaqus systematically stores its data. To access the original ``meshio.Mesh`` one has to use ``model.parts[part_name].mesh``.
 
 Proving that the information from inp is properly stored, the transformation to dat file is done by a simple command
 

--- a/doc/readthedocs/python/plot.py
+++ b/doc/readthedocs/python/plot.py
@@ -192,14 +192,14 @@ def plot3D_surfaces(ax, surfaces, coords, parameter):
             )
         )
 
-        # draw shrinked faces
-        shrinked_verts = [
+        # draw shrunk faces
+        shrunk_verts = [
             surf_center_coord
             + parameter.shrink_factor * (np.array(verts) - surf_center_coord)
         ]
         ax.add_collection3d(
             Poly3DCollection(
-                shrinked_verts,
+                shrunk_verts,
                 edgecolor=parameter.colorlist[k],
                 facecolor=(1, 1, 1, 0.01),
             )

--- a/doc/readthedocs/referenceintroduction.rst
+++ b/doc/readthedocs/referenceintroduction.rst
@@ -14,7 +14,7 @@ example is the ``PROBLEM TYPE`` introductory line
 
    -------------------------------------PROBLEM TYPE
 
-Plenty of keyword lines and blocks refere to special applications of the
+Plenty of keyword lines and blocks refer to special applications of the
 program (such as ``OPTIMIZATION`` , ``ALE DYNAMIC`` etc.). These
 often can be omitted when not required, which shortens the file and
 eases its use. Other blocks however are of general character and must

--- a/doc/readthedocs/struct_dynamics.rst
+++ b/doc/readthedocs/struct_dynamics.rst
@@ -206,7 +206,7 @@ are introduced to control the behavior of this approximation
    \boldsymbol{A}^\gamma(\tau) &= \boldsymbol{A}_n + 2\gamma \frac{\boldsymbol{A}_{n+1} - \boldsymbol{A}_n}{\Delta t}\tau\\
    \boldsymbol{A}^\beta(\tau) &= \boldsymbol{A}_n + 6\beta  \frac{\boldsymbol{A}_{n+1} - \boldsymbol{A}_n}{\Delta t}\tau
 
-If :math:`\gamma=\frac{1}{2}` and :math:`\beta=\frac{1}{6}` are choosen,
+If :math:`\gamma=\frac{1}{2}` and :math:`\beta=\frac{1}{6}` are chosen,
 a linear acceleration scheme is obtained. The
 :math:`\gamma`-parameterized acceleration
 :math:`\boldsymbol{A}^\gamma(\tau)` is integrated once over
@@ -351,7 +351,7 @@ vector:
    \end{array} \right\}  \quad \alpha_\text{f} \in[0,1]
 
 with the parameters :math:`\alpha_\text{m},\alpha_\text{f}\in[0,1]`.
-There two possibilties for the internal mid-forces
+There two possibilities for the internal mid-forces
 :math:`\boldsymbol{F}_{\text{int},\text{mid}}`. Either they are
 defined as well by a linear combination (which we call ‘TR-like’) or
 by inserting mid-displacements (which we call ‘IMR-like’), i.e.
@@ -817,7 +817,7 @@ with GA2 and GA3 would require two iterative solutions. This can be
 overcome by avoiding a direct determination of the GA3. The results of
 the marching GA2 method (:math:`\boldsymbol{D}_{n+1}^\text{GA2}`,
 :math:`\boldsymbol{V}_{n+1}^\text{GA2}`,
-:math:`\boldsymbol{A}_{n+1}^\text{GA2}`) can be used to explicitely
+:math:`\boldsymbol{A}_{n+1}^\text{GA2}`) can be used to explicitly
 construct a third-order accurate result, which is related to the NM3 and
 is called ZX here.
 

--- a/doc/readthedocs/surface_int.rst
+++ b/doc/readthedocs/surface_int.rst
@@ -20,7 +20,7 @@ spanned by the vectors :math:`a^1` and :math:`a^2`.
 
 (b) In the case :math:`k=n`, it holds that
 :math:`\operatorname{vol}_{n}\bigl(A\bigl([0,1]^{n}\bigr)\bigr)=\lvert\det A\rvert`.
-If :math:`a^{1},\ldots,a^{n}` are linearly dependent, then boths sides
+If :math:`a^{1},\ldots,a^{n}` are linearly dependent, then both sides
 are :math:`=0`, for :math:`A\bigl([0,1]^{k}\bigr)` has width :math:`0`
 in (at least) one direction.
 
@@ -53,7 +53,7 @@ an example: Let :math:`n=k+1` and
 :math:`A\bigl([0,1]^{k}\bigr)\subseteq\mathbb{R}^{k}\times\{0\}`, e.g.
 the parallelepiped has width :math:`0` in the direction of
 :math:`e_{n}=e_{k+1}`. Let :math:`Q:\mathbb{R}^{k+1}\to\mathbb{R}^{k}`
-be the projektion onto the first :math:`k` coordinates (thus
+be the projection onto the first :math:`k` coordinates (thus
 :math:`Q(x)=Q\bigl((x_{1},\ldots,x_{n})\bigr)=(x_{1},\ldots,x_{k})`),
 then\
 
@@ -124,7 +124,7 @@ sphere, by\
 Remark.
 '''''''
 
-For vectors :math:`a,b\in\mathbb{R}^{3}` in the three-dimensonal space
+For vectors :math:`a,b\in\mathbb{R}^{3}` in the three-dimensional space
 :math:`\mathbb{R}^{3}` it holds that\
 
 .. math::
@@ -148,5 +148,5 @@ is known in engineering as the *area element.*
    Actually, this is not a parameterization of all of the unit sphere:
    The half-plane :math:`\{x\in\mathbb{R}^{3};\,x_{2}=0,x_{1}\le 0\}` is
    missing. A global parameterization of the unit sphere doesn’t exist,
-   and the missing half-plane is a set of :math:`2`-dimensonal measure
+   and the missing half-plane is a set of :math:`2`-dimensional measure
    zero, so we can disregard it.

--- a/doc/readthedocs/tut_fluid_preexo.rst
+++ b/doc/readthedocs/tut_fluid_preexo.rst
@@ -157,7 +157,7 @@ Creating a |FOURC| input file with *pre_exodus*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The previously created files have to be merged to a |FOURC| input file in
-oder to solve the problem. We will use *pre_exodus* for this purpose.
+order to solve the problem. We will use *pre_exodus* for this purpose.
 Open a terminal and execute the following command in the
 ``build-release`` folder:
 
@@ -187,7 +187,7 @@ be applied to all output files that |FOURC| generates.
 Postprocessing
 --------------
 
-You can postprocess your results with any vizualization software you
+You can postprocess your results with any visualization software you
 like. In this tutorial, we choose *Paraview*.
 
 Filtering result data

--- a/doc/readthedocs/tut_fsi_preexo.rst
+++ b/doc/readthedocs/tut_fsi_preexo.rst
@@ -60,7 +60,7 @@ Information about this tool can be found in the :ref:`Analysis Guide <pre_exodus
 
 Besides a given mesh as the one we just created using CUBIT (see above), we need two more files:
 
-- the bc-file, which contains the specific element declation and the particular boundary conditions, and
+- the bc-file, which contains the specific element declaration and the particular boundary conditions, and
 - the header file, which contains the general parameters such as solvers, algorithmic parameters, etc..
 
 In the following sections, we'll learn how to create the these two files.
@@ -826,7 +826,7 @@ to |FOURC| and postprocess the results.
 Postprocessing
 --------------
 
-You can postprocess your results with any vizualization software you
+You can postprocess your results with any visualization software you
 like. In this tutorial, we choose *Paraview*.
 
 Before you can open the results, you have to generate a filter again.

--- a/doc/readthedocs/tut_fsi_preexo_2d.rst
+++ b/doc/readthedocs/tut_fsi_preexo_2d.rst
@@ -386,7 +386,7 @@ to |FOURC| and postprocess the results.
 Postprocessing
 --------------
 
-You can postprocess your results with any vizualization software you
+You can postprocess your results with any visualization software you
 like. In this tutorial, we choose *Paraview*.
 
 Before you can open the results, you have to generate a filter again.
@@ -435,7 +435,7 @@ There are two possibilities for monolithic schemes:
 
 In order to use a monolithic solver, change the coupling algorithm
 ``COUPALGO`` in the ``FSI DYNAMIC`` section in the \*.head-file.
-Additionaly, special care has to be taken of the interface degrees of
+Additionally, special care has to be taken of the interface degrees of
 freedom, that are subject to Dirichlet boundary conditions. The
 interface is always governed by the master field. The slave interface
 degrees of freedom do not occur in the global system of equations and,
@@ -481,7 +481,7 @@ fluid split
    in order to remove the Dirichlet boundary conditions from the fluid
    (=slave) interface degrees of freedom.
 
-Create the input file as desribed above. Start |FOURC| as usual.
+Create the input file as described above. Start |FOURC| as usual.
 
 structure split
 ~~~~~~~~~~~~~~~
@@ -501,4 +501,4 @@ structure split
    in order to remove the Dirichlet boundary conditions from the
    structure (=slave) interface degrees of freedom.
 
-Create the input file as desribed above. Start |FOURC| as usual.
+Create the input file as described above. Start |FOURC| as usual.

--- a/doc/readthedocs/tutorial_contact_3d.md
+++ b/doc/readthedocs/tutorial_contact_3d.md
@@ -99,7 +99,7 @@ The terminal command to obtain both prototype files is:
 In `tutorial_contact_3d.bc` it can be seen, that the first two blocks of text define the structure elements, which will
 later fill the system matrices.
 The other text blocks define conditions on parts of the system.
-The first line of each block assignes an (optional) name to the element block/nodeset and the shape of the element type
+The first line of each block assigns an (optional) name to the element block/nodeset and the shape of the element type
 is specified.
 The next part has already been filled in by `pre_exodus`.
 For our simple geometry and discretization it can easily be checked that the number of elements/nodes in the
@@ -118,7 +118,7 @@ Last, the element type/condition specific set of parameters is given and the nam
 Hint: A list of possible options can be found in the `.bc` default file.
 
 Remark: Apart from the separate listing of problem specific conditions, Dirichlet and Neumann BCs (as well as many other
-types of conditions) are also listed seperately,
+types of conditions) are also listed separately,
 depending on the geometric entity that they are imposed on, e.g. points, lines, surfaces or volumes.
 
 The parameters for the definition of a DBC are:
@@ -144,14 +144,14 @@ Hint: Use the search function of your editor to navigate the 13000 lines of text
 
 As we are setting up a structural contact problem, not all sections and parameters are required (e.g. sections
 concerning the simulation of fluids, etc. can be left out).
-If they are not specified explicitely in our input file, the parameters take on default values.
+If they are not specified explicitly in our input file, the parameters take on default values.
 Some sections that are required by all problem types include `PROBLEM SIZE`, `PROBLEM TYPE`, `DISCRETIZATION`, `IO` (
 Input/Output),
 at least one `SOLVER` section (for contact problems we need to specify two solvers:
 one for the state, where not contact is active, and one for the state with active contact) and a `MATERIALS` section.
 The time integration method `DYNAMICTYPE` (Generalized alpha method), time step size `TIMESTEP` and final time `MAXTIME`
 are also specified for structural dynamics.
-An important parameter is `RESULTSEVERY`, which specifies how often output is written and thus directly controles the
+An important parameter is `RESULTSEVERY`, which specifies how often output is written and thus directly controls the
 size of the output file.
 
 The contact specific parameters are given under `--MORTAR COUPLING`. Dual Lagrange multipliers are chosen for the

--- a/tests/framework-test/tutorial_contact_3d.md
+++ b/tests/framework-test/tutorial_contact_3d.md
@@ -77,7 +77,7 @@ Simulations". The terminal command to obtain both prototype files is:
 
 In `tutorial_contact_3d.bc` it can be seen, that the first two blocks of text define the structure elements, which will
 later fill the system matrices. The other text blocks define conditions on parts of the system. The first line of each
-block assignes an (optional) name to the element block/nodeset and the shape of the element type is specified. The next
+block assigns an (optional) name to the element block/nodeset and the shape of the element type is specified. The next
 part has already been filled in by `pre_exodus`. For our simple geometry and discretization it can easily be checked
 that the number of elements/nodes in the corresponding element blocks and nodesets is correct. Next, the Section of
 the `.dat` file under which this information will be listed is given. the structure element properties are listed
@@ -93,7 +93,7 @@ element type/condition specific set of parameters is given and the name of the e
 of possible options can be found in the `.bc` default file.
 
 Remark: Apart from the separate listing of problem specific conditions, Dirichlet and Neumann BCs (as well as many other
-types of conditions) are also listed seperately, depending on the geometric entity that they are imposed on, e.g.
+types of conditions) are also listed separately, depending on the geometric entity that they are imposed on, e.g.
 points, lines, surfaces or volumes.
 
 The parameters for the definition of a DBC are:
@@ -116,13 +116,13 @@ The prototype of the `.head` file contains an extensive list of possible paramet
 your editor to navigate the 13000 lines of text.
 
 As we are setting up a structural contact problem, not all sections and parameters are required (e.g. sections
-concerning the simulation of fluids, etc. can be left out). If they are not specified explicitely in our input file, the
+concerning the simulation of fluids, etc. can be left out). If they are not specified explicitly in our input file, the
 parameters take on default values. Some sections that are required by all problem types
 include `PROBLEM SIZE`, `PROBLEM TYPE`, `DISCRETIZATION`, `IO` (Input/Output), at least one `SOLVER` section (for
 contact problems we need to specify two solvers: one for the state, where not contact is active, and one for the state
 with active contact) and a `MATERIALS` section. The time integration method `DYNAMICTYPE` (Generalized alpha method),
 time step size `TIMESTEP` and final time `MAXTIME` are also specified for structural dynamics. An important parameter
-is `RESULTSEVERY`, which specifies how often output is written and thus directly controles the size of the output file.
+is `RESULTSEVERY`, which specifies how often output is written and thus directly controls the size of the output file.
 
 The contact specific parameters are given under `--MORTAR COUPLING`. Dual Lagrange multipliers are chosen for the
 coupling of the interface. Either the `BruteForceEleBased` algorithm, or the more efficient `BinaryTree` can be chosen

--- a/tests/post_processing_test/datfile_reader.py
+++ b/tests/post_processing_test/datfile_reader.py
@@ -103,7 +103,7 @@ def read_sections(filename):
                 # this is a section title
                 current_section = match_title.group(1)
                 if current_section in content:
-                    raise ValueError("{0} is dublicate!".format(current_section))
+                    raise ValueError("{0} is duplicate!".format(current_section))
 
                 content[current_section] = []
             else:

--- a/tests/testconfig/README.md
+++ b/tests/testconfig/README.md
@@ -42,7 +42,7 @@ submitting a merge request.
 For each job certain testing output is displayed in GitLab (select job under `CI/CD - Pipelines`).
 During the build process all lines starting with `[` are displayed and the build summary at the end is displayed.
 The final line of each testing output is also shown.
-Therefore it is always possilbe to see the current state of the testing pipeline.
+Therefore it is always possible to see the current state of the testing pipeline.
 If the pipeline fails, the full `log` file is compressed and uploaded as a GitLab `artifact`.
 The `artifacts` can be found under `CI/CD - Pipelines` (on the right hand side of the failed pipeline).
 After 4 weeks the `artifacts` are deleted.

--- a/utilities/clang_tidy/filter_output.py
+++ b/utilities/clang_tidy/filter_output.py
@@ -13,7 +13,7 @@ begin_note_regex = re.compile(r"^\/\S+\:\d+\:\d+\: note: .*$")
 note_regex = re.compile(r"^note: .*$")
 message_block_regex = re.compile(r"^ *\d* \|.*$")
 number_of_warnings = re.compile(r"^\d+ warnings generated.$")
-supressed_warnings_hint = re.compile(r"^Suppressed \d+ warnings")
+suppressed_warnings_hint = re.compile(r"^Suppressed \d+ warnings")
 display_warning_hint = re.compile(r"^Use -header-filter=\.\* to display errors")
 
 clang_invocation = re.compile(r"^\/?\S*\/?clang-tidy-?\d* ")
@@ -43,14 +43,14 @@ for line in sys.stdin:
     if note_regex.match(line_removed_coloroutput):
         continue
 
-    # remove clang invokation message
+    # remove clang invocation message
     if clang_invocation.match(line_removed_coloroutput):
         continue
 
     # remove suppressed warnings
     if (
         number_of_warnings.match(line_removed_coloroutput)
-        or supressed_warnings_hint.match(line_removed_coloroutput)
+        or suppressed_warnings_hint.match(line_removed_coloroutput)
         or display_warning_hint.match(line_removed_coloroutput)
     ):
         continue

--- a/utilities/code_checks/commit-msg
+++ b/utilities/code_checks/commit-msg
@@ -135,7 +135,7 @@ read_commit_message() {
 }
 
 #
-# Validate the contents of the commmit msg against the good commit guidelines.
+# Validate the contents of the commit msg against the good commit guidelines.
 #
 
 validate_commit_message() {

--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -49,7 +49,7 @@ def create_properties_dict(properties_entry: dict) -> dict:
     # Loop over the definitions of the properties
     for key, value in properties_entry.items():
 
-        # Check if the optains contains the type
+        # Check if the obtains contains the type
         if "type" not in value.keys():
             raise Exception(f"Ups could not load {key}: {value}")
 
@@ -96,7 +96,7 @@ def create_json_schema(fourc_metadata: dict) -> dict:
     """Create a JSON schema dict.
 
     Args:
-        fourc_metada (dict): Metadata exported by 4C
+        fourc_metadata (dict): Metadata exported by 4C
 
     Returns:
         dict: data for the JSON schema

--- a/utilities/four_c_utils/src/four_c_utils/check_filenames_and_includes.py
+++ b/utilities/four_c_utils/src/four_c_utils/check_filenames_and_includes.py
@@ -12,7 +12,7 @@ from four_c_utils import common_utils as utils
 import os
 import re
 
-# The name of files that indicate that a directory should be treated as module root directoy.
+# The name of files that indicate that a directory should be treated as module root directory.
 module_root_maker_file_name = ".contains_modules"
 
 


### PR DESCRIPTION
I thought we should enable this, so we write typo-free docs in #171 and #279 :) 

Closes #240 