### PR TITLE
Enable -Wpedantic warnings

### DIFF
--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -36,6 +36,7 @@ endfunction()
 # Enable all warnings that are supported by the compiler
 enable_compiler_flag_if_supported("-Wall")
 enable_compiler_flag_if_supported("-Wextra")
+enable_compiler_flag_if_supported("-Wpedantic")
 enable_compiler_flag_if_supported("-Wvla")
 
 # Disable unused parameter detection since there would be too many hits to fix

--- a/src/core/utils/src/exceptions/4C_utils_exceptions.hpp
+++ b/src/core/utils/src/exceptions/4C_utils_exceptions.hpp
@@ -115,12 +115,13 @@ namespace Core
  *   FOUR_C_ASSERT_ALWAYS(vector.size() == dim, "Vector size does not equal dimension d=%d.", dim);
  * @endcode
  */
-#define FOUR_C_ASSERT_ALWAYS(test, args...)                                                      \
-  if (!(test))                                                                                   \
-  {                                                                                              \
-    FourC::Core::Internal::ErrorHelper{                                                          \
-        .file_name = __FILE__, .line_number = __LINE__, .failed_assertion_string = #test}(args); \
-  }                                                                                              \
+#define FOUR_C_ASSERT_ALWAYS(test, ...)                       \
+  if (!(test))                                                \
+  {                                                           \
+    FourC::Core::Internal::ErrorHelper{.file_name = __FILE__, \
+        .line_number = __LINE__,                              \
+        .failed_assertion_string = #test}(__VA_ARGS__);       \
+  }                                                           \
   static_assert(true, "Terminate with a comma.")
 
 
@@ -138,14 +139,14 @@ namespace Core
  *   FOUR_C_ASSERT(vector.size() == dim, "Vector size does not equal dimension.");
  * @endcode
  */
-#define FOUR_C_ASSERT(test, args...) FOUR_C_ASSERT_ALWAYS(test, args)
+#define FOUR_C_ASSERT(test, ...) FOUR_C_ASSERT_ALWAYS(test, __VA_ARGS__)
 
 #else
 
 /**
  * This macro would assert that @p test is true, but only if FOUR_C_ENABLE_ASSERTIONS is set.
  */
-#define FOUR_C_ASSERT(test, args...) static_assert(true, "Terminate with a comma.")
+#define FOUR_C_ASSERT(test, ...) static_assert(true, "Terminate with a comma.")
 
 #endif
 

--- a/src/core/utils/src/functions/4C_utils_function_manager.hpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.hpp
@@ -79,7 +79,7 @@ namespace Core::Utils
     void set_functions(const std::vector<T>& functions)
     {
       functions_ = functions;
-    };
+    }
 
    private:
     /// Internal storage for all functions. We use type erasure via std::any to store various

--- a/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
+++ b/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
@@ -1016,7 +1016,7 @@ Core::Utils::SymbolicExpression<Number>& Core::Utils::SymbolicExpression<Number>
 
 
 template <typename Number>
-Core::Utils::SymbolicExpression<Number>::~SymbolicExpression() = default;
+Core::Utils::SymbolicExpression<Number>::~SymbolicExpression<Number>() = default;
 
 // explicit instantiations
 template class Core::Utils::SymbolicExpression<double>;

--- a/src/cut/4C_cut_intersection.hpp
+++ b/src/cut/4C_cut_intersection.hpp
@@ -1360,7 +1360,7 @@ namespace Cut
           exit(EXIT_FAILURE);
       }
       return inter_ptr;
-    };
+    }
 
   };  // class IntersectionFactory
 

--- a/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.hpp
@@ -490,7 +490,7 @@ namespace Discret
         if (h_k <= 0.0) FOUR_C_THROW("negative or zero diameter for current element!");
 
         return;
-      };
+      }
 
       //! compute surface diameter w.r.t to parent master element or parent slave element (flag
       //! master=true/false)

--- a/src/fpsi/4C_fpsi_coupling.hpp
+++ b/src/fpsi/4C_fpsi_coupling.hpp
@@ -240,7 +240,7 @@ namespace FPSI
     std::shared_ptr<Coupling::Adapter::MatrixRowTransform>
         couplingrowtransform4_;  /// g_fpsi || F->PS transform (FPSI)
     std::shared_ptr<Coupling::Adapter::MatrixRowTransform> couplingrowtransform5_;
-    ;  /// g_fpsi || F->PS transform (FPSI)
+    /// g_fpsi || F->PS transform (FPSI)
     std::shared_ptr<Coupling::Adapter::MatrixColTransform>
         couplingcoltransform_;  /// for Row/Col-Map for Full - fluid_field & F->PS transform (FPSI)
     std::shared_ptr<Coupling::Adapter::MatrixColTransform>

--- a/src/mat/4C_mat_fluidporo.cpp
+++ b/src/mat/4C_mat_fluidporo.cpp
@@ -71,7 +71,7 @@ namespace Mat::FLUIDPORO
      *
      * @param [in] params Material parameters
      */
-    PoroAnisotropyStrategyBase(const Mat::PAR::FluidPoro* params) : params_(params) {};
+    PoroAnisotropyStrategyBase(const Mat::PAR::FluidPoro* params) : params_(params) {}
 
     //! Virtual default destructor
     virtual ~PoroAnisotropyStrategyBase() = default;
@@ -166,7 +166,7 @@ namespace Mat::FLUIDPORO
       // This is the standard case, so it is implemented in the base class
       linreac_dphi.clear();
       linreac_dJ.clear();
-    };
+    }
 
    protected:
     //! Material parameters
@@ -200,7 +200,7 @@ namespace Mat::FLUIDPORO
       const double reacoeff = viscosity / permeability;
 
       return reacoeff;
-    };
+    }
 
     //! compute isotropic reaction tensor - 2D
     void compute_reaction_tensor(Core::LinAlg::Matrix<2, 2>& reaction_tensor, const double& J,
@@ -211,7 +211,7 @@ namespace Mat::FLUIDPORO
     {
       compute_reaction_tensor_for_isotropy<2>(reaction_tensor, J, porosity,
           anisotropic_permeability_directions, anisotropic_permeability_coeffs);
-    };
+    }
 
     //! compute isotropic reaction tensor - 3D
     void compute_reaction_tensor(Core::LinAlg::Matrix<3, 3>& reaction_tensor, const double& J,
@@ -222,7 +222,7 @@ namespace Mat::FLUIDPORO
     {
       compute_reaction_tensor_for_isotropy<3>(reaction_tensor, J, porosity,
           anisotropic_permeability_directions, anisotropic_permeability_coeffs);
-    };
+    }
 
     /*!
      * @brief Compute reaction tensor for isotropy
@@ -260,7 +260,7 @@ namespace Mat::FLUIDPORO
       }
 
       for (unsigned int i = 0; i < dim; i++) reaction_tensor(i, i) = reacoeff;
-    };
+    }
 
     //! compute linearization of isotropic reaction tensor - 2D
     void compute_lin_mat_reaction_tensor(Core::LinAlg::Matrix<2, 2>& linreac_dphi,
@@ -268,7 +268,7 @@ namespace Mat::FLUIDPORO
         const double& porosity) const override
     {
       compute_lin_mat_reaction_tensor_for_isotropy<2>(linreac_dphi, linreac_dJ, J, porosity);
-    };
+    }
 
     //! compute linearization of isotropic reaction tensor - 3D
     void compute_lin_mat_reaction_tensor(Core::LinAlg::Matrix<3, 3>& linreac_dphi,
@@ -276,7 +276,7 @@ namespace Mat::FLUIDPORO
         const double& porosity) const override
     {
       compute_lin_mat_reaction_tensor_for_isotropy<3>(linreac_dphi, linreac_dJ, J, porosity);
-    };
+    }
 
     /*!
      * @brief Compute linearization reaction tensor for isotropy
@@ -327,7 +327,7 @@ namespace Mat::FLUIDPORO
           linreac_dJ(i, i) = linreac_dJ(0, 0);
         }
       }
-    };
+    }
   };
 
   /*!
@@ -358,7 +358,7 @@ namespace Mat::FLUIDPORO
       const double reacoeff = viscosity / 3. * (1. / axial_permeability + 2. / permeability);
 
       return reacoeff;
-    };
+    }
 
     //! compute reaction tensor for constant material transverse isotropy - 2D
     void compute_reaction_tensor(Core::LinAlg::Matrix<2, 2>& reaction_tensor, const double& J,
@@ -368,7 +368,7 @@ namespace Mat::FLUIDPORO
     {
       compute_reaction_tensor_for_constant_material_transverse_isotropy<2>(reaction_tensor, J,
           porosity, anisotropic_permeability_directions, anisotropic_permeability_coeffs);
-    };
+    }
 
     //! compute reaction tensor for constant material transverse isotropy - 3D
     void compute_reaction_tensor(Core::LinAlg::Matrix<3, 3>& reaction_tensor, const double& J,
@@ -378,7 +378,7 @@ namespace Mat::FLUIDPORO
     {
       compute_reaction_tensor_for_constant_material_transverse_isotropy<3>(reaction_tensor, J,
           porosity, anisotropic_permeability_directions, anisotropic_permeability_coeffs);
-    };
+    }
 
     /*!
      * @brief Compute reaction tensor for constant material transverse isotropy
@@ -462,7 +462,7 @@ namespace Mat::FLUIDPORO
               1. / orthotropic_permeabilities[2]);
 
       return reacoeff;
-    };
+    }
 
     //! constant material orthotropy in 2D is not allowed
     void compute_reaction_tensor(Core::LinAlg::Matrix<2, 2>& reaction_tensor, const double& J,
@@ -471,7 +471,7 @@ namespace Mat::FLUIDPORO
         [[maybe_unused]] const std::vector<double>& anisotropic_permeability_coeffs) const override
     {
       FOUR_C_THROW("Use transverse isotropy in 2D!");
-    };
+    }
 
     //! compute reaction tensor for constant material orthotropy - 3D
     void compute_reaction_tensor(Core::LinAlg::Matrix<3, 3>& reaction_tensor, const double& J,
@@ -503,7 +503,7 @@ namespace Mat::FLUIDPORO
 
       reaction_tensor.invert(permeability_tensor);
       reaction_tensor.scale(dynamic_viscosity);
-    };
+    }
 
     //! constant material orthotropy in 2D is not allowed
     void compute_lin_mat_reaction_tensor(Core::LinAlg::Matrix<2, 2>& linreac_dphi,
@@ -512,7 +512,7 @@ namespace Mat::FLUIDPORO
     {
       // constant material orthotropy in 2D is not allowed
       FOUR_C_THROW("Use transverse isotropy in 2D!");
-    };
+    }
   };
 
   /*!
@@ -549,7 +549,7 @@ namespace Mat::FLUIDPORO
       const double reacoeff = viscosity / permeability;
 
       return reacoeff;
-    };
+    }
 
     //!  compute reaction tensor for constant material nodal orthotropy - 2D
     void compute_reaction_tensor(Core::LinAlg::Matrix<2, 2>& reaction_tensor, const double& J,
@@ -559,7 +559,7 @@ namespace Mat::FLUIDPORO
     {
       compute_reaction_tensor_for_constant_material_nodal_orthotropy<2>(reaction_tensor, J,
           porosity, anisotropic_permeability_directions, anisotropic_permeability_coeffs);
-    };
+    }
 
     //! compute reaction tensor for constant material nodal orthotropy - 3D
     void compute_reaction_tensor(Core::LinAlg::Matrix<3, 3>& reaction_tensor, const double& J,
@@ -569,7 +569,7 @@ namespace Mat::FLUIDPORO
     {
       compute_reaction_tensor_for_constant_material_nodal_orthotropy<3>(reaction_tensor, J,
           porosity, anisotropic_permeability_directions, anisotropic_permeability_coeffs);
-    };
+    }
 
     /*!
      * @brief Compute reaction tensor for constant material nodal orthotropy

--- a/src/mat/4C_mat_plasticdruckerprager.hpp
+++ b/src/mat/4C_mat_plasticdruckerprager.hpp
@@ -71,7 +71,7 @@ namespace Mat
   {
    public:
     std::string name() const override { return "PlasticDruckerPragerType"; }
-    static PlasticDruckerPragerType& instance() { return instance_; };
+    static PlasticDruckerPragerType& instance() { return instance_; }
     Core::Communication::ParObject* create(Core::Communication::UnpackBuffer& buffer) override;
 
    private:
@@ -123,7 +123,7 @@ namespace Mat
         Core::LinAlg::Matrix<NUM_STRESS_3D, NUM_STRESS_3D>* cmat, int gp, int eleGID) override
     {
       this->evaluate_fad(defgrd, linstrain, params, stress, cmat, gp, eleGID);
-    };
+    }
 
     template <typename ScalarT>
     void evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
@@ -132,7 +132,7 @@ namespace Mat
         Core::LinAlg::Matrix<NUM_STRESS_3D, NUM_STRESS_3D>* cmat, int gp, int eleGID)
     {
       this->evaluate_fad(defgrd, linstrain, params, stress, cmat, gp, eleGID);
-    };
+    }
     template <typename ScalarT>
     void evaluate_fad(const Core::LinAlg::Matrix<3, 3>* defgrd,
         const Core::LinAlg::Matrix<NUM_STRESS_3D, 1, ScalarT>* linstrain,

--- a/src/mat/elast/4C_mat_elast_coupanisoexpoactive.hpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoexpoactive.hpp
@@ -203,9 +203,9 @@ namespace Mat
       inline void get_derivative_aniso_active(T& dPIact) const
       {
         dPIact = d_p_iact_;
-      };
+      }
 
-      double get_derivative_aniso_active() const override { return d_p_iact_; };
+      double get_derivative_aniso_active() const override { return d_p_iact_; }
 
       //@}
 

--- a/src/w1/4C_w1_poro_p1_scatra.hpp
+++ b/src/w1/4C_w1_poro_p1_scatra.hpp
@@ -113,7 +113,7 @@ namespace Discret
 
       /// @name params
       /// return ScaTra::ImplType
-      const Inpar::ScaTra::ImplType& impl_type() const { return impltype_; };
+      const Inpar::ScaTra::ImplType& impl_type() const { return impltype_; }
 
      private:
       //! scalar transport implementation type (physics)

--- a/src/xfem/4C_xfem_coupling_fpi_mesh.hpp
+++ b/src/xfem/4C_xfem_coupling_fpi_mesh.hpp
@@ -104,7 +104,7 @@ namespace XFEM
     {
       eval_projection_matrix<distype>(projection_matrix, normal);
       return;
-    };
+    }
 
     // finalize the interface true residual vector
     void complete_state_vectors() override;

--- a/src/xfem/4C_xfem_coupling_levelset.hpp
+++ b/src/xfem/4C_xfem_coupling_levelset.hpp
@@ -393,7 +393,7 @@ namespace XFEM
             projection_matrix, ivel);  // apply Projection matrix from the right. (u_0 * P^t)
         ivel.update(1.0, tmp_ivel, 0.0);
       }
-    };
+    }
 
     /*!
      Return a smoothed/non-smoothed tangiential projection of the level set surface.

--- a/src/xfem/4C_xfem_coupling_mesh_coupled_levelset.hpp
+++ b/src/xfem/4C_xfem_coupling_mesh_coupled_levelset.hpp
@@ -142,7 +142,7 @@ namespace XFEM
         FOUR_C_THROW("Key was not found in this instance!! Fatal error! (force_tangvel_map_)");
       }
 #endif
-    };
+    }
 
 
     // template <Core::FE::CellType DISTYPE>//,class M1, class M2>


### PR DESCRIPTION
This enforces strict compliance with standard C/C++ and warns of non-standard compiler extensions. If the need for these extensions arises, we can still disable the warning, but for now the code compiles in this pedantic mode.

The only things I needed to fix are named `__VA_ARGS__` and a few superfluous semicolons.

Closes #65 
