### PR TITLE
InputSpec: rename anonymous_group -> all_of

### DIFF
--- a/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
+++ b/apps/create_rtdfiles/4C_create_rtdfiles_utils.cpp
@@ -498,7 +498,7 @@ namespace RTD
     // Avoid writing an empty code block if there are no specs for this condition
     if (!condition.specs().empty())
     {
-      auto cond_spec = Core::IO::InputSpecBuilders::anonymous_group(condition.specs());
+      auto cond_spec = Core::IO::InputSpecBuilders::all_of(condition.specs());
 
       std::stringstream specs_string;
       cond_spec.print_as_dat(specs_string);

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -292,7 +292,7 @@ int main(int argc, char* argv[])
         }
 
         using namespace Core::IO::InputSpecBuilders;
-        auto all_materials = anonymous_group({
+        auto all_materials = all_of({
             entry<int>("MAT"),
             one_of(possible_materials),
         });

--- a/apps/pre_exodus/4C_pre_exodus.cpp
+++ b/apps/pre_exodus/4C_pre_exodus.cpp
@@ -336,7 +336,7 @@ int main(int argc, char** argv)
         }
 
         using namespace Core::IO::InputSpecBuilders;
-        auto all_materials = anonymous_group({
+        auto all_materials = all_of({
             entry<int>("MAT"),
             one_of(possible_materials),
         });

--- a/src/ale/4C_ale_ale2.cpp
+++ b/src/ale/4C_ale_ale2.cpp
@@ -84,27 +84,27 @@ void Discret::Elements::Ale2Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD8"] = anonymous_group({
+  defs["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
   });
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
   });

--- a/src/ale/4C_ale_ale3.cpp
+++ b/src/ale/4C_ale_ale3.cpp
@@ -83,42 +83,42 @@ void Discret::Elements::Ale3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["HEX20"] = anonymous_group({
+  defs["HEX20"] = all_of({
       entry<std::vector<int>>("HEX20", {.size = 20}),
       entry<int>("MAT"),
   });
 
-  defs["HEX27"] = anonymous_group({
+  defs["HEX27"] = all_of({
       entry<std::vector<int>>("HEX27", {.size = 27}),
       entry<int>("MAT"),
   });
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       entry<std::vector<int>>("TET10", {.size = 10}),
       entry<int>("MAT"),
   });
 
-  defs["WEDGE6"] = anonymous_group({
+  defs["WEDGE6"] = all_of({
       entry<std::vector<int>>("WEDGE6", {.size = 6}),
       entry<int>("MAT"),
   });
 
-  defs["WEDGE15"] = anonymous_group({
+  defs["WEDGE15"] = all_of({
       entry<std::vector<int>>("WEDGE15", {.size = 15}),
       entry<int>("MAT"),
   });
 
-  defs["PYRAMID5"] = anonymous_group({
+  defs["PYRAMID5"] = all_of({
       entry<std::vector<int>>("PYRAMID5", {.size = 5}),
       entry<int>("MAT"),
   });

--- a/src/art_net/4C_art_net_artery.cpp
+++ b/src/art_net/4C_art_net_artery.cpp
@@ -58,7 +58,7 @@ void Discret::Elements::ArteryType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<int>("GP"),

--- a/src/beam3/4C_beam3_euler_bernoulli.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli.cpp
@@ -211,7 +211,7 @@ void Discret::Elements::Beam3ebType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
   });

--- a/src/beam3/4C_beam3_kirchhoff.cpp
+++ b/src/beam3/4C_beam3_kirchhoff.cpp
@@ -98,7 +98,7 @@ void Discret::Elements::Beam3kType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("WK"),
       entry<int>("ROTVEC"),
@@ -107,7 +107,7 @@ void Discret::Elements::Beam3kType::setup_element_definition(
       tag("FAD", {.default_value = false}),
   });
 
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("WK"),
       entry<int>("ROTVEC"),
@@ -116,7 +116,7 @@ void Discret::Elements::Beam3kType::setup_element_definition(
       tag("FAD", {.default_value = false}),
   });
 
-  defs["LINE4"] = anonymous_group({
+  defs["LINE4"] = all_of({
       entry<std::vector<int>>("LINE4", {.size = 4}),
       entry<int>("WK"),
       entry<int>("ROTVEC"),

--- a/src/beam3/4C_beam3_reissner.cpp
+++ b/src/beam3/4C_beam3_reissner.cpp
@@ -110,7 +110,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   // note: LINE2 refers to linear Lagrange interpolation of centerline AND triad field
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 6}),
@@ -118,7 +118,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   });
 
   // note: LINE3 refers to quadratic Lagrange interpolation of centerline AND triad field
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 9}),
@@ -126,7 +126,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   });
 
   // note: LINE4 refers to cubic Lagrange interpolation of centerline AND triad field
-  defs["LINE4"] = anonymous_group({
+  defs["LINE4"] = all_of({
       entry<std::vector<int>>("LINE4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 12}),
@@ -134,7 +134,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   });
 
   // note: LINE5 refers to quartic Lagrange interpolation of centerline AND triad field
-  defs["LINE5"] = anonymous_group({
+  defs["LINE5"] = all_of({
       entry<std::vector<int>>("LINE5", {.size = 5}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 15}),
@@ -143,7 +143,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   /* note: HERM2 refers to cubic Hermite interpolation of centerline (2 nodes)
    *       LINE2 refers to linear Lagrange interpolation of the triad field*/
-  defs["HERM2LINE2"] = anonymous_group({
+  defs["HERM2LINE2"] = all_of({
       entry<std::vector<int>>("HERM2LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 6}),
@@ -152,7 +152,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   /* note: HERM2 refers to cubic order Hermite interpolation of centerline (2 nodes)
    *       LINE3 refers to quadratic Lagrange interpolation of the triad field*/
-  defs["HERM2LINE3"] = anonymous_group({
+  defs["HERM2LINE3"] = all_of({
       entry<std::vector<int>>("HERM2LINE3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 9}),
@@ -161,7 +161,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   /* note: HERM2 refers to cubic Hermite interpolation of centerline (2 nodes)
    *       LINE4 refers to cubic Lagrange interpolation of the triad field*/
-  defs["HERM2LINE4"] = anonymous_group({
+  defs["HERM2LINE4"] = all_of({
       entry<std::vector<int>>("HERM2LINE4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 12}),
@@ -170,7 +170,7 @@ void Discret::Elements::Beam3rType::setup_element_definition(
 
   /* note: HERM2 refers to cubic Hermite interpolation of centerline (2 nodes)
    *       LINE5 refers to quartic Lagrange interpolation of the triad field*/
-  defs["HERM2LINE5"] = anonymous_group({
+  defs["HERM2LINE5"] = all_of({
       entry<std::vector<int>>("HERM2LINE5", {.size = 5}),
       entry<int>("MAT"),
       entry<std::vector<double>>("TRIADS", {.size = 15}),

--- a/src/bele/4C_bele_bele3.cpp
+++ b/src/bele/4C_bele_bele3.cpp
@@ -95,27 +95,27 @@ void Discret::Elements::Bele3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs3["TRI3"] = anonymous_group({
+  defs3["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT", {.required = false}),
   });
 
-  defs3["TRI6"] = anonymous_group({
+  defs3["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT", {.required = false}),
   });
 
-  defs3["QUAD4"] = anonymous_group({
+  defs3["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT", {.required = false}),
   });
 
-  defs3["QUAD8"] = anonymous_group({
+  defs3["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT", {.required = false}),
   });
 
-  defs3["QUAD9"] = anonymous_group({
+  defs3["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT", {.required = false}),
   });

--- a/src/bele/4C_bele_vele3.cpp
+++ b/src/bele/4C_bele_vele3.cpp
@@ -70,7 +70,7 @@ void Discret::Elements::Vele3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
   });
 }

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_valid_laws.cpp
@@ -134,7 +134,7 @@ Core::IO::InputSpec CONTACT::CONSTITUTIVELAW::valid_contact_constitutive_laws()
     group_index_to_type.push_back(Inpar::CONTACT::ConstitutiveLawType::colaw_mirco);
   }
 
-  auto valid_law = anonymous_group({
+  auto valid_law = all_of({
       entry<int>("LAW"),
       one_of(specs, store_index_as("LAW_TYPE", group_index_to_type)),
   });

--- a/src/core/fem/src/condition/4C_fem_condition_definition.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_definition.cpp
@@ -99,7 +99,7 @@ void Core::Conditions::ConditionDefinition::read(Core::IO::InputFile& input,
         condition_count, sectionname_.c_str());
   }
 
-  auto condition_spec = Core::IO::InputSpecBuilders::anonymous_group(specs_);
+  auto condition_spec = Core::IO::InputSpecBuilders::all_of(specs_);
 
   for (auto i = section_vec.begin() + 1; i != section_vec.end(); ++i)
   {
@@ -161,9 +161,9 @@ std::ostream& Core::Conditions::ConditionDefinition::print(std::ostream& stream)
   stream << ' ' << count << '\n';
 
   using namespace Core::IO::InputSpecBuilders;
-  auto condition_spec = anonymous_group({
+  auto condition_spec = all_of({
       entry<int>("E"),
-      anonymous_group(specs_),
+      all_of(specs_),
   });
 
   condition_spec.print_as_dat(stream);

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -252,7 +252,7 @@ void Core::FE::DiscretizationCreatorBase::finalize(
 Core::IO::InputSpec Core::FE::valid_cloning_material_map()
 {
   using namespace Core::IO::InputSpecBuilders;
-  return anonymous_group({
+  return all_of({
       entry<std::string>("SRC_FIELD"),
       entry<int>("SRC_MAT"),
       entry<std::string>("TAR_FIELD"),

--- a/src/core/utils/src/functions/4C_utils_function_library.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_library.cpp
@@ -62,12 +62,12 @@ void Core::Utils::add_valid_library_functions(Core::Utils::FunctionManager& func
   using namespace IO::InputSpecBuilders;
 
   auto spec = one_of({
-      anonymous_group({
+      all_of({
           tag("FASTPOLYNOMIAL"),
           entry<int>("NUMCOEFF"),
           entry<std::vector<double>>("COEFF", {.size = from_parameter<int>("NUMCOEFF")}),
       }),
-      anonymous_group({
+      all_of({
           tag("CUBIC_SPLINE_FROM_CSV"),
           entry<std::filesystem::path>("CSV"),
       }),

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -70,14 +70,14 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
   using namespace IO::InputSpecBuilders;
 
   auto spec = one_of({
-      anonymous_group({
+      all_of({
           entry<int>("COMPONENT", {.required = false}),
           entry<std::string>("SYMBOLIC_FUNCTION_OF_SPACE_TIME"),
       }),
 
       entry<std::string>("SYMBOLIC_FUNCTION_OF_TIME"),
 
-      anonymous_group({
+      all_of({
           entry<int>("VARIABLE"),
           entry<std::string>("NAME"),
           entry<std::string>("TYPE"),
@@ -109,7 +109,7 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
           entry<double>("T2", {.required = false}),
       }),
 
-      anonymous_group({
+      all_of({
           entry<std::string>("VARFUNCTION"),
           entry<int>("NUMCONSTANTS", {.required = false}),
           entry<std::vector<std::pair<std::string, double>>>(

--- a/src/elemag/4C_elemag_diff_ele.cpp
+++ b/src/elemag/4C_elemag_diff_ele.cpp
@@ -99,14 +99,14 @@ void Discret::Elements::ElemagDiffType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   // 3D elements
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<int>("DEG"),
       entry<int>("SPC"),
   });
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
       entry<int>("DEG"),
@@ -114,21 +114,21 @@ void Discret::Elements::ElemagDiffType::setup_element_definition(
   });
 
   // 2D elements
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<int>("DEG"),
       entry<int>("SPC"),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<int>("DEG"),
       entry<int>("SPC"),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<int>("DEG"),

--- a/src/elemag/4C_elemag_ele.cpp
+++ b/src/elemag/4C_elemag_ele.cpp
@@ -93,14 +93,14 @@ void Discret::Elements::ElemagType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   // 3D elements
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<int>("DEG"),
       entry<int>("SPC"),
   });
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
       entry<int>("DEG"),
@@ -108,21 +108,21 @@ void Discret::Elements::ElemagType::setup_element_definition(
   });
 
   // 2D elements
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<int>("DEG"),
       entry<int>("SPC"),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<int>("DEG"),
       entry<int>("SPC"),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<int>("DEG"),

--- a/src/fluid/4C_fluid_functions.cpp
+++ b/src/fluid/4C_fluid_functions.cpp
@@ -334,94 +334,94 @@ void FLD::add_valid_fluid_functions(Core::Utils::FunctionManager& function_manag
 {
   using namespace Core::IO::InputSpecBuilders;
   auto spec = one_of({
-      anonymous_group({
+      all_of({
           tag("BELTRAMI"),
           entry<double>("c1"),
       }),
       tag("CHANNELWEAKLYCOMPRESSIBLE"),
       tag("CORRECTIONTERMCHANNELWEAKLYCOMPRESSIBLE"),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_POISEUILLE"),
           entry<int>("MAT"),
           entry<double>("L"),
           entry<double>("R"),
           entry<double>("U"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE"),
           entry<int>("MAT"),
           entry<double>("L"),
           entry<double>("R"),
           entry<double>("U"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW"),
           entry<int>("MAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW_FORCE"),
           entry<int>("MAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD"),
           entry<int>("MAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE"),
           entry<int>("MAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_CFD_VISCOSITY"),
           entry<int>("MAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID"),
           entry<int>("MAT_FLUID"),
           entry<int>("MAT_STRUCT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_FORCE"),
           entry<int>("MAT_FLUID"),
           entry<int>("MAT_STRUCT"),
       }),
-      anonymous_group({
+      all_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_VISCOSITY"),
           entry<int>("MAT_FLUID"),
           entry<int>("MAT_STRUCT"),
       }),
-      anonymous_group({
+      all_of({
           tag("BELTRAMI-UP"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("BELTRAMI-GRADU"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("BELTRAMI-RHS"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),
           entry<int>("ISSTOKES"),
       }),
-      anonymous_group({
+      all_of({
           tag("KIMMOIN-UP"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("KIMMOIN-GRADU"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),
       }),
-      anonymous_group({
+      all_of({
           tag("KIMMOIN-RHS"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),
           entry<int>("ISSTOKES"),
       }),
-      anonymous_group({
+      all_of({
           tag("KIMMOIN-STRESS"),
           entry<int>("MAT"),
           entry<int>("ISSTAT"),

--- a/src/fluid_ele/4C_fluid_ele.cpp
+++ b/src/fluid_ele/4C_fluid_ele.cpp
@@ -75,104 +75,104 @@ void Discret::Elements::FluidType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defsgeneral["HEX8"] = anonymous_group({
+  defsgeneral["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["HEX20"] = anonymous_group({
+  defsgeneral["HEX20"] = all_of({
       entry<std::vector<int>>("HEX20", {.size = 20}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["HEX27"] = anonymous_group({
+  defsgeneral["HEX27"] = all_of({
       entry<std::vector<int>>("HEX27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["TET4"] = anonymous_group({
+  defsgeneral["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["TET10"] = anonymous_group({
+  defsgeneral["TET10"] = all_of({
       entry<std::vector<int>>("TET10", {.size = 10}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["WEDGE6"] = anonymous_group({
+  defsgeneral["WEDGE6"] = all_of({
       entry<std::vector<int>>("WEDGE6", {.size = 6}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["WEDGE15"] = anonymous_group({
+  defsgeneral["WEDGE15"] = all_of({
       entry<std::vector<int>>("WEDGE15", {.size = 15}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["PYRAMID5"] = anonymous_group({
+  defsgeneral["PYRAMID5"] = all_of({
       entry<std::vector<int>>("PYRAMID5", {.size = 5}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["NURBS8"] = anonymous_group({
+  defsgeneral["NURBS8"] = all_of({
       entry<std::vector<int>>("NURBS8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["NURBS27"] = anonymous_group({
+  defsgeneral["NURBS27"] = all_of({
       entry<std::vector<int>>("NURBS27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
   // 2D elements
-  defsgeneral["QUAD4"] = anonymous_group({
+  defsgeneral["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["QUAD8"] = anonymous_group({
+  defsgeneral["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["QUAD9"] = anonymous_group({
+  defsgeneral["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["TRI3"] = anonymous_group({
+  defsgeneral["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["TRI6"] = anonymous_group({
+  defsgeneral["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["NURBS4"] = anonymous_group({
+  defsgeneral["NURBS4"] = all_of({
       entry<std::vector<int>>("NURBS4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
 
-  defsgeneral["NURBS9"] = anonymous_group({
+  defsgeneral["NURBS9"] = all_of({
       entry<std::vector<int>>("NURBS9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("NA"),

--- a/src/fluid_ele/4C_fluid_ele_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.cpp
@@ -134,7 +134,7 @@ void Discret::Elements::FluidHDGType ::setup_element_definition(
 
   for (const auto& [key, fluid_line_def] : defs_fluid)
   {
-    defs_hdg[key] = anonymous_group({
+    defs_hdg[key] = all_of({
         fluid_line_def,
         entry<int>("DEG"),
         entry<int>("SPC", {.required = false}),

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
@@ -96,7 +96,7 @@ void Discret::Elements::FluidHDGWeakCompType ::setup_element_definition(
 
   for (const auto& [key, fluid_line_def] : defs_fluid)
   {
-    defs_hdg[key] = anonymous_group({
+    defs_hdg[key] = all_of({
         fluid_line_def,
         entry<int>("DEG"),
         entry<int>("SPC", {.required = false}),

--- a/src/fluid_ele/4C_fluid_ele_xwall.cpp
+++ b/src/fluid_ele/4C_fluid_ele_xwall.cpp
@@ -70,12 +70,12 @@ void Discret::Elements::FluidXWallType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defsxwall["HEX8"] = anonymous_group({
+  defsxwall["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("NA"),
   });
-  defsxwall["TET4"] = anonymous_group({
+  defsxwall["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("NA"),

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
@@ -195,7 +195,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
 
   auto spec = one_of({
       tag("FORWARDFACINGSTEP"),
-      anonymous_group({
+      all_of({
           tag("MOVINGLEVELSETCYLINDER"),
           entry<std::vector<double>>("ORIGIN", {.size = 3}),
           entry<double>("RADIUS"),
@@ -203,7 +203,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<double>("DISTANCE"),
           entry<double>("MAXSPEED"),
       }),
-      anonymous_group({
+      all_of({
           tag("MOVINGLEVELSETTORUS"),
           entry<std::vector<double>>("ORIGIN", {.size = 3}),
           entry<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
@@ -216,7 +216,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<double>("ROTATION_SPEED"),
           entry<double>("ROTATION_RAMPTIME"),
       }),
-      anonymous_group({
+      all_of({
           tag("MOVINGLEVELSETTORUSVELOCITY"),
           entry<std::vector<double>>("ORIGIN", {.size = 3}),
           entry<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
@@ -229,7 +229,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<double>("ROTATION_SPEED"),
           entry<double>("ROTATION_RAMPTIME"),
       }),
-      anonymous_group({
+      all_of({
           tag("MOVINGLEVELSETTORUSSLIPLENGTH"),
           entry<std::vector<double>>("ORIGIN", {.size = 3}),
           entry<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
@@ -243,7 +243,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<double>("ROTATION_RAMPTIME"),
           entry<int>("SLIP_FUNCT"),
       }),
-      anonymous_group({
+      all_of({
           tag("TAYLORCOUETTEFLOW"),
           entry<double>("RADIUS_I"),
           entry<double>("RADIUS_O"),
@@ -255,7 +255,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<double>("TRACTION_THETA_O"),
           entry<double>("VISCOSITY"),
       }),
-      anonymous_group({
+      all_of({
           tag("URQUIZABOXFLOW"),
           entry<double>("LENGTHX"),
           entry<double>("LENGTHY"),
@@ -265,7 +265,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<int>("CASE"),
           entry<std::vector<double>>("COMBINATION", {.size = 2}),
       }),
-      anonymous_group({
+      all_of({
           tag("URQUIZABOXFLOW_TRACTION"),
           entry<double>("LENGTHX"),
           entry<double>("LENGTHY"),
@@ -275,7 +275,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           entry<int>("CASE"),
           entry<std::vector<double>>("COMBINATION", {.size = 2}),
       }),
-      anonymous_group({
+      all_of({
           tag("URQUIZABOXFLOW_FORCE"),
           entry<double>("LENGTHX"),
           entry<double>("LENGTHY"),

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -2036,7 +2036,7 @@ void Global::read_materials(Global::Problem& problem, Core::IO::InputFile& input
 
   using namespace Core::IO::InputSpecBuilders;
 
-  auto all_materials = anonymous_group({
+  auto all_materials = all_of({
       entry<int>("MAT", {.description = "Material ID that may be used to refer to this material."}),
       one_of(all_specs, [&current_index](Core::IO::ValueParser& parser,
                             Core::IO::InputParameterContainer& container, std::size_t index)

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -329,7 +329,7 @@ namespace
         group("STRUCTURE",
             {
                 one_of({
-                    anonymous_group({
+                    all_of({
                         entry<std::string>("DIS"),
                         one_of({
                             entry<int>("NODE"),
@@ -422,7 +422,7 @@ namespace
         group("SSI",
             {
                 one_of({
-                    anonymous_group({
+                    all_of({
                         entry<std::string>("DIS"),
                         entry<int>("NODE"),
                     }),

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -234,7 +234,7 @@ void Inpar::ElCh::set_valid_conditions(
   // electrode kinetics as boundary condition on electrolyte
   {
     auto reaction_model_choices = one_of({
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer", Inpar::ElCh::ElectrodeKinetics::butler_volmer},
@@ -248,7 +248,7 @@ void Inpar::ElCh::set_valid_conditions(
             entry<double>("REFCON"),
             entry<double>("DL_SPEC_CAP"),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL", {{"Tafel", Inpar::ElCh::ElectrodeKinetics::tafel}}),
             entry<double>("ALPHA"),
             entry<double>("I0"),
@@ -256,7 +256,7 @@ void Inpar::ElCh::set_valid_conditions(
             entry<double>("REFCON"),
             entry<double>("DL_SPEC_CAP"),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL", {{"linear", Inpar::ElCh::ElectrodeKinetics::linear}}),
             entry<double>("ALPHA"),
             entry<double>("I0"),
@@ -264,7 +264,7 @@ void Inpar::ElCh::set_valid_conditions(
             entry<double>("REFCON"),
             entry<double>("DL_SPEC_CAP"),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL",
                 {{"Butler-Volmer-Newman", Inpar::ElCh::ElectrodeKinetics::butler_volmer_newman}}),
             entry<double>("K_A"),
@@ -272,7 +272,7 @@ void Inpar::ElCh::set_valid_conditions(
             entry<double>("BETA"),
             entry<double>("DL_SPEC_CAP"),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL",
                 {{"Butler-Volmer-Bard", Inpar::ElCh::ElectrodeKinetics::butler_volmer_bard}}),
             entry<double>("E0"),
@@ -282,7 +282,7 @@ void Inpar::ElCh::set_valid_conditions(
             entry<double>("C_A0"),
             entry<double>("DL_SPEC_CAP"),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL", {{"Nernst", Inpar::ElCh::ElectrodeKinetics::nernst}}),
             entry<double>("E0"),
             entry<double>("C0"),
@@ -343,7 +343,7 @@ void Inpar::ElCh::set_valid_conditions(
         Core::Conditions::geometry_type_volume);
 
     // equip condition definition with input file line components
-    auto electrodedomainkineticscomponents = anonymous_group({
+    auto electrodedomainkineticscomponents = all_of({
         entry<int>("ConditionID"),
         entry<double>("POT"),
         entry<Core::IO::Noneable<int>>("FUNCT"),

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -167,7 +167,7 @@ void Inpar::S2I::set_valid_conditions(
     {
       {
         // constant and linear permeability
-        auto constlinperm = anonymous_group({
+        auto constlinperm = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"ConstantPermeability", Inpar::S2I::kinetics_constperm},
@@ -181,7 +181,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto butler_volmer = anonymous_group({
+        auto butler_volmer = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer", Inpar::S2I::kinetics_butlervolmer},
@@ -202,7 +202,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto butler_volmer_peltier = anonymous_group({
+        auto butler_volmer_peltier = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer-Peltier", Inpar::S2I::kinetics_butlervolmerpeltier},
@@ -221,7 +221,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto butler_volmer_reduced_capacitance = anonymous_group({
+        auto butler_volmer_reduced_capacitance = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Capacitance",
@@ -241,7 +241,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto butler_volmer_resistance = anonymous_group({
+        auto butler_volmer_resistance = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer_Resistance", Inpar::S2I::kinetics_butlervolmerresistance},
@@ -261,7 +261,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto butler_volmer_reduced_with_resistance = anonymous_group({
+        auto butler_volmer_reduced_with_resistance = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Resistance",
@@ -283,7 +283,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto butler_volmer_reduced_thermo = anonymous_group({
+        auto butler_volmer_reduced_thermo = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_ThermoResistance",
@@ -304,7 +304,7 @@ void Inpar::S2I::set_valid_conditions(
       }
 
       {
-        auto constant_interface_resistance = anonymous_group({
+        auto constant_interface_resistance = all_of({
             selection<int>("KINETIC_MODEL",
                 {
                     {"ConstantInterfaceResistance",
@@ -333,13 +333,13 @@ void Inpar::S2I::set_valid_conditions(
     }
 
     auto interface_side_options = one_of({
-        anonymous_group({
+        all_of({
             selection<int>("INTERFACE_SIDE", {{"Master", side_master}}),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("INTERFACE_SIDE", {{"Undefined", side_undefined}}),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("INTERFACE_SIDE", {{"Slave", side_slave}}),
             one_of(kinetic_model_choices),
         }),
@@ -379,7 +379,7 @@ void Inpar::S2I::set_valid_conditions(
         "Scatra-scatra surface interface layer growth kinetics",
         Core::Conditions::S2IKineticsGrowth, true, Core::Conditions::geometry_type_surface);
 
-    auto butler_volmer = anonymous_group({
+    auto butler_volmer = all_of({
         entry<int>("NUMSCAL"),
         entry<std::vector<int>>("STOICHIOMETRIES", {.size = from_parameter<int>("NUMSCAL")}),
         entry<int>("E-"),

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -383,14 +383,14 @@ void Inpar::SSI::set_valid_conditions(
     using namespace Core::IO::InputSpecBuilders;
 
     surfmanifoldkinetics->add_component(one_of({
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL", {{"ConstantInterfaceResistance",
                                                 Inpar::S2I::kinetics_constantinterfaceresistance}}),
             entry<std::vector<int>>("ONOFF", {.size = 2}),
             entry<double>("RESISTANCE"),
             entry<int>("E-"),
         }),
-        anonymous_group({
+        all_of({
             selection<int>("KINETIC_MODEL",
                 {{"Butler-VolmerReduced", Inpar::S2I::kinetics_butlervolmerreduced}}),
             entry<int>("NUMSCAL"),

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -387,7 +387,7 @@ void Inpar::XFEM::set_valid_conditions(
   using namespace Core::IO;
   using namespace Core::IO::InputSpecBuilders;
 
-  auto dirichletbundcomponents = anonymous_group({
+  auto dirichletbundcomponents = all_of({
       entry<int>("NUMDOF"),
       entry<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       entry<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
@@ -396,7 +396,7 @@ void Inpar::XFEM::set_valid_conditions(
           "TAG", {{"none", "none"}, {"monitor_reaction", "monitor_reaction"}}, {.required = false}),
   });
 
-  auto neumanncomponents = anonymous_group({
+  auto neumanncomponents = all_of({
       entry<int>("NUMDOF"),
       entry<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       entry<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
@@ -453,7 +453,7 @@ void Inpar::XFEM::set_valid_conditions(
   //*----------------*/
   // Levelset field condition components
 
-  auto levelsetfield_components = anonymous_group({
+  auto levelsetfield_components = all_of({
       entry<int>("COUPLINGID"),
       entry<int>("LEVELSETFIELDNO"),
       selection<std::string>("BOOLEANTYPE",

--- a/src/lubrication/src/4C_lubrication_ele.cpp
+++ b/src/lubrication/src/4C_lubrication_ele.cpp
@@ -75,37 +75,37 @@ void Discret::Elements::LubricationType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD8"] = anonymous_group({
+  defs["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
   });
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
   });
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
   });
 
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("MAT"),
   });

--- a/src/mat/4C_mat_materialdefinition.cpp
+++ b/src/mat/4C_mat_materialdefinition.cpp
@@ -45,7 +45,7 @@ void Mat::MaterialDefinition::add_component(Core::IO::InputSpec&& c)
 std::ostream& Mat::MaterialDefinition::print(
     std::ostream& stream, const Core::FE::Discretization* dis)
 {
-  auto input_line = Core::IO::InputSpecBuilders::anonymous_group(components_);
+  auto input_line = Core::IO::InputSpecBuilders::all_of(components_);
 
   input_line.print_as_dat(stream);
 

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -73,7 +73,7 @@ void Discret::Elements::MembraneTri3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -148,7 +148,7 @@ void Discret::Elements::MembraneTri6Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -223,7 +223,7 @@ void Discret::Elements::MembraneQuad4Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -298,7 +298,7 @@ void Discret::Elements::MembraneQuad9Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/membrane/4C_membrane_scatra_eletypes.cpp
+++ b/src/membrane/4C_membrane_scatra_eletypes.cpp
@@ -62,7 +62,7 @@ void Discret::Elements::MembraneScatraTri3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       defs_membrane["TRI3"],
       entry<std::string>("TYPE"),
   });
@@ -119,7 +119,7 @@ void Discret::Elements::MembraneScatraTri6Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       defs_membrane["TRI6"],
       entry<std::string>("TYPE"),
   });
@@ -176,7 +176,7 @@ void Discret::Elements::MembraneScatraQuad4Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       defs_membrane["QUAD4"],
       entry<std::string>("TYPE"),
   });
@@ -233,7 +233,7 @@ void Discret::Elements::MembraneScatraQuad9Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       defs_membrane["QUAD9"],
       entry<std::string>("TYPE"),
   });

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
@@ -103,52 +103,52 @@ void Discret::Elements::PoroFluidMultiPhaseType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD8"] = anonymous_group({
+  defs["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
   });
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
   });
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
   });
 
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("MAT"),
   });
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       entry<std::vector<int>>("TET10", {.size = 10}),
       entry<int>("MAT"),
   });

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
@@ -116,7 +116,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
   using namespace Core::IO::InputSpecBuilders;
 
   function_manager.add_function_definition(
-      anonymous_group({
+      all_of({
           entry<std::string>("POROMULTIPHASESCATRA_FUNCTION"),
           entry<int>("NUMPARAMS", {.required = false}),
           entry<std::vector<std::pair<std::string, double>>>(

--- a/src/red_airways/4C_red_airways_acinus.cpp
+++ b/src/red_airways/4C_red_airways_acinus.cpp
@@ -64,7 +64,7 @@ void Discret::Elements::RedAcinusType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),

--- a/src/red_airways/4C_red_airways_airway.cpp
+++ b/src/red_airways/4C_red_airways_airway.cpp
@@ -65,7 +65,7 @@ void Discret::Elements::RedAirwayType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<std::string>("ElemSolvingType"),

--- a/src/red_airways/4C_red_airways_interacinardep.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep.cpp
@@ -72,7 +72,7 @@ void Discret::Elements::RedInterAcinarDepType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
   });

--- a/src/rigidsphere/4C_rigidsphere.cpp
+++ b/src/rigidsphere/4C_rigidsphere.cpp
@@ -96,7 +96,7 @@ void Discret::Elements::RigidsphereType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["POINT1"] = anonymous_group({
+  defs["POINT1"] = all_of({
       entry<std::vector<int>>("POINT1", {.size = 1}),
       entry<double>("RADIUS"),
       entry<double>("DENSITY"),

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -94,147 +94,147 @@ void Discret::Elements::TransportType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["HEX20"] = anonymous_group({
+  defs["HEX20"] = all_of({
       entry<std::vector<int>>("HEX20", {.size = 20}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["HEX27"] = anonymous_group({
+  defs["HEX27"] = all_of({
       entry<std::vector<int>>("HEX27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["NURBS27"] = anonymous_group({
+  defs["NURBS27"] = all_of({
       entry<std::vector<int>>("NURBS27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["NURBS8"] = anonymous_group({
+  defs["NURBS8"] = all_of({
       entry<std::vector<int>>("NURBS8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       entry<std::vector<int>>("TET10", {.size = 10}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["WEDGE6"] = anonymous_group({
+  defs["WEDGE6"] = all_of({
       entry<std::vector<int>>("WEDGE6", {.size = 6}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["WEDGE15"] = anonymous_group({
+  defs["WEDGE15"] = all_of({
       entry<std::vector<int>>("WEDGE15", {.size = 15}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["PYRAMID5"] = anonymous_group({
+  defs["PYRAMID5"] = all_of({
       entry<std::vector<int>>("PYRAMID5", {.size = 5}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["QUAD8"] = anonymous_group({
+  defs["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["NURBS4"] = anonymous_group({
+  defs["NURBS4"] = all_of({
       entry<std::vector<int>>("NURBS4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       entry<std::vector<int>>("NURBS9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["NURBS2"] = anonymous_group({
+  defs["NURBS2"] = all_of({
       entry<std::vector<int>>("NURBS2", {.size = 2}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),
       entry<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
   });
 
-  defs["NURBS3"] = anonymous_group({
+  defs["NURBS3"] = all_of({
       entry<std::vector<int>>("NURBS3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("TYPE"),

--- a/src/scatra_ele/4C_scatra_ele_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.cpp
@@ -135,7 +135,7 @@ void Discret::Elements::ScaTraHDGType ::setup_element_definition(
 
   for (const auto& [key, scatra_line_def] : defs_scatra)
   {
-    defs[key] = anonymous_group({
+    defs[key] = all_of({
         scatra_line_def,
         entry<int>("DEG"),
         entry<int>("SPC", {.required = false}),

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -83,7 +83,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defsgeneral["QUAD4"] = anonymous_group({
+  defsgeneral["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -98,7 +98,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       entry<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
   });
 
-  defsgeneral["QUAD8"] = anonymous_group({
+  defsgeneral["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -113,7 +113,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       entry<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
   });
 
-  defsgeneral["QUAD9"] = anonymous_group({
+  defsgeneral["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -128,7 +128,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       entry<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
   });
 
-  defsgeneral["TRI3"] = anonymous_group({
+  defsgeneral["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -141,7 +141,7 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       entry<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
   });
 
-  defsgeneral["TRI6"] = anonymous_group({
+  defsgeneral["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
       entry<double>("THICK"),

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -78,7 +78,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defsgeneral["QUAD4"] = anonymous_group({
+  defsgeneral["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -94,7 +94,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       entry<std::string>("TYPE", {.required = false}),
   });
 
-  defsgeneral["QUAD8"] = anonymous_group({
+  defsgeneral["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -110,7 +110,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       entry<std::string>("TYPE", {.required = false}),
   });
 
-  defsgeneral["QUAD9"] = anonymous_group({
+  defsgeneral["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -126,7 +126,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       entry<std::string>("TYPE", {.required = false}),
   });
 
-  defsgeneral["TRI3"] = anonymous_group({
+  defsgeneral["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<double>("THICK"),
@@ -140,7 +140,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       entry<std::string>("TYPE", {.required = false}),
   });
 
-  defsgeneral["TRI6"] = anonymous_group({
+  defsgeneral["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
       entry<double>("THICK"),

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
@@ -96,7 +96,7 @@ void Discret::Elements::KirchhoffLoveShellNurbsType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       entry<std::vector<int>>("NURBS9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::vector<int>>("GP", {.size = 2}),

--- a/src/so3/4C_so3_hex27.cpp
+++ b/src/so3/4C_so3_hex27.cpp
@@ -81,7 +81,7 @@ void Discret::Elements::SoHex27Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX27"] = anonymous_group({
+  defs["HEX27"] = all_of({
       entry<std::vector<int>>("HEX27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/so3/4C_so3_hex8.cpp
+++ b/src/so3/4C_so3_hex8.cpp
@@ -91,7 +91,7 @@ void Discret::Elements::SoHex8Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/so3/4C_so3_nurbs27.cpp
+++ b/src/so3/4C_so3_nurbs27.cpp
@@ -79,7 +79,7 @@ void Discret::Elements::Nurbs::SoNurbs27Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS27"] = anonymous_group({
+  defs["NURBS27"] = all_of({
       entry<std::vector<int>>("NURBS27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::vector<int>>("GP", {.size = 3}),

--- a/src/so3/4C_so3_poro_eletypes.cpp
+++ b/src/so3/4C_so3_poro_eletypes.cpp
@@ -67,7 +67,7 @@ void Discret::Elements::SoHex8PoroType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       defs_hex8["HEX8"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
@@ -147,7 +147,7 @@ void Discret::Elements::SoTet4PoroType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       defs_tet4["TET4"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
@@ -226,7 +226,7 @@ void Discret::Elements::SoHex27PoroType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["HEX27"] = anonymous_group({
+  defs["HEX27"] = all_of({
       defs_hex27["HEX27"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
@@ -302,7 +302,7 @@ void Discret::Elements::SoTet10PoroType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       defs_tet10["TET10"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
@@ -376,7 +376,7 @@ void Discret::Elements::SoNurbs27PoroType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["NURBS27"] = anonymous_group({
+  defs["NURBS27"] = all_of({
       defs_nurbs27["NURBS27"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),

--- a/src/so3/4C_so3_poro_p1_scatra_eletypes.cpp
+++ b/src/so3/4C_so3_poro_p1_scatra_eletypes.cpp
@@ -68,7 +68,7 @@ void Discret::Elements::SoHex8PoroP1ScatraType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       defs_hex8["HEX8"],
       entry<std::string>("TYPE"),
   });
@@ -128,7 +128,7 @@ void Discret::Elements::SoTet4PoroP1ScatraType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       defs_tet4["TET4"],
       entry<std::string>("TYPE"),
   });

--- a/src/so3/4C_so3_poro_scatra_eletypes.cpp
+++ b/src/so3/4C_so3_poro_scatra_eletypes.cpp
@@ -69,7 +69,7 @@ void Discret::Elements::SoHex8PoroScatraType::setup_element_definition(
   auto& defs = definitions[get_element_type_string()];
 
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       defs_hex8["HEX8"],
       entry<std::string>("TYPE"),
   });
@@ -131,7 +131,7 @@ void Discret::Elements::SoTet4PoroScatraType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       defs_tet4["TET4"],
       entry<std::string>("TYPE"),
   });
@@ -193,7 +193,7 @@ void Discret::Elements::SoHex27PoroScatraType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["HEX27"] = anonymous_group({
+  defs["HEX27"] = all_of({
       defs_hex27["HEX27"],
       entry<std::string>("TYPE"),
   });
@@ -256,7 +256,7 @@ void Discret::Elements::SoTet10PoroScatraType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       defs_tet10["TET10"],
       entry<std::string>("TYPE"),
   });
@@ -317,7 +317,7 @@ void Discret::Elements::SoNurbs27PoroScatraType::setup_element_definition(
 
   auto& defs = definitions[get_element_type_string()];
 
-  defs["NURBS27"] = anonymous_group({
+  defs["NURBS27"] = all_of({
       defs_nurbs27["NURBS27"],
       entry<std::string>("TYPE"),
   });

--- a/src/so3/4C_so3_sh8.cpp
+++ b/src/so3/4C_so3_sh8.cpp
@@ -74,7 +74,7 @@ void Discret::Elements::SoSh8Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/so3/4C_so3_tet10.cpp
+++ b/src/so3/4C_so3_tet10.cpp
@@ -86,7 +86,7 @@ void Discret::Elements::SoTet10Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       entry<std::vector<int>>("TET10", {.size = 10}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/so3/4C_so3_tet4.cpp
+++ b/src/so3/4C_so3_tet4.cpp
@@ -92,7 +92,7 @@ void Discret::Elements::SoTet4Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -31,7 +31,7 @@ namespace
   template <Core::FE::CellType celltype>
   auto get_default_input_spec()
   {
-    return anonymous_group({
+    return all_of({
         entry<std::vector<int>>(
             Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
         entry<int>("MAT"),
@@ -56,7 +56,7 @@ void Discret::Elements::SolidType::setup_element_definition(
 {
   auto& defsgeneral = definitions["SOLID"];
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       get_default_input_spec<Core::FE::CellType::hex8>(),
       entry<std::string>("TECH", {.required = false}),
   });
@@ -76,17 +76,17 @@ void Discret::Elements::SolidType::setup_element_definition(
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::tet10)] =
       get_default_input_spec<Core::FE::CellType::tet10>();
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::wedge6)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::wedge6)] = all_of({
       get_default_input_spec<Core::FE::CellType::wedge6>(),
       entry<std::string>("TECH", {.required = false}),
   });
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::pyramid5)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::pyramid5)] = all_of({
       get_default_input_spec<Core::FE::CellType::pyramid5>(),
       entry<std::string>("TECH", {.required = false}),
   });
 
-  defsgeneral["NURBS27"] = anonymous_group({
+  defsgeneral["NURBS27"] = all_of({
       entry<std::vector<int>>("NURBS27", {.size = 27}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -35,7 +35,7 @@ namespace Discret::Elements::SolidPoroPressureBasedInternal
     template <Core::FE::CellType celltype>
     auto get_default_input_spec()
     {
-      return anonymous_group({
+      return all_of({
           entry<std::vector<int>>(
               Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
           entry<int>("MAT"),
@@ -60,7 +60,7 @@ void Discret::Elements::SolidPoroPressureBasedType::setup_element_definition(
 {
   auto& defsgeneral = definitions["SOLIDPORO_PRESSURE_BASED"];
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       Discret::Elements::SolidPoroPressureBasedInternal::get_default_input_spec<
           Core::FE::CellType::hex8>(),
       entry<std::string>("EAS", {.required = false}),

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -34,7 +34,7 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
     template <Core::FE::CellType celltype>
     auto get_default_input_spec()
     {
-      return anonymous_group({
+      return all_of({
           entry<std::vector<int>>(
               Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
           entry<int>("MAT"),
@@ -61,7 +61,7 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
 {
   auto& defsgeneral = definitions["SOLIDPORO_PRESSURE_VELOCITY_BASED"];
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::hex8>(),
       entry<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 8}),
@@ -74,7 +74,7 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
           Core::FE::CellType::hex27>();
 
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::tet4)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::tet4)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::tet4>(),
       entry<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 8}),

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -27,7 +27,7 @@ namespace
   template <Core::FE::CellType celltype>
   auto get_default_input_spec()
   {
-    return anonymous_group({
+    return all_of({
         entry<std::vector<int>>(
             Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
         entry<int>("MAT"),
@@ -57,7 +57,7 @@ void Discret::Elements::SolidScatraType::setup_element_definition(
 {
   auto& defsgeneral = definitions["SOLIDSCATRA"];
 
-  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = anonymous_group({
+  defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       get_default_input_spec<Core::FE::CellType::hex8>(),
       entry<std::string>("TECH", {.required = false}),
   });

--- a/src/structure_new/src/utils/4C_structure_new_functions.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_functions.cpp
@@ -82,7 +82,7 @@ void Solid::add_valid_structure_functions(Core::Utils::FunctionManager& function
 {
   using namespace Core::IO::InputSpecBuilders;
 
-  auto spec = anonymous_group({
+  auto spec = all_of({
       one_of({
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE"),
           tag("WEAKLYCOMPRESSIBLE_ETIENNE_FSI_STRUCTURE_FORCE"),

--- a/src/thermo/4C_thermo_element.cpp
+++ b/src/thermo/4C_thermo_element.cpp
@@ -108,92 +108,92 @@ void Thermo::ElementType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = anonymous_group({
+  defs["HEX8"] = all_of({
       entry<std::vector<int>>("HEX8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["HEX20"] = anonymous_group({
+  defs["HEX20"] = all_of({
       entry<std::vector<int>>("HEX20", {.size = 20}),
       entry<int>("MAT"),
   });
 
-  defs["HEX27"] = anonymous_group({
+  defs["HEX27"] = all_of({
       entry<std::vector<int>>("HEX27", {.size = 27}),
       entry<int>("MAT"),
   });
 
-  defs["TET4"] = anonymous_group({
+  defs["TET4"] = all_of({
       entry<std::vector<int>>("TET4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["TET10"] = anonymous_group({
+  defs["TET10"] = all_of({
       entry<std::vector<int>>("TET10", {.size = 10}),
       entry<int>("MAT"),
   });
 
-  defs["WEDGE6"] = anonymous_group({
+  defs["WEDGE6"] = all_of({
       entry<std::vector<int>>("WEDGE6", {.size = 6}),
       entry<int>("MAT"),
   });
 
-  defs["WEDGE15"] = anonymous_group({
+  defs["WEDGE15"] = all_of({
       entry<std::vector<int>>("WEDGE15", {.size = 15}),
       entry<int>("MAT"),
   });
 
-  defs["PYRAMID5"] = anonymous_group({
+  defs["PYRAMID5"] = all_of({
       entry<std::vector<int>>("PYRAMID5", {.size = 5}),
       entry<int>("MAT"),
   });
 
-  defs["NURBS27"] = anonymous_group({
+  defs["NURBS27"] = all_of({
       entry<std::vector<int>>("NURBS27", {.size = 27}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD8"] = anonymous_group({
+  defs["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
   });
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
   });
 
-  defs["NURBS4"] = anonymous_group({
+  defs["NURBS4"] = all_of({
       entry<std::vector<int>>("NURBS4", {.size = 4}),
       entry<int>("MAT"),
   });
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       entry<std::vector<int>>("NURBS9", {.size = 9}),
       entry<int>("MAT"),
   });
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
   });
 
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("MAT"),
   });

--- a/src/torsion3/4C_torsion3.cpp
+++ b/src/torsion3/4C_torsion3.cpp
@@ -73,7 +73,7 @@ void Discret::Elements::Torsion3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE3"] = anonymous_group({
+  defs["LINE3"] = all_of({
       entry<std::vector<int>>("LINE3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("BENDINGPOTENTIAL"),

--- a/src/truss3/4C_truss3.cpp
+++ b/src/truss3/4C_truss3.cpp
@@ -74,7 +74,7 @@ void Discret::Elements::Truss3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       entry<std::vector<int>>("LINE2", {.size = 2}),
       entry<int>("MAT"),
       entry<double>("CROSS"),

--- a/src/truss3/4C_truss3_scatra.cpp
+++ b/src/truss3/4C_truss3_scatra.cpp
@@ -79,7 +79,7 @@ void Discret::Elements::Truss3ScatraType::setup_element_definition(
   auto& defs_truss = definitions_truss["TRUSS3"];
 
   // copy definitions of standard truss element to truss element for scalar transport coupling
-  defs["LINE2"] = anonymous_group({
+  defs["LINE2"] = all_of({
       defs_truss["LINE2"],
       entry<std::string>("TYPE"),
   });

--- a/src/w1/4C_w1.cpp
+++ b/src/w1/4C_w1.cpp
@@ -71,7 +71,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       entry<std::vector<int>>("QUAD4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -81,7 +81,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["QUAD8"] = anonymous_group({
+  defs["QUAD8"] = all_of({
       entry<std::vector<int>>("QUAD8", {.size = 8}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -91,7 +91,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       entry<std::vector<int>>("QUAD9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -101,7 +101,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       entry<std::vector<int>>("TRI3", {.size = 3}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -111,7 +111,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["TRI6"] = anonymous_group({
+  defs["TRI6"] = all_of({
       entry<std::vector<int>>("TRI6", {.size = 6}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -121,7 +121,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["NURBS4"] = anonymous_group({
+  defs["NURBS4"] = all_of({
       entry<std::vector<int>>("NURBS4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -131,7 +131,7 @@ void Discret::Elements::Wall1Type::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       entry<std::vector<int>>("NURBS9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/w1/4C_w1_nurbs.cpp
+++ b/src/w1/4C_w1_nurbs.cpp
@@ -70,7 +70,7 @@ void Discret::Elements::Nurbs::Wall1NurbsType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS4"] = anonymous_group({
+  defs["NURBS4"] = all_of({
       entry<std::vector<int>>("NURBS4", {.size = 4}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),
@@ -80,7 +80,7 @@ void Discret::Elements::Nurbs::Wall1NurbsType::setup_element_definition(
       entry<std::vector<int>>("GP", {.size = 2}),
   });
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       entry<std::vector<int>>("NURBS9", {.size = 9}),
       entry<int>("MAT"),
       entry<std::string>("KINEM"),

--- a/src/w1/4C_w1_poro_eletypes.cpp
+++ b/src/w1/4C_w1_poro_eletypes.cpp
@@ -64,7 +64,7 @@ void Discret::Elements::WallQuad4PoroType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       defs_wall["QUAD4"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
@@ -137,7 +137,7 @@ void Discret::Elements::WallQuad9PoroType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       defs_wall["QUAD9"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
@@ -209,7 +209,7 @@ void Discret::Elements::WallNurbs4PoroType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS4"] = anonymous_group({
+  defs["NURBS4"] = all_of({
       defs_wall["NURBS4"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
@@ -281,7 +281,7 @@ void Discret::Elements::WallNurbs9PoroType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       defs_wall["NURBS9"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
@@ -353,7 +353,7 @@ void Discret::Elements::WallTri3PoroType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       defs_wall["TRI3"],
       entry<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
       entry<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),

--- a/src/w1/4C_w1_poro_p1_scatra_eletypes.cpp
+++ b/src/w1/4C_w1_poro_p1_scatra_eletypes.cpp
@@ -76,7 +76,7 @@ void Discret::Elements::WallQuad4PoroP1ScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       defs_wallporo["QUAD4"],
       entry<std::string>("TYPE"),
   });
@@ -146,7 +146,7 @@ void Discret::Elements::WallQuad9PoroP1ScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       defs_wallporo["QUAD9"],
       entry<std::string>("TYPE"),
   });
@@ -213,7 +213,7 @@ void Discret::Elements::WallTri3PoroP1ScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       defs_wallporo["TRI3"],
       entry<std::string>("TYPE"),
   });

--- a/src/w1/4C_w1_poro_scatra_eletypes.cpp
+++ b/src/w1/4C_w1_poro_scatra_eletypes.cpp
@@ -73,7 +73,7 @@ void Discret::Elements::WallQuad4PoroScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD4"] = anonymous_group({
+  defs["QUAD4"] = all_of({
       defs_wall["QUAD4"],
       entry<std::string>("TYPE"),
   });
@@ -140,7 +140,7 @@ void Discret::Elements::WallQuad9PoroScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["QUAD9"] = anonymous_group({
+  defs["QUAD9"] = all_of({
       defs_wall["QUAD9"],
       entry<std::string>("TYPE"),
   });
@@ -207,7 +207,7 @@ void Discret::Elements::WallNurbs4PoroScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS4"] = anonymous_group({
+  defs["NURBS4"] = all_of({
       defs_wall["NURBS4"],
       entry<std::string>("TYPE"),
   });
@@ -274,7 +274,7 @@ void Discret::Elements::WallNurbs9PoroScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["NURBS9"] = anonymous_group({
+  defs["NURBS9"] = all_of({
       defs_wall["NURBS9"],
       entry<std::string>("TYPE"),
   });
@@ -341,7 +341,7 @@ void Discret::Elements::WallTri3PoroScatraType::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["TRI3"] = anonymous_group({
+  defs["TRI3"] = all_of({
       defs_wall["TRI3"],
       entry<std::string>("TYPE"),
   });

--- a/src/w1/4C_w1_scatra.cpp
+++ b/src/w1/4C_w1_scatra.cpp
@@ -61,7 +61,7 @@ void Discret::Elements::Wall1ScatraType::setup_element_definition(
 
   for (const auto& [key, wall_line_def] : defs_wall)
   {
-    defs[key] = anonymous_group({
+    defs[key] = all_of({
         wall_line_def,
         entry<std::string>("TYPE"),
     });


### PR DESCRIPTION
In discussion with @c-p-schmidt and @lauraengelhardt we realized that `anonymous_group` is actually `all_of`, the counterpart of `one_of`.