### PR TITLE
Add workflow for testing against Trilinos develop

### DIFF
--- a/.github/workflows/trilinos-develop.yml
+++ b/.github/workflows/trilinos-develop.yml
@@ -1,0 +1,118 @@
+name: Trilinos develop
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 8 * * 6'
+
+env:
+  IMAGE_NAME: ghcr.io/4c-multiphysics/4c-dependencies-trilinos
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-push-trilinos-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          labels: |
+            org.opencontainers.image.description=Image containing all the dependencies required for building and testing 4C based on the specified Trilinos commit ref
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: .
+          file: docker/trilinos_develop/Dockerfile
+          build-args: |
+            TRILINOS_VERSION=develop
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:develop
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build:
+    needs: build-and-push-trilinos-image
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos:develop
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      test-chunks: ${{ steps.set-matrix.outputs.chunk-array }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build_4C
+        with:
+          cmake-preset: docker_assertions
+          build-targets: full
+          build-directory: ${{ github.workspace }}/build
+          use-ccache: "false"
+      - uses: ./.github/actions/upload_4C_build
+        with:
+          build-directory: ${{ github.workspace }}/build
+          retention-days: 1
+      - uses: ./.github/actions/chunk_test_suite
+        id: set-matrix
+        with:
+          build-directory: ${{ github.workspace }}/build
+          source-directory: ${{ github.workspace }}
+          number-of-chunks: 15
+          junit-report-artifact-name: trilinos_test_report.xml
+
+  test:
+    needs: build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-trilinos:develop
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    strategy:
+      fail-fast: false
+      matrix:
+        test-chunk: ${{fromJson(needs.build.outputs.test-chunks)}}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: build
+          destination: ${{ github.workspace }}/build
+      - name: Test
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/trilinos_test_report-$TEST_CHUNK.xml
+        env:
+          TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        if: success() || failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: trilinos_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/trilinos_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1

--- a/dependencies/trilinos_develop/trilinos/install.sh
+++ b/dependencies/trilinos_develop/trilinos/install.sh
@@ -22,7 +22,7 @@ VERSION=${2:-develop}
 
 
 # Location of script to apply patches later
-SCRIPT_DIR="`dirname "$0"`"
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 CMAKE_COMMAND=cmake
 
 git clone https://github.com/trilinos/Trilinos.git
@@ -111,3 +111,4 @@ $CMAKE_COMMAND \
 
 make -j${NPROCS} install
 cd ..
+rm -rf Trilinos trilinos_build

--- a/docker/trilinos_develop/Dockerfile
+++ b/docker/trilinos_develop/Dockerfile
@@ -5,8 +5,9 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-FROM ubuntu:focal
-LABEL project=4C
+FROM ubuntu:24.04
+LABEL org.opencontainers.image.description="Image containing all the dependencies required for building and testing 4C based on the specified Trilinos commit ref"
+LABEL org.4c-multiphysics.project=4C
 
 # Prevents tzdata asking for user feedback
 ENV DEBIAN_FRONTEND=noninteractive
@@ -15,8 +16,9 @@ USER root
 
 # Set locale information:. region and timezone
 RUN apt-get update && apt-get install -y locales && \
-    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
-RUN locale-gen en_US.UTF-8
+    localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8 && \
+    locale-gen en_US.UTF-8 && \
+    rm -rf /var/lib/apt/lists/*
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
@@ -30,9 +32,9 @@ RUN apt-get update && apt-get install -y \
       sudo \
       unzip \
       vim \
-      wget
-
-RUN apt-get update && apt-get install -y \
+      wget \
+      && \
+    apt-get install -y \
       doxygen \
       graphviz \
       texinfo \
@@ -46,14 +48,19 @@ RUN apt-get update && apt-get install -y \
       libfftw3-dev \
       lld \
       python3 \
-      python3.8-venv \
+      python3-venv \
       python-is-python3 \
       liblapack-dev \
       libopenmpi-dev \
       libparmetis-dev \
       metis \
       ninja-build \
-      libyaml-dev
+      libyaml-dev \
+      clang \
+      clang-tidy \
+      clang-tools \
+      libomp-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Create directory for dependencies
 ARG NPROCS=12
@@ -67,17 +74,20 @@ COPY dependencies /dependencies
 # Install cmake
 RUN /dependencies/current/cmake/install.sh /usr/local
 
-# Install SuiteSparse
+# Install SuiteSparse 5.4.0
 RUN /dependencies/current/suitesparse/install.sh ${INSTALL_DIR}
 
-# Install superLU_dist
+# Install superLU_dist 7.2.0
 RUN /dependencies/current/superlu_dist/install.sh ${INSTALL_DIR}
 
-# Install qhull
+# Install qhull 2012.1
 RUN /dependencies/current/qhull/install.sh ${INSTALL_DIR}
 
 # Install Trilinos
 RUN /dependencies/trilinos_develop/trilinos/install.sh ${INSTALL_DIR} ${TRILINOS_VERSION}
+
+# Install deal.II (needs to happen after Trilinos)
+RUN /dependencies/current/dealii/install.sh ${INSTALL_DIR}
 
 # Install (optional) backtrace library
 RUN /dependencies/current/backtrace/install.sh ${INSTALL_DIR}
@@ -87,9 +97,6 @@ RUN /dependencies/current/backtrace/install.sh ${INSTALL_DIR}
 ENV FOUR_C_TESTING_DEPENDENCIES_DIR="/opt/4C-dependencies-testing/"
 RUN mkdir ${FOUR_C_TESTING_DEPENDENCIES_DIR}
 
-# Install LLVM (use standard install directory)
-RUN /dependencies/testing/llvm/install.sh /usr/local
-
 # Install Mathjax
 RUN /dependencies/testing/mathjax/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}
 
@@ -97,7 +104,7 @@ RUN /dependencies/testing/mathjax/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}
 RUN /dependencies/testing/paraview/install.sh ${FOUR_C_TESTING_DEPENDENCIES_DIR}
 
 # add and enable the default user
-ARG USER=user
+ENV USER=user
 RUN adduser --disabled-password --shell '/usr/bin/bash' --gecos '' $USER
 RUN adduser $USER sudo; echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 

--- a/utilities/four_c_utils/src/four_c_utils/check_workflow_dependencies_hash.py
+++ b/utilities/four_c_utils/src/four_c_utils/check_workflow_dependencies_hash.py
@@ -37,7 +37,7 @@ def main():
                 if "container" in job and "image" in job["container"]:
                     image_name = job["container"]["image"]
                     if image_name.startswith(
-                        "ghcr.io/4c-multiphysics/4c-dependencies"
+                        "ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04"
                     ) and not image_name.endswith(f":{dependencies_hash}"):
                         if file not in jobs_with_wrong_dependency_hash:
                             jobs_with_wrong_dependency_hash[file] = []


### PR DESCRIPTION
## Description and Context
This PR adds a workflow that builds the 4C dependencies image with the Trilinos develop branch, builds 4C, and runs the tests. The workflow is scheduled to run on Saturdays at 8:00 am. 

~~Adds a workflow that builds the Docker image with the Trilinos develop version, builds 4C, and runs the tests.
This is a draft for now because~~
1. ~~the [build fails](https://github.com/ppraegla/4C/actions/runs/13005412107/job/36271309120) (something with arborX) and~~ fixed with #591 
2. ~~the workflow schedule is not finalized yet. Ideally, I would like to run this workflow weekly and allow the option to run the workflow manually for specific commit SHAs. However, I have not yet found a nice way to add the manual trigger without duplicating the jobs.~~ I think a manual run of the workflow with a different commit than the develop branch is not needed at the moment

@maxfirmbach , @eulovi (I added you to my fork. So you can directly push to my branch. Hopefully, this works)

## Related Issues and Merge Requests
#288, #291, #290
