### PR TITLE
Provide more input metadata for schema generation

### DIFF
--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -269,8 +269,7 @@ int main(int argc, char* argv[])
   {
     if (Core::Communication::my_mpi_rank(lcomm) == 0)
     {
-      auto valid_parameters = Input::valid_parameters();
-      Core::IO::print_metadata_yaml(std::cout, *valid_parameters);
+      write_input_metadata(std::cout);
     }
   }
   else if ((argc == 2) && ((strcmp(argv[1], "-d") == 0) || (strcmp(argv[1], "--datfile") == 0)))

--- a/src/core/io/src/4C_io_input_file_utils.hpp
+++ b/src/core/io/src/4C_io_input_file_utils.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_io_input_parameter_container.hpp"
+#include "4C_io_input_spec.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 #include <functional>
@@ -57,11 +58,16 @@ namespace Core::IO
 
 
   /**
-   * Print the metadata of what can be put into a ParameterList @p list. The result is formatted as
-   * YAML. This information can be useful for additional tools that generate schema files or
-   * documentation.
+   * Print the metadata of what can be put into a ParameterList @p list. All nested sub-lists inside
+   * @p list are concatenated into a top-level input file section containing the respective
+   * parameters of that sublist. Additionally, @p section_specs contains the InputSpec which may
+   * be read for a specific section.
+   *
+   * The output is formatted as YAML. This information can be useful for additional tools that
+   * generate schema files or documentation.
    */
-  void print_metadata_yaml(std::ostream& stream, const Teuchos::ParameterList& list);
+  void print_metadata_yaml(std::ostream& stream, const Teuchos::ParameterList& list,
+      const std::map<std::string, InputSpec>& section_specs = {});
 
   /**
    * Return true if the @p list contains any parameter that has whitespace in the key name.

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -62,8 +62,7 @@ void Core::IO::InputSpec::emit_metadata(YamlEmitter& yaml) const
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
 
   auto root = yaml.node;
-  root |= ryml::MAP;
-  pimpl_->emit_metadata(root.append_child());
+  pimpl_->emit_metadata(root);
 }
 
 Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl()

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -215,17 +215,24 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::print(
 
 void Core::IO::InputSpecBuilders::Internal::GroupSpec::emit_metadata(ryml::NodeRef node) const
 {
-  node << ryml::key(name.empty() ? data.description : name);
   node |= ryml::MAP;
+  if (!name.empty())
+  {
+    node["name"] << name;
+  }
 
   node["type"] << (name.empty() ? "all_of" : "group");
-  node["description"] << data.description;
+  if (!data.description.empty())
+  {
+    node["description"] << data.description;
+  }
   emit_value_as_yaml(node["required"], data.required);
-  node["specs"] |= ryml::MAP;
+  node["specs"] |= ryml::SEQ;
   {
     for (const auto& spec : specs)
     {
       auto child = node["specs"].append_child();
+      child |= ryml::MAP;
       spec.impl().emit_metadata(child);
     };
   }
@@ -308,13 +315,15 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::print(
 
 void Core::IO::InputSpecBuilders::Internal::OneOfSpec::emit_metadata(ryml::NodeRef node) const
 {
-  node << ryml::key(data.description);
   node |= ryml::MAP;
 
   node["type"] << "one_of";
-  node["description"] << data.description;
+  if (!data.description.empty())
+  {
+    node["description"] << data.description;
+  }
   emit_value_as_yaml(node["required"], data.required);
-  node["specs"] |= ryml::MAP;
+  node["specs"] |= ryml::SEQ;
   for (const auto& spec : specs)
   {
     auto child = node["specs"].append_child();

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -923,14 +923,26 @@ void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataTypeIn>::emit_metadata
     ryml::NodeRef node) const
 {
   node |= ryml::MAP;
-  node << ryml::key(name);
+  node["name"] << name;
 
   node["type"] << IO::Internal::get_pretty_type_name<StoredType>();
-  node["description"] << data.description;
+  if (!data.description.empty())
+  {
+    node["description"] << data.description;
+  }
   emit_value_as_yaml(node["required"], data.required.value());
   if (data.default_value.has_value())
   {
     emit_value_as_yaml(node["default"], data.default_value.value());
+  }
+
+  if constexpr (InputSpecBuilders::Internal::is_sized_data<DataType>)
+  {
+    // Size can only be emitted if it is fixed.
+    if (data.size.index() == 0)
+    {
+      node["size"] << std::get<0>(data.size);
+    }
   }
 }
 
@@ -994,10 +1006,13 @@ void Core::IO::InputSpecBuilders::Internal::SelectionSpec<DataTypeIn>::emit_meta
     ryml::NodeRef node) const
 {
   node |= ryml::MAP;
-  node << ryml::key(name);
+  node["name"] << name;
 
   node["type"] = "selection";
-  node["description"] << data.description;
+  if (!data.description.empty())
+  {
+    node["description"] << data.description;
+  }
   emit_value_as_yaml(node["required"], data.required.value());
   if (data.default_value.has_value())
   {
@@ -1046,8 +1061,8 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::user_defined(std::string name, 
 {
   auto default_emitter = [name](ryml::NodeRef node)
   {
-    node << ryml::key(name);
     node |= ryml::MAP;
+    node["name"] << name;
     node["type"] = "user_defined";
   };
 

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -561,11 +561,17 @@ namespace
             }),
             group("group",
                 {
-                    entry<std::string>("c"),
+                    entry<std::string>("c", {.description = "A string"}),
                     entry<double>("d"),
-                }),
+                },
+                {.description = "A group"}),
         }),
         selection<int>("e", {{"e1", 1}, {"e2", 2}}, {.default_value = 1}),
+        group("group2",
+            {
+                entry<int>("g"),
+            },
+            {.required = false}),
     });
 
 
@@ -577,63 +583,63 @@ namespace
       line.emit_metadata(yaml);
       out << tree;
 
-      std::string expected = R"('all_of {a, b, one_of {all_of {b, c}, group}, e}':
-  type: all_of
-  description: 'all_of {a, b, one_of {all_of {b, c}, group}, e}'
-  required: true
-  specs:
-    a:
-      type: int
-      description: ''
-      required: false
-      default: 42
-    b:
-      type: vector<double>
-      description: ''
-      required: false
-      default: [1,2,3]
-    'one_of {all_of {b, c}, group}':
-      type: one_of
-      description: 'one_of {all_of {b, c}, group}'
-      required: true
-      specs:
-        'all_of {b, c}':
-          type: all_of
-          description: 'all_of {b, c}'
-          required: true
-          specs:
-            b:
-              type: 'pair<int, string>'
-              description: ''
-              required: false
-              default: [1,abc]
-            c:
-              type: string
-              description: ''
-              required: true
-        group:
-          type: group
-          description: ''
-          required: true
-          specs:
-            c:
-              type: string
-              description: ''
-              required: true
-            d:
-              type: double
-              description: ''
-              required: true
-    e:
-      type: selection
-      description: ''
-      required: false
-      default: 1
-      choices:
-        e1: 1
-        e2: 2
+      std::string expected = R"(type: all_of
+description: 'all_of {a, b, one_of {all_of {b, c}, group}, e, group2}'
+required: true
+specs:
+  - name: a
+    type: int
+    required: false
+    default: 42
+  - name: b
+    type: vector<double>
+    required: false
+    default: [1,2,3]
+    size: 3
+  - type: one_of
+    description: 'one_of {all_of {b, c}, group}'
+    required: true
+    specs:
+      - type: all_of
+        description: 'all_of {b, c}'
+        required: true
+        specs:
+          - name: b
+            type: 'pair<int, string>'
+            required: false
+            default: [1,abc]
+          - name: c
+            type: string
+            required: true
+      - name: group
+        type: group
+        description: A group
+        required: true
+        specs:
+          - name: c
+            type: string
+            description: A string
+            required: true
+          - name: d
+            type: double
+            required: true
+  - name: e
+    type: selection
+    required: false
+    default: 1
+    choices:
+      e1: 1
+      e2: 2
+  - name: group2
+    type: group
+    required: false
+    specs:
+      - name: g
+        type: int
+        required: true
 )";
       EXPECT_EQ(out.str(), expected);
+      std::cout << out.str() << std::endl;
     }
   }
 

--- a/src/global_legacy_module/4C_global_legacy_module.hpp
+++ b/src/global_legacy_module/4C_global_legacy_module.hpp
@@ -22,6 +22,14 @@ FOUR_C_NAMESPACE_OPEN
  */
 [[nodiscard]] ModuleCallbacks global_legacy_module_callbacks();
 
+/**
+ * Write metadata for input files to @p out.
+ *
+ * @note This function exists for historic reasons. Its internals need to be split up to remove
+ * forced dependencies on the main apps.
+ */
+void write_input_metadata(std::ostream& out);
+
 FOUR_C_NAMESPACE_CLOSE
 
 #endif


### PR DESCRIPTION
Part of #113 

Includes a few of the more complicated input file sections. The remaining ones need a little bit of polishing and simplification to be as easy to add.

Draft as I will iterate over this state with @gilrrei to see which (more or less arbitrary) structure makes the most sense for our 4C_metadata.yaml.