### PR TITLE
Remove input tag() in functions

### DIFF
--- a/src/core/utils/src/functions/4C_utils_function.cpp
+++ b/src/core/utils/src/functions/4C_utils_function.cpp
@@ -272,11 +272,11 @@ Core::Utils::try_create_symbolic_function_of_space_time(
           // read periodicity data
           Periodicstruct periodicdata{};
 
-          periodicdata.periodic = line.get<bool>("PERIODIC");
+          periodicdata.periodic = line.has_group("PERIODIC");
           if (periodicdata.periodic)
           {
-            periodicdata.t1 = line.get<double>("T1");
-            periodicdata.t2 = line.get<double>("T2");
+            periodicdata.t1 = line.group("PERIODIC").get<double>("T1");
+            periodicdata.t2 = line.group("PERIODIC").get<double>("T2");
           }
           else
           {
@@ -287,16 +287,9 @@ Core::Utils::try_create_symbolic_function_of_space_time(
           // distinguish the type of the variable
           if (vartype == "expression")
           {
-            auto description_vec = line.get<std::vector<std::string>>("DESCRIPTION");
-            if (description_vec.size() != 1)
-            {
-              FOUR_C_THROW(
-                  "Only expect one DESCRIPTION for variable of type 'expression' but %d were "
-                  "given.",
-                  description_vec.size());
-            }
+            auto description = line.get<std::string>("DESCRIPTION");
 
-            return std::make_shared<ParsedFunctionVariable>(varname, description_vec.front());
+            return std::make_shared<ParsedFunctionVariable>(varname, description);
           }
           else if (vartype == "linearinterpolation")
           {

--- a/src/core/utils/src/functions/4C_utils_function_library.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_library.cpp
@@ -31,15 +31,17 @@ namespace
 
     const auto& function_lin_def = parameters.front();
 
-    if (function_lin_def.get_or<bool>("FASTPOLYNOMIAL", false))
+    if (function_lin_def.has_group("FASTPOLYNOMIAL"))
     {
-      std::vector<double> coefficients = function_lin_def.get<std::vector<double>>("COEFF");
+      const auto& group = function_lin_def.group("FASTPOLYNOMIAL");
+      std::vector<double> coefficients = group.get<std::vector<double>>("COEFF");
 
       return std::make_shared<Core::Utils::FastPolynomialFunction>(std::move(coefficients));
     }
-    else if (function_lin_def.get_or<bool>("CUBIC_SPLINE_FROM_CSV", false))
+    else if (function_lin_def.has_group("CUBIC_SPLINE_FROM_CSV"))
     {
-      const auto csv_file = function_lin_def.get<std::filesystem::path>("CSV");
+      const auto& group = function_lin_def.group("CUBIC_SPLINE_FROM_CSV");
+      const auto csv_file = group.get<std::filesystem::path>("CSV");
 
       // safety check
       if (csv_file.empty())
@@ -62,15 +64,15 @@ void Core::Utils::add_valid_library_functions(Core::Utils::FunctionManager& func
   using namespace IO::InputSpecBuilders;
 
   auto spec = one_of({
-      all_of({
-          tag("FASTPOLYNOMIAL"),
-          entry<int>("NUMCOEFF"),
-          entry<std::vector<double>>("COEFF", {.size = from_parameter<int>("NUMCOEFF")}),
-      }),
-      all_of({
-          tag("CUBIC_SPLINE_FROM_CSV"),
-          entry<std::filesystem::path>("CSV"),
-      }),
+      group("FASTPOLYNOMIAL",
+          {
+              entry<int>("NUMCOEFF"),
+              entry<std::vector<double>>("COEFF", {.size = from_parameter<int>("NUMCOEFF")}),
+          }),
+      group("CUBIC_SPLINE_FROM_CSV",
+          {
+              entry<std::filesystem::path>("CSV"),
+          }),
   });
 
   function_manager.add_function_definition(spec, create_library_function_scalar);

--- a/src/core/utils/src/functions/4C_utils_function_of_time.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_of_time.cpp
@@ -146,11 +146,11 @@ std::shared_ptr<Core::Utils::FunctionOfTime> Core::Utils::try_create_function_of
           // read periodicity data
           Periodicstruct periodicdata{};
 
-          periodicdata.periodic = line.get<bool>("PERIODIC");
+          periodicdata.periodic = line.has_group("PERIODIC");
           if (periodicdata.periodic)
           {
-            periodicdata.t1 = line.get<double>("T1");
-            periodicdata.t2 = line.get<double>("T2");
+            periodicdata.t1 = line.group("PERIODIC").get<double>("T1");
+            periodicdata.t2 = line.group("PERIODIC").get<double>("T2");
           }
           else
           {

--- a/src/core/utils/src/functions/4C_utils_functionvariables.cpp
+++ b/src/core/utils/src/functions/4C_utils_functionvariables.cpp
@@ -536,7 +536,7 @@ std::vector<double> Core::Utils::Internal::extract_time_vector(
   int numpoints = timevar.get<int>("NUMPOINTS");
 
   // read whether times are defined by number of points or by vector
-  bool bynum = timevar.get<bool>("BYNUM");
+  bool bynum = timevar.has_group("BYNUM");
 
   // read respectively create times vector
   std::vector<double> times = std::invoke(
@@ -545,7 +545,7 @@ std::vector<double> Core::Utils::Internal::extract_time_vector(
         if (bynum)  // times defined by number of points
         {
           // read the time range
-          auto timerange = timevar.get<std::vector<double>>("TIMERANGE");
+          auto timerange = timevar.group("BYNUM").get<std::vector<double>>("TIMERANGE");
 
           std::vector<double> times;
 


### PR DESCRIPTION
As described in #73, the `tag()` function is rather questionable as we nowadays have better ways to describe input, e.g. `group()`, `one_of` and `selection`. This PR removes the tags from the functions. Note that I favored backward-compatibility and only performed restructuring that does not break existing files.