### PR TITLE
Remove output of membrane thickness from old structure time integration

### DIFF
--- a/src/membrane/4C_membrane_evaluate.cpp
+++ b/src/membrane/4C_membrane_evaluate.cpp
@@ -115,8 +115,6 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       act = Core::Elements::struct_calc_reset_istep;
     else if (action == "calc_struct_stress")
       act = Core::Elements::struct_calc_stress;
-    else if (action == "calc_struct_thickness")
-      act = Core::Elements::struct_calc_thickness;
     else if (action == "calc_struct_energy")
       act = Core::Elements::struct_calc_energy;
     else if (action == "postprocess_thickness")
@@ -281,12 +279,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       // nothing to do for ghost elements
       if (Core::Communication::my_mpi_rank(discretization.get_comm()) == owner())
       {
-        std::shared_ptr<std::vector<char>> thickdata = nullptr;
-
-        if (is_params_interface())  // new structural time integration
-          thickdata = str_params_interface().opt_quantity_data_ptr();
-        else  // old structural time integration
-          thickdata = params.get<std::shared_ptr<std::vector<char>>>("optquantity", nullptr);
+        auto thickdata = str_params_interface().opt_quantity_data_ptr();
 
         if (thickdata == nullptr) FOUR_C_THROW("Cannot get 'thickness' data");
 

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -382,9 +382,6 @@ namespace Solid
     //! Calculate kinetic, internal and external energy
     virtual void determine_energy();
 
-    //! Calculate an optional quantity
-    void determine_optional_quantity();
-
     /// create result test for encapsulated structure algorithm
     std::shared_ptr<Core::Utils::ResultTest> create_field_test() override;
 
@@ -455,11 +452,6 @@ namespace Solid
 
     //! Energy output
     void output_energy();
-
-    //! Optional quantity output
-    void output_opt_quantity(bool& datawritten  //!< (in/out) read and append if
-                                                //!< it was written at this time step
-    );
 
     //! Active set, energy and momentum output for contact
     void output_contact();
@@ -1063,11 +1055,10 @@ namespace Solid
     Inpar::Solid::StressType writecouplstress_;  //!< output type of coupling stress
     Inpar::Solid::StrainType writestrain_;       //!< strain output type
     Inpar::Solid::StrainType writeplstrain_;     //!< plastic strain output type
-    Inpar::Solid::OptQuantityType writeoptquantity_;  //!< stress output type
-    int writeenergyevery_;                            //!< write system energy every given step
-    bool writesurfactant_;                            //!< write surfactant output
-    bool writerotation_;                              //!< write strutural rotation tensor output
-    std::shared_ptr<std::ofstream> energyfile_;       //!< outputfile for energy
+    int writeenergyevery_;                       //!< write system energy every given step
+    bool writesurfactant_;                       //!< write surfactant output
+    bool writerotation_;                         //!< write strutural rotation tensor output
+    std::shared_ptr<std::ofstream> energyfile_;  //!< outputfile for energy
 
     std::shared_ptr<std::vector<char>> stressdata_;  //!< container for element GP stresses
     std::shared_ptr<std::vector<char>>
@@ -1075,11 +1066,9 @@ namespace Solid
     std::shared_ptr<std::vector<char>> straindata_;  //!< container for element GP strains
     std::shared_ptr<std::vector<char>> plstraindata_;  //!< container for element GP plastic strains
     std::shared_ptr<std::vector<char>> rotdata_;       //!< container for element rotation tensor
-    std::shared_ptr<std::vector<char>>
-        optquantitydata_;  //!< container for element GP optional quantities
-    double kinergy_;       //!< kinetic energy
-    double intergy_;       //!< internal energy
-    double extergy_;       //!< external energy
+    double kinergy_;                                   //!< kinetic energy
+    double intergy_;                                   //!< internal energy
+    double extergy_;                                   //!< external energy
     //@}
 
     //! @name Damping

--- a/src/structure_new/src/4C_structure_new_elements_paramsinterface.hpp
+++ b/src/structure_new/src/4C_structure_new_elements_paramsinterface.hpp
@@ -157,7 +157,7 @@ namespace Solid
 
       virtual std::shared_ptr<std::vector<char>>& coupling_stress_data_ptr() = 0;
 
-      virtual std::shared_ptr<std::vector<char>>& opt_quantity_data_ptr() = 0;
+      virtual std::shared_ptr<std::vector<char>> opt_quantity_data_ptr() = 0;
 
       //! get the current stress type
       virtual enum Inpar::Solid::StressType get_stress_output_type() const = 0;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -584,7 +584,7 @@ const std::vector<char>& Solid::ModelEvaluator::Data::coupling_stress_data() con
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::shared_ptr<std::vector<char>>& Solid::ModelEvaluator::Data::opt_quantity_data_ptr()
+std::shared_ptr<std::vector<char>> Solid::ModelEvaluator::Data::opt_quantity_data_ptr()
 {
   check_init_setup();
   return optquantitydata_ptr_;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -185,7 +185,7 @@ namespace Solid
       std::shared_ptr<std::vector<char>>& coupling_stress_data_ptr() override;
 
       //! mutable access to the optional quantity data vector
-      std::shared_ptr<std::vector<char>>& opt_quantity_data_ptr() override;
+      std::shared_ptr<std::vector<char>> opt_quantity_data_ptr() override;
 
       //! get the current stress type [derived]
       [[nodiscard]] enum Inpar::Solid::StressType get_stress_output_type() const override;


### PR DESCRIPTION
## Description and Context
While working on some vtk-based output inside the new structure time integration I realized that the membrane output in the old time integration is unused. Thus removing it as a preparatory step for the vtk-based output.

## Related Issues and Merge Requests
Related to #211 
