### PR TITLE
Add const qualifier to nullspace extraction

### DIFF
--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -162,27 +162,18 @@ void Core::LinearSolver::Parameters::fix_null_space(std::string field, const Epe
 //----------------------------------------------------------------------------------
 Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
 Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist(
-    const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& row_map, Teuchos::ParameterList& list)
+    const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& row_map,
+    const Teuchos::ParameterList& list)
 {
   if (!list.isParameter("null space: dimension"))
-    FOUR_C_THROW(
-        "Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist: Multigrid "
-        "parameter "
-        "'null space: dimension' missing  in solver parameter list.");
+    FOUR_C_THROW("Multigrid parameter 'null space: dimension' missing  in solver parameter list.");
 
   const int nullspace_dimension = list.get<int>("null space: dimension");
   if (nullspace_dimension < 1)
-    FOUR_C_THROW(
-        "Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist: Multigrid "
-        "parameter "
-        "'null space: dimension' wrong. It has to be > 0.");
+    FOUR_C_THROW("Multigrid parameter 'null space: dimension' wrong. It has to be > 0.");
 
-  std::shared_ptr<Core::LinAlg::MultiVector<double>> nullspace_data =
-      list.get<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("nullspace", nullptr);
-  if (!nullspace_data)
-    FOUR_C_THROW(
-        "Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist: Nullspace data is "
-        "null.");
+  auto nullspace_data = list.get<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("nullspace");
+  if (!nullspace_data) FOUR_C_THROW("Nullspace data is null.");
 
   Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>> nullspace =
       Teuchos::make_rcp<Xpetra::EpetraMultiVectorT<GlobalOrdinal, Node>>(

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.hpp
@@ -56,7 +56,7 @@ namespace Core::LinearSolver
      *
      * \pre The input parameter list needs to contain these entries:
      *   - "null space: dimension" (type: \c int )
-     *   - "nullspace" (type: \c RCP<Core::LinAlg::MultiVector<double>> )
+     *   - "nullspace" (type: \c std::shared_ptr<Core::LinAlg::MultiVector<double>> )
      *
      * @param[in] row_map Xpetra-style map to be used to create the nullspace vector
      * @param[in] list Parameter list, where 4C has stored the nullspace data as

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.hpp
@@ -66,7 +66,7 @@ namespace Core::LinearSolver
     static Teuchos::RCP<Xpetra::MultiVector<Scalar, LocalOrdinal, GlobalOrdinal, Node>>
     extract_nullspace_from_parameterlist(
         const Xpetra::Map<LocalOrdinal, GlobalOrdinal, Node>& row_map,
-        Teuchos::ParameterList& list);
+        const Teuchos::ParameterList& list);
   };
 }  // namespace Core::LinearSolver
 

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
@@ -72,7 +72,7 @@ void Core::LinearSolver::MueLuPreconditioner::setup(bool create, Epetra_Operator
       pmatrix_ = Xpetra::MatrixFactory<SC, LO, GO, NO>::BuildCopy(
           Teuchos::make_rcp<Xpetra::CrsMatrixWrap<SC, LO, GO, NO>>(mueluA));
 
-      Teuchos::ParameterList& inverseList = muelulist_.sublist("MueLu Parameters");
+      const Teuchos::ParameterList& inverseList = muelulist_.sublist("MueLu Parameters");
 
       auto xmlFileName = inverseList.get<std::string>("MUELU_XML_FILE");
 
@@ -167,7 +167,7 @@ void Core::LinearSolver::MueLuPreconditioner::setup(bool create, Epetra_Operator
       for (int block = 0; block < A->rows(); block++)
       {
         const std::string inverse = "Inverse" + std::to_string(block + 1);
-        Teuchos::ParameterList& inverse_list =
+        const Teuchos::ParameterList& inverse_list =
             muelulist_.sublist(inverse).sublist("MueLu Parameters");
 
         Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> nullspace =


### PR DESCRIPTION
## Description and Context

- [x] Add const qualifier to `extract_nullspace_from_parameterlist()`
- [x] Fix type in documentation 
- [x] Make `Teuchos::ParameterList&` in MueLu preconditioner `const` (following PR #127)
- [x] Check for other calls to `extract_nullspace_from_parameterlist()` and pass in a `const Teuchos::ParameterList&`

## Related Issues and Merge Requests

Originates from a comment in PR #127, will be addressed after merging PR #127.