### PR TITLE
Minor enhancements to all_of and one_of

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -471,6 +471,17 @@ namespace Core::IO
         void emit_metadata(ryml::NodeRef node) const;
       };
 
+      struct AllOfSpec
+      {
+        GroupData data;
+        std::vector<InputSpec> specs;
+
+        void parse(ValueParser& parser, InputParameterContainer& container) const;
+        void set_default_value(InputParameterContainer& container) const;
+        void print(std::ostream& stream, std::size_t indent) const;
+        void emit_metadata(ryml::NodeRef node) const;
+      };
+
       struct OneOfSpec
       {
         // A one_of spec is essentially an unnamed group with additional logic to ensure that

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -522,6 +522,38 @@ namespace
     }
   }
 
+  TEST(InputSpecTest, NestedOneOfs)
+  {
+    auto spec = one_of({
+        one_of({
+            entry<int>("a"),
+            entry<double>("b"),
+        }),
+        one_of({
+            entry<std::string>("c"),
+            entry<double>("d"),
+            one_of({
+                entry<int>("e"),
+                entry<std::string>("f"),
+            }),
+        }),
+    });
+
+    {
+      // Verify that all entries got pulled to the highest level.
+      std::ostringstream out;
+      spec.print_as_dat(out);
+      EXPECT_EQ(out.str(), R"(// <one_of>:
+//   a <int>
+//   b <double>
+//   c <string>
+//   d <double>
+//   e <int>
+//   f <string>
+)");
+    }
+  }
+
   TEST(InputSpecTest, PrintAsDat)
   {
     auto line =


### PR DESCRIPTION
- `all_of` uses its own internal implementation: this makes `GroupSpec` easier to handle as the previously unnamed `all_of` case moved into `AllOfSpec`.
- nested `one_of`s are now also flattened into parent `one_of`, same as `all_of`s are