### PR TITLE
Implement user-friendly yaml error handling

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -529,7 +529,9 @@ namespace Core::IO
       }
       else
       {
-        return spec.match(ConstYamlNodeRef(node, pimpl_->section->file));
+        InputParameterContainer container;
+        spec.match(ConstYamlNodeRef(node, pimpl_->section->file), container);
+        return container;
       }
     }
   }

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -50,21 +50,14 @@ void Core::IO::InputSpec::fully_parse(
   }
 }
 
-std::optional<Core::IO::InputParameterContainer> Core::IO::InputSpec::match(
-    ConstYamlNodeRef yaml) const
+void Core::IO::InputSpec::match(ConstYamlNodeRef yaml, InputParameterContainer& container) const
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
 
-  std::optional<Core::IO::InputParameterContainer> container{std::in_place};
-  Internal::Matches matches;
-  const bool success = pimpl_->match(yaml, *container, matches);
+  Internal::MatchTree match_tree{*this};
+  pimpl_->match(yaml, container, match_tree.root());
 
-  // Additional to the self-reported success, we also check that all content of the node was
-  // matched.
-  if (success && matches.are_direct_children_matched(yaml))
-    return container;
-  else
-    return std::nullopt;
+  match_tree.assert_match(yaml.node);
 }
 
 void Core::IO::InputSpec::print_as_dat(std::ostream& stream) const

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -53,7 +53,13 @@ namespace Core::IO
      */
     void fully_parse(ValueParser& parser, InputParameterContainer& container) const;
 
-    [[nodiscard]] std::optional<InputParameterContainer> match(ConstYamlNodeRef yaml) const;
+    /**
+     * Match the content in @p yaml to the expected input format of this InputSpec. If the content
+     * matches, fill the @p container with the parsed data. If the content does not match, throws an
+     * exception. A successful match means that @p yaml contains all required entries and no unknown
+     * content.
+     */
+    void match(ConstYamlNodeRef yaml, InputParameterContainer& container) const;
 
     /**
      * Print the expected input format of this InputSpec to @p stream in dat format.

--- a/src/core/io/src/4C_io_yaml.cpp
+++ b/src/core/io/src/4C_io_yaml.cpp
@@ -27,4 +27,28 @@ ryml::Tree Core::IO::init_yaml_tree_with_exceptions()
   return ryml::Tree{cb};
 }
 
+void Core::IO::read_value_from_yaml(Core::IO::ConstYamlNodeRef node, double& value)
+{
+  FOUR_C_ASSERT_ALWAYS(node.node.has_val(), "Expected a value node.");
+  // Instead of relying on the ryml library to parse the double value, we do it ourselves to
+  // ensure that we only accept data that fully parses as a double.
+
+  // Null-terminate the string.
+  std::string string(node.node.val().data(), node.node.val().size());
+  std::size_t end;
+  try
+  {
+    value = std::stod(string.data(), &end);
+  }
+  catch (const std::logic_error&)
+  {
+    throw YamlException("Could not parse '" + string + "' as a double value.");
+  }
+
+  if (end != string.size())
+  {
+    throw YamlException("Could not parse '" + string + "' as a double value.");
+  }
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -176,6 +176,8 @@ namespace Core::IO
     node.node >> value;
   }
 
+  void read_value_from_yaml(ConstYamlNodeRef node, double& value);
+
   template <typename T>
   void read_value_from_yaml(ConstYamlNodeRef node, std::optional<T>& value)
   {


### PR DESCRIPTION
As promised in #316, this PR implements useful error messages for yaml input. Here are some examples:

```
Could not match this input

MAT: 1
MAT_ElastHyper:
  NUMMAT: 1
  MATIDS: 10
  DENS: 0.1


against the given input specification. This was the best attempt to match the input:

{
  Fully matched entry 'MAT'
  Expected exactly one of a few choices but matched:
    Partially matched group 'MAT_ElastHyper'
      Fully matched entry 'NUMMAT'
      Partially matched entry 'MATIDS' (expected type 'vector<int>' did not validate)
}
```

or

```
Could not match this input

MAT: 1
MAT_ElastHyper:
  NUMMAT: 1
  MATIDS: [10]
  DENS: 0.1
ELAST_CoupNeoHooke:
  YOUNG: 10
  NUE: 0.25


against the given input specification. This was the best attempt to match the input:

{
  Fully matched entry 'MAT'
  Expected exactly one but matched multiple:
    Fully matched group 'MAT_ElastHyper'
    Fully matched group 'ELAST_CoupNeoHooke'
}
```

