### PR TITLE
Add CITATION.cff to the repository

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,14 @@
+cff-version: 1.2.0
+title: '4C: A Comprehensive Multi-Physics Simulation Framework'
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - name: 4C
+identifiers:
+  - type: url
+    value: 'https://www.4c-multiphysics.org'
+repository-code: 'https://github.com/4C-multiphysics/4C'
+url: 'https://www.4c-multiphysics.org'
+license: LGPL-3.0


### PR DESCRIPTION
This adds a CITATION.cff file to the repo. GitHub recognizes the file and shows it on the sidebar:

![image](https://github.com/user-attachments/assets/5ef4d02b-7f81-44e9-b7b7-7eb2b0442685)

see https://github.com/amgebauer/4C