### PR TITLE
Remove InputSpecBuilders::user_defined

### DIFF
--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -37,7 +37,7 @@ namespace
     }
     else if (activation_type == Inpar::Mat::ActivationType::map)
     {
-      return matdata.parameters.get<const ActivationMapType>("MAPFILE");
+      return matdata.parameters.get<const ActivationMapType>("MAPFILE_CONTENT");
     }
     else
       return std::monostate{};

--- a/src/mixture/4C_mixture_rule_map.cpp
+++ b/src/mixture/4C_mixture_rule_map.cpp
@@ -61,7 +61,7 @@ Mixture::PAR::MapMixtureRule::MapMixtureRule(const Core::Mat::PAR::Parameter::Da
       initial_reference_density_(matdata.parameters.get<double>("DENS")),
       num_constituents_(matdata.parameters.get<int>("NUMCONST")),
       mass_fractions_map_(matdata.parameters.get<std::unordered_map<int, std::vector<double>>>(
-          "MASSFRACMAPFILE")) {};
+          "MASSFRACMAPFILE_CONTENT")) {};
 
 std::unique_ptr<Mixture::MixtureRule> Mixture::PAR::MapMixtureRule::create_rule()
 {


### PR DESCRIPTION
Instead of hooking deeply into the `InputSpec` mechanism with `user_defined`, let users attach `on_parse` callbacks to entries. 

Implemented on top of #320, will be rebased.