### PR TITLE
Wrap Teuchos::setStringToIntegralParameter

### DIFF
--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -17,19 +17,18 @@ FOUR_C_NAMESPACE_OPEN
 
 void BeamContact::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& beamcontact = list.sublist("BEAM CONTACT", false, "");
 
-  setStringToIntegralParameter<BeamContact::Strategy>("BEAMS_STRATEGY", "None",
+  Core::Utils::string_to_integral_parameter<BeamContact::Strategy>("BEAMS_STRATEGY", "None",
       "Type of employed solving strategy",
       tuple<std::string>("None", "none", "Penalty", "penalty", "Gmshonly", "gmshonly"),
       tuple<BeamContact::Strategy>(
           bstr_none, bstr_none, bstr_penalty, bstr_penalty, bstr_gmshonly, bstr_gmshonly),
       &beamcontact);
 
-  setStringToIntegralParameter<BeamContact::Modelevaluator>("MODELEVALUATOR", "old",
+  Core::Utils::string_to_integral_parameter<BeamContact::Modelevaluator>("MODELEVALUATOR", "old",
       "Type of model evaluator", tuple<std::string>("Old", "old", "Standard", "standard"),
       tuple<BeamContact::Modelevaluator>(bstr_old, bstr_old, bstr_standard, bstr_standard),
       &beamcontact);
@@ -56,11 +55,11 @@ void BeamContact::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("BEAMS_ENDPOINTPENALTY", "No",
       "Additional consideration of endpoint-line and endpoint-endpoint contacts", &beamcontact);
 
-  setStringToIntegralParameter<BeamContact::Smoothing>("BEAMS_SMOOTHING", "None",
+  Core::Utils::string_to_integral_parameter<BeamContact::Smoothing>("BEAMS_SMOOTHING", "None",
       "Application of smoothed tangent field", tuple<std::string>("None", "none", "Cpp", "cpp"),
       tuple<BeamContact::Smoothing>(bsm_none, bsm_none, bsm_cpp, bsm_cpp), &beamcontact);
 
-  setStringToIntegralParameter<BeamContact::Damping>("BEAMS_DAMPING", "No",
+  Core::Utils::string_to_integral_parameter<BeamContact::Damping>("BEAMS_DAMPING", "No",
       "Application of a contact damping force", tuple<std::string>("No", "no", "Yes", "yes"),
       tuple<BeamContact::Damping>(bd_no, bd_no, bd_yes, bd_yes), &beamcontact);
 
@@ -98,7 +97,7 @@ void BeamContact::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("BEAMS_NUMINTEGRATIONINTERVAL", 1,
       "Number of integration intervals per element", &beamcontact);
 
-  setStringToIntegralParameter<BeamContact::PenaltyLaw>("BEAMS_PENALTYLAW", "LinPen",
+  Core::Utils::string_to_integral_parameter<BeamContact::PenaltyLaw>("BEAMS_PENALTYLAW", "LinPen",
       "Applied Penalty Law",
       tuple<std::string>("LinPen", "QuadPen", "LinNegQuadPen", "LinPosQuadPen", "LinPosCubPen",
           "LinPosDoubleQuadPen", "LinPosExpPen"),
@@ -124,7 +123,7 @@ void BeamContact::set_valid_parameters(Teuchos::ParameterList& list)
 
   // enable octree search and determine type of bounding box (aabb = axis aligned, cobb =
   // cylindrical oriented)
-  setStringToIntegralParameter<BeamContact::OctreeType>("BEAMS_OCTREE", "None",
+  Core::Utils::string_to_integral_parameter<BeamContact::OctreeType>("BEAMS_OCTREE", "None",
       "octree and bounding box type for octree search routine",
       tuple<std::string>(
           "None", "none", "octree_axisaligned", "octree_cylorient", "octree_spherical"),

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -14,7 +14,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void BrownianDynamics::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& browniandyn_list = list.sublist("BROWNIAN DYNAMICS", false, "");
@@ -40,7 +39,7 @@ void BrownianDynamics::set_valid_parameters(Teuchos::ParameterList& list)
       "Within this time interval the random numbers remain constant. -1.0 ", &browniandyn_list);
 
   // the way how damping coefficient values for beams are specified
-  setStringToIntegralParameter<BeamDampingCoefficientSpecificationType>(
+  Core::Utils::string_to_integral_parameter<BeamDampingCoefficientSpecificationType>(
       "BEAMS_DAMPING_COEFF_SPECIFIED_VIA", "cylinder_geometry_approx",
       "In which way are damping coefficient values for beams specified?",
       tuple<std::string>(

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
@@ -58,6 +58,19 @@ namespace Core
         std::string const& docString, Teuchos::ParameterList* paramList,
         std::vector<std::string> const& validParams = {});
 
+
+    /**
+     * Add an integral parameter to a parameter list with a list of valid strings.
+     */
+    template <typename T>
+    void string_to_integral_parameter(const std::string& paramName, const std::string& defaultValue,
+        const std::string& docString, const Teuchos::ArrayView<const std::string>& strings,
+        const Teuchos::ArrayView<const T>& integrals, Teuchos::ParameterList* paramList)
+    {
+      Teuchos::setStringToIntegralParameter<T>(
+          paramName, defaultValue, docString, strings, integrals, paramList);
+    }
+
   }  // namespace Utils
 }  // namespace Core
 

--- a/src/cut/4C_cut_input.cpp
+++ b/src/cut/4C_cut_input.cpp
@@ -18,40 +18,43 @@ FOUR_C_NAMESPACE_OPEN
 void Cut::set_valid_parameters(Teuchos::ParameterList& list)
 {
   using namespace FourC::Cut;
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& cut_general = list.sublist("CUT GENERAL", false, "");
 
   // intersection precision (double or cln)
-  setStringToIntegralParameter<FourC::Cut::CutFloatType>("KERNEL_INTERSECTION_FLOATTYPE", "double",
+  Core::Utils::string_to_integral_parameter<FourC::Cut::CutFloatType>(
+      "KERNEL_INTERSECTION_FLOATTYPE", "double",
       "The floattype of the cut surface-edge intersection", tuple<std::string>("cln", "double"),
       tuple<FourC::Cut::CutFloatType>(floattype_cln, floattype_double), &cut_general);
 
   // Computing disctance surface to point precision (double or cln)
-  setStringToIntegralParameter<FourC::Cut::CutFloatType>("KERNEL_DISTANCE_FLOATTYPE", "double",
-      "The floattype of the cut distance computation", tuple<std::string>("cln", "double"),
+  Core::Utils::string_to_integral_parameter<FourC::Cut::CutFloatType>("KERNEL_DISTANCE_FLOATTYPE",
+      "double", "The floattype of the cut distance computation",
+      tuple<std::string>("cln", "double"),
       tuple<FourC::Cut::CutFloatType>(floattype_cln, floattype_double), &cut_general);
 
   // A general floattype for Cut::Position for Embedded Elements (compute_distance)
   // If specified this floattype is used for all computations of Cut::Position with
   // embedded elements
-  setStringToIntegralParameter<FourC::Cut::CutFloatType>("GENERAL_POSITION_DISTANCE_FLOATTYPE",
-      "none", "A general floattype for Cut::Position for Embedded Elements (compute_distance)",
+  Core::Utils::string_to_integral_parameter<FourC::Cut::CutFloatType>(
+      "GENERAL_POSITION_DISTANCE_FLOATTYPE", "none",
+      "A general floattype for Cut::Position for Embedded Elements (compute_distance)",
       tuple<std::string>("none", "cln", "double"),
       tuple<FourC::Cut::CutFloatType>(floattype_none, floattype_cln, floattype_double),
       &cut_general);
 
   // A general floattype for Cut::Position for Elements (ComputePosition)
   // If specified this floattype is used for all computations of Cut::Position
-  setStringToIntegralParameter<FourC::Cut::CutFloatType>("GENERAL_POSITION_POSITION_FLOATTYPE",
-      "none", "A general floattype for Cut::Position Elements (ComputePosition)",
+  Core::Utils::string_to_integral_parameter<FourC::Cut::CutFloatType>(
+      "GENERAL_POSITION_POSITION_FLOATTYPE", "none",
+      "A general floattype for Cut::Position Elements (ComputePosition)",
       tuple<std::string>("none", "cln", "double"),
       tuple<FourC::Cut::CutFloatType>(floattype_none, floattype_cln, floattype_double),
       &cut_general);
 
   // Specify which Referenceplanes are used in DirectDivergence
-  setStringToIntegralParameter<FourC::Cut::CutDirectDivergenceRefplane>(
+  Core::Utils::string_to_integral_parameter<FourC::Cut::CutDirectDivergenceRefplane>(
       "DIRECT_DIVERGENCE_REFPLANE", "all",
       "Specify which Referenceplanes are used in DirectDivergence",
       tuple<std::string>("all", "diagonal_side", "facet", "diagonal", "side", "none"),

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -22,7 +22,6 @@ namespace Inpar
      *----------------------------------------------------------------------*/
     void set_valid_parameters(Teuchos::ParameterList& list)
     {
-      using Teuchos::setStringToIntegralParameter;
       using Teuchos::tuple;
 
       // related sublist
@@ -44,8 +43,8 @@ namespace Inpar
           &sublist_IO_monitor_structure_dbc);
 
       // type of written output file
-      setStringToIntegralParameter<Inpar::IOMonitorStructureDBC::FileType>("FILE_TYPE", "csv",
-          "type of written output file",
+      Core::Utils::string_to_integral_parameter<Inpar::IOMonitorStructureDBC::FileType>("FILE_TYPE",
+          "csv", "type of written output file",
           tuple<std::string>("csv", "CSV", "Csv", "data", "Data", "DATA"),
           tuple<Inpar::IOMonitorStructureDBC::FileType>(Inpar::IOMonitorStructureDBC::csv,
               Inpar::IOMonitorStructureDBC::csv, Inpar::IOMonitorStructureDBC::csv,

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -22,7 +22,6 @@ namespace Inpar
      *----------------------------------------------------------------------*/
     void set_valid_parameters(Teuchos::ParameterList& list)
     {
-      using Teuchos::setStringToIntegralParameter;
       using Teuchos::tuple;
 
       // related sublist
@@ -43,8 +42,8 @@ namespace Inpar
 
 
       // data format for written numeric data
-      setStringToIntegralParameter<Core::IO::OutputDataFormat>("OUTPUT_DATA_FORMAT", "binary",
-          "data format for written numeric data", tuple<std::string>("binary", "ascii"),
+      Core::Utils::string_to_integral_parameter<Core::IO::OutputDataFormat>("OUTPUT_DATA_FORMAT",
+          "binary", "data format for written numeric data", tuple<std::string>("binary", "ascii"),
           tuple<Core::IO::OutputDataFormat>(
               Core::IO::OutputDataFormat::binary, Core::IO::OutputDataFormat::ascii),
           &sublist_IO_VTK_structure);
@@ -71,7 +70,8 @@ namespace Inpar
           &sublist_IO_VTK_structure);
 
       // specify the actual visualization writer
-      setStringToIntegralParameter<Core::IO::OutputWriter>("OUTPUT_WRITER", "vtu_per_rank",
+      Core::Utils::string_to_integral_parameter<Core::IO::OutputWriter>("OUTPUT_WRITER",
+          "vtu_per_rank",
           "Specify which output writer shall be used to write the visualization data to disk",
           tuple<std::string>("vtu_per_rank"),
           tuple<Core::IO::OutputWriter>(Core::IO::OutputWriter::vtu_per_rank),

--- a/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
@@ -23,7 +23,6 @@ namespace Inpar
        *----------------------------------------------------------------------*/
       void set_valid_parameters(Teuchos::ParameterList& list)
       {
-        using Teuchos::setStringToIntegralParameter;
         using Teuchos::tuple;
 
         // related sublist

--- a/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
@@ -24,7 +24,6 @@ namespace Inpar
        *----------------------------------------------------------------------*/
       void set_valid_parameters(Teuchos::ParameterList& list)
       {
-        using Teuchos::setStringToIntegralParameter;
         using Teuchos::tuple;
 
         // related sublist

--- a/src/inpar/4C_inpar_IO_runtime_output_thermo.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_thermo.cpp
@@ -19,7 +19,6 @@ namespace Inpar
     {
       void set_valid_parameters(Teuchos::ParameterList& list)
       {
-        using Teuchos::setStringToIntegralParameter;
         using Teuchos::tuple;
 
         // related sublist

--- a/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
@@ -24,7 +24,6 @@ namespace Inpar
        *----------------------------------------------------------------------*/
       void set_valid_parameters(Teuchos::ParameterList& list)
       {
-        using Teuchos::setStringToIntegralParameter;
         using Teuchos::tuple;
 
         // related sublist
@@ -73,7 +72,7 @@ namespace Inpar
             &sublist_IO_VTK_structure);
 
         // mode to write gauss point data
-        setStringToIntegralParameter<Inpar::Solid::GaussPointDataOutputType>(
+        Core::Utils::string_to_integral_parameter<Inpar::Solid::GaussPointDataOutputType>(
             "GAUSS_POINT_DATA_OUTPUT_TYPE", "none",
             "Where to write gauss point data. (none, projected to nodes, projected to element "
             "center, raw at gauss points)",

--- a/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
@@ -22,7 +22,6 @@ namespace Inpar
      *----------------------------------------------------------------------*/
     void set_valid_parameters(Teuchos::ParameterList& list)
     {
-      using Teuchos::setStringToIntegralParameter;
       using Teuchos::tuple;
 
       // related sublist

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -51,7 +51,6 @@ void Inpar::BeamToSolid::beam_to_solid_interaction_get_string(
  */
 void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& beaminteraction = list.sublist("BEAM INTERACTION", false, "");
@@ -60,8 +59,8 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& beam_to_solid_volume_mestying =
       beaminteraction.sublist("BEAM TO SOLID VOLUME MESHTYING", false, "");
   {
-    setStringToIntegralParameter<BeamToSolidContactDiscretization>("CONTACT_DISCRETIZATION", "none",
-        "Type of employed contact discretization",
+    Core::Utils::string_to_integral_parameter<BeamToSolidContactDiscretization>(
+        "CONTACT_DISCRETIZATION", "none", "Type of employed contact discretization",
         tuple<std::string>("none", "gauss_point_to_segment", "mortar", "gauss_point_cross_section",
             "mortar_cross_section"),
         tuple<BeamToSolidContactDiscretization>(BeamToSolidContactDiscretization::none,
@@ -71,14 +70,15 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
             BeamToSolidContactDiscretization::mortar_cross_section),
         &beam_to_solid_volume_mestying);
 
-    setStringToIntegralParameter<BeamToSolidConstraintEnforcement>("CONSTRAINT_STRATEGY", "none",
-        "Type of employed constraint enforcement strategy", tuple<std::string>("none", "penalty"),
+    Core::Utils::string_to_integral_parameter<BeamToSolidConstraintEnforcement>(
+        "CONSTRAINT_STRATEGY", "none", "Type of employed constraint enforcement strategy",
+        tuple<std::string>("none", "penalty"),
         tuple<BeamToSolidConstraintEnforcement>(
             BeamToSolidConstraintEnforcement::none, BeamToSolidConstraintEnforcement::penalty),
         &beam_to_solid_volume_mestying);
 
-    setStringToIntegralParameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION", "none",
-        "Shape function for the mortar Lagrange-multipliers",
+    Core::Utils::string_to_integral_parameter<BeamToSolidMortarShapefunctions>(
+        "MORTAR_SHAPE_FUNCTION", "none", "Shape function for the mortar Lagrange-multipliers",
         tuple<std::string>("none", "line2", "line3", "line4"),
         tuple<BeamToSolidMortarShapefunctions>(BeamToSolidMortarShapefunctions::none,
             BeamToSolidMortarShapefunctions::line2, BeamToSolidMortarShapefunctions::line3,
@@ -105,8 +105,8 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
         "Enable / disable the coupling of the restart configuration.",
         &beam_to_solid_volume_mestying);
 
-    setStringToIntegralParameter<BeamToSolidRotationCoupling>("ROTATION_COUPLING", "none",
-        "Type of rotational coupling",
+    Core::Utils::string_to_integral_parameter<BeamToSolidRotationCoupling>("ROTATION_COUPLING",
+        "none", "Type of rotational coupling",
         tuple<std::string>("none", "deformation_gradient_3d_general_in_cross_section_plane",
             "polar_decomposition_2d", "deformation_gradient_y_2d", "deformation_gradient_z_2d",
             "deformation_gradient_average_2d", "fix_triad_2d", "deformation_gradient_3d_local_1",
@@ -128,7 +128,7 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
             BeamToSolidRotationCoupling::deformation_gradient_3d_base_1),
         &beam_to_solid_volume_mestying);
 
-    setStringToIntegralParameter<BeamToSolidMortarShapefunctions>(
+    Core::Utils::string_to_integral_parameter<BeamToSolidMortarShapefunctions>(
         "ROTATION_COUPLING_MORTAR_SHAPE_FUNCTION", "none",
         "Shape function for the mortar Lagrange-multipliers",
         tuple<std::string>("none", "line2", "line3", "line4"),
@@ -189,21 +189,22 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& beam_to_solid_surface_mestying =
       beaminteraction.sublist("BEAM TO SOLID SURFACE MESHTYING", false, "");
   {
-    setStringToIntegralParameter<BeamToSolidContactDiscretization>("CONTACT_DISCRETIZATION", "none",
-        "Type of employed contact discretization",
+    Core::Utils::string_to_integral_parameter<BeamToSolidContactDiscretization>(
+        "CONTACT_DISCRETIZATION", "none", "Type of employed contact discretization",
         tuple<std::string>("none", "gauss_point_to_segment", "mortar"),
         tuple<BeamToSolidContactDiscretization>(BeamToSolidContactDiscretization::none,
             BeamToSolidContactDiscretization::gauss_point_to_segment,
             BeamToSolidContactDiscretization::mortar),
         &beam_to_solid_surface_mestying);
 
-    setStringToIntegralParameter<BeamToSolidConstraintEnforcement>("CONSTRAINT_STRATEGY", "none",
-        "Type of employed constraint enforcement strategy", tuple<std::string>("none", "penalty"),
+    Core::Utils::string_to_integral_parameter<BeamToSolidConstraintEnforcement>(
+        "CONSTRAINT_STRATEGY", "none", "Type of employed constraint enforcement strategy",
+        tuple<std::string>("none", "penalty"),
         tuple<BeamToSolidConstraintEnforcement>(
             BeamToSolidConstraintEnforcement::none, BeamToSolidConstraintEnforcement::penalty),
         &beam_to_solid_surface_mestying);
 
-    setStringToIntegralParameter<BeamToSolidSurfaceCoupling>("COUPLING_TYPE", "none",
+    Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceCoupling>("COUPLING_TYPE", "none",
         "How the coupling constraints are formulated/",
         tuple<std::string>("none", "reference_configuration_forced_to_zero",
             "reference_configuration_forced_to_zero_fad", "displacement", "displacement_fad",
@@ -215,8 +216,8 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
             BeamToSolidSurfaceCoupling::consistent_fad),
         &beam_to_solid_surface_mestying);
 
-    setStringToIntegralParameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION", "none",
-        "Shape function for the mortar Lagrange-multipliers",
+    Core::Utils::string_to_integral_parameter<BeamToSolidMortarShapefunctions>(
+        "MORTAR_SHAPE_FUNCTION", "none", "Shape function for the mortar Lagrange-multipliers",
         tuple<std::string>("none", "line2", "line3", "line4"),
         tuple<BeamToSolidMortarShapefunctions>(BeamToSolidMortarShapefunctions::none,
             BeamToSolidMortarShapefunctions::line2, BeamToSolidMortarShapefunctions::line3,
@@ -232,7 +233,7 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
     Core::Utils::double_parameter("ROTATIONAL_COUPLING_PENALTY_PARAMETER", 0.0,
         "Penalty parameter for beam-to-solid surface rotational meshtying",
         &beam_to_solid_surface_mestying);
-    setStringToIntegralParameter<BeamToSolidSurfaceRotationCoupling>(
+    Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceRotationCoupling>(
         "ROTATIONAL_COUPLING_SURFACE_TRIAD", "none", "Construction method for surface triad",
         tuple<std::string>("none", "surface_cross_section_director", "averaged"),
         tuple<BeamToSolidSurfaceRotationCoupling>(BeamToSolidSurfaceRotationCoupling::none,
@@ -251,16 +252,17 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& beam_to_solid_surface_contact =
       beaminteraction.sublist("BEAM TO SOLID SURFACE CONTACT", false, "");
   {
-    setStringToIntegralParameter<BeamToSolidContactDiscretization>("CONTACT_DISCRETIZATION", "none",
-        "Type of employed contact discretization",
+    Core::Utils::string_to_integral_parameter<BeamToSolidContactDiscretization>(
+        "CONTACT_DISCRETIZATION", "none", "Type of employed contact discretization",
         tuple<std::string>("none", "gauss_point_to_segment", "mortar"),
         tuple<BeamToSolidContactDiscretization>(BeamToSolidContactDiscretization::none,
             BeamToSolidContactDiscretization::gauss_point_to_segment,
             BeamToSolidContactDiscretization::mortar),
         &beam_to_solid_surface_contact);
 
-    setStringToIntegralParameter<BeamToSolidConstraintEnforcement>("CONSTRAINT_STRATEGY", "none",
-        "Type of employed constraint enforcement strategy", tuple<std::string>("none", "penalty"),
+    Core::Utils::string_to_integral_parameter<BeamToSolidConstraintEnforcement>(
+        "CONSTRAINT_STRATEGY", "none", "Type of employed constraint enforcement strategy",
+        tuple<std::string>("none", "penalty"),
         tuple<BeamToSolidConstraintEnforcement>(
             BeamToSolidConstraintEnforcement::none, BeamToSolidConstraintEnforcement::penalty),
         &beam_to_solid_surface_contact);
@@ -268,15 +270,15 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
     Core::Utils::double_parameter("PENALTY_PARAMETER", 0.0,
         "Penalty parameter for beam-to-solid surface contact", &beam_to_solid_surface_contact);
 
-    setStringToIntegralParameter<BeamToSolidSurfaceContact>("CONTACT_TYPE", "none",
+    Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceContact>("CONTACT_TYPE", "none",
         "How the contact constraints are formulated",
         tuple<std::string>("none", "gap_variation", "potential"),
         tuple<BeamToSolidSurfaceContact>(BeamToSolidSurfaceContact::none,
             BeamToSolidSurfaceContact::gap_variation, BeamToSolidSurfaceContact::potential),
         &beam_to_solid_surface_contact);
 
-    setStringToIntegralParameter<BeamToSolidSurfaceContactPenaltyLaw>("PENALTY_LAW", "none",
-        "Type of penalty law", tuple<std::string>("none", "linear", "linear_quadratic"),
+    Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceContactPenaltyLaw>("PENALTY_LAW",
+        "none", "Type of penalty law", tuple<std::string>("none", "linear", "linear_quadratic"),
         tuple<BeamToSolidSurfaceContactPenaltyLaw>(BeamToSolidSurfaceContactPenaltyLaw::none,
             BeamToSolidSurfaceContactPenaltyLaw::linear,
             BeamToSolidSurfaceContactPenaltyLaw::linear_quadratic),
@@ -286,7 +288,7 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
         "First penalty regularization parameter G0 >=0: For gap<G0 contact is active",
         &beam_to_solid_surface_contact);
 
-    setStringToIntegralParameter<BeamToSolidSurfaceContactMortarDefinedIn>(
+    Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceContactMortarDefinedIn>(
         "MORTAR_CONTACT_DEFINED_IN", "none", "Configuration where the mortar contact is defined",
         tuple<std::string>("none", "reference_configuration", "current_configuration"),
         tuple<BeamToSolidSurfaceContactMortarDefinedIn>(
@@ -302,8 +304,9 @@ void Inpar::BeamToSolid::set_valid_parameters(Teuchos::ParameterList& list)
     Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(beam_to_solid_surface_contact);
 
     // Define the mortar shape functions for contact
-    setStringToIntegralParameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION", "none",
-        "Shape function for the mortar Lagrange-multipliers", tuple<std::string>("none", "line2"),
+    Core::Utils::string_to_integral_parameter<BeamToSolidMortarShapefunctions>(
+        "MORTAR_SHAPE_FUNCTION", "none", "Shape function for the mortar Lagrange-multipliers",
+        tuple<std::string>("none", "line2"),
         tuple<BeamToSolidMortarShapefunctions>(
             BeamToSolidMortarShapefunctions::none, BeamToSolidMortarShapefunctions::line2),
         &beam_to_solid_surface_contact);

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -28,20 +28,19 @@ void Inpar::BeamInteraction::beam_interaction_conditions_get_all(
 
 void Inpar::BeamInteraction::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& beaminteraction = list.sublist("BEAM INTERACTION", false, "");
 
-  setStringToIntegralParameter<Inpar::BeamInteraction::RepartitionStrategy>("REPARTITIONSTRATEGY",
-      "Adaptive", "Type of employed repartitioning strategy",
+  Core::Utils::string_to_integral_parameter<Inpar::BeamInteraction::RepartitionStrategy>(
+      "REPARTITIONSTRATEGY", "Adaptive", "Type of employed repartitioning strategy",
       tuple<std::string>("Adaptive", "adaptive", "Everydt", "everydt"),
       tuple<Inpar::BeamInteraction::RepartitionStrategy>(
           repstr_adaptive, repstr_adaptive, repstr_everydt, repstr_everydt),
       &beaminteraction);
 
-  setStringToIntegralParameter<SearchStrategy>("SEARCH_STRATEGY", "bruteforce_with_binning",
-      "Type of search strategy used for finding coupling pairs",
+  Core::Utils::string_to_integral_parameter<SearchStrategy>("SEARCH_STRATEGY",
+      "bruteforce_with_binning", "Type of search strategy used for finding coupling pairs",
       tuple<std::string>("bruteforce_with_binning", "bounding_volume_hierarchy"),
       tuple<SearchStrategy>(
           SearchStrategy::bruteforce_with_binning, SearchStrategy::bounding_volume_hierarchy),
@@ -140,7 +139,7 @@ void Inpar::BeamInteraction::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& beamtobeamcontact =
       beaminteraction.sublist("BEAM TO BEAM CONTACT", false, "");
 
-  setStringToIntegralParameter<Inpar::BeamInteraction::Strategy>("STRATEGY", "None",
+  Core::Utils::string_to_integral_parameter<Inpar::BeamInteraction::Strategy>("STRATEGY", "None",
       "Type of employed solving strategy", tuple<std::string>("None", "none", "Penalty", "penalty"),
       tuple<Inpar::BeamInteraction::Strategy>(bstr_none, bstr_none, bstr_penalty, bstr_penalty),
       &beamtobeamcontact);
@@ -153,7 +152,7 @@ void Inpar::BeamInteraction::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& beamtospherecontact =
       beaminteraction.sublist("BEAM TO SPHERE CONTACT", false, "");
 
-  setStringToIntegralParameter<Inpar::BeamInteraction::Strategy>("STRATEGY", "None",
+  Core::Utils::string_to_integral_parameter<Inpar::BeamInteraction::Strategy>("STRATEGY", "None",
       "Type of employed solving strategy", tuple<std::string>("None", "none", "Penalty", "penalty"),
       tuple<Inpar::BeamInteraction::Strategy>(bstr_none, bstr_none, bstr_penalty, bstr_penalty),
       &beamtospherecontact);

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -18,7 +18,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::BeamPotential::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /* parameters for potential-based beam interaction */
@@ -31,14 +30,15 @@ void Inpar::BeamPotential::set_valid_parameters(Teuchos::ParameterList& list)
   setNumericStringParameter("POT_LAW_PREFACTOR", "0.0",
       "prefactor(s) $k_i$ of potential law $\\Phi(r) = \\sum_i (k_i * r^{-m_i})$.", &beampotential);
 
-  setStringToIntegralParameter<Inpar::BeamPotential::BeamPotentialType>("BEAMPOTENTIAL_TYPE",
-      "Surface", "Type of potential interaction: surface (default) or volume potential",
+  Core::Utils::string_to_integral_parameter<Inpar::BeamPotential::BeamPotentialType>(
+      "BEAMPOTENTIAL_TYPE", "Surface",
+      "Type of potential interaction: surface (default) or volume potential",
       tuple<std::string>("Surface", "surface", "Volume", "volume"),
       tuple<Inpar::BeamPotential::BeamPotentialType>(
           beampot_surf, beampot_surf, beampot_vol, beampot_vol),
       &beampotential);
 
-  setStringToIntegralParameter<Inpar::BeamPotential::BeamPotentialStrategy>("STRATEGY",
+  Core::Utils::string_to_integral_parameter<Inpar::BeamPotential::BeamPotentialStrategy>("STRATEGY",
       "DoubleLengthSpecific_LargeSepApprox",
       "strategy to evaluate interaction potential: double/single length specific, "
       "small/large separation approximation, ...",
@@ -55,7 +55,7 @@ void Inpar::BeamPotential::set_valid_parameters(Teuchos::ParameterList& list)
       "than this cutoff radius",
       &beampotential);
 
-  setStringToIntegralParameter<Inpar::BeamPotential::BeamPotentialRegularizationType>(
+  Core::Utils::string_to_integral_parameter<Inpar::BeamPotential::BeamPotentialRegularizationType>(
       "REGULARIZATION_TYPE", "none", "Type of regularization applied to the force law",
       tuple<std::string>("linear_extrapolation", "constant_extrapolation", "None", "none"),
       tuple<Inpar::BeamPotential::BeamPotentialRegularizationType>(
@@ -76,7 +76,8 @@ void Inpar::BeamPotential::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("AUTOMATIC_DIFFERENTIATION", "No",
       "apply automatic differentiation via FAD?", &beampotential);
 
-  setStringToIntegralParameter<MasterSlaveChoice>("CHOICE_MASTER_SLAVE", "smaller_eleGID_is_slave",
+  Core::Utils::string_to_integral_parameter<MasterSlaveChoice>("CHOICE_MASTER_SLAVE",
+      "smaller_eleGID_is_slave",
       "According to which rule shall the role of master and slave be assigned to beam elements?",
       tuple<std::string>("smaller_eleGID_is_slave", "higher_eleGID_is_slave"),
       tuple<MasterSlaveChoice>(
@@ -92,7 +93,7 @@ void Inpar::BeamPotential::set_valid_parameters(Teuchos::ParameterList& list)
       &beampotential);
 
   // enable octree search and determine type of bounding box (aabb = axis aligned, spbb = spherical)
-  setStringToIntegralParameter<BeamContact::OctreeType>("BEAMPOT_OCTREE", "None",
+  Core::Utils::string_to_integral_parameter<BeamContact::OctreeType>("BEAMPOT_OCTREE", "None",
       "octree and bounding box type for octree search routine",
       tuple<std::string>(
           "None", "none", "octree_axisaligned", "octree_cylorient", "octree_spherical"),

--- a/src/inpar/4C_inpar_binningstrategy.cpp
+++ b/src/inpar/4C_inpar_binningstrategy.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::BINSTRATEGY::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& binningstrategy = list.sublist("BINNING STRATEGY", false, "");
@@ -41,7 +40,7 @@ void Inpar::BINSTRATEGY::set_valid_parameters(Teuchos::ParameterList& list)
       "points",
       &binningstrategy);
 
-  setStringToIntegralParameter<Core::Binstrategy::WriteBins>("WRITEBINS", "none",
+  Core::Utils::string_to_integral_parameter<Core::Binstrategy::WriteBins>("WRITEBINS", "none",
       "Write none, row or column bins for visualization",
       tuple<std::string>("none", "rows", "cols"),
       tuple<Core::Binstrategy::WriteBins>(Core::Binstrategy::WriteBins::none,

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -17,12 +17,12 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::ArtDyn::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
   Teuchos::ParameterList& andyn = list.sublist("ARTERIAL DYNAMIC", false, "");
 
-  setStringToIntegralParameter<TimeIntegrationScheme>("DYNAMICTYPE", "ExpTaylorGalerkin",
-      "Explicit Taylor Galerkin Scheme", tuple<std::string>("ExpTaylorGalerkin", "Stationary"),
+  Core::Utils::string_to_integral_parameter<TimeIntegrationScheme>("DYNAMICTYPE",
+      "ExpTaylorGalerkin", "Explicit Taylor Galerkin Scheme",
+      tuple<std::string>("ExpTaylorGalerkin", "Stationary"),
       tuple<TimeIntegrationScheme>(tay_gal, stationary), &andyn);
 
   Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", &andyn);
@@ -42,7 +42,7 @@ void Inpar::ArtDyn::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("INITFUNCNO", -1, "function number for artery initial field", &andyn);
 
   // type of initial field
-  setStringToIntegralParameter<InitialField>("INITIALFIELD", "zero_field",
+  Core::Utils::string_to_integral_parameter<InitialField>("INITIALFIELD", "zero_field",
       "Initial Field for artery problem",
       tuple<std::string>("zero_field", "field_by_function", "field_by_condition"),
       tuple<InitialField>(
@@ -54,7 +54,6 @@ void Inpar::ArtDyn::set_valid_parameters(Teuchos::ParameterList& list)
 
 void Inpar::ArteryNetwork::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& redtisdyn =
@@ -64,7 +63,7 @@ void Inpar::ArteryNetwork::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("CONVTOL_Q", 1E-6,
       "Coupled red_airway and tissue iteration convergence for flux", &redtisdyn);
   Core::Utils::int_parameter("MAXITER", 5, "Maximum coupling iterations", &redtisdyn);
-  setStringToIntegralParameter<Relaxtype3D0D>("RELAXTYPE", "norelaxation",
+  Core::Utils::string_to_integral_parameter<Relaxtype3D0D>("RELAXTYPE", "norelaxation",
       "Dynamic Relaxation Type",
       tuple<std::string>("norelaxation", "fixedrelaxation", "Aitken", "SD"),
       tuple<Relaxtype3D0D>(norelaxation, fixedrelaxation, Aitken, SD), &redtisdyn);
@@ -251,18 +250,17 @@ void Inpar::BioFilm::set_valid_conditions(
 
 void Inpar::ReducedLung::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& redawdyn = list.sublist("REDUCED DIMENSIONAL AIRWAYS DYNAMIC", false, "");
 
-  setStringToIntegralParameter<RedAirwaysDyntype>("DYNAMICTYPE", "OneStepTheta",
+  Core::Utils::string_to_integral_parameter<RedAirwaysDyntype>("DYNAMICTYPE", "OneStepTheta",
       "OneStepTheta Scheme", tuple<std::string>("OneStepTheta"),
       tuple<RedAirwaysDyntype>(one_step_theta), &redawdyn);
 
-  setStringToIntegralParameter<RedAirwaysDyntype>("SOLVERTYPE", "Linear", "Solver type",
-      tuple<std::string>("Linear", "Nonlinear"), tuple<RedAirwaysDyntype>(linear, nonlinear),
-      &redawdyn);
+  Core::Utils::string_to_integral_parameter<RedAirwaysDyntype>("SOLVERTYPE", "Linear",
+      "Solver type", tuple<std::string>("Linear", "Nonlinear"),
+      tuple<RedAirwaysDyntype>(linear, nonlinear), &redawdyn);
 
   Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", &redawdyn);
   Core::Utils::int_parameter("NUMSTEP", 0, "Number of Time Steps", &redawdyn);

--- a/src/inpar/4C_inpar_cardiac_monodomain.cpp
+++ b/src/inpar/4C_inpar_cardiac_monodomain.cpp
@@ -14,7 +14,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::ElectroPhysiology::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& epcontrol = list.sublist("CARDIAC MONODOMAIN CONTROL", false,

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Cardiovascular0D::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& cardvasc0dstruct =
@@ -41,7 +40,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("LINEAR_COUPLED_SOLVER", -1,
       "number of linear solver used for cardiovascular 0D-structural problems", &cardvasc0dstruct);
 
-  setStringToIntegralParameter<Cardvasc0DSolveAlgo>("SOLALGORITHM", "direct", "",
+  Core::Utils::string_to_integral_parameter<Cardvasc0DSolveAlgo>("SOLALGORITHM", "direct", "",
       tuple<std::string>("block", "direct"),
       tuple<Cardvasc0DSolveAlgo>(Inpar::Cardiovascular0D::cardvasc0dsolve_block,
           Inpar::Cardiovascular0D::cardvasc0dsolve_direct),
@@ -77,7 +76,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("R_atvalve_min_r", 0.0,
       "minimal right atrial (atrioventricular) valve resistance", &cardvasc0dsyspulcirc);
 
-  setStringToIntegralParameter<Cardvasc0DAtriumModel>("ATRIUM_MODEL", "0D", "",
+  Core::Utils::string_to_integral_parameter<Cardvasc0DAtriumModel>("ATRIUM_MODEL", "0D", "",
       tuple<std::string>("0D", "3D", "prescribed"),
       tuple<Cardvasc0DAtriumModel>(Inpar::Cardiovascular0D::atr_elastance_0d,
           Inpar::Cardiovascular0D::atr_structure_3d, Inpar::Cardiovascular0D::atr_prescribed),
@@ -101,7 +100,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter(
       "E_at_min_r", 0.0, "0D baseline right atrial elastance", &cardvasc0dsyspulcirc);
 
-  setStringToIntegralParameter<Cardvasc0DVentricleModel>("VENTRICLE_MODEL", "3D", "",
+  Core::Utils::string_to_integral_parameter<Cardvasc0DVentricleModel>("VENTRICLE_MODEL", "3D", "",
       tuple<std::string>("3D", "0D", "prescribed"),
       tuple<Cardvasc0DVentricleModel>(Inpar::Cardiovascular0D::ventr_structure_3d,
           Inpar::Cardiovascular0D::ventr_elastance_0d, Inpar::Cardiovascular0D::ventr_prescribed),
@@ -328,8 +327,8 @@ void Inpar::Cardiovascular0D::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& cardvascrespir0d =
       cardvasc0dstruct.sublist("RESPIRATORY PARAMETERS", false, "");
 
-  setStringToIntegralParameter<Cardvasc0DRespiratoryModel>("RESPIRATORY_MODEL", "None", "",
-      tuple<std::string>("None", "Standard"),
+  Core::Utils::string_to_integral_parameter<Cardvasc0DRespiratoryModel>("RESPIRATORY_MODEL", "None",
+      "", tuple<std::string>("None", "Standard"),
       tuple<Cardvasc0DRespiratoryModel>(
           Inpar::Cardiovascular0D::resp_none, Inpar::Cardiovascular0D::resp_standard),
       &cardvascrespir0d);

--- a/src/inpar/4C_inpar_constraint_framework.cpp
+++ b/src/inpar/4C_inpar_constraint_framework.cpp
@@ -17,18 +17,19 @@ FOUR_C_NAMESPACE_OPEN
  */
 void Inpar::CONSTRAINTS::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& embeddedmeshcoupling = list.sublist("EMBEDDED MESH COUPLING", false, "");
   {
-    setStringToIntegralParameter<EmbeddedMeshCouplingStrategy>("COUPLING_STRATEGY", "none",
-        "Strategy to couple background and overlapping mesh", tuple<std::string>("none", "mortar"),
+    Core::Utils::string_to_integral_parameter<EmbeddedMeshCouplingStrategy>("COUPLING_STRATEGY",
+        "none", "Strategy to couple background and overlapping mesh",
+        tuple<std::string>("none", "mortar"),
         tuple<EmbeddedMeshCouplingStrategy>(
             EmbeddedMeshCouplingStrategy::none, EmbeddedMeshCouplingStrategy::mortar),
         &embeddedmeshcoupling);
 
-    setStringToIntegralParameter<SolidToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION", "none",
+    Core::Utils::string_to_integral_parameter<SolidToSolidMortarShapefunctions>(
+        "MORTAR_SHAPE_FUNCTION", "none",
         "Shape functions that should be use in case of coupling using the Mortar/Lagrange "
         "Multiplier method",
         tuple<std::string>("none", "quad4", "quad9", "nurbs9"),
@@ -37,8 +38,9 @@ void Inpar::CONSTRAINTS::set_valid_parameters(Teuchos::ParameterList& list)
             SolidToSolidMortarShapefunctions::nurbs9),
         &embeddedmeshcoupling);
 
-    setStringToIntegralParameter<EmbeddedMeshConstraintEnforcement>("CONSTRAINT_ENFORCEMENT",
-        "none", "Apply a constraint enforcement in the embedded mesh coupling strategy",
+    Core::Utils::string_to_integral_parameter<EmbeddedMeshConstraintEnforcement>(
+        "CONSTRAINT_ENFORCEMENT", "none",
+        "Apply a constraint enforcement in the embedded mesh coupling strategy",
         tuple<std::string>("none", "penalty"),
         tuple<EmbeddedMeshConstraintEnforcement>(
             EmbeddedMeshConstraintEnforcement::none, EmbeddedMeshConstraintEnforcement::penalty),

--- a/src/inpar/4C_inpar_contact.cpp
+++ b/src/inpar/4C_inpar_contact.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /* parameters for structural meshtying and contact */
@@ -28,13 +27,13 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("RESTART_WITH_CONTACT", "No",
       "Must be chosen if a non-contact simulation is to be restarted with contact", &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::AdhesionType>("ADHESION", "None",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::AdhesionType>("ADHESION", "None",
       "Type of adhesion law", tuple<std::string>("None", "none", "bounded", "b"),
       tuple<Inpar::CONTACT::AdhesionType>(
           adhesion_none, adhesion_none, adhesion_bound, adhesion_bound),
       &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::FrictionType>("FRICTION", "None",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::FrictionType>("FRICTION", "None",
       "Type of friction law", tuple<std::string>("None", "Stick", "Tresca", "Coulomb"),
       tuple<Inpar::CONTACT::FrictionType>(
           friction_none, friction_stick, friction_tresca, friction_coulomb),
@@ -49,8 +48,8 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
       "but this would be consistent to wear and tsi calculations.",
       &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::SolvingStrategy>("STRATEGY", "LagrangianMultipliers",
-      "Type of employed solving strategy",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::SolvingStrategy>("STRATEGY",
+      "LagrangianMultipliers", "Type of employed solving strategy",
       tuple<std::string>("LagrangianMultipliers", "lagrange", "Lagrange", "penalty", "Penalty",
           "Uzawa", "Nitsche", "Ehl", "MultiScale"),
       tuple<Inpar::CONTACT::SolvingStrategy>(solution_lagmult, solution_lagmult, solution_lagmult,
@@ -58,7 +57,7 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
           solution_multiscale),
       &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::SystemType>("SYSTEM", "Condensed",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::SystemType>("SYSTEM", "Condensed",
       "Type of linear system setup / solution",
       tuple<std::string>("Condensed", "condensed", "cond", "Condensedlagmult", "condensedlagmult",
           "condlm", "SaddlePoint", "Saddlepoint", "saddlepoint", "sp", "none"),
@@ -93,7 +92,7 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter(
       "VELOCITY_UPDATE", "No", "If chosen, velocity update method is applied", &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::EmOutputType>("EMOUTPUT", "None",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::EmOutputType>("EMOUTPUT", "None",
       "Type of energy and momentum output",
       tuple<std::string>(
           "None", "none", "No", "no", "Screen", "screen", "File", "file", "Both", "both"),
@@ -108,12 +107,12 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
       "Value for initialization of init contact set with gap vector", &scontact);
 
   // solver convergence test parameters for contact/meshtying in saddlepoint formulation
-  setStringToIntegralParameter<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFCONTCONSTR", "And",
-      "binary operator to combine contact constraints and residual force values",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFCONTCONSTR",
+      "And", "binary operator to combine contact constraints and residual force values",
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), &scontact);
 
-  setStringToIntegralParameter<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPLAGR", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPLAGR", "And",
       "binary operator to combine displacement increments and Lagrange multiplier increment values",
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), &scontact);
@@ -126,13 +125,14 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
       "tolerance in the LM norm for the newton iteration (saddlepoint formulation only)",
       &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::ConstraintDirection>("CONSTRAINT_DIRECTIONS", "ntt",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::ConstraintDirection>(
+      "CONSTRAINT_DIRECTIONS", "ntt",
       "formulation of constraints in normal/tangential or xyz-direction",
       tuple<std::string>("ntt", "xyz"),
       tuple<Inpar::CONTACT::ConstraintDirection>(constr_ntt, constr_xyz), &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::Regularization>("CONTACT_REGULARIZATION", "no",
-      "use regularized contact", tuple<std::string>("no", "tanh"),
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::Regularization>(
+      "CONTACT_REGULARIZATION", "no", "use regularized contact", tuple<std::string>("no", "tanh"),
       tuple<Inpar::CONTACT::Regularization>(reg_none, reg_tanh), &scontact);
 
   Core::Utils::bool_parameter("NONSMOOTH_GEOMETRIES", "No",
@@ -167,8 +167,8 @@ void Inpar::CONTACT::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("NITSCHE_THETA_2", 1.0,
       "+1: Chouly-type, 0: Burman penalty-free (only with theta=-1)", &scontact);
 
-  setStringToIntegralParameter<Inpar::CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING", "harmonic",
-      "how to weight consistency terms in Nitsche contact formulation",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING",
+      "harmonic", "how to weight consistency terms in Nitsche contact formulation",
       tuple<std::string>("slave", "master", "harmonic"),
       tuple<Inpar::CONTACT::NitscheWeighting>(NitWgt_slave, NitWgt_master, NitWgt_harmonic),
       &scontact);

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::EHL::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& ehldyn = list.sublist("ELASTO HYDRO DYNAMIC", false,
@@ -41,12 +40,12 @@ void Inpar::EHL::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("ITEMIN", 1, "minimal number of iterations over fields", &ehldyn);
 
   // Type of coupling strategy between the two fields
-  setStringToIntegralParameter<FieldCoupling>("FIELDCOUPLING", "none",
+  Core::Utils::string_to_integral_parameter<FieldCoupling>("FIELDCOUPLING", "none",
       "Type of coupling strategy between fields", tuple<std::string>("none", "matching"),
       tuple<FieldCoupling>(coupling_none, coupling_matching), &ehldyn);
 
   // Coupling strategy for EHL solvers
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "ehl_Monolithic",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO", "ehl_Monolithic",
       "Coupling strategies for EHL solvers", tuple<std::string>("ehl_IterStagg", "ehl_Monolithic"),
       tuple<SolutionSchemeOverFields>(ehl_IterStagg, ehl_Monolithic), &ehldyn);
 
@@ -63,17 +62,17 @@ void Inpar::EHL::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("TOLINC", 1.0e-6,
       "tolerance for convergence check of EHL-increment in monolithic EHL", &ehldynmono);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_RESF", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &ehldynmono);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_INC", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_INC", "Abs",
       "type of norm for convergence check of primary variables in EHL",
       tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &ehldynmono);
 
 
-  setStringToIntegralParameter<BinaryOp>("NORMCOMBI_RESFINC", "Coupl_And_Single",
+  Core::Utils::string_to_integral_parameter<BinaryOp>("NORMCOMBI_RESFINC", "Coupl_And_Single",
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>(
           "And", "Or", "Coupl_Or_Single", "Coupl_And_Single", "And_Single", "Or_Single"),
@@ -81,7 +80,7 @@ void Inpar::EHL::set_valid_parameters(Teuchos::ParameterList& list)
           bop_or_single),
       &ehldynmono);
 
-  setStringToIntegralParameter<VectorNorm>("ITERNORM", "Rms",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("ITERNORM", "Rms",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(norm_l1, norm_l1_scaled, norm_l2, norm_rms, norm_inf), &ehldynmono);

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::ElCh::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& elchcontrol =
@@ -39,12 +38,9 @@ void Inpar::ElCh::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("GAS_CONSTANT", 8.314472,
       "(universal) gas constant (in unit system as chosen in input file)", &elchcontrol);
   // parameter for possible types of ELCH algorithms for deforming meshes
-  setStringToIntegralParameter<Inpar::ElCh::ElchMovingBoundary>("MOVINGBOUNDARY", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::ElCh::ElchMovingBoundary>("MOVINGBOUNDARY", "No",
       "ELCH algorithm for deforming meshes",
       tuple<std::string>("No", "pseudo-transient", "fully-transient"),
-      tuple<std::string>("no moving boundary algorithm",
-          "pseudo-transient moving boundary algorithm",
-          "full moving boundary algorithm including fluid solve"),
       tuple<Inpar::ElCh::ElchMovingBoundary>(
           elch_mov_bndry_no, elch_mov_bndry_pseudo_transient, elch_mov_bndry_fully_transient),
       &elchcontrol);
@@ -53,8 +49,8 @@ void Inpar::ElCh::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("MOVBOUNDARYTHETA", 0.0,
       "One-step-theta factor in electrode shape change computations", &elchcontrol);
   Core::Utils::bool_parameter("GALVANOSTATIC", "No", "flag for galvanostatic mode", &elchcontrol);
-  setStringToIntegralParameter<Inpar::ElCh::ApproxElectResist>("GSTAT_APPROX_ELECT_RESIST",
-      "relation_pot_cur", "relation of potential and current flow",
+  Core::Utils::string_to_integral_parameter<Inpar::ElCh::ApproxElectResist>(
+      "GSTAT_APPROX_ELECT_RESIST", "relation_pot_cur", "relation of potential and current flow",
       tuple<std::string>("relation_pot_cur", "effective_length_with_initial_cond",
           "effective_length_with_integrated_cond"),
       tuple<Inpar::ElCh::ApproxElectResist>(approxelctresist_relpotcur,
@@ -74,7 +70,7 @@ void Inpar::ElCh::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter(
       "GSTAT_LENGTH_CURRENTPATH", 0.0, "average length of the current path", &elchcontrol);
 
-  setStringToIntegralParameter<Inpar::ElCh::EquPot>("EQUPOT", "Undefined",
+  Core::Utils::string_to_integral_parameter<Inpar::ElCh::EquPot>("EQUPOT", "Undefined",
       "type of closing equation for electric potential",
       tuple<std::string>(
           "Undefined", "ENC", "ENC_PDE", "ENC_PDE_ELIM", "Poisson", "Laplace", "divi"),
@@ -143,7 +139,7 @@ void Inpar::ElCh::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter(
       "INITPOTCALC", "No", "calculate initial potential field?", &sclcontrol);
   Core::Utils::int_parameter("SOLVER", -1, "solver for coupled SCL problem", &sclcontrol);
-  setStringToIntegralParameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
       "type of global system matrix in global system of equations",
       tuple<std::string>("undefined", "block", "sparse"),
       tuple<Core::LinAlg::MatrixType>(Core::LinAlg::MatrixType::undefined,
@@ -153,7 +149,7 @@ void Inpar::ElCh::set_valid_parameters(Teuchos::ParameterList& list)
       "time step when time step size should be updated to 'ADAPTED_TIME_STEP_SIZE'.", &sclcontrol);
   Core::Utils::double_parameter("ADAPTED_TIME_STEP_SIZE", -1.0, "new time step size.", &sclcontrol);
 
-  setStringToIntegralParameter<ScaTra::InitialField>("INITIALFIELD", "zero_field",
+  Core::Utils::string_to_integral_parameter<ScaTra::InitialField>("INITIALFIELD", "zero_field",
       "Initial Field for scalar transport problem",
       tuple<std::string>("zero_field", "field_by_function", "field_by_condition"),
       tuple<ScaTra::InitialField>(ScaTra::initfield_zero_field, ScaTra::initfield_field_by_function,

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::EleMag::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& electromagneticdyn = list.sublist(
@@ -61,8 +60,8 @@ void Inpar::EleMag::set_valid_parameters(Teuchos::ParameterList& list)
     name[7] = "Crank_Nicolson";
     label[7] = elemag_cn;
 
-    setStringToIntegralParameter<Inpar::EleMag::DynamicType>("TIMEINT", "One_Step_Theta",
-        "Type of time integration scheme", name, label, &electromagneticdyn);
+    Core::Utils::string_to_integral_parameter<Inpar::EleMag::DynamicType>("TIMEINT",
+        "One_Step_Theta", "Type of time integration scheme", name, label, &electromagneticdyn);
   }
 
   {
@@ -78,8 +77,8 @@ void Inpar::EleMag::set_valid_parameters(Teuchos::ParameterList& list)
     name[3] = "field_by_steady_state_hdg";
     label[3] = initfield_scatra_hdg;
 
-    setStringToIntegralParameter<Inpar::EleMag::InitialField>("INITIALFIELD", "zero_field",
-        "Initial field for ele problem", name, label, &electromagneticdyn);
+    Core::Utils::string_to_integral_parameter<Inpar::EleMag::InitialField>("INITIALFIELD",
+        "zero_field", "Initial field for ele problem", name, label, &electromagneticdyn);
 
     // Error calculation
     Core::Utils::bool_parameter(
@@ -94,8 +93,8 @@ void Inpar::EleMag::set_valid_parameters(Teuchos::ParameterList& list)
       "ERRORFUNCNO", -1, "Function for error calculation", &electromagneticdyn);
 
   // flag for equilibration of global system of equations
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "columns_full", "columns_maindiag",
           "rowsandcolumns_full", "rowsandcolumns_maindiag"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,

--- a/src/inpar/4C_inpar_fbi.cpp
+++ b/src/inpar/4C_inpar_fbi.cpp
@@ -15,7 +15,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::FBI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& fbi = list.sublist("FLUID BEAM INTERACTION", false, "");
@@ -23,8 +22,8 @@ void Inpar::FBI::set_valid_parameters(Teuchos::ParameterList& list)
   /*----------------------------------------------------------------------*/
   /* parameters for beam to fluid meshtying */
 
-  setStringToIntegralParameter<BeamToFluidCoupling>("COUPLING", "two-way", "Type of FBI coupling",
-      tuple<std::string>("two-way", "fluid", "solid"),
+  Core::Utils::string_to_integral_parameter<BeamToFluidCoupling>("COUPLING", "two-way",
+      "Type of FBI coupling", tuple<std::string>("two-way", "fluid", "solid"),
       tuple<BeamToFluidCoupling>(
           BeamToFluidCoupling::twoway, BeamToFluidCoupling::fluid, BeamToFluidCoupling::solid),
       &fbi);
@@ -33,8 +32,9 @@ void Inpar::FBI::set_valid_parameters(Teuchos::ParameterList& list)
       "Time Step at which to begin the fluid beam coupling. Usually this will be the first step.",
       &fbi);
 
-  setStringToIntegralParameter<BeamToFluidPreSortStrategy>("PRESORT_STRATEGY", "bruteforce",
-      "Presort strategy for the beam elements", tuple<std::string>("bruteforce", "binning"),
+  Core::Utils::string_to_integral_parameter<BeamToFluidPreSortStrategy>("PRESORT_STRATEGY",
+      "bruteforce", "Presort strategy for the beam elements",
+      tuple<std::string>("bruteforce", "binning"),
       tuple<BeamToFluidPreSortStrategy>(
           BeamToFluidPreSortStrategy::bruteforce, BeamToFluidPreSortStrategy::binning),
       &fbi);
@@ -44,15 +44,16 @@ void Inpar::FBI::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& beam_to_fluid_meshtying =
       fbi.sublist("BEAM TO FLUID MESHTYING", false, "");
 
-  setStringToIntegralParameter<BeamToFluidDiscretization>("MESHTYING_DISCRETIZATION", "none",
-      "Type of employed meshtying discretization",
+  Core::Utils::string_to_integral_parameter<BeamToFluidDiscretization>("MESHTYING_DISCRETIZATION",
+      "none", "Type of employed meshtying discretization",
       tuple<std::string>("none", "gauss_point_to_segment", "mortar"),
       tuple<FBI::BeamToFluidDiscretization>(BeamToFluidDiscretization::none,
           BeamToFluidDiscretization::gauss_point_to_segment, BeamToFluidDiscretization::mortar),
       &beam_to_fluid_meshtying);
 
-  setStringToIntegralParameter<BeamToFluidConstraintEnforcement>("CONSTRAINT_STRATEGY", "none",
-      "Type of employed constraint enforcement strategy", tuple<std::string>("none", "penalty"),
+  Core::Utils::string_to_integral_parameter<BeamToFluidConstraintEnforcement>("CONSTRAINT_STRATEGY",
+      "none", "Type of employed constraint enforcement strategy",
+      tuple<std::string>("none", "penalty"),
       tuple<BeamToFluidConstraintEnforcement>(
           BeamToFluidConstraintEnforcement::none, BeamToFluidConstraintEnforcement::penalty),
       &beam_to_fluid_meshtying);
@@ -65,7 +66,7 @@ void Inpar::FBI::set_valid_parameters(Teuchos::ParameterList& list)
       "memory demand but to still find all interaction pairs!",
       &beam_to_fluid_meshtying);
 
-  setStringToIntegralParameter<Inpar::FBI::BeamToFluidMeshtingMortarShapefunctions>(
+  Core::Utils::string_to_integral_parameter<Inpar::FBI::BeamToFluidMeshtingMortarShapefunctions>(
       "MORTAR_SHAPE_FUNCTION", "none", "Shape function for the mortar Lagrange-multipliers",
       tuple<std::string>("none", "line2", "line3", "line4"),
       tuple<Inpar::FBI::BeamToFluidMeshtingMortarShapefunctions>(

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -19,15 +19,14 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& fdyn = list.sublist("FLUID DYNAMIC", false, "");
 
   // physical type of fluid flow (incompressible, varying density, loma, Boussinesq approximation,
   // temperature-dependent water)
-  setStringToIntegralParameter<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE", "Incompressible",
-      "Physical Type",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE",
+      "Incompressible", "Physical Type",
       tuple<std::string>("Incompressible", "Weakly_compressible", "Weakly_compressible_stokes",
           "Weakly_compressible_dens_mom", "Weakly_compressible_stokes_dens_mom",
           "Artificial_compressibility", "Varying_density", "Loma", "Temp_dep_water", "Boussinesq",
@@ -50,10 +49,9 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn);
 
   // Flag to define the way of calculating stresses and wss
-  setStringToIntegralParameter<Inpar::FLUID::WSSType>("WSS_TYPE", "Standard",
-      "which type of stresses and wss", tuple<std::string>("Standard", "Aggregation", "Mean"),
-      tuple<std::string>(
-          "calculate 'normal' wss", "calculate aggregated wss", "calculate mean wss"),
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::WSSType>("WSS_TYPE", "Standard",
+      "which type of stresses and wall shear stress",
+      tuple<std::string>("Standard", "Aggregation", "Mean"),
       tuple<Inpar::FLUID::WSSType>(wss_standard, wss_aggregation, wss_mean), &fdyn);
 
   // Set ML-solver number for smoothing of residual-based calculated wallshearstress via plain
@@ -63,14 +61,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       "aggregation.",
       &fdyn);
 
-  setStringToIntegralParameter<Inpar::FLUID::TimeIntegrationScheme>("TIMEINTEGR", "One_Step_Theta",
-      "Time Integration Scheme",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::TimeIntegrationScheme>("TIMEINTEGR",
+      "One_Step_Theta", "Time Integration Scheme",
       tuple<std::string>("Stationary", "Np_Gen_Alpha", "Af_Gen_Alpha", "One_Step_Theta", "BDF2"),
       tuple<Inpar::FLUID::TimeIntegrationScheme>(timeint_stationary, timeint_npgenalpha,
           timeint_afgenalpha, timeint_one_step_theta, timeint_bdf2),
       &fdyn);
 
-  setStringToIntegralParameter<Inpar::FLUID::OstContAndPress>("OST_CONT_PRESS",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::OstContAndPress>("OST_CONT_PRESS",
       "Cont_normal_Press_normal",
       "One step theta option for time discretization of continuity eq. and pressure",
       tuple<std::string>(
@@ -79,14 +77,15 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
           Cont_normal_Press_normal, Cont_impl_Press_normal, Cont_impl_Press_impl),
       &fdyn);
 
-  setStringToIntegralParameter<Core::IO::GeometryType>("GEOMETRY", "full",
+  Core::Utils::string_to_integral_parameter<Core::IO::GeometryType>("GEOMETRY", "full",
       "How the geometry is specified", tuple<std::string>("full", "box", "file"),
       tuple<Core::IO::GeometryType>(
           Core::IO::geometry_full, Core::IO::geometry_box, Core::IO::geometry_file),
       &fdyn);
 
-  setStringToIntegralParameter<Inpar::FLUID::LinearisationAction>("NONLINITER", "fixed_point_like",
-      "Nonlinear iteration scheme", tuple<std::string>("fixed_point_like", "Newton"),
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::LinearisationAction>("NONLINITER",
+      "fixed_point_like", "Nonlinear iteration scheme",
+      tuple<std::string>("fixed_point_like", "Newton"),
       tuple<Inpar::FLUID::LinearisationAction>(fixed_point_like, Newton), &fdyn);
 
   std::vector<std::string> predictor_valid_input = {"steady_state", "zero_acceleration",
@@ -95,10 +94,9 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       "Predictor for first guess in nonlinear iteration", &fdyn, predictor_valid_input);
 
 
-  setStringToIntegralParameter<Inpar::FLUID::ItNorm>("CONVCHECK", "L_2_norm",
-      "norm for convergence check", tuple<std::string>("L_2_norm"),
-      tuple<std::string>("compute L2 errors of increments (relative) and residuals (absolute)"),
-      tuple<Inpar::FLUID::ItNorm>(fncc_L2), &fdyn);
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::ItNorm>("CONVCHECK", "L_2_norm",
+      "Norm for convergence check (relative increments and absolute residuals)",
+      tuple<std::string>("L_2_norm"), tuple<Inpar::FLUID::ItNorm>(fncc_L2), &fdyn);
 
   Core::Utils::bool_parameter("INCONSISTENT_RESIDUAL", "No",
       "do not evaluate residual after solution has converged (->faster)", &fdyn);
@@ -130,7 +128,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
     name[10] = "channel_weakly_compressible";
     label[10] = initfield_channel_weakly_compressible;
 
-    setStringToIntegralParameter<Inpar::FLUID::InitialField>(
+    Core::Utils::string_to_integral_parameter<Inpar::FLUID::InitialField>(
         "INITIALFIELD", "zero_field", "Initial field for fluid problem", name, label, &fdyn);
   }
 
@@ -149,14 +147,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       "Flag to activate check for potential nonlinear boundary conditions", &fdyn,
       nonlinearbc_valid_input);
 
-  setStringToIntegralParameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
       "Flag to (de)activate mesh tying algorithm",
       tuple<std::string>("no", "Condensed_Smat", "Condensed_Bmat", "Condensed_Bmat_merged"),
       tuple<Inpar::FLUID::MeshTying>(
           no_meshtying, condensed_smat, condensed_bmat, condensed_bmat_merged),
       &fdyn);
 
-  setStringToIntegralParameter<Inpar::FLUID::Gridvel>("GRIDVEL", "BE",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::Gridvel>("GRIDVEL", "BE",
       "scheme for determination of gridvelocity from displacements",
       tuple<std::string>("BE", "BDF2", "OST"), tuple<Inpar::FLUID::Gridvel>(BE, BDF2, OST), &fdyn);
 
@@ -200,7 +198,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
     name[15] = "channel_weakly_compressible";
     label[15] = channel_weakly_compressible;
 
-    setStringToIntegralParameter<Inpar::FLUID::CalcError>(
+    Core::Utils::string_to_integral_parameter<Inpar::FLUID::CalcError>(
         "CALCERROR", "no", "Flag to (de)activate error calculations", name, label, &fdyn);
   }
   Core::Utils::int_parameter("CALCERRORFUNCNO", -1, "Function for Error Calculation", &fdyn);
@@ -234,7 +232,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
     name[1] = "yes";
     label[1] = yes_pressure_average_bc;
 
-    setStringToIntegralParameter<Inpar::FLUID::PressAvgBc>("PRESSAVGBC", "no",
+    Core::Utils::string_to_integral_parameter<Inpar::FLUID::PressAvgBc>("PRESSAVGBC", "no",
         "Flag to (de)activate imposition of boundary condition for the considered element average "
         "pressure",
         name, label, &fdyn);
@@ -290,12 +288,9 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "VELGRAD_PROJ_SOLVER", -1, "Number of linear solver used for L2 projection", &fdyn);
 
-  setStringToIntegralParameter<Inpar::FLUID::GradientReconstructionMethod>("VELGRAD_PROJ_METHOD",
-      "none", "Flag to (de)activate gradient reconstruction.",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::GradientReconstructionMethod>(
+      "VELGRAD_PROJ_METHOD", "none", "Flag to (de)activate gradient reconstruction.",
       tuple<std::string>("none", "superconvergent_patch_recovery", "L2_projection"),
-      tuple<std::string>("no gradient reconstruction",
-          "gradient reconstruction via superconvergent patch recovery",
-          "gracient reconstruction via l2-projection"),
       tuple<Inpar::FLUID::GradientReconstructionMethod>(
           gradreco_none,  // no convective streamline edge-based stabilization
           gradreco_spr,   // convective streamline edge-based stabilization on the entire domain
@@ -325,15 +320,16 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   /*----------------------------------------------------------------------*/
   Teuchos::ParameterList& fdyn_stab = fdyn.sublist("RESIDUAL-BASED STABILIZATION", false, "");
   // this parameter defines various stabilized methods
-  setStringToIntegralParameter<Inpar::FLUID::StabType>("STABTYPE", "residual_based",
-      "Apply (un)stabilized fluid formulation",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::StabType>("STABTYPE", "residual_based",
+      "Apply (un)stabilized fluid formulation. No stabilization is only possible for inf-sup "
+      "stable elements."
+      "Use a residual-based stabilization or, more generally, a stabilization \nbased on the "
+      "concept of the residual-based variational multiscale method...\nExpecting additional "
+      "input. "
+      "Use an edge-based stabilization, especially for XFEM. "
+      "Alternative: Element/cell based polynomial pressure projection, see Dohrmann/Bochev 2004, "
+      "IJNMF",
       tuple<std::string>("no_stabilization", "residual_based", "edge_based", "pressure_projection"),
-      tuple<std::string>("Do not use any stabilization -> inf-sup stable elements required!",
-          "Use a residual-based stabilization or, more generally, a stabilization \nbased on the "
-          "concept of the residual-based variational multiscale method...\nExpecting additional "
-          "input",
-          "Use an edge-based stabilization, especially for XFEM",
-          "Element/cell based polynomial pressure projection, see Dohrmann/Bochev 2004, IJNMF"),
       tuple<Inpar::FLUID::StabType>(
           stabtype_nostab, stabtype_residualbased, stabtype_edgebased, stabtype_pressureprojection),
       &fdyn_stab);
@@ -348,20 +344,16 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_stab);
 
   // the following parameters are necessary only if a residual based stabilized method is applied
-  setStringToIntegralParameter<SubscalesTD>("TDS", "quasistatic",
+  Core::Utils::string_to_integral_parameter<SubscalesTD>("TDS", "quasistatic",
       "Flag to allow time dependency of subscales for residual-based stabilization.",
       tuple<std::string>("quasistatic", "time_dependent"),
-      tuple<std::string>("Use a quasi-static residual-based stabilization (standard case)",
-          "Residual-based stabilization including time evolution equations for subscales"),
       tuple<SubscalesTD>(subscales_quasistatic, subscales_time_dependent), &fdyn_stab);
 
-  setStringToIntegralParameter<Transient>("TRANSIENT", "no_transient",
-      "Specify how to treat the transient term.",
+  Core::Utils::string_to_integral_parameter<Transient>("TRANSIENT", "no_transient",
+      "Specify how to treat the transient term. "
+      "Use transient term (recommended for time dependent subscales) or "
+      "use transient term including a linearisation of 1/tau",
       tuple<std::string>("no_transient", "yes_transient", "transient_complete"),
-      tuple<std::string>(
-          "Do not use transient term (currently only opportunity for quasistatic stabilization)",
-          "Use transient term (recommended for time dependent subscales)",
-          "Use transient term including a linearisation of 1/tau"),
       tuple<Transient>(inertia_stab_drop, inertia_stab_keep, inertia_stab_keep_complete),
       &fdyn_stab);
 
@@ -371,48 +363,36 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       "SUPG", "Yes", "Flag to (de)activate SUPG stabilization.", &fdyn_stab);
   Core::Utils::bool_parameter("GRAD_DIV", "Yes", "Flag to (de)activate grad-div term.", &fdyn_stab);
 
-  setStringToIntegralParameter<VStab>("VSTAB", "no_vstab",
-      "Flag to (de)activate viscous term in residual-based stabilization.",
+  Core::Utils::string_to_integral_parameter<VStab>("VSTAB", "no_vstab",
+      "Flag to (de)activate viscous term in residual-based stabilization. Options: "
+      "No viscous term in stabilization, or, "
+      "Viscous stabilization of GLS type, or, "
+      "Viscous stabilization of GLS type, included only on the right hand side, or, "
+      "Viscous stabilization of USFEM type, or, "
+      "Viscous stabilization of USFEM type, included only on the right hand side",
       tuple<std::string>(
           "no_vstab", "vstab_gls", "vstab_gls_rhs", "vstab_usfem", "vstab_usfem_rhs"),
-      tuple<std::string>("No viscous term in stabilization", "Viscous stabilization of GLS type",
-          "Viscous stabilization of GLS type, included only on the right hand side",
-          "Viscous stabilization of USFEM type",
-          "Viscous stabilization of USFEM type, included only on the right hand side"),
       tuple<VStab>(viscous_stab_none, viscous_stab_gls, viscous_stab_gls_only_rhs,
           viscous_stab_usfem, viscous_stab_usfem_only_rhs),
       &fdyn_stab);
 
-  setStringToIntegralParameter<RStab>("RSTAB", "no_rstab",
+  Core::Utils::string_to_integral_parameter<RStab>("RSTAB", "no_rstab",
       "Flag to (de)activate reactive term in residual-based stabilization.",
       tuple<std::string>("no_rstab", "rstab_gls", "rstab_usfem"),
-      tuple<std::string>("no reactive term in stabilization", "reactive stabilization of GLS type",
-          "reactive stabilization of USFEM type"),
       tuple<RStab>(reactive_stab_none, reactive_stab_gls, reactive_stab_usfem), &fdyn_stab);
 
-  setStringToIntegralParameter<CrossStress>("CROSS-STRESS", "no_cross",
-      "Flag to (de)activate cross-stress term -> residual-based VMM.",
-      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"
-          //"cross_complete"
-          ),
-      tuple<std::string>("No cross-stress term",
-          "Include the cross-stress term with a linearization of the convective part",
-          "Include cross-stress term, but only explicitly on right hand side"
-          //""
-          ),
+  Core::Utils::string_to_integral_parameter<CrossStress>("CROSS-STRESS", "no_cross",
+      "Flag to (de)activate cross-stress term -> residual-based VMM. Options:"
+      "No cross-stress term, or,"
+      "Include the cross-stress term with a linearization of the convective part, or, "
+      "Include cross-stress term, but only explicitly on right hand side",
+      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"),
       tuple<CrossStress>(cross_stress_stab_none, cross_stress_stab, cross_stress_stab_only_rhs),
       &fdyn_stab);
 
-  setStringToIntegralParameter<ReynoldsStress>("REYNOLDS-STRESS", "no_reynolds",
+  Core::Utils::string_to_integral_parameter<ReynoldsStress>("REYNOLDS-STRESS", "no_reynolds",
       "Flag to (de)activate Reynolds-stress term -> residual-based VMM.",
-      tuple<std::string>("no_reynolds", "yes_reynolds", "reynolds_rhs"
-          //"reynolds_complete"
-          ),
-      tuple<std::string>(
-          "No Reynolds-stress term", "Include Reynolds-stress term with linearisation",
-          "Include Reynolds-stress term explicitly on right hand side"
-          //""
-          ),
+      tuple<std::string>("no_reynolds", "yes_reynolds", "reynolds_rhs"),
       tuple<ReynoldsStress>(
           reynolds_stress_stab_none, reynolds_stress_stab, reynolds_stress_stab_only_rhs),
       &fdyn_stab);
@@ -455,13 +435,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
     name[15] = "Hughes_Franca_Balestra_wo_dt";
     label[15] = tau_hughes_franca_balestra_wo_dt;
 
-    setStringToIntegralParameter<TauType>("DEFINITION_TAU", "Franca_Barrenechea_Valentin_Frey_Wall",
-        "Definition of tau_M and Tau_C", name, label, &fdyn_stab);
+    Core::Utils::string_to_integral_parameter<TauType>("DEFINITION_TAU",
+        "Franca_Barrenechea_Valentin_Frey_Wall", "Definition of tau_M and Tau_C", name, label,
+        &fdyn_stab);
   }
 
   // this parameter selects the characteristic element length for tau_Mu for all
   // stabilization parameter definitions requiring such a length
-  setStringToIntegralParameter<CharEleLengthU>("CHARELELENGTH_U", "streamlength",
+  Core::Utils::string_to_integral_parameter<CharEleLengthU>("CHARELELENGTH_U", "streamlength",
       "Characteristic element length for tau_Mu",
       tuple<std::string>("streamlength", "volume_equivalent_diameter", "root_of_volume"),
       tuple<CharEleLengthU>(streamlength_u, volume_equivalent_diameter_u, root_of_volume_u),
@@ -469,8 +450,8 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
 
   // this parameter selects the characteristic element length for tau_Mp and tau_C for
   // all stabilization parameter definitions requiring such a length
-  setStringToIntegralParameter<CharEleLengthPC>("CHARELELENGTH_PC", "volume_equivalent_diameter",
-      "Characteristic element length for tau_Mp/tau_C",
+  Core::Utils::string_to_integral_parameter<CharEleLengthPC>("CHARELELENGTH_PC",
+      "volume_equivalent_diameter", "Characteristic element length for tau_Mp/tau_C",
       tuple<std::string>("streamlength", "volume_equivalent_diameter", "root_of_volume"),
       tuple<CharEleLengthPC>(streamlength_pc, volume_equivalent_diameter_pc, root_of_volume_pc),
       &fdyn_stab);
@@ -493,27 +474,16 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("LOMA_CONTI_SUPG", "No",
       "Flag to (de)activate SUPG stabilization in loma continuity equation.", &fdyn_stab);
 
-  setStringToIntegralParameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
+  Core::Utils::string_to_integral_parameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
       "Flag to (de)activate cross-stress term loma continuity equation-> residual-based VMM.",
-      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"
-          //"cross_complete"
-          ),
-      tuple<std::string>("No cross-stress term",
-          "Include the cross-stress term with a linearization of the convective part",
-          "Include cross-stress term, but only explicitly on right hand side"
-          //""
-          ),
+      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"),
       tuple<CrossStress>(cross_stress_stab_none, cross_stress_stab, cross_stress_stab_only_rhs),
       &fdyn_stab);
 
-  setStringToIntegralParameter<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS", "no_reynolds",
+  Core::Utils::string_to_integral_parameter<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS",
+      "no_reynolds",
       "Flag to (de)activate Reynolds-stress term loma continuity equation-> residual-based VMM.",
       tuple<std::string>("no_reynolds", "yes_reynolds", "reynolds_rhs"),
-      tuple<std::string>(
-          "No Reynolds-stress term", "Include Reynolds-stress term with linearisation",
-          "Include Reynolds-stress term explicitly on right hand side"
-          //""
-          ),
       tuple<ReynoldsStress>(
           reynolds_stress_stab_none, reynolds_stress_stab, reynolds_stress_stab_only_rhs),
       &fdyn_stab);
@@ -523,14 +493,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       fdyn.sublist("EDGE-BASED STABILIZATION", false, "");
 
   //! Flag to (de)activate edge-based (EOS) pressure stabilization
-  setStringToIntegralParameter<EosPres>("EOS_PRES", "none",
-      "Flag to (de)activate pressure edge-based stabilization.",
+  Core::Utils::string_to_integral_parameter<EosPres>("EOS_PRES", "none",
+      "Flag to (de)activate pressure edge-based stabilization. Options: "
+      "do not use pressure edge-based stabilization, or, "
+      "use pressure edge-based stabilization as standard edge-based stabilization on the "
+      "entire domain, or, "
+      "use pressure edge-based stabilization as xfem ghost-penalty stabilization just around "
+      "cut elements",
       tuple<std::string>("none", "std_eos", "xfem_gp"),
-      tuple<std::string>("do not use pressure edge-based stabilization",
-          "use pressure edge-based stabilization as standard edge-based stabilization on the "
-          "entire domain",
-          "use pressure edge-based stabilization as xfem ghost-penalty stabilization just around "
-          "cut elements"),
       tuple<EosPres>(EOS_PRES_none,  // no pressure edge-based stabilization
           EOS_PRES_std_eos,          // pressure edge-based stabilization on the entire domain
           EOS_PRES_xfem_gp  // pressure edge-based stabilization as ghost penalty around cut
@@ -539,14 +509,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_edge_based_stab);
 
   //! Flag to (de)activate edge-based (EOS) convective streamline stabilization
-  setStringToIntegralParameter<EosConvStream>("EOS_CONV_STREAM", "none",
-      "Flag to (de)activate convective streamline edge-based stabilization.",
+  Core::Utils::string_to_integral_parameter<EosConvStream>("EOS_CONV_STREAM", "none",
+      "Flag to (de)activate convective streamline edge-based stabilization. Options: "
+      "do not use convective streamline edge-based stabilization, or, "
+      "use convective streamline edge-based stabilization as standard edge-based stabilization "
+      "on the entire domain, or, "
+      "use convective streamline edge-based stabilization as xfem ghost-penalty stabilization "
+      "just around cut elements",
       tuple<std::string>("none", "std_eos", "xfem_gp"),
-      tuple<std::string>("do not use convective streamline edge-based stabilization",
-          "use convective streamline edge-based stabilization as standard edge-based stabilization "
-          "on the entire domain",
-          "use convective streamline edge-based stabilization as xfem ghost-penalty stabilization "
-          "just around cut elements"),
       tuple<EosConvStream>(
           EOS_CONV_STREAM_none,     // no convective streamline edge-based stabilization
           EOS_CONV_STREAM_std_eos,  // convective streamline edge-based stabilization on the entire
@@ -557,14 +527,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_edge_based_stab);
 
   //! Flag to (de)activate edge-based (EOS) convective crosswind stabilization
-  setStringToIntegralParameter<EosConvCross>("EOS_CONV_CROSS", "none",
-      "Flag to (de)activate convective crosswind edge-based stabilization.",
+  Core::Utils::string_to_integral_parameter<EosConvCross>("EOS_CONV_CROSS", "none",
+      "Flag to (de)activate convective crosswind edge-based stabilization. Options:"
+      "do not use convective crosswind edge-based stabilization, or, "
+      "use convective crosswind edge-based stabilization as standard edge-based stabilization "
+      "on the entire domain, or, "
+      "use convective crosswind edge-based stabilization as xfem ghost-penalty stabilization "
+      "just around cut elements",
       tuple<std::string>("none", "std_eos", "xfem_gp"),
-      tuple<std::string>("do not use convective crosswind edge-based stabilization",
-          "use convective crosswind edge-based stabilization as standard edge-based stabilization "
-          "on the entire domain",
-          "use convective crosswind edge-based stabilization as xfem ghost-penalty stabilization "
-          "just around cut elements"),
       tuple<EosConvCross>(EOS_CONV_CROSS_none,  // no convective crosswind edge-based stabilization
           EOS_CONV_CROSS_std_eos,  // convective crosswind edge-based stabilization on the entire
                                    // domain
@@ -574,15 +544,15 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_edge_based_stab);
 
   //! Flag to (de)activate edge-based (EOS) divergence stabilization
-  setStringToIntegralParameter<EosDiv>("EOS_DIV", "none",
-      "Flag to (de)activate divergence edge-based stabilization.",
+  Core::Utils::string_to_integral_parameter<EosDiv>("EOS_DIV", "none",
+      "Flag to (de)activate divergence edge-based stabilization. Options: "
+      "do not use divergence edge-based stabilization, or, "
+      "divergence edge-based stabilization based on velocity jump on the entire domain, or, "
+      "divergence edge-based stabilization based on divergence jump just around cut elements, or, "
+      "divergence edge-based stabilization based on velocity jump on the entire domain, or, "
+      "divergence edge-based stabilization based on divergence jump just around cut elements",
       tuple<std::string>(
           "none", "vel_jump_std_eos", "vel_jump_xfem_gp", "div_jump_std_eos", "div_jump_xfem_gp"),
-      tuple<std::string>("do not use divergence edge-based stabilization",
-          "divergence edge-based stabilization based on velocity jump on the entire domain",
-          "divergence edge-based stabilization based on divergence jump just around cut elements",
-          "divergence edge-based stabilization based on velocity jump on the entire domain",
-          "divergence edge-based stabilization based on divergence jump just around cut elements"),
       tuple<EosDiv>(EOS_DIV_none,    // no convective edge-based stabilization
           EOS_DIV_vel_jump_std_eos,  // streamline convective edge-based stabilization
           EOS_DIV_vel_jump_xfem_gp,  // streamline convective edge-based stabilization
@@ -598,7 +568,8 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_edge_based_stab);
 
   //! this parameter selects the definition of Edge-based stabilization parameter
-  setStringToIntegralParameter<EosTauType>("EOS_DEFINITION_TAU", "Burman_Hansbo_DAngelo_Zunino",
+  Core::Utils::string_to_integral_parameter<EosTauType>("EOS_DEFINITION_TAU",
+      "Burman_Hansbo_DAngelo_Zunino",
       "Definition of stabilization parameter for edge-based stabilization",
       tuple<std::string>("Burman_Fernandez_Hansbo", "Burman_Fernandez_Hansbo_wo_dt",
           "Braack_Burman_John_Lube", "Braack_Burman_John_Lube_wo_divjump",
@@ -606,18 +577,6 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
           "Burman_Hansbo_DAngelo_Zunino_wo_dt", "Schott_Massing_Burman_DAngelo_Zunino",
           "Schott_Massing_Burman_DAngelo_Zunino_wo_dt", "Burman",
           "Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling", "tau_not_defined"),
-      tuple<std::string>("definition of burman_fernandez_hansbo",
-          "definition of burman_fernandez_hansbo for stationary problems",
-          "definition of braack_burman_john_lube",
-          "definition of braack_burman_john_lube without explicit inclusion of divergence jump",
-          "definition of tau_franca_barrenechea_valentin_wall",
-          "definition of EOS_tau_burman_fernandez",
-          "definition of EOS_tau_burman_hansbo_dangelo_zunino",
-          "definition of EOS_tau_burman_hansbo_dangelo_zunino for stationary problems",
-          "definition of EOS_tau_schott_massing_burman_dangelo_zunino",
-          "definition of EOS_tau_schott_massing_burman_dangelo_zunino for stationary problems",
-          "definition of EOS_tau_burman",
-          "definition of EOS_tau related to residual-based stabilization", "no chosen definition"),
       tuple<EosTauType>(Inpar::FLUID::EOS_tau_burman_fernandez_hansbo,
           Inpar::FLUID::EOS_tau_burman_fernandez_hansbo_wo_dt,
           Inpar::FLUID::EOS_tau_braack_burman_john_lube,
@@ -634,19 +593,20 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_edge_based_stab);
 
   //! this parameter selects how the element length of Edge-based stabilization is defined
-  setStringToIntegralParameter<EosElementLength>("EOS_H_DEFINITION",
+  Core::Utils::string_to_integral_parameter<EosElementLength>("EOS_H_DEFINITION",
       "EOS_he_max_diameter_to_opp_surf",
-      "Definition of element length for edge-based stabilization",
+      "Definition of element length for edge-based stabilization. Options:"
+      "take the maximal (nsd-1)D diameter of faces that connect the internal "
+      "face to its opposite faces, or, "
+      "take the maximal 1D distance along 1D edge to opposite surface for both parent elements, "
+      "or, "
+      "take the maximal (nsd-1)D face diameter of all faces for both parent elements, or, "
+      "maximal nD diameter of the neighboring elements, or, "
+      "maximal (n-1)D diameter of the internal face/edge, or, "
+      "take the maximal volume equivalent diameter of adjacent elements",
       tuple<std::string>("EOS_he_max_diameter_to_opp_surf", "EOS_he_max_dist_to_opp_surf",
           "EOS_he_surf_with_max_diameter", "EOS_hk_max_diameter", "EOS_he_surf_diameter",
           "EOS_he_vol_eq_diameter"),
-      tuple<std::string>("take the maximal (nsd-1)D diameter of faces that connect the internal "
-                         "face to its opposite faces",
-          "take the maximal 1D distance along 1D edge to opposite surface for both parent elements",
-          "take the maximal (nsd-1)D face diameter of all faces for both parent elements",
-          "maximal nD diameter of the neighboring elements",
-          "maximal (n-1)D diameter of the internal face/edge",
-          "take the maximal volume equivalent diameter of adjacent elements"),
       tuple<EosElementLength>(EOS_he_max_diameter_to_opp_surf, EOS_he_max_dist_to_opp_surf,
           EOS_he_surf_with_max_diameter, EOS_hk_max_diameter, EOS_he_surf_diameter,
           EOS_he_vol_eq_diameter),
@@ -662,14 +622,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_porostab);
 
   // this parameter defines various stabilized methods
-  setStringToIntegralParameter<Inpar::FLUID::StabType>("STABTYPE", "residual_based",
-      "Apply (un)stabilized fluid formulation",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::StabType>("STABTYPE", "residual_based",
+      "Apply (un)stabilized fluid formulation. No stabilization is only possible for inf-sup "
+      "stable elements. "
+      "Use a residual-based stabilization or, more generally, a stabilization \nbased on the "
+      "concept of the residual-based variational multiscale method...\nExpecting additional "
+      "input"
+      "Use an edge-based stabilization, especially for XFEM",
       tuple<std::string>("no_stabilization", "residual_based", "edge_based"),
-      tuple<std::string>("Do not use any stabilization -> inf-sup stable elements required!",
-          "Use a residual-based stabilization or, more generally, a stabilization \nbased on the "
-          "concept of the residual-based variational multiscale method...\nExpecting additional "
-          "input",
-          "Use an edge-based stabilization, especially for XFEM"),
       tuple<Inpar::FLUID::StabType>(stabtype_nostab, stabtype_residualbased, stabtype_edgebased),
       &fdyn_porostab);
 
@@ -683,20 +643,14 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       &fdyn_porostab);
 
   // the following parameters are necessary only if a residual based stabilized method is applied
-  setStringToIntegralParameter<SubscalesTD>("TDS", "quasistatic",
+  Core::Utils::string_to_integral_parameter<SubscalesTD>("TDS", "quasistatic",
       "Flag to allow time dependency of subscales for residual-based stabilization.",
       tuple<std::string>("quasistatic", "time_dependent"),
-      tuple<std::string>("Use a quasi-static residual-based stabilization (standard case)",
-          "Residual-based stabilization including time evolution equations for subscales"),
       tuple<SubscalesTD>(subscales_quasistatic, subscales_time_dependent), &fdyn_porostab);
 
-  setStringToIntegralParameter<Transient>("TRANSIENT", "no_transient",
+  Core::Utils::string_to_integral_parameter<Transient>("TRANSIENT", "no_transient",
       "Specify how to treat the transient term.",
       tuple<std::string>("no_transient", "yes_transient", "transient_complete"),
-      tuple<std::string>(
-          "Do not use transient term (currently only opportunity for quasistatic stabilization)",
-          "Use transient term (recommended for time dependent subscales)",
-          "Use transient term including a linearisation of 1/tau"),
       tuple<Transient>(inertia_stab_drop, inertia_stab_keep, inertia_stab_keep_complete),
       &fdyn_porostab);
 
@@ -707,55 +661,35 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter(
       "GRAD_DIV", "Yes", "Flag to (de)activate grad-div term.", &fdyn_porostab);
 
-  setStringToIntegralParameter<VStab>("VSTAB", "no_vstab",
+  Core::Utils::string_to_integral_parameter<VStab>("VSTAB", "no_vstab",
       "Flag to (de)activate viscous term in residual-based stabilization.",
       tuple<std::string>(
           "no_vstab", "vstab_gls", "vstab_gls_rhs", "vstab_usfem", "vstab_usfem_rhs"),
-      tuple<std::string>("No viscous term in stabilization", "Viscous stabilization of GLS type",
-          "Viscous stabilization of GLS type, included only on the right hand side",
-          "Viscous stabilization of USFEM type",
-          "Viscous stabilization of USFEM type, included only on the right hand side"),
       tuple<VStab>(viscous_stab_none, viscous_stab_gls, viscous_stab_gls_only_rhs,
           viscous_stab_usfem, viscous_stab_usfem_only_rhs),
       &fdyn_porostab);
 
-  setStringToIntegralParameter<RStab>("RSTAB", "no_rstab",
+  Core::Utils::string_to_integral_parameter<RStab>("RSTAB", "no_rstab",
       "Flag to (de)activate reactive term in residual-based stabilization.",
       tuple<std::string>("no_rstab", "rstab_gls", "rstab_usfem"),
-      tuple<std::string>("no reactive term in stabilization", "reactive stabilization of GLS type",
-          "reactive stabilization of USFEM type"),
       tuple<RStab>(reactive_stab_none, reactive_stab_gls, reactive_stab_usfem), &fdyn_porostab);
 
-  setStringToIntegralParameter<CrossStress>("CROSS-STRESS", "no_cross",
+  Core::Utils::string_to_integral_parameter<CrossStress>("CROSS-STRESS", "no_cross",
       "Flag to (de)activate cross-stress term -> residual-based VMM.",
-      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"
-          //"cross_complete"
-          ),
-      tuple<std::string>("No cross-stress term",
-          "Include the cross-stress term with a linearization of the convective part",
-          "Include cross-stress term, but only explicitly on right hand side"
-          //""
-          ),
+      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"),
       tuple<CrossStress>(cross_stress_stab_none, cross_stress_stab, cross_stress_stab_only_rhs),
       &fdyn_porostab);
 
-  setStringToIntegralParameter<ReynoldsStress>("REYNOLDS-STRESS", "no_reynolds",
+  Core::Utils::string_to_integral_parameter<ReynoldsStress>("REYNOLDS-STRESS", "no_reynolds",
       "Flag to (de)activate Reynolds-stress term -> residual-based VMM.",
-      tuple<std::string>("no_reynolds", "yes_reynolds", "reynolds_rhs"
-          //"reynolds_complete"
-          ),
-      tuple<std::string>(
-          "No Reynolds-stress term", "Include Reynolds-stress term with linearisation",
-          "Include Reynolds-stress term explicitly on right hand side"
-          //""
-          ),
+      tuple<std::string>("no_reynolds", "yes_reynolds", "reynolds_rhs"),
       tuple<ReynoldsStress>(
           reynolds_stress_stab_none, reynolds_stress_stab, reynolds_stress_stab_only_rhs),
       &fdyn_porostab);
 
   // this parameter selects the tau definition applied
-  setStringToIntegralParameter<TauType>("DEFINITION_TAU", "Franca_Barrenechea_Valentin_Frey_Wall",
-      "Definition of tau_M and Tau_C",
+  Core::Utils::string_to_integral_parameter<TauType>("DEFINITION_TAU",
+      "Franca_Barrenechea_Valentin_Frey_Wall", "Definition of tau_M and Tau_C",
       tuple<std::string>("Taylor_Hughes_Zarins", "Taylor_Hughes_Zarins_wo_dt",
           "Taylor_Hughes_Zarins_Whiting_Jansen", "Taylor_Hughes_Zarins_Whiting_Jansen_wo_dt",
           "Taylor_Hughes_Zarins_scaled", "Taylor_Hughes_Zarins_scaled_wo_dt",
@@ -774,7 +708,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
 
   // this parameter selects the characteristic element length for tau_Mu for all
   // stabilization parameter definitions requiring such a length
-  setStringToIntegralParameter<CharEleLengthU>("CHARELELENGTH_U", "streamlength",
+  Core::Utils::string_to_integral_parameter<CharEleLengthU>("CHARELELENGTH_U", "streamlength",
       "Characteristic element length for tau_Mu",
       tuple<std::string>("streamlength", "volume_equivalent_diameter", "root_of_volume"),
       tuple<CharEleLengthU>(streamlength_u, volume_equivalent_diameter_u, root_of_volume_u),
@@ -782,8 +716,8 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
 
   // this parameter selects the characteristic element length for tau_Mp and tau_C for
   // all stabilization parameter definitions requiring such a length
-  setStringToIntegralParameter<CharEleLengthPC>("CHARELELENGTH_PC", "volume_equivalent_diameter",
-      "Characteristic element length for tau_Mp/tau_C",
+  Core::Utils::string_to_integral_parameter<CharEleLengthPC>("CHARELELENGTH_PC",
+      "volume_equivalent_diameter", "Characteristic element length for tau_Mp/tau_C",
       tuple<std::string>("streamlength", "volume_equivalent_diameter", "root_of_volume"),
       tuple<CharEleLengthPC>(streamlength_pc, volume_equivalent_diameter_pc, root_of_volume_pc),
       &fdyn_porostab);
@@ -805,27 +739,16 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("LOMA_CONTI_SUPG", "No",
       "Flag to (de)activate SUPG stabilization in loma continuity equation.", &fdyn_porostab);
 
-  setStringToIntegralParameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
+  Core::Utils::string_to_integral_parameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
       "Flag to (de)activate cross-stress term loma continuity equation-> residual-based VMM.",
-      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"
-          //"cross_complete"
-          ),
-      tuple<std::string>("No cross-stress term",
-          "Include the cross-stress term with a linearization of the convective part",
-          "Include cross-stress term, but only explicitly on right hand side"
-          //""
-          ),
+      tuple<std::string>("no_cross", "yes_cross", "cross_rhs"),
       tuple<CrossStress>(cross_stress_stab_none, cross_stress_stab, cross_stress_stab_only_rhs),
       &fdyn_porostab);
 
-  setStringToIntegralParameter<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS", "no_reynolds",
+  Core::Utils::string_to_integral_parameter<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS",
+      "no_reynolds",
       "Flag to (de)activate Reynolds-stress term loma continuity equation-> residual-based VMM.",
       tuple<std::string>("no_reynolds", "yes_reynolds", "reynolds_rhs"),
-      tuple<std::string>(
-          "No Reynolds-stress term", "Include Reynolds-stress term with linearisation",
-          "Include Reynolds-stress term explicitly on right hand side"
-          //""
-          ),
       tuple<ReynoldsStress>(
           reynolds_stress_stab_none, reynolds_stress_stab, reynolds_stress_stab_only_rhs),
       &fdyn_porostab);
@@ -863,7 +786,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::string_parameter("PHYSICAL_MODEL", "no_model", physical_model_doc_string,
       &fdyn_turbu, physical_model_valid_input);
 
-  setStringToIntegralParameter<Inpar::FLUID::FineSubgridVisc>("FSSUGRVISC", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::FineSubgridVisc>("FSSUGRVISC", "No",
       "fine-scale subgrid viscosity",
       tuple<std::string>("No", "Smagorinsky_all", "Smagorinsky_small"),
       tuple<Inpar::FLUID::FineSubgridVisc>(no_fssgv, smagorinsky_all, smagorinsky_small),
@@ -983,7 +906,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       "direction.",
       &fdyn_turbu);
 
-  setStringToIntegralParameter<ForcingType>("FORCING_TYPE",
+  Core::Utils::string_to_integral_parameter<ForcingType>("FORCING_TYPE",
       "linear_compensation_from_intermediate_spectrum", "forcing strategy",
       tuple<std::string>("linear_compensation_from_intermediate_spectrum", "fixed_power_input"),
       tuple<ForcingType>(linear_compensation_from_intermediate_spectrum, fixed_power_input),
@@ -1060,7 +983,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
       "(Constant) turbulent Prandtl number for the Smagorinsky model in scalar transport.",
       &fdyn_turbsgv);
 
-  setStringToIntegralParameter<VremanFiMethod>("FILTER_WIDTH", "CubeRootVol",
+  Core::Utils::string_to_integral_parameter<VremanFiMethod>("FILTER_WIDTH", "CubeRootVol",
       "The Vreman model requires a filter width.",
       tuple<std::string>("CubeRootVol", "Direction_dependent", "Minimum_length"),
       tuple<VremanFiMethod>(cuberootvol, dir_dep, min_len), &fdyn_turbsgv);
@@ -1243,7 +1166,7 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("TURBULENTINFLOW", "No",
       "Flag to (de)activate potential separate turbulent inflow section", &fdyn_turbinf);
 
-  setStringToIntegralParameter<InitialField>("INITIALINFLOWFIELD", "zero_field",
+  Core::Utils::string_to_integral_parameter<InitialField>("INITIALINFLOWFIELD", "zero_field",
       "Initial field for inflow section",
       tuple<std::string>("zero_field", "field_by_function", "disturbed_field_from_function"),
       tuple<InitialField>(initfield_zero_field, initfield_field_by_function,
@@ -1310,13 +1233,9 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for time adaptivity in fluid/ coupled problems
   Teuchos::ParameterList& fdyn_timintada = fdyn.sublist("TIMEADAPTIVITY", false, "");
-  setStringToIntegralParameter<AdaptiveTimeStepEstimator>("ADAPTIVE_TIME_STEP_ESTIMATOR", "none",
-      "Method used to determine adaptive time step size.",
+  Core::Utils::string_to_integral_parameter<AdaptiveTimeStepEstimator>(
+      "ADAPTIVE_TIME_STEP_ESTIMATOR", "none", "Method used to determine adaptive time step size.",
       tuple<std::string>("none", "cfl_number", "only_print_cfl_number"),
-      tuple<std::string>(
-          "constant time step", "evaluated via CFL number", "CFL number evaluated and printed"
-          //""
-          ),
       tuple<AdaptiveTimeStepEstimator>(const_dt, cfl_number, only_print_cfl_number),
       &fdyn_timintada);
 
@@ -1334,7 +1253,6 @@ void Inpar::FLUID::set_valid_parameters(Teuchos::ParameterList& list)
 
 void Inpar::LowMach::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& lomacontrol =

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::FPSI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& fpsidyn = list.sublist("FPSI DYNAMIC", false,
@@ -31,7 +30,7 @@ void Inpar::FPSI::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::Array<FpsiCouplingType> label(1);
   name[0] = "fpsi_monolithic_plain";
   label[0] = fpsi_monolithic_plain;
-  setStringToIntegralParameter<FpsiCouplingType>("COUPALGO", "fpsi_monolithic_plain",
+  Core::Utils::string_to_integral_parameter<FpsiCouplingType>("COUPALGO", "fpsi_monolithic_plain",
       "Iteration Scheme over the fields", name, label, &fpsidyn);
 
   Core::Utils::bool_parameter("SHAPEDERIVATIVES", "No",
@@ -45,7 +44,7 @@ void Inpar::FPSI::set_valid_parameters(Teuchos::ParameterList& list)
       "Supported in monolithic FPSI for now.",
       &fpsidyn);
 
-  setStringToIntegralParameter<Inpar::FPSI::PartitionedCouplingMethod>("PARTITIONED",
+  Core::Utils::string_to_integral_parameter<Inpar::FPSI::PartitionedCouplingMethod>("PARTITIONED",
       "RobinNeumann", "Coupling strategies for partitioned FPSI solvers.",
       tuple<std::string>("RobinNeumann", "monolithic", "nocoupling"),
       tuple<Inpar::FPSI::PartitionedCouplingMethod>(RobinNeumann, monolithic, nocoupling),
@@ -69,7 +68,7 @@ void Inpar::FPSI::set_valid_parameters(Teuchos::ParameterList& list)
       "fluidpressure, ale",
       &fpsidyn);
 
-  setStringToIntegralParameter<Inpar::FPSI::ConvergenceNorm>("NORM_INC", "Abs",
+  Core::Utils::string_to_integral_parameter<Inpar::FPSI::ConvergenceNorm>("NORM_INC", "Abs",
       "Type of norm for primary variables convergence check.  \n"
       "Abs: absolute values, Abs_sys_split: absolute values with correction of systemsize for "
       "every field separate, Rel_sys: relative values with correction of systemsize.",
@@ -78,7 +77,7 @@ void Inpar::FPSI::set_valid_parameters(Teuchos::ParameterList& list)
           absoluteconvergencenorm, absoluteconvergencenorm_sys_split, relativconvergencenorm_sys),
       &fpsidyn);
 
-  setStringToIntegralParameter<Inpar::FPSI::ConvergenceNorm>("NORM_RESF", "Abs",
+  Core::Utils::string_to_integral_parameter<Inpar::FPSI::ConvergenceNorm>("NORM_RESF", "Abs",
       "Type of norm for primary variables convergence check. \n"
       "Abs: absolute values, Abs_sys_split: absolute values with correction of systemsize for "
       "every field separate, Rel_sys: relative values with correction of systemsize.",
@@ -87,7 +86,7 @@ void Inpar::FPSI::set_valid_parameters(Teuchos::ParameterList& list)
           absoluteconvergencenorm, absoluteconvergencenorm_sys_split, relativconvergencenorm_sys),
       &fpsidyn);
 
-  setStringToIntegralParameter<Inpar::FPSI::BinaryOp>("NORMCOMBI_RESFINC", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::FPSI::BinaryOp>("NORMCOMBI_RESFINC", "And",
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>("And", "Or"), tuple<Inpar::FPSI::BinaryOp>(bop_and, bop_or), &fpsidyn);
 

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::FS3I::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& fs3idyn =
@@ -27,8 +26,8 @@ void Inpar::FS3I::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", &fs3idyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", &fs3idyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", &fs3idyn);
-  setStringToIntegralParameter<Inpar::ScaTra::SolverType>("SCATRA_SOLVERTYPE", "nonlinear",
-      "type of scalar transport solver", tuple<std::string>("linear", "nonlinear"),
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::SolverType>("SCATRA_SOLVERTYPE",
+      "nonlinear", "type of scalar transport solver", tuple<std::string>("linear", "nonlinear"),
       tuple<Inpar::ScaTra::SolverType>(
           Inpar::ScaTra::solvertype_linear_incremental, Inpar::ScaTra::solvertype_nonlinear),
       &fs3idyn);
@@ -45,15 +44,15 @@ void Inpar::FS3I::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "LINEAR_SOLVER2", -1, "number of linear solver used for structural problem", &fs3idyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::ConvForm>("STRUCTSCAL_CONVFORM", "conservative",
-      "form of convective term of structure scalar",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ConvForm>("STRUCTSCAL_CONVFORM",
+      "conservative", "form of convective term of structure scalar",
       tuple<std::string>("convective", "conservative"),
       tuple<Inpar::ScaTra::ConvForm>(
           Inpar::ScaTra::convform_convective, Inpar::ScaTra::convform_conservative),
       &fs3idyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::InitialField>("STRUCTSCAL_INITIALFIELD", "zero_field",
-      "Initial Field for structure scalar transport problem",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("STRUCTSCAL_INITIALFIELD",
+      "zero_field", "Initial Field for structure scalar transport problem",
       tuple<std::string>("zero_field", "field_by_function"),
       tuple<Inpar::ScaTra::InitialField>(
           Inpar::ScaTra::initfield_zero_field, Inpar::ScaTra::initfield_field_by_function),
@@ -63,19 +62,19 @@ void Inpar::FS3I::set_valid_parameters(Teuchos::ParameterList& list)
       "function number for structure scalar transport initial field", &fs3idyn);
 
   // Type of coupling strategy between structure and structure-scalar field
-  setStringToIntegralParameter<VolumeCoupling>("STRUCTSCAL_FIELDCOUPLING", "volume_matching",
-      "Type of coupling strategy between structure and structure-scalar field",
+  Core::Utils::string_to_integral_parameter<VolumeCoupling>("STRUCTSCAL_FIELDCOUPLING",
+      "volume_matching", "Type of coupling strategy between structure and structure-scalar field",
       tuple<std::string>("volume_matching", "volume_nonmatching"),
       tuple<VolumeCoupling>(coupling_match, coupling_nonmatch), &fs3idyn);
 
   // Type of coupling strategy between fluid and fluid-scalar field
-  setStringToIntegralParameter<VolumeCoupling>("FLUIDSCAL_FIELDCOUPLING", "volume_matching",
-      "Type of coupling strategy between fluid and fluid-scalar field",
+  Core::Utils::string_to_integral_parameter<VolumeCoupling>("FLUIDSCAL_FIELDCOUPLING",
+      "volume_matching", "Type of coupling strategy between fluid and fluid-scalar field",
       tuple<std::string>("volume_matching", "volume_nonmatching"),
       tuple<VolumeCoupling>(coupling_match, coupling_nonmatch), &fs3idyn);
 
   // type of scalar transport
-  setStringToIntegralParameter<Inpar::ScaTra::ImplType>("FLUIDSCAL_SCATRATYPE",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ImplType>("FLUIDSCAL_SCATRATYPE",
       "ConvectionDiffusion", "Type of scalar transport problem",
       tuple<std::string>("Undefined", "ConvectionDiffusion", "Loma", "Advanced_Reaction",
           "Chemotaxis", "Chemo_Reac"),
@@ -96,7 +95,7 @@ void Inpar::FS3I::set_valid_parameters(Teuchos::ParameterList& list)
       "partitioned fluid-structure-scalar-scalar interaction control section");
 
   // Coupling strategy for partitioned FS3I
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "fs3i_IterStagg",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO", "fs3i_IterStagg",
       "Coupling strategies for FS3I solvers",
       tuple<std::string>("fs3i_SequStagg", "fs3i_IterStagg"),
       tuple<SolutionSchemeOverFields>(fs3i_SequStagg, fs3i_IterStagg), &fs3idynpart);

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------------*/
 void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& fsidyn = list.sublist("FSI DYNAMIC", false,
@@ -70,7 +69,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
   label[20] = fsi_iter_mortar_monolithicfluidsplit_saddlepoint;
 
 
-  setStringToIntegralParameter<FsiCoupling>("COUPALGO", "iter_stagg_AITKEN_rel_param",
+  Core::Utils::string_to_integral_parameter<FsiCoupling>("COUPALGO", "iter_stagg_AITKEN_rel_param",
       "Iteration Scheme over the fields", name, label, &fsidyn);
 
   std::string debugoutput_doc =
@@ -98,7 +97,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("SECONDORDER", "No",
       "Second order displacement-velocity conversion at the interface.", &fsidyn);
 
-  setStringToIntegralParameter<Inpar::FSI::SlideALEProj>("SLIDEALEPROJ", "None",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::SlideALEProj>("SLIDEALEPROJ", "None",
       "Projection method to use for sliding FSI.",
       tuple<std::string>("None", "Curr", "Ref", "RotZ", "RotZSphere"),
       tuple<Inpar::FSI::SlideALEProj>(Inpar::FSI::ALEprojection_none,
@@ -110,7 +109,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
 
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", &fsidyn);
 
-  setStringToIntegralParameter<Inpar::FSI::Verbosity>("VERBOSITY", "full",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::Verbosity>("VERBOSITY", "full",
       "Verbosity of the FSI problem.", tuple<std::string>("full", "medium", "low", "subproblem"),
       tuple<Inpar::FSI::Verbosity>(Inpar::FSI::verbosity_full, Inpar::FSI::verbosity_medium,
           Inpar::FSI::verbosity_low, Inpar::FSI::verbosity_subproblem),
@@ -125,7 +124,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
       "(>0)",
       &fsiadapt);
 
-  setStringToIntegralParameter<Inpar::FSI::FluidMethod>("AUXINTEGRATORFLUID", "AB2",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::FluidMethod>("AUXINTEGRATORFLUID", "AB2",
       "Method for error estimation in the fluid field",
       tuple<std::string>("None", "ExplicitEuler", "AB2"),
       tuple<Inpar::FSI::FluidMethod>(Inpar::FSI::timada_fld_none, Inpar::FSI::timada_fld_expleuler,
@@ -140,7 +139,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
       &fsiadapt);
 
 
-  setStringToIntegralParameter<Inpar::FSI::DivContAct>("DIVERCONT", "stop",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::DivContAct>("DIVERCONT", "stop",
       "What to do if nonlinear solver does not converge?",
       tuple<std::string>("stop", "continue", "halve_step", "revert_dt"),
       tuple<Inpar::FSI::DivContAct>(Inpar::FSI::divcont_stop, Inpar::FSI::divcont_continue,
@@ -217,7 +216,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
 
   Core::Utils::int_parameter("KRYLOV_SIZE", 50, "Size of Krylov Subspace.", &fsimono);
 
-  setStringToIntegralParameter<Inpar::FSI::LinearBlockSolver>("LINEARBLOCKSOLVER",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::LinearBlockSolver>("LINEARBLOCKSOLVER",
       "PreconditionedKrylov", "Linear block preconditioner for block system in monolithic FSI.",
       tuple<std::string>("PreconditionedKrylov", "LinalgSolver"),
       tuple<Inpar::FSI::LinearBlockSolver>(
@@ -229,7 +228,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
 
   // Iteration parameters for convergence check of newton loop
   // for implementations without NOX
-  setStringToIntegralParameter<Inpar::FSI::ConvNorm>("NORM_INC", "Rel",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::ConvNorm>("NORM_INC", "Rel",
       "type of norm for primary variables convergence check",
       tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<Inpar::FSI::ConvNorm>(
@@ -237,14 +236,14 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
       &fsimono);
 
   // for implementations without NOX
-  setStringToIntegralParameter<Inpar::FSI::ConvNorm>("NORM_RESF", "Rel",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::ConvNorm>("NORM_RESF", "Rel",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<Inpar::FSI::ConvNorm>(
           Inpar::FSI::convnorm_abs, Inpar::FSI::convnorm_rel, Inpar::FSI::convnorm_mix),
       &fsimono);
 
   // for implementations without NOX
-  setStringToIntegralParameter<Inpar::FSI::BinaryOp>("NORMCOMBI_RESFINC", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::BinaryOp>("NORMCOMBI_RESFINC", "And",
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>("And"), tuple<Inpar::FSI::BinaryOp>(Inpar::FSI::bop_and), &fsimono);
 
@@ -369,7 +368,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::string_parameter("COUPMETHOD", "conforming",
       "Coupling Method mortar or conforming nodes at interface", &fsipart, coupmethod_valid_input);
 
-  setStringToIntegralParameter<Inpar::FSI::CoupVarPart>("COUPVARIABLE", "Displacement",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::CoupVarPart>("COUPVARIABLE", "Displacement",
       "Coupling variable at the interface", tuple<std::string>("Displacement", "Force", "Velocity"),
       tuple<Inpar::FSI::CoupVarPart>(Inpar::FSI::CoupVarPart::disp, Inpar::FSI::CoupVarPart::force,
           Inpar::FSI::CoupVarPart::vel),
@@ -387,7 +386,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
       "MINOMEGA", -1.0, "smallest omega allowed for Aitken relaxation (default is -1.0)", &fsipart);
 
 
-  setStringToIntegralParameter<Inpar::FSI::PartitionedCouplingMethod>("PARTITIONED",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::PartitionedCouplingMethod>("PARTITIONED",
       "DirichletNeumann", "Coupling strategies for partitioned FSI solvers.",
       tuple<std::string>(
           "DirichletNeumann", "DirichletNeumannSlideALE", "DirichletNeumannVolCoupl"),
@@ -407,7 +406,7 @@ void Inpar::FSI::set_valid_parameters(Teuchos::ParameterList& list)
   /* ----------------------------------------------------------------------- */
   Teuchos::ParameterList& constrfsi = fsidyn.sublist("CONSTRAINT", false, "");
 
-  setStringToIntegralParameter<Inpar::FSI::PrecConstr>("PRECONDITIONER", "Simple",
+  Core::Utils::string_to_integral_parameter<Inpar::FSI::PrecConstr>("PRECONDITIONER", "Simple",
       "preconditioner to use", tuple<std::string>("Simple", "Simplec"),
       tuple<Inpar::FSI::PrecConstr>(Inpar::FSI::Simple, Inpar::FSI::Simplec), &constrfsi);
   Core::Utils::int_parameter("SIMPLEITER", 2, "Number of iterations for simple pc", &constrfsi);

--- a/src/inpar/4C_inpar_geometry_pair.cpp
+++ b/src/inpar/4C_inpar_geometry_pair.cpp
@@ -20,8 +20,8 @@ void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(Teuchos::ParameterList
   // Add the input parameters for line to 3D coupling.
 
   // Segmentation strategy.
-  Teuchos::setStringToIntegralParameter<LineTo3DStrategy>("GEOMETRY_PAIR_STRATEGY", "segmentation",
-      "Type of employed segmentation strategy",
+  Core::Utils::string_to_integral_parameter<LineTo3DStrategy>("GEOMETRY_PAIR_STRATEGY",
+      "segmentation", "Type of employed segmentation strategy",
       Teuchos::tuple<std::string>("none", "segmentation",
           "gauss_point_projection_without_boundary_segmentation",
           "gauss_point_projection_boundary_segmentation", "gauss_point_projection_cross_section"),
@@ -36,7 +36,7 @@ void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(Teuchos::ParameterList
       "Number of search points for segmentation", &list);
 
   // What to do if not all Gauss points of a segment project valid
-  Teuchos::setStringToIntegralParameter<NotAllGaussPointsProjectValidAction>(
+  Core::Utils::string_to_integral_parameter<NotAllGaussPointsProjectValidAction>(
       "GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION", "fail",
       "What to do if not all Gauss points of a segment project valid",
       Teuchos::tuple<std::string>("fail", "warning"),
@@ -64,7 +64,7 @@ void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(Teuchos::Paramete
   // Add the input parameters for line to surface coupling.
 
   // Add the surface normal option.
-  Teuchos::setStringToIntegralParameter<GEOMETRYPAIR::SurfaceNormals>(
+  Core::Utils::string_to_integral_parameter<GEOMETRYPAIR::SurfaceNormals>(
       "GEOMETRY_PAIR_SURFACE_NORMALS", "standard", "How the surface normals are evaluated",
       Teuchos::tuple<std::string>("standard", "extended_volume"),
       Teuchos::tuple<GEOMETRYPAIR::SurfaceNormals>(

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::IO::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& io = list.sublist("IO", false, "");
@@ -41,7 +40,8 @@ void Inpar::IO::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("STRUCT_VEL_ACC", "No", "Output of velocity and acceleration", &io);
   Core::Utils::bool_parameter("STRUCT_CURRENT_VOLUME", "No",
       "Output of current element volume as scalar value for each structural element", &io);
-  setStringToIntegralParameter<Inpar::Solid::StressType>("STRUCT_STRESS", "No", "Output of stress",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::StressType>("STRUCT_STRESS", "No",
+      "Output of stress",
       tuple<std::string>("No", "no", "NO", "Yes", "yes", "YES", "Cauchy", "cauchy", "2PK", "2pk"),
       tuple<Inpar::Solid::StressType>(Inpar::Solid::stress_none, Inpar::Solid::stress_none,
           Inpar::Solid::stress_none, Inpar::Solid::stress_2pk, Inpar::Solid::stress_2pk,
@@ -50,14 +50,16 @@ void Inpar::IO::set_valid_parameters(Teuchos::ParameterList& list)
       &io);
   // in case of a coupled problem (e.g. TSI) the additional stresses are
   // (TSI: thermal stresses) are printed here
-  setStringToIntegralParameter<Inpar::Solid::StressType>("STRUCT_COUPLING_STRESS", "No", "",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::StressType>("STRUCT_COUPLING_STRESS",
+      "No", "",
       tuple<std::string>("No", "no", "NO", "Yes", "yes", "YES", "Cauchy", "cauchy", "2PK", "2pk"),
       tuple<Inpar::Solid::StressType>(Inpar::Solid::stress_none, Inpar::Solid::stress_none,
           Inpar::Solid::stress_none, Inpar::Solid::stress_2pk, Inpar::Solid::stress_2pk,
           Inpar::Solid::stress_2pk, Inpar::Solid::stress_cauchy, Inpar::Solid::stress_cauchy,
           Inpar::Solid::stress_2pk, Inpar::Solid::stress_2pk),
       &io);
-  setStringToIntegralParameter<Inpar::Solid::StrainType>("STRUCT_STRAIN", "No", "Output of strains",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::StrainType>("STRUCT_STRAIN", "No",
+      "Output of strains",
       tuple<std::string>(
           "No", "no", "NO", "Yes", "yes", "YES", "EA", "ea", "GL", "gl", "LOG", "log"),
       tuple<Inpar::Solid::StrainType>(Inpar::Solid::strain_none, Inpar::Solid::strain_none,
@@ -66,22 +68,24 @@ void Inpar::IO::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::Solid::strain_gl, Inpar::Solid::strain_gl, Inpar::Solid::strain_log,
           Inpar::Solid::strain_log),
       &io);
-  setStringToIntegralParameter<Inpar::Solid::StrainType>("STRUCT_PLASTIC_STRAIN", "No", "",
-      tuple<std::string>("No", "no", "NO", "Yes", "yes", "YES", "EA", "ea", "GL", "gl"),
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::StrainType>("STRUCT_PLASTIC_STRAIN", "No",
+      "", tuple<std::string>("No", "no", "NO", "Yes", "yes", "YES", "EA", "ea", "GL", "gl"),
       tuple<Inpar::Solid::StrainType>(Inpar::Solid::strain_none, Inpar::Solid::strain_none,
           Inpar::Solid::strain_none, Inpar::Solid::strain_gl, Inpar::Solid::strain_gl,
           Inpar::Solid::strain_gl, Inpar::Solid::strain_ea, Inpar::Solid::strain_ea,
           Inpar::Solid::strain_gl, Inpar::Solid::strain_gl),
       &io);
-  setStringToIntegralParameter<Inpar::Solid::OptQuantityType>("STRUCT_OPTIONAL_QUANTITY", "No",
-      "Output of an optional quantity", tuple<std::string>("No", "no", "NO", "membranethickness"),
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::OptQuantityType>(
+      "STRUCT_OPTIONAL_QUANTITY", "No", "Output of an optional quantity",
+      tuple<std::string>("No", "no", "NO", "membranethickness"),
       tuple<Inpar::Solid::OptQuantityType>(Inpar::Solid::optquantity_none,
           Inpar::Solid::optquantity_none, Inpar::Solid::optquantity_none,
           Inpar::Solid::optquantity_membranethickness),
       &io);
   Core::Utils::bool_parameter("STRUCT_SURFACTANT", "No", "", &io);
   Core::Utils::bool_parameter("STRUCT_JACOBIAN_MATLAB", "No", "", &io);
-  setStringToIntegralParameter<Inpar::Solid::ConditionNumber>("STRUCT_CONDITION_NUMBER", "none",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::ConditionNumber>(
+      "STRUCT_CONDITION_NUMBER", "none",
       "Compute the condition number of the structural system matrix and write it to a text file.",
       tuple<std::string>("gmres_estimate", "max_min_ev_ratio", "one-norm", "inf-norm", "none"),
       tuple<Inpar::Solid::ConditionNumber>(Inpar::Solid::ConditionNumber::gmres_estimate,
@@ -93,14 +97,14 @@ void Inpar::IO::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("FLUID_ELEDATA_EVERY_STEP", "No", "", &io);
   Core::Utils::bool_parameter("FLUID_NODEDATA_FIRST_STEP", "No", "", &io);
   Core::Utils::bool_parameter("THERM_TEMPERATURE", "No", "", &io);
-  setStringToIntegralParameter<Inpar::Thermo::HeatFluxType>("THERM_HEATFLUX", "None", "",
-      tuple<std::string>("None", "No", "NO", "no", "Current", "Initial"),
+  Core::Utils::string_to_integral_parameter<Inpar::Thermo::HeatFluxType>("THERM_HEATFLUX", "None",
+      "", tuple<std::string>("None", "No", "NO", "no", "Current", "Initial"),
       tuple<Inpar::Thermo::HeatFluxType>(Inpar::Thermo::heatflux_none, Inpar::Thermo::heatflux_none,
           Inpar::Thermo::heatflux_none, Inpar::Thermo::heatflux_none,
           Inpar::Thermo::heatflux_current, Inpar::Thermo::heatflux_initial),
       &io);
-  setStringToIntegralParameter<Inpar::Thermo::TempGradType>("THERM_TEMPGRAD", "None", "",
-      tuple<std::string>("None", "No", "NO", "no", "Current", "Initial"),
+  Core::Utils::string_to_integral_parameter<Inpar::Thermo::TempGradType>("THERM_TEMPGRAD", "None",
+      "", tuple<std::string>("None", "No", "NO", "no", "Current", "Initial"),
       tuple<Inpar::Thermo::TempGradType>(Inpar::Thermo::tempgrad_none, Inpar::Thermo::tempgrad_none,
           Inpar::Thermo::tempgrad_none, Inpar::Thermo::tempgrad_none,
           Inpar::Thermo::tempgrad_current, Inpar::Thermo::tempgrad_initial),
@@ -124,7 +128,8 @@ void Inpar::IO::set_valid_parameters(Teuchos::ParameterList& list)
       "PREFIX_GROUP_ID", "No", "Put a <GroupID>: in front of every line", &io);
   Core::Utils::int_parameter(
       "LIMIT_OUTP_TO_PROC", -1, "Only the specified procs will write output", &io);
-  setStringToIntegralParameter<FourC::Core::IO::Verbositylevel>("VERBOSITY", "verbose", "",
+  Core::Utils::string_to_integral_parameter<FourC::Core::IO::Verbositylevel>("VERBOSITY", "verbose",
+      "",
       tuple<std::string>(
           "minimal", "Minimal", "standard", "Standard", "verbose", "Verbose", "debug", "Debug"),
       tuple<FourC::Core::IO::Verbositylevel>(FourC::Core::IO::minimal, FourC::Core::IO::minimal,

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& levelsetcontrol =
@@ -28,7 +27,7 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", &levelsetcontrol);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", &levelsetcontrol);
 
-  setStringToIntegralParameter<Inpar::ScaTra::CalcErrorLevelSet>("CALCERROR", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::CalcErrorLevelSet>("CALCERROR", "No",
       "compute error compared to analytical solution", tuple<std::string>("No", "InitialField"),
       tuple<Inpar::ScaTra::CalcErrorLevelSet>(
           Inpar::ScaTra::calcerror_no_ls, Inpar::ScaTra::calcerror_initial_field),
@@ -46,8 +45,8 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
   /*----------------------------------------------------------------------*/
   Teuchos::ParameterList& ls_reinit = levelsetcontrol.sublist("REINITIALIZATION", false, "");
 
-  setStringToIntegralParameter<Inpar::ScaTra::ReInitialAction>("REINITIALIZATION", "None",
-      "Type of reinitialization strategy for level set function",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ReInitialAction>("REINITIALIZATION",
+      "None", "Type of reinitialization strategy for level set function",
       tuple<std::string>("None", "Signed_Distance_Function", "Sussman", "EllipticEq"),
       tuple<Inpar::ScaTra::ReInitialAction>(Inpar::ScaTra::reinitaction_none,
           Inpar::ScaTra::reinitaction_signeddistancefunction, Inpar::ScaTra::reinitaction_sussman,
@@ -68,8 +67,9 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "NUMSTEPSREINIT", 1, "(maximal) number of pseudo-time steps", &ls_reinit);
   // this parameter selects the tau definition applied
-  setStringToIntegralParameter<Inpar::ScaTra::LinReinit>("LINEARIZATIONREINIT", "fixed_point",
-      "linearization of reinitialization equation", tuple<std::string>("newton", "fixed_point"),
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::LinReinit>("LINEARIZATIONREINIT",
+      "fixed_point", "linearization of reinitialization equation",
+      tuple<std::string>("newton", "fixed_point"),
       tuple<Inpar::ScaTra::LinReinit>(Inpar::ScaTra::newton, Inpar::ScaTra::fixed_point),
       &ls_reinit);
   Core::Utils::double_parameter("TIMESTEPREINIT", 1.0,
@@ -78,17 +78,14 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
       &ls_reinit);
   Core::Utils::double_parameter(
       "THETAREINIT", 1.0, "theta for time discretization of reinitialization equation", &ls_reinit);
-  setStringToIntegralParameter<Inpar::ScaTra::StabType>("STABTYPEREINIT", "SUPG",
-      "type of stabilization (if any)",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::StabType>("STABTYPEREINIT", "SUPG",
+      "Type of stabilization (if any). No stabilization is only reasonable for low-Peclet-number.",
       tuple<std::string>("no_stabilization", "SUPG", "GLS", "USFEM"),
-      tuple<std::string>(
-          "Do not use any stabilization -> only reasonable for low-Peclet-number flows", "Use SUPG",
-          "Use GLS", "Use USFEM"),
       tuple<Inpar::ScaTra::StabType>(Inpar::ScaTra::stabtype_no_stabilization,
           Inpar::ScaTra::stabtype_SUPG, Inpar::ScaTra::stabtype_GLS, Inpar::ScaTra::stabtype_USFEM),
       &ls_reinit);
   // this parameter selects the tau definition applied
-  setStringToIntegralParameter<Inpar::ScaTra::TauType>("DEFINITION_TAU_REINIT",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::TauType>("DEFINITION_TAU_REINIT",
       "Taylor_Hughes_Zarins", "Definition of tau",
       tuple<std::string>("Taylor_Hughes_Zarins", "Taylor_Hughes_Zarins_wo_dt", "Franca_Valentin",
           "Franca_Valentin_wo_dt", "Shakib_Hughes_Codina", "Shakib_Hughes_Codina_wo_dt", "Codina",
@@ -100,31 +97,20 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::ScaTra::tau_codina_wo_dt, Inpar::ScaTra::tau_exact_1d, Inpar::ScaTra::tau_zero),
       &ls_reinit);
   // this parameter governs whether all-scale subgrid diffusivity is included
-  setStringToIntegralParameter<Inpar::ScaTra::ArtDiff>("ARTDIFFREINIT", "no",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ArtDiff>("ARTDIFFREINIT", "no",
       "potential incorporation of all-scale subgrid diffusivity (a.k.a. discontinuity-capturing) "
       "term",
       tuple<std::string>("no", "isotropic", "crosswind"),
-      tuple<std::string>("no artificial diffusion", "homogeneous artificial diffusion",
-          "artificial diffusion in crosswind directions only"),
       tuple<Inpar::ScaTra::ArtDiff>(Inpar::ScaTra::artdiff_none, Inpar::ScaTra::artdiff_isotropic,
           Inpar::ScaTra::artdiff_crosswind),
       &ls_reinit);
   // this parameter selects the all-scale subgrid-diffusivity definition applied
-  setStringToIntegralParameter<Inpar::ScaTra::AssgdType>("DEFINITION_ARTDIFFREINIT",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::AssgdType>("DEFINITION_ARTDIFFREINIT",
       "artificial_linear", "Definition of (all-scale) subgrid diffusivity",
       tuple<std::string>("artificial_linear", "artificial_linear_reinit",
           "Hughes_etal_86_nonlinear", "Tezduyar_Park_86_nonlinear",
           "Tezduyar_Park_86_nonlinear_wo_phizero", "doCarmo_Galeao_91_nonlinear",
           "Almeida_Silva_97_nonlinear", "YZbeta_nonlinear", "Codina_nonlinear"),
-      tuple<std::string>("simple linear artificial diffusion",
-          "simple linear artificial diffusion const*h",
-          "nonlinear isotropic according to Hughes et al. (1986)",
-          "nonlinear isotropic according to Tezduyar and Park (1986)",
-          "nonlinear isotropic according to Tezduyar and Park (1986) without user parameter "
-          "phi_zero",
-          "nonlinear isotropic according to doCarmo and Galeao (1991)",
-          "nonlinear isotropic according to Almeida and Silva (1997)", "nonlinear YZ beta model",
-          "nonlinear isotropic according to Codina"),
       tuple<Inpar::ScaTra::AssgdType>(Inpar::ScaTra::assgd_artificial,
           Inpar::ScaTra::assgd_lin_reinit, Inpar::ScaTra::assgd_hughes,
           Inpar::ScaTra::assgd_tezduyar, Inpar::ScaTra::assgd_tezduyar_wo_phizero,
@@ -132,7 +118,7 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::ScaTra::assgd_codina),
       &ls_reinit);
 
-  setStringToIntegralParameter<Inpar::ScaTra::SmoothedSignType>("SMOOTHED_SIGN_TYPE",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::SmoothedSignType>("SMOOTHED_SIGN_TYPE",
       "SussmanSmerekaOsher1994", "sign function for reinitialization equation",
       tuple<std::string>("NonSmoothed",
           "SussmanFatemi1999",  // smeared-out Heaviside function
@@ -141,22 +127,23 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::ScaTra::signtype_SussmanFatemi1999,
           Inpar::ScaTra::signtype_SussmanSmerekaOsher1994, Inpar::ScaTra::signtype_PengEtAl1999),
       &ls_reinit);
-  setStringToIntegralParameter<Inpar::ScaTra::CharEleLengthReinit>("CHARELELENGTHREINIT",
-      "root_of_volume", "characteristic element length for sign function",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::CharEleLengthReinit>(
+      "CHARELELENGTHREINIT", "root_of_volume", "characteristic element length for sign function",
       tuple<std::string>("root_of_volume", "streamlength"),
       tuple<Inpar::ScaTra::CharEleLengthReinit>(
           Inpar::ScaTra::root_of_volume_reinit, Inpar::ScaTra::streamlength_reinit),
       &ls_reinit);
   Core::Utils::double_parameter("INTERFACE_THICKNESS", 1.0,
       "factor for interface thickness (multiplied by element length)", &ls_reinit);
-  setStringToIntegralParameter<Inpar::ScaTra::VelReinit>("VELREINIT", "integration_point_based",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::VelReinit>("VELREINIT",
+      "integration_point_based",
       "evaluate velocity at integration point or compute node-based velocity",
       tuple<std::string>("integration_point_based", "node_based"),
       tuple<Inpar::ScaTra::VelReinit>(
           Inpar::ScaTra::vel_reinit_integration_point_based, Inpar::ScaTra::vel_reinit_node_based),
       &ls_reinit);
-  setStringToIntegralParameter<Inpar::ScaTra::LinReinit>("LINEARIZATIONREINIT", "newton",
-      "linearization scheme for nonlinear convective term of reinitialization equation",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::LinReinit>("LINEARIZATIONREINIT",
+      "newton", "linearization scheme for nonlinear convective term of reinitialization equation",
       tuple<std::string>("newton", "fixed_point"),
       tuple<Inpar::ScaTra::LinReinit>(Inpar::ScaTra::newton, Inpar::ScaTra::fixed_point),
       &ls_reinit);
@@ -173,7 +160,7 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter(
       "PENALTY_PARA", -1.0, "penalty parameter for elliptic reinitialization", &ls_reinit);
 
-  setStringToIntegralParameter<Inpar::ScaTra::LSDim>("DIMENSION", "3D",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::LSDim>("DIMENSION", "3D",
       "number of space dimensions for handling of quasi-2D problems with 3D elements",
       tuple<std::string>("3D", "2Dx", "2Dy", "2Dz"),
       tuple<Inpar::ScaTra::LSDim>(Inpar::ScaTra::ls_3D, Inpar::ScaTra::ls_2Dx,
@@ -187,7 +174,7 @@ void Inpar::LevelSet::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter(
       "LUMPING", "no", "use lumped mass matrix for L2-projection", &ls_reinit);
 
-  setStringToIntegralParameter<Inpar::ScaTra::DiffFunc>("DIFF_FUNC", "hyperbolic",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::DiffFunc>("DIFF_FUNC", "hyperbolic",
       "function for diffusivity",
       tuple<std::string>("hyperbolic", "hyperbolic_smoothed_positive", "hyperbolic_clipped_05",
           "hyperbolic_clipped_1"),

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -17,13 +17,12 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /* parameters for mortar coupling */
   Teuchos::ParameterList& mortar = list.sublist("MORTAR COUPLING", false, "");
 
-  setStringToIntegralParameter<Inpar::Mortar::ShapeFcn>("LM_SHAPEFCN", "Dual",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::ShapeFcn>("LM_SHAPEFCN", "Dual",
       "Type of employed set of shape functions",
       tuple<std::string>(
           "Dual", "dual", "Standard", "standard", "std", "PetrovGalerkin", "petrovgalerkin", "pg"),
@@ -31,16 +30,17 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
           shape_standard, shape_petrovgalerkin, shape_petrovgalerkin, shape_petrovgalerkin),
       &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::SearchAlgorithm>("SEARCH_ALGORITHM", "Binarytree",
-      "Type of contact search",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::SearchAlgorithm>("SEARCH_ALGORITHM",
+      "Binarytree", "Type of contact search",
       tuple<std::string>("BruteForce", "bruteforce", "BruteForceEleBased", "bruteforceelebased",
           "BinaryTree", "Binarytree", "binarytree"),
       tuple<Inpar::Mortar::SearchAlgorithm>(search_bfele, search_bfele, search_bfele, search_bfele,
           search_binarytree, search_binarytree, search_binarytree),
       &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::BinaryTreeUpdateType>("BINARYTREE_UPDATETYPE",
-      "BottomUp", "Type of binary tree update, which is either a bottom up or a top down approach.",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::BinaryTreeUpdateType>(
+      "BINARYTREE_UPDATETYPE", "BottomUp",
+      "Type of binary tree update, which is either a bottom up or a top down approach.",
       tuple<std::string>("BottomUp", "TopDown"),
       tuple<Inpar::Mortar::BinaryTreeUpdateType>(binarytree_bottom_up, binarytree_top_down),
       &mortar);
@@ -51,7 +51,7 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("SEARCH_USE_AUX_POS", "Yes",
       "If chosen auxiliary position is used for computing dops", &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::LagMultQuad>("LM_QUAD", "undefined",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::LagMultQuad>("LM_QUAD", "undefined",
       "Type of LM interpolation for quadratic FE",
       tuple<std::string>(
           "undefined", "quad", "quadratic", "pwlin", "piecewiselinear", "lin", "linear", "const"),
@@ -62,7 +62,8 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("CROSSPOINTS", "No",
       "If chosen, multipliers are removed from crosspoints / edge nodes", &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::ConsistentDualType>("LM_DUAL_CONSISTENT", "boundary",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::ConsistentDualType>("LM_DUAL_CONSISTENT",
+      "boundary",
       "For which elements should the dual basis be calculated on EXACTLY the same GPs as the "
       "contact terms",
       tuple<std::string>("none", "boundary", "all"),
@@ -70,14 +71,14 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
           consistent_none, consistent_boundary, consistent_all),
       &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::MeshRelocation>("MESH_RELOCATION", "Initial",
-      "Type of mesh relocation",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::MeshRelocation>("MESH_RELOCATION",
+      "Initial", "Type of mesh relocation",
       tuple<std::string>("Initial", "initial", "Every_Timestep", "every_timestep", "No", "no"),
       tuple<Inpar::Mortar::MeshRelocation>(relocation_initial, relocation_initial,
           relocation_timestep, relocation_timestep, relocation_none, relocation_none),
       &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::AlgorithmType>("ALGORITHM", "Mortar",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::AlgorithmType>("ALGORITHM", "Mortar",
       "Type of meshtying/contact algorithm",
       tuple<std::string>("mortar", "Mortar", "nts", "NTS", "gpts", "GPTS", "lts", "LTS", "ltl",
           "LTL", "stl", "STL"),
@@ -86,7 +87,7 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
           algorithm_ltl, algorithm_ltl, algorithm_stl, algorithm_stl),
       &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::IntType>("INTTYPE", "Segments",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::IntType>("INTTYPE", "Segments",
       "Type of numerical integration scheme",
       tuple<std::string>(
           "Segments", "segments", "Elements", "elements", "Elements_BS", "elements_BS"),
@@ -97,8 +98,8 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "NUMGP_PER_DIM", 0, "Number of employed integration points per dimension", &mortar);
 
-  setStringToIntegralParameter<Inpar::Mortar::Triangulation>("TRIANGULATION", "Delaunay",
-      "Type of triangulation for segment-based integration",
+  Core::Utils::string_to_integral_parameter<Inpar::Mortar::Triangulation>("TRIANGULATION",
+      "Delaunay", "Type of triangulation for segment-based integration",
       tuple<std::string>("Delaunay", "delaunay", "Center", "center"),
       tuple<Inpar::Mortar::Triangulation>(triangulation_delaunay, triangulation_delaunay,
           triangulation_center, triangulation_center),
@@ -123,7 +124,7 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
       "non-close parts and redistribute them independently. [Contact only]",
       &parallelRedist);
 
-  setStringToIntegralParameter<ExtendGhosting>("GHOSTING_STRATEGY", "redundant_master",
+  Core::Utils::string_to_integral_parameter<ExtendGhosting>("GHOSTING_STRATEGY", "redundant_master",
       "Type of interface ghosting and ghosting extension algorithm",
       tuple<std::string>("redundant_all", "redundant_master", "round_robin", "binning"),
       tuple<ExtendGhosting>(ExtendGhosting::redundant_all, ExtendGhosting::redundant_master,
@@ -146,7 +147,7 @@ void Inpar::Mortar::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("MIN_ELEPROC", 0,
       "Minimum no. of elements per processor for parallel redistribution", &parallelRedist);
 
-  setStringToIntegralParameter<ParallelRedist>("PARALLEL_REDIST", "Static",
+  Core::Utils::string_to_integral_parameter<ParallelRedist>("PARALLEL_REDIST", "Static",
       "Type of redistribution algorithm",
       tuple<std::string>("None", "none", "No", "no", "Static", "static", "Dynamic", "dynamic"),
       tuple<ParallelRedist>(ParallelRedist::redist_none, ParallelRedist::redist_none,

--- a/src/inpar/4C_inpar_mpc_rve.cpp
+++ b/src/inpar/4C_inpar_mpc_rve.cpp
@@ -10,29 +10,26 @@
 #include "4C_inpar_mpc_rve.hpp"
 
 #include "4C_fem_condition_definition.hpp"
-#include "4C_inpar_validparameters.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 // set the mpc specific parameters
 void Inpar::RveMpc::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
-
-
   Teuchos::ParameterList& mpc = list.sublist("MULTI POINT CONSTRAINTS", false, "");
 
-  Teuchos::setStringToIntegralParameter<Inpar::RveMpc::RveReferenceDeformationDefinition>(
+  Core::Utils::string_to_integral_parameter<Inpar::RveMpc::RveReferenceDeformationDefinition>(
       "RVE_REFERENCE_POINTS", "automatic", "Method of definition of the reference points of an RVE",
       Teuchos::tuple<std::string>("automatic", "manual"),
       Teuchos::tuple<Inpar::RveMpc::RveReferenceDeformationDefinition>(automatic, manual), &mpc);
 
-  Teuchos::setStringToIntegralParameter<Inpar::RveMpc::EnforcementStrategy>("ENFORCEMENT",
+  Core::Utils::string_to_integral_parameter<Inpar::RveMpc::EnforcementStrategy>("ENFORCEMENT",
       "penalty_method", "Method to enforce the multi point constraint",
       Teuchos::tuple<std::string>("penalty_method", "lagrange_multiplier_method"),
       Teuchos::tuple<Inpar::RveMpc::EnforcementStrategy>(penalty, lagrangeMultiplier), &mpc);
 
-  Teuchos::setDoubleParameter("PENALTY_PARAM", 1e5, "Value of the penalty parameter", &mpc);
+  Core::Utils::double_parameter("PENALTY_PARAM", 1e5, "Value of the penalty parameter", &mpc);
 }
 
 // set mpc specific conditions

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -18,7 +18,6 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /*-------------------------------------------------------------------------*
@@ -28,7 +27,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       list.sublist("PARTICLE DYNAMIC", false, "control parameters for particle simulations\n");
 
   // type of particle time integration
-  setStringToIntegralParameter<DynamicType>("DYNAMICTYPE", "VelocityVerlet",
+  Core::Utils::string_to_integral_parameter<DynamicType>("DYNAMICTYPE", "VelocityVerlet",
       "type of particle time integration",
       tuple<std::string>("SemiImplicitEuler", "VelocityVerlet"),
       tuple<DynamicType>(
@@ -36,7 +35,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledyn);
 
   // type of particle interaction
-  setStringToIntegralParameter<InteractionType>("INTERACTION", "None",
+  Core::Utils::string_to_integral_parameter<InteractionType>("INTERACTION", "None",
       "type of particle interaction", tuple<std::string>("None", "SPH", "DEM"),
       tuple<InteractionType>(Inpar::PARTICLE::interaction_none, Inpar::PARTICLE::interaction_sph,
           Inpar::PARTICLE::interaction_dem),
@@ -84,8 +83,8 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "amplitude of noise added to initial position for each spatial direction", &particledyn);
 
   // type of particle wall source
-  setStringToIntegralParameter<ParticleWallSource>("PARTICLE_WALL_SOURCE", "NoParticleWall",
-      "type of particle wall source",
+  Core::Utils::string_to_integral_parameter<ParticleWallSource>("PARTICLE_WALL_SOURCE",
+      "NoParticleWall", "type of particle wall source",
       tuple<std::string>("NoParticleWall", "DiscretCondition", "BoundingBox"),
       tuple<ParticleWallSource>(Inpar::PARTICLE::NoParticleWall, Inpar::PARTICLE::DiscretCondition,
           Inpar::PARTICLE::BoundingBox),
@@ -163,14 +162,14 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "write particle-wall interaction output", &particledynsph);
 
   // type of smoothed particle hydrodynamics kernel
-  setStringToIntegralParameter<KernelType>("KERNEL", "CubicSpline",
+  Core::Utils::string_to_integral_parameter<KernelType>("KERNEL", "CubicSpline",
       "type of smoothed particle hydrodynamics kernel",
       tuple<std::string>("CubicSpline", "QuinticSpline"),
       tuple<KernelType>(Inpar::PARTICLE::CubicSpline, Inpar::PARTICLE::QuinticSpline),
       &particledynsph);
 
   // kernel space dimension number
-  setStringToIntegralParameter<KernelSpaceDimension>("KERNEL_SPACE_DIM", "Kernel3D",
+  Core::Utils::string_to_integral_parameter<KernelSpaceDimension>("KERNEL_SPACE_DIM", "Kernel3D",
       "kernel space dimension number", tuple<std::string>("Kernel1D", "Kernel2D", "Kernel3D"),
       tuple<KernelSpaceDimension>(
           Inpar::PARTICLE::Kernel1D, Inpar::PARTICLE::Kernel2D, Inpar::PARTICLE::Kernel3D),
@@ -180,14 +179,14 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "INITIALPARTICLESPACING", 0.0, "initial spacing of particles", &particledynsph);
 
   // type of smoothed particle hydrodynamics equation of state
-  setStringToIntegralParameter<EquationOfStateType>("EQUATIONOFSTATE", "GenTait",
+  Core::Utils::string_to_integral_parameter<EquationOfStateType>("EQUATIONOFSTATE", "GenTait",
       "type of smoothed particle hydrodynamics equation of state",
       tuple<std::string>("GenTait", "IdealGas"),
       tuple<EquationOfStateType>(Inpar::PARTICLE::GenTait, Inpar::PARTICLE::IdealGas),
       &particledynsph);
 
   // type of smoothed particle hydrodynamics momentum formulation
-  setStringToIntegralParameter<MomentumFormulationType>("MOMENTUMFORMULATION",
+  Core::Utils::string_to_integral_parameter<MomentumFormulationType>("MOMENTUMFORMULATION",
       "AdamiMomentumFormulation", "type of smoothed particle hydrodynamics momentum formulation",
       tuple<std::string>("AdamiMomentumFormulation", "MonaghanMomentumFormulation"),
       tuple<MomentumFormulationType>(
@@ -195,16 +194,16 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledynsph);
 
   // type of density evaluation scheme
-  setStringToIntegralParameter<DensityEvaluationScheme>("DENSITYEVALUATION", "DensitySummation",
-      "type of density evaluation scheme",
+  Core::Utils::string_to_integral_parameter<DensityEvaluationScheme>("DENSITYEVALUATION",
+      "DensitySummation", "type of density evaluation scheme",
       tuple<std::string>("DensitySummation", "DensityIntegration", "DensityPredictCorrect"),
       tuple<DensityEvaluationScheme>(Inpar::PARTICLE::DensitySummation,
           Inpar::PARTICLE::DensityIntegration, Inpar::PARTICLE::DensityPredictCorrect),
       &particledynsph);
 
   // type of density correction scheme
-  setStringToIntegralParameter<DensityCorrectionScheme>("DENSITYCORRECTION", "NoCorrection",
-      "type of density correction scheme",
+  Core::Utils::string_to_integral_parameter<DensityCorrectionScheme>("DENSITYCORRECTION",
+      "NoCorrection", "type of density correction scheme",
       tuple<std::string>(
           "NoCorrection", "InteriorCorrection", "NormalizedCorrection", "RandlesCorrection"),
       tuple<DensityCorrectionScheme>(Inpar::PARTICLE::NoCorrection,
@@ -213,32 +212,35 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledynsph);
 
   // type of boundary particle formulation
-  setStringToIntegralParameter<BoundaryParticleFormulationType>("BOUNDARYPARTICLEFORMULATION",
-      "NoBoundaryFormulation", "type of boundary particle formulation",
+  Core::Utils::string_to_integral_parameter<BoundaryParticleFormulationType>(
+      "BOUNDARYPARTICLEFORMULATION", "NoBoundaryFormulation",
+      "type of boundary particle formulation",
       tuple<std::string>("NoBoundaryFormulation", "AdamiBoundaryFormulation"),
       tuple<BoundaryParticleFormulationType>(
           Inpar::PARTICLE::NoBoundaryFormulation, Inpar::PARTICLE::AdamiBoundaryFormulation),
       &particledynsph);
 
   // type of boundary particle interaction
-  setStringToIntegralParameter<BoundaryParticleInteraction>("BOUNDARYPARTICLEINTERACTION",
-      "NoSlipBoundaryParticle", "type of boundary particle interaction",
+  Core::Utils::string_to_integral_parameter<BoundaryParticleInteraction>(
+      "BOUNDARYPARTICLEINTERACTION", "NoSlipBoundaryParticle",
+      "type of boundary particle interaction",
       tuple<std::string>("NoSlipBoundaryParticle", "FreeSlipBoundaryParticle"),
       tuple<BoundaryParticleInteraction>(
           Inpar::PARTICLE::NoSlipBoundaryParticle, Inpar::PARTICLE::FreeSlipBoundaryParticle),
       &particledynsph);
 
   // type of wall formulation
-  setStringToIntegralParameter<WallFormulationType>("WALLFORMULATION", "NoWallFormulation",
-      "type of wall formulation",
+  Core::Utils::string_to_integral_parameter<WallFormulationType>("WALLFORMULATION",
+      "NoWallFormulation", "type of wall formulation",
       tuple<std::string>("NoWallFormulation", "VirtualParticleWallFormulation"),
       tuple<WallFormulationType>(
           Inpar::PARTICLE::NoWallFormulation, Inpar::PARTICLE::VirtualParticleWallFormulation),
       &particledynsph);
 
   // type of transport velocity formulation
-  setStringToIntegralParameter<TransportVelocityFormulation>("TRANSPORTVELOCITYFORMULATION",
-      "NoTransportVelocity", "type of transport velocity formulation",
+  Core::Utils::string_to_integral_parameter<TransportVelocityFormulation>(
+      "TRANSPORTVELOCITYFORMULATION", "NoTransportVelocity",
+      "type of transport velocity formulation",
       tuple<std::string>(
           "NoTransportVelocity", "StandardTransportVelocity", "GeneralizedTransportVelocity"),
       tuple<TransportVelocityFormulation>(Inpar::PARTICLE::NoTransportVelocity,
@@ -247,7 +249,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledynsph);
 
   // type of temperature evaluation scheme
-  setStringToIntegralParameter<TemperatureEvaluationScheme>("TEMPERATUREEVALUATION",
+  Core::Utils::string_to_integral_parameter<TemperatureEvaluationScheme>("TEMPERATUREEVALUATION",
       "NoTemperatureEvaluation", "type of temperature evaluation scheme",
       tuple<std::string>("NoTemperatureEvaluation", "TemperatureIntegration"),
       tuple<TemperatureEvaluationScheme>(
@@ -258,7 +260,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "TEMPERATUREGRADIENT", "no", "evaluate temperature gradient", &particledynsph);
 
   // type of heat source
-  setStringToIntegralParameter<HeatSourceType>("HEATSOURCETYPE", "NoHeatSource",
+  Core::Utils::string_to_integral_parameter<HeatSourceType>("HEATSOURCETYPE", "NoHeatSource",
       "type of heat source",
       tuple<std::string>("NoHeatSource", "VolumeHeatSource", "SurfaceHeatSource"),
       tuple<HeatSourceType>(Inpar::PARTICLE::NoHeatSource, Inpar::PARTICLE::VolumeHeatSource,
@@ -294,7 +296,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "VAPOR_RECOIL_TFAC", 0.0, "temperature factor in recoil pressure formula", &particledynsph);
 
   // type of surface tension formulation
-  setStringToIntegralParameter<SurfaceTensionFormulation>("SURFACETENSIONFORMULATION",
+  Core::Utils::string_to_integral_parameter<SurfaceTensionFormulation>("SURFACETENSIONFORMULATION",
       "NoSurfaceTension", "type of surface tension formulation",
       tuple<std::string>("NoSurfaceTension", "ContinuumSurfaceForce"),
       tuple<SurfaceTensionFormulation>(
@@ -361,7 +363,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "transition temperature difference for barrier force evaluation", &particledynsph);
 
   // type of dirichlet open boundary
-  setStringToIntegralParameter<DirichletOpenBoundaryType>("DIRICHLETBOUNDARYTYPE",
+  Core::Utils::string_to_integral_parameter<DirichletOpenBoundaryType>("DIRICHLETBOUNDARYTYPE",
       "NoDirichletOpenBoundary", "type of dirichlet open boundary",
       tuple<std::string>("NoDirichletOpenBoundary", "DirichletNormalToPlane"),
       tuple<DirichletOpenBoundaryType>(
@@ -378,7 +380,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "point on dirichlet open boundary plane", &particledynsph);
 
   // type of neumann open boundary
-  setStringToIntegralParameter<NeumannOpenBoundaryType>("NEUMANNBOUNDARYTYPE",
+  Core::Utils::string_to_integral_parameter<NeumannOpenBoundaryType>("NEUMANNBOUNDARYTYPE",
       "NoNeumannOpenBoundary", "type of neumann open boundary",
       tuple<std::string>("NoNeumannOpenBoundary", "NeumannNormalToPlane"),
       tuple<NeumannOpenBoundaryType>(
@@ -394,7 +396,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "point on neumann open boundary plane", &particledynsph);
 
   // type of phase change
-  setStringToIntegralParameter<PhaseChangeType>("PHASECHANGETYPE", "NoPhaseChange",
+  Core::Utils::string_to_integral_parameter<PhaseChangeType>("PHASECHANGETYPE", "NoPhaseChange",
       "type of phase change",
       tuple<std::string>("NoPhaseChange", "OneWayScalarBelowToAbovePhaseChange",
           "OneWayScalarAboveToBelowPhaseChange", "TwoWayScalarPhaseChange"),
@@ -409,7 +411,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "PHASECHANGEDEFINITION", "none", "phase change definition", &particledynsph);
 
   // type of rigid particle contact
-  setStringToIntegralParameter<RigidParticleContactType>("RIGIDPARTICLECONTACTTYPE",
+  Core::Utils::string_to_integral_parameter<RigidParticleContactType>("RIGIDPARTICLECONTACTTYPE",
       "NoRigidParticleContact", "type of rigid particle contact",
       tuple<std::string>("NoRigidParticleContact", "ElasticRigidParticleContact"),
       tuple<RigidParticleContactType>(
@@ -436,7 +438,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "write particle-wall interaction output", &particledyndem);
 
   // type of normal contact law
-  setStringToIntegralParameter<NormalContact>("NORMALCONTACTLAW", "NormalLinearSpring",
+  Core::Utils::string_to_integral_parameter<NormalContact>("NORMALCONTACTLAW", "NormalLinearSpring",
       "normal contact law for particles",
       tuple<std::string>("NormalLinearSpring", "NormalLinearSpringDamp", "NormalHertz",
           "NormalLeeHerrmann", "NormalKuwabaraKono", "NormalTsuji"),
@@ -446,15 +448,15 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledyndem);
 
   // type of tangential contact law
-  setStringToIntegralParameter<TangentialContact>("TANGENTIALCONTACTLAW", "NoTangentialContact",
-      "tangential contact law for particles",
+  Core::Utils::string_to_integral_parameter<TangentialContact>("TANGENTIALCONTACTLAW",
+      "NoTangentialContact", "tangential contact law for particles",
       tuple<std::string>("NoTangentialContact", "TangentialLinSpringDamp"),
       tuple<TangentialContact>(
           Inpar::PARTICLE::NoTangentialContact, Inpar::PARTICLE::TangentialLinSpringDamp),
       &particledyndem);
 
   // type of rolling contact law
-  setStringToIntegralParameter<RollingContact>("ROLLINGCONTACTLAW", "NoRollingContact",
+  Core::Utils::string_to_integral_parameter<RollingContact>("ROLLINGCONTACTLAW", "NoRollingContact",
       "rolling contact law for particles",
       tuple<std::string>("NoRollingContact", "RollingViscous", "RollingCoulomb"),
       tuple<RollingContact>(Inpar::PARTICLE::NoRollingContact, Inpar::PARTICLE::RollingViscous,
@@ -462,7 +464,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledyndem);
 
   // type of normal adhesion law
-  setStringToIntegralParameter<AdhesionLaw>("ADHESIONLAW", "NoAdhesion",
+  Core::Utils::string_to_integral_parameter<AdhesionLaw>("ADHESIONLAW", "NoAdhesion",
       "type of adhesion law for particles",
       tuple<std::string>("NoAdhesion", "AdhesionVdWDMT", "AdhesionRegDMT"),
       tuple<AdhesionLaw>(Inpar::PARTICLE::NoAdhesion, Inpar::PARTICLE::AdhesionVdWDMT,
@@ -470,8 +472,9 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       &particledyndem);
 
   // type of (random) surface energy distribution
-  setStringToIntegralParameter<SurfaceEnergyDistribution>("ADHESION_SURFACE_ENERGY_DISTRIBUTION",
-      "ConstantSurfaceEnergy", "type of (random) surface energy distribution",
+  Core::Utils::string_to_integral_parameter<SurfaceEnergyDistribution>(
+      "ADHESION_SURFACE_ENERGY_DISTRIBUTION", "ConstantSurfaceEnergy",
+      "type of (random) surface energy distribution",
       tuple<std::string>("ConstantSurfaceEnergy", "NormalSurfaceEnergyDistribution",
           "LogNormalSurfaceEnergyDistribution"),
       tuple<SurfaceEnergyDistribution>(Inpar::PARTICLE::ConstantSurfaceEnergy,
@@ -487,7 +490,7 @@ void Inpar::PARTICLE::set_valid_parameters(Teuchos::ParameterList& list)
       "MAX_VELOCITY", -1.0, "maximum expected particle velocity", &particledyndem);
 
   // type of initial particle radius assignment
-  setStringToIntegralParameter<InitialRadiusAssignment>("INITIAL_RADIUS",
+  Core::Utils::string_to_integral_parameter<InitialRadiusAssignment>("INITIAL_RADIUS",
       "RadiusFromParticleMaterial", "type of initial particle radius assignment",
       tuple<std::string>("RadiusFromParticleMaterial", "RadiusFromParticleInput",
           "NormalRadiusDistribution", "LogNormalRadiusDistribution"),

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------------*/
 void Inpar::PaSI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& pasidyn = list.sublist("PASI DYNAMIC", false,
@@ -30,7 +29,8 @@ void Inpar::PaSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("MAXTIME", 1.0, "Total simulation time", &pasidyn);
 
   // type of partitioned coupling
-  setStringToIntegralParameter<PartitionedCouplingType>("COUPLING", "partitioned_onewaycoup",
+  Core::Utils::string_to_integral_parameter<PartitionedCouplingType>("COUPLING",
+      "partitioned_onewaycoup",
       "partitioned coupling strategies for particle structure interaction",
       tuple<std::string>("partitioned_onewaycoup", "partitioned_twowaycoup",
           "partitioned_twowaycoup_disprelax", "partitioned_twowaycoup_disprelaxaitken"),

--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Plasticity::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /*----------------------------------------------------------------------*/
@@ -30,12 +29,13 @@ void Inpar::Plasticity::set_valid_parameters(Teuchos::ParameterList& list)
       "STABILIZATION_S", 1.0, "Stabilization factor s for semi-smooth PDASS", &iplast);
 
   // solver convergence test parameters for semi-smooth plasticity formulation
-  setStringToIntegralParameter<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFPLASTCONSTR", "And",
-      "binary operator to combine plasticity constraints and residual force values",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFPLASTCONSTR",
+      "And", "binary operator to combine plasticity constraints and residual force values",
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), &iplast);
 
-  setStringToIntegralParameter<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPPLASTINCR", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPPLASTINCR",
+      "And",
       "binary operator to combine displacement increments and plastic flow (Delta Lp) increment "
       "values",
       tuple<std::string>("And", "Or"),
@@ -46,12 +46,12 @@ void Inpar::Plasticity::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("TOLDELTALP", 1.0E-8,
       "tolerance in the plastic flow (Delta Lp) norm for the Newton iteration", &iplast);
 
-  setStringToIntegralParameter<Inpar::Solid::BinaryOp>("NORMCOMBI_EASRES", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_EASRES", "And",
       "binary operator to combine EAS-residual and residual force values",
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), &iplast);
 
-  setStringToIntegralParameter<Inpar::Solid::BinaryOp>("NORMCOMBI_EASINCR", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_EASINCR", "And",
       "binary operator to combine displacement increments and EAS increment values",
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), &iplast);
@@ -61,8 +61,8 @@ void Inpar::Plasticity::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("TOLEASINCR", 1.0E-8,
       "tolerance in the EAS increment norm for the Newton iteration", &iplast);
 
-  setStringToIntegralParameter<Inpar::TSI::DissipationMode>("DISSIPATION_MODE", "pl_multiplier",
-      "method to calculate the plastic dissipation",
+  Core::Utils::string_to_integral_parameter<Inpar::TSI::DissipationMode>("DISSIPATION_MODE",
+      "pl_multiplier", "method to calculate the plastic dissipation",
       tuple<std::string>("pl_multiplier", "pl_flow", "Taylor_Quinney"),
       tuple<Inpar::TSI::DissipationMode>(
           Inpar::TSI::pl_multiplier, Inpar::TSI::pl_flow, Inpar::TSI::Taylor_Quinney),

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -16,14 +16,13 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::PoroElast::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& poroelastdyn =
       list.sublist("POROELASTICITY DYNAMIC", false, "Poroelasticity");
 
   // Coupling strategy for (monolithic) porous media solvers
-  setStringToIntegralParameter<Inpar::PoroElast::SolutionSchemeOverFields>("COUPALGO",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::SolutionSchemeOverFields>("COUPALGO",
       "poro_monolithic", "Coupling strategies for poroelasticity solvers",
       tuple<std::string>("poro_partitioned", "poro_monolithic", "poro_monolithicstructuresplit",
           "poro_monolithicfluidsplit", "poro_monolithicnopenetrationsplit",
@@ -35,14 +34,14 @@ void Inpar::PoroElast::set_valid_parameters(Teuchos::ParameterList& list)
 
   // physical type of poro fluid flow (incompressible, varying density, loma, Boussinesq
   // approximation)
-  setStringToIntegralParameter<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE", "Poro",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE", "Poro",
       "Physical Type of Porofluid", tuple<std::string>("Poro", "Poro_P1"),
       tuple<Inpar::FLUID::PhysicalType>(Inpar::FLUID::poro, Inpar::FLUID::poro_p1), &poroelastdyn);
 
   // physical type of poro fluid flow (incompressible, varying density, loma, Boussinesq
   // approximation)
-  setStringToIntegralParameter<Inpar::PoroElast::TransientEquationsOfPoroFluid>("TRANSIENT_TERMS",
-      "all", "which equation includes transient terms",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::TransientEquationsOfPoroFluid>(
+      "TRANSIENT_TERMS", "all", "which equation includes transient terms",
       tuple<std::string>("none", "momentum", "continuity", "all"),
       tuple<Inpar::PoroElast::TransientEquationsOfPoroFluid>(
           transient_none, transient_momentum_only, transient_continuity_only, transient_all),
@@ -86,30 +85,30 @@ void Inpar::PoroElast::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("TOLRES_NCOUP", 1e-8,
       "tolerance in the residual norm for the Newton iteration", &poroelastdyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::ConvNorm>("NORM_INC", "AbsSingleFields",
-      "type of norm for primary variables convergence check",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::ConvNorm>("NORM_INC",
+      "AbsSingleFields", "type of norm for primary variables convergence check",
       tuple<std::string>("AbsGlobal", "AbsSingleFields"),
       tuple<Inpar::PoroElast::ConvNorm>(convnorm_abs_global, convnorm_abs_singlefields),
       &poroelastdyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::ConvNorm>("NORM_RESF", "AbsSingleFields",
-      "type of norm for residual convergence check",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::ConvNorm>("NORM_RESF",
+      "AbsSingleFields", "type of norm for residual convergence check",
       tuple<std::string>("AbsGlobal", "AbsSingleFields"),
       tuple<Inpar::PoroElast::ConvNorm>(convnorm_abs_global, convnorm_abs_singlefields),
       &poroelastdyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::BinaryOp>("NORMCOMBI_RESFINC", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::BinaryOp>("NORMCOMBI_RESFINC", "And",
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>("And", "Or"), tuple<Inpar::PoroElast::BinaryOp>(bop_and, bop_or),
       &poroelastdyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_RESF", "L2",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_RESF", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<Inpar::PoroElast::VectorNorm>(norm_l1, norm_l1_scaled, norm_l2, norm_rms, norm_inf),
       &poroelastdyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_INC", "L2",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_INC", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<Inpar::PoroElast::VectorNorm>(norm_l1, norm_l1_scaled, norm_l2, norm_rms, norm_inf),
@@ -134,8 +133,8 @@ void Inpar::PoroElast::set_valid_parameters(Teuchos::ParameterList& list)
       "number of linear solver used for poroelasticity problems", &poroelastdyn);
 
   // flag for equilibration of global system of equations
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "columns_full", "columns_maindiag",
           "rowsandcolumns_full", "rowsandcolumns_maindiag"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,

--- a/src/inpar/4C_inpar_porofluidmultiphase.cpp
+++ b/src/inpar/4C_inpar_porofluidmultiphase.cpp
@@ -14,7 +14,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& porofluidmultiphasedyn = list.sublist("POROFLUIDMULTIPHASE DYNAMIC",
@@ -32,11 +31,11 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
   Core::Utils::double_parameter(
       "THETA", 0.5, "One-step-theta time integration factor", &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<TimeIntegrationScheme>("TIMEINTEGR", "One_Step_Theta",
+  Core::Utils::string_to_integral_parameter<TimeIntegrationScheme>("TIMEINTEGR", "One_Step_Theta",
       "Time Integration Scheme", tuple<std::string>("One_Step_Theta"),
       tuple<TimeIntegrationScheme>(timeint_one_step_theta), &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<CalcError>("CALCERROR", "No",
+  Core::Utils::string_to_integral_parameter<CalcError>("CALCERROR", "No",
       "compute error compared to analytical solution",
       tuple<std::string>("No", "error_by_function"),
       tuple<CalcError>(calcerror_no, calcerror_byfunction), &porofluidmultiphasedyn);
@@ -64,7 +63,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
       &porofluidmultiphasedyn);
 
   // parameters for finite difference check
-  setStringToIntegralParameter<FdCheck>("FDCHECK", "none",
+  Core::Utils::string_to_integral_parameter<FdCheck>("FDCHECK", "none",
       "flag for finite difference check: none, local, or global",
       tuple<std::string>("none",
           "global"),  // perform finite difference check on time integrator level
@@ -93,7 +92,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
       "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
       &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<VectorNorm>("VECTORNORM_RESF", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_RESF", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(Inpar::POROFLUIDMULTIPHASE::norm_l1,
@@ -101,7 +100,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
           Inpar::POROFLUIDMULTIPHASE::norm_rms, Inpar::POROFLUIDMULTIPHASE::norm_inf),
       &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<VectorNorm>("VECTORNORM_INC", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_INC", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(Inpar::POROFLUIDMULTIPHASE::norm_l1,
@@ -115,7 +114,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
   Core::Utils::double_parameter("TOLINC", 1e-6,
       "tolerance in the increment norm for the Newton iteration", &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<InitialField>("INITIALFIELD", "zero_field",
+  Core::Utils::string_to_integral_parameter<InitialField>("INITIALFIELD", "zero_field",
       "Initial Field for transport problem",
       tuple<std::string>("zero_field", "field_by_function", "field_by_condition"),
       tuple<InitialField>(
@@ -125,7 +124,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
   Core::Utils::int_parameter("INITFUNCNO", -1, "function number for scalar transport initial field",
       &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<DivContAct>("DIVERCONT", "stop",
+  Core::Utils::string_to_integral_parameter<DivContAct>("DIVERCONT", "stop",
       "What to do with time integration when Newton-Raphson iteration failed",
       tuple<std::string>("stop", "continue"), tuple<DivContAct>(divcont_stop, divcont_continue),
       &porofluidmultiphasedyn);
@@ -133,9 +132,8 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
   Core::Utils::int_parameter("FLUX_PROJ_SOLVER", -1,
       "Number of linear solver used for L2 projection", &porofluidmultiphasedyn);
 
-  setStringToIntegralParameter<FluxReconstructionMethod>("FLUX_PROJ_METHOD", "none",
+  Core::Utils::string_to_integral_parameter<FluxReconstructionMethod>("FLUX_PROJ_METHOD", "none",
       "Flag to (de)activate flux reconstruction.", tuple<std::string>("none", "L2_projection"),
-      tuple<std::string>("no gradient reconstruction", "gracient reconstruction via l2-projection"),
       tuple<FluxReconstructionMethod>(
           gradreco_none,  // no convective streamline edge-based stabilization
           gradreco_l2     // pressure edge-based stabilization as ghost penalty around cut elements
@@ -173,11 +171,10 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& li
   Core::Utils::double_parameter(
       "PENALTY", 1000.0, "Penalty parameter for line-based coupling", &porofluidmultiphasemshtdyn);
 
-  setStringToIntegralParameter<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
-      "ARTERY_COUPLING_METHOD", "None", "Coupling method for artery coupling.",
+  Core::Utils::string_to_integral_parameter<
+      Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>("ARTERY_COUPLING_METHOD",
+      "None", "Coupling method for artery coupling.",
       tuple<std::string>("None", "Nodal", "GPTS", "MP", "NTP"),
-      tuple<std::string>("none", "Nodal Coupling", "Gauss-Point-To-Segment Approach",
-          "Mortar Penalty Approach", "1D node-to-point in 2D/3D Approach"),
       tuple<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
           Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::none,   // none
           Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::nodal,  // Nodal Coupling

--- a/src/inpar/4C_inpar_poromultiphase.cpp
+++ b/src/inpar/4C_inpar_poromultiphase.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::POROMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   // ----------------------------------------------------------------------
@@ -43,8 +42,8 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
 
 
   // Coupling strategy for solvers
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "twoway_partitioned",
-      "Coupling strategies for poro multiphase solvers",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO",
+      "twoway_partitioned", "Coupling strategies for poro multiphase solvers",
       tuple<std::string>("twoway_partitioned", "twoway_monolithic"),
       tuple<SolutionSchemeOverFields>(solscheme_twoway_partitioned, solscheme_twoway_monolithic),
       &poromultiphasedyn);
@@ -69,13 +68,13 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
       "number of linear solver used for poroelasticity problems", &poromultiphasedynmono);
 
   // parameters for finite difference check
-  setStringToIntegralParameter<FdCheck>("FDCHECK", "none",
+  Core::Utils::string_to_integral_parameter<FdCheck>("FDCHECK", "none",
       "flag for finite difference check: none or global",
       tuple<std::string>("none",
           "global"),  // perform finite difference check on time integrator level
       tuple<FdCheck>(fdcheck_none, fdcheck_global), &poromultiphasedynmono);
 
-  setStringToIntegralParameter<VectorNorm>("VECTORNORM_RESF", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_RESF", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(Inpar::POROMULTIPHASE::norm_l1, Inpar::POROMULTIPHASE::norm_l1_scaled,
@@ -83,7 +82,7 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::POROMULTIPHASE::norm_inf),
       &poromultiphasedynmono);
 
-  setStringToIntegralParameter<VectorNorm>("VECTORNORM_INC", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_INC", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(Inpar::POROMULTIPHASE::norm_l1, Inpar::POROMULTIPHASE::norm_l1_scaled,
@@ -92,8 +91,8 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
       &poromultiphasedynmono);
 
   // flag for equilibration of global system of equations
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "columns_full", "columns_maindiag",
           "rowsandcolumns_full", "rowsandcolumns_maindiag"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -124,7 +123,7 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(Teuchos::ParameterList& list)
       "tolerance for convergence check of outer iteration", &poromultiphasedynpart);
 
   // flag for relaxation of partitioned scheme
-  setStringToIntegralParameter<RelaxationMethods>("RELAXATION", "none",
+  Core::Utils::string_to_integral_parameter<RelaxationMethods>("RELAXATION", "none",
       "flag for relaxation of partitioned scheme", tuple<std::string>("none", "Constant", "Aitken"),
       tuple<RelaxationMethods>(relaxation_none, relaxation_constant, relaxation_aitken),
       &poromultiphasedynpart);

--- a/src/inpar/4C_inpar_poromultiphase_scatra.cpp
+++ b/src/inpar/4C_inpar_poromultiphase_scatra.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   // ----------------------------------------------------------------------
@@ -42,8 +41,8 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(Teuchos::ParameterList& l
       "ITEMIN", 1, "minimal number of iterations over fields", &poromultiphasescatradyn);
 
   // Coupling strategy for poroscatra solvers
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "twoway_partitioned_nested",
-      "Coupling strategies for poroscatra solvers",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO",
+      "twoway_partitioned_nested", "Coupling strategies for poroscatra solvers",
       tuple<std::string>(
           "twoway_partitioned_nested", "twoway_partitioned_sequential", "twoway_monolithic"),
       tuple<SolutionSchemeOverFields>(solscheme_twoway_partitioned_nested,
@@ -55,7 +54,7 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(Teuchos::ParameterList& l
       "ARTERY_COUPLING", "No", "Coupling with 1D blood vessels.", &poromultiphasescatradyn);
 
   // no convergence of coupling scheme
-  setStringToIntegralParameter<DivContAct>("DIVERCONT", "stop",
+  Core::Utils::string_to_integral_parameter<DivContAct>("DIVERCONT", "stop",
       "What to do with time integration when Poromultiphase-Scatra iteration failed",
       tuple<std::string>("stop", "continue"), tuple<DivContAct>(divcont_stop, divcont_continue),
       &poromultiphasescatradyn);
@@ -65,7 +64,7 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(Teuchos::ParameterList& l
   Teuchos::ParameterList& poromultiphasescatradynmono = poromultiphasescatradyn.sublist(
       "MONOLITHIC", false, "Parameters for monolithic Poro-Multiphase-Scatra Interaction");
 
-  setStringToIntegralParameter<VectorNorm>("VECTORNORM_RESF", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_RESF", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(Inpar::PoroMultiPhaseScaTra::norm_l1,
@@ -73,7 +72,7 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(Teuchos::ParameterList& l
           Inpar::PoroMultiPhaseScaTra::norm_rms, Inpar::PoroMultiPhaseScaTra::norm_inf),
       &poromultiphasescatradynmono);
 
-  setStringToIntegralParameter<VectorNorm>("VECTORNORM_INC", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_INC", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(Inpar::PoroMultiPhaseScaTra::norm_l1,
@@ -102,15 +101,15 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(Teuchos::ParameterList& l
       &poromultiphasescatradynmono);
 
   // parameters for finite difference check
-  setStringToIntegralParameter<FdCheck>("FDCHECK", "none",
+  Core::Utils::string_to_integral_parameter<FdCheck>("FDCHECK", "none",
       "flag for finite difference check: none or global",
       tuple<std::string>("none",
           "global"),  // perform finite difference check on time integrator level
       tuple<FdCheck>(fdcheck_none, fdcheck_global), &poromultiphasescatradynmono);
 
   // flag for equilibration of global system of equations
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "columns_full", "columns_maindiag",
           "rowsandcolumns_full", "rowsandcolumns_maindiag"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::PoroScaTra::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& poroscatradyn = list.sublist(
@@ -58,27 +57,27 @@ void Inpar::PoroScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("TOLINC_SCALAR", 1e-8,
       "tolerance in the increment norm for the Newton iteration", &poroscatradyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::ConvNorm>("NORM_INC", "AbsSingleFields",
-      "type of norm for primary variables convergence check",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::ConvNorm>("NORM_INC",
+      "AbsSingleFields", "type of norm for primary variables convergence check",
       tuple<std::string>("AbsGlobal", "AbsSingleFields"),
       tuple<Inpar::PoroElast::ConvNorm>(
           Inpar::PoroElast::convnorm_abs_global, Inpar::PoroElast::convnorm_abs_singlefields),
       &poroscatradyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::ConvNorm>("NORM_RESF", "AbsSingleFields",
-      "type of norm for residual convergence check",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::ConvNorm>("NORM_RESF",
+      "AbsSingleFields", "type of norm for residual convergence check",
       tuple<std::string>("AbsGlobal", "AbsSingleFields"),
       tuple<Inpar::PoroElast::ConvNorm>(
           Inpar::PoroElast::convnorm_abs_global, Inpar::PoroElast::convnorm_abs_singlefields),
       &poroscatradyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::BinaryOp>("NORMCOMBI_RESFINC", "And",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::BinaryOp>("NORMCOMBI_RESFINC", "And",
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>("And", "Or"),
       tuple<Inpar::PoroElast::BinaryOp>(Inpar::PoroElast::bop_and, Inpar::PoroElast::bop_or),
       &poroscatradyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_RESF", "L2",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_RESF", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<Inpar::PoroElast::VectorNorm>(Inpar::PoroElast::norm_l1,
@@ -86,7 +85,7 @@ void Inpar::PoroScaTra::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::PoroElast::norm_inf),
       &poroscatradyn);
 
-  setStringToIntegralParameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_INC", "L2",
+  Core::Utils::string_to_integral_parameter<Inpar::PoroElast::VectorNorm>("VECTORNORM_INC", "L2",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<Inpar::PoroElast::VectorNorm>(Inpar::PoroElast::norm_l1,
@@ -99,7 +98,7 @@ void Inpar::PoroScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       "number of linear solver used for monolithic poroscatra problems", &poroscatradyn);
 
   // Coupling strategy for poroscatra solvers
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "solid_to_scatra",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO", "solid_to_scatra",
       "Coupling strategies for poroscatra solvers",
       tuple<std::string>("monolithic", "scatra_to_solid", "solid_to_scatra", "two_way"),
       tuple<SolutionSchemeOverFields>(

--- a/src/inpar/4C_inpar_problemtype.cpp
+++ b/src/inpar/4C_inpar_problemtype.cpp
@@ -17,7 +17,6 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*/
 void Inpar::PROBLEMTYPE::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /*----------------------------------------------------------------------*/
@@ -34,7 +33,7 @@ void Inpar::PROBLEMTYPE::set_valid_parameters(Teuchos::ParameterList& list)
       label.push_back(prb_enum);
     }
 
-    setStringToIntegralParameter<IntegerType>(
+    Core::Utils::string_to_integral_parameter<IntegerType>(
         "PROBLEMTYPE", "Fluid_Structure_Interaction", "", name, label, &type);
   }
 
@@ -49,7 +48,7 @@ void Inpar::PROBLEMTYPE::set_valid_parameters(Teuchos::ParameterList& list)
       label.push_back(prb_enum);
     }
 
-    setStringToIntegralParameter<IntegerType>("SHAPEFCT", "Polynomial",
+    Core::Utils::string_to_integral_parameter<IntegerType>("SHAPEFCT", "Polynomial",
         "Defines the function spaces for the spatial approximation", name, label, &type);
   }
 

--- a/src/inpar/4C_inpar_rebalance.cpp
+++ b/src/inpar/4C_inpar_rebalance.cpp
@@ -14,12 +14,11 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Rebalance::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& meshpartitioning = list.sublist("MESH PARTITIONING", false, "");
 
-  setStringToIntegralParameter<Core::Rebalance::RebalanceType>("METHOD", "hypergraph",
+  Core::Utils::string_to_integral_parameter<Core::Rebalance::RebalanceType>("METHOD", "hypergraph",
       "Type of rebalance/partition algorithm to be used for decomposing the entire mesh into "
       "subdomains for parallel computing.",
       tuple<std::string>("none", "hypergraph", "recursive_coordinate_bisection", "monolithic"),

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -18,7 +18,6 @@ FOUR_C_NAMESPACE_OPEN
  *------------------------------------------------------------------------*/
 void Inpar::S2I::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& s2icoupling =
@@ -27,7 +26,7 @@ void Inpar::S2I::set_valid_parameters(Teuchos::ParameterList& list)
               "S2I COUPLING", false, "control parameters for scatra-scatra interface coupling");
 
   // type of mortar meshtying
-  setStringToIntegralParameter<CouplingType>("COUPLINGTYPE", "Undefined",
+  Core::Utils::string_to_integral_parameter<CouplingType>("COUPLINGTYPE", "Undefined",
       "type of mortar meshtying",
       tuple<std::string>("Undefined", "MatchingNodes", "StandardMortar", "SaddlePointMortar_Petrov",
           "SaddlePointMortar_Bubnov", "CondensedMortar_Petrov", "CondensedMortar_Bubnov",
@@ -39,7 +38,7 @@ void Inpar::S2I::set_valid_parameters(Teuchos::ParameterList& list)
       &s2icoupling);
 
   // flag for interface side underlying Lagrange multiplier definition
-  setStringToIntegralParameter<InterfaceSides>("LMSIDE", "slave",
+  Core::Utils::string_to_integral_parameter<InterfaceSides>("LMSIDE", "slave",
       "flag for interface side underlying Lagrange multiplier definition",
       tuple<std::string>("slave", "master"), tuple<InterfaceSides>(side_slave, side_master),
       &s2icoupling);
@@ -54,7 +53,7 @@ void Inpar::S2I::set_valid_parameters(Teuchos::ParameterList& list)
       "NTSPROJTOL", 0.0, "node-to-segment projection tolerance", &s2icoupling);
 
   // flag for evaluation of scatra-scatra interface coupling involving interface layer growth
-  setStringToIntegralParameter<GrowthEvaluation>("INTLAYERGROWTH_EVALUATION", "none",
+  Core::Utils::string_to_integral_parameter<GrowthEvaluation>("INTLAYERGROWTH_EVALUATION", "none",
       "flag for evaluation of scatra-scatra interface coupling involving interface layer growth",
       tuple<std::string>("none", "monolithic", "semi-implicit"),
       tuple<GrowthEvaluation>(

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -10,7 +10,6 @@
 #include "4C_fem_condition_definition.hpp"
 #include "4C_inpar_bio.hpp"
 #include "4C_inpar_fluid.hpp"
-#include "4C_inpar_s2i.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_sparseoperator.hpp"
@@ -20,13 +19,12 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& scatradyn = list.sublist(
       "SCALAR TRANSPORT DYNAMIC", false, "control parameters for scalar transport problems\n");
 
-  setStringToIntegralParameter<Inpar::ScaTra::SolverType>("SOLVERTYPE", "linear_full",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::SolverType>("SOLVERTYPE", "linear_full",
       "type of scalar transport solver",
       tuple<std::string>("linear_full", "linear_incremental", "nonlinear",
           "nonlinear_multiscale_macrotomicro", "nonlinear_multiscale_macrotomicro_aitken",
@@ -38,8 +36,8 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
           solvertype_nonlinear_multiscale_microtomacro),
       &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::TimeIntegrationScheme>("TIMEINTEGR", "One_Step_Theta",
-      "Time Integration Scheme",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::TimeIntegrationScheme>("TIMEINTEGR",
+      "One_Step_Theta", "Time Integration Scheme",
       tuple<std::string>("Stationary", "One_Step_Theta", "BDF2", "Gen_Alpha"),
       tuple<Inpar::ScaTra::TimeIntegrationScheme>(
           timeint_stationary, timeint_one_step_theta, timeint_bdf2, timeint_gen_alpha),
@@ -59,7 +57,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", &scatradyn);
   Core::Utils::int_parameter("MATID", -1, "Material ID for automatic mesh generation", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::VelocityField>("VELOCITYFIELD", "zero",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::VelocityField>("VELOCITYFIELD", "zero",
       "type of velocity field used for scalar transport problems",
       tuple<std::string>("zero", "function", "Navier_Stokes"),
       tuple<Inpar::ScaTra::VelocityField>(velocity_zero, velocity_function, velocity_Navier_Stokes),
@@ -99,8 +97,8 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
     name[12] = "algebraic_field_dependence";
     label[12] = initialfield_algebraic_field_dependence;
 
-    setStringToIntegralParameter<Inpar::ScaTra::InitialField>("INITIALFIELD", "zero_field",
-        "Initial Field for scalar transport problem", name, label, &scatradyn);
+    Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("INITIALFIELD",
+        "zero_field", "Initial Field for scalar transport problem", name, label, &scatradyn);
   }
 
   Core::Utils::int_parameter(
@@ -108,7 +106,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
 
   Core::Utils::bool_parameter("SPHERICALCOORDS", "No", "use of spherical coordinates", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::CalcError>("CALCERROR", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::CalcError>("CALCERROR", "No",
       "compute error compared to analytical solution",
       tuple<std::string>("No", "Kwok_Wu", "ConcentricCylinders", "Electroneutrality",
           "error_by_function", "error_by_condition", "SphereDiffusion", "AnalyticSeries"),
@@ -120,7 +118,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "CALCERRORNO", -1, "function number for scalar transport error computation", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::FluxType>("CALCFLUX_DOMAIN", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FluxType>("CALCFLUX_DOMAIN", "No",
       "output of diffusive/total flux vectors inside domain",
       tuple<std::string>("No", "total", "diffusive"),
       tuple<Inpar::ScaTra::FluxType>(flux_none, flux_total, flux_diffusive), &scatradyn);
@@ -128,7 +126,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("CALCFLUX_DOMAIN_LUMPED", "Yes",
       "perform approximate domain flux calculation involving matrix lumping", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::FluxType>("CALCFLUX_BOUNDARY", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FluxType>("CALCFLUX_BOUNDARY", "No",
       "output of convective/diffusive/total flux vectors on boundary",
       tuple<std::string>("No", "total", "diffusive", "convective"),
       tuple<Inpar::ScaTra::FluxType>(flux_none, flux_total, flux_diffusive, flux_convective),
@@ -141,8 +139,8 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       "Write diffusive/total flux vector fields for these scalar fields only (starting with 1)",
       &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::OutputScalarType>("OUTPUTSCALARS", "none",
-      "Output of total and mean values for transported scalars",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::OutputScalarType>("OUTPUTSCALARS",
+      "none", "Output of total and mean values for transported scalars",
       tuple<std::string>("none", "entire_domain", "by_condition", "entire_domain_and_by_condition"),
       tuple<Inpar::ScaTra::OutputScalarType>(outputscalars_none, outputscalars_entiredomain,
           outputscalars_condition, outputscalars_entiredomain_condition),
@@ -157,7 +155,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", "No",
       "Do you want to write the state solution to Matlab file?", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::ConvForm>("CONVFORM", "convective",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ConvForm>("CONVFORM", "convective",
       "form of convective term", tuple<std::string>("convective", "conservative"),
       tuple<Inpar::ScaTra::ConvForm>(convform_convective, convform_conservative), &scatradyn);
 
@@ -170,7 +168,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter(
       "SKIPINITDER", "no", "Flag to skip computation of initial time derivative", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::ScaTra::FSSUGRDIFF>("FSSUGRDIFF", "No",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FSSUGRDIFF>("FSSUGRDIFF", "No",
       "fine-scale subgrid diffusivity",
       tuple<std::string>("No", "artificial", "Smagorinsky_all", "Smagorinsky_small"),
       tuple<Inpar::ScaTra::FSSUGRDIFF>(fssugrdiff_no, fssugrdiff_artificial,
@@ -184,7 +182,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   // Current density source function for EMD problems
   Core::Utils::int_parameter("EMDSOURCE", -1, "Current density source", &scatradyn);
 
-  setStringToIntegralParameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
+  Core::Utils::string_to_integral_parameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
       "Flag to (de)activate mesh tying algorithm",
       tuple<std::string>("no", "Condensed_Smat", "Condensed_Bmat", "Condensed_Bmat_merged"),
       tuple<Inpar::FLUID::MeshTying>(Inpar::FLUID::no_meshtying, Inpar::FLUID::condensed_smat,
@@ -192,8 +190,9 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       &scatradyn);
 
   // Type of coupling strategy between the two fields
-  setStringToIntegralParameter<Inpar::ScaTra::FieldCoupling>("FIELDCOUPLING", "matching",
-      "Type of coupling strategy between fields", tuple<std::string>("matching", "volmortar"),
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FieldCoupling>("FIELDCOUPLING",
+      "matching", "Type of coupling strategy between fields",
+      tuple<std::string>("matching", "volmortar"),
       tuple<Inpar::ScaTra::FieldCoupling>(coupling_match, coupling_volmortar), &scatradyn);
 
   // linear solver id used for scalar transport/elch problems
@@ -204,8 +203,8 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       "number of linear solver used for l2-projection sub-problems", &scatradyn);
 
   // flag for equilibration of global system of equations
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "columns_full", "columns_maindiag",
           "rowsandcolumns_full", "rowsandcolumns_maindiag"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -218,7 +217,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       &scatradyn);
 
   // type of global system matrix in global system of equations
-  setStringToIntegralParameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "sparse",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "sparse",
       "type of global system matrix in global system of equations",
       tuple<std::string>("sparse", "block_condition", "block_condition_dof"),
       tuple<Core::LinAlg::MatrixType>(Core::LinAlg::MatrixType::sparse,
@@ -230,7 +229,7 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       "NATURAL_CONVECTION", "No", "Include natural convection effects", &scatradyn);
 
   // parameters for finite difference check
-  setStringToIntegralParameter<Inpar::ScaTra::FdCheck>("FDCHECK", "none",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FdCheck>("FDCHECK", "none",
       "flag for finite difference check: none, local, or global",
       tuple<std::string>("none",
           "global",           // perform finite difference check on time integrator level
@@ -251,8 +250,8 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
 
   // parameter for optional computation of domain and boundary integrals, i.e., of surface areas and
   // volumes associated with specified nodesets
-  setStringToIntegralParameter<Inpar::ScaTra::ComputeIntegrals>("COMPUTEINTEGRALS", "none",
-      "flag for optional computation of domain integrals",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ComputeIntegrals>("COMPUTEINTEGRALS",
+      "none", "flag for optional computation of domain integrals",
       tuple<std::string>("none", "initial", "repeated"),
       tuple<Inpar::ScaTra::ComputeIntegrals>(
           computeintegrals_none, computeintegrals_initial, computeintegrals_repeated),
@@ -322,12 +321,9 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       "control parameters for the stabilization of scalar transport problems");
 
   // this parameter governs type of stabilization
-  setStringToIntegralParameter<Inpar::ScaTra::StabType>("STABTYPE", "SUPG",
-      "type of stabilization (if any)",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::StabType>("STABTYPE", "SUPG",
+      "Type of stabilization (if any). No stabilization is only reasonable for low-Peclet-number.",
       tuple<std::string>("no_stabilization", "SUPG", "GLS", "USFEM", "centered", "upwind"),
-      tuple<std::string>(
-          "Do not use any stabilization -> only reasonable for low-Peclet-number flows", "Use SUPG",
-          "Use GLS", "Use USFEM", "Use centered scheme", "Use upwinded scheme"),
       tuple<Inpar::ScaTra::StabType>(stabtype_no_stabilization, stabtype_SUPG, stabtype_GLS,
           stabtype_USFEM, stabtype_hdg_centered, stabtype_hdg_upwind),
       &scatradyn_stab);
@@ -343,8 +339,8 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
       &scatradyn_stab);
 
   // this parameter selects the tau definition applied
-  setStringToIntegralParameter<Inpar::ScaTra::TauType>("DEFINITION_TAU", "Franca_Valentin",
-      "Definition of tau",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::TauType>("DEFINITION_TAU",
+      "Franca_Valentin", "Definition of tau",
       tuple<std::string>("Taylor_Hughes_Zarins", "Taylor_Hughes_Zarins_wo_dt", "Franca_Valentin",
           "Franca_Valentin_wo_dt", "Shakib_Hughes_Codina", "Shakib_Hughes_Codina_wo_dt", "Codina",
           "Codina_wo_dt", "Franca_Madureira_Valentin", "Franca_Madureira_Valentin_wo_dt",
@@ -358,55 +354,43 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
 
   // this parameter selects the characteristic element length for tau for all
   // stabilization parameter definitions requiring such a length
-  setStringToIntegralParameter<Inpar::ScaTra::CharEleLength>("CHARELELENGTH", "streamlength",
-      "Characteristic element length for tau",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::CharEleLength>("CHARELELENGTH",
+      "streamlength", "Characteristic element length for tau",
       tuple<std::string>("streamlength", "volume_equivalent_diameter", "root_of_volume"),
       tuple<Inpar::ScaTra::CharEleLength>(streamlength, volume_equivalent_diameter, root_of_volume),
       &scatradyn_stab);
 
   // this parameter selects the all-scale subgrid-diffusivity definition applied
-  setStringToIntegralParameter<Inpar::ScaTra::AssgdType>("DEFINITION_ASSGD", "artificial_linear",
-      "Definition of (all-scale) subgrid diffusivity",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::AssgdType>("DEFINITION_ASSGD",
+      "artificial_linear", "Definition of (all-scale) subgrid diffusivity",
       tuple<std::string>("artificial_linear", "artificial_linear_reinit",
           "Hughes_etal_86_nonlinear", "Tezduyar_Park_86_nonlinear",
           "Tezduyar_Park_86_nonlinear_wo_phizero", "doCarmo_Galeao_91_nonlinear",
           "Almeida_Silva_97_nonlinear", "YZbeta_nonlinear", "Codina_nonlinear"),
-      tuple<std::string>("classical linear artificial subgrid-diffusivity",
-          "simple linear artificial subgrid-diffusivity const*h",
-          "nonlinear isotropic according to Hughes et al. (1986)",
-          "nonlinear isotropic according to Tezduyar and Park (1986)",
-          "nonlinear isotropic according to Tezduyar and Park (1986) without user parameter "
-          "phi_zero",
-          "nonlinear isotropic according to doCarmo and Galeao (1991)",
-          "nonlinear isotropic according to Almeida and Silva (1997)", "nonlinear YZ beta model",
-          "nonlinear isotropic according to Codina"),
       tuple<Inpar::ScaTra::AssgdType>(assgd_artificial, assgd_lin_reinit, assgd_hughes,
           assgd_tezduyar, assgd_tezduyar_wo_phizero, assgd_docarmo, assgd_almeida, assgd_yzbeta,
           assgd_codina),
       &scatradyn_stab);
 
   // this parameter selects the location where tau is evaluated
-  setStringToIntegralParameter<Inpar::ScaTra::EvalTau>("EVALUATION_TAU", "element_center",
-      "Location where tau is evaluated", tuple<std::string>("element_center", "integration_point"),
-      tuple<std::string>("evaluate tau at element center", "evaluate tau at integration point"),
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::EvalTau>("EVALUATION_TAU",
+      "element_center", "Location where tau is evaluated",
+      tuple<std::string>("element_center", "integration_point"),
       tuple<Inpar::ScaTra::EvalTau>(evaltau_element_center, evaltau_integration_point),
       &scatradyn_stab);
 
   // this parameter selects the location where the material law is evaluated
   // (does not fit here very well, but parameter transfer is easier)
-  setStringToIntegralParameter<Inpar::ScaTra::EvalMat>("EVALUATION_MAT", "element_center",
-      "Location where material law is evaluated",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::EvalMat>("EVALUATION_MAT",
+      "element_center", "Location where material law is evaluated",
       tuple<std::string>("element_center", "integration_point"),
-      tuple<std::string>(
-          "evaluate material law at element center", "evaluate material law at integration point"),
       tuple<Inpar::ScaTra::EvalMat>(evalmat_element_center, evalmat_integration_point),
       &scatradyn_stab);
 
   // this parameter selects methods for improving consistency of stabilization terms
-  setStringToIntegralParameter<Inpar::ScaTra::Consistency>("CONSISTENCY", "no",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::Consistency>("CONSISTENCY", "no",
       "improvement of consistency for stabilization",
       tuple<std::string>("no", "L2_projection_lumped"),
-      tuple<std::string>("inconsistent", "L2 projection with lumped mass matrix"),
       tuple<Inpar::ScaTra::Consistency>(consistency_no, consistency_l2_projection_lumped),
       &scatradyn_stab);
 
@@ -419,11 +403,10 @@ void Inpar::ScaTra::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& scatradyn_art =
       scatradyn.sublist("ARTERY COUPLING", false, "Parameters for artery mesh tying");
 
-  setStringToIntegralParameter<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
-      "ARTERY_COUPLING_METHOD", "None", "Coupling method for artery coupling.",
+  Core::Utils::string_to_integral_parameter<
+      Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>("ARTERY_COUPLING_METHOD",
+      "None", "Coupling method for artery coupling.",
       tuple<std::string>("None", "Nodal", "GPTS", "MP", "NTP"),
-      tuple<std::string>("none", "Nodal Coupling", "Gauss-Point-To-Segment Approach",
-          "Mortar Penalty Approach", "1D node-to-point in 2D/3D Approach"),
       tuple<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
           Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::none,   // none
           Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::nodal,  // Nodal Coupling

--- a/src/inpar/4C_inpar_searchtree.cpp
+++ b/src/inpar/4C_inpar_searchtree.cpp
@@ -15,13 +15,12 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Geo::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& search_tree = list.sublist("SEARCH TREE", false, "");
 
-  setStringToIntegralParameter<Inpar::Geo::TreeType>("TREE_TYPE", "notree", "set tree type",
-      tuple<std::string>("notree", "octree3d", "quadtree3d", "quadtree2d"),
+  Core::Utils::string_to_integral_parameter<Inpar::Geo::TreeType>("TREE_TYPE", "notree",
+      "set tree type", tuple<std::string>("notree", "octree3d", "quadtree3d", "quadtree2d"),
       tuple<Inpar::Geo::TreeType>(
           Inpar::Geo::Notree, Inpar::Geo::Octree3D, Inpar::Geo::Quadtree3D, Inpar::Geo::Quadtree2D),
       &search_tree);

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -20,7 +20,8 @@ namespace Inpar::SOLVER
   {
     // Solver options
     {
-      Teuchos::setStringToIntegralParameter<Core::LinearSolver::SolverType>("SOLVER", "undefined",
+      Core::Utils::string_to_integral_parameter<Core::LinearSolver::SolverType>("SOLVER",
+          "undefined",
           "The solver to attack the system of linear equations arising of FE approach with.",
           Teuchos::tuple<std::string>("UMFPACK", "Superlu", "Belos", "undefined"),
           Teuchos::tuple<Core::LinearSolver::SolverType>(Core::LinearSolver::SolverType::umfpack,
@@ -31,7 +32,7 @@ namespace Inpar::SOLVER
 
     // Iterative solver options
     {
-      Teuchos::setStringToIntegralParameter<Core::LinearSolver::IterativeSolverType>("AZSOLVE",
+      Core::Utils::string_to_integral_parameter<Core::LinearSolver::IterativeSolverType>("AZSOLVE",
           "GMRES", "Type of linear solver algorithm to use.",
           Teuchos::tuple<std::string>("CG", "GMRES", "BiCGSTAB"),
           Teuchos::tuple<Core::LinearSolver::IterativeSolverType>(
@@ -43,7 +44,8 @@ namespace Inpar::SOLVER
 
     // Preconditioner options
     {
-      Teuchos::setStringToIntegralParameter<Core::LinearSolver::PreconditionerType>("AZPREC", "ILU",
+      Core::Utils::string_to_integral_parameter<Core::LinearSolver::PreconditionerType>("AZPREC",
+          "ILU",
           "Type of internal preconditioner to use.\n"
           "Note! this preconditioner will only be used if the input operator\n"
           "supports the Epetra_RowMatrix interface and the client does not pass\n"
@@ -81,7 +83,7 @@ namespace Inpar::SOLVER
       Core::Utils::double_parameter("AZTOL", 1e-8,
           "The level the residual norms must reach to decide about successful convergence", &list);
 
-      Teuchos::setStringToIntegralParameter<Belos::ScaleType>("AZCONV", "AZ_r0",
+      Core::Utils::string_to_integral_parameter<Belos::ScaleType>("AZCONV", "AZ_r0",
           "The implicit residual norm scaling type to use for terminating the iterative solver.",
           Teuchos::tuple<std::string>("AZ_r0", "AZ_noscaled"),
           Teuchos::tuple<Belos::ScaleType>(Belos::ScaleType::NormOfInitRes, Belos::ScaleType::None),

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------------*/
 void Inpar::NlnSol::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /*----------------------------------------------------------------------*
@@ -157,7 +156,7 @@ void Inpar::NlnSol::set_valid_parameters(Teuchos::ParameterList& list)
 
     Teuchos::Array<std::string> checktypes =
         Teuchos::tuple<std::string>("Complete", "Minimal", "None");
-    Teuchos::setStringToIntegralParameter<::NOX::StatusTest::CheckType>(
+    Core::Utils::string_to_integral_parameter<::NOX::StatusTest::CheckType>(
         "Inner Status Test Check Type", "Minimal",
         "Specify the check type for the inner status tests.", checktypes,
         Teuchos::tuple<::NOX::StatusTest::CheckType>(
@@ -354,8 +353,8 @@ void Inpar::NlnSol::set_valid_parameters(Teuchos::ParameterList& list)
 
   {
     Teuchos::Array<std::string> meritFct = Teuchos::tuple<std::string>("Sum of Squares");
-    Teuchos::setStringToIntegralParameter<NOX::Nln::MeritFunction::MeritFctName>("Merit Function",
-        "Sum of Squares", "", meritFct,
+    Core::Utils::string_to_integral_parameter<NOX::Nln::MeritFunction::MeritFctName>(
+        "Merit Function", "Sum of Squares", "", meritFct,
         Teuchos::tuple<NOX::Nln::MeritFunction::MeritFctName>(
             NOX::Nln::MeritFunction::mrtfct_sum_of_squares),
         &solverOptions);

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -19,7 +19,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& ssidyn =
@@ -47,7 +46,7 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
       "SCATRA_FILENAME", "nil", "Control-file name for reading scatra results in SSI", &ssidyn);
 
   // Type of coupling strategy between the two fields
-  setStringToIntegralParameter<FieldCoupling>("FIELDCOUPLING", "volume_matching",
+  Core::Utils::string_to_integral_parameter<FieldCoupling>("FIELDCOUPLING", "volume_matching",
       "Type of coupling strategy between fields",
       tuple<std::string>("volume_matching", "volume_nonmatching", "boundary_nonmatching",
           "volumeboundary_matching"),
@@ -56,7 +55,7 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
       &ssidyn);
 
   // Coupling strategy for SSI solvers
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "ssi_IterStagg",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO", "ssi_IterStagg",
       "Coupling strategies for SSI solvers",
       tuple<std::string>("ssi_OneWay_ScatraToSolid", "ssi_OneWay_SolidToScatra",
           //                                "ssi_SequStagg_ScatraToSolid",
@@ -77,7 +76,7 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
       &ssidyn);
 
   // type of scalar transport time integration
-  setStringToIntegralParameter<ScaTraTimIntType>("SCATRATIMINTTYPE", "Standard",
+  Core::Utils::string_to_integral_parameter<ScaTraTimIntType>("SCATRATIMINTTYPE", "Standard",
       "scalar transport time integration type is needed to instantiate correct scalar transport "
       "time integration scheme for ssi problems",
       tuple<std::string>("Standard", "Cardiac_Monodomain", "Elch"),
@@ -136,15 +135,15 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
       "LINEAR_SOLVER", -1, "ID of linear solver for global system of equations", &ssidynmono);
 
   // type of global system matrix in global system of equations
-  setStringToIntegralParameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
       "type of global system matrix in global system of equations",
       tuple<std::string>("undefined", "block", "sparse"),
       tuple<Core::LinAlg::MatrixType>(Core::LinAlg::MatrixType::undefined,
           Core::LinAlg::MatrixType::block_field, Core::LinAlg::MatrixType::sparse),
       &ssidynmono);
 
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "columns_full", "columns_maindiag",
           "rowsandcolumns_full", "rowsandcolumns_maindiag", "local"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -157,8 +156,8 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
           Core::LinAlg::EquilibrationMethod::local),
       &ssidynmono);
 
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_STRUCTURE", "none",
-      "flag for equilibration of structural equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>(
+      "EQUILIBRATION_STRUCTURE", "none", "flag for equilibration of structural equations",
       tuple<std::string>(
           "none", "rows_maindiag", "columns_maindiag", "rowsandcolumns_maindiag", "symmetry"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -168,8 +167,8 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
           Core::LinAlg::EquilibrationMethod::symmetry),
       &ssidynmono);
 
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_SCATRA", "none",
-      "flag for equilibration of scatra equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>(
+      "EQUILIBRATION_SCATRA", "none", "flag for equilibration of scatra equations",
       tuple<std::string>(
           "none", "rows_maindiag", "columns_maindiag", "rowsandcolumns_maindiag", "symmetry"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -206,8 +205,8 @@ void Inpar::SSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("MESHTYING_MANIFOLD", "no",
       "activate meshtying between all manifold fields in case they intersect?", &ssidynmanifold);
 
-  setStringToIntegralParameter<Inpar::ScaTra::InitialField>("INITIALFIELD", "zero_field",
-      "Initial field for scalar transport on manifold",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("INITIALFIELD",
+      "zero_field", "Initial field for scalar transport on manifold",
       tuple<std::string>("zero_field", "field_by_function", "field_by_condition"),
       tuple<Inpar::ScaTra::InitialField>(Inpar::ScaTra::initfield_zero_field,
           Inpar::ScaTra::initfield_field_by_function, Inpar::ScaTra::initfield_field_by_condition),

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -19,7 +19,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& sstidyn = list.sublist(
@@ -41,10 +40,10 @@ void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
       &sstidyn);
   Core::Utils::string_parameter(
       "SCATRA_FILENAME", "nil", "Control-file name for reading scatra results in SSTI", &sstidyn);
-  setStringToIntegralParameter<SolutionScheme>("COUPALGO", "ssti_Monolithic",
+  Core::Utils::string_to_integral_parameter<SolutionScheme>("COUPALGO", "ssti_Monolithic",
       "Coupling strategies for SSTI solvers", tuple<std::string>("ssti_Monolithic"),
       tuple<Inpar::SSTI::SolutionScheme>(SolutionScheme::monolithic), &sstidyn);
-  setStringToIntegralParameter<ScaTraTimIntType>("SCATRATIMINTTYPE", "Elch",
+  Core::Utils::string_to_integral_parameter<ScaTraTimIntType>("SCATRATIMINTTYPE", "Elch",
       "scalar transport time integration type is needed to instantiate correct scalar transport "
       "time integration scheme for ssi problems",
       tuple<std::string>("Elch"), tuple<ScaTraTimIntType>(ScaTraTimIntType::elch), &sstidyn);
@@ -65,14 +64,14 @@ void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
       &sstidynmono);
   Core::Utils::int_parameter(
       "LINEAR_SOLVER", -1, "ID of linear solver for global system of equations", &sstidynmono);
-  setStringToIntegralParameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
       "type of global system matrix in global system of equations",
       tuple<std::string>("undefined", "block", "sparse"),
       tuple<Core::LinAlg::MatrixType>(Core::LinAlg::MatrixType::undefined,
           Core::LinAlg::MatrixType::block_field, Core::LinAlg::MatrixType::sparse),
       &sstidynmono);
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION", "none",
-      "flag for equilibration of global system of equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
+      "none", "flag for equilibration of global system of equations",
       tuple<std::string>("none", "rows_full", "rows_maindiag", "rowsandcolumns_full",
           "rowsandcolumns_maindiag", "local"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -82,8 +81,8 @@ void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
           Core::LinAlg::EquilibrationMethod::rowsandcolumns_maindiag,
           Core::LinAlg::EquilibrationMethod::local),
       &sstidynmono);
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_STRUCTURE", "none",
-      "flag for equilibration of structural equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>(
+      "EQUILIBRATION_STRUCTURE", "none", "flag for equilibration of structural equations",
       tuple<std::string>(
           "none", "rows_maindiag", "columns_maindiag", "rowsandcolumns_maindiag", "symmetry"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -92,8 +91,8 @@ void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
           Core::LinAlg::EquilibrationMethod::rowsandcolumns_maindiag,
           Core::LinAlg::EquilibrationMethod::symmetry),
       &sstidynmono);
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_SCATRA", "none",
-      "flag for equilibration of scatra equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>(
+      "EQUILIBRATION_SCATRA", "none", "flag for equilibration of scatra equations",
       tuple<std::string>(
           "none", "rows_maindiag", "columns_maindiag", "rowsandcolumns_maindiag", "symmetry"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -102,8 +101,8 @@ void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
           Core::LinAlg::EquilibrationMethod::rowsandcolumns_maindiag,
           Core::LinAlg::EquilibrationMethod::symmetry),
       &sstidynmono);
-  setStringToIntegralParameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_THERMO", "none",
-      "flag for equilibration of scatra equations",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::EquilibrationMethod>(
+      "EQUILIBRATION_THERMO", "none", "flag for equilibration of scatra equations",
       tuple<std::string>(
           "none", "rows_maindiag", "columns_maindiag", "rowsandcolumns_maindiag", "symmetry"),
       tuple<Core::LinAlg::EquilibrationMethod>(Core::LinAlg::EquilibrationMethod::none,
@@ -124,8 +123,8 @@ void Inpar::SSTI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "INITTHERMOFUNCT", -1, "initial function for thermo field", &thermodyn);
   Core::Utils::int_parameter("LINEAR_SOLVER", -1, "linear solver for thermo field", &thermodyn);
-  setStringToIntegralParameter<Inpar::ScaTra::InitialField>("INITIALFIELD", "field_by_function",
-      "defines, how to set the initial field",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("INITIALFIELD",
+      "field_by_function", "defines, how to set the initial field",
       tuple<std::string>("field_by_function", "field_by_condition"),
       tuple<Inpar::ScaTra::InitialField>(Inpar::ScaTra::InitialField::initfield_field_by_function,
           Inpar::ScaTra::InitialField::initfield_field_by_condition),

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -19,21 +19,20 @@ FOUR_C_NAMESPACE_OPEN
  *------------------------------------------------------------------------*/
 void Inpar::STI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& stidyn = list.sublist(
       "STI DYNAMIC", false, "general control parameters for scatra-thermo interaction problems");
 
   // type of scalar transport time integration
-  setStringToIntegralParameter<ScaTraTimIntType>("SCATRATIMINTTYPE", "Standard",
+  Core::Utils::string_to_integral_parameter<ScaTraTimIntType>("SCATRATIMINTTYPE", "Standard",
       "scalar transport time integration type is needed to instantiate correct scalar transport "
       "time integration scheme for scatra-thermo interaction problems",
       tuple<std::string>("Standard", "Elch"),
       tuple<ScaTraTimIntType>(ScaTraTimIntType::standard, ScaTraTimIntType::elch), &stidyn);
 
   // type of coupling between scatra and thermo fields
-  setStringToIntegralParameter<CouplingType>("COUPLINGTYPE", "Undefined",
+  Core::Utils::string_to_integral_parameter<CouplingType>("COUPLINGTYPE", "Undefined",
       "type of coupling between scatra and thermo fields",
       tuple<std::string>("Undefined", "Monolithic", "OneWay_ScatraToThermo",
           "OneWay_ThermoToScatra", "TwoWay_ScatraToThermo", "TwoWay_ScatraToThermo_Aitken",
@@ -47,8 +46,8 @@ void Inpar::STI::set_valid_parameters(Teuchos::ParameterList& list)
       &stidyn);
 
   // specification of initial temperature field
-  setStringToIntegralParameter<Inpar::ScaTra::InitialField>("THERMO_INITIALFIELD", "zero_field",
-      "initial temperature field for scatra-thermo interaction problems",
+  Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("THERMO_INITIALFIELD",
+      "zero_field", "initial temperature field for scatra-thermo interaction problems",
       tuple<std::string>("zero_field", "field_by_function", "field_by_condition"),
       tuple<Inpar::ScaTra::InitialField>(Inpar::ScaTra::initfield_zero_field,
           Inpar::ScaTra::initfield_field_by_function, Inpar::ScaTra::initfield_field_by_condition),
@@ -78,7 +77,7 @@ void Inpar::STI::set_valid_parameters(Teuchos::ParameterList& list)
       "ID of linear solver for global system of equations", &stidyn_monolithic);
 
   // type of global system matrix in global system of equations
-  setStringToIntegralParameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "block",
+  Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "block",
       "type of global system matrix in global system of equations",
       tuple<std::string>("block", "sparse"),
       tuple<Core::LinAlg::MatrixType>(

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -22,10 +22,9 @@ namespace Inpar
     /*----------------------------------------------------------------------*/
     void set_valid_time_adaptivity_parameters(Teuchos::ParameterList& list)
     {
-      using Teuchos::setStringToIntegralParameter;
       using Teuchos::tuple;
 
-      setStringToIntegralParameter<Inpar::Solid::TimAdaKind>("KIND", "None",
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::TimAdaKind>("KIND", "None",
           "Method for time step size adaptivity",
           tuple<std::string>("None", "ZienkiewiczXie", "JointExplicit", "AdamsBashforth2",
               "ExplicitEuler", "CentralDifference"),
@@ -63,7 +62,7 @@ namespace Inpar
           "and must be larger than 0",
           &list);
 
-      setStringToIntegralParameter<Inpar::Solid::VectorNorm>("LOCERRNORM", "Vague",
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::VectorNorm>("LOCERRNORM", "Vague",
           "Vector norm to treat error vector with",
           tuple<std::string>("Vague", "L1", "L2", "Rms", "Inf"),
           tuple<Inpar::Solid::VectorNorm>(Inpar::Solid::norm_vague, Inpar::Solid::norm_l1,
@@ -81,12 +80,13 @@ namespace Inpar
       Core::Utils::int_parameter(
           "LINEAR_SOLVER", -1, "number of linear solver used for auxiliary integrator", &jep);
 
-      setStringToIntegralParameter<Inpar::Solid::IntegrationStrategy>("INT_STRATEGY", "Standard",
-          "global type of the used integration strategy", tuple<std::string>("Standard"),
-          tuple<Inpar::Solid::IntegrationStrategy>(int_standard), &jep);
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::IntegrationStrategy>("INT_STRATEGY",
+          "Standard", "global type of the used integration strategy",
+          tuple<std::string>("Standard"), tuple<Inpar::Solid::IntegrationStrategy>(int_standard),
+          &jep);
 
-      setStringToIntegralParameter<Inpar::Solid::DynamicType>("DYNAMICTYPE", "CentrDiff",
-          "type of the specific auxiliary dynamic time integration scheme",
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::DynamicType>("DYNAMICTYPE",
+          "CentrDiff", "type of the specific auxiliary dynamic time integration scheme",
           tuple<std::string>("ExplicitEuler", "CentrDiff", "AdamsBashforth2", "AdamsBashforth4"),
           tuple<Inpar::Solid::DynamicType>(dyna_expleuler, dyna_centrdiff, dyna_ab2, dyna_ab4),
           &jep);
@@ -94,7 +94,7 @@ namespace Inpar
       Core::Utils::bool_parameter(
           "LUMPMASS", "No", "Lump the mass matrix for explicit time integration", &jep);
 
-      setStringToIntegralParameter<Inpar::Solid::DampKind>("DAMPING", "No",
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::DampKind>("DAMPING", "No",
           "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M + K_DAMP x K, "
           "(2) Material based and calculated in elements",
           tuple<std::string>("no", "No", "NO", "yes", "Yes", "YES", "Rayleigh", "Material"),
@@ -110,19 +110,18 @@ namespace Inpar
 
     void set_valid_parameters(Teuchos::ParameterList& list)
     {
-      using Teuchos::setStringToIntegralParameter;
       using Teuchos::tuple;
 
       Teuchos::ParameterList& sdyn = list.sublist("STRUCTURAL DYNAMIC", false, "");
 
-      setStringToIntegralParameter<Solid::IntegrationStrategy>("INT_STRATEGY", "Old",
+      Core::Utils::string_to_integral_parameter<Solid::IntegrationStrategy>("INT_STRATEGY", "Old",
           "global type of the used integration strategy", tuple<std::string>("Old", "Standard"),
           tuple<Solid::IntegrationStrategy>(int_old, int_standard), &sdyn);
 
       Core::Utils::bool_parameter(
           "TIME_ADAPTIVITY", "No", "Enable adaptive time integration", &sdyn);
 
-      setStringToIntegralParameter<Solid::DynamicType>("DYNAMICTYPE", "GenAlpha",
+      Core::Utils::string_to_integral_parameter<Solid::DynamicType>("DYNAMICTYPE", "GenAlpha",
           "type of the specific dynamic time integration scheme",
           tuple<std::string>("Statics", "GenAlpha", "GenAlphaLieGroup", "OneStepTheta",
               "ExplicitEuler", "CentrDiff", "AdamsBashforth2", "AdamsBashforth4"),
@@ -130,7 +129,7 @@ namespace Inpar
               dyna_onesteptheta, dyna_expleuler, dyna_centrdiff, dyna_ab2, dyna_ab4),
           &sdyn);
 
-      setStringToIntegralParameter<Inpar::Solid::PreStress>("PRESTRESS", "none",
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::PreStress>("PRESTRESS", "none",
           "prestressing takes values none mulf material_iterative",
           tuple<std::string>("none", "None", "NONE", "mulf", "Mulf", "MULF", "Material_Iterative",
               "MATERIAL_ITERATIVE", "material_iterative"),
@@ -169,7 +168,7 @@ namespace Inpar
       Core::Utils::double_parameter("MAXTIME", 5.0, "maximum time", &sdyn);
 
       // Damping
-      setStringToIntegralParameter<Solid::DampKind>("DAMPING", "No",
+      Core::Utils::string_to_integral_parameter<Solid::DampKind>("DAMPING", "No",
           "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M + K_DAMP x K, "
           "(2) Material based and calculated in elements",
           tuple<std::string>("no", "No", "NO", "yes", "Yes", "YES", "Rayleigh", "Material"),
@@ -181,42 +180,42 @@ namespace Inpar
 
       Core::Utils::double_parameter(
           "TOLDISP", 1.0E-10, "tolerance in the displacement norm for the newton iteration", &sdyn);
-      setStringToIntegralParameter<Solid::ConvNorm>("NORM_DISP", "Abs",
+      Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_DISP", "Abs",
           "type of norm for displacement convergence check",
           tuple<std::string>("Abs", "Rel", "Mix"),
           tuple<Solid::ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &sdyn);
 
       Core::Utils::double_parameter(
           "TOLRES", 1.0E-08, "tolerance in the residual norm for the newton iteration", &sdyn);
-      setStringToIntegralParameter<Solid::ConvNorm>("NORM_RESF", "Abs",
+      Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_RESF", "Abs",
           "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
           tuple<Solid::ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &sdyn);
 
       Core::Utils::double_parameter(
           "TOLPRE", 1.0E-08, "tolerance in pressure norm for the newton iteration", &sdyn);
-      setStringToIntegralParameter<Solid::ConvNorm>("NORM_PRES", "Abs",
+      Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_PRES", "Abs",
           "type of norm for pressure convergence check", tuple<std::string>("Abs"),
           tuple<Solid::ConvNorm>(convnorm_abs), &sdyn);
 
       Core::Utils::double_parameter("TOLINCO", 1.0E-08,
           "tolerance in the incompressible residual norm for the newton iteration", &sdyn);
-      setStringToIntegralParameter<Solid::ConvNorm>("NORM_INCO", "Abs",
+      Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_INCO", "Abs",
           "type of norm for incompressible residual convergence check", tuple<std::string>("Abs"),
           tuple<Solid::ConvNorm>(convnorm_abs), &sdyn);
 
-      setStringToIntegralParameter<Solid::BinaryOp>("NORMCOMBI_DISPPRES", "And",
+      Core::Utils::string_to_integral_parameter<Solid::BinaryOp>("NORMCOMBI_DISPPRES", "And",
           "binary operator to combine pressure and displacement values",
           tuple<std::string>("And", "Or"), tuple<Solid::BinaryOp>(bop_and, bop_or), &sdyn);
 
-      setStringToIntegralParameter<Solid::BinaryOp>("NORMCOMBI_RESFINCO", "And",
+      Core::Utils::string_to_integral_parameter<Solid::BinaryOp>("NORMCOMBI_RESFINCO", "And",
           "binary operator to combine force and incompressible residual",
           tuple<std::string>("And", "Or"), tuple<Solid::BinaryOp>(bop_and, bop_or), &sdyn);
 
-      setStringToIntegralParameter<Solid::BinaryOp>("NORMCOMBI_RESFDISP", "And",
+      Core::Utils::string_to_integral_parameter<Solid::BinaryOp>("NORMCOMBI_RESFDISP", "And",
           "binary operator to combine displacement and residual force values",
           tuple<std::string>("And", "Or"), tuple<Solid::BinaryOp>(bop_and, bop_or), &sdyn);
 
-      setStringToIntegralParameter<Solid::StcScale>("STC_SCALING", "no",
+      Core::Utils::string_to_integral_parameter<Solid::StcScale>("STC_SCALING", "no",
           "Scaled director conditioning for thin shell structures",
           tuple<std::string>("no", "No", "NO", "Symmetric", "Right"),
           tuple<Solid::StcScale>(stc_none, stc_none, stc_none, stc_currsym, stc_curr), &sdyn);
@@ -238,11 +237,11 @@ namespace Inpar
           &sdyn);
       Core::Utils::int_parameter("MINITER", 0,
           "minimum number of iterations to be done within Newton-Raphson loop", &sdyn);
-      setStringToIntegralParameter<Solid::VectorNorm>("ITERNORM", "L2",
+      Core::Utils::string_to_integral_parameter<Solid::VectorNorm>("ITERNORM", "L2",
           "type of norm to be applied to residuals", tuple<std::string>("L1", "L2", "Rms", "Inf"),
           tuple<Solid::VectorNorm>(norm_l1, norm_l2, norm_rms, norm_inf), &sdyn);
 
-      setStringToIntegralParameter<Solid::DivContAct>("DIVERCONT", "stop",
+      Core::Utils::string_to_integral_parameter<Solid::DivContAct>("DIVERCONT", "stop",
           "What to do with time integration when Newton-Raphson iteration failed",
           tuple<std::string>("stop", "continue", "repeat_step", "halve_step", "adapt_step",
               "rand_adapt_step", "rand_adapt_step_ele_err", "repeat_simulation",
@@ -256,7 +255,7 @@ namespace Inpar
       Core::Utils::int_parameter("MAXDIVCONREFINEMENTLEVEL", 10,
           "number of times timestep is halved in case nonlinear solver diverges", &sdyn);
 
-      setStringToIntegralParameter<Solid::NonlinSolTech>("NLNSOL", "fullnewton",
+      Core::Utils::string_to_integral_parameter<Solid::NonlinSolTech>("NLNSOL", "fullnewton",
           "Nonlinear solution technique",
           tuple<std::string>("vague", "fullnewton", "modnewton", "lsnewton", "ptc",
               "newtonlinuzawa", "augmentedlagrange", "NoxNewtonLineSearch", "noxgeneral", "noxnln",
@@ -280,7 +279,7 @@ namespace Inpar
       Core::Utils::bool_parameter(
           "LOADLIN", "No", "Use linearization of external follower load in Newton", &sdyn);
 
-      setStringToIntegralParameter<Solid::MassLin>("MASSLIN", "No",
+      Core::Utils::string_to_integral_parameter<Solid::MassLin>("MASSLIN", "No",
           "Application of nonlinear inertia terms",
           tuple<std::string>("No", "no", "Standard", "standard", "Rotations", "rotations"),
           tuple<Solid::MassLin>(
@@ -290,7 +289,8 @@ namespace Inpar
       Core::Utils::bool_parameter("NEGLECTINERTIA", "No", "Neglect inertia", &sdyn);
 
       // Since predictor "none" would be misleading, the usage of no predictor is called vague.
-      setStringToIntegralParameter<Solid::PredEnum>("PREDICT", "ConstDis", "Type of predictor",
+      Core::Utils::string_to_integral_parameter<Solid::PredEnum>("PREDICT", "ConstDis",
+          "Type of predictor",
           tuple<std::string>("Vague", "ConstDis", "ConstVel", "ConstAcc", "ConstDisVelAcc",
               "TangDis", "TangDisConstFext", "ConstDisPres", "ConstDisVelAccPres"),
           tuple<Solid::PredEnum>(pred_vague, pred_constdis, pred_constvel, pred_constacc,
@@ -307,7 +307,7 @@ namespace Inpar
           "maximum number of iterations allowed for uzawa algorithm before failure going to next "
           "newton step",
           &sdyn);
-      setStringToIntegralParameter<Solid::ConSolveAlgo>("UZAWAALGO", "direct", "",
+      Core::Utils::string_to_integral_parameter<Solid::ConSolveAlgo>("UZAWAALGO", "direct", "",
           tuple<std::string>("uzawa", "simple", "direct"),
           tuple<Solid::ConSolveAlgo>(consolve_uzawa, consolve_simple, consolve_direct), &sdyn);
 
@@ -330,20 +330,20 @@ namespace Inpar
           "LINEAR_SOLVER", -1, "number of linear solver used for structural problems", &sdyn);
 
       // where the geometry comes from
-      setStringToIntegralParameter<Core::IO::GeometryType>("GEOMETRY", "full",
+      Core::Utils::string_to_integral_parameter<Core::IO::GeometryType>("GEOMETRY", "full",
           "How the geometry is specified", tuple<std::string>("full", "box", "file"),
           tuple<Core::IO::GeometryType>(
               Core::IO::geometry_full, Core::IO::geometry_box, Core::IO::geometry_file),
           &sdyn);
 
-      setStringToIntegralParameter<Solid::MidAverageEnum>("MIDTIME_ENERGY_TYPE", "vague",
-          "Specify the mid-averaging type for the structural energy contributions",
+      Core::Utils::string_to_integral_parameter<Solid::MidAverageEnum>("MIDTIME_ENERGY_TYPE",
+          "vague", "Specify the mid-averaging type for the structural energy contributions",
           tuple<std::string>("vague", "imrLike", "trLike"),
           tuple<Solid::MidAverageEnum>(midavg_vague, midavg_imrlike, midavg_trlike), &sdyn);
 
       // Initial displacement
-      setStringToIntegralParameter<Solid::InitialDisp>("INITIALDISP", "zero_displacement",
-          "Initial displacement for structure problem",
+      Core::Utils::string_to_integral_parameter<Solid::InitialDisp>("INITIALDISP",
+          "zero_displacement", "Initial displacement for structure problem",
           tuple<std::string>("zero_displacement", "displacement_by_function"),
           tuple<Solid::InitialDisp>(initdisp_zero_disp, initdisp_disp_by_function), &sdyn);
 
@@ -359,7 +359,7 @@ namespace Inpar
       /* parameters for generalised-alpha structural integrator */
       Teuchos::ParameterList& genalpha = sdyn.sublist("GENALPHA", false, "");
 
-      setStringToIntegralParameter<Solid::MidAverageEnum>("GENAVG", "TrLike",
+      Core::Utils::string_to_integral_parameter<Solid::MidAverageEnum>("GENAVG", "TrLike",
           "mid-average type of internal forces", tuple<std::string>("Vague", "ImrLike", "TrLike"),
           tuple<Solid::MidAverageEnum>(midavg_vague, midavg_imrlike, midavg_trlike), &genalpha);
       Core::Utils::double_parameter("BETA", -1.0, "Generalised-alpha factor in (0,1/2]", &genalpha);

--- a/src/inpar/4C_inpar_thermo.cpp
+++ b/src/inpar/4C_inpar_thermo.cpp
@@ -18,12 +18,11 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& tdyn = list.sublist("THERMAL DYNAMIC", false, "");
 
-  setStringToIntegralParameter<DynamicType>("DYNAMICTYPE", "OneStepTheta",
+  Core::Utils::string_to_integral_parameter<DynamicType>("DYNAMICTYPE", "OneStepTheta",
       "type of time integration control",
       tuple<std::string>("Statics", "OneStepTheta", "GenAlpha", "ExplicitEuler"),
       tuple<DynamicType>(dyna_statics, dyna_onesteptheta, dyna_genalpha, dyna_expleuler), &tdyn);
@@ -36,7 +35,7 @@ void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", &tdyn);
 
-  setStringToIntegralParameter<InitialField>("INITIALFIELD", "zero_field",
+  Core::Utils::string_to_integral_parameter<InitialField>("INITIALFIELD", "zero_field",
       "Initial Field for thermal problem",
       tuple<std::string>("zero_field", "field_by_function", "field_by_condition"),
       tuple<InitialField>(
@@ -54,18 +53,18 @@ void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter(
       "TOLTEMP", 1.0E-10, "tolerance in the temperature norm of the Newton iteration", &tdyn);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_TEMP", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_TEMP", "Abs",
       "type of norm for temperature convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &tdyn);
 
   Core::Utils::double_parameter(
       "TOLRES", 1.0E-08, "tolerance in the residual norm for the Newton iteration", &tdyn);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_RESF", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &tdyn);
 
-  setStringToIntegralParameter<BinaryOp>("NORMCOMBI_RESFTEMP", "And",
+  Core::Utils::string_to_integral_parameter<BinaryOp>("NORMCOMBI_RESFTEMP", "And",
       "binary operator to combine temperature and residual force values",
       tuple<std::string>("And", "Or"), tuple<BinaryOp>(bop_and, bop_or), &tdyn);
 
@@ -75,11 +74,11 @@ void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "MINITER", 0, "minimum number of iterations to be done within Newton-Raphson loop", &tdyn);
 
-  setStringToIntegralParameter<VectorNorm>("ITERNORM", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("ITERNORM", "L2",
       "type of norm to be applied to residuals", tuple<std::string>("L1", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(norm_l1, norm_l2, norm_rms, norm_inf), &tdyn);
 
-  setStringToIntegralParameter<DivContAct>("DIVERCONT", "stop",
+  Core::Utils::string_to_integral_parameter<DivContAct>("DIVERCONT", "stop",
       "What to do with time integration when Newton-Raphson iteration failed",
       tuple<std::string>("stop", "continue", "halve_step", "repeat_step", "repeat_simulation"),
       tuple<DivContAct>(divcont_stop, divcont_continue, divcont_halve_step, divcont_repeat_step,
@@ -89,11 +88,11 @@ void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("MAXDIVCONREFINEMENTLEVEL", 10,
       "number of times timestep is halved in case nonlinear solver diverges", &tdyn);
 
-  setStringToIntegralParameter<NonlinSolTech>("NLNSOL", "fullnewton",
+  Core::Utils::string_to_integral_parameter<NonlinSolTech>("NLNSOL", "fullnewton",
       "Nonlinear solution technique", tuple<std::string>("vague", "fullnewton"),
       tuple<NonlinSolTech>(soltech_vague, soltech_newtonfull), &tdyn);
 
-  setStringToIntegralParameter<PredEnum>("PREDICT", "ConstTemp",
+  Core::Utils::string_to_integral_parameter<PredEnum>("PREDICT", "ConstTemp",
       "Predictor of iterative solution techniques",
       tuple<std::string>("Vague", "ConstTemp", "ConstTempRate", "TangTemp"),
       tuple<PredEnum>(pred_vague, pred_consttemp, pred_consttemprate, pred_tangtemp), &tdyn);
@@ -114,13 +113,13 @@ void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
       "LINEAR_SOLVER", -1, "number of linear solver used for thermal problems", &tdyn);
 
   // where the geometry comes from
-  setStringToIntegralParameter<Core::IO::GeometryType>("GEOMETRY", "full",
+  Core::Utils::string_to_integral_parameter<Core::IO::GeometryType>("GEOMETRY", "full",
       "How the geometry is specified", tuple<std::string>("full", "box", "file"),
       tuple<Core::IO::GeometryType>(
           Core::IO::geometry_full, Core::IO::geometry_box, Core::IO::geometry_file),
       &tdyn);
 
-  setStringToIntegralParameter<CalcError>("CALCERROR", "No",
+  Core::Utils::string_to_integral_parameter<CalcError>("CALCERROR", "No",
       "compute error compared to analytical solution", tuple<std::string>("No", "byfunct"),
       tuple<CalcError>(no_error_calculation, calcerror_byfunct), &tdyn);
   Core::Utils::int_parameter("CALCERRORFUNCNO", -1, "Function for Error Calculation", &tdyn);
@@ -129,7 +128,7 @@ void Inpar::Thermo::set_valid_parameters(Teuchos::ParameterList& list)
   /* parameters for generalised-alpha thermal integrator */
   Teuchos::ParameterList& tgenalpha = tdyn.sublist("GENALPHA", false, "");
 
-  setStringToIntegralParameter<MidAverageEnum>("GENAVG", "TrLike",
+  Core::Utils::string_to_integral_parameter<MidAverageEnum>("GENAVG", "TrLike",
       "mid-average type of internal forces", tuple<std::string>("Vague", "ImrLike", "TrLike"),
       tuple<MidAverageEnum>(midavg_vague, midavg_imrlike, midavg_trlike), &tgenalpha);
 

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -16,7 +16,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& tsidyn = list.sublist("TSI DYNAMIC", false,
@@ -24,7 +23,7 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
       "Dynamic section for TSI solver with various coupling methods");
 
   // coupling strategy for (partitioned and monolithic) TSI solvers
-  setStringToIntegralParameter<SolutionSchemeOverFields>("COUPALGO", "tsi_monolithic",
+  Core::Utils::string_to_integral_parameter<SolutionSchemeOverFields>("COUPALGO", "tsi_monolithic",
       "Coupling strategies for TSI solvers",
       tuple<std::string>("tsi_oneway", "tsi_sequstagg", "tsi_iterstagg", "tsi_iterstagg_aitken",
           "tsi_iterstagg_aitkenirons", "tsi_iterstagg_fixedrelax", "tsi_monolithic"),
@@ -46,7 +45,7 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("ITEMIN", 1, "minimal number of iterations over fields", &tsidyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", &tsidyn);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_INC", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_INC", "Abs",
       "type of norm for convergence check of primary variables in TSI",
       tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &tsidyn);
@@ -64,11 +63,11 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("TOLINC", 1.0e-6,
       "tolerance for convergence check of TSI-increment in monolithic TSI", &tsidynmono);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_RESF", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &tsidynmono);
 
-  setStringToIntegralParameter<BinaryOp>("NORMCOMBI_RESFINC", "Coupl_And_Single",
+  Core::Utils::string_to_integral_parameter<BinaryOp>("NORMCOMBI_RESFINC", "Coupl_And_Single",
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>(
           "And", "Or", "Coupl_Or_Single", "Coupl_And_Single", "And_Single", "Or_Single"),
@@ -76,14 +75,14 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
           bop_or_single),
       &tsidynmono);
 
-  setStringToIntegralParameter<VectorNorm>("ITERNORM", "Rms",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("ITERNORM", "Rms",
       "type of norm to be applied to residuals",
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(norm_l1, norm_l1_scaled, norm_l2, norm_rms, norm_inf), &tsidynmono);
 
-  setStringToIntegralParameter<NlnSolTech>("NLNSOL", "fullnewton", "Nonlinear solution technique",
-      tuple<std::string>("fullnewton", "ptc"), tuple<NlnSolTech>(soltech_newtonfull, soltech_ptc),
-      &tsidynmono);
+  Core::Utils::string_to_integral_parameter<NlnSolTech>("NLNSOL", "fullnewton",
+      "Nonlinear solution technique", tuple<std::string>("fullnewton", "ptc"),
+      tuple<NlnSolTech>(soltech_newtonfull, soltech_ptc), &tsidynmono);
 
   Core::Utils::double_parameter("PTCDT", 0.1,
       "pseudo time step for pseudo-transient continuation (PTC) stabilised Newton procedure",
@@ -151,8 +150,9 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter(
       "NITSCHE_THETA_TSI", 0.0, "+1: symmetric, 0: non-symmetric, -1: skew-symmetric", &tsic);
 
-  setStringToIntegralParameter<Inpar::CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING_TSI",
-      "harmonic", "how to weight consistency terms in Nitsche contact formulation",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::NitscheWeighting>(
+      "NITSCHE_WEIGHTING_TSI", "harmonic",
+      "how to weight consistency terms in Nitsche contact formulation",
       tuple<std::string>("slave", "master", "harmonic", "physical"),
       tuple<Inpar::CONTACT::NitscheWeighting>(Inpar::CONTACT::NitWgt_slave,
           Inpar::CONTACT::NitWgt_master, Inpar::CONTACT::NitWgt_harmonic,
@@ -165,7 +165,8 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter(
       "PENALTYPARAM_THERMO", 0.0, "Penalty parameter for Nitsche solution strategy", &tsic);
 
-  setStringToIntegralParameter<Inpar::CONTACT::NitscheThermoMethod>("NITSCHE_METHOD_TSI", "nitsche",
+  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::NitscheThermoMethod>(
+      "NITSCHE_METHOD_TSI", "nitsche",
       "how to treat thermal interface problem: strong substitution or Nitsche for general "
       "interface conditions",
       tuple<std::string>("nitsche", "substitution"),
@@ -173,8 +174,8 @@ void Inpar::TSI::set_valid_parameters(Teuchos::ParameterList& list)
           Inpar::CONTACT::NitThermo_nitsche, Inpar::CONTACT::NitThermo_substitution),
       &tsic);
 
-  setStringToIntegralParameter<LineSearch>("TSI_LINE_SEARCH", "none", "line-search strategy",
-      tuple<std::string>("none", "structure", "thermo", "and", "or"),
+  Core::Utils::string_to_integral_parameter<LineSearch>("TSI_LINE_SEARCH", "none",
+      "line-search strategy", tuple<std::string>("none", "structure", "thermo", "and", "or"),
       tuple<LineSearch>(LS_none, LS_structure, LS_thermo, LS_and, LS_or), &tsidynmono);
 }
 

--- a/src/inpar/4C_inpar_volmortar.cpp
+++ b/src/inpar/4C_inpar_volmortar.cpp
@@ -16,13 +16,12 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::VolMortar::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /* parameters for volmortar */
   Teuchos::ParameterList& volmortar = list.sublist("VOLMORTAR COUPLING", false, "");
 
-  setStringToIntegralParameter<Coupling::VolMortar::IntType>("INTTYPE", "Elements",
+  Core::Utils::string_to_integral_parameter<Coupling::VolMortar::IntType>("INTTYPE", "Elements",
       "Type of numerical integration scheme",
       tuple<std::string>("Elements", "elements", "Segments", "segments"),
       tuple<Coupling::VolMortar::IntType>(Coupling::VolMortar::inttype_elements,
@@ -30,15 +29,15 @@ void Inpar::VolMortar::set_valid_parameters(Teuchos::ParameterList& list)
           Coupling::VolMortar::inttype_segments),
       &volmortar);
 
-  setStringToIntegralParameter<Coupling::VolMortar::CouplingType>("COUPLINGTYPE", "Volmortar",
-      "Type of coupling",
+  Core::Utils::string_to_integral_parameter<Coupling::VolMortar::CouplingType>("COUPLINGTYPE",
+      "Volmortar", "Type of coupling",
       tuple<std::string>("Volmortar", "volmortar", "consistentinterpolation", "consint"),
       tuple<Coupling::VolMortar::CouplingType>(Coupling::VolMortar::couplingtype_volmortar,
           Coupling::VolMortar::couplingtype_volmortar, Coupling::VolMortar::couplingtype_coninter,
           Coupling::VolMortar::couplingtype_coninter),
       &volmortar);
 
-  setStringToIntegralParameter<Coupling::VolMortar::Shapefcn>("SHAPEFCN", "Dual",
+  Core::Utils::string_to_integral_parameter<Coupling::VolMortar::Shapefcn>("SHAPEFCN", "Dual",
       "Type of employed set of shape functions",
       tuple<std::string>("Dual", "dual", "Standard", "standard", "std"),
       tuple<Coupling::VolMortar::Shapefcn>(Coupling::VolMortar::shape_dual,
@@ -46,7 +45,7 @@ void Inpar::VolMortar::set_valid_parameters(Teuchos::ParameterList& list)
           Coupling::VolMortar::shape_std, Coupling::VolMortar::shape_std),
       &volmortar);
 
-  setStringToIntegralParameter<Coupling::VolMortar::CutType>("CUTTYPE", "dd",
+  Core::Utils::string_to_integral_parameter<Coupling::VolMortar::CutType>("CUTTYPE", "dd",
       "Type of cut procedure/ integration point calculation",
       tuple<std::string>(
           "dd", "directdivergence", "DirectDivergence", "tessellation", "t", "Tessellation"),
@@ -56,7 +55,7 @@ void Inpar::VolMortar::set_valid_parameters(Teuchos::ParameterList& list)
           Coupling::VolMortar::cuttype_tessellation, Coupling::VolMortar::cuttype_tessellation),
       &volmortar);
 
-  setStringToIntegralParameter<Coupling::VolMortar::DualQuad>("DUALQUAD", "nomod",
+  Core::Utils::string_to_integral_parameter<Coupling::VolMortar::DualQuad>("DUALQUAD", "nomod",
       "Type of dual shape function for weighting function for quadr. problems",
       tuple<std::string>("nm", "nomod", "lm", "lin_mod", "qm", "quad_mod"),
       tuple<Coupling::VolMortar::DualQuad>(Coupling::VolMortar::dualquad_no_mod,

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -15,19 +15,18 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Wear::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   /* parameters for wear */
   Teuchos::ParameterList& wear = list.sublist("WEAR", false, "");
 
-  setStringToIntegralParameter<WearLaw>("WEARLAW", "None", "Type of wear law",
+  Core::Utils::string_to_integral_parameter<WearLaw>("WEARLAW", "None", "Type of wear law",
       tuple<std::string>("None", "none", "Archard", "archard"),
       tuple<WearLaw>(wear_none, wear_none, wear_archard, wear_archard), &wear);
 
   Core::Utils::bool_parameter("MATCHINGGRID", "Yes", "is matching grid", &wear);
 
-  setStringToIntegralParameter<WearShape>("WEAR_SHAPEFCN", "std",
+  Core::Utils::string_to_integral_parameter<WearShape>("WEAR_SHAPEFCN", "std",
       "Type of employed set of shape functions for wear",
       tuple<std::string>("Dual", "dual", "Standard", "standard", "std"),
       tuple<WearShape>(wear_shape_dual, wear_shape_dual, wear_shape_standard, wear_shape_standard,
@@ -46,23 +45,24 @@ void Inpar::Wear::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter(
       "VOLMASS_OUTPUT", "No", "flag for output of mass/volume in ref,mat and cur. conf.", &wear);
 
-  setStringToIntegralParameter<WearSide>("WEAR_SIDE", "slave", "Definition of wear side",
+  Core::Utils::string_to_integral_parameter<WearSide>("WEAR_SIDE", "slave",
+      "Definition of wear side",
       tuple<std::string>("s", "slave", "Slave", "both", "slave_master", "sm"),
       tuple<WearSide>(wear_slave, wear_slave, wear_slave, wear_both, wear_both, wear_both), &wear);
 
-  setStringToIntegralParameter<WearType>("WEARTYPE", "internal_state",
+  Core::Utils::string_to_integral_parameter<WearType>("WEARTYPE", "internal_state",
       "Definition of wear algorithm",
       tuple<std::string>("intstate", "is", "internal_state", "primvar", "pv", "primary_variable"),
       tuple<WearType>(
           wear_intstate, wear_intstate, wear_intstate, wear_primvar, wear_primvar, wear_primvar),
       &wear);
 
-  setStringToIntegralParameter<WearTimInt>("WEARTIMINT", "explicit",
+  Core::Utils::string_to_integral_parameter<WearTimInt>("WEARTIMINT", "explicit",
       "Definition of wear time integration",
       tuple<std::string>("explicit", "e", "expl", "implicit", "i", "impl"),
       tuple<WearTimInt>(wear_expl, wear_expl, wear_expl, wear_impl, wear_impl, wear_impl), &wear);
 
-  setStringToIntegralParameter<WearTimeScale>("WEAR_TIMESCALE", "equal",
+  Core::Utils::string_to_integral_parameter<WearTimeScale>("WEAR_TIMESCALE", "equal",
       "Definition wear time scale compares to std. time scale",
       tuple<std::string>("equal", "e", "different", "d"),
       tuple<WearTimeScale>(

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -18,7 +18,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& xfem_general = list.sublist("XFEM GENERAL", false, "");
@@ -44,8 +43,8 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "MAX_NUM_DOFSETS", 3, "Maximum number of volumecells in the XFEM element", &xfem_general);
 
-  setStringToIntegralParameter<Cut::NodalDofSetStrategy>("NODAL_DOFSET_STRATEGY", "full",
-      "Strategy used for the nodal dofset management per node",
+  Core::Utils::string_to_integral_parameter<Cut::NodalDofSetStrategy>("NODAL_DOFSET_STRATEGY",
+      "full", "Strategy used for the nodal dofset management per node",
       tuple<std::string>(
           "OneDofset_PerNodeAndPosition", "ConnectGhostDofsets_PerNodeAndPosition", "full"),
       tuple<Cut::NodalDofSetStrategy>(Cut::NDS_Strategy_OneDofset_PerNodeAndPosition,
@@ -53,15 +52,15 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
       &xfem_general);
 
   // Integration options
-  setStringToIntegralParameter<Cut::VCellGaussPts>("VOLUME_GAUSS_POINTS_BY", "Tessellation",
-      "Method for finding Gauss Points for the cut volumes",
+  Core::Utils::string_to_integral_parameter<Cut::VCellGaussPts>("VOLUME_GAUSS_POINTS_BY",
+      "Tessellation", "Method for finding Gauss Points for the cut volumes",
       tuple<std::string>("Tessellation", "MomentFitting", "DirectDivergence"),
       tuple<Cut::VCellGaussPts>(Cut::VCellGaussPts_Tessellation, Cut::VCellGaussPts_MomentFitting,
           Cut::VCellGaussPts_DirectDivergence),
       &xfem_general);
 
-  setStringToIntegralParameter<Cut::BCellGaussPts>("BOUNDARY_GAUSS_POINTS_BY", "Tessellation",
-      "Method for finding Gauss Points for the boundary cells",
+  Core::Utils::string_to_integral_parameter<Cut::BCellGaussPts>("BOUNDARY_GAUSS_POINTS_BY",
+      "Tessellation", "Method for finding Gauss Points for the boundary cells",
       tuple<std::string>("Tessellation", "MomentFitting", "DirectDivergence"),
       tuple<Cut::BCellGaussPts>(Cut::BCellGaussPts_Tessellation, Cut::BCellGaussPts_MomentFitting,
           Cut::BCellGaussPts_DirectDivergence),
@@ -87,7 +86,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
       "XFLUIDFLUID_SEARCHRADIUS", 1.0, "Radius of the search tree", &xfluid_general);
 
   // xfluidfluid-fsi-monolithic approach
-  setStringToIntegralParameter<MonolithicXffsiApproach>("MONOLITHIC_XFFSI_APPROACH",
+  Core::Utils::string_to_integral_parameter<MonolithicXffsiApproach>("MONOLITHIC_XFFSI_APPROACH",
       "xffsi_fixedALE_partitioned", "The monolithic approach for xfluidfluid-fsi",
       tuple<std::string>(
           "xffsi_full_newton", "xffsi_fixedALE_interpolation", "xffsi_fixedALE_partitioned"),
@@ -102,8 +101,8 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
       &xfluid_general);
 
   // xfluidfluid time integration approach
-  setStringToIntegralParameter<XFluidFluidTimeInt>("XFLUIDFLUID_TIMEINT", "Xff_TimeInt_FullProj",
-      "The xfluidfluid-timeintegration approach",
+  Core::Utils::string_to_integral_parameter<XFluidFluidTimeInt>("XFLUIDFLUID_TIMEINT",
+      "Xff_TimeInt_FullProj", "The xfluidfluid-timeintegration approach",
       tuple<std::string>("Xff_TimeInt_FullProj", "Xff_TimeInt_ProjIfMoved",
           "Xff_TimeInt_KeepGhostValues", "Xff_TimeInt_IncompProj"),
       tuple<XFluidFluidTimeInt>(Inpar::XFEM::Xff_TimeInt_FullProj,  // always project nodes from
@@ -117,7 +116,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_general);
 
-  setStringToIntegralParameter<XFluidTimeIntScheme>("XFLUID_TIMEINT",
+  Core::Utils::string_to_integral_parameter<XFluidTimeIntScheme>("XFLUID_TIMEINT",
       "STD=COPY/SL_and_GHOST=COPY/GP", "The xfluid time integration approach",
       tuple<std::string>("STD=COPY_and_GHOST=COPY/GP", "STD=COPY/SL_and_GHOST=COPY/GP",
           "STD=SL(boundary-zone)_and_GHOST=GP", "STD=COPY/PROJ_and_GHOST=COPY/PROJ/GP"),
@@ -140,8 +139,8 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::bool_parameter("ALE_XFluid", "no", "XFluid is Ale Fluid?", &xfluid_general);
 
   // for new OST-implementation: which interface terms to be evaluated for previous time step
-  setStringToIntegralParameter<InterfaceTermsPreviousState>("INTERFACE_TERMS_PREVIOUS_STATE",
-      "PreviousState_only_consistency",
+  Core::Utils::string_to_integral_parameter<InterfaceTermsPreviousState>(
+      "INTERFACE_TERMS_PREVIOUS_STATE", "PreviousState_only_consistency",
       "how to treat interface terms from previous time step (new OST)",
       tuple<std::string>("PreviousState_only_consistency", "PreviousState_full"),
       tuple<InterfaceTermsPreviousState>(
@@ -162,7 +161,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
   Teuchos::ParameterList& xfluid_stab = xfluid_dyn.sublist("STABILIZATION", false, "");
 
   // Boundary-Coupling options
-  setStringToIntegralParameter<CouplingMethod>("COUPLING_METHOD", "Nitsche",
+  Core::Utils::string_to_integral_parameter<CouplingMethod>("COUPLING_METHOD", "Nitsche",
       "method how to enforce embedded boundary/coupling conditions at the interface",
       tuple<std::string>("Hybrid_LM_Cauchy_stress", "Hybrid_LM_viscous_stress", "Nitsche"),
       tuple<CouplingMethod>(
@@ -172,7 +171,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_stab);
 
-  setStringToIntegralParameter<HybridLmL2Proj>("HYBRID_LM_L2_PROJ", "part_ele_proj",
+  Core::Utils::string_to_integral_parameter<HybridLmL2Proj>("HYBRID_LM_L2_PROJ", "part_ele_proj",
       "perform the L2 projection between stress fields on whole element or on fluid part?",
       tuple<std::string>("full_ele_proj", "part_ele_proj"),
       tuple<HybridLmL2Proj>(
@@ -182,7 +181,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_stab);
 
-  setStringToIntegralParameter<AdjointScaling>("VISC_ADJOINT_SYMMETRY", "yes",
+  Core::Utils::string_to_integral_parameter<AdjointScaling>("VISC_ADJOINT_SYMMETRY", "yes",
       "viscous and adjoint viscous interface terms with matching sign?",
       tuple<std::string>("yes", "no", "sym", "skew", "none"),
       tuple<AdjointScaling>(Inpar::XFEM::adj_sym, Inpar::XFEM::adj_skew, Inpar::XFEM::adj_sym,
@@ -195,8 +194,8 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::double_parameter("NIT_STAB_FAC_TANG", 35.0,
       " ( stabilization parameter for Nitsche's penalty tangential term", &xfluid_stab);
 
-  setStringToIntegralParameter<ViscStabTraceEstimate>("VISC_STAB_TRACE_ESTIMATE", "CT_div_by_hk",
-      "how to estimate the scaling from the trace inequality in Nitsche's method",
+  Core::Utils::string_to_integral_parameter<ViscStabTraceEstimate>("VISC_STAB_TRACE_ESTIMATE",
+      "CT_div_by_hk", "how to estimate the scaling from the trace inequality in Nitsche's method",
       tuple<std::string>("CT_div_by_hk", "eigenvalue"),
       tuple<ViscStabTraceEstimate>(
           Inpar::XFEM::ViscStab_TraceEstimate_CT_div_by_hk,  // estimate the trace inequality by a
@@ -207,14 +206,16 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_stab);
 
-  setStringToIntegralParameter<TraceEstimateEigenvalueUpdate>("UPDATE_EIGENVALUE_TRACE_ESTIMATE",
-      "every_iter", "how often should the local eigenvalue problem be updated",
+  Core::Utils::string_to_integral_parameter<TraceEstimateEigenvalueUpdate>(
+      "UPDATE_EIGENVALUE_TRACE_ESTIMATE", "every_iter",
+      "how often should the local eigenvalue problem be updated",
       tuple<std::string>("every_iter", "every_timestep", "once"),
       tuple<TraceEstimateEigenvalueUpdate>(Inpar::XFEM::Eigenvalue_update_every_iter,
           Inpar::XFEM::Eigenvalue_update_every_timestep, Inpar::XFEM::Eigenvalue_update_once),
       &xfluid_stab);
 
-  setStringToIntegralParameter<ViscStabHk>("VISC_STAB_HK", "ele_vol_div_by_max_ele_surf",
+  Core::Utils::string_to_integral_parameter<ViscStabHk>("VISC_STAB_HK",
+      "ele_vol_div_by_max_ele_surf",
       "how to define the characteristic element length in cut elements",
       tuple<std::string>("vol_equivalent", "cut_vol_div_by_cut_surf", "ele_vol_div_by_cut_surf",
           "ele_vol_div_by_ele_surf", "ele_vol_div_by_max_ele_surf"),
@@ -247,7 +248,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
       &xfluid_stab);
 
 
-  setStringToIntegralParameter<ConvStabScaling>("CONV_STAB_SCALING", "none",
+  Core::Utils::string_to_integral_parameter<ConvStabScaling>("CONV_STAB_SCALING", "none",
       "scaling factor for viscous interface stabilization (Nitsche, MSH)",
       tuple<std::string>("inflow", "abs_inflow", "none"),
       tuple<ConvStabScaling>(Inpar::XFEM::ConvStabScaling_inflow,  // scaling with max(0,-u*n)
@@ -256,7 +257,7 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_stab);
 
-  setStringToIntegralParameter<XffConvStabScaling>("XFF_CONV_STAB_SCALING", "none",
+  Core::Utils::string_to_integral_parameter<XffConvStabScaling>("XFF_CONV_STAB_SCALING", "none",
       "scaling factor for convective interface stabilization of fluid-fluid Coupling",
       tuple<std::string>("inflow", "averaged", "none"),
       tuple<XffConvStabScaling>(
@@ -266,8 +267,8 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_stab);
 
-  setStringToIntegralParameter<MassConservationCombination>("MASS_CONSERVATION_COMBO", "max",
-      "choose the maximum from viscous and convective contributions or just sum both up",
+  Core::Utils::string_to_integral_parameter<MassConservationCombination>("MASS_CONSERVATION_COMBO",
+      "max", "choose the maximum from viscous and convective contributions or just sum both up",
       tuple<std::string>("max", "sum"),
       tuple<MassConservationCombination>(
           Inpar::XFEM::MassConservationCombination_max,  /// use the maximum contribution
@@ -275,7 +276,8 @@ void Inpar::XFEM::set_valid_parameters(Teuchos::ParameterList& list)
           ),
       &xfluid_stab);
 
-  setStringToIntegralParameter<MassConservationScaling>("MASS_CONSERVATION_SCALING", "only_visc",
+  Core::Utils::string_to_integral_parameter<MassConservationScaling>("MASS_CONSERVATION_SCALING",
+      "only_visc",
       "apply additional scaling of penalty term to enforce mass conservation for "
       "convection-dominated flow",
       tuple<std::string>("full", "only_visc"),

--- a/src/lubrication/src/4C_lubrication_input.cpp
+++ b/src/lubrication/src/4C_lubrication_input.cpp
@@ -13,7 +13,6 @@ FOUR_C_NAMESPACE_OPEN
 
 void Lubrication::set_valid_parameters(Teuchos::ParameterList& list)
 {
-  using Teuchos::setStringToIntegralParameter;
   using Teuchos::tuple;
 
   Teuchos::ParameterList& lubricationdyn =
@@ -25,7 +24,7 @@ void Lubrication::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", &lubricationdyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", &lubricationdyn);
 
-  setStringToIntegralParameter<Lubrication::CalcError>("CALCERROR", "No",
+  Core::Utils::string_to_integral_parameter<Lubrication::CalcError>("CALCERROR", "No",
       "compute error compared to analytical solution",
       tuple<std::string>("No", "error_by_function"),
       tuple<Lubrication::CalcError>(calcerror_no, calcerror_byfunction), &lubricationdyn);
@@ -33,7 +32,7 @@ void Lubrication::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "CALCERRORNO", -1, "function number for lubrication error computation", &lubricationdyn);
 
-  setStringToIntegralParameter<Lubrication::VelocityField>("VELOCITYFIELD", "zero",
+  Core::Utils::string_to_integral_parameter<Lubrication::VelocityField>("VELOCITYFIELD", "zero",
       "type of velocity field used for lubrication problems",
       tuple<std::string>("zero", "function", "EHL"),
       tuple<Lubrication::VelocityField>(velocity_zero, velocity_function, velocity_EHL),
@@ -42,7 +41,7 @@ void Lubrication::set_valid_parameters(Teuchos::ParameterList& list)
   Core::Utils::int_parameter(
       "VELFUNCNO", -1, "function number for lubrication velocity field", &lubricationdyn);
 
-  setStringToIntegralParameter<Lubrication::HeightField>("HEIGHTFEILD", "zero",
+  Core::Utils::string_to_integral_parameter<Lubrication::HeightField>("HEIGHTFEILD", "zero",
       "type of height field used for lubrication problems",
       tuple<std::string>("zero", "function", "EHL"),
       tuple<Lubrication::HeightField>(height_zero, height_function, height_EHL), &lubricationdyn);
@@ -79,15 +78,15 @@ void Lubrication::set_valid_parameters(Teuchos::ParameterList& list)
       "nonlinear convergence limit",
       &lubricationdyn);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_PRE", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_PRE", "Abs",
       "type of norm for temperature convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &lubricationdyn);
 
-  setStringToIntegralParameter<ConvNorm>("NORM_RESF", "Abs",
+  Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), &lubricationdyn);
 
-  setStringToIntegralParameter<VectorNorm>("ITERNORM", "L2",
+  Core::Utils::string_to_integral_parameter<VectorNorm>("ITERNORM", "L2",
       "type of norm to be applied to residuals", tuple<std::string>("L1", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(norm_l1, norm_l2, norm_rms, norm_inf), &lubricationdyn);
 


### PR DESCRIPTION
In preparation to replace the ParameterList-based input mechanism with InputSpec. A few parameters contained documentation of the valid options. We never did anything with this information passed in this place, so I copied the information to the general description where it provided useful information that is not merely a repetition of information inferable from the strings.
