### PR TITLE
Github: enable dependabot updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Note that directory is relative to .github/workflows
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I believe some of our CI actions are outdated. Let's enable `dependabot` (https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) to ensure we stay up-to-date with minimal manual effort.