### PR TITLE
InputSpec: clearly state supported types for input

### DIFF
--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -98,10 +98,13 @@ namespace Core::IO
   };
 
 
+  /**
+   * The types that we support for yaml (de)serialization.
+   */
   template <typename T>
-  concept YamlSupportedType = requires(ryml::NodeRef node, const T& value) {
-    { node << value };
-  };
+  concept YamlSupportedType =
+      std::same_as<T, int> || std::same_as<T, double> || std::same_as<T, bool> ||
+      std::same_as<T, std::string> || std::same_as<T, std::filesystem::path>;
 
   /**
    * An exception thrown when an error occurs during yaml processing..
@@ -134,6 +137,11 @@ namespace Core::IO
     node << (value ? "true" : "false");
   }
 
+  inline void emit_value_as_yaml(ryml::NodeRef node, const std::filesystem::path& value)
+  {
+    node << value.string();
+  }
+
   template <typename T>
   void emit_value_as_yaml(ryml::NodeRef node, const std::optional<T>& value)
   {
@@ -146,7 +154,6 @@ namespace Core::IO
       node << "none";
     }
   }
-
 
   template <typename T, typename U>
   void emit_value_as_yaml(ryml::NodeRef node, const std::pair<T, U>& value)

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -72,6 +72,33 @@ namespace
     }
   }
 
+  TEST(InputSpecTest, EnumClassSelection)
+  {
+    enum class EnumClass
+    {
+      A,
+      B,
+      C,
+    };
+
+    auto spec = all_of({
+        selection<EnumClass>("enum",
+            {
+                {"A", EnumClass::A},
+                {"B", EnumClass::B},
+                {"C", EnumClass::C},
+            }),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("enum A");
+      ValueParser parser(stream);
+      spec.fully_parse(parser, container);
+      EXPECT_EQ(container.get<EnumClass>("enum"), EnumClass::A);
+    }
+  }
+
   TEST(InputSpecTest, Vector)
   {
     auto spec = all_of({
@@ -637,10 +664,10 @@ specs:
   - name: e
     type: selection
     required: false
-    default: 1
+    default: e1
     choices:
-      e1: 1
-      e2: 2
+      - name: e1
+      - name: e2
   - name: group2
     type: group
     required: false


### PR DESCRIPTION
Also fix a small bug where selection prints the wrong value for enum classes.

