### PR TITLE
Create some basic utility functions to integrate over a celltype in any dimension

### DIFF
--- a/src/core/fem/src/general/element/4C_fem_general_element_integration.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element_integration.hpp
@@ -1,0 +1,259 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_FEM_GENERAL_ELEMENT_INTEGRATION_HPP
+#define FOUR_C_FEM_GENERAL_ELEMENT_INTEGRATION_HPP
+
+
+#include "4C_config.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_fem_general_cell_type.hpp"
+#include "4C_fem_general_cell_type_traits.hpp"
+#include "4C_fem_general_node.hpp"
+#include "4C_fem_general_utils_gausspoints.hpp"
+#include "4C_fem_general_utils_nurbs_shapefunctions.hpp"
+#include "4C_fem_nurbs_discretization_utils.hpp"
+#include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_utils_exceptions.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::Elements
+{
+  template <Core::FE::CellType celltype, unsigned dim>
+  struct ElementNodes
+  {
+    /*!
+     * @brief Position of nodes in the reference configuration
+     */
+    Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, dim> coordinates;
+  };
+
+  template <Core::FE::CellType celltype, unsigned dim>
+    requires(Core::FE::is_nurbs<celltype>)
+  struct ElementNodes<celltype, dim>
+  {
+    /*!
+     * @brief Position of nodes in the reference configuration
+     */
+    Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, dim> coordinates;
+
+    /*!
+     * @brief Knot span of a NURBS element
+     */
+    std::vector<Core::LinAlg::SerialDenseVector> knots;
+
+    /*!
+     * @brief Weights of control points
+     */
+    Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, 1, double> weights;
+  };
+
+  /*!
+   * @brief Evaluate element node information given the element and a displacement vector
+   *
+   * @tparam celltype
+   * @param ele (in): Element
+   * @param disp (in) : Vector of nodal displacements of the element
+   * @return ElementNodes<celltype>
+   */
+  template <Core::FE::CellType celltype, unsigned dim>
+  ElementNodes<celltype, dim> evaluate_element_nodes(
+      const Core::FE::Discretization& discretization, const Core::Elements::Element& ele)
+  {
+    ElementNodes<celltype, dim> element_nodes;
+    for (int i = 0; i < Core::FE::num_nodes<celltype>; ++i)
+    {
+      for (unsigned d = 0; d < dim; ++d)
+      {
+        element_nodes.coordinates(i, d) = ele.nodes()[i]->x()[d];
+      }
+    }
+
+    if constexpr (Core::FE::is_nurbs<celltype>)
+    {
+      // Obtain the information required for a NURBS element
+      bool zero_size = Core::FE::Nurbs::get_my_nurbs_knots_and_weights(
+          discretization, &ele, element_nodes.knots, element_nodes.weights);
+
+      FOUR_C_ASSERT_ALWAYS(!zero_size,
+          "get_my_nurbs_knots_and_weights has to return a non zero size NURBS element.");
+    }
+
+    return element_nodes;
+  }
+
+  /*!
+   * @brief Evaluates the parameter coordinate of the Gauss point according the the Gauss rule
+   *
+   * @tparam celltype : Cell type
+   * @param intpoints (in) : Gauss integration points
+   * @param gp (in) : id of the Gauss point
+   * @return Core::LinAlg::Matrix<num_dim<celltype>, 1> : Coordinates of the Gauss Point in the
+   * parameter space
+   */
+  template <Core::FE::CellType celltype>
+  Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> evaluate_parameter_coordinate(
+      const Core::FE::GaussIntegration& intpoints, const int gp)
+  {
+    Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> xi;
+    for (int d = 0; d < Core::FE::dim<celltype>; ++d) xi(d) = intpoints.point(gp)[d];
+
+    return xi;
+  }
+
+  /*!
+   * @brief A struct holding the shape functions and its derivatives evaluated at a point within the
+   * element
+   */
+  template <Core::FE::CellType celltype>
+  struct ShapeFunctionsAndDerivatives
+  {
+    Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, 1> values{};
+    Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::num_nodes<celltype>> derivatives{};
+  };
+
+  /*!
+   * @brief Evaluates the shape functions and their derivatives at the specified point in the
+   * parameter space
+   *
+   * @tparam celltype : Discretizationt type
+   * @param xi (in) : Coordinate in the parameter space
+   * @return ShapeFunctionsAndDerivatives<celltype> : An object holding the shape functions and the
+   * first derivatives evaluated at the respective point in the parameter space
+   */
+  template <Core::FE::CellType celltype, unsigned dim>
+  ShapeFunctionsAndDerivatives<celltype> evaluate_shape_functions_and_derivs(
+      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+      const ElementNodes<celltype, dim>& nodal_coordinates)
+    requires(Core::FE::use_lagrange_shapefnct<celltype>)
+  {
+    ShapeFunctionsAndDerivatives<celltype> shapefcns;
+    Core::FE::shape_function<celltype>(xi, shapefcns.values);
+    Core::FE::shape_function_deriv1<celltype>(xi, shapefcns.derivatives);
+
+    return shapefcns;
+  }
+
+  template <Core::FE::CellType celltype, unsigned dim>
+  ShapeFunctionsAndDerivatives<celltype> evaluate_shape_functions_and_derivs(
+      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+      const ElementNodes<celltype, dim>& nodal_coordinates)
+    requires(Core::FE::is_nurbs<celltype>)
+  {
+    ShapeFunctionsAndDerivatives<celltype> shapefcns;
+    Core::FE::Nurbs::nurbs_get_funct_deriv(shapefcns.values, shapefcns.derivatives, xi,
+        nodal_coordinates.knots, nodal_coordinates.weights, celltype);
+
+    return shapefcns;
+  }
+
+  /*!
+   * @brief A matrix holding the jacobian mapping from the parameter space to the physical space
+   *
+   * @tparam celltype
+   * @tparam dim
+   */
+  template <Core::FE::CellType celltype, unsigned dim>
+  using JacobianMapping = Core::LinAlg::Matrix<Core::FE::dim<celltype>, dim>;
+
+  /*!
+   * @brief Evaluates the jacobian mapping of the element
+   *
+   * @tparam celltype : Cell type
+   * @param shapefcns (in) : Shape functions and derivatives evaluated at the respective point in
+   * the parameter space
+   * @param element_nodes (in) : Reference and current coordinates of the nodes of the element
+   * @param gp (in) : Id of the Gauss point
+   * @return JacobianMapping<celltype> : An object holding quantities of the jacobian mapping
+   * (inverse Jacobian, determinant, derivatives of the shape functions w.r.t. XYZ, integration
+   * factor)
+   */
+  template <unsigned dim, Core::FE::CellType celltype>
+  JacobianMapping<celltype, dim> evaluate_jacobian_mapping(
+      const ShapeFunctionsAndDerivatives<celltype>& shapefcns,
+      const ElementNodes<celltype, dim>& element_nodes)
+  {
+    JacobianMapping<celltype, dim> jacobian;
+    jacobian.multiply(shapefcns.derivatives, element_nodes.coordinates);
+
+    return jacobian;
+  }
+
+  /*!
+   * @brief The concept for a callable object called at each Gauss point during integration
+   *
+   * @tparam dim : Dimension of the space where the element is embedded (default is the dimension of
+   * the element)
+   * @tparam celltype : Cell type of the element
+   * @tparam T
+   */
+  template <unsigned dim, Core::FE::CellType celltype, typename T>
+  concept GaussPointEvaluatable = requires(T gp_evaluator,
+      Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> xi,
+      const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
+      const JacobianMapping<celltype, dim>& jacobian_mapping, double integration_factor, int gp) {
+    { gp_evaluator(xi, shape_functions, jacobian_mapping, integration_factor, gp) };
+  };
+  template <Core::FE::CellType celltype, unsigned dim>
+  double evaluate_integral_transformation_factor(
+      const JacobianMapping<celltype, dim> jacobian_mapping)
+  {
+    if constexpr (dim == Core::FE::dim<celltype>)
+    {
+      return jacobian_mapping.determinant();
+    }
+    else
+    {
+      Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::dim<celltype>> metric_tensor;
+      metric_tensor.multiply_nt(jacobian_mapping, jacobian_mapping);
+      return std::sqrt(metric_tensor.determinant());
+    }
+  }
+
+  /*!
+   * @brief Calls the @p gp_evaluator for each Gauss point with evaluated jacobian mapping using the
+   * integration rule defined by @p integration.
+   *
+   * @tparam celltype : Cell type of the element
+   * @tparam dim : Dimension of the space where the element is embedded (default is the dimension of
+   * the element)
+   * @tparam GaussPointEvaluator
+   * @param nodal_coordinates (in) : The nodal coordinates of the element
+   * @param integration (in) : The integration rule to be used.
+   * @param gp_evaluator (in) : A callable object (e.g. lambda-function) with that is @p
+   * GaussPointEvaluatable that will be called for each integration point.
+   */
+  template <Core::FE::CellType celltype, unsigned dim, typename GaussPointEvaluator>
+  void for_each_gauss_point(const ElementNodes<celltype, dim>& element_nodes,
+      const Core::FE::GaussIntegration& integration, GaussPointEvaluator gp_evaluator)
+    requires GaussPointEvaluatable<dim, celltype, GaussPointEvaluator>
+  {
+    for (int gp = 0; gp < integration.num_points(); ++gp)
+    {
+      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> xi =
+          evaluate_parameter_coordinate<celltype>(integration, gp);
+
+      const ShapeFunctionsAndDerivatives<celltype> shape_functions =
+          evaluate_shape_functions_and_derivs<celltype>(xi, element_nodes);
+
+      const JacobianMapping<celltype, dim> jacobian_mapping =
+          evaluate_jacobian_mapping<dim>(shape_functions, element_nodes);
+
+      const double integration_factor =
+          evaluate_integral_transformation_factor<celltype>(jacobian_mapping) *
+          integration.weight(gp);
+
+      gp_evaluator(xi, shape_functions, jacobian_mapping, integration_factor, gp);
+    }
+  }
+}  // namespace Core::Elements
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_gausspoints.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_gausspoints.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
+#include "4C_fem_general_utils_integration.hpp"
 #include "4C_fem_geometry_element_coordtrafo.hpp"
 
 #include <map>
@@ -384,6 +385,29 @@ namespace Core::FE
     /// internal collection
     std::shared_ptr<GaussPoints> gp_;
   };
+
+  /*!
+   * @brief Create a Gauss integration interface from a given Gauss rule type
+   */
+  template <Core::FE::CellType celltype, typename GaussRuleType>
+  GaussIntegration create_gauss_integration(GaussRuleType rule)
+  {
+    // setup default integration
+    IntPointsAndWeights<Core::FE::dim<celltype>> intpoints(rule);
+
+    // format as Discret::Utils::GaussIntegration
+    std::shared_ptr<Core::FE::CollectedGaussPoints> gp =
+        std::make_shared<Core::FE::CollectedGaussPoints>();
+
+    std::array<double, 3> xi = {0., 0., 0.};
+    for (int i = 0; i < intpoints.ip().nquad; ++i)
+    {
+      for (int d = 0; d < Core::FE::dim<celltype>; ++d) xi[d] = intpoints.ip().qxg[i][d];
+      gp->append(xi[0], xi[1], xi[2], intpoints.ip().qwgt[i]);
+    }
+
+    return Core::FE::GaussIntegration(gp);
+  }
 
 }  // namespace Core::FE
 

--- a/src/core/fem/tests/general/4C_fem_general_element_integration_test.cpp
+++ b/src/core/fem/tests/general/4C_fem_general_element_integration_test.cpp
@@ -1,0 +1,188 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_fem_general_element_integration.hpp"
+
+#include "4C_fem_general_cell_type.hpp"
+#include "4C_fem_general_element_integration_select.hpp"
+#include "4C_fem_general_utils_gausspoints.hpp"
+#include "4C_utils_exceptions.hpp"
+
+
+namespace
+{
+  using namespace FourC;
+
+  template <Core::FE::CellType celltype, unsigned dim>
+  std::tuple<Core::Elements::ElementNodes<celltype, dim>, double>
+  generate_element_nodes_and_reference_solution()
+  {
+    if constexpr (celltype == Core::FE::CellType::quad4)
+    {
+      if constexpr (dim == 2)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.2;
+        element_nodes.coordinates(0, 1) = 1.5;
+        element_nodes.coordinates(1, 0) = 4.3;
+        element_nodes.coordinates(1, 1) = 1.8;
+        element_nodes.coordinates(2, 0) = 4.0;
+        element_nodes.coordinates(2, 1) = 3.6;
+        element_nodes.coordinates(3, 0) = 1.5;
+        element_nodes.coordinates(3, 1) = 3.2;
+
+        return {element_nodes, 4.9};
+      }
+
+      if constexpr (dim == 3)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.2;
+        element_nodes.coordinates(0, 1) = 1.5;
+        element_nodes.coordinates(0, 2) = 1.5;
+        element_nodes.coordinates(1, 0) = 4.3;
+        element_nodes.coordinates(1, 1) = 1.8;
+        element_nodes.coordinates(1, 2) = 1.5;
+        element_nodes.coordinates(2, 0) = 4.0;
+        element_nodes.coordinates(2, 1) = 3.6;
+        element_nodes.coordinates(2, 2) = 1.5;
+        element_nodes.coordinates(3, 0) = 1.5;
+        element_nodes.coordinates(3, 1) = 3.2;
+        element_nodes.coordinates(3, 2) = 1.5;
+
+        return {element_nodes, 4.9};
+      }
+    }
+
+
+    if constexpr (celltype == Core::FE::CellType::tri3)
+    {
+      if constexpr (dim == 2)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.5;
+        element_nodes.coordinates(0, 1) = 2.3;
+        element_nodes.coordinates(1, 0) = 3.1;
+        element_nodes.coordinates(1, 1) = 1.8;
+        element_nodes.coordinates(2, 0) = 4.7;
+        element_nodes.coordinates(2, 1) = 5.2;
+
+        return {element_nodes, 3.12};
+      }
+
+      if constexpr (dim == 3)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.5;
+        element_nodes.coordinates(0, 1) = 2.3;
+        element_nodes.coordinates(0, 2) = 2.1;
+        element_nodes.coordinates(1, 0) = 3.1;
+        element_nodes.coordinates(1, 1) = 1.8;
+        element_nodes.coordinates(1, 2) = 2.2;
+        element_nodes.coordinates(2, 0) = 4.7;
+        element_nodes.coordinates(2, 1) = 5.2;
+        element_nodes.coordinates(2, 2) = 2.4;
+
+        return {element_nodes, 3.128769726266218};
+      }
+    }
+
+    if constexpr (celltype == Core::FE::CellType::line2)
+    {
+      if constexpr (dim == 1)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.5;
+        element_nodes.coordinates(1, 0) = 5.6;
+
+        return {element_nodes, 4.1};
+      }
+
+      if constexpr (dim == 2)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.5;
+        element_nodes.coordinates(0, 1) = 2.3;
+        element_nodes.coordinates(1, 0) = 3.1;
+        element_nodes.coordinates(1, 1) = 1.8;
+
+        return {element_nodes, std::sqrt(2.81)};
+      }
+
+      if constexpr (dim == 3)
+      {
+        Core::Elements::ElementNodes<celltype, dim> element_nodes;
+        element_nodes.coordinates(0, 0) = 1.5;
+        element_nodes.coordinates(0, 1) = 2.3;
+        element_nodes.coordinates(0, 2) = 2.1;
+        element_nodes.coordinates(1, 0) = 3.1;
+        element_nodes.coordinates(1, 1) = 1.8;
+        element_nodes.coordinates(1, 2) = 2.2;
+
+        return {element_nodes, std::sqrt(2.82)};
+      }
+    }
+
+    FOUR_C_THROW("Unsupported celltype or dim");
+  }
+
+
+  template <Core::FE::CellType celltype, unsigned dim>
+  void test_element_integration()
+  {
+    const auto [element_nodes, ref_solution] =
+        generate_element_nodes_and_reference_solution<celltype, dim>();
+
+    Core::FE::GaussIntegration gauss_integration = Core::FE::create_gauss_integration<celltype>(
+        Discret::Elements::DisTypeToOptGaussRule<celltype>::rule);
+
+    double unit_integral = 0.0;
+    Core::Elements::for_each_gauss_point(element_nodes, gauss_integration,
+        [&](auto xi, auto shape_functions, auto jacobian_mapping, auto integration_factor, auto gp)
+        { unit_integral += integration_factor; });
+
+    EXPECT_NEAR(unit_integral, ref_solution, 1.0e-10);
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationQuad4Dim2)
+  {
+    test_element_integration<Core::FE::CellType::quad4, 2>();
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationQuad4Dim3)
+  {
+    test_element_integration<Core::FE::CellType::quad4, 3>();
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationTri3Dim2)
+  {
+    test_element_integration<Core::FE::CellType::tri3, 2>();
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationTri3Dim3)
+  {
+    test_element_integration<Core::FE::CellType::tri3, 3>();
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationLine2Dim1)
+  {
+    test_element_integration<Core::FE::CellType::line2, 1>();
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationLine2Dim2)
+  {
+    test_element_integration<Core::FE::CellType::line2, 2>();
+  }
+
+  TEST(ElementIntegrationTest, TestIntegrationLine2Dim3)
+  {
+    test_element_integration<Core::FE::CellType::line2, 3>();
+  }
+
+}  // namespace

--- a/src/so3/4C_so3_poro.cpp
+++ b/src/so3/4C_so3_poro.cpp
@@ -23,7 +23,7 @@ FOUR_C_NAMESPACE_OPEN
 template <class So3Ele, Core::FE::CellType distype>
 Discret::Elements::So3Poro<So3Ele, distype>::So3Poro(int id, int owner)
     : So3Ele(id, owner),
-      intpoints_(Discret::Elements::create_gauss_integration<distype>(
+      intpoints_(Core::FE::create_gauss_integration<distype>(
           Discret::Elements::DisTypeToOptGaussRule<distype>::rule)),
       init_(false),
       isNurbs_(false),
@@ -49,7 +49,7 @@ Discret::Elements::So3Poro<So3Ele, distype>::So3Poro(
       invJ_(old.invJ_),
       detJ_(old.detJ_),
       xsi_(old.xsi_),
-      intpoints_(Discret::Elements::create_gauss_integration<distype>(
+      intpoints_(Core::FE::create_gauss_integration<distype>(
           Discret::Elements::DisTypeToOptGaussRule<distype>::rule)),
       init_(old.init_),
       isNurbs_(old.isNurbs_),

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc.cpp
@@ -85,10 +85,10 @@ namespace
 
 template <Core::FE::CellType celltype, typename ElementFormulation>
 Discret::Elements::SolidEleCalc<celltype, ElementFormulation>::SolidEleCalc()
-    : stiffness_matrix_integration_(
-          create_gauss_integration<celltype>(get_gauss_rule_stiffness_matrix<celltype>())),
+    : stiffness_matrix_integration_(Core::FE::create_gauss_integration<celltype>(
+          get_gauss_rule_stiffness_matrix<celltype>())),
       mass_matrix_integration_(
-          create_gauss_integration<celltype>(get_gauss_rule_mass_matrix<celltype>()))
+          Core::FE::create_gauss_integration<celltype>(get_gauss_rule_mass_matrix<celltype>()))
 {
   Discret::Elements::resize_gp_history(history_data_, stiffness_matrix_integration_.num_points());
 }

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
@@ -1021,7 +1021,7 @@ namespace Discret::Elements
     constexpr auto numdim = Core::FE::dim<celltype>;
     const ElementNodes<celltype> nodal_coordinates =
         evaluate_element_nodes<celltype>(element, discretization, lm);
-    Core::FE::GaussIntegration gauss_integration = create_gauss_integration<celltype>(
+    Core::FE::GaussIntegration gauss_integration = Core::FE::create_gauss_integration<celltype>(
         Discret::Elements::get_gauss_rule_stiffness_matrix<celltype>());
 
     AnalyticalDisplacementErrorIntegrationResults error_result;

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_integration.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_integration.hpp
@@ -60,29 +60,6 @@ namespace Discret::Elements
   {
     return Core::FE::GaussRule3D::tet_1point;
   }
-
-  /*!
-   * @brief Create a Gauss integration interface from a given Gauss rule type
-   */
-  template <Core::FE::CellType celltype, typename GaussRuleType>
-  Core::FE::GaussIntegration create_gauss_integration(GaussRuleType rule)
-  {
-    // setup default integration
-    Core::FE::IntPointsAndWeights<Core::FE::dim<celltype>> intpoints(rule);
-
-    // format as Discret::Utils::GaussIntegration
-    std::shared_ptr<Core::FE::CollectedGaussPoints> gp =
-        std::make_shared<Core::FE::CollectedGaussPoints>();
-
-    std::array<double, 3> xi = {0., 0., 0.};
-    for (int i = 0; i < intpoints.ip().nquad; ++i)
-    {
-      for (int d = 0; d < Core::FE::dim<celltype>; ++d) xi[d] = intpoints.ip().qxg[i][d];
-      gp->append(xi[0], xi[1], xi[2], intpoints.ip().qwgt[i]);
-    }
-
-    return Core::FE::GaussIntegration(gp);
-  }
   /// @}
 }  // namespace Discret::Elements
 FOUR_C_NAMESPACE_CLOSE

--- a/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
@@ -76,7 +76,7 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
 {
   constexpr auto numdim = Core::FE::dim<celltype>;
   constexpr auto numnod = Core::FE::num_nodes<celltype>;
-  Core::FE::GaussIntegration gauss_integration = create_gauss_integration<celltype>(
+  Core::FE::GaussIntegration gauss_integration = Core::FE::create_gauss_integration<celltype>(
       Discret::Elements::get_gauss_rule_stiffness_matrix<celltype>());
 
   // get values and switches from the condition

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
@@ -20,8 +20,8 @@ FOUR_C_NAMESPACE_OPEN
 
 template <Core::FE::CellType celltype>
 Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::SolidPoroPressureBasedEleCalc()
-    : gauss_integration_(
-          create_gauss_integration<celltype>(get_gauss_rule_stiffness_matrix_poro<celltype>()))
+    : gauss_integration_(Core::FE::create_gauss_integration<celltype>(
+          get_gauss_rule_stiffness_matrix_poro<celltype>()))
 {
 }
 

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.cpp
@@ -130,8 +130,8 @@ namespace
 template <Core::FE::CellType celltype>
 Discret::Elements::SolidPoroPressureVelocityBasedEleCalc<
     celltype>::SolidPoroPressureVelocityBasedEleCalc()
-    : gauss_integration_(
-          create_gauss_integration<celltype>(get_gauss_rule_stiffness_matrix_poro<celltype>()))
+    : gauss_integration_(Core::FE::create_gauss_integration<celltype>(
+          get_gauss_rule_stiffness_matrix_poro<celltype>()))
 {
 }
 

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.cpp
@@ -250,10 +250,10 @@ namespace
 
 template <Core::FE::CellType celltype, typename SolidFormulation>
 Discret::Elements::SolidScatraEleCalc<celltype, SolidFormulation>::SolidScatraEleCalc()
-    : stiffness_matrix_integration_(
-          create_gauss_integration<celltype>(get_gauss_rule_stiffness_matrix<celltype>())),
+    : stiffness_matrix_integration_(Core::FE::create_gauss_integration<celltype>(
+          get_gauss_rule_stiffness_matrix<celltype>())),
       mass_matrix_integration_(
-          create_gauss_integration<celltype>(get_gauss_rule_mass_matrix<celltype>()))
+          Core::FE::create_gauss_integration<celltype>(get_gauss_rule_mass_matrix<celltype>()))
 {
 }
 


### PR DESCRIPTION
This PR adds some utility functions for integrating over any celltype in core.

These functions are similar to that what we also have in the new solid elements. I just generalized them a bit, so that they are not connected to solids, and can also handle manifolds (e.g., a surface in the 3d space).

I will use this in another PR to extract the spring-dashpots from so3_surface.

I will also reuse this in the new solid elements, but I want to keep the changes in here small.