### PR TITLE
Allow reading a few more values as bools from yaml files

### DIFF
--- a/src/core/io/src/4C_io_yaml.cpp
+++ b/src/core/io/src/4C_io_yaml.cpp
@@ -51,4 +51,19 @@ void Core::IO::read_value_from_yaml(Core::IO::ConstYamlNodeRef node, double& val
   }
 }
 
+void Core::IO::read_value_from_yaml(FourC::Core::IO::ConstYamlNodeRef node, bool& value)
+{
+  FOUR_C_ASSERT_ALWAYS(node.node.has_val(), "Expected a value node.");
+  std::string token(node.node.val().data(), node.node.val().size());
+  std::transform(token.begin(), token.end(), token.begin(), ::tolower);
+  if (token == "true" || token == "yes" || token == "on" || token == "1")
+    value = true;
+  else if (token == "false" || token == "no" || token == "off" || token == "0")
+    value = false;
+  else
+  {
+    throw YamlException("Could not parse '" + token + "' as a boolean value.");
+  }
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -185,6 +185,16 @@ namespace Core::IO
 
   void read_value_from_yaml(ConstYamlNodeRef node, double& value);
 
+  /**
+   * Reading a bool currently supports the following options:
+   *
+   * - truthy values: "true", "yes", "on", "1"
+   * - falsy values: "false", "no", "off", "0"
+   *
+   * All of them are case-insensitive.
+   */
+  void read_value_from_yaml(ConstYamlNodeRef node, bool& value);
+
   template <typename T>
   void read_value_from_yaml(ConstYamlNodeRef node, std::optional<T>& value)
   {


### PR DESCRIPTION
Although it would be great to only support `true` and `false` as boolean values, the input files are not in this state. However, we always emit the pretty values. Once we have automatic conversion between file formats, all the messy values will be cleaned up over time.