### PR TITLE
Just set necessary parameters in unit tests

### DIFF
--- a/unittests/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_mortar_test.cpp
+++ b/unittests/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_mortar_test.cpp
@@ -21,6 +21,17 @@ namespace
 {
   using namespace FourC;
 
+
+  void set_up_default_parameters_line_to_3d(Teuchos::ParameterList& list)
+  {
+    list.set("GEOMETRY_PAIR_STRATEGY", Inpar::GEOMETRYPAIR::LineTo3DStrategy::segmentation);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS", 6);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION",
+        Inpar::GEOMETRYPAIR::NotAllGaussPointsProjectValidAction::fail);
+    list.set("GAUSS_POINTS", 6);
+    list.set("INTEGRATION_POINTS_CIRCUMFERENCE", 6);
+  }
+
   /**
    * Class to test the local mortar matrices calculated by the beam to volume mesh tying mortar
    * pair.
@@ -35,7 +46,7 @@ namespace
     {
       // Set up the evaluation data container for the geometry pairs.
       Teuchos::ParameterList line_to_volume_params_list;
-      Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(line_to_volume_params_list);
+      set_up_default_parameters_line_to_3d(line_to_volume_params_list);
       evaluation_data_ =
           std::make_shared<GEOMETRYPAIR::LineTo3DEvaluationData>(line_to_volume_params_list);
     }

--- a/unittests/fbi/4C_beam_to_fluid_meshtying_pair_gauss_point_test.cpp
+++ b/unittests/fbi/4C_beam_to_fluid_meshtying_pair_gauss_point_test.cpp
@@ -27,6 +27,16 @@ namespace
 {
   using namespace FourC;
 
+  void set_up_default_parameters_line_to_3d(Teuchos::ParameterList& list)
+  {
+    list.set("GEOMETRY_PAIR_STRATEGY", Inpar::GEOMETRYPAIR::LineTo3DStrategy::segmentation);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS", 6);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION",
+        Inpar::GEOMETRYPAIR::NotAllGaussPointsProjectValidAction::fail);
+    list.set("GAUSS_POINTS", 6);
+    list.set("INTEGRATION_POINTS_CIRCUMFERENCE", 6);
+  }
+
   /**
    * Class to test the local coupling matrices calculated by the beam to fluid meshtying gpts pair.
    */
@@ -41,7 +51,7 @@ namespace
     {
       // Set up the evaluation data container for the geometry pairs.
       Teuchos::ParameterList line_to_volume_params_list;
-      Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(line_to_volume_params_list);
+      set_up_default_parameters_line_to_3d(line_to_volume_params_list);
       evaluation_data_ =
           std::make_shared<GEOMETRYPAIR::LineTo3DEvaluationData>(line_to_volume_params_list);
     }

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_surface_test.cpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_surface_test.cpp
@@ -21,6 +21,19 @@ using namespace GEOMETRYPAIR;
 
 namespace
 {
+
+  void set_up_default_parameters_line_to_3d(Teuchos::ParameterList& list)
+  {
+    list.set("GEOMETRY_PAIR_STRATEGY", Inpar::GEOMETRYPAIR::LineTo3DStrategy::segmentation);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS", 6);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION",
+        Inpar::GEOMETRYPAIR::NotAllGaussPointsProjectValidAction::fail);
+    list.set("GAUSS_POINTS", 6);
+    list.set("INTEGRATION_POINTS_CIRCUMFERENCE", 6);
+
+    list.set("GEOMETRY_PAIR_SURFACE_NORMALS", Inpar::GEOMETRYPAIR::SurfaceNormals::standard);
+  }
+
   /**
    * Class to test the line to volume geometry pair segmentation algorithm.
    */
@@ -34,8 +47,7 @@ namespace
     {
       // Set up the evaluation data container for the geometry pairs.
       Teuchos::ParameterList line_to_surface_params_list;
-      Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(line_to_surface_params_list);
-      Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(line_to_surface_params_list);
+      set_up_default_parameters_line_to_3d(line_to_surface_params_list);
       evaluation_data_ =
           std::make_shared<GEOMETRYPAIR::LineToSurfaceEvaluationData>(line_to_surface_params_list);
     }

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_volume_segmentation_test.cpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_volume_segmentation_test.cpp
@@ -21,6 +21,17 @@
 
 namespace
 {
+
+  void set_up_default_parameters_line_to_3d(Teuchos::ParameterList& list)
+  {
+    list.set("GEOMETRY_PAIR_STRATEGY", Inpar::GEOMETRYPAIR::LineTo3DStrategy::segmentation);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS", 6);
+    list.set("GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION",
+        Inpar::GEOMETRYPAIR::NotAllGaussPointsProjectValidAction::fail);
+    list.set("GAUSS_POINTS", 6);
+    list.set("INTEGRATION_POINTS_CIRCUMFERENCE", 6);
+  }
+
   /**
    * Class to test the line to volume geometry pair segmentation algorithm.
    */
@@ -34,7 +45,7 @@ namespace
     {
       // Set up the evaluation data container for the geometry pairs.
       Teuchos::ParameterList line_to_volume_params_list;
-      Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(line_to_volume_params_list);
+      set_up_default_parameters_line_to_3d(line_to_volume_params_list);
       evaluation_data_ =
           std::make_shared<GEOMETRYPAIR::LineTo3DEvaluationData>(line_to_volume_params_list);
     }
@@ -384,10 +395,11 @@ namespace
     // We change the default settings here, to run into the case where the obtained segment has
     // Gauss points that do not project valid
     Teuchos::ParameterList line_to_volume_params_list;
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(line_to_volume_params_list);
+    set_up_default_parameters_line_to_3d(line_to_volume_params_list);
     line_to_volume_params_list.set("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS", 2);
     line_to_volume_params_list.set(
-        "GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION", "warning");
+        "GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION",
+        Inpar::GEOMETRYPAIR::NotAllGaussPointsProjectValidAction::warning);
     evaluation_data_ =
         std::make_shared<GEOMETRYPAIR::LineTo3DEvaluationData>(line_to_volume_params_list);
 
@@ -428,7 +440,7 @@ namespace
     // We change the default settings here, to run into the case where the obtained segment has
     // Gauss points that do not project valid
     Teuchos::ParameterList line_to_volume_params_list;
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(line_to_volume_params_list);
+    set_up_default_parameters_line_to_3d(line_to_volume_params_list);
     line_to_volume_params_list.set("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS", 2);
     evaluation_data_ =
         std::make_shared<GEOMETRYPAIR::LineTo3DEvaluationData>(line_to_volume_params_list);

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -175,8 +175,10 @@ namespace
       // add the ocp model
       electrode_data.add("OCP_MODEL", ocp_model);
 
-      // make sure that the default parameters exist in the problem
-      Global::Problem::instance()->set_parameter_list(std::make_shared<Teuchos::ParameterList>());
+      // Set up parameters in global problem instance
+      auto params = std::make_shared<Teuchos::ParameterList>();
+      params->sublist("ELCH CONTROL").set("GAS_CONSTANT", 8.314472);
+      Global::Problem::instance()->set_parameter_list(params);
 
       // add actually required parameters to electrode material
       const double c_max(4.91375e4);

--- a/unittests/mat/4C_multiplicative_split_defgrad_elasthyper_test.cpp
+++ b/unittests/mat/4C_multiplicative_split_defgrad_elasthyper_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "4C_global_data.hpp"
+#include "4C_inpar_ssi.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_multiplicative_split_defgrad_elasthyper.hpp"
@@ -98,9 +99,10 @@ namespace
 
       // set parameter list
       auto parameter_list_pointer = std::make_shared<Teuchos::ParameterList>();
-      auto structural_dynamic_params = parameter_list_pointer->sublist("STRUCTURAL DYNAMIC", false);
-
-      structural_dynamic_params.set("MASSLIN", "No");
+      parameter_list_pointer->sublist("STRUCTURAL DYNAMIC", false)
+          .set("MASSLIN", Inpar::Solid::MassLin::ml_none);
+      parameter_list_pointer->sublist("SSI CONTROL")
+          .set("COUPALGO", Inpar::SSI::SolutionSchemeOverFields::ssi_IterStagg);
 
       // set the parameter list in the global problem
       problem.set_parameter_list(parameter_list_pointer);


### PR DESCRIPTION
Instead of going through the parameter list, which magically sets some defaults, just set the parameters that are necessary for the unit tests. This does not solve the bigger issue that parameters are retrieved from a shared global variable but it at least makes these parameters explicit and helps in decoupling the implementation from input mechanism details, which is useful for the next steps in in this direction.
