### PR TITLE
Avoid Teuchos::getStringValue

### DIFF
--- a/src/adapter/4C_adapter_str_structure.cpp
+++ b/src/adapter/4C_adapter_str_structure.cpp
@@ -68,9 +68,7 @@ void Adapter::StructureBaseAlgorithm::create_structure(const Teuchos::ParameterL
       create_tim_int(prbdyn, sdyn, actdis);  // <-- here is the show
       break;
     default:
-      FOUR_C_THROW("unknown time integration scheme '%s'",
-          Teuchos::getStringValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE").c_str());
-      break;
+      FOUR_C_THROW("Unknown time integration scheme");
   }
 }
 

--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -98,9 +98,7 @@ void Adapter::StructureBaseAlgorithmNew::setup()
       setup_tim_int();  // <-- here is the show
       break;
     default:
-      FOUR_C_THROW("Unknown time integration scheme '%s'",
-          Teuchos::getStringValue<Inpar::Solid::DynamicType>(*sdyn_, "DYNAMICTYPE").c_str());
-      break;
+      FOUR_C_THROW("Unknown time integration scheme");
   }
 
   issetup_ = true;

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -349,14 +349,16 @@ bool Core::IO::need_to_print_equal_sign(const Teuchos::ParameterList& list)
 
         const std::string& name = it.key;
 
-        const Teuchos::RCP<const Teuchos::Array<std::string>>& values_ptr =
-            it.second.validator()->validStringValues();
-
-        const bool value_has_space =
-            (values_ptr != Teuchos::null) &&
-            std::any_of(values_ptr->begin(), values_ptr->end(), string_has_space);
-
-        return value_has_space || string_has_space(name);
+        // Only check string values for spaces.
+        if (list.isType<std::string>(name))
+        {
+          const std::string& value = list.get<std::string>(name);
+          return string_has_space(value) || string_has_space(name);
+        }
+        else
+        {
+          return string_has_space(name);
+        }
       });
 }
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -5711,7 +5711,7 @@ void FLD::FluidImplicitTimeInt::print_stabilization_details() const
   if (myrank_ == 0)
   {
     std::cout << "Stabilization type         : "
-              << Teuchos::getStringValue<Inpar::FLUID::StabType>(*stabparams, "STABTYPE") << "\n";
+              << to_string(Teuchos::get<Inpar::FLUID::StabType>(*stabparams, "STABTYPE")) << "\n";
     std::cout << "                             "
               << "Evaluation Tau  = " << stabparams->get<std::string>("EVALUATION_TAU") << "\n";
     std::cout << "                             "
@@ -5726,7 +5726,7 @@ void FLD::FluidImplicitTimeInt::print_stabilization_details() const
       std::cout << "\n";
       std::cout << "                             "
                 << "Tau Type        = "
-                << Teuchos::getStringValue<Inpar::FLUID::TauType>(*stabparams, "DEFINITION_TAU")
+                << to_string(Teuchos::get<Inpar::FLUID::TauType>(*stabparams, "DEFINITION_TAU"))
                 << "\n";
 
       if (Teuchos::getIntegralValue<Inpar::FLUID::SubscalesTD>(*stabparams, "TDS") ==
@@ -5742,32 +5742,32 @@ void FLD::FluidImplicitTimeInt::print_stabilization_details() const
       }
 
       std::cout << "                             "
-                << "SUPG            = " << Teuchos::getStringValue<bool>(*stabparams, "SUPG")
+                << "SUPG            = " << std::boolalpha << Teuchos::get<bool>(*stabparams, "SUPG")
                 << "\n";
       std::cout << "                             "
-                << "PSPG            = " << Teuchos::getStringValue<bool>(*stabparams, "PSPG")
+                << "PSPG            = " << std::boolalpha << Teuchos::get<bool>(*stabparams, "PSPG")
                 << "\n";
       std::cout << "                             "
-                << "GRAD_DIV        = " << Teuchos::getStringValue<bool>(*stabparams, "GRAD_DIV")
-                << "\n";
+                << "GRAD_DIV        = " << std::boolalpha
+                << Teuchos::get<bool>(*stabparams, "GRAD_DIV") << "\n";
       std::cout << "                             "
                 << "CROSS-STRESS    = "
-                << Teuchos::getStringValue<Inpar::FLUID::CrossStress>(*stabparams, "CROSS-STRESS")
+                << to_string(Teuchos::get<Inpar::FLUID::CrossStress>(*stabparams, "CROSS-STRESS"))
                 << "\n";
       std::cout << "                             "
                 << "REYNOLDS-STRESS = "
-                << Teuchos::getStringValue<Inpar::FLUID::ReynoldsStress>(
-                       *stabparams, "REYNOLDS-STRESS")
+                << to_string(
+                       Teuchos::get<Inpar::FLUID::ReynoldsStress>(*stabparams, "REYNOLDS-STRESS"))
                 << "\n";
       std::cout << "                             "
                 << "VSTAB           = "
-                << Teuchos::getStringValue<Inpar::FLUID::VStab>(*stabparams, "VSTAB") << "\n";
+                << to_string(Teuchos::get<Inpar::FLUID::VStab>(*stabparams, "VSTAB")) << "\n";
       std::cout << "                             "
                 << "RSTAB           = "
-                << Teuchos::getStringValue<Inpar::FLUID::RStab>(*stabparams, "RSTAB") << "\n";
+                << to_string(Teuchos::get<Inpar::FLUID::RStab>(*stabparams, "RSTAB")) << "\n";
       std::cout << "                             "
                 << "TRANSIENT       = "
-                << Teuchos::getStringValue<Inpar::FLUID::Transient>(*stabparams, "TRANSIENT")
+                << to_string(Teuchos::get<Inpar::FLUID::Transient>(*stabparams, "TRANSIENT"))
                 << "\n";
       std::cout << "\n";
       std::cout << std::endl;
@@ -5783,32 +5783,32 @@ void FLD::FluidImplicitTimeInt::print_stabilization_details() const
 
       std::cout << "                    "
                 << "EOS_PRES             = "
-                << Teuchos::getStringValue<Inpar::FLUID::EosPres>(
-                       *stabparams_edgebased, ("EOS_PRES"))
+                << to_string(
+                       Teuchos::get<Inpar::FLUID::EosPres>(*stabparams_edgebased, ("EOS_PRES")))
                 << "\n";
       std::cout << "                    "
                 << "EOS_CONV_STREAM      = "
-                << Teuchos::getStringValue<Inpar::FLUID::EosConvStream>(
-                       *stabparams_edgebased, "EOS_CONV_STREAM")
+                << to_string(Teuchos::get<Inpar::FLUID::EosConvStream>(
+                       *stabparams_edgebased, "EOS_CONV_STREAM"))
                 << "\n";
       std::cout << "                    "
                 << "EOS_CONV_CROSS       = "
-                << Teuchos::getStringValue<Inpar::FLUID::EosConvCross>(
-                       *stabparams_edgebased, "EOS_CONV_CROSS")
+                << to_string(Teuchos::get<Inpar::FLUID::EosConvCross>(
+                       *stabparams_edgebased, "EOS_CONV_CROSS"))
                 << "\n";
       std::cout << "                    "
                 << "EOS_DIV              = "
-                << Teuchos::getStringValue<Inpar::FLUID::EosDiv>(*stabparams_edgebased, "EOS_DIV")
+                << to_string(Teuchos::get<Inpar::FLUID::EosDiv>(*stabparams_edgebased, "EOS_DIV"))
                 << "\n";
       std::cout << "                    "
                 << "EOS_DEFINITION_TAU   = "
-                << Teuchos::getStringValue<Inpar::FLUID::EosTauType>(
-                       *stabparams_edgebased, "EOS_DEFINITION_TAU")
+                << to_string(Teuchos::get<Inpar::FLUID::EosTauType>(
+                       *stabparams_edgebased, "EOS_DEFINITION_TAU"))
                 << "\n";
       std::cout << "                    "
                 << "EOS_H_DEFINITION     = "
-                << Teuchos::getStringValue<Inpar::FLUID::EosElementLength>(
-                       *stabparams_edgebased, "EOS_H_DEFINITION")
+                << to_string(Teuchos::get<Inpar::FLUID::EosElementLength>(
+                       *stabparams_edgebased, "EOS_H_DEFINITION"))
                 << "\n";
       std::cout
           << "+---------------------------------------------------------------------------------+\n"
@@ -5899,8 +5899,8 @@ void FLD::FluidImplicitTimeInt::print_turbulence_model()
       std::cout << "\n";
       std::cout << "- Vreman model with constant coefficient\n";
       std::cout << "- Use filter width method:  "
-                << Teuchos::getStringValue<Inpar::FLUID::VremanFiMethod>(
-                       params_->sublist("SUBGRID VISCOSITY"), "FILTER_WIDTH")
+                << to_string(Teuchos::get<Inpar::FLUID::VremanFiMethod>(
+                       params_->sublist("SUBGRID VISCOSITY"), "FILTER_WIDTH"))
                 << "\n";
       std::cout << &std::endl;
     }

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -356,8 +356,8 @@ void FSI::Partitioned::set_default_parameters(
     }
     default:
     {
-      FOUR_C_THROW("coupling method type '%s' unsupported",
-          Teuchos::getStringValue<FsiCoupling>(fsidyn, "COUPALGO").c_str());
+      FOUR_C_THROW("Coupling method type %d unsupported",
+          Teuchos::getIntegralValue<FsiCoupling>(fsidyn, "COUPALGO"));
     }
   }
 

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -57,6 +57,19 @@ namespace Inpar
           "write information about monitored boundary condition to output file",
           &sublist_IO_monitor_structure_dbc);
     }
+
+    std::string to_string(FileType type)
+    {
+      switch (type)
+      {
+        case FileType::csv:
+          return "csv";
+        case FileType::data:
+          return "data";
+        default:
+          FOUR_C_THROW("Unknown file type");
+      }
+    }
   }  // namespace IOMonitorStructureDBC
 }  // namespace Inpar
 

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.hpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.hpp
@@ -32,6 +32,8 @@ namespace Inpar
       data
     };
 
+    std::string to_string(FileType type);
+
     /// set the valid parameters related to writing of output at runtime
     void set_valid_parameters(Teuchos::ParameterList& list);
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1691,4 +1691,279 @@ void Inpar::FLUID::set_valid_conditions(
   condlist.push_back(poropresint_line);
 }
 
+std::string Inpar::FLUID::to_string(Inpar::FLUID::StabType stabtype)
+{
+  switch (stabtype)
+  {
+    case stabtype_nostab:
+      return "no_stabilization";
+    case stabtype_residualbased:
+      return "residual_based";
+    case stabtype_edgebased:
+      return "edge_based";
+    case stabtype_pressureprojection:
+      return "pressure_projection";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::TauType tau)
+{
+  switch (tau)
+  {
+    case tau_taylor_hughes_zarins:
+      return "Taylor_Hughes_Zarins";
+    case tau_taylor_hughes_zarins_wo_dt:
+      return "Taylor_Hughes_Zarins_wo_dt";
+    case tau_taylor_hughes_zarins_whiting_jansen:
+      return "Taylor_Hughes_Zarins_Whiting_Jansen";
+    case tau_taylor_hughes_zarins_whiting_jansen_wo_dt:
+      return "Taylor_Hughes_Zarins_Whiting_Jansen_wo_dt";
+    case tau_taylor_hughes_zarins_scaled:
+      return "Taylor_Hughes_Zarins_scaled";
+    case tau_taylor_hughes_zarins_scaled_wo_dt:
+      return "Taylor_Hughes_Zarins_scaled_wo_dt";
+    case tau_franca_barrenechea_valentin_frey_wall:
+      return "Franca_Barrenechea_Valentin_Frey_Wall";
+    case tau_franca_barrenechea_valentin_frey_wall_wo_dt:
+      return "Franca_Barrenechea_Valentin_Frey_Wall_wo_dt";
+    case tau_shakib_hughes_codina:
+      return "Shakib_Hughes_Codina";
+    case tau_shakib_hughes_codina_wo_dt:
+      return "Shakib_Hughes_Codina_wo_dt";
+    case tau_codina:
+      return "Codina";
+    case tau_codina_wo_dt:
+      return "Codina_wo_dt";
+    case tau_codina_convscaled:
+      return "Codina_convscaled";
+    case tau_franca_madureira_valentin_badia_codina:
+      return "Franca_Madureira_Valentin_Badia_Codina";
+    case tau_franca_madureira_valentin_badia_codina_wo_dt:
+      return "Franca_Madureira_Valentin_Badia_Codina_wo_dt";
+    case tau_hughes_franca_balestra_wo_dt:
+      return "Hughes_Franca_Balestra_wo_dt";
+    case tau_not_defined:
+      return "not_defined";
+  }
+  return "not_defined";
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::CrossStress crossstress)
+{
+  switch (crossstress)
+  {
+    case cross_stress_stab_none:
+      return "no_cross";
+    case cross_stress_stab:
+      return "yes_cross";
+    case cross_stress_stab_only_rhs:
+      return "cross_rhs";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::VStab vstab)
+{
+  switch (vstab)
+  {
+    case viscous_stab_none:
+      return "no_viscous";
+    case viscous_stab_gls:
+      return "yes_viscous";
+    case viscous_stab_gls_only_rhs:
+      return "viscous_rhs";
+    case viscous_stab_usfem:
+      return "usfem_viscous";
+    case viscous_stab_usfem_only_rhs:
+      return "usfem_viscous_rhs";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::RStab rstab)
+{
+  switch (rstab)
+  {
+    case reactive_stab_none:
+      return "no_reactive";
+    case reactive_stab_gls:
+      return "yes_reactive";
+    case reactive_stab_usfem:
+      return "usfem_reactive";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::ReynoldsStress reynoldsstress)
+{
+  switch (reynoldsstress)
+  {
+    case reynolds_stress_stab_none:
+      return "no_reynolds";
+    case reynolds_stress_stab:
+      return "yes_reynolds";
+    case reynolds_stress_stab_only_rhs:
+      return "reynolds_rhs";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::Transient transient)
+{
+  switch (transient)
+  {
+    case inertia_stab_drop:
+      return "no_transient";
+    case inertia_stab_keep:
+      return "yes_transient";
+    case inertia_stab_keep_complete:
+      return "transient_complete";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::EosPres eospres)
+{
+  switch (eospres)
+  {
+    case EOS_PRES_none:
+      return "none";
+    case EOS_PRES_std_eos:
+      return "std_eos";
+    case EOS_PRES_xfem_gp:
+      return "xfem_gp";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::EosConvStream eosconvstream)
+{
+  switch (eosconvstream)
+  {
+    case EOS_CONV_STREAM_none:
+      return "none";
+    case EOS_CONV_STREAM_std_eos:
+      return "std_eos";
+    case EOS_CONV_STREAM_xfem_gp:
+      return "xfem_gp";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::EosConvCross eosconvcross)
+{
+  switch (eosconvcross)
+  {
+    case EOS_CONV_CROSS_none:
+      return "none";
+    case EOS_CONV_CROSS_std_eos:
+      return "std_eos";
+    case EOS_CONV_CROSS_xfem_gp:
+      return "xfem_gp";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::EosDiv eosdiv)
+{
+  switch (eosdiv)
+  {
+    case EOS_DIV_none:
+      return "none";
+    case EOS_DIV_vel_jump_std_eos:
+      return "vel_jump_std_eos";
+    case EOS_DIV_vel_jump_xfem_gp:
+      return "vel_jump_xfem_gp";
+    case EOS_DIV_div_jump_std_eos:
+      return "div_jump_std_eos";
+    case EOS_DIV_div_jump_xfem_gp:
+      return "div_jump_xfem_gp";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::EosTauType eostautype)
+{
+  switch (eostautype)
+  {
+    case EOS_tau_burman:
+      return "Burman";
+    case EOS_tau_burman_fernandez_hansbo:
+      return "Burman_Fernandez_Hansbo";
+    case EOS_tau_burman_fernandez_hansbo_wo_dt:
+      return "Burman_Fernandez_Hansbo_wo_dt";
+    case EOS_tau_braack_burman_john_lube:
+      return "Braack_Burman_John_Lube";
+    case EOS_tau_braack_burman_john_lube_wo_divjump:
+      return "Braack_Burman_John_Lube_wo_divjump";
+    case EOS_tau_franca_barrenechea_valentin_wall:
+      return "Franca_Barrenechea_Valentin_Wall";
+    case EOS_tau_burman_fernandez:
+      return "Burman_Fernandez";
+    case EOS_tau_burman_hansbo_dangelo_zunino:
+      return "Burman_Hansbo_DAngelo_Zunino";
+    case EOS_tau_burman_hansbo_dangelo_zunino_wo_dt:
+      return "Burman_Hansbo_DAngelo_Zunino_wo_dt";
+    case EOS_tau_schott_massing_burman_dangelo_zunino:
+      return "Schott_Massing_Burman_DAngelo_Zunino";
+    case EOS_tau_schott_massing_burman_dangelo_zunino_wo_dt:
+      return "Schott_Massing_Burman_DAngelo_Zunino_wo_dt";
+    case EOS_tau_Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling:
+      return "Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling";
+    case EOS_tau_poroelast_fluid:
+      return "Poroelast_Fluid";
+    case EOS_tau_not_defined:
+      return "not_defined";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::EosElementLength eoselementlength)
+{
+  switch (eoselementlength)
+  {
+    case EOS_he_max_diameter_to_opp_surf:
+      return "EOS_he_max_diameter_to_opp_surf";
+    case EOS_he_max_dist_to_opp_surf:
+      return "EOS_he_max_dist_to_opp_surf";
+    case EOS_he_surf_with_max_diameter:
+      return "EOS_he_surf_with_max_diameter";
+    case EOS_hk_max_diameter:
+      return "EOS_hk_max_diameter";
+    case EOS_he_surf_diameter:
+      return "EOS_he_surf_diameter";
+    case EOS_he_vol_eq_diameter:
+      return "EOS_he_vol_eq_diameter";
+    default:
+      return "unknown";
+  }
+}
+
+std::string Inpar::FLUID::to_string(Inpar::FLUID::VremanFiMethod vremanfimethod)
+{
+  switch (vremanfimethod)
+  {
+    case cuberootvol:
+      return "CubeRootVol";
+    case dir_dep:
+      return "Direction_dependent";
+    case min_len:
+      return "Minimum_length";
+    default:
+      return "unknown";
+  }
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_fluid.hpp
+++ b/src/inpar/4C_inpar_fluid.hpp
@@ -56,6 +56,8 @@ namespace Inpar
       stabtype_pressureprojection
     };
 
+    [[nodiscard]] std::string to_string(StabType stabtype);
+
     //! flag to select the type of viscosity stabilization
     enum VStab
     {
@@ -66,6 +68,9 @@ namespace Inpar
       viscous_stab_usfem_only_rhs
     };
 
+    [[nodiscard]] std::string to_string(VStab vstab);
+
+
     //! flag to select the type of reactive stabilization
     enum RStab
     {
@@ -73,6 +78,8 @@ namespace Inpar
       reactive_stab_gls,
       reactive_stab_usfem
     };
+
+    [[nodiscard]] std::string to_string(RStab rstab);
 
     //! flag to select the type of cross stress stabilization
     enum CrossStress
@@ -82,6 +89,8 @@ namespace Inpar
       cross_stress_stab_only_rhs
     };
 
+    std::string to_string(CrossStress crossstress);
+
     //! flag to select the type of Reynolds stress stabilization
     enum ReynoldsStress
     {
@@ -89,6 +98,8 @@ namespace Inpar
       reynolds_stress_stab,
       reynolds_stress_stab_only_rhs
     };
+
+    std::string to_string(ReynoldsStress reynoldsstress);
 
     //! flag to select time-dependent subgrid-scales
     enum SubscalesTD
@@ -103,6 +114,8 @@ namespace Inpar
       inertia_stab_keep,
       inertia_stab_keep_complete
     };
+
+    [[nodiscard]] std::string to_string(Transient transient);
 
     /// tau type for residual based fluid stabilizations
     enum TauType
@@ -125,6 +138,8 @@ namespace Inpar
       tau_hughes_franca_balestra_wo_dt,
       tau_not_defined
     };
+
+    std::string to_string(TauType tau);
 
     /// characteristic element length for tau_Mu
     enum CharEleLengthU
@@ -150,6 +165,8 @@ namespace Inpar
       EOS_PRES_xfem_gp
     };
 
+    [[nodiscard]] std::string to_string(EosPres eospres);
+
     //! flag to select the type of convective streamline edge-based (EOS) stabilization
     enum EosConvStream
     {
@@ -158,6 +175,8 @@ namespace Inpar
       EOS_CONV_STREAM_xfem_gp
     };
 
+    [[nodiscard]] std::string to_string(EosConvStream eosconvstream);
+
     //! flag to select the type of convective crosswind edge-based (EOS) stabilization
     enum EosConvCross
     {
@@ -165,6 +184,8 @@ namespace Inpar
       EOS_CONV_CROSS_std_eos,
       EOS_CONV_CROSS_xfem_gp
     };
+
+    [[nodiscard]] std::string to_string(EosConvCross eosconvcross);
 
     //! flag to select the type of divergence EOS stabilization
     enum EosDiv
@@ -175,6 +196,8 @@ namespace Inpar
       EOS_DIV_div_jump_std_eos,
       EOS_DIV_div_jump_xfem_gp
     };
+
+    [[nodiscard]] std::string to_string(EosDiv eosdiv);
 
     /// tau type for edge-oriented / continuous interior penalty stabilization
     enum EosTauType
@@ -195,6 +218,8 @@ namespace Inpar
       EOS_tau_not_defined
     };
 
+    [[nodiscard]] std::string to_string(EosTauType eostautype);
+
     /// Element length for edge-oriented / continuous interior penalty stabilization
     enum EosElementLength
     {
@@ -205,6 +230,8 @@ namespace Inpar
       EOS_he_surf_diameter,  // maximal (n-1)D diameter of the internal face/edge
       EOS_he_vol_eq_diameter
     };
+
+    [[nodiscard]] std::string to_string(EosElementLength eoselementlength);
 
     /// EdgeBased (EOS) and Ghost Penalty matrix pattern
     enum EosGpPattern
@@ -328,6 +355,8 @@ namespace Inpar
       dir_dep,
       min_len
     };
+
+    [[nodiscard]] std::string to_string(VremanFiMethod vremanfimethod);
 
     //! options for forcing of homogeneous isotropic turbulence
     enum ForcingType

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -652,8 +652,8 @@ void Airway::RedAirwayImplicitTimeInt::time_step(
   }
   else
   {
-    FOUR_C_THROW("[%s] is not a defined solver",
-        (Teuchos::getStringValue<RedAirwaysDyntype>(params_, "solver type").c_str()));
+    FOUR_C_THROW("RedAirwaysDynType %d is not a defined solver",
+        params_.get<RedAirwaysDyntype>("solver type"));
   }
 
   // Update solution: current solution becomes old solution of next timestep
@@ -704,8 +704,8 @@ void Airway::RedAirwayImplicitTimeInt::integrate_step(
   }
   else
   {
-    FOUR_C_THROW("[%s] is not a defined solver",
-        (Teuchos::getStringValue<RedAirwaysDyntype>(params_, "solver type").c_str()));
+    FOUR_C_THROW("RedAirwaysDynType %d is not a defined solver",
+        params_.get<RedAirwaysDyntype>("solver type"));
   }
 
 }  // RedAirwayImplicitTimeInt::IntegrateStep

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -129,7 +129,7 @@ void Solid::MonitorDbc::setup()
   const Teuchos::ParameterList& sublist_IO_monitor_structure_dbc =
       Global::Problem::instance()->io_params().sublist("MONITOR STRUCTURE DBC");
 
-  std::string filetype = Teuchos::getStringValue<Inpar::IOMonitorStructureDBC::FileType>(
+  auto filetype = Teuchos::getIntegralValue<Inpar::IOMonitorStructureDBC::FileType>(
       sublist_IO_monitor_structure_dbc, "FILE_TYPE");
   if (isempty_)
   {
@@ -158,7 +158,8 @@ void Solid::MonitorDbc::setup()
       Global::Problem::instance()->output_control_file()->file_name_only_prefix());
   Core::IO::create_directory(full_dirpath, Core::Communication::my_mpi_rank(get_comm()));
   // ... create files paths ...
-  full_filepaths_ = create_file_paths(rconds, full_dirpath, filename_only_prefix, filetype);
+  full_filepaths_ =
+      create_file_paths(rconds, full_dirpath, filename_only_prefix, to_string(filetype));
   // ... clear them and write header
   clear_files_and_write_header(
       rconds, full_filepaths_, sublist_IO_monitor_structure_dbc.get<bool>("WRITE_HEADER"));
@@ -171,8 +172,8 @@ void Solid::MonitorDbc::setup()
     const std::string filename_restart_only_prefix(Core::IO::extract_file_name(
         Global::Problem::instance()->output_control_file()->restart_name()));
 
-    std::vector<std::string> full_restart_filepaths =
-        create_file_paths(rconds, full_restart_dirpath, filename_restart_only_prefix, filetype);
+    std::vector<std::string> full_restart_filepaths = create_file_paths(
+        rconds, full_restart_dirpath, filename_restart_only_prefix, to_string(filetype));
 
     read_results_prior_restart_step_and_write_to_file(
         full_restart_filepaths, gstate_ptr_->get_step_n());

--- a/src/structure_new/src/utils/4C_structure_new_timint_basedataio_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_timint_basedataio_monitor_dbc.cpp
@@ -45,8 +45,8 @@ void Solid::TimeInt::ParamsMonitorDBC::init(
   os_precision_ = IO_monitor_dbc_structure_paramslist.get<int>("PRECISION_SCREEN");
 
   // file type
-  file_type_ = Teuchos::getStringValue<Inpar::IOMonitorStructureDBC::FileType>(
-      IO_monitor_dbc_structure_paramslist, "FILE_TYPE");
+  file_type_ = to_string(Teuchos::getIntegralValue<Inpar::IOMonitorStructureDBC::FileType>(
+      IO_monitor_dbc_structure_paramslist, "FILE_TYPE"));
 
   // write header in csv file
   write_header_ = IO_monitor_dbc_structure_paramslist.get<bool>("WRITE_HEADER");

--- a/src/thermo/src/4C_thermo_adapter.cpp
+++ b/src/thermo/src/4C_thermo_adapter.cpp
@@ -52,8 +52,7 @@ void Thermo::BaseAlgorithm::setup_thermo(
       setup_tim_int(prbdyn, timinttype, actdis);  // <-- here is the show
       break;
     default:
-      FOUR_C_THROW("unknown time integration scheme '%s'",
-          Teuchos::getStringValue<Inpar::Thermo::DynamicType>(tdyn, "DYNAMICTYPE").c_str());
+      FOUR_C_THROW("Unknown time integration scheme");
   }
 
 }  // setup_thermo()


### PR DESCRIPTION
This call only works when you attach an EntryValidator for an entry beforehand. Previously, this worked as long as all the parameters came from the global parameter list where these values were set. On the one hand, this will no longer work once I change this part of the input to `InputSpec`. On the other hand, the change in this PR makes sense in isolation to make the respective functions useable without setting up the implicit global state.

This PR removes all occurrences of `Teuchos::getStringValue`.

Related to #339 