### PR TITLE
Change LNM name

### DIFF
--- a/doc/readthedocs/4Csetup.rst
+++ b/doc/readthedocs/4Csetup.rst
@@ -6,7 +6,7 @@ Setup Guide
 Here you'll find some useful notes on setting up and running |FOURC|,
 the multi purpose multi physics multi-modelling code developed at
 
-- Chair of Computational Mechanics,
+- Institute for Computational Mechanics of the Technische Universität München,
 - IMCS of the Hochschule der Bunderwehr München, and
 - Institute of Material Systems Modelling of the Helmholtz Zentrum Hereon.
 

--- a/tests/input_files/mat_iso_viscoplast_refJC_log_substep.dat
+++ b/tests/input_files/mat_iso_viscoplast_refJC_log_substep.dat
@@ -10,7 +10,7 @@ Reformulated Johnson-Cook law, as shown in:
 - time integration of internal variables using logarithmic substepping, as shown in:
    Ana: Continuum Modeling and Calibration of Viscoplasticity in the Context
 	of the Lithium Anode in Solid-State Batteries
-	(Master's Thesis, Chair of Computational Mechanics, TU Munich, 2024)
+	(Master's Thesis, Institute for Computational Mechanics, TU Munich, 2024)
 ------------------------------------------------------PROBLEM SIZE
 DIM           3
 -------------------------------------------------------PROBLEM TYPE

--- a/tests/input_files/mat_transviso_viscoplast_refJC_log_substep.dat
+++ b/tests/input_files/mat_transviso_viscoplast_refJC_log_substep.dat
@@ -10,7 +10,7 @@ Reformulated Johnson-Cook law, as shown in:
 - time integration of internal variables using logarithmic substepping, as shown in:
    Ana: Continuum Modeling and Calibration of Viscoplasticity in the Context
 	of the Lithium Anode in Solid-State Batteries
-	(Master's Thesis, Chair of Computational Mechanics, TU Munich, 2024)
+	(Master's Thesis, Institute for Computational Mechanics, TU Munich, 2024)
 ------------------------------------------------------PROBLEM SIZE
 DIM           3
 -------------------------------------------------------PROBLEM TYPE

--- a/tests/input_files/mat_transviso_viscoplast_refJC_standard_substep.dat
+++ b/tests/input_files/mat_transviso_viscoplast_refJC_standard_substep.dat
@@ -10,7 +10,7 @@ Reformulated Johnson-Cook law, as shown in:
 - time integration of internal variables using standard substepping, as shown in:
    Ana: Continuum Modeling and Calibration of Viscoplasticity in the Context
 	of the Lithium Anode in Solid-State Batteries
-	(Master's Thesis, Chair of Computational Mechanics, TU Munich, 2024)
+	(Master's Thesis, Institute for Computational Mechanics, TU Munich, 2024)
 ------------------------------------------------------PROBLEM SIZE
 DIM           3
 -------------------------------------------------------PROBLEM TYPE


### PR DESCRIPTION
Whilst reading the installation process, I stumbled upon *Chair of Computational Mechanics*, but the LNM publishes under *Institute for Computational Mechanics*

@dragos-ana FYI I changed some files where your master's thesis is referenced
## Description and Context

## Related Issues and Merge Requests
