### PR TITLE
Update links from GitLab to GitHub

### DIFF
--- a/doc/readthedocs/4Csetup.rst
+++ b/doc/readthedocs/4Csetup.rst
@@ -18,8 +18,8 @@ Additionally, |FOURC| can be compiled under Windows using the WSL (Windows Subsy
 which provides a complete Linux Environment within the Windows operating system.
 
 You'll find more information about the |FOURC| installation in the
-`README.md <https://gitlab.lrz.de/baci/baci/blob/main/README.md>`_ and the
-`CONTRIBUTING.md <https://gitlab.lrz.de/baci/baci/blob/main/CONTRIBUTING.md>`_
+`README.md <https://github.com/4C-multiphysics/4C/blob/main/README.md>`_ and the
+`CONTRIBUTING.md <https://github.com/4C-multiphysics/4C/blob/main/CONTRIBUTING.md>`_
 files located in the |FOURC| root directory.
 
 Besides the basic setup of the software, the following topics are of particular interest for **all** developers:
@@ -133,7 +133,7 @@ Clone the repository
 
     cd <someBaseDir>
     mkdir <sourceDir>
-    git clone git@gitlab.lrz.de:baci/baci.git <sourceDir>
+    git clone git@github.com:4C-multiphysics/4C.git <sourceDir>
     cd <sourceDir>
 
 where `<someBaseDir>` is some directory on your machine and `<sourceDir>` will contain the |FOURC| source code.
@@ -272,7 +272,7 @@ To enable the code indexer, right-click on the project and select :menuselection
 
 *Source code*
 
-|FOURC| uses a mandatory code style defined as a `.clang-format style file <https://gitlab.lrz.de/baci/baci/blob/main/.clang-format>`_.
+|FOURC| uses a mandatory code style defined as a `.clang-format style file <https://github.com/4C-multiphysics/4C/blob/main/.clang-format>`_.
 Adherence to this code style will be checked on each commit as well as on each merge request.
 To a priori conform to the codes style and avoid issues in your daily workflow,
 you can configure Eclipse to apply the code style to your source code at every file save.
@@ -321,7 +321,7 @@ Eclipse provides automated features to help you with these rules. To configure t
 
 *Automation and utilities for Doxygen documentation*
 
-|FOURC| mandates documentation via Doxygen. Further information and an introduction is summarized in |FOURC|'s `Doxygen guidelines <https://gitlab.lrz.de/baci/baci/-/wikis/doxygen>`_.
+|FOURC| mandates documentation via Doxygen. Further information and an introduction is summarized in |FOURC|'s :ref:`Doxygen guidelines <doxygen>`.
 Eclipse can assist in writing Doxygen documentation by auto-generating lists of input and return parameters when writing a function's documentation.
 
 To enable this utility in Eclipse, perform these steps:

--- a/doc/readthedocs/about.rst
+++ b/doc/readthedocs/about.rst
@@ -23,7 +23,7 @@ Besides classical FEM, cut finite element methods (CutFEMs) allow to treat embed
 Furthermore, particle methods such as the discrete element method (DEM) and smoothed particle hydrodynamics (SPH) are available
 and can be combined with FEM discretizations.
 |FOURC|'s embedding into customizable pre- and postprocessing routines
-as well as its interoperability with the `QUEENS library <https://queens_community.pages.gitlab.lrz.de/website/>`_,
+as well as its interoperability with the `QUEENS library <https://www.queens-py.org/>`_,
 an open-source Python framework for conducting intricate multi-query analyses of arbitrary computational models
 including parameter studies, uncertainty quantification, and inverse problems,
 elevates |FOURC| to a powerful and comprehensive tool in modern computational engineering.

--- a/doc/readthedocs/coverage_report.rst
+++ b/doc/readthedocs/coverage_report.rst
@@ -6,8 +6,8 @@ Coverage report
 The |FOURC| coverage report can be used to verify existing tests and to detect untested parts of the code.
 
 
-You can find it by clicking on the coverage badge `here <https://baci.pages.gitlab.lrz.de/baci/coverage_report/index.html>`_
-or at the |FOURC| `frontpage <https://gitlab.lrz.de/baci/baci/>`.
+You can find it by clicking on the coverage badge `here <https://4c-multiphysics.github.io/4C/coverage_report/index.html>`_
+or at the |FOURC| `frontpage <https://github.com/4C-multiphysics/4C>`.
 
 The report contains the source code annotated with coverage information.
 Coverage in its simplest form gives the ratio of executed lines of code over total lines of code of a testsuite run

--- a/doc/readthedocs/developer_cluster.rst
+++ b/doc/readthedocs/developer_cluster.rst
@@ -10,11 +10,11 @@ In general there are several ways to get the |FOURC| source code to a cluster. I
   remember to set up |FOURC| as described in the |FOURC| ``README.md`` or in the :ref:`Setup guide <SetupGuideto4C>`.
   However, in general, it is recommended to develop code primarily on your workstation.
 
-Method 1: Clone |FOURC| repository from Gitlab
+Method 1: Clone |FOURC| repository from GitHub
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Clone the |FOURC| repository from Gitlab to a cluster following the procedure as described in ``README.md``.
-**Note:** This requires that firewall settings allow access from the cluster to the Gitlab repository.
+Clone the |FOURC| repository from GitHub to a cluster following the procedure as described in ``README.md``.
+**Note:** This requires that firewall settings allow access from the cluster to the GitHub repository.
 
 Method 2: Clone |FOURC| from local workstation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/readthedocs/doxygen.rst
+++ b/doc/readthedocs/doxygen.rst
@@ -5,7 +5,7 @@ Documenting the code with Doxygen
 
 
 |FOURC| uses `Doxygen <http://www.doxygen.nl>`__ to generate documentation from annotated source code.
-You can find a current documentation `here <https://baci.pages.gitlab.lrz.de/baci/doxygen/index.html>`_.
+You can find a current documentation `here <https://4c-multiphysics.github.io/4C/doxygen/index.html>`_.
 
 What is Doxygen and why does |FOURC| rely on it?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/readthedocs/tutorial_contact_3d.md
+++ b/doc/readthedocs/tutorial_contact_3d.md
@@ -8,7 +8,7 @@ settings for a given (contact) problem.
 It is assumed that |FOURC| has been built on your machine according to the instructions and has passed the tests without
 error messages.
 For further information on how to build |FOURC| and to test the build, please refer to
-the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md).
+the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md).
 
 ## Overview
 
@@ -89,7 +89,7 @@ It also gives a list of all possible conditions that can be defined, as well as 
 corresponding shapes.
 Depending on the type of the problem, undefined/empty/unnecessary lines can be deleted when using it as a template.
 Information on how to obtain prototypes for both the `.bc` file and the `.head` file is given in
-the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md) under the heading "Prepare and Run Simulations".
+the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md) under the heading "Prepare and Run Simulations".
 The terminal command to obtain both prototype files is:
 
 ```bash
@@ -164,7 +164,7 @@ DBC.
 ## Create input file
 
 The final `.dat` input file for |FOURC| can be created with the `pre_exodus` executable
-as described in the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md).
+as described in the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md).
 To manually create the `.dat` file the full command states:
 
 ```bash
@@ -180,7 +180,7 @@ plus a list of all nodes and structure elements.
 
 ## Run Simulation
 
-Again, following the instructions from the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md), the
+Again, following the instructions from the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md), the
 |FOURC|
 executable can be invoked with the `tutorial_contact_3d.dat` input file.
 Since we chose the binary output option in our `.head` file (section `IO`),

--- a/tests/framework-test/tutorial_contact_3d.md
+++ b/tests/framework-test/tutorial_contact_3d.md
@@ -5,7 +5,7 @@ give an overview of the general workflow in 4C and to show how to create a worki
 intended to be an introduction to the theory of contact mechanics, nor demonstrate all possible optional settings for a
 given (contact) problem. It is assumed that 4C has been built on your machine according to the instructions and has
 passed the tests without error messages. For further information on how to build 4C and to test the build, please refer
-to the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md).
+to the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md).
 
 ## Overview
 
@@ -68,7 +68,7 @@ syntax examples and a basic structure that automatically inserts the information
 element/nodeset/etc. It also gives a list of all possible conditions that can be defined, as well as the element type
 names and the corresponding shapes. Depending on the type of the problem, undefined/empty/unnecessary lines can be
 deleted when using it as a template. Information on how to obtain prototypes for both the `.bc` file and the `.head`
-file is given in the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md) under the heading "Prepare and Run
+file is given in the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md) under the heading "Prepare and Run
 Simulations". The terminal command to obtain both prototype files is:
 
 ```bash
@@ -132,7 +132,7 @@ is used for the time dependent DBC.
 ## Create input file
 
 The final `.dat` input file for 4C can be created with the `pre_exodus` executable as described in
-the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md). To manually create the `.dat` file the full
+the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md). To manually create the `.dat` file the full
 command states:
 
 ```bash
@@ -146,6 +146,6 @@ created files, plus a list of all nodes and structure elements.
 
 ## Run Simulation
 
-Again, following the instructions from the [README.md](https://gitlab.lrz.de/baci/baci/blob/main/README.md), the 4C
+Again, following the instructions from the [README.md](https://github.com/4C-multiphysics/4C/blob/main/README.md), the 4C
 executable can be invoked with the `tutorial_contact_3d.dat` input file. Since we chose the binary output option in
 our `.head` file (section `IO`), we also have to run a post processing tool before visualizing the results in Paraview.


### PR DESCRIPTION
Changes GitLab mentions and links to GitHub, mainly in the documentation.

I only changed the ones I could find the information on GitHub for. There are more, lots also referencing GitLab runners or old MR, these ones I didn't change.

## Description and Context

## Related Issues and Merge Requests

