### PR TITLE
Remove obsolete content from documentation

### DIFF
--- a/doc/readthedocs/4Csetup.rst
+++ b/doc/readthedocs/4Csetup.rst
@@ -3,12 +3,7 @@
 Setup Guide
 =============
 
-Here you'll find some useful notes on setting up and running |FOURC|,
-the multi purpose multi physics multi-modelling code developed at
-
-- Institute for Computational Mechanics of the Technische Universität München,
-- IMCS of the Hochschule der Bunderwehr München, and
-- Institute of Material Systems Modelling of the Helmholtz Zentrum Hereon.
+Here you'll find some useful notes on setting up and running |FOURC|.
 
 |FOURC| is developed and used on Linux. Other Unixes work as well.
 Windows versions might be created using cygwin or mingw, but this will require some small modifications and is not covered here.

--- a/doc/readthedocs/developer_cmake.rst
+++ b/doc/readthedocs/developer_cmake.rst
@@ -3,15 +3,14 @@
 cmake presets
 --------------
 
-CMake presets have been introduced with the Merge Request `!1392 <https://gitlab.lrz.de/baci/baci/-/merge_requests/1392>`_
-and can be used to configure and manage different configurations of |FOURC| in a very convenient way.
+CMake presets are |FOURC|'s recommended way to configure and manage different configurations of |FOURC|.
 This small article will go through a few of them. The experts should also read the
 `official CMake presets documentation <https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html>`_ to get all convenient tricks.
-If you find a nice one, feel free to tell your colleagues (via issue, Slack or TGM).
 
-CMake presets are available since cmake 3.19 and have been improved in the following versions.
-We are currently using CMake preset version 5, which requires at least cmake 3.24.
-Make sure to have a sufficient cmake-version in your path or use the provided ones on the institute's server.
+.. note::
+  CMake presets are available since cmake 3.19 and have been improved in the following versions.
+  We are currently using CMake preset version 5, which requires at least cmake 3.24.
+  Make sure to have a sufficient cmake-version in your path or use the provided ones on the institute's server.
 
 Configuration from a terminal
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Description and Context

- Information on participating institutes is not required in the description of how to setup 4C.
- Historic remarks and links to GitLab are not required to work with CMake presets.

## Related Issues and Merge Requests

I came across this through PRs #341, #342