### PR TITLE
Consistent naming of multiphysics

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,5 @@
 cff-version: 1.2.0
-title: '4C: A Comprehensive Multi-Physics Simulation Framework'
+title: '4C: A Comprehensive Multiphysics Simulation Framework'
 message: >-
   If you use this software, please cite it using the
   metadata from this file.

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ All people and activities in and around 4C are subject to our [Code of Conduct](
 Please cite 4C as follows:
 
 ```
-4C: A Comprehensive Multi-Physics Simulation Framework, https://www.4c-multiphysics.org
+4C: A Comprehensive Multiphysics Simulation Framework, https://www.4c-multiphysics.org
 ```
 
 You could use the following BibTeX entry:
@@ -169,7 +169,7 @@ You could use the following BibTeX entry:
 ```bibtex
 @misc{4C,
   author       = {{4C}},
-  title        = {{4C}: A {C}omprehensive {M}ulti-{P}hysics {S}imulation {F}ramework},
+  title        = {{4C}: A {C}omprehensive {M}ultiphysics {S}imulation {F}ramework},
   howpublished = {\url{https://www.4c-multiphysics.org}},
   year         = {YEAR},
   note         = {Accessed: DATE}

--- a/doc/doxygen/index.doc
+++ b/doc/doxygen/index.doc
@@ -1,10 +1,10 @@
-/*! \mainpage 4C: A Comprehensive Multi-Physics Simulation Framework
+/*! \mainpage 4C: A Comprehensive Multiphysics Simulation Framework
 \htmlonly
 \endhtmlonly
 
 \section mainpageoverview Overview
 
-4C (Comprehensive Computational Community Code) is a powerful research code for multi-physics computer simulations.
+4C (Comprehensive Computational Community Code) is a powerful research code for multiphysics computer simulations.
 Building on more than 20 years of research and development, 4C can model a plethora of physical systems, including solid mechanics, fluid dynamics, scalar transport, and chemical reaction among others.
 
 4C mainly implements finite element methods (FEM) but also offers alternative discretization methods such as discontinuous Galerkin methods (DG), particle methods, and mesh-free methods. 4C is written in C++ using modern software design and uses MPI for distributed memory hardware architectures.

--- a/doc/readthedocs/about.rst
+++ b/doc/readthedocs/about.rst
@@ -16,7 +16,7 @@ At its core,
 Ready-to-use single-field solvers range from solid and structural mechanics over scalar transport all the way to fluid flow.
 Through partitioned or monolithic coupling of single-field solvers,
 either through volume-, surface-, or line-coupling on matching, non-matching or embedded meshes,
-multi-physics phenomena such as fluid-solid interaction (FSI), thermo-mechanics, or coupled scalar-solid-thermo systems can be tackled.
+multiphysics phenomena such as fluid-solid interaction (FSI), thermo-mechanics, or coupled scalar-solid-thermo systems can be tackled.
 Through its versatile library of constitutive laws,
 |FOURC| is well positioned for the analysis of biological tissue, all-solid-state batteries, or plasticity to just name a few.
 Besides classical FEM, cut finite element methods (CutFEMs) allow to treat embedded interfaces.
@@ -33,7 +33,7 @@ While |FOURC| delivers different physics modules, distributed sparse linear alge
 all of its components, e.g., single- and multi-field solvers, coupling schemes, numerical algorithms,
 can be tailored to the research problem at hand
 to also allow the solution of unseen challenges in computational mechanics
-while still standing on the solid foundation of a powerful and mature multi-physics simulation framework.
+while still standing on the solid foundation of a powerful and mature multiphysics simulation framework.
 This approach enables the user to exert fine-grained control over *every* aspect and component of the simulation tool chain
 and, thus, allows for research in advanced numerical methods within a code base
 that is capable to answer real-world problems accurately and at scale.
@@ -63,9 +63,9 @@ For biomedical applications,
 reduced order models for flow in arteries or airways are available alongside suitable Windkessel models.
 Finally, solvers for transport of scalar fields such as heat or chemical concentrations are available.
 
-With the intent to study multi-physics phenomena,
+With the intent to study multiphysics phenomena,
 |FOURC| builds upon its single-field solvers
-to implement partitioned and monolithic multi-physics solvers for surface- and volume-coupled problems.
+to implement partitioned and monolithic multiphysics solvers for surface- and volume-coupled problems.
 In surface coupling,
 existing capabilities from the solid and structural mechanics module are coupled to incompressible fluid flow,
 resulting in partitioned and monolithic FSI solvers
@@ -87,7 +87,7 @@ in and with numerical methods for ordinary and partial differential equations
 and to advance complex models for real-world applications,
 all based on a proper theoretical foundation and with verified and state-of-the-art methods and software implementations.
 Since suitable tools are often not available either in commercial or in other (academic) research codes,
-we want to close this gap by developing |FOURC|, a comprehensive multi-physics simulation framework.
+we want to close this gap by developing |FOURC|, a comprehensive multiphysics simulation framework.
 |FOURC| originated in the 2000s at the `Institute for Computational Mechanics <https://www.epc.ed.tum.de/lnm/home/>`_ of the Technical University of Munich [#f1]_.
 
 .. rubric:: Footnotes

--- a/doc/readthedocs/index.rst
+++ b/doc/readthedocs/index.rst
@@ -9,7 +9,7 @@
 Mission statement
 =================
 
-|FOURC| is a parallel multi-physics research code
+|FOURC| is a parallel multiphysics research code
 to analyze and solve a plethora of physical problems
 described by ordinary or partial differential equations.
 Its development is driven by challenging research questions and real-world problems,
@@ -18,7 +18,7 @@ either due to the lack of capabilities or due to falling short of accuracy or pe
 
 |FOURC| not only provides ready-to-use simulation capabilities for a variety of physical models,
 including single fields such as solids and structures, fluids, or scalar transport,
-and multi-physics coupling and interactions between several fields,
+and multiphysics coupling and interactions between several fields,
 but also a modular software environment for research in mathematical modeling and numerical methods.
 Pre- and post-processing tools facilitate the use of |FOURC| within streamlined application workflows in science and engineering.
 For spatial discretization, |FOURC| mostly relies on finite element methods (FEM, CutFEM).

--- a/doc/readthedocs/materials.rst
+++ b/doc/readthedocs/materials.rst
@@ -53,7 +53,7 @@ Other Material Models
 Coupling Material Models for Various Physics on a Single Discretization
 -----------------------------------------------------------------------
 
-One may use a single (multi-physics) element type for a multi-physics simulation with matching discretizations.
+One may use a single (multiphysics) element type for a multiphysics simulation with matching discretizations.
 However, since each discretization belongs to a single physics representation and can thus only be connected to a single material,
 the other material has to be connected to the same discretization by cloning the discretization to the other physics.
 


### PR DESCRIPTION
## Description and Context
So far we had an inconsistent naming of multiphysics, i.e., multiphysics and multi-physics. This inconsistency is now resolved.

## Related Issues and Merge Requests
https://github.com/4C-multiphysics/website/pull/14
https://github.com/4C-multiphysics/website/issues/13