### PR TITLE
Fix a parser bug for single defaulted dat params

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -1070,7 +1070,18 @@ template <typename DataType>
 void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataType>::parse(
     ValueParser& parser, InputParameterContainer& container) const
 {
-  parser.consume(name);
+  if (parser.peek() == name)
+    parser.consume(name);
+  else if (data.required.value())
+  {
+    std::string next_token{parser.peek()};
+    FOUR_C_THROW("Could not parse '%s'. Next token is '%s'.", name.c_str(), next_token.c_str());
+  }
+  else if (data.default_value.has_value())
+  {
+    container.add(name, data.default_value.value());
+    return;
+  }
 
   if constexpr (InputSpecBuilders::Internal::is_sized_data<DataType>)
   {
@@ -1170,7 +1181,19 @@ template <typename DataTypeIn>
 void Core::IO::InputSpecBuilders::Internal::SelectionSpec<DataTypeIn>::parse(
     ValueParser& parser, InputParameterContainer& container) const
 {
-  parser.consume(name);
+  if (parser.peek() == name)
+    parser.consume(name);
+  else if (data.required.value())
+  {
+    std::string next_token{parser.peek()};
+    FOUR_C_THROW("Could not parse '%s'. Next token is '%s'.", name.c_str(), next_token.c_str());
+  }
+  else if (data.default_value.has_value())
+  {
+    container.add(name, data.default_value.value());
+    return;
+  }
+
   auto value = parser.read<std::string>();
   for (const auto& choice : choices)
   {

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -99,6 +99,39 @@ namespace
     }
   }
 
+  TEST(InputSpecTest, ParseSingleDefaultedEntryDat)
+  {
+    // This used to be a bug where a single default dat parameter was not accepted.
+    auto spec = all_of({
+        entry<double>("a", {.default_value = 1.0}),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("");
+      ValueParser parser(stream);
+      spec.fully_parse(parser, container);
+      EXPECT_EQ(container.get<double>("a"), 1.0);
+    }
+  }
+
+  TEST(InputSpecTest, ParseSingleDefaultedSelectionDat)
+  {
+    // This used to be a bug where a single default selection parameter was not accepted.
+    auto spec = all_of({
+        selection<int>("a", {{"A", 1}, {"B", 2}}, {.default_value = 2}),
+    });
+
+    {
+      InputParameterContainer container;
+      std::string stream("");
+      ValueParser parser(stream);
+      spec.fully_parse(parser, container);
+      EXPECT_EQ(container.get<int>("a"), 2);
+    }
+  }
+
+
   TEST(InputSpecTest, Vector)
   {
     auto spec = all_of({


### PR DESCRIPTION
Essentially the same fix as in 4692c3e4cfdf4ec656fea1b40d6eafcceb4ddea0 but this time for dat parameters.

Side note: I think the code duplication in this PRs shows that I can probably restructure the internals of `InputSpecBuilders` a bit more.