### PR TITLE
Trim descriptions when printing to dat comments

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -7,6 +7,8 @@
 
 #include "4C_io_input_spec_builders.hpp"
 
+#include "4C_utils_string.hpp"
+
 #include <format>
 #include <iostream>
 #include <numeric>
@@ -474,6 +476,12 @@ Core::IO::Internal::MatchEntry& Core::IO::Internal::MatchEntry::append_child(
   auto& child = tree->append_child(in_spec);
   children.push_back(&child);
   return child;
+}
+
+
+std::string Core::IO::Internal::InputSpecTypeErasedBase::description_one_line() const
+{
+  return Core::Utils::trim(data.description);
 }
 
 

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -14,6 +14,7 @@
 #include "4C_io_input_spec.hpp"
 #include "4C_io_value_parser.hpp"
 #include "4C_io_yaml.hpp"
+#include "4C_utils_string.hpp"
 
 #include <algorithm>
 #include <functional>
@@ -269,6 +270,8 @@ namespace Core::IO
 
       [[nodiscard]] const std::string& description() const { return data.description; }
 
+      [[nodiscard]] std::string description_one_line() const;
+
       [[nodiscard]] bool required() const { return data.required; }
 
       [[nodiscard]] bool has_default_value() const { return data.has_default_value; }
@@ -355,7 +358,7 @@ namespace Core::IO
 
           if (!description().empty())
           {
-            stream << " " << std::quoted(description());
+            stream << " " << std::quoted(description_one_line());
           }
           stream << "\n";
         }
@@ -1263,7 +1266,7 @@ void Core::IO::InputSpecBuilders::Internal::SelectionSpec<DataTypeIn>::print(
   }
   if (!data.description.empty())
   {
-    stream << " " << std::quoted(data.description);
+    stream << " " << std::quoted(Core::Utils::trim(data.description));
   }
   stream << "\n";
 }

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -573,7 +573,7 @@ namespace
                            selection<int>("c", {{"c1", 1}, {"c2", 2}},
                                {.description = "Selection", .default_value = 1}),
                        }),
-                       entry<int>("d", {.description = "Another integer", .default_value = 42}),
+                       entry<int>("d", {.description = "Another\n integer ", .default_value = 42}),
                    });
 
     {

--- a/src/core/utils/src/string_utils/4C_utils_string.cpp
+++ b/src/core/utils/src/string_utils/4C_utils_string.cpp
@@ -14,21 +14,25 @@ namespace Core::Utils
 {
   std::string trim(const std::string& line)
   {
-#if (BOOST_MAJOR_VERSION == 1) && (BOOST_MINOR_VERSION >= 47)
-    return boost::algorithm::trim_all_copy(boost::algorithm::replace_all_copy(line, "\t", " "));
-#else
-    std::istringstream t;
-    std::string s;
-    std::string newline;
-    t.str(line);
-    while (t >> s)
+    // Replace all whitespace character sequences with a single space. Remove leading and trailing
+    // spaces.
+    std::string result;
+    for (auto c : line)
     {
-      newline.append(s);
-      newline.append(" ");
+      if (std::isspace(c))
+      {
+        if (!result.empty() && result.back() != ' ') result.push_back(' ');
+      }
+      else
+      {
+        result.push_back(c);
+      }
     }
-    if (newline.size() > 0) newline.resize(newline.size() - 1);
-    return newline;
-#endif
+
+    // Remove trailing space
+    if (!result.empty() && result.back() == ' ') result.pop_back();
+
+    return result;
   }
 
   std::vector<std::string> split(const std::string& input, const std::string& delimiter)

--- a/src/core/utils/tests/string_utils/4C_utils_string_test.cpp
+++ b/src/core/utils/tests/string_utils/4C_utils_string_test.cpp
@@ -17,6 +17,20 @@ namespace
   using namespace FourC;
   using namespace Core::Utils;
 
+  TEST(StringUtils, TrimEmpty)
+  {
+    const std::string str = "";
+    auto trimmed_str = trim(str);
+    EXPECT_EQ(trimmed_str, "");
+  }
+
+  TEST(StringUtils, TrimMultiple)
+  {
+    const std::string str = "  abc  \tdef\n  ";
+    auto trimmed_str = trim(str);
+    EXPECT_EQ(trimmed_str, "abc def");
+  }
+
   TEST(StringUtils, SplitStringSeparatorInString)
   {
     const std::string str = "1.1,2.2,3.3,4.4,5.5";


### PR DESCRIPTION
Another fix to get #343 working (maybe the last one :crossed_fingers:). Some parameters have line breaks in their descriptions but these don't make a ton of sense in a one-liner dat description of a parameter.