### PR TITLE
Add InputSpecBuilders::list()

### DIFF
--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -57,6 +57,16 @@ namespace Core::IO
   {
    public:
     /**
+     * A type to store a list of InputParameterContainers. This type is used to represent what is
+     * often called a *list*, *array*, or *sequence* of data in the input file.
+     *
+     * @note This type is called `List` to more clearly distinguish it from a simple `std::vector`
+     * entry in the container. A `List` contains nested InputParameterContainers and encodes
+     * rather complex data structures. Nevertheless, it is implemented as a `std::vector`.
+     */
+    using List = std::vector<InputParameterContainer>;
+
+    /**
      * \brief Add @data to the container at the given key @name.
      *
      * If an entry with given @p name already exists, it will be overwritten.
@@ -78,6 +88,24 @@ namespace Core::IO
      * Check if a group with the name @p name exists.
      */
     [[nodiscard]] bool has_group(const std::string& name) const;
+
+    /**
+     * Add the list @p data at the given key @p name.
+     *
+     * @note This functions is a more obvious way to add a list to the container compared to
+     * the add() function with a List template argument, although this is precisely what happens
+     * internally.
+     */
+    void add_list(const std::string& name, List&& list);
+
+    /**
+     * Access the list @p name. This function throws an error if the list does not exist.
+     *
+     * @note This functions is a more obvious way to get a list from the container compared to
+     * the get() function with a List template argument, although this is precisely
+     * what happens internally.
+     */
+    [[nodiscard]] const List& get_list(const std::string& name) const;
 
     /**
      * Combine the data from another container with this one. Conflicting data will throw an

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -54,10 +54,10 @@ void Core::IO::InputSpec::match(ConstYamlNodeRef yaml, InputParameterContainer& 
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
 
-  Internal::MatchTree match_tree{*this};
+  Internal::MatchTree match_tree{*this, yaml};
   pimpl_->match(yaml, container, match_tree.root());
 
-  match_tree.assert_match(yaml.node);
+  match_tree.assert_match();
 }
 
 void Core::IO::InputSpec::print_as_dat(std::ostream& stream) const

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -186,7 +186,8 @@ namespace
 }  // namespace
 
 
-Core::IO::Internal::MatchTree::MatchTree(const Core::IO::InputSpec& root)
+Core::IO::Internal::MatchTree::MatchTree(const Core::IO::InputSpec& root, ConstYamlNodeRef node)
+    : node_(node)
 {
   // The number of nodes in the tree is known in advance as it is exactly equal to the
   // number of specs. This is why we can reserve the space for the entries and do not need
@@ -198,7 +199,7 @@ Core::IO::Internal::MatchTree::MatchTree(const Core::IO::InputSpec& root)
 
 namespace
 {
-
+  using namespace Core::IO;
   using namespace Core::IO::Internal;
   //! Helper function to dump the match tree for visual inspection during debugging.
   [[maybe_unused]] void dump_match_entry(std::ostream& stream, const MatchEntry& entry, int depth)
@@ -263,6 +264,44 @@ namespace
           for (const auto* child : entry.children)
           {
             recursively_print_match_entries(*child, out, depth + 2);
+          }
+        }
+        break;
+      }
+      case MatchEntry::Type::list:
+      {
+        out << indent;
+        out << std::format("{} {} list '{}'\n", state_symbol[static_cast<int>(entry.state)],
+            state_phrase[static_cast<int>(entry.state)], entry.spec->impl().name());
+        if (entry.state == MatchEntry::State::partial)
+        {
+          FOUR_C_ASSERT(entry.children.size() == 1,
+              "Internal error: lists should only store one MatchEntry.");
+
+          auto partially_matched_list_node =
+              entry.tree->node().node.tree()->ref(entry.matched_node);
+
+          if (entry.children.front()->state == MatchEntry::State::matched)
+          {
+            auto* list_spec = dynamic_cast<
+                const InputSpecTypeErasedImplementation<InputSpecBuilders::Internal::ListSpec>*>(
+                &entry.spec->impl());
+            FOUR_C_ASSERT(list_spec != nullptr, "Internal error: ListSpec expected.");
+
+            const int n_actual_entries = partially_matched_list_node.num_children();
+            const int n_expected_entries = list_spec->wrapped.data.size;
+            // If the last entry was matched, this means that the list was too long.
+            out << indent << "  ";
+            out << std::format("{} Too many list entries encountered: expected {} but matched {}\n",
+                state_symbol[static_cast<int>(MatchEntry::State::unmatched)], n_expected_entries,
+                n_actual_entries);
+          }
+          else
+          {
+            out << indent << "  ";
+            out << std::format("{} The following list entry did not match:\n",
+                state_symbol[static_cast<int>(MatchEntry::State::partial)]);
+            recursively_print_match_entries(*entry.children.front(), out, depth + 4);
           }
         }
         break;
@@ -411,6 +450,15 @@ namespace
           }
           break;
         }
+        case MatchEntry::Type::list:
+        {
+          if (entry.state == MatchEntry::State::matched)
+          {
+            // If the list is matched, just add all child nodes as well
+            recursively_add_node_ids(node.tree()->ref(entry.matched_node), matched_node_ids);
+          }
+          break;
+        }
         default:
           break;
       }
@@ -439,11 +487,11 @@ void Core::IO::Internal::MatchTree::dump(std::ostream& stream) const
 
 
 
-void Core::IO::Internal::MatchTree::assert_match(ryml::ConstNodeRef node) const
+void Core::IO::Internal::MatchTree::assert_match() const
 {
   std::stringstream ss;
   ss << "Could not match this input\n\n";
-  ss << node << "\n\n";
+  ss << node_.node << "\n\n";
   ss << "against the given input specification. ";
 
   if (entries_.front().state != MatchEntry::State::matched &&
@@ -455,17 +503,29 @@ void Core::IO::Internal::MatchTree::assert_match(ryml::ConstNodeRef node) const
   }
 
   // Check that everything in the input was actually used.
-  auto unmatched_node_ids = unmatched_input_nodes(entries_, node);
+  auto unmatched_node_ids = unmatched_input_nodes(entries_, node_.node);
   if (!unmatched_node_ids.empty())
   {
     ss << "The following parts of the input did not match:\n\n";
 
     for (const auto& id : unmatched_node_ids)
     {
-      ss << node.tree()->ref(id) << "\n";
+      ss << node_.node.tree()->ref(id) << "\n";
     }
     FOUR_C_THROW("%s", ss.str().c_str());
   }
+}
+
+void Core::IO::Internal::MatchTree::erase_everything_after(const MatchEntry& entry)
+{
+  // We know that the entry must be stored in the memory of entries_. This means we can find the
+  // entry by pointer comparison.
+  auto it = std::find_if(entries_.begin(), entries_.end(),
+      [&entry](const MatchEntry& stored_entry) { return &stored_entry == &entry; });
+  FOUR_C_ASSERT(it != entries_.end(), "Internal error: entry not found in MatchTree.");
+
+  // Erase everything that follows the entry.
+  entries_.erase(it + 1, entries_.end());
 }
 
 
@@ -476,6 +536,15 @@ Core::IO::Internal::MatchEntry& Core::IO::Internal::MatchEntry::append_child(
   auto& child = tree->append_child(in_spec);
   children.push_back(&child);
   return child;
+}
+
+void MatchEntry::reset()
+{
+  state = State::unmatched;
+  type = Type::unknown;
+  matched_node = ryml::npos;
+  children.clear();
+  tree->erase_everything_after(*this);
 }
 
 
@@ -505,6 +574,7 @@ bool Core::IO::InputSpecBuilders::Internal::GroupSpec::match(ConstYamlNodeRef no
 {
   match_entry.type = IO::Internal::MatchEntry::Type::group;
   FOUR_C_ASSERT(!name.empty(), "Internal error: group name must not be empty.");
+  FOUR_C_ASSERT(node.node.is_map(), "Internal error: group node must be a map.");
   const auto group_name = ryml::to_csubstr(name);
 
   const bool group_exists = node.node.has_child(group_name) && node.node[group_name].is_map();
@@ -803,6 +873,106 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::emit_metadata(ryml::NodeR
 }
 
 
+void Core::IO::InputSpecBuilders::Internal::ListSpec::parse(
+    Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
+{
+  FOUR_C_THROW("Cannot parse a list from dat file format.");
+}
+
+
+bool Core::IO::InputSpecBuilders::Internal::ListSpec::match(ConstYamlNodeRef node,
+    Core::IO::InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
+{
+  match_entry.type = IO::Internal::MatchEntry::Type::list;
+  FOUR_C_ASSERT(!name.empty(), "Internal error: list name must not be empty.");
+  FOUR_C_ASSERT(node.node.is_map(), "Internal error: list node must be a map.");
+  const auto list_name = ryml::to_csubstr(name);
+
+  const bool list_exists = node.node.has_child(list_name) && node.node[list_name].is_seq();
+  if (!list_exists)
+  {
+    return !data.required;
+  }
+
+  auto list_node = node.wrap(node.node[list_name]);
+  // Matching the key is at least a partial match.
+  match_entry.state = IO::Internal::MatchEntry::State::partial;
+  match_entry.matched_node = list_node.node.id();
+
+  std::vector<InputParameterContainer> container_list;
+
+  const std::size_t max_entries = data.size > 0 ? data.size : std::numeric_limits<int>::max();
+
+  // Parse all child nodes of the list node. Reuse the same MatchEntry.
+  auto& child_match_entry = match_entry.append_child(&spec);
+  for (const auto child : list_node.node.children())
+  {
+    // Always reset the match entry. We only store the last match attempt for lists.
+    child_match_entry.reset();
+    bool child_matched =
+        spec.impl().match(list_node.wrap(child), container_list.emplace_back(), child_match_entry);
+    if (!child_matched)
+    {
+      // Match will stay a partial match and the MatchEntry will have more details.
+      return false;
+    }
+  }
+
+  if (container_list.size() > max_entries)
+  {
+    // The list is too long. This is a partial match, and we can figure out the reason in the
+    // error message constructed by the MatchTree.
+    return false;
+  }
+
+  // Everything was correctly matched, so mark the list node as matched.
+  container.add_list(name, std::move(container_list));
+  match_entry.state = IO::Internal::MatchEntry::State::matched;
+
+  return true;
+}
+
+
+void Core::IO::InputSpecBuilders::Internal::ListSpec::set_default_value(
+    Core::IO::InputParameterContainer& container) const
+{
+  std::vector<InputParameterContainer> default_list(data.size);
+
+  for (auto& subcontainer : default_list)
+  {
+    spec.impl().set_default_value(subcontainer);
+  }
+
+  container.add_list(name, std::move(default_list));
+}
+
+
+void Core::IO::InputSpecBuilders::Internal::ListSpec::print(
+    std::ostream& stream, std::size_t indent) const
+{
+  stream << "// " << std::string(indent, ' ') << "list '" << name << "'"
+         << " with entries:\n";
+  spec.impl().print(stream, indent + 2);
+}
+
+void Core::IO::InputSpecBuilders::Internal::ListSpec::emit_metadata(ryml::NodeRef node) const
+{
+  node |= ryml::MAP;
+
+  node["name"] << name;
+
+  node["type"] << "list";
+  if (!data.description.empty())
+  {
+    node["description"] << Core::Utils::trim(data.description);
+  }
+  emit_value_as_yaml(node["required"], data.required);
+  if (data.size > 0) node["size"] << data.size;
+  node["spec"] |= ryml::MAP;
+  spec.impl().emit_metadata(node["spec"]);
+}
+
+
 namespace
 {
   // Nesting all_of or one_of within another spec of that same type is the same as pulling the
@@ -945,6 +1115,28 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::one_of(std::vector<InputSpec> s
   return IO::Internal::make_spec(Internal::OneOfSpec{.data = std::move(group_data),
                                      .specs = std::move(flattened_specs),
                                      .on_parse_callback = std::move(on_parse_callback)},
+      std::move(common_data));
+}
+
+Core::IO::InputSpec Core::IO::InputSpecBuilders::list(
+    std::string name, Core::IO::InputSpec spec, ListData data)
+{
+  IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
+      .name = name,
+      .description = data.description,
+      .required = data.required,
+      // We can only set a default value if the size is fixed and the contained spec has
+      // a default value.
+      .has_default_value = spec.impl().has_default_value() && data.size != dynamic_size,
+      .n_specs = spec.impl().data.n_specs + 1,
+  };
+
+  return IO::Internal::make_spec(
+      Internal::ListSpec{
+          .name = name,
+          .spec = std::move(spec),
+          .data = std::move(data),
+      },
       std::move(common_data));
 }
 

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -160,6 +160,7 @@ namespace Core::IO
         group,
         all_of,
         one_of,
+        list,
       };
 
       State state{State::unmatched};
@@ -171,6 +172,12 @@ namespace Core::IO
        * child is passed on to the match function of @p in_spec.
        */
       MatchEntry& append_child(const InputSpec* in_spec);
+
+      /**
+       * Reset the state of this entry. This includes dropping all children from the MatchTree.
+       * The state of the entry and MatchTree is the same as if append_child was just called.
+       */
+      void reset();
     };
 
     /**
@@ -179,9 +186,11 @@ namespace Core::IO
     class MatchTree
     {
      public:
-      MatchTree(const InputSpec& root);
+      MatchTree(const InputSpec& root, ConstYamlNodeRef node);
 
       MatchEntry& root() { return entries_.front(); }
+
+      ConstYamlNodeRef node() const { return node_; }
 
       MatchEntry& append_child(const InputSpec* spec);
 
@@ -191,10 +200,17 @@ namespace Core::IO
        * Throw an exception that contains the input and match tree in a user-friendly format, if
        * the match was not successful.
        */
-      void assert_match(ryml::ConstNodeRef node) const;
+      void assert_match() const;
+
+      /**
+       * A helper function to remove every entry added after @p entry. This function is especially
+       * useful to keep the number of stored entries low when matching a list().
+       */
+      void erase_everything_after(const MatchEntry& entry);
 
      private:
       std::vector<MatchEntry> entries_;
+      ConstYamlNodeRef node_;
     };
 
     class InputSpecTypeErasedBase
@@ -478,6 +494,15 @@ namespace Core::IO
     using Core::IO::Noneable;
 
     /**
+     * This constant signifies that a size is dynamic and will be determined at runtime. Pass this
+     * value to the size parameter of a vector-valued entry() or the list() function.
+     *
+     * @note Dynamic sizes do not work for the legacy dat file format and will throw a runtime
+     * error.
+     */
+    constexpr int dynamic_size = 0;
+
+    /**
      * Callback function that may be attached to entry().
      */
     using EntryCallback = std::function<void(InputParameterContainer&)>;
@@ -568,6 +593,25 @@ namespace Core::IO
        * Whether the Group is required or optional.
        */
       bool required{true};
+    };
+
+    //! Additional parameters for a list().
+    struct ListData
+    {
+      /**
+       * An optional description of the List.
+       */
+      std::string description{};
+
+      /**
+       * Whether the List is required or optional.
+       */
+      bool required{true};
+
+      /**
+       * The size of the List.
+       */
+      int size{dynamic_size};
     };
 
     namespace Internal
@@ -694,6 +738,23 @@ namespace Core::IO
 
         void print(std::ostream& stream, std::size_t indent) const;
 
+        void emit_metadata(ryml::NodeRef node) const;
+      };
+
+      struct ListSpec
+      {
+        //! The name of the list.
+        std::string name;
+        //! The spec that fits the list elements.
+        InputSpec spec;
+
+        ListData data;
+
+        void parse(ValueParser& parser, InputParameterContainer& container) const;
+        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+            IO::Internal::MatchEntry& match_entry) const;
+        void set_default_value(InputParameterContainer& container) const;
+        void print(std::ostream& stream, std::size_t indent) const;
         void emit_metadata(ryml::NodeRef node) const;
       };
 
@@ -1063,6 +1124,30 @@ namespace Core::IO
      */
     template <typename T>
     auto store_index_as(std::string name, std::vector<T> reindexing = {});
+
+    /**
+     * The InputSpec returned by this function represents a list where each element matches the
+     * given @p spec. The size of the list can be specified in the @p data, either as a fixed value
+     * or dynamic_size (the default). For example,
+     *
+     * @code
+     * list("my_list", entry<int>("a"), {.size = 3});
+     * @endcode
+     *
+     * will match the following yaml input:
+     *
+     * @code
+     * my_list:
+     *   - a: 42
+     *   - a: 7
+     *   - a: 3
+     * @endcode
+     *
+     * @note The list() function is not intended to specify an array of primitive values of type T.
+     * Use the `entry<std::vector<T>>()` function for this purpose. As a developer of a new
+     * InputSpec, you should rarely need the list() function.
+     */
+    [[nodiscard]] InputSpec list(std::string name, InputSpec spec, ListData data = {});
   }  // namespace InputSpecBuilders
 }  // namespace Core::IO
 
@@ -1090,8 +1175,13 @@ void Core::IO::InputSpecBuilders::Internal::BasicSpec<DataType>::parse(
   {
     struct SizeVisitor
     {
-      std::size_t operator()(std::size_t size) const { return size; }
-      std::size_t operator()(const typename DataType::SizeCallback& callback) const
+      int operator()(int size) const
+      {
+        if (size > 0) return size;
+
+        FOUR_C_THROW("Reading a vector from a dat-style string requires a known size.");
+      }
+      int operator()(const typename DataType::SizeCallback& callback) const
       {
         return callback(container);
       }

--- a/src/core/io/tests/4C_io_input_parameter_container_test.cpp
+++ b/src/core/io/tests/4C_io_input_parameter_container_test.cpp
@@ -13,9 +13,11 @@ namespace
 {
   using namespace FourC;
 
+  using namespace Core::IO;
+
   TEST(InputParameterContainerTest, ToTeuchosParameterList)
   {
-    Core::IO::InputParameterContainer container;
+    InputParameterContainer container;
     container.add<int>("a", 1);
     container.add<double>("b", 2.0);
     container.add<std::string>("c", "string");
@@ -36,5 +38,23 @@ namespace
     EXPECT_EQ(list.get<Core::IO::Noneable<int>>("n"), Core::IO::none<int>);
     EXPECT_EQ(list.sublist("group").get<std::string>("e"), "group string");
     EXPECT_EQ(list.sublist("group").sublist("deeply").sublist("nested").get<int>("f"), 42);
+  }
+
+  TEST(InputParameterContainerTest, Lists)
+  {
+    InputParameterContainer container;
+    InputParameterContainer::List list;
+
+    list.emplace_back().add("a", 1);
+    auto& list2 = list.emplace_back();
+    list2.group("group").add("b", 2);
+
+    container.add_list("list", std::move(list));
+
+    Teuchos::ParameterList pl;
+    container.to_teuchos_parameter_list(pl);
+
+    EXPECT_EQ(
+        pl.get<std::vector<Teuchos::ParameterList>>("list")[1].sublist("group").get<int>("b"), 2);
   }
 }  // namespace


### PR DESCRIPTION
This is the missing link to treat the full input file structure (except the geometry sections) as a single InputSpec.