### PR TITLE
Input: ensure printable names and descriptions

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -237,9 +237,8 @@ namespace Core::IO
 
       /**
        * @param data The common data of the spec.
-       * @param n_specs The number of specs (itself included) that make up this spec.
        */
-      InputSpecTypeErasedBase(CommonData data) : data(std::move(data)) {}
+      InputSpecTypeErasedBase(CommonData data);
 
       virtual void parse(ValueParser& parser, InputParameterContainer& container) const = 0;
 


### PR DESCRIPTION
Catch unprintable characters, notably `\f`, early.

FYI @gilrrei @ischeider 