### PR TITLE
InputSpec: support more expressive map<string,T>

### DIFF
--- a/src/core/io/src/4C_io_value_parser.hpp
+++ b/src/core/io/src/4C_io_value_parser.hpp
@@ -15,6 +15,7 @@
 
 #include <array>
 #include <filesystem>
+#include <map>
 #include <optional>
 #include <stack>
 #include <string>
@@ -191,11 +192,15 @@ namespace Core::IO
       }
     }
 
-    template <typename T, typename U, typename... SizeInfo>
-    void read_internal(std::pair<T, U>& value, SizeInfo&&... size_info)
+    template <typename U, typename... SizeInfo>
+    void read_internal(std::map<std::string, U>& value, std::size_t size, SizeInfo&&... size_info)
     {
-      read_internal(value.first, std::forward<SizeInfo>(size_info)...);
-      read_internal(value.second, std::forward<SizeInfo>(size_info)...);
+      for (std::size_t i = 0; i < size; ++i)
+      {
+        std::string key;
+        read_internal(key);
+        read_internal(value[key], std::forward<SizeInfo>(size_info)...);
+      }
     }
 
     //! The data to parse from.

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -627,7 +627,9 @@ namespace
         entry<std::vector<double>>("b", {.default_value = std::vector{1., 2., 3.}, .size = 3}),
         one_of({
             all_of({
-                entry<std::pair<int, std::string>>("b", {.default_value = std::pair{1, "abc"}}),
+                entry<std::map<std::string, std::string>>(
+                    "b", {.default_value = std::map<std::string, std::string>{{"key", "abc"}},
+                             .size = 1}),
                 entry<std::string>("c"),
             }),
             group("group",
@@ -682,9 +684,11 @@ specs:
         required: true
         specs:
           - name: b
-            type: 'pair<int, string>'
+            type: 'map<string, string>'
             required: false
-            default: [1,abc]
+            default:
+              key: abc
+            size: 1
           - name: c
             type: string
             required: true

--- a/src/core/io/tests/4C_io_value_parser_test.cpp
+++ b/src/core/io/tests/4C_io_value_parser_test.cpp
@@ -245,6 +245,19 @@ namespace
     }
   }
 
+  TEST(ValueParser, Map)
+  {
+    std::string_view in("key1 1 2 key2 2 3 key3 3 4");
+    Core::IO::ValueParser parser(in);
+
+    auto map = parser.read<std::map<std::string, std::vector<int>>>(3, 2);
+
+    EXPECT_EQ(map.size(), 3);
+    EXPECT_EQ(map.at("key1"), (std::vector{1, 2}));
+    EXPECT_EQ(map.at("key2"), (std::vector{2, 3}));
+    EXPECT_EQ(map.at("key3"), (std::vector{3, 4}));
+  }
+
   TEST(ValueParser, Unparsed)
   {
     std::string_view in("a 1 b 2 c 3");

--- a/src/core/utils/src/functions/4C_utils_function.cpp
+++ b/src/core/utils/src/functions/4C_utils_function.cpp
@@ -177,10 +177,10 @@ Core::Utils::try_create_symbolic_function_of_anything(
     std::string component = function_lin_def.get<std::string>("VARFUNCTION");
 
     std::vector<std::pair<std::string, double>> constants;
-    if (function_lin_def.get_if<std::vector<std::pair<std::string, double>>>("CONSTANTS") !=
-        nullptr)
+    if (auto* constants_map = function_lin_def.get_if<std::map<std::string, double>>("CONSTANTS");
+        constants_map)
     {
-      constants = function_lin_def.get<std::vector<std::pair<std::string, double>>>("CONSTANTS");
+      constants.insert(constants.end(), constants_map->begin(), constants_map->end());
     }
 
     return std::make_shared<Core::Utils::SymbolicFunctionOfAnything>(component, constants);

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -121,7 +121,7 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
       all_of({
           entry<std::string>("VARFUNCTION"),
           entry<int>("NUMCONSTANTS", {.required = false}),
-          entry<std::vector<std::pair<std::string, double>>>(
+          entry<std::map<std::string, double>>(
               "CONSTANTS", {.required = false, .size = from_parameter<int>("NUMCONSTANTS")}),
       }),
   });

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
@@ -74,9 +74,10 @@ namespace
     {
       std::string type = function_lin_def.get<std::string>("POROMULTIPHASESCATRA_FUNCTION");
 
-      auto params = function_lin_def.get<std::vector<std::pair<std::string, double>>>("PARAMS");
+      auto params = function_lin_def.get<std::map<std::string, double>>("PARAMS");
+      std::vector<std::pair<std::string, double>> params_vec(params.begin(), params.end());
 
-      return create_poro_function<dim>(type, params);
+      return create_poro_function<dim>(type, params_vec);
     }
     else
     {
@@ -119,7 +120,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
       all_of({
           entry<std::string>("POROMULTIPHASESCATRA_FUNCTION"),
           entry<int>("NUMPARAMS", {.required = false}),
-          entry<std::vector<std::pair<std::string, double>>>(
+          entry<std::map<std::string, double>>(
               "PARAMS", {.required = false, .size = from_parameter<int>("NUMPARAMS")}),
       }),
       try_create_poro_function_dispatch);

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
@@ -23,7 +23,7 @@ namespace
 
   template <int dim>
   std::shared_ptr<Core::Utils::FunctionOfAnything> create_poro_function(
-      const std::string& type, const std::vector<std::pair<std::string, double>>& params)
+      const std::string& type, const std::map<std::string, double>& params)
   {
     if (type == "TUMOR_GROWTH_LAW_HEAVISIDE")
       return std::make_shared<PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>>(params);
@@ -75,9 +75,8 @@ namespace
       std::string type = function_lin_def.get<std::string>("POROMULTIPHASESCATRA_FUNCTION");
 
       auto params = function_lin_def.get<std::map<std::string, double>>("PARAMS");
-      std::vector<std::pair<std::string, double>> params_vec(params.begin(), params.end());
 
-      return create_poro_function<dim>(type, params_vec);
+      return create_poro_function<dim>(type, params);
     }
     else
     {
@@ -130,7 +129,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::TumorGrowthLawHeaviside(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -241,7 +240,7 @@ std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::evaluate
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::NecrosisLawHeaviside(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -377,7 +376,7 @@ std::vector<double> PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::evaluate_de
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::OxygenConsumptionLawHeaviside(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -519,7 +518,7 @@ std::vector<double> PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::ev
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::TumorGrowthLawHeavisideOxy(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -656,7 +655,7 @@ std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::evalu
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::TumorGrowthLawHeavisideNecro(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -798,7 +797,7 @@ std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::eva
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::OxygenTransvascularExchangeLawCont(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -927,7 +926,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate_derivati
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::OxygenTransvascularExchangeLawDisc(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params), pos_oxy_art_(-1), pos_diam_(-1)
 {
 }
@@ -1047,7 +1046,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate_derivati
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::LungOxygenExchangeLaw(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }
@@ -1228,7 +1227,7 @@ std::vector<double> PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate_d
 /*----------------------------------------------------------------------*/
 template <int dim>
 PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::LungCarbonDioxideExchangeLaw(
-    const std::vector<std::pair<std::string, double>>& funct_params)
+    const std::map<std::string, double>& funct_params)
     : PoroMultiPhaseScaTraFunction<dim>(), parameter_(funct_params)
 {
 }

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.hpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.hpp
@@ -88,7 +88,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    TumorGrowthLawHeaviside(const std::vector<std::pair<std::string, double>>& funct_params);
+    TumorGrowthLawHeaviside(const std::map<std::string, double>& funct_params);
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
         const std::vector<std::pair<std::string, double>>& constants,
@@ -129,7 +129,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    NecrosisLawHeaviside(const std::vector<std::pair<std::string, double>>& funct_params);
+    NecrosisLawHeaviside(const std::map<std::string, double>& funct_params);
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
         const std::vector<std::pair<std::string, double>>& constants,
@@ -170,7 +170,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    OxygenConsumptionLawHeaviside(const std::vector<std::pair<std::string, double>>& funct_params);
+    OxygenConsumptionLawHeaviside(const std::map<std::string, double>& funct_params);
 
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
@@ -213,7 +213,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    TumorGrowthLawHeavisideOxy(const std::vector<std::pair<std::string, double>>& funct_params);
+    TumorGrowthLawHeavisideOxy(const std::map<std::string, double>& funct_params);
 
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
@@ -255,7 +255,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    TumorGrowthLawHeavisideNecro(const std::vector<std::pair<std::string, double>>& funct_params);
+    TumorGrowthLawHeavisideNecro(const std::map<std::string, double>& funct_params);
 
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
@@ -293,8 +293,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    OxygenTransvascularExchangeLawCont(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    OxygenTransvascularExchangeLawCont(const std::map<std::string, double>& funct_params);
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
         const std::vector<std::pair<std::string, double>>& constants,
@@ -331,8 +330,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    OxygenTransvascularExchangeLawDisc(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    OxygenTransvascularExchangeLawDisc(const std::map<std::string, double>& funct_params);
 
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
@@ -374,7 +372,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    LungOxygenExchangeLaw(const std::vector<std::pair<std::string, double>>& funct_params);
+    LungOxygenExchangeLaw(const std::map<std::string, double>& funct_params);
 
 
     double evaluate(const std::vector<std::pair<std::string, double>>& variables,
@@ -419,7 +417,7 @@ namespace PoroMultiPhaseScaTra
      * \brief Constructor creating empty object. Add the function parameters (read from the
      * input file) to the function
      */
-    LungCarbonDioxideExchangeLaw(const std::vector<std::pair<std::string, double>>& funct_params);
+    LungCarbonDioxideExchangeLaw(const std::map<std::string, double>& funct_params);
 
     /*!
      * \brief evaluate function for a given set of variables

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function_parameters.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function_parameters.cpp
@@ -11,236 +11,141 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace
-{
-  /*!
-   * @brief check for correct naming and order of input parameters
-   *
-   * @tparam NumberOfParameters: Number of parameters
-   * @param param_map: array including all valid parameter names in the correct order
-   * @param funct_params: parameters read from input, which are checked
-   * @param function_name: name of the function whose parameters are checked
-   */
-
-  template <int number_of_parameters>
-  void check_naming_and_order_of_parameters(
-      const std::array<std::string, number_of_parameters>& param_map,
-      const std::vector<std::pair<std::string, double>>& funct_params, std::string function_name)
-  {
-    if (funct_params.size() != number_of_parameters)
-    {
-      std::string list_of_parameters{};
-      for (std::size_t i = 0; i < number_of_parameters; ++i)
-      {
-        list_of_parameters += param_map[i] + ", ";
-      }
-
-      auto const message = "Wrong size of funct_params for " + function_name +
-                           ", it should have exactly\n" + std::to_string(number_of_parameters) +
-                           " funct_params (in this order): " + list_of_parameters;
-
-      FOUR_C_THROW(message.c_str());
-    }
-
-    for (std::size_t i = 0; i < funct_params.size(); ++i)
-    {
-      auto const message = "Parameter number " + std::to_string(i + 1) + " for " + function_name +
-                           " has to be " + param_map[i];
-      if (funct_params[i].first != param_map[i]) FOUR_C_THROW(message.c_str());
-    }
-  }
-}  // namespace
-
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::TumorGrowthLawHeavisideParameters::TumorGrowthLawHeavisideParameters(
-    const std::vector<std::pair<std::string, double>>& funct_params)
-    : gamma_T_growth(funct_params[0].second),
-      w_nl_crit(funct_params[1].second),
-      w_nl_env(funct_params[2].second),
-      lambda(funct_params[3].second),
-      p_t_crit(funct_params[4].second)
+    const std::map<std::string, double>& funct_params)
+    : gamma_T_growth(funct_params.at("gamma_T_growth")),
+      w_nl_crit(funct_params.at("w_nl_crit")),
+      w_nl_env(funct_params.at("w_nl_env")),
+      lambda(funct_params.at("lambda")),
+      p_t_crit(funct_params.at("p_t_crit"))
 {
   constexpr int NUMBER_OF_PARAMS = 5;
-  const std::string function_name = "TUMOR_GROWTH_LAW_HEAVISIDE";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{
-      "gamma_T_growth", "w_nl_crit", "w_nl_env", "lambda", "p_t_crit"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::NecrosisLawHeavisideParameters::NecrosisLawHeavisideParameters(
-    const std::vector<std::pair<std::string, double>>& funct_params)
-    : gamma_t_necr(funct_params[0].second),
-      w_nl_crit(funct_params[1].second),
-      w_nl_env(funct_params[2].second),
-      delta_a_t(funct_params[3].second),
-      p_t_crit(funct_params[4].second)
+    const std::map<std::string, double>& funct_params)
+    : gamma_t_necr(funct_params.at("gamma_t_necr")),
+      w_nl_crit(funct_params.at("w_nl_crit")),
+      w_nl_env(funct_params.at("w_nl_env")),
+      delta_a_t(funct_params.at("delta_a_t")),
+      p_t_crit(funct_params.at("p_t_crit"))
 {
   constexpr int NUMBER_OF_PARAMS = 5;
-  const std::string function_name = "NECROSIS_LAW_HEAVISIDE";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{
-      "gamma_t_necr", "w_nl_crit", "w_nl_env", "delta_a_t", "p_t_crit"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::OxygenConsumptionLawHeavisideParameters::
-    OxygenConsumptionLawHeavisideParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params)
-    : gamma_nl_growth(funct_params[0].second),
-      gamma_0_nl(funct_params[1].second),
-      w_nl_crit(funct_params[2].second),
-      w_nl_env(funct_params[3].second),
-      p_t_crit(funct_params[4].second)
+    OxygenConsumptionLawHeavisideParameters(const std::map<std::string, double>& funct_params)
+    : gamma_nl_growth(funct_params.at("gamma_nl_growth")),
+      gamma_0_nl(funct_params.at("gamma_0_nl")),
+      w_nl_crit(funct_params.at("w_nl_crit")),
+      w_nl_env(funct_params.at("w_nl_env")),
+      p_t_crit(funct_params.at("p_t_crit"))
 {
   constexpr int NUMBER_OF_PARAMS = 5;
-  const std::string function_name = "OXYGEN_CONSUMPTION_LAW_HEAVISIDE";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{
-      "gamma_nl_growth", "gamma_0_nl", "w_nl_crit", "w_nl_env", "p_t_crit"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecroOxyParameters::
-    TumorGrowthLawHeavisideNecroOxyParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params)
-    : gamma_T_growth(funct_params[0].second),
-      w_nl_crit(funct_params[1].second),
-      w_nl_env(funct_params[2].second),
-      lambda(funct_params[3].second),
-      p_t_crit(funct_params[4].second)
+    TumorGrowthLawHeavisideNecroOxyParameters(const std::map<std::string, double>& funct_params)
+    : gamma_T_growth(funct_params.at("gamma_T_growth")),
+      w_nl_crit(funct_params.at("w_nl_crit")),
+      w_nl_env(funct_params.at("w_nl_env")),
+      lambda(funct_params.at("lambda")),
+      p_t_crit(funct_params.at("p_t_crit"))
 {
   constexpr int NUMBER_OF_PARAMS = 5;
-  const std::string function_name = "TUMOR_GROWTH_LAW_HEAVISIDE_OXY";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{
-      "gamma_T_growth", "w_nl_crit", "w_nl_env", "lambda", "p_t_crit"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawContParameters::
-    OxygenTransvascularExchangeLawContParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params)
-    : n(funct_params[0].second),
-      Pb50(funct_params[1].second),
-      CaO2_max(funct_params[2].second),
-      alpha_bl_eff(funct_params[3].second),
-      gammarhoSV(funct_params[4].second),
-      rho_oxy(funct_params[5].second),
-      rho_if(funct_params[6].second),
-      rho_bl(funct_params[7].second),
-      alpha_IF(funct_params[8].second)
+    OxygenTransvascularExchangeLawContParameters(const std::map<std::string, double>& funct_params)
+    : n(funct_params.at("n")),
+      Pb50(funct_params.at("Pb50")),
+      CaO2_max(funct_params.at("CaO2_max")),
+      alpha_bl_eff(funct_params.at("alpha_bl_eff")),
+      gammarhoSV(funct_params.at("gammarhoSV")),
+      rho_oxy(funct_params.at("rho_oxy")),
+      rho_if(funct_params.at("rho_if")),
+      rho_bl(funct_params.at("rho_bl")),
+      alpha_IF(funct_params.at("alpha_IF"))
 {
   constexpr int NUMBER_OF_PARAMS = 9;
-  const std::string function_name = "OXYGEN_TRANSVASCULAR_EXCHANGE_LAW_CONT";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{"n", "Pb50", "CaO2_max",
-      "alpha_bl_eff", "gammarhoSV", "rho_oxy", "rho_IF", "rho_bl", " alpha_IF"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDiscParameters::
-    OxygenTransvascularExchangeLawDiscParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params)
-    : n(funct_params[0].second),
-      Pb50(funct_params[1].second),
-      CaO2_max(funct_params[2].second),
-      alpha_bl_eff(funct_params[3].second),
-      gammarho(funct_params[4].second),
-      rho_oxy(funct_params[5].second),
-      rho_if(funct_params[6].second),
-      rho_bl(funct_params[7].second),
-      S2_max(funct_params[8].second),
-      alpha_IF(funct_params[9].second)
+    OxygenTransvascularExchangeLawDiscParameters(const std::map<std::string, double>& funct_params)
+    : n(funct_params.at("n")),
+      Pb50(funct_params.at("Pb50")),
+      CaO2_max(funct_params.at("CaO2_max")),
+      alpha_bl_eff(funct_params.at("alpha_bl_eff")),
+      gammarho(funct_params.at("gamma*rho")),
+      rho_oxy(funct_params.at("rho_oxy")),
+      rho_if(funct_params.at("rho_IF")),
+      rho_bl(funct_params.at("rho_bl")),
+      S2_max(funct_params.at("S2_max")),
+      alpha_IF(funct_params.at("alpha_IF"))
 {
   constexpr int NUMBER_OF_PARAMS = 10;
-  const std::string function_name = "OXYGEN_TRANSVASCULAR_EXCHANGE_LAW_DISC";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{"n", "Pb50", "CaO2_max",
-      "alpha_bl_eff", "gamma*rho", "rho_oxy", "rho_IF", "rho_bl", "S2_max", "alpha_IF"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::LungOxygenExchangeLawParameters::LungOxygenExchangeLawParameters(
-    const std::vector<std::pair<std::string, double>>& funct_params)
-    : rho_oxy(funct_params[0].second),
-      DiffAdVTLC(funct_params[1].second),
-      alpha_oxy(funct_params[2].second),
-      rho_air(funct_params[3].second),
-      rho_bl(funct_params[4].second),
-      n(funct_params[5].second),
-      P_oB50(funct_params[6].second),
-      NC_Hb(funct_params[7].second),
-      P_atmospheric(funct_params[8].second),
-      volfrac_blood_ref(funct_params[9].second)
+    const std::map<std::string, double>& funct_params)
+    : rho_oxy(funct_params.at("rho_oxy")),
+      DiffAdVTLC(funct_params.at("DiffAdVTLC")),
+      alpha_oxy(funct_params.at("alpha_oxy")),
+      rho_air(funct_params.at("rho_air")),
+      rho_bl(funct_params.at("rho_bl")),
+      n(funct_params.at("n")),
+      P_oB50(funct_params.at("P_oB50")),
+      NC_Hb(funct_params.at("NC_Hb")),
+      P_atmospheric(funct_params.at("P_atmospheric")),
+      volfrac_blood_ref(funct_params.at("volfrac_blood_ref"))
 {
   constexpr int NUMBER_OF_PARAMS = 10;
-  const std::string function_name = "LUNG_OXYGEN_EXCHANGE_LAW";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{"rho_oxy", "DiffAdVTLC",
-      "alpha_oxy", "rho_air", "rho_bl", "n", "P_oB50", "NC_Hb", "P_atmospheric",
-      "volfrac_blood_ref"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLawParameters::
-    LungCarbonDioxideExchangeLawParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params)
-    : rho_CO2(funct_params[0].second),
-      DiffsolAdVTLC(funct_params[1].second),
-      pH(funct_params[2].second),
-      rho_air(funct_params[3].second),
-      rho_bl(funct_params[4].second),
-      rho_oxy(funct_params[5].second),
-      n(funct_params[6].second),
-      P_oB50(funct_params[7].second),
-      C_Hb(funct_params[8].second),
-      NC_Hb(funct_params[9].second),
-      alpha_oxy(funct_params[10].second),
-      P_atmospheric(funct_params[11].second),
-      ScalingFormmHg(funct_params[12].second),
-      volfrac_blood_ref(funct_params[13].second)
+    LungCarbonDioxideExchangeLawParameters(const std::map<std::string, double>& funct_params)
+    : rho_CO2(funct_params.at("rho_CO2")),
+      DiffsolAdVTLC(funct_params.at("DiffsolAdVTLC")),
+      pH(funct_params.at("pH")),
+      rho_air(funct_params.at("rho_air")),
+      rho_bl(funct_params.at("rho_bl")),
+      rho_oxy(funct_params.at("rho_oxy")),
+      n(funct_params.at("n")),
+      P_oB50(funct_params.at("P_oB50")),
+      C_Hb(funct_params.at("C_Hb")),
+      NC_Hb(funct_params.at("NC_Hb")),
+      alpha_oxy(funct_params.at("alpha_oxy")),
+      P_atmospheric(funct_params.at("P_atmospheric")),
+      ScalingFormmHg(funct_params.at("ScalingFormmHg")),
+      volfrac_blood_ref(funct_params.at("volfrac_blood_ref"))
 {
   constexpr int NUMBER_OF_PARAMS = 14;
-  const std::string function_name = "LUNG_CARBONDIOXIDE_EXCHANGE_LAW";
-
-  static const std::array<std::string, NUMBER_OF_PARAMS> param_map{"rho_CO2", "DiffsolAdVTLC", "pH",
-      "rho_air", "rho_bl", "rho_oxy", "n", "P_oB50", "C_Hb", "NC_Hb", "alpha_oxy", "P_atmospheric",
-      "ScalingFormmHg", "volfrac_blood_ref"};
-
-  // Check parameters
-  check_naming_and_order_of_parameters<NUMBER_OF_PARAMS>(param_map, funct_params, function_name);
+  FOUR_C_ASSERT_ALWAYS(funct_params.size() == NUMBER_OF_PARAMS, "Wrong size of funct_params");
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function_parameters.hpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function_parameters.hpp
@@ -12,8 +12,8 @@
 #include "4C_config.hpp"
 
 #include <array>
+#include <map>
 #include <string>
-#include <vector>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -29,8 +29,7 @@ namespace PoroMultiPhaseScaTra
   {
     TumorGrowthLawHeavisideParameters() = default;
 
-    TumorGrowthLawHeavisideParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    TumorGrowthLawHeavisideParameters(const std::map<std::string, double>& funct_params);
 
     double gamma_T_growth{};
     double w_nl_crit{};
@@ -47,7 +46,7 @@ namespace PoroMultiPhaseScaTra
   {
     NecrosisLawHeavisideParameters() = default;
 
-    NecrosisLawHeavisideParameters(const std::vector<std::pair<std::string, double>>& funct_params);
+    NecrosisLawHeavisideParameters(const std::map<std::string, double>& funct_params);
 
     double gamma_t_necr{};
     double w_nl_crit{};
@@ -64,8 +63,7 @@ namespace PoroMultiPhaseScaTra
   {
     OxygenConsumptionLawHeavisideParameters() = default;
 
-    OxygenConsumptionLawHeavisideParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    OxygenConsumptionLawHeavisideParameters(const std::map<std::string, double>& funct_params);
 
     double gamma_nl_growth{};
     double gamma_0_nl{};
@@ -83,8 +81,7 @@ namespace PoroMultiPhaseScaTra
   {
     TumorGrowthLawHeavisideNecroOxyParameters() = default;
 
-    TumorGrowthLawHeavisideNecroOxyParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    TumorGrowthLawHeavisideNecroOxyParameters(const std::map<std::string, double>& funct_params);
 
     double gamma_T_growth{};
     double w_nl_crit{};
@@ -101,8 +98,7 @@ namespace PoroMultiPhaseScaTra
   {
     OxygenTransvascularExchangeLawContParameters() = default;
 
-    OxygenTransvascularExchangeLawContParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    OxygenTransvascularExchangeLawContParameters(const std::map<std::string, double>& funct_params);
 
     double n{};
     double Pb50{};
@@ -123,8 +119,7 @@ namespace PoroMultiPhaseScaTra
   {
     OxygenTransvascularExchangeLawDiscParameters() = default;
 
-    OxygenTransvascularExchangeLawDiscParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    OxygenTransvascularExchangeLawDiscParameters(const std::map<std::string, double>& funct_params);
 
     double n{};
     double Pb50{};
@@ -146,8 +141,7 @@ namespace PoroMultiPhaseScaTra
   {
     LungOxygenExchangeLawParameters() = default;
 
-    LungOxygenExchangeLawParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    LungOxygenExchangeLawParameters(const std::map<std::string, double>& funct_params);
 
     double rho_oxy{};
     double DiffAdVTLC{};
@@ -169,8 +163,7 @@ namespace PoroMultiPhaseScaTra
   {
     LungCarbonDioxideExchangeLawParameters() = default;
 
-    LungCarbonDioxideExchangeLawParameters(
-        const std::vector<std::pair<std::string, double>>& funct_params);
+    LungCarbonDioxideExchangeLawParameters(const std::map<std::string, double>& funct_params);
 
     double rho_CO2{};
     double DiffsolAdVTLC{};

--- a/unittests/poromultiphase_scatra/4C_poromultiphase_scatra_function_test.cpp
+++ b/unittests/poromultiphase_scatra/4C_poromultiphase_scatra_function_test.cpp
@@ -24,7 +24,7 @@ namespace
     void SetUp() override
     {
       // function parameters
-      const std::vector<std::pair<std::string, double>> func_params = {{"rho_oxy", 1.429e-9},
+      const std::map<std::string, double> func_params = {{"rho_oxy", 1.429e-9},
           {"DiffAdVTLC", 5.36}, {"alpha_oxy", 2.1e-4}, {"rho_air", 1.0e-9}, {"rho_bl", 1.03e-6},
           {"n", 3}, {"P_oB50", 3.6}, {"NC_Hb", 0.25}, {"P_atmospheric", 101.3},
           {"volfrac_blood_ref", 0.1}};
@@ -43,7 +43,7 @@ namespace
     void SetUp() override
     {
       // function parameters
-      const std::vector<std::pair<std::string, double>> func_params = {{"rho_CO2", 1.98e-9},
+      const std::map<std::string, double> func_params = {{"rho_CO2", 1.98e-9},
           {"DiffsolAdVTLC", 4.5192e-3}, {"pH", 7.352}, {"rho_air", 1.0e-9}, {"rho_bl", 1.03e-6},
           {"rho_oxy", 1.429e-9}, {"n", 3}, {"P_oB50", 3.6}, {"C_Hb", 18.2}, {"NC_Hb", 0.25},
           {"alpha_oxy", 2.1e-4}, {"P_atmospheric", 101.3}, {"ScalingFormmHg", 133.3e-3},


### PR DESCRIPTION
Replaces `vector<pair<string,T>>` with this more expressive input for yaml. In dat, both are the same.

Note: I deliberately only support string keys for now. In the future, I am open to allowing `int` as well but we are not using this right now. Btw, yaml technically allows arbitrary objects as keys, but I don't think we want this in our code. 

FYI @gilrrei 
