### PR TITLE
Update metadata file to emit lists

### DIFF
--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -235,12 +235,10 @@ void Core::IO::print_metadata_yaml(
 
   {
     auto sections = root["sections"];
-    sections |= ryml::MAP;
+    sections |= ryml::SEQ;
     for (const auto& [name, spec] : section_specs)
     {
       auto section = sections.append_child();
-      section |= ryml::MAP;
-      section << ryml::key(name);
       YamlNodeRef spec_emitter{section, ""};
       spec.emit_metadata(spec_emitter);
     }

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -599,7 +599,21 @@ void write_input_metadata(std::ostream& out)
     }
   }
 
+  // Up to here all the sections allow for multiple entries. Thus, wrap up the specs into
+  // lists.
+  for (auto& [section_name, spec] : section_specs)
+  {
+    spec = Core::IO::InputSpecBuilders::list(section_name, spec);
+  }
+
+  // The so-called "parameters" are key-values which can only appear once. Wrap them up into
+  // groups.
   auto valid_parameters = Input::valid_parameters();
+  for (auto& [section_name, spec] : valid_parameters)
+  {
+    spec = Core::IO::InputSpecBuilders::group(section_name, {spec}, {.required = false});
+  }
+
   section_specs.merge(valid_parameters);
   Core::IO::print_metadata_yaml(out, section_specs);
 }


### PR DESCRIPTION
Use the new `list` feature to properly describe `MATERIALS`, `FUNCT`, etc. These sections contain multiple entries of the same `InputSpec` and this is exactly what `list` encodes.

@gilrrei Sorry it still does not contain all the sections, but I am working on it.