### PR TITLE
Use transpose of displacements and coordinates to avoid copies and be able to reuse core utilities

### DIFF
--- a/src/core/fem/src/general/utils/4C_fem_general_element_dof_matrix.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_element_dof_matrix.hpp
@@ -37,7 +37,7 @@ namespace Core::FE
    * @param values
    * @return Core::LinAlg::Matrix<num_dof_per_node, Core::FE::num_nodes<celltype>>
    */
-  template <Core::FE::CellType celltype, int num_dof_per_node, std::ranges::contiguous_range R>
+  template <Core::FE::CellType celltype, unsigned num_dof_per_node, std::ranges::contiguous_range R>
     requires std::ranges::sized_range<R>
   auto get_element_dof_matrix(R&& values) -> Core::LinAlg::Matrix<num_dof_per_node,
       Core::FE::num_nodes<celltype>, typename std::remove_cvref_t<R>::value_type>
@@ -58,7 +58,7 @@ namespace Core::FE
    outlive
    * the returned matrix object.
    */
-  template <Core::FE::CellType celltype, int num_dof_per_node, std::ranges::contiguous_range R>
+  template <Core::FE::CellType celltype, unsigned num_dof_per_node, std::ranges::contiguous_range R>
     requires std::ranges::sized_range<R>
   auto get_element_dof_matrix_view(R&& values) -> Core::LinAlg::Matrix<num_dof_per_node,
       Core::FE::num_nodes<celltype>, typename std::remove_cvref_t<R>::value_type>
@@ -69,6 +69,41 @@ namespace Core::FE
     constexpr bool view = true;
     return Core::LinAlg::Matrix<num_dof_per_node, Core::FE::num_nodes<celltype>,
         typename std::remove_cvref_t<R>::value_type>(std::ranges::data(values), view);
+  }
+
+  /*!
+   * @brief Get the dof column vector in form of a @p LinAlg::Matrix from a matrix of dof values.
+   *
+   * @tparam celltype : celltype of the element
+   * @tparam num_dof_per_node : Number of dofs per node
+   * @tparam Number : Type of the values
+   * @param matrix : Matrix of the dof values
+   * @return auto
+   */
+  template <Core::FE::CellType celltype, unsigned num_dof_per_node, typename Number>
+  auto get_element_dof_vector(
+      const Core::LinAlg::Matrix<num_dof_per_node, Core::FE::num_nodes<celltype>, Number>& matrix)
+  {
+    return Core::LinAlg::Matrix<num_dof_per_node * Core::FE::num_nodes<celltype>, 1, Number>(
+        matrix.data(), false);
+  }
+
+  /*!
+   * @brief Get a view in form of a dof column vector as @p LinAlg::Matrix to a matrix of
+   * dof values.
+   *
+   * @tparam celltype : celltype of the element
+   * @tparam num_dof_per_node : Number of dofs per node
+   * @tparam Number : Type of the values
+   * @param matrix : Matrix of the dof values
+   * @return auto
+   */
+  template <Core::FE::CellType celltype, unsigned num_dof_per_node, typename Number>
+  auto get_element_dof_vector_view(
+      const Core::LinAlg::Matrix<num_dof_per_node, Core::FE::num_nodes<celltype>, Number>& matrix)
+  {
+    return Core::LinAlg::Matrix<num_dof_per_node * Core::FE::num_nodes<celltype>, 1, Number>(
+        matrix.data(), true);
   }
 }  // namespace Core::FE
 

--- a/src/core/fem/tests/utils/4C_fem_general_element_dof_matrix_test.cpp
+++ b/src/core/fem/tests/utils/4C_fem_general_element_dof_matrix_test.cpp
@@ -82,4 +82,34 @@ namespace
 
     EXPECT_EQ(arr[5], 12.3);
   }
+
+  TEST(ElementDofMatrixTest, GetVector)
+  {
+    const auto arr = get_dof_array<std::array<double, 8>>();
+    const Core::LinAlg::Matrix<2, 4> dof_matrix =
+        Core::FE::get_element_dof_matrix<Core::FE::CellType::quad4, 2>(arr);
+    const Core::LinAlg::Matrix<8, 1> dof_vector =
+        Core::FE::get_element_dof_vector<Core::FE::CellType::quad4, 2>(dof_matrix);
+
+    // copying the data vice versa must result in the same data
+    for (int i = 0; i < 8; ++i)
+    {
+      EXPECT_EQ(dof_vector(i, 0), arr[i]);
+    }
+  }
+
+  TEST(ElementDofMatrixTest, GetVectorView)
+  {
+    const auto arr = get_dof_array<std::array<double, 8>>();
+    const Core::LinAlg::Matrix<2, 4> dof_matrix =
+        Core::FE::get_element_dof_matrix<Core::FE::CellType::quad4, 2>(arr);
+    const Core::LinAlg::Matrix<8, 1> dof_vector =
+        Core::FE::get_element_dof_vector_view<Core::FE::CellType::quad4, 2>(dof_matrix);
+
+    // copying the data vice versa must result in the same data
+    for (int i = 0; i < 8; ++i)
+    {
+      EXPECT_EQ(dof_vector(i, 0), arr[i]);
+    }
+  }
 }  // namespace

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_displacement_based.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_displacement_based.hpp
@@ -110,20 +110,20 @@ namespace Discret::Elements
     {
       Core::LinAlg::Matrix<9, Core::FE::dim<celltype>> d_F_dxi{};
 
-      Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, Core::FE::dim<celltype>> xXF(true);
+      Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::num_nodes<celltype>> xXFT(true);
       Core::LinAlg::Matrix<Core::FE::dim<celltype>,
           Core::FE::DisTypeToNumDeriv2<celltype>::numderiv2>
           xXFsec(true);
-      xXF.update(1.0, element_nodes.reference_coordinates, 0.0);
-      xXF.update(1.0, element_nodes.displacements, 1.0);
-      xXF.multiply_nt(-1.0, element_nodes.reference_coordinates, deformation_gradient, 1.0);
+      xXFT.update(1.0, element_nodes.reference_coordinates, 0.0);
+      xXFT.update(1.0, element_nodes.displacements, 1.0);
+      xXFT.multiply(-1.0, deformation_gradient, element_nodes.reference_coordinates, 1.0);
 
       Core::LinAlg::Matrix<Core::FE::DisTypeToNumDeriv2<celltype>::numderiv2,
           Core::FE::num_nodes<celltype>>
           deriv2(true);
       Core::FE::shape_function_deriv2<celltype>(xi, deriv2);
 
-      xXFsec.multiply_tt(1.0, xXF, deriv2, 0.0);
+      xXFsec.multiply_nt(1.0, xXFT, deriv2, 0.0);
 
       for (int a = 0; a < Core::FE::dim<celltype>; ++a)
       {
@@ -174,7 +174,7 @@ namespace Discret::Elements
           Core::FE::num_nodes<celltype>>
           deriv2(true);
       Core::FE::shape_function_deriv2<celltype>(xi, deriv2);
-      Xsec.multiply(1.0, deriv2, element_nodes.reference_coordinates, 0.0);
+      Xsec.multiply_nt(1.0, deriv2, element_nodes.reference_coordinates, 0.0);
       N_XYZ_Xsec.multiply_tt(1.0, jacobian_mapping.N_XYZ_, Xsec, 0.0);
 
       for (int i = 0; i < Core::FE::dim<celltype>; ++i)

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_mulf.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_mulf.hpp
@@ -40,7 +40,7 @@ namespace Discret::Elements
   Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::dim<celltype>>
   evaluate_mulf_deformation_gradient_update(
       const Discret::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
-      const Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, Core::FE::dim<celltype>>&
+      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::num_nodes<celltype>>&
           nodal_displacements,
       const Discret::Elements::MulfHistoryData<celltype>& mulf_history_data)
   {
@@ -51,7 +51,7 @@ namespace Discret::Elements
     Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::dim<celltype>> defgrd =
         Core::LinAlg::identity_matrix<Core::FE::dim<celltype>>();
 
-    defgrd.multiply_tt(1.0, nodal_displacements, N_xyz, 1.0);
+    defgrd.multiply_nt(1.0, nodal_displacements, N_xyz, 1.0);
 
     return defgrd;
   }
@@ -63,7 +63,7 @@ namespace Discret::Elements
   Discret::Elements::SpatialMaterialMapping<celltype> evaluate_mulf_spatial_material_mapping(
       const Discret::Elements::JacobianMapping<celltype>& jacobian_mapping,
       const Discret::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
-      const Core::LinAlg::Matrix<Core::FE::num_nodes<celltype>, Core::FE::dim<celltype>>&
+      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::num_nodes<celltype>>&
           nodal_displacements,
       const Discret::Elements::MulfHistoryData<celltype>& mulf_history_data)
   {

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_shell_ans_lib.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_shell_ans_lib.hpp
@@ -62,7 +62,8 @@ namespace Discret::Elements
         Internal::num_dof_per_ele<Core::FE::CellType::hex8>>
         bop_loc{};
     Core::LinAlg::Matrix<3, 3> current_jacobian(jacobian_mapping.jacobian_);
-    current_jacobian.multiply(1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
+    current_jacobian.multiply_nt(
+        1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
 
     for (int inode = 0; inode < Core::FE::num_nodes<Core::FE::CellType::hex8>; ++inode)
     {
@@ -118,7 +119,8 @@ namespace Discret::Elements
         Internal::num_dof_per_ele<Core::FE::CellType::wedge6>>
         bop_loc{};
     Core::LinAlg::Matrix<3, 3> current_jacobian(jacobian_mapping.jacobian_);
-    current_jacobian.multiply(1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
+    current_jacobian.multiply_nt(
+        1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
 
     for (int inode = 0; inode < Core::FE::num_nodes<Core::FE::CellType::wedge6>; ++inode)
     {
@@ -165,7 +167,8 @@ namespace Discret::Elements
       const std::array<SamplingPointData<Core::FE::CellType::hex8>, 8>& sampling_point_data)
   {
     Core::LinAlg::Matrix<3, 3> current_jacobian(jacobian_mapping.jacobian_);
-    current_jacobian.multiply(1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
+    current_jacobian.multiply_nt(
+        1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
 
     Core::LinAlg::Matrix<Internal::num_str<Core::FE::CellType::hex8>, 1> glstrain;
     // evaluate glstrains in local(parameter) coords
@@ -275,7 +278,8 @@ namespace Discret::Elements
       const std::array<SamplingPointData<Core::FE::CellType::wedge6>, 5>& sampling_point_data)
   {
     Core::LinAlg::Matrix<3, 3> current_jacobian(jacobian_mapping.jacobian_);
-    current_jacobian.multiply(1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
+    current_jacobian.multiply_nt(
+        1.0, shape_functions.derivatives_, element_nodes.displacements, 1.0);
 
     Core::LinAlg::Matrix<Internal::num_str<Core::FE::CellType::wedge6>, 1> glstrain;
     // evaluate glstrains in local(parameter) coords
@@ -525,11 +529,11 @@ namespace Discret::Elements
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions =
           sampling_point_data[i].shape_functions;
 
-      sampling_point_data[i].reference_jacobian.multiply(
+      sampling_point_data[i].reference_jacobian.multiply_nt(
           shape_functions.derivatives_, nodal_coordinates.reference_coordinates);
 
       sampling_point_data[i].current_jacobian = sampling_point_data[i].reference_jacobian;
-      sampling_point_data[i].current_jacobian.multiply(
+      sampling_point_data[i].current_jacobian.multiply_nt(
           1.0, shape_functions.derivatives_, nodal_coordinates.displacements, 1.0);
 
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
@@ -119,7 +119,7 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
 
         // material/reference co-ordinates of Gauss point
         Core::LinAlg::Matrix<numdim, 1> gauss_point_reference_coordinates;
-        gauss_point_reference_coordinates.multiply_tn(
+        gauss_point_reference_coordinates.multiply_nn(
             nodal_coordinates.reference_coordinates, shape_functions.shapefunctions_);
 
         for (auto dim = 0; dim < numdim; dim++)

--- a/unittests/solid_3D_ele/4C_solid_3D_ele_calc_lib_test.cpp
+++ b/unittests/solid_3D_ele/4C_solid_3D_ele_calc_lib_test.cpp
@@ -79,36 +79,36 @@ namespace
     Discret::Elements::ElementNodes<distype> nodal_coordinates;
 
     nodal_coordinates.reference_coordinates(0, 0) = 0;
-    nodal_coordinates.reference_coordinates(0, 1) = 0;
-    nodal_coordinates.reference_coordinates(0, 2) = 0;
+    nodal_coordinates.reference_coordinates(1, 0) = 0;
+    nodal_coordinates.reference_coordinates(2, 0) = 0;
 
-    nodal_coordinates.reference_coordinates(1, 0) = 4;
+    nodal_coordinates.reference_coordinates(0, 1) = 4;
     nodal_coordinates.reference_coordinates(1, 1) = 0;
-    nodal_coordinates.reference_coordinates(1, 2) = 0;
+    nodal_coordinates.reference_coordinates(2, 1) = 0;
 
-    nodal_coordinates.reference_coordinates(2, 0) = 4;
-    nodal_coordinates.reference_coordinates(2, 1) = 1;
+    nodal_coordinates.reference_coordinates(0, 2) = 4;
+    nodal_coordinates.reference_coordinates(1, 2) = 1;
     nodal_coordinates.reference_coordinates(2, 2) = 0;
 
-    nodal_coordinates.reference_coordinates(3, 0) = 0;
-    nodal_coordinates.reference_coordinates(3, 1) = 1;
-    nodal_coordinates.reference_coordinates(3, 2) = 0;
+    nodal_coordinates.reference_coordinates(0, 3) = 0;
+    nodal_coordinates.reference_coordinates(1, 3) = 1;
+    nodal_coordinates.reference_coordinates(2, 3) = 0;
 
-    nodal_coordinates.reference_coordinates(4, 0) = 0;
-    nodal_coordinates.reference_coordinates(4, 1) = 0;
-    nodal_coordinates.reference_coordinates(4, 2) = 2;
+    nodal_coordinates.reference_coordinates(0, 4) = 0;
+    nodal_coordinates.reference_coordinates(1, 4) = 0;
+    nodal_coordinates.reference_coordinates(2, 4) = 2;
 
-    nodal_coordinates.reference_coordinates(5, 0) = 4;
-    nodal_coordinates.reference_coordinates(5, 1) = 0;
-    nodal_coordinates.reference_coordinates(5, 2) = 2;
+    nodal_coordinates.reference_coordinates(0, 5) = 4;
+    nodal_coordinates.reference_coordinates(1, 5) = 0;
+    nodal_coordinates.reference_coordinates(2, 5) = 2;
 
-    nodal_coordinates.reference_coordinates(6, 0) = 4;
-    nodal_coordinates.reference_coordinates(6, 1) = 1;
-    nodal_coordinates.reference_coordinates(6, 2) = 2;
+    nodal_coordinates.reference_coordinates(0, 6) = 4;
+    nodal_coordinates.reference_coordinates(1, 6) = 1;
+    nodal_coordinates.reference_coordinates(2, 6) = 2;
 
-    nodal_coordinates.reference_coordinates(7, 0) = 0;
-    nodal_coordinates.reference_coordinates(7, 1) = 1;
-    nodal_coordinates.reference_coordinates(7, 2) = 2;
+    nodal_coordinates.reference_coordinates(0, 7) = 0;
+    nodal_coordinates.reference_coordinates(1, 7) = 1;
+    nodal_coordinates.reference_coordinates(2, 7) = 2;
 
     Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(true);
     x_centroid_ref(0) = 2;
@@ -131,20 +131,20 @@ namespace
     Discret::Elements::ElementNodes<distype> nodal_coordinates;
 
     nodal_coordinates.reference_coordinates(0, 0) = 0;
-    nodal_coordinates.reference_coordinates(0, 1) = 0;
-    nodal_coordinates.reference_coordinates(0, 2) = 0;
-
-    nodal_coordinates.reference_coordinates(1, 0) = 1;
-    nodal_coordinates.reference_coordinates(1, 1) = 0;
-    nodal_coordinates.reference_coordinates(1, 2) = 0;
-
+    nodal_coordinates.reference_coordinates(1, 0) = 0;
     nodal_coordinates.reference_coordinates(2, 0) = 0;
-    nodal_coordinates.reference_coordinates(2, 1) = 2;
+
+    nodal_coordinates.reference_coordinates(0, 1) = 1;
+    nodal_coordinates.reference_coordinates(1, 1) = 0;
+    nodal_coordinates.reference_coordinates(2, 1) = 0;
+
+    nodal_coordinates.reference_coordinates(0, 2) = 0;
+    nodal_coordinates.reference_coordinates(1, 2) = 2;
     nodal_coordinates.reference_coordinates(2, 2) = 0;
 
-    nodal_coordinates.reference_coordinates(3, 0) = 0;
-    nodal_coordinates.reference_coordinates(3, 1) = 0;
-    nodal_coordinates.reference_coordinates(3, 2) = 4;
+    nodal_coordinates.reference_coordinates(0, 3) = 0;
+    nodal_coordinates.reference_coordinates(1, 3) = 0;
+    nodal_coordinates.reference_coordinates(2, 3) = 4;
 
     Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(true);
     x_centroid_ref(0) = 0.25;
@@ -167,24 +167,24 @@ namespace
     Discret::Elements::ElementNodes<distype> nodal_coordinates;
 
     nodal_coordinates.reference_coordinates(0, 0) = -2;
-    nodal_coordinates.reference_coordinates(0, 1) = -1;
-    nodal_coordinates.reference_coordinates(0, 2) = 0;
+    nodal_coordinates.reference_coordinates(1, 0) = -1;
+    nodal_coordinates.reference_coordinates(2, 0) = 0;
 
-    nodal_coordinates.reference_coordinates(1, 0) = 4;
+    nodal_coordinates.reference_coordinates(0, 1) = 4;
     nodal_coordinates.reference_coordinates(1, 1) = -1;
-    nodal_coordinates.reference_coordinates(1, 2) = 0;
+    nodal_coordinates.reference_coordinates(2, 1) = 0;
 
-    nodal_coordinates.reference_coordinates(2, 0) = 4;
-    nodal_coordinates.reference_coordinates(2, 1) = 1;
+    nodal_coordinates.reference_coordinates(0, 2) = 4;
+    nodal_coordinates.reference_coordinates(1, 2) = 1;
     nodal_coordinates.reference_coordinates(2, 2) = 0;
 
-    nodal_coordinates.reference_coordinates(3, 0) = -2;
-    nodal_coordinates.reference_coordinates(3, 1) = 1;
-    nodal_coordinates.reference_coordinates(3, 2) = 0;
+    nodal_coordinates.reference_coordinates(0, 3) = -2;
+    nodal_coordinates.reference_coordinates(1, 3) = 1;
+    nodal_coordinates.reference_coordinates(2, 3) = 0;
 
-    nodal_coordinates.reference_coordinates(4, 0) = 1;
-    nodal_coordinates.reference_coordinates(4, 1) = 0;
-    nodal_coordinates.reference_coordinates(4, 2) = 4;
+    nodal_coordinates.reference_coordinates(0, 4) = 1;
+    nodal_coordinates.reference_coordinates(1, 4) = 0;
+    nodal_coordinates.reference_coordinates(2, 4) = 4;
 
     Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(true);
     x_centroid_ref(0) = 1.0;
@@ -207,28 +207,28 @@ namespace
     Discret::Elements::ElementNodes<distype> nodal_coordinates;
 
     nodal_coordinates.reference_coordinates(0, 0) = 0;
-    nodal_coordinates.reference_coordinates(0, 1) = 0;
-    nodal_coordinates.reference_coordinates(0, 2) = 0;
-
-    nodal_coordinates.reference_coordinates(1, 0) = 3;
-    nodal_coordinates.reference_coordinates(1, 1) = 0;
-    nodal_coordinates.reference_coordinates(1, 2) = 0;
-
+    nodal_coordinates.reference_coordinates(1, 0) = 0;
     nodal_coordinates.reference_coordinates(2, 0) = 0;
-    nodal_coordinates.reference_coordinates(2, 1) = 6;
+
+    nodal_coordinates.reference_coordinates(0, 1) = 3;
+    nodal_coordinates.reference_coordinates(1, 1) = 0;
+    nodal_coordinates.reference_coordinates(2, 1) = 0;
+
+    nodal_coordinates.reference_coordinates(0, 2) = 0;
+    nodal_coordinates.reference_coordinates(1, 2) = 6;
     nodal_coordinates.reference_coordinates(2, 2) = 0;
 
-    nodal_coordinates.reference_coordinates(3, 0) = 0;
-    nodal_coordinates.reference_coordinates(3, 1) = 0;
-    nodal_coordinates.reference_coordinates(3, 2) = 1;
+    nodal_coordinates.reference_coordinates(0, 3) = 0;
+    nodal_coordinates.reference_coordinates(1, 3) = 0;
+    nodal_coordinates.reference_coordinates(2, 3) = 1;
 
-    nodal_coordinates.reference_coordinates(4, 0) = 3;
-    nodal_coordinates.reference_coordinates(4, 1) = 0;
-    nodal_coordinates.reference_coordinates(4, 2) = 1;
+    nodal_coordinates.reference_coordinates(0, 4) = 3;
+    nodal_coordinates.reference_coordinates(1, 4) = 0;
+    nodal_coordinates.reference_coordinates(2, 4) = 1;
 
-    nodal_coordinates.reference_coordinates(5, 0) = 0;
-    nodal_coordinates.reference_coordinates(5, 1) = 6;
-    nodal_coordinates.reference_coordinates(5, 2) = 1;
+    nodal_coordinates.reference_coordinates(0, 5) = 0;
+    nodal_coordinates.reference_coordinates(1, 5) = 6;
+    nodal_coordinates.reference_coordinates(2, 5) = 1;
 
     Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(true);
     x_centroid_ref(0) = 1;


### PR DESCRIPTION
This PR applies the transpose to the displacements in the element dof matrices to reuse core utilities and avoid unnecessary copies.