### PR TITLE
Add missing definitions of class `Core::LinAlg::Solver`

### DIFF
--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -13,6 +13,7 @@
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
 #include "4C_structure_new_dbc.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -17,6 +17,7 @@
 #include "4C_inpar_structure.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
 #include "4C_solver_nonlin_nox_constraint_interface_preconditioner.hpp"
 #include "4C_solver_nonlin_nox_constraint_interface_required.hpp"


### PR DESCRIPTION
Without these 2 additional headers the code does not compile with `Trilinos` built in debug mode. The error was here:
```
include/Teuchos_TypeNameTraits.hpp:58:27: error: invalid use of incomplete type ‘class FourC::Core::LinAlg::Solver’
   58 |       return demangleName(typeid(T).name());
```