### PR TITLE
InputSpec can emit data to yaml files

### DIFF
--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -60,6 +60,23 @@ void Core::IO::InputSpec::match(ConstYamlNodeRef yaml, InputParameterContainer& 
   match_tree.assert_match();
 }
 
+void Core::IO::InputSpec::emit(YamlNodeRef yaml,
+    FourC::Core::IO::InputParameterContainer& container, InputSpecEmitOptions options) const
+{
+  FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
+
+  bool success = pimpl_->emit(yaml, container, options);
+  if (!success)
+  {
+    std::stringstream ss;
+    ss << "Failed to emit this data\n";
+    container.print(ss);
+    ss << "under the following specification\n";
+    print_as_dat(ss);
+    FOUR_C_THROW(ss.str().c_str());
+  }
+}
+
 void Core::IO::InputSpec::print_as_dat(std::ostream& stream) const
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -27,6 +27,15 @@ namespace Core::IO
     class InputSpecTypeErasedBase;
   }  // namespace Internal
 
+  struct InputSpecEmitOptions
+  {
+    /**
+     * If set to true, entries which have a default value are emitted even if their values are equal
+     * to the default.
+     */
+    bool emit_defaulted_values{false};
+  };
+
   /**
    * Objects of this class encapsulate knowledge about the input. You can create objects using the
    * helper functions in the InputSpecBuilders namespace. See the function
@@ -60,6 +69,14 @@ namespace Core::IO
      * content.
      */
     void match(ConstYamlNodeRef yaml, InputParameterContainer& container) const;
+
+    /**
+     * Emit the data in @p container to @p yaml. The data in @p container has to fit the
+     * specification encoded in this InputSpec; otherwise an exception is thrown. This function is
+     * the inverse of match().
+     */
+    void emit(YamlNodeRef yaml, InputParameterContainer& container,
+        InputSpecEmitOptions options = {}) const;
 
     /**
      * Print the expected input format of this InputSpec to @p stream in dat format.


### PR DESCRIPTION
Paves the way towards a `dat` -> `yaml` converter
