### PR TITLE
Improvements to input mechanism

### DIFF
--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -220,20 +220,24 @@ namespace Core::IO
      * associated with this object. Depending on the section size, the content might need to be
      * distributed from rank 0 to all other ranks. This happens automatically.
      */
-    FragmentIteratorRange in_section(const std::string& section_name);
+    FragmentIteratorRange in_section(const std::string& section_name) const;
 
     /**
      * This function is similar to in_section(), but it only returns the lines on rank 0 and
      * returns an empty range on all other ranks. This is useful for sections that might be huge and
      * are not processed on all ranks.
      */
-    FragmentIteratorRange in_section_rank_0_only(const std::string& section_name);
+    FragmentIteratorRange in_section_rank_0_only(const std::string& section_name) const;
 
     /**
-     * Match a whole section named @p section_name against the given @p spec.
+     * Match a whole section named @p section_name against the input file content. The results are
+     * stored in the @p container. If the section is not known, an exception is thrown. Note that
+     * you do not need to pass an InputSpec to this function, since the InputFile object already
+     * knows about the expected format of the section. Nevertheless, this function only makes sense
+     * for sections with a known InputSpec. Legacy string sections cannot use this function and must
+     * be processed with in_section() or in_section_rank_0_only().
      */
-    void match_section(
-        const std::string& section_name, const InputSpec& spec, InputParameterContainer& container);
+    void match_section(const std::string& section_name, InputParameterContainer& container) const;
 
     /**
      * Returns true if the input file contains a section with the given name.

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -219,13 +219,6 @@ void Core::IO::print_dat(
   }
 }
 
-
-void Core::IO::print_metadata_yaml(
-    std::ostream& stream, const std::map<std::string, InputSpec>& section_specs)
-{
-}
-
-
 bool Core::IO::need_to_print_equal_sign(const Teuchos::ParameterList& list)
 {
   // Helper function to check if string contains a space.
@@ -349,28 +342,18 @@ namespace
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::IO::read_parameters_in_section(InputFile& input, const std::string& section_name,
-    Teuchos::ParameterList& list, const InputSpec& spec)
+void Core::IO::read_parameters_in_section(
+    InputFile& input, const std::string& section_name, Teuchos::ParameterList& list)
 {
   if (section_name.empty()) FOUR_C_THROW("Empty section name given.");
 
   InputParameterContainer container;
-  Teuchos::ParameterList& sublist = find_sublist(section_name, list);
-  if (input.has_section(section_name))
-  {
-    input.match_section(section_name, spec, container);
-  }
-  else
-  {
-    // Match against an empty section to get all the defaults set correctly.
-    ryml::Tree tree = init_yaml_tree_with_exceptions();
-    ryml::NodeRef root = tree.rootref();
-    root |= ryml::MAP;
-    ConstYamlNodeRef yaml{root, ""};
-    spec.match(yaml, container);
-  }
+  input.match_section(section_name, container);
 
-  container.to_teuchos_parameter_list(sublist);
+  FOUR_C_ASSERT(container.has_group(section_name),
+      "Internal error: group '%s' not found in container.", section_name.c_str());
+
+  container.group(section_name).to_teuchos_parameter_list(find_sublist(section_name, list));
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/core/io/src/4C_io_input_file_utils.hpp
+++ b/src/core/io/src/4C_io_input_file_utils.hpp
@@ -60,16 +60,6 @@ namespace Core::IO
   void print_dat(std::ostream& stream, const std::map<std::string, Core::IO::InputSpec>& map);
 
   /**
-   * Print the metadata for @p section_specs which contains the InputSpec which may be read for a
-   * specific section.
-   *
-   * The output is formatted as YAML. This information can be useful for additional tools that
-   * generate schema files or documentation.
-   */
-  void print_metadata_yaml(
-      std::ostream& stream, const std::map<std::string, InputSpec>& section_specs = {});
-
-  /**
    * Return true if the @p list contains any parameter that has whitespace in the key name.
    *
    * @note This is needed for the NOX parameters whose keywords and value have white spaces and
@@ -117,8 +107,8 @@ namespace Core::IO
    */
   std::pair<std::string, std::string> read_key_value(const std::string& line);
 
-  void read_parameters_in_section(InputFile& input, const std::string& section_name,
-      Teuchos::ParameterList& list, const InputSpec& spec);
+  void read_parameters_in_section(
+      InputFile& input, const std::string& section_name, Teuchos::ParameterList& list);
 
   /**
    * Read a node-design topology section. This is a collective call that propagates data that

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -635,8 +635,11 @@ bool Core::IO::InputSpecBuilders::Internal::GroupSpec::match(ConstYamlNodeRef no
   FOUR_C_ASSERT(node.node.is_map(), "Internal error: group node must be a map.");
   const auto group_name = ryml::to_csubstr(name);
 
-  const bool group_exists = node.node.has_child(group_name) && node.node[group_name].is_map();
-  if (!group_exists)
+  const bool group_node_is_input = node.node.has_key() && (node.node.key() == group_name);
+  const bool group_exists_nested =
+      node.node.has_child(group_name) && node.node[group_name].is_map();
+
+  if (!group_exists_nested && !group_node_is_input)
   {
     if (data.defaultable)
     {
@@ -646,7 +649,8 @@ bool Core::IO::InputSpecBuilders::Internal::GroupSpec::match(ConstYamlNodeRef no
     return !data.required.value();
   }
 
-  auto group_node = node.wrap(node.node[group_name]);
+  auto group_node = group_node_is_input ? node : node.wrap(node.node[group_name]);
+
   // Matching the key of the group is at least a partial match.
   match_entry.state = IO::Internal::MatchEntry::State::partial;
   match_entry.matched_node = group_node.node.id();

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -603,7 +603,13 @@ namespace Core::IO
       /**
        * Whether the Group is required or optional.
        */
-      bool required{true};
+      std::optional<bool> required{};
+
+      /**
+       * Whether the Group will store itself and its children with defaulted values, if the Group
+       * is not encountered in the input. This only works if all children have default values.
+       */
+      bool defaultable{};
     };
 
     //! Additional parameters for a list().
@@ -1006,10 +1012,18 @@ namespace Core::IO
      * exactly what you need: a group activates a feature which requires certain parameters to
      * be present.
      *
-     * Whether a group has a default value is determined by the default values of its entries. If
-     * all entries have default values, the group implicitly has a default value. In this case, if
-     * the group is optional and not present in the input, the default values of the entries are
-     * stored under the group name in the container.
+     * Whether a group can have a default value is determined by the default values of its entries.
+     * If all of its entries have default values, the group can have a default value. In this case,
+     * you may set the `defaultable` option to guarantee that the default values of the entries are
+     * stored under the group name in the container, even if the group is not present in the input.
+     * Obviously, this only makes sense if the group is not required.
+     * This behavior is analogous to the behavior of the entry() function. While entries with
+     * default values are often a good idea (if the default value is meaningful), groups with
+     * default values are less common. If you follow the advice to use groups to activate features,
+     * you will usually have required entries in the group and, consequently, the group cannot be
+     * `defaultable`. Put differently, if you have a group with many default values, you are likely
+     * not using the InputSpecs to their full potential. Consider splitting the group into multiple
+     * smaller groups or use the one_of() function to select between different groups.
      *
      * @note If you want to group multiple InputSpecs without creating a new named scope, use the
      * all_of() function.

--- a/src/core/io/tests/4C_io_input_file_test.cpp
+++ b/src/core/io/tests/4C_io_input_file_test.cpp
@@ -127,15 +127,19 @@ namespace
 
   TEST(InputFile, YamlIncludes)
   {
+    using namespace Core::IO::InputSpecBuilders;
     const std::string input_file_name =
         TESTING::get_support_file_path("test_files/yaml_includes/main.yaml");
 
     MPI_Comm comm(MPI_COMM_WORLD);
-    Core::IO::InputFile input{{},
+    Core::IO::InputFile input{{{"INCLUDED SECTION 2", all_of({
+                                                          entry<int>("a"),
+                                                          entry<double>("b"),
+                                                          entry<bool>("c"),
+                                                      })}},
         {
             "MAIN SECTION",
             "INCLUDED SECTION 1",
-            "INCLUDED SECTION 2",
             "INCLUDED SECTION 3",
             "SECTION WITH SUBSTRUCTURE",
         },
@@ -154,7 +158,7 @@ namespace
     });
 
     Core::IO::InputParameterContainer container;
-    input.match_section("INCLUDED SECTION 2", spec, container);
+    input.match_section("INCLUDED SECTION 2", container);
     EXPECT_EQ(container.get<int>("a"), 1);
     EXPECT_EQ(container.get<double>("b"), 2.0);
     EXPECT_EQ(container.get<bool>("c"), true);

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -800,6 +800,42 @@ specs:
     }
   }
 
+  TEST(InputSpecTest, MatchYamlGroup)
+  {
+    auto spec = group("group", {
+                                   entry<int>("a"),
+                                   entry<std::string>("b"),
+                               });
+
+    {
+      ryml::Tree tree = init_yaml_tree_with_exceptions();
+      ryml::NodeRef root = tree.rootref();
+
+      root |= ryml::MAP;
+      root["group"] |= ryml::MAP;
+      root["group"]["a"] << 1;
+      root["group"]["b"] << "b";
+
+      {
+        SCOPED_TRACE("Match root node.");
+        ConstYamlNodeRef node(root, "");
+        InputParameterContainer container;
+        spec.match(node, container);
+        EXPECT_EQ(container.group("group").get<int>("a"), 1);
+        EXPECT_EQ(container.group("group").get<std::string>("b"), "b");
+      }
+
+      {
+        SCOPED_TRACE("Match group node.");
+        ConstYamlNodeRef node(root["group"], "");
+        InputParameterContainer container;
+        spec.match(node, container);
+        EXPECT_EQ(container.group("group").get<int>("a"), 1);
+        EXPECT_EQ(container.group("group").get<std::string>("b"), "b");
+      }
+    }
+  }
+
 
   TEST(InputSpecTest, MatchYamlAllOf)
   {

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -383,6 +383,7 @@ namespace
             },
             {
                 .required = false,
+                .defaultable = true,
             }),
         entry<std::string>("c"),
     });
@@ -677,7 +678,6 @@ specs:
     size: 3
   - type: one_of
     description: 'one_of {all_of {b, c}, group}'
-    required: true
     specs:
       - type: all_of
         description: 'all_of {b, c}'
@@ -696,6 +696,7 @@ specs:
         type: group
         description: A group
         required: true
+        defaultable: false
         specs:
           - name: c
             type: string
@@ -714,6 +715,7 @@ specs:
   - name: group2
     type: group
     required: false
+    defaultable: false
     specs:
       - name: g
         type: int

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -1022,14 +1022,30 @@ specs:
         first_entry["a"] << 1;
         first_entry["b"] << "string";
       }
-      ConstYamlNodeRef node(root, "");
 
-      InputParameterContainer container;
-      spec.match(node, container);
-      const auto& list = container.get_list("list");
-      EXPECT_EQ(list.size(), 1);
-      EXPECT_EQ(list[0].get<int>("a"), 1);
-      EXPECT_EQ(list[0].get<std::string>("b"), "string");
+      {
+        SCOPED_TRACE("Match root node.");
+        ConstYamlNodeRef node(root, "");
+
+        InputParameterContainer container;
+        spec.match(node, container);
+        const auto& list = container.get_list("list");
+        EXPECT_EQ(list.size(), 1);
+        EXPECT_EQ(list[0].get<int>("a"), 1);
+        EXPECT_EQ(list[0].get<std::string>("b"), "string");
+      }
+
+      {
+        SCOPED_TRACE("Match list node.");
+        ConstYamlNodeRef node(root["list"], "");
+
+        InputParameterContainer container;
+        spec.match(node, container);
+        const auto& list = container.get_list("list");
+        EXPECT_EQ(list.size(), 1);
+        EXPECT_EQ(list[0].get<int>("a"), 1);
+        EXPECT_EQ(list[0].get<std::string>("b"), "string");
+      }
     }
 
     // unmatched node

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -110,7 +110,7 @@ namespace
     auto valid_parameters = Input::valid_parameters();
     for (auto& [section_name, spec] : valid_parameters)
     {
-      spec = Core::IO::InputSpecBuilders::group(section_name, {spec}, {.required = false});
+      spec = Core::IO::InputSpecBuilders::group(section_name, {spec}, {.defaultable = true});
     }
 
     section_specs.merge(valid_parameters);
@@ -1869,9 +1869,9 @@ void Global::read_parameter(Global::Problem& problem, Core::IO::InputFile& input
 
   auto parameter_section_specs = Input::valid_parameters();
 
-  for (const auto& [section_name, spec] : parameter_section_specs)
+  for (const auto& [section_name, _] : parameter_section_specs)
   {
-    Core::IO::read_parameters_in_section(input, section_name, *list, spec);
+    Core::IO::read_parameters_in_section(input, section_name, *list);
   }
 
   // check for invalid parameters


### PR DESCRIPTION
The first four commits introduce small enhancements to existing `InputSpec` functionality to enable the fifth commit, where `InputSpec` is used more directly in `InputFile`.

Found while working on #382 