### PR TITLE
Rework `Core::FE::extract_my_values()`

### DIFF
--- a/src/ale/4C_ale_ale2_evaluate.cpp
+++ b/src/ale/4C_ale_ale2_evaluate.cpp
@@ -65,8 +65,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       static_ke_nonlinear(lm, my_dispnp, &elemat1, &elevec1, params, true, false);
 
@@ -76,8 +75,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       static_ke_nonlinear(lm, my_dispnp, &elemat1, &elevec1, params, spatialconfiguration, true);
 
@@ -87,8 +85,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
       static_ke_laplace(discretization, lm, &elemat1, elevec1, my_dispnp, spatialconfiguration);
 
       break;
@@ -97,8 +94,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
       static_ke_laplace(discretization, lm, &elemat1, elevec1, my_dispnp, true);
 
       break;
@@ -107,8 +103,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");  // get the displacements
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       static_ke_spring(&elemat1, elevec1, my_dispnp, spatialconfiguration);
 
@@ -118,8 +113,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");  // get the displacements
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       static_ke_spring(&elemat1, elevec1, my_dispnp, true);
 
@@ -151,8 +145,7 @@ int Discret::Elements::Ale2::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       compute_det_jac(elevec1, lm, my_dispnp);
 

--- a/src/ale/4C_ale_ale3_evaluate.cpp
+++ b/src/ale/4C_ale_ale3_evaluate.cpp
@@ -129,11 +129,9 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
   {
     case calc_ale_laplace_material:
     {
-      std::vector<double> my_dispnp;
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      my_dispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->static_ke_laplace(
           this, discretization, elemat1, elevec1, my_dispnp, mat, false);
@@ -142,11 +140,9 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
     }
     case calc_ale_laplace_spatial:
     {
-      std::vector<double> my_dispnp;
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      my_dispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->static_ke_laplace(
           this, discretization, elemat1, elevec1, my_dispnp, mat, true);
@@ -157,8 +153,7 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->static_ke_nonlinear(
           this, discretization, lm, elemat1, elevec1, my_dispnp, params, true);
@@ -169,8 +164,7 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->static_ke_nonlinear(
           this, discretization, lm, elemat1, elevec1, my_dispnp, params, false);
@@ -181,8 +175,7 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->static_ke_spring(this, elemat1, elevec1, my_dispnp, false);
 
@@ -192,8 +185,7 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->static_ke_spring(this, elemat1, elevec1, my_dispnp, true);
 
@@ -203,8 +195,7 @@ int Discret::Elements::Ale3::evaluate(Teuchos::ParameterList& params,
     {
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp =
           discretization.get_state("dispnp");
-      std::vector<double> my_dispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, my_dispnp, lm);
+      std::vector<double> my_dispnp = Core::FE::extract_values(*dispnp, lm);
 
       Ale3ImplInterface::impl(this)->element_node_normal(this, elevec1, my_dispnp);
 

--- a/src/ale/4C_ale_ale3_surface_evaluate.cpp
+++ b/src/ale/4C_ale_ale3_surface_evaluate.cpp
@@ -71,7 +71,7 @@ int Discret::Elements::Ale3Surface::evaluate(Teuchos::ParameterList& params,
       if (dispnp != nullptr)
       {
         mydispnp.resize(lm.size());
-        Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+        mydispnp = Core::FE::extract_values(*dispnp, lm);
       }
 
       Ale3SurfaceImplInterface::impl(this)->element_node_normal(

--- a/src/art_net/4C_art_net_art_write_gnuplot.cpp
+++ b/src/art_net/4C_art_net_art_write_gnuplot.cpp
@@ -312,8 +312,7 @@ void Arteries::Utils::ArtWriteGnuplot::write(Core::FE::Discretization& discret,
 
     // get the degrees of freedom
     std::shared_ptr<const Core::LinAlg::Vector<double>> qanp = discret.get_state("qanp");
-    std::vector<double> myqanp(lm.size());
-    Core::FE::extract_my_values(*qanp, myqanp, lm);
+    std::vector<double> myqanp = Core::FE::extract_values(*qanp, lm);
 
     // get the current simulation time
     time = params.get<double>("total time");

--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
@@ -105,8 +105,7 @@ int Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate(Artery* ele,
   if (qanp == nullptr) FOUR_C_THROW("Cannot get state vectors 'qanp'");
 
   // extract local values from the global vectors
-  std::vector<double> myqanp(la[0].lm_.size());
-  Core::FE::extract_my_values(*qanp, myqanp, la[0].lm_);
+  std::vector<double> myqanp = Core::FE::extract_values(*qanp, la[0].lm_);
 
   // create objects for element arrays
   Core::LinAlg::Matrix<numnode, 1> eareanp;
@@ -245,8 +244,7 @@ int Discret::Elements::ArteryEleCalcLinExp<distype>::scatra_evaluate(Artery* ele
   // extract local values from the global vectors
   std::vector<double> myqanp(lm.size());
   std::vector<double> myqan(lm.size());
-  std::vector<double> myescatran(lm.size());
-  Core::FE::extract_my_values(*scatran, myescatran, lm);
+  std::vector<double> myescatran = Core::FE::extract_values(*scatran, lm);
   //  Core::FE::extract_my_values(*qan ,myqan ,lm);
 
   // create objects for element arrays
@@ -993,8 +991,7 @@ bool Discret::Elements::ArteryEleCalcLinExp<distype>::solve_riemann(Artery* ele,
   if (qanp == nullptr) FOUR_C_THROW("Cannot get state vectors 'qanp'");
 
   // extract local values from the global vectors
-  std::vector<double> myqanp(lm.size());
-  Core::FE::extract_my_values(*qanp, myqanp, lm);
+  std::vector<double> myqanp = Core::FE::extract_values(*qanp, lm);
 
   // create objects for element arrays
   Core::LinAlg::Matrix<numnode, 1> earean;
@@ -1235,8 +1232,7 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate_terminal_bc(Arter
   if (qanp == nullptr) FOUR_C_THROW("Cannot get state vectors 'qanp'");
 
   // extract local values from the global vectors
-  std::vector<double> myqanp(lm.size());
-  Core::FE::extract_my_values(*qanp, myqanp, lm);
+  std::vector<double> myqanp = Core::FE::extract_values(*qanp, lm);
 
   // create objects for element arrays
   Core::LinAlg::Matrix<numnode, 1> eareanp;
@@ -1626,8 +1622,7 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::calc_postprocessing_values
   if (qanp == nullptr) FOUR_C_THROW("Cannot get state vectors 'qanp'");
 
   // extract local values from the global vectors
-  std::vector<double> myqanp(lm.size());
-  Core::FE::extract_my_values(*qanp, myqanp, lm);
+  std::vector<double> myqanp = Core::FE::extract_values(*qanp, lm);
 
   // create objects for element arrays
   Core::LinAlg::Matrix<numnode, 1> eareanp;
@@ -1706,8 +1701,7 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::calc_scatra_from_scatra_fw
   const int numnode = my::iel_;
 
   // extract local values from the global vectors
-  std::vector<double> myscatra_fb(lm.size());
-  Core::FE::extract_my_values(*scatra_fb, myscatra_fb, lm);
+  std::vector<double> myscatra_fb = Core::FE::extract_values(*scatra_fb, lm);
 
   // get all values at the last computed time step
   double val = 0.0;
@@ -1798,8 +1792,7 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate_wf_and_wb(Artery*
   if (qanp == nullptr) FOUR_C_THROW("Cannot get state vectors 'qanp'");
 
   // extract local values from the global vectors
-  std::vector<double> myqanp(lm.size());
-  Core::FE::extract_my_values(*qanp, myqanp, lm);
+  std::vector<double> myqanp = Core::FE::extract_values(*qanp, lm);
 
   // create objects for element arrays
   Core::LinAlg::Matrix<numnode, 1> earean;
@@ -1901,8 +1894,7 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::solve_scatra_analytically(
       params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("scatranp");
 
   // extract local values from the global vectors
-  std::vector<double> myescatran(lm.size());
-  Core::FE::extract_my_values(*scatran, myescatran, lm);
+  std::vector<double> myescatran = Core::FE::extract_values(*scatran, lm);
   //  Core::FE::extract_my_values(*qan ,myqan ,lm);
 
   // create objects for element arrays

--- a/src/art_net/4C_art_net_artery_ele_calc_pres_based.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_pres_based.cpp
@@ -255,9 +255,7 @@ double Discret::Elements::ArteryEleCalcPresBased<distype>::calculate_ele_length(
   {
     std::shared_ptr<const Core::LinAlg::Vector<double>> curr_seg_lengths =
         discretization.get_state(1, "curr_seg_lengths");
-    std::vector<double> seglengths(la[1].lm_.size());
-
-    Core::FE::extract_my_values(*curr_seg_lengths, seglengths, la[1].lm_);
+    std::vector<double> seglengths = Core::FE::extract_values(*curr_seg_lengths, la[1].lm_);
 
     length = std::accumulate(seglengths.begin(), seglengths.end(), 0.0);
   }

--- a/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
@@ -113,21 +113,18 @@ int Discret::Elements::Beam3eb::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // get residual displacements
       std::shared_ptr<const Core::LinAlg::Vector<double>> res =
           discretization.get_state("residual displacement");
       if (res == nullptr) FOUR_C_THROW("Cannot get state vectors 'residual displacement'");
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       // Only in the dynamic case the velocities are needed.
       // get element velocities only if example is static in nature
       std::shared_ptr<const Core::LinAlg::Vector<double>> vel;
       std::vector<double> myvel(lm.size(), 0.0);
-      myvel.clear();
       const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
 
       if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE") !=
@@ -135,7 +132,7 @@ int Discret::Elements::Beam3eb::evaluate(Teuchos::ParameterList& params,
       {
         vel = discretization.get_state("velocity");
         if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
-        Core::FE::extract_my_values(*vel, myvel, lm);
+        myvel = Core::FE::extract_values(*vel, lm);
       }
 
       if (act == Core::Elements::struct_calc_nlnstiffmass)
@@ -169,15 +166,13 @@ int Discret::Elements::Beam3eb::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // get element velocity
       std::shared_ptr<const Core::LinAlg::Vector<double>> vel =
           discretization.get_state("velocity");
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
 
       if (act == Core::Elements::struct_calc_brownianforce)
         calc_brownian_forces_and_stiff<2, 2, 3>(params, myvel, mydisp, nullptr, &elevec1);
@@ -241,8 +236,7 @@ int Discret::Elements::Beam3eb::evaluate_neumann(Teuchos::ParameterList& params,
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement new");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
-  std::vector<double> mydisp(lm.size());
-  Core::FE::extract_my_values(*disp, mydisp, lm);
+  std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
 #ifndef INEXTENSIBLE
   const int dofpn = 3 * NODALDOFS;
@@ -260,8 +254,7 @@ int Discret::Elements::Beam3eb::evaluate_neumann(Teuchos::ParameterList& params,
   {
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel = discretization.get_state("velocity");
     if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
-    std::vector<double> myvel(lm.size());
-    Core::FE::extract_my_values(*vel, myvel, lm);
+    std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
   }
   // find out whether we will use a time curve
   double time = -1.0;

--- a/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
+++ b/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
@@ -120,8 +120,7 @@ int Discret::Elements::Beam3k::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("displacement");
 
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
 
       if (act == Core::Elements::struct_calc_nlnstiffmass)
@@ -166,15 +165,13 @@ int Discret::Elements::Beam3k::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // get element velocity
       std::shared_ptr<const Core::LinAlg::Vector<double>> vel =
           discretization.get_state("velocity");
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
 
       if (act == Core::Elements::struct_calc_brownianforce)
         calc_brownian_forces_and_stiff<2, 2, 3>(params, myvel, mydisp, nullptr, &elevec1);
@@ -2083,8 +2080,7 @@ int Discret::Elements::Beam3k::evaluate_neumann(Teuchos::ParameterList& params,
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement new");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
-  std::vector<double> mydisp(lm.size());
-  Core::FE::extract_my_values(*disp, mydisp, lm);
+  std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
   Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, double> disp_totlag(true);
 

--- a/src/beam3/4C_beam3_reissner_evaluate.cpp
+++ b/src/beam3/4C_beam3_reissner_evaluate.cpp
@@ -147,8 +147,7 @@ int Discret::Elements::Beam3r::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       if (act == Core::Elements::struct_calc_nlnstiffmass)
       {
@@ -403,15 +402,13 @@ int Discret::Elements::Beam3r::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // get element velocity
       std::shared_ptr<const Core::LinAlg::Vector<double>> vel =
           discretization.get_state("velocity");
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
 
       if (act == Core::Elements::struct_calc_brownianforce)
       {

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_surface_contact_pair_mortar.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_surface_contact_pair_mortar.cpp
@@ -246,8 +246,7 @@ void BeamInteraction::BeamToSolidSurfaceContactPairMortar<ScalarType, Beam, Surf
 
   // Get the Lagrange multipliers DOF vector for this pair
   const auto& [lambda_gid_pos, _] = mortar_manager->location_vector(*this);
-  std::vector<double> lambda_pos_vector;
-  Core::FE::extract_my_values(global_lambda, lambda_pos_vector, lambda_gid_pos);
+  std::vector<double> lambda_pos_vector = Core::FE::extract_values(global_lambda, lambda_gid_pos);
   const auto lambda_pos = Core::LinAlg::Matrix<Mortar::n_dof_, 1, double>(lambda_pos_vector.data());
 
   // Multiply with the matrices evaluated in evaluate_and_assemble_mortar_contributions
@@ -335,8 +334,7 @@ void BeamInteraction::BeamToSolidSurfaceContactPairMortar<ScalarType, Beam, Surf
     // Get the lambda GIDs of this pair.
     auto q_lambda = GEOMETRYPAIR::InitializeElementData<Mortar, double>::initialize(nullptr);
     const auto& [lambda_row_pos, _] = mortar_manager->location_vector(*this);
-    std::vector<double> lambda_pair;
-    Core::FE::extract_my_values(*lambda, lambda_pair, lambda_row_pos);
+    std::vector<double> lambda_pair = Core::FE::extract_values(*lambda, lambda_row_pos);
     for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
       q_lambda.element_position_(i_dof) = lambda_pair[i_dof];
 

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_surface_meshtying_pair_mortar_FAD.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_surface_meshtying_pair_mortar_FAD.cpp
@@ -62,8 +62,7 @@ void BeamInteraction::BeamToSolidSurfaceMeshtyingPairMortarFAD<ScalarType, Beam,
 
   // Get the positional Lagrange multipliers for this pair.
   const auto& [lambda_gid_pos, _] = mortar_manager->location_vector(*this);
-  std::vector<double> local_lambda_pos;
-  Core::FE::extract_my_values(global_lambda, local_lambda_pos, lambda_gid_pos);
+  std::vector<double> local_lambda_pos = Core::FE::extract_values(global_lambda, lambda_gid_pos);
   auto q_lambda = GEOMETRYPAIR::InitializeElementData<Mortar, double>::initialize(nullptr);
   q_lambda.element_position_ =
       Core::LinAlg::Matrix<Mortar::n_dof_, 1, double>(local_lambda_pos.data());
@@ -500,8 +499,7 @@ void BeamInteraction::BeamToSolidSurfaceMeshtyingPairMortarRotationFAD<ScalarTyp
 
   // Get the rotational Lagrange multipliers for this pair.
   const auto& [_, lambda_gid_rot] = mortar_manager->location_vector(*this);
-  std::vector<double> lambda_rot_double;
-  Core::FE::extract_my_values(global_lambda, lambda_rot_double, lambda_gid_rot);
+  std::vector<double> lambda_rot_double = Core::FE::extract_values(global_lambda, lambda_gid_rot);
   Core::LinAlg::Matrix<Mortar::n_dof_, 1, double> lambda_rot;
   for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
     lambda_rot(i_dof) = lambda_rot_double[i_dof];

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_surface_meshtying_pair_mortar_base.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_surface_meshtying_pair_mortar_base.cpp
@@ -81,8 +81,7 @@ void BeamInteraction::BeamToSolidSurfaceMeshtyingPairMortarBase<ScalarType, Beam
     // Get the lambda GIDs of this pair.
     auto q_lambda = GEOMETRYPAIR::InitializeElementData<Mortar, double>::initialize(nullptr);
     const auto& [lambda_row_pos, _] = mortar_manager->location_vector(*this);
-    std::vector<double> lambda_pair;
-    Core::FE::extract_my_values(*lambda, lambda_pair, lambda_row_pos);
+    std::vector<double> lambda_pair = Core::FE::extract_values(*lambda, lambda_row_pos);
     for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
       q_lambda.element_position_(i_dof) = lambda_pair[i_dof];
 

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.cpp
@@ -150,8 +150,6 @@ void BeamInteraction::get_global_coupling_force_resultants(const Core::FE::Discr
   solid_resultant.clear();
 
   // Initialize variables.
-  std::vector<double> local_force;
-  std::vector<double> local_position;
   std::vector<int> gid_node;
 
   // Loop over the nodes and sum up the forces and moments.
@@ -162,8 +160,8 @@ void BeamInteraction::get_global_coupling_force_resultants(const Core::FE::Discr
     discret.dof(current_node, gid_node);
 
     // Get the local force and displacement values.
-    Core::FE::extract_my_values(force, local_force, gid_node);
-    Core::FE::extract_my_values(displacement, local_position, gid_node);
+    std::vector<double> local_force = Core::FE::extract_values(force, gid_node);
+    std::vector<double> local_position = Core::FE::extract_values(displacement, gid_node);
     for (unsigned int dim = 0; dim < 3; ++dim) local_position[dim] += current_node->x()[dim];
 
     if (BeamInteraction::Utils::is_beam_node(*current_node))

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_2d-3d_mortar.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_2d-3d_mortar.cpp
@@ -353,8 +353,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPair2D3DMortar<Beam, Solid,
 
   // Get the Lagrange multipliers DOF vector for this pair
   const auto& [lambda_gid_pos, _] = mortar_manager->location_vector(*this);
-  std::vector<double> lambda_pos_vector;
-  Core::FE::extract_my_values(global_lambda, lambda_pos_vector, lambda_gid_pos);
+  std::vector<double> lambda_pos_vector = Core::FE::extract_values(global_lambda, lambda_gid_pos);
   const auto lambda_pos = Core::LinAlg::Matrix<Mortar::n_dof_, 1, double>(lambda_pos_vector.data());
 
   // Multiply with the matrices evaluated in evaluate_and_assemble_mortar_contributions
@@ -458,8 +457,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPair2D3DMortar<Beam, Solid,
       // Get the lambda GIDs of this pair.
       const auto& [lambda_row_pos, _] = mortar_manager->location_vector(*this);
 
-      std::vector<double> lambda_pair;
-      Core::FE::extract_my_values(*lambda, lambda_pair, lambda_row_pos);
+      std::vector<double> lambda_pair = Core::FE::extract_values(*lambda, lambda_row_pos);
       for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
         element_data_lambda.element_position_(i_dof) = lambda_pair[i_dof];
 

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_mortar.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_mortar.cpp
@@ -126,8 +126,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<Beam, Solid,
     // Get the lambda GIDs of this pair.
     const auto& [lambda_row_pos, _] = mortar_manager->location_vector(*this);
 
-    std::vector<double> lambda_pair;
-    Core::FE::extract_my_values(*lambda, lambda_pair, lambda_row_pos);
+    std::vector<double> lambda_pair = Core::FE::extract_values(*lambda, lambda_row_pos);
     for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
       element_data_lambda.element_position_(i_dof) = lambda_pair[i_dof];
 

--- a/src/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_mortar_rotation.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_mortar_rotation.cpp
@@ -362,8 +362,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPairMortarRotation<Beam, Solid, 
   // Get the rotational Lagrange multipliers for this pair.
   const auto& [_, lambda_gid_rot] = mortar_manager->location_vector(*this);
 
-  std::vector<double> lambda_rot_double;
-  Core::FE::extract_my_values(global_lambda, lambda_rot_double, lambda_gid_rot);
+  std::vector<double> lambda_rot_double = Core::FE::extract_values(global_lambda, lambda_gid_rot);
   Core::LinAlg::Matrix<MortarRot::n_dof_, 1, double> lambda_rot;
   for (unsigned int i_dof = 0; i_dof < MortarRot::n_dof_; i_dof++)
     lambda_rot(i_dof) = lambda_rot_double[i_dof];

--- a/src/beaminteraction/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/4C_beaminteraction_calc_utils.cpp
@@ -198,7 +198,7 @@ namespace BeamInteraction
       std::vector<int> lm, lmowner, lmstride;
 
       ele->location_vector(discret, lm, lmowner, lmstride);
-      Core::FE::extract_my_values(ia_discolnp, eledisp, lm);
+      eledisp = Core::FE::extract_values(ia_discolnp, lm);
     }
 
     /*-----------------------------------------------------------------------------*

--- a/src/bele/4C_bele_bele3_evaluate.cpp
+++ b/src/bele/4C_bele_bele3_evaluate.cpp
@@ -89,8 +89,7 @@ int Discret::Elements::Bele3::evaluate(Teuchos::ParameterList& params,
         std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
             discretization.get_state("displacement");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
         const int numdim = 3;
         Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
         spatial_configuration(xscurr, mydisp);
@@ -106,8 +105,7 @@ int Discret::Elements::Bele3::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numdim = 3;
       Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
       spatial_configuration(xscurr, mydisp);

--- a/src/bele/4C_bele_bele3_line_evaluate.cpp
+++ b/src/bele/4C_bele_bele3_line_evaluate.cpp
@@ -50,8 +50,7 @@ int Discret::Elements::Bele3Line::evaluate(Teuchos::ParameterList& params,
         dispnp = discretization.get_state("dispnp");
         if (dispnp != nullptr)
         {
-          mydispnp.resize(lm.size());
-          Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+          mydispnp = Core::FE::extract_values(*dispnp, lm);
         }
         else
         {

--- a/src/cardiovascular0d/4C_cardiovascular0d.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d.cpp
@@ -347,8 +347,7 @@ void Utils::Cardiovascular0D::evaluate_d_struct_dp(
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
       std::shared_ptr<const Core::LinAlg::Vector<double>> curdispl =
           actdisc_->get_state("displacement");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*curdispl, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*curdispl, lm);
 
       for (int j = 0; j < numnode; ++j)
       {

--- a/src/constraint/4C_constraint_element2_evaluate.cpp
+++ b/src/constraint/4C_constraint_element2_evaluate.cpp
@@ -61,8 +61,7 @@ int Discret::Elements::ConstraintElement2::evaluate(Teuchos::ParameterList& para
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numnode = 3;
       const int numdim = 2;
       Core::LinAlg::Matrix<numnode, numdim> xscurr;  // material coord. of element
@@ -82,8 +81,7 @@ int Discret::Elements::ConstraintElement2::evaluate(Teuchos::ParameterList& para
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numnode = 3;
       const int numdim = 2;
       Core::LinAlg::Matrix<numnode, numdim> xscurr;  // material coord. of element

--- a/src/constraint/4C_constraint_element3_evaluate.cpp
+++ b/src/constraint/4C_constraint_element3_evaluate.cpp
@@ -53,8 +53,7 @@ int Discret::Elements::ConstraintElement3::evaluate(Teuchos::ParameterList& para
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numnod = num_node();
 
       if (numnod == 4)
@@ -96,8 +95,7 @@ int Discret::Elements::ConstraintElement3::evaluate(Teuchos::ParameterList& para
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numnod = num_node();
 
       if (numnod == 4)

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -406,14 +406,11 @@ void CONSTRAINTS::SpringDashpot::evaluate_robin(std::shared_ptr<Core::LinAlg::Sp
         }
 
         // extract velocity
-        std::vector<double> velocities(lm.size());
-        Core::FE::extract_my_values(velo_with_ghosted, velocities, lm);
+        std::vector<double> velocities = Core::FE::extract_values(velo_with_ghosted, lm);
 
-        std::vector<double> displacements(lm.size());
-        Core::FE::extract_my_values(disp_with_ghosted, displacements, lm);
+        std::vector<double> displacements = Core::FE::extract_values(disp_with_ghosted, lm);
 
-        std::vector<double> displacement_offset(lm.size());
-        Core::FE::extract_my_values(offset_with_ghosted, displacement_offset, lm);
+        std::vector<double> displacement_offset = Core::FE::extract_values(offset_with_ghosted, lm);
 
 
         Core::LinAlg::SerialDenseMatrix elestiff;

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_interaction_pair_mortar.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_interaction_pair_mortar.cpp
@@ -119,8 +119,7 @@ void CONSTRAINTS::EMBEDDEDMESH::SurfaceToBackgroundCouplingPairMortar<Interface,
   // Get the lambda GIDs of this pair.
   std::vector<int> lambda_row;
   get_mortar_gid(mortar_manager, this, Mortar::n_dof_, &lambda_row);
-  std::vector<double> lambda_pair;
-  Core::FE::extract_my_values(*lambda, lambda_pair, lambda_row);
+  std::vector<double> lambda_pair = Core::FE::extract_values(*lambda, lambda_row);
   for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
     q_lambda(i_dof) = lambda_pair[i_dof];
 

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_utils.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_utils.cpp
@@ -379,12 +379,10 @@ void CONSTRAINTS::EMBEDDEDMESH::get_current_element_displacement(
     Core::FE::Discretization const& discret, Core::Elements::Element const* ele,
     const Core::LinAlg::Vector<double>& displacement_vector, std::vector<double>& eledisp)
 {
-  // clear
-  eledisp.clear();
   std::vector<int> lm, lmowner, lmstride;
 
   ele->location_vector(discret, lm, lmowner, lmstride);
-  Core::FE::extract_my_values(displacement_vector, eledisp, lm);
+  eledisp = Core::FE::extract_values(displacement_vector, lm);
 }
 
 void CONSTRAINTS::EMBEDDEDMESH::get_mortar_gid(

--- a/src/contact/4C_contact_lagrange_strategy_poro.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_poro.cpp
@@ -1292,11 +1292,10 @@ void CONTACT::LagrangeStrategyPoro::set_state(
             {
               CONTACT::Node* node = dynamic_cast<CONTACT::Node*>(idiscret_.l_col_node(i));
               const int numdof = node->num_dof();
-              std::vector<double> myvel(numdof);
               std::vector<int> lm(numdof);
 
               for (int j = 0; j < numdof; ++j) lm[j] = node->dofs()[j];
-              Core::FE::extract_my_values(global, myvel, lm);
+              std::vector<double> myvel = Core::FE::extract_values(global, lm);
 
               // add myvel[2]=0 for 2D problems
               if (myvel.size() < 3) myvel.resize(3);
@@ -1324,12 +1323,11 @@ void CONTACT::LagrangeStrategyPoro::set_state(
               CONTACT::Node* node = dynamic_cast<CONTACT::Node*>(idiscret_.l_col_node(i));
 
               const int numdof = node->num_dof();
-              std::vector<double> mylm(numdof);
               std::vector<int> lm(numdof);
 
               for (int j = 0; j < numdof; ++j) lm[j] = node->dofs()[j];
 
-              Core::FE::extract_my_values(global, mylm, lm);
+              std::vector<double> mylm = Core::FE::extract_values(global, lm);
 
               // add myvel[2]=0 for 2D problems
               if (mylm.size() < 3) mylm.resize(3);
@@ -1421,8 +1419,7 @@ void CONTACT::LagrangeStrategyPoro::set_parent_state(const enum Mortar::StateTyp
           // this gets values in local order
           ele->parent_element()->location_vector(dis, lm, lmowner, lmstride);
 
-          std::vector<double> myval;
-          Core::FE::extract_my_values(global, myval, lm);
+          std::vector<double> myval = Core::FE::extract_values(global, lm);
 
           ele->mo_data().parent_disp() = myval;
           ele->mo_data().parent_dof() = lm;
@@ -1443,8 +1440,7 @@ void CONTACT::LagrangeStrategyPoro::set_parent_state(const enum Mortar::StateTyp
           // this gets values in local order
           mele->parent_element()->location_vector(dis, lm, lmowner, lmstride);
 
-          std::vector<double> myval;
-          Core::FE::extract_my_values(global, myval, lm);
+          std::vector<double> myval = Core::FE::extract_values(global, lm);
 
           mele->mo_data().parent_disp() = myval;
           mele->mo_data().parent_dof() = lm;

--- a/src/contact/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_tsi.cpp
@@ -60,10 +60,9 @@ void CONTACT::LagrangeStrategyTsi::set_state(
         {
           CONTACT::Node* node = dynamic_cast<CONTACT::Node*>(idiscr.l_col_node(i));
           if (node == nullptr) FOUR_C_THROW("cast failed");
-          std::vector<double> mytemp(1);
           std::vector<int> lm(1, node->dofs()[0]);
 
-          Core::FE::extract_my_values(global, mytemp, lm);
+          std::vector<double> mytemp = Core::FE::extract_values(global, lm);
           if (node->has_tsi_data())  // in case the interface has not been initialized yet
             node->tsi_data().temp() = mytemp[0];
         }
@@ -83,8 +82,7 @@ void CONTACT::LagrangeStrategyTsi::set_state(
         {
           CONTACT::Node* node = dynamic_cast<CONTACT::Node*>(idiscr.l_col_node(i));
           std::vector<int> lm(1, node->dofs()[0]);
-          std::vector<double> myThermoLM(1, 0.);
-          Core::FE::extract_my_values(global, myThermoLM, lm);
+          std::vector<double> myThermoLM = Core::FE::extract_values(global, lm);
           node->tsi_data().thermo_lm() = myThermoLM[0];
         }
       }

--- a/src/contact/4C_contact_nitsche_strategy.cpp
+++ b/src/contact/4C_contact_nitsche_strategy.cpp
@@ -167,8 +167,7 @@ void CONTACT::NitscheStrategy::set_parent_state(const enum Mortar::StateType& st
         // this gets values in local order
         ele->parent_element()->location_vector(dis, lm, lmowner, lmstride);
 
-        std::vector<double> myval;
-        Core::FE::extract_my_values(global, myval, lm);
+        std::vector<double> myval = Core::FE::extract_values(global, lm);
 
         switch (statename)
         {

--- a/src/contact/4C_contact_nitsche_strategy_poro.cpp
+++ b/src/contact/4C_contact_nitsche_strategy_poro.cpp
@@ -101,8 +101,7 @@ void CONTACT::NitscheStrategyPoro::set_parent_state(const enum Mortar::StateType
           // this gets values in local order
           ele->parent_slave_element()->location_vector(dis, lm, lmowner, lmstride);
 
-          std::vector<double> myval;
-          Core::FE::extract_my_values(global, myval, lm);
+          std::vector<double> myval = Core::FE::extract_values(global, lm);
 
           std::vector<double> vel;
           std::vector<double> pres;

--- a/src/contact/4C_contact_nitsche_strategy_ssi.cpp
+++ b/src/contact/4C_contact_nitsche_strategy_ssi.cpp
@@ -123,8 +123,7 @@ void CONTACT::NitscheStrategySsi::set_parent_state(const enum Mortar::StateType&
           else
             mortar_parent_ele->location_vector(dis, lm, lmowner, lmstride);
 
-          std::vector<double> myval;
-          Core::FE::extract_my_values(scatra_dofcolmap, myval, lm);
+          std::vector<double> myval = Core::FE::extract_values(scatra_dofcolmap, lm);
 
           mortar_ele->mo_data().parent_scalar() = myval;
           mortar_ele->mo_data().parent_scalar_dof() = lm;

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
@@ -201,10 +201,7 @@ void Core::Conditions::LocsysManager::update(const double time,
                   std::vector<int> lm;
                   discret().dof(node, lm);
 
-                  std::vector<double> currDisp;
-                  currDisp.resize(lm.size());
-
-                  Core::FE::extract_my_values(*dispnp, currDisp, lm);
+                  std::vector<double> currDisp = Core::FE::extract_values(*dispnp, lm);
 
                   // Calculate current position for node
                   std::vector<double> currPos(n_dim());

--- a/src/core/fem/src/general/utils/4C_fem_general_extract_values.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_extract_values.cpp
@@ -22,25 +22,6 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Core::FE::extract_my_values(const Core::LinAlg::Vector<double>& global,
-    std::vector<double>& local, const std::vector<int>& lm)
-{
-  const size_t ldim = lm.size();
-  local.resize(ldim);
-  for (size_t i = 0; i < ldim; ++i)
-  {
-    const int lid = global.Map().LID(lm[i]);
-    if (lid < 0)
-      FOUR_C_THROW("Proc %d: Cannot find gid=%d in Core::LinAlg::Vector<double>",
-          Core::Communication::my_mpi_rank(global.Comm()), lm[i]);
-    local[i] = global[lid];
-  }
-  return;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::FE::extract_my_values(const Core::LinAlg::Vector<double>& global,
     Core::LinAlg::SerialDenseVector& local, const std::vector<int>& lm)
 {
   const size_t ldim = lm.size();
@@ -52,34 +33,6 @@ void Core::FE::extract_my_values(const Core::LinAlg::Vector<double>& global,
       FOUR_C_THROW("Proc %d: Cannot find gid=%d in Core::LinAlg::Vector<double>",
           Core::Communication::my_mpi_rank(global.Comm()), lm[i]);
     local[i] = global[lid];
-  }
-  return;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::FE::extract_my_values(const Core::LinAlg::MultiVector<double>& global,
-    std::vector<double>& local, const std::vector<int>& lm)
-{
-  const int numcol = global.NumVectors();
-  const size_t ldim = lm.size();
-
-  local.resize(ldim * numcol);
-
-  // loop over element nodes
-  for (size_t i = 0; i < ldim; ++i)
-  {
-    const int lid = global.Map().LID(lm[i]);
-    if (lid < 0)
-      FOUR_C_THROW("Proc %d: Cannot find gid=%d in Core::LinAlg::MultiVector<double>",
-          Core::Communication::my_mpi_rank(global.Comm()), lm[i]);
-
-    // loop over multi vector columns (numcol=1 for Core::LinAlg::Vector<double>)
-    for (int col = 0; col < numcol; col++)
-    {
-      local[col + (numcol * i)] = global(col)[lid];
-    }
   }
   return;
 }
@@ -137,27 +90,6 @@ void Core::FE::extract_my_node_based_values(const Core::Elements::Element* ele,
             Core::Communication::my_mpi_rank(global.Comm()), nodegid);
       local(i + (nsd * j)) = global(i)[lid];
     }
-  }
-  return;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Core::FE::extract_my_node_based_values(const Core::Nodes::Node* node,
-    Core::LinAlg::SerialDenseVector& local, Core::LinAlg::MultiVector<double>& global,
-    const int nsd)
-{
-  if (nsd > global.NumVectors())
-    FOUR_C_THROW("Requested %d of %d available columns", nsd, global.NumVectors());
-  if (local.length() != nsd) FOUR_C_THROW("vector size mismatch.");
-
-  const int nodegid = node->id();
-  const int lid = global.Map().LID(nodegid);
-
-  for (int i = 0; i < nsd; i++)
-  {
-    // access actual component column of multi-vector
-    local(i + nsd) = global(i)[lid];
   }
   return;
 }

--- a/src/core/fem/src/general/utils/4C_fem_general_extract_values.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_extract_values.hpp
@@ -189,17 +189,6 @@ namespace Core::FE
       const int nsd                               ///< number of space dimensions
   );
 
-  /// Locally extract a subset of values from a (column)-nodemap-based
-  /// Core::LinAlg::MultiVector<double>
-  /*  \author schott
-   *  \date 12/16
-   */
-  void extract_my_node_based_values(const Core::Nodes::Node* node,  ///< pointer to current element
-      Core::LinAlg::SerialDenseVector& local,                       ///< local vector on node-level
-      Core::LinAlg::MultiVector<double>& global,                    ///< global vector
-      const int nsd                                                 ///< number of space dimensions
-  );
-
 
   /// Locally extract a subset of values from a (column)-nodemap-based
   /// Core::LinAlg::MultiVector<double> and fill a local matrix that has implemented the (.,.)

--- a/src/core/io/src/4C_io_element_append_visualization.hpp
+++ b/src/core/io/src/4C_io_element_append_visualization.hpp
@@ -291,10 +291,9 @@ namespace Core::IO
       // Get the element result vector.
       Core::LinAlg::Matrix<number_of_output_points * result_num_dofs_per_node, 1, double>
           dof_result;
-      std::vector<double> ele_dof_values;
       std::vector<int> lm, lmowner, lmstride;
       ele.location_vector(discret, lm, lmowner, lmstride);
-      Core::FE::extract_my_values(result_data_dofbased, ele_dof_values, lm);
+      std::vector<double> ele_dof_values = Core::FE::extract_values(result_data_dofbased, lm);
 
       const auto total_dofs_per_node = ele_dof_values.size() / number_of_output_points;
       FOUR_C_ASSERT((ele_dof_values.size() % total_dofs_per_node) == 0,

--- a/src/core/io/src/4C_io_gmsh.cpp
+++ b/src/core/io/src/4C_io_gmsh.cpp
@@ -295,8 +295,7 @@ void Core::IO::Gmsh::vector_field_multi_vector_dof_based_to_gmsh(
     // extract local values from the global vector
     // Core::LinAlg::SerialDenseVector extractmyvectorfield(la[nds].lm_.size());
     Core::LinAlg::SerialDenseMatrix myvectorfield(nsd, numnode);
-    std::vector<double> local_vector;
-    Core::FE::extract_my_values(vectorfield, local_vector, la[nds].lm_);
+    std::vector<double> local_vector = Core::FE::extract_values(vectorfield, la[nds].lm_);
 
     for (int inode = 0; inode < numnode; ++inode)
     {

--- a/src/cut/4C_cut_cutwizard.cpp
+++ b/src/cut/4C_cut_cutwizard.cpp
@@ -410,7 +410,7 @@ void evaluate_position_on_nurbs9(Core::Elements::Element* element,
     lm.clear();
     mydisp.clear();
     cutterdis->dof(controlpoint, lm);
-    Core::FE::extract_my_values(cutter_disp_col, mydisp, lm);
+    mydisp = Core::FE::extract_values(cutter_disp_col, lm);
 
     // Obtain the displacements on control points
     for (int i_dim = 0; i_dim < prob_dim; ++i_dim)
@@ -469,7 +469,7 @@ void evaluate_position_on_lagrange_element(Core::Elements::Element* element,
     {
       if (lm.size() == 3)  // case for BELE3 boundary elements
       {
-        Core::FE::extract_my_values(*cutter_disp_col, mydisp, lm);
+        mydisp = Core::FE::extract_values(*cutter_disp_col, lm);
       }
       else if (lm.size() == 4)  // case for BELE3_4 boundary elements
       {
@@ -479,7 +479,7 @@ void evaluate_position_on_lagrange_element(Core::Elements::Element* element,
         lm_red.clear();
         for (int k = 0; k < 3; k++) lm_red.push_back(lm[k]);
 
-        Core::FE::extract_my_values(*cutter_disp_col, mydisp, lm_red);
+        mydisp = Core::FE::extract_values(*cutter_disp_col, lm_red);
       }
       else
         FOUR_C_THROW("wrong number of dofs for node %i", lm.size());
@@ -696,7 +696,7 @@ Core::LinAlg::SerialDenseMatrix Cut::CutWizard::get_current_element_position(
       lm_red.clear();
       for (int k = 0; k < 3; k++) lm_red.push_back(lm[k]);
 
-      Core::FE::extract_my_values(back_mesh_->back_disp_col(), mydisp, lm_red);
+      mydisp = Core::FE::extract_values(back_mesh_->back_disp_col(), lm_red);
 
       if (mydisp.size() != 3) FOUR_C_THROW("we need 3 displacements here");
 
@@ -1051,7 +1051,7 @@ void Cut::CutWizard::update_boundary_cell_coords(
       {
         if (lm.size() == 3)  // case for BELE3 boundary elements
         {
-          Core::FE::extract_my_values(*cutter_disp_col, mydisp, lm);
+          mydisp = Core::FE::extract_values(*cutter_disp_col, lm);
         }
         else if (lm.size() == 4)  // case for BELE3_4 boundary elements
         {
@@ -1061,7 +1061,7 @@ void Cut::CutWizard::update_boundary_cell_coords(
           lm_red.clear();
           for (int k = 0; k < 3; k++) lm_red.push_back(lm[k]);
 
-          Core::FE::extract_my_values(*cutter_disp_col, mydisp, lm_red);
+          mydisp = Core::FE::extract_values(*cutter_disp_col, lm_red);
         }
         else
           FOUR_C_THROW("wrong number of dofs for node %i", lm.size());

--- a/src/elemag/4C_elemag_diff_ele_calc.cpp
+++ b/src/elemag/4C_elemag_diff_ele_calc.cpp
@@ -433,7 +433,7 @@ void Discret::Elements::ElemagDiffEleCalc<distype>::element_init_from_restart(
   std::shared_ptr<const Core::LinAlg::Vector<double>> intVar =
       discretization.get_state(1, "intVar");
   std::vector<int> localDofs1 = discretization.dof(1, ele);
-  Core::FE::extract_my_values(*intVar, interiorVar, localDofs1);
+  interiorVar = Core::FE::extract_values(*intVar, localDofs1);
   // now write this in corresponding eleinteriorElectric_ and eleinteriorMagnetic_
   for (unsigned int i = 0; i < size; ++i)
   {
@@ -445,7 +445,7 @@ void Discret::Elements::ElemagDiffEleCalc<distype>::element_init_from_restart(
 
   std::shared_ptr<const Core::LinAlg::Vector<double>> intVarnm =
       discretization.get_state(1, "intVarnm");
-  Core::FE::extract_my_values(*intVarnm, interiorVarnm, localDofs1);
+  interiorVarnm = Core::FE::extract_values(*intVarnm, localDofs1);
   for (unsigned int i = 0; i < size; ++i)
   {
     elemagele->eleinteriorElectricnm1_(i) = interiorVarnm[size + i];

--- a/src/elemag/4C_elemag_ele_calc.cpp
+++ b/src/elemag/4C_elemag_ele_calc.cpp
@@ -398,12 +398,10 @@ void Discret::Elements::ElemagEleCalc<distype>::element_init_from_restart(
   Discret::Elements::Elemag* elemagele = dynamic_cast<Discret::Elements::Elemag*>(ele);
   int size = shapes_->ndofs_ * nsd_ * 2;
 
-  std::vector<double> interiorVar(size);
-
   std::shared_ptr<const Core::LinAlg::Vector<double>> intVar =
       discretization.get_state(1, "intVar");
   std::vector<int> localDofs1 = discretization.dof(1, ele);
-  Core::FE::extract_my_values(*intVar, interiorVar, localDofs1);
+  std::vector<double> interiorVar = Core::FE::extract_values(*intVar, localDofs1);
   // now write this in corresponding eleinteriorElectric_ and eleinteriorMagnetic_
   for (unsigned int i = 0; i < shapes_->ndofs_ * nsd_; ++i)
   {
@@ -415,7 +413,7 @@ void Discret::Elements::ElemagEleCalc<distype>::element_init_from_restart(
 
   std::shared_ptr<const Core::LinAlg::Vector<double>> intVarnm =
       discretization.get_state(1, "intVarnm");
-  Core::FE::extract_my_values(*intVarnm, interiorVarnm, localDofs1);
+  interiorVarnm = Core::FE::extract_values(*intVarnm, localDofs1);
   for (unsigned int i = 0; i < shapes_->ndofs_ * nsd_; ++i)
   {
     elemagele->eleinteriorMagneticnm1_(i) = interiorVarnm[i];

--- a/src/fbi/4C_fbi_beam_to_fluid_meshtying_pair_mortar.cpp
+++ b/src/fbi/4C_fbi_beam_to_fluid_meshtying_pair_mortar.cpp
@@ -178,9 +178,8 @@ void BeamInteraction::BeamToFluidMeshtyingPairMortar<Beam, Fluid, Mortar>::get_p
     // Get the lambda GIDs of this pair.
     std::shared_ptr<const BeamContactPair> this_rcp = Core::Utils::shared_ptr_from_ref(*this);
     std::vector<int> lambda_row;
-    std::vector<double> lambda_pair;
     mortar_manager->location_vector(*this_rcp, lambda_row);
-    Core::FE::extract_my_values(*lambda, lambda_pair, lambda_row);
+    std::vector<double> lambda_pair = Core::FE::extract_values(*lambda, lambda_row);
     for (unsigned int i_dof = 0; i_dof < Mortar::n_dof_; i_dof++)
       q_lambda.element_position_(i_dof) = lambda_pair[i_dof];
 

--- a/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
+++ b/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
@@ -326,8 +326,6 @@ void FBI::FBIGeometryCoupler::compute_current_positions(Core::FE::Discretization
   positions->clear();
   std::vector<int> src_dofs(
       9);  // todo this does not work for all possible elements, does it? Variable size?
-  std::vector<double> mydisp(3, 0.0);
-
   for (int lid = 0; lid < dis.num_my_col_nodes(); ++lid)
   {
     const Core::Nodes::Node* node = dis.l_col_node(lid);
@@ -336,7 +334,7 @@ void FBI::FBIGeometryCoupler::compute_current_positions(Core::FE::Discretization
       // get the DOF numbers of the current node
       dis.dof(node, 0, src_dofs);
       // get the current displacements
-      Core::FE::extract_my_values(*disp, mydisp, src_dofs);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, src_dofs);
 
       for (int d = 0; d < 3; ++d) (*positions)[node->id()](d) = node->x()[d] + mydisp.at(d);
     }

--- a/src/fbi/4C_fbi_immersed_geometry_coupler_binning.cpp
+++ b/src/fbi/4C_fbi_immersed_geometry_coupler_binning.cpp
@@ -140,7 +140,6 @@ void FBI::FBIBinningGeometryCoupler::compute_current_positions(Core::FE::Discret
   positions->clear();
   std::vector<int> src_dofs(
       9);  // todo this does not work for all possible elements, does it? Variable size?
-  std::vector<double> mydisp(3, 0.0);
 
   const Epetra_Map* bincolmap = binstrategy_->bin_discret()->element_col_map();
   std::vector<int> colbinvec;
@@ -170,7 +169,7 @@ void FBI::FBIBinningGeometryCoupler::compute_current_positions(Core::FE::Discret
         // get the DOF numbers of the current node
         dis.dof(node, 0, src_dofs);
         // get the current displacements
-        Core::FE::extract_my_values(*disp, mydisp, src_dofs);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, src_dofs);
 
         for (int d = 0; d < 3; ++d) (*positions)[node->id()](d) = node->x()[d] + mydisp.at(d);
       }

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
@@ -80,8 +80,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::evaluate_action(
         dispnp = discretization.get_state("dispnp");
         if (dispnp != nullptr)
         {
-          mydispnp.resize(lm.size());
-          Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+          mydispnp = Core::FE::extract_values(*dispnp, lm);
         }
       }
 
@@ -134,7 +133,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::evaluate_action(
         if (dispnp != nullptr)
         {
           mydispnp.resize(lm.size());
-          Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+          mydispnp = Core::FE::extract_values(*dispnp, lm);
         }
       }
 
@@ -154,7 +153,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::evaluate_action(
         if (dispnp != nullptr)
         {
           mydispnp.resize(lm.size());
-          Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+          mydispnp = Core::FE::extract_values(*dispnp, lm);
         }
       }
 
@@ -165,7 +164,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::evaluate_action(
       if (normals != nullptr)
       {
         mynormals.resize(lm.size());
-        Core::FE::extract_my_values(*normals, mynormals, lm);
+        mynormals = Core::FE::extract_values(*normals, lm);
       }
 
       // what happens, if the mynormals vector is empty? (ehrl)
@@ -248,8 +247,7 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
   if (scaaf == nullptr) FOUR_C_THROW("Cannot get state vector 'scaaf'");
 
   // extract local values from global vector
-  std::vector<double> myscaaf(lm.size());
-  Core::FE::extract_my_values(*scaaf, myscaaf, lm);
+  std::vector<double> myscaaf = Core::FE::extract_values(*scaaf, lm);
 
   Core::LinAlg::Matrix<bdrynen_, 1> escaaf(true);
 
@@ -275,8 +273,7 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
     if (velaf == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
     // extract local values from global vector
-    std::vector<double> myvelaf(lm.size());
-    Core::FE::extract_my_values(*velaf, myvelaf, lm);
+    std::vector<double> myvelaf = Core::FE::extract_values(*velaf, lm);
 
     // insert pressure into element array
     for (int inode = 0; inode < bdrynen_; inode++)
@@ -304,7 +301,7 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
 
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -552,7 +549,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::neumann_inflow(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
 
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -573,8 +570,8 @@ void Discret::Elements::FluidBoundaryImpl<distype>::neumann_inflow(
   // extract local values from global vector
   std::vector<double> myvelaf(lm.size());
   std::vector<double> myscaaf(lm.size());
-  Core::FE::extract_my_values(*velaf, myvelaf, lm);
-  Core::FE::extract_my_values(*scaaf, myscaaf, lm);
+  myvelaf = Core::FE::extract_values(*velaf, lm);
+  myscaaf = Core::FE::extract_values(*scaaf, lm);
 
   // create Epetra objects for scalar array and velocities
   Core::LinAlg::Matrix<nsd_, bdrynen_> evelaf(true);
@@ -1021,7 +1018,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::area_calculation(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -1073,8 +1070,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::pressure_boundary_integral(
   std::shared_ptr<const Core::LinAlg::Vector<double>> velnp = discretization.get_state("velaf");
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
   Core::LinAlg::Matrix<1, bdrynen_> eprenp(true);
   for (int inode = 0; inode < bdrynen_; inode++)
@@ -1095,7 +1091,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::pressure_boundary_integral(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -1168,7 +1164,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::center_of_mass_calculation(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -1254,8 +1250,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::compute_flow_rate(
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
   // allocate velocity vector
   Core::LinAlg::Matrix<nsd_, bdrynen_> evelnp(true);
@@ -1287,7 +1282,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::compute_flow_rate(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -1381,7 +1376,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::flow_rate_deriv(
     dispnp = discretization.get_state("dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vectors 'dispnp'");
     edispnp.resize(lm.size());
-    Core::FE::extract_my_values(*dispnp, edispnp, lm);
+    edispnp = Core::FE::extract_values(*dispnp, lm);
   }
 
   // get integration rule
@@ -1421,8 +1416,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::flow_rate_deriv(
   if (convelnp == nullptr) FOUR_C_THROW("Cannot get state vector 'convectivevel'");
 
   // extract local values from the global vectors
-  std::vector<double> myconvelnp(lm.size());
-  Core::FE::extract_my_values(*convelnp, myconvelnp, lm);
+  std::vector<double> myconvelnp = Core::FE::extract_values(*convelnp, lm);
 
   // allocate velocities vector
   Core::LinAlg::Matrix<nsd_, bdrynen_> evelnp(true);
@@ -1671,7 +1665,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::impedance_integration(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -1732,7 +1726,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::d_qdu(Discret::Elements::Flu
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)
@@ -1898,8 +1892,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::calc_traction_velocity_compo
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
   // allocate velocity vector
   Core::LinAlg::Matrix<nsd_, bdrynen_> evelnp(true);
@@ -1980,7 +1973,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::calc_traction_velocity_compo
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "paranoid");
     for (int inode = 0; inode < bdrynen_; ++inode)

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc_poro.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc_poro.cpp
@@ -417,8 +417,8 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::fpsi_coupling(
   if (displacements_np != nullptr)
   {
     my_displacements_np.resize(lm.size());
-    Core::FE::extract_my_values(*displacements_np, my_displacements_np, lm);
-    Core::FE::extract_my_values(*displacements_np, my_parentdisp_np, plm);
+    my_displacements_np = Core::FE::extract_values(*displacements_np, lm);
+    my_parentdisp_np = Core::FE::extract_values(*displacements_np, plm);
   }
   FOUR_C_ASSERT(my_displacements_np.size() != 0, "no displacement values for boundary element");
   FOUR_C_ASSERT(my_parentdisp_np.size() != 0, "no displacement values for parent element");
@@ -426,8 +426,8 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::fpsi_coupling(
   if (displacements_n != nullptr)
   {
     my_displacements_n.resize(lm.size());
-    Core::FE::extract_my_values(*displacements_n, my_displacements_n, lm);
-    Core::FE::extract_my_values(*displacements_n, my_parentdisp_n, plm);
+    my_displacements_n = Core::FE::extract_values(*displacements_n, lm);
+    my_parentdisp_n = Core::FE::extract_values(*displacements_n, plm);
   }
   FOUR_C_ASSERT(
       my_displacements_n.size() != 0, "no displacement values for boundary element at time step n");
@@ -462,16 +462,13 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::fpsi_coupling(
   }
 
   // extract local values from the global vectors
-  std::vector<double> my_fluidvelocity_np(lm.size());
-  Core::FE::extract_my_values(*fluidvelocity_np, my_fluidvelocity_np, lm);
+  std::vector<double> my_fluidvelocity_np = Core::FE::extract_values(*fluidvelocity_np, lm);
   std::vector<double> my_fluidvelocity_n(lm.size());  // at previous time step n
-  Core::FE::extract_my_values(*fluidvelocity_n, my_fluidvelocity_n, lm);
-  std::vector<double> my_gridvelocity(lm.size());
-  Core::FE::extract_my_values(*gridvelocity, my_gridvelocity, lm);
-  std::vector<double> my_parentfluidvelocity_np(plm.size());
-  Core::FE::extract_my_values(*fluidvelocity_np, my_parentfluidvelocity_np, plm);
+  my_fluidvelocity_n = Core::FE::extract_values(*fluidvelocity_n, lm);
+  std::vector<double> my_gridvelocity = Core::FE::extract_values(*gridvelocity, lm);
+  std::vector<double> my_parentfluidvelocity_np = Core::FE::extract_values(*fluidvelocity_np, plm);
   std::vector<double> my_parentfluidvelocity_n(plm.size());  // at previous time step n
-  Core::FE::extract_my_values(*fluidvelocity_n, my_parentfluidvelocity_n, plm);
+  my_parentfluidvelocity_n = Core::FE::extract_values(*fluidvelocity_n, plm);
 
   // split velocity and pressure, insert into element arrays
   for (int inode = 0; inode < Base::bdrynen_; inode++)
@@ -1840,8 +1837,8 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::compute_flow_rate(
   if (dispnp != nullptr)
   {
     mydispnp.resize(lm.size());
-    Core::FE::extract_my_values(*dispnp, mydispnp, lm);
-    Core::FE::extract_my_values(*dispnp, parentdispnp, plm);
+    mydispnp = Core::FE::extract_values(*dispnp, lm);
+    parentdispnp = Core::FE::extract_values(*dispnp, plm);
   }
   FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
   FOUR_C_ASSERT(parentdispnp.size() != 0, "no displacement values for parent element");
@@ -1875,10 +1872,8 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::compute_flow_rate(
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
   if (gridvel == nullptr) FOUR_C_THROW("Cannot get state vector 'gridv'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
-  std::vector<double> mygridvel(lm.size());
-  Core::FE::extract_my_values(*gridvel, mygridvel, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
+  std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -2078,7 +2073,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration(
   if (dispnp != nullptr)
   {
     mydispnp.resize(lm.size());
-    Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+    mydispnp = Core::FE::extract_values(*dispnp, lm);
   }
   FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -2096,7 +2091,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration(
   else
   {
     mycondVector.resize(lm.size());
-    Core::FE::extract_my_values(*condVector, mycondVector, lm);
+    mycondVector = Core::FE::extract_values(*condVector, lm);
   }
   FOUR_C_ASSERT(mycondVector.size() != 0, "no condition IDs values for boundary element");
 
@@ -2160,10 +2155,8 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration(
     if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
     if (gridvel == nullptr) FOUR_C_THROW("Cannot get state vector 'gridv'");
 
-    std::vector<double> myvelnp(lm.size());
-    Core::FE::extract_my_values(*velnp, myvelnp, lm);
-    std::vector<double> mygridvel(lm.size());
-    Core::FE::extract_my_values(*gridvel, mygridvel, lm);
+    std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
+    std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
 
     // allocate velocity vectors
     Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -2312,7 +2305,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_i_ds(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -2550,8 +2543,8 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::poro_boundary(
   if (dispnp != nullptr)
   {
     mydispnp.resize(lm.size());
-    Core::FE::extract_my_values(*dispnp, mydispnp, lm);
-    Core::FE::extract_my_values(*dispnp, parentdispnp, plm);
+    mydispnp = Core::FE::extract_values(*dispnp, lm);
+    parentdispnp = Core::FE::extract_values(*dispnp, plm);
   }
   FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
   FOUR_C_ASSERT(parentdispnp.size() != 0, "no displacement values for parent element");
@@ -2585,12 +2578,9 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::poro_boundary(
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
   if (gridvel == nullptr) FOUR_C_THROW("Cannot get state vector 'gridv'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
-  std::vector<double> mygridvel(lm.size());
-  Core::FE::extract_my_values(*gridvel, mygridvel, lm);
-  std::vector<double> myscaaf(lm.size());
-  Core::FE::extract_my_values(*scaaf, myscaaf, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
+  std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
+  std::vector<double> myscaaf = Core::FE::extract_values(*scaaf, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -2905,7 +2895,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::pressure_coupling(
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -2924,8 +2914,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::pressure_coupling(
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<Base::bdrynen_, 1> epressnp(true);
@@ -3221,7 +3210,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_an
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -3241,11 +3230,9 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_an
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
-  std::vector<double> mygridvel(lm.size());
-  Core::FE::extract_my_values(*gridvel, mygridvel, lm);
+  std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -3282,8 +3269,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_an
   std::vector<int> plmstride;
   pele->Core::Elements::Element::location_vector(discretization, plm, plmowner, plmstride);
 
-  std::vector<double> parentdispnp;
-  Core::FE::extract_my_values(*dispnp, parentdispnp, plm);
+  std::vector<double> parentdispnp = Core::FE::extract_values(*dispnp, plm);
 
   // update element geometry of parent element
   Core::LinAlg::Matrix<nsd_, nenparent> xrefe;  // material coord. of parent element
@@ -3301,8 +3287,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_an
     }
   }
 
-  std::vector<double> pvelnp(plm.size());
-  Core::FE::extract_my_values(*velnp, pvelnp, plm);
+  std::vector<double> pvelnp = Core::FE::extract_values(*velnp, plm);
 
   // allocate vectors
   Core::LinAlg::Matrix<nenparent, 1> pepressnp(true);
@@ -3596,7 +3581,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -3616,11 +3601,9 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
-  std::vector<double> mygridvel(lm.size());
-  Core::FE::extract_my_values(*gridvel, mygridvel, lm);
+  std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -3640,8 +3623,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
 
   if (glambda == nullptr) FOUR_C_THROW("Cannot get state vector 'lambda'");
 
-  std::vector<double> mylambda(lm.size());
-  Core::FE::extract_my_values(*glambda, mylambda, lm);
+  std::vector<double> mylambda = Core::FE::extract_values(*glambda, lm);
 
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> elambda(true);
 
@@ -3676,8 +3658,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
   std::vector<int> plmstride;
   pele->Core::Elements::Element::location_vector(discretization, plm, plmowner, plmstride);
 
-  std::vector<double> parentdispnp;
-  Core::FE::extract_my_values(*dispnp, parentdispnp, plm);
+  std::vector<double> parentdispnp = Core::FE::extract_values(*dispnp, plm);
 
   // update element geometry of parent element
   Core::LinAlg::Matrix<nsd_, nenparent> xrefe;  // material coord. of parent element
@@ -3695,8 +3676,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
     }
   }
 
-  std::vector<double> pvelnp(plm.size());
-  Core::FE::extract_my_values(*velnp, pvelnp, plm);
+  std::vector<double> pvelnp = Core::FE::extract_values(*velnp, plm);
 
   // allocate vectors
   Core::LinAlg::Matrix<nenparent, 1> pepressnp(true);
@@ -4204,7 +4184,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -4224,11 +4204,9 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
-  std::vector<double> mygridvel(lm.size());
-  Core::FE::extract_my_values(*gridvel, mygridvel, lm);
+  std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -4266,8 +4244,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
   std::vector<int> plmstride;
   pele->Core::Elements::Element::location_vector(discretization, plm, plmowner, plmstride);
 
-  std::vector<double> parentdispnp;
-  Core::FE::extract_my_values(*dispnp, parentdispnp, plm);
+  std::vector<double> parentdispnp = Core::FE::extract_values(*dispnp, plm);
 
   // update element geometry of parent element
   Core::LinAlg::Matrix<nsd_, nenparent> xrefe;  // material coord. of parent element
@@ -4285,8 +4262,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
     }
   }
 
-  std::vector<double> pvelnp(plm.size());
-  Core::FE::extract_my_values(*velnp, pvelnp, plm);
+  std::vector<double> pvelnp = Core::FE::extract_values(*velnp, plm);
 
   // allocate vectors
   Core::LinAlg::Matrix<nenparent, 1> pepressnp(true);
@@ -4572,7 +4548,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
     if (dispnp != nullptr)
     {
       mydispnp.resize(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      mydispnp = Core::FE::extract_values(*dispnp, lm);
     }
     FOUR_C_ASSERT(mydispnp.size() != 0, "no displacement values for boundary element");
 
@@ -4592,11 +4568,9 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
 
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
-  std::vector<double> myvelnp(lm.size());
-  Core::FE::extract_my_values(*velnp, myvelnp, lm);
+  std::vector<double> myvelnp = Core::FE::extract_values(*velnp, lm);
 
-  std::vector<double> mygridvel(lm.size());
-  Core::FE::extract_my_values(*gridvel, mygridvel, lm);
+  std::vector<double> mygridvel = Core::FE::extract_values(*gridvel, lm);
 
   // allocate velocity vectors
   Core::LinAlg::Matrix<nsd_, Base::bdrynen_> evelnp(true);
@@ -4628,8 +4602,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
   // number of parentnodes
   static const int nenparent = Core::FE::num_nodes<pdistype>;
 
-  std::vector<double> parentdispnp;
-  Core::FE::extract_my_values(*dispnp, parentdispnp, plm);
+  std::vector<double> parentdispnp = Core::FE::extract_values(*dispnp, plm);
 
   // update element geometry of parent element
   Core::LinAlg::Matrix<nsd_, nenparent> xrefe;  // material coord. of parent element
@@ -4647,8 +4620,7 @@ void Discret::Elements::FluidEleBoundaryCalcPoro<distype>::no_penetration_mat_od
     }
   }
 
-  std::vector<double> pvelnp(plm.size());
-  Core::FE::extract_my_values(*velnp, pvelnp, plm);
+  std::vector<double> pvelnp = Core::FE::extract_values(*velnp, plm);
 
   // allocate vectors
   Core::LinAlg::Matrix<nenparent, 1> pepressnp(true);

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
@@ -680,8 +680,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::flow_dep_pressure_bc(
 
     std::vector<double> mypvelaf(plm.size());
     std::vector<double> mypscaaf(plm.size());
-    Core::FE::extract_my_values(*velaf, mypvelaf, plm);
-    Core::FE::extract_my_values(*scaaf, mypscaaf, plm);
+    mypvelaf = Core::FE::extract_values(*velaf, plm);
+    mypscaaf = Core::FE::extract_values(*scaaf, plm);
 
     Core::LinAlg::Matrix<nsd, piel> pevelaf(true);
     Core::LinAlg::Matrix<piel, 1> pescaaf(true);
@@ -703,8 +703,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::flow_dep_pressure_bc(
           discretization.get_state("dispnp");
       if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vector 'dispnp'");
 
-      Core::FE::extract_my_values(*dispnp, mypedispnp, plm);
-      Core::FE::extract_my_values(*dispnp, mybedispnp, blm);
+      mypedispnp = Core::FE::extract_values(*dispnp, plm);
+      mybedispnp = Core::FE::extract_values(*dispnp, blm);
 
       // add parent and boundary displacement at n+1
       for (int idim = 0; idim < nsd; ++idim)
@@ -1335,8 +1335,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::slip_supp_bc(
   std::shared_ptr<const Core::LinAlg::Vector<double>> velaf = discretization.get_state("velaf");
   if (velaf == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
-  std::vector<double> mypvelaf(plm.size());
-  Core::FE::extract_my_values(*velaf, mypvelaf, plm);
+  std::vector<double> mypvelaf = Core::FE::extract_values(*velaf, plm);
 
   Core::LinAlg::Matrix<nsd, piel> pevelaf(true);
   for (int inode = 0; inode < piel; ++inode)
@@ -1348,8 +1347,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::slip_supp_bc(
   }
 
   // boundary pressure
-  std::vector<double> mybvelaf(blm.size());
-  Core::FE::extract_my_values(*velaf, mybvelaf, blm);
+  std::vector<double> mybvelaf = Core::FE::extract_values(*velaf, blm);
 
   Core::LinAlg::Matrix<1, biel> epressnp(true);
 
@@ -1366,8 +1364,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::slip_supp_bc(
     std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp = discretization.get_state("dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vector 'dispnp'");
 
-    Core::FE::extract_my_values(*dispnp, mypedispnp, plm);
-    Core::FE::extract_my_values(*dispnp, mybedispnp, blm);
+    mypedispnp = Core::FE::extract_values(*dispnp, plm);
+    mybedispnp = Core::FE::extract_values(*dispnp, blm);
 
     // add parent and boundary displacement at n+1
     for (int idim = 0; idim < nsd; ++idim)
@@ -1669,8 +1667,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::navier_slip_bc(
   std::shared_ptr<const Core::LinAlg::Vector<double>> velaf = discretization.get_state("velaf");
   if (velaf == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
-  std::vector<double> mypvelaf(plm.size());
-  Core::FE::extract_my_values(*velaf, mypvelaf, plm);
+  std::vector<double> mypvelaf = Core::FE::extract_values(*velaf, plm);
 
   Core::LinAlg::Matrix<nsd, piel> pevelaf(true);
   for (int inode = 0; inode < piel; ++inode)
@@ -1689,8 +1686,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::navier_slip_bc(
     std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp = discretization.get_state("dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vector 'dispnp'");
 
-    Core::FE::extract_my_values(*dispnp, mypedispnp, plm);
-    Core::FE::extract_my_values(*dispnp, mybedispnp, blm);
+    mypedispnp = Core::FE::extract_values(*dispnp, plm);
+    mybedispnp = Core::FE::extract_values(*dispnp, blm);
 
     // add parent and boundary displacement at n+1
     for (int idim = 0; idim < nsd; ++idim)
@@ -2005,8 +2002,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::evaluate_weak_dbc(
   std::shared_ptr<const Core::LinAlg::Vector<double>> velaf = discretization.get_state("velaf");
   if (velaf == nullptr) FOUR_C_THROW("Cannot get state vector 'velaf'");
 
-  std::vector<double> mypvelaf(plm.size());
-  Core::FE::extract_my_values(*velaf, mypvelaf, plm);
+  std::vector<double> mypvelaf = Core::FE::extract_values(*velaf, plm);
 
   Core::LinAlg::Matrix<nsd, piel> pevelaf(true);
   for (int inode = 0; inode < piel; ++inode)
@@ -2025,10 +2021,10 @@ void Discret::Elements::FluidBoundaryParent<distype>::evaluate_weak_dbc(
     std::shared_ptr<const Core::LinAlg::Vector<double>> velnp = discretization.get_state("velnp");
     if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
-    Core::FE::extract_my_values(*velnp, mypvelnp, plm);
+    mypvelnp = Core::FE::extract_values(*velnp, plm);
   }
   else
-    Core::FE::extract_my_values(*velaf, mypvelnp, plm);
+    mypvelnp = Core::FE::extract_values(*velaf, plm);
 
   Core::LinAlg::Matrix<nsd, piel> pevelnp(true);
   Core::LinAlg::Matrix<piel, 1> peprenp(true);
@@ -2049,8 +2045,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::evaluate_weak_dbc(
     std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp = discretization.get_state("dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vector 'dispnp'");
 
-    Core::FE::extract_my_values(*dispnp, mypedispnp, plm);
-    Core::FE::extract_my_values(*dispnp, mybedispnp, blm);
+    mypedispnp = Core::FE::extract_values(*dispnp, plm);
+    mybedispnp = Core::FE::extract_values(*dispnp, blm);
 
     // add parent and boundary displacement at n+1
     for (int idim = 0; idim < nsd; ++idim)
@@ -3810,8 +3806,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::estimate_nitsche_trace_max
           discretization.get_state("dispnp");
       if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vector 'dispnp'");
 
-      Core::FE::extract_my_values(*dispnp, mypedispnp, plm);
-      Core::FE::extract_my_values(*dispnp, mybedispnp, blm);
+      mypedispnp = Core::FE::extract_values(*dispnp, plm);
+      mybedispnp = Core::FE::extract_values(*dispnp, blm);
 
       // add parent and boundary displacement at n+1
       for (int idim = 0; idim < nsd; ++idim)
@@ -4421,8 +4417,8 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
     std::vector<double> mypvelaf((plm).size());
     std::vector<double> mypvelnp((plm).size());
 
-    Core::FE::extract_my_values(*vel, mypvelaf, plm);
-    Core::FE::extract_my_values(*velnp, mypvelnp, plm);
+    mypvelaf = Core::FE::extract_values(*vel, plm);
+    mypvelnp = Core::FE::extract_values(*velnp, plm);
 
     for (int inode = 0; inode < piel; ++inode)
     {
@@ -4452,9 +4448,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
   }
   else
   {
-    std::vector<double> mypvel((plm).size());
-
-    Core::FE::extract_my_values(*vel, mypvel, plm);
+    std::vector<double> mypvel = Core::FE::extract_values(*vel, plm);
 
 
     for (int inode = 0; inode < piel; ++inode)

--- a/src/fluid_ele/4C_fluid_ele_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc.cpp
@@ -7055,8 +7055,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::extract_values_from_glob
   if (matrix_state == nullptr) FOUR_C_THROW("Cannot get state vector %s", state.c_str());
 
   // extract local values of the global vectors
-  std::vector<double> mymatrix(lm.size());
-  Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+  std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
   // rotate the vector field in the case of rotationally symmetric boundary conditions
   if (matrixtofill != nullptr) rotsymmpbc.rotate_my_values_if_necessary(mymatrix);
@@ -8753,8 +8752,7 @@ int Discret::Elements::FluidEleCalc<distype, enrtype>::calc_channel_statistics(
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'velnp'");
 
   // extract local values from the global vectors
-  std::vector<double> mysol(lm.size());
-  Core::FE::extract_my_values(*velnp, mysol, lm);
+  std::vector<double> mysol = Core::FE::extract_values(*velnp, lm);
   // get view of solution and subgrid-viscosity vector
   Core::LinAlg::Matrix<4 * nen_, 1> sol(mysol.data(), true);
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
@@ -115,7 +115,7 @@ int Discret::Elements::FluidEleCalcHDG<distype>::evaluate(Discret::Elements::Flu
     std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
         discretization.get_state(1, "forcing");
     std::vector<int> localDofs = discretization.dof(1, ele);
-    Core::FE::extract_my_values(*matrix_state, interiorebofoaf_, localDofs);
+    interiorebofoaf_ = Core::FE::extract_values(*matrix_state, localDofs);
   }
 
   // interior correction term for the weakly compressible benchmark if applicable
@@ -191,15 +191,15 @@ void Discret::Elements::FluidEleCalcHDG<distype>::read_global_vectors(
   FOUR_C_ASSERT(lm.size() == trace_val_.size(), "Internal error");
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
       discretization.get_state("velaf");
-  Core::FE::extract_my_values(*matrix_state, trace_val_, lm);
+  trace_val_ = Core::FE::extract_values(*matrix_state, lm);
 
   // read the interior values from solution vector
   matrix_state = discretization.get_state(1, "intvelaf");
   std::vector<int> localDofs = discretization.dof(1, &ele);
-  Core::FE::extract_my_values(*matrix_state, interior_val_, localDofs);
+  interior_val_ = Core::FE::extract_values(*matrix_state, localDofs);
 
   matrix_state = discretization.get_state(1, "intaccam");
-  Core::FE::extract_my_values(*matrix_state, interior_acc_, localDofs);
+  interior_acc_ = Core::FE::extract_values(*matrix_state, localDofs);
 }
 
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
@@ -153,18 +153,18 @@ void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::read_global_vectors(
   // read the trace values
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
       discretization.get_state(0, "velaf");
-  Core::FE::extract_my_values(*matrix_state, trace_val_, lm);
+  trace_val_ = Core::FE::extract_values(*matrix_state, lm);
 
   // get local dofs
   std::vector<int> localDofs = discretization.dof(1, &ele);
 
   // read the interior values
   matrix_state = discretization.get_state(1, "intvelaf");
-  Core::FE::extract_my_values(*matrix_state, interior_val_, localDofs);
+  interior_val_ = Core::FE::extract_values(*matrix_state, localDofs);
 
   // read the interior time derivatives
   matrix_state = discretization.get_state(1, "intaccam");
-  Core::FE::extract_my_values(*matrix_state, interior_acc_, localDofs);
+  interior_acc_ = Core::FE::extract_values(*matrix_state, localDofs);
 
   // read ale vectors
   read_ale_vectors(ele, discretization);
@@ -201,11 +201,11 @@ void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::read_ale_vectors(
 
       // read the ale displacement
       matrix_state = discretization.get_state(2, "dispnp");
-      Core::FE::extract_my_values(*matrix_state, ale_dis_, aleDofs);
+      ale_dis_ = Core::FE::extract_values(*matrix_state, aleDofs);
 
       // read the ale velocity
       matrix_state = discretization.get_state(2, "gridv");
-      Core::FE::extract_my_values(*matrix_state, ale_vel_, aleDofs);
+      ale_vel_ = Core::FE::extract_values(*matrix_state, aleDofs);
     }
   }
 }
@@ -294,11 +294,9 @@ int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::update_local_solution(
   local_solver_->invert_local_local_matrix();
 
   // extract local trace increments
-  std::vector<double> localtraceinc_vec;
-  localtraceinc_vec.resize(nfaces_ * (1 + nsd_) * shapesface_->nfdofs_);
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
       discretization.get_state(0, "globaltraceinc");
-  Core::FE::extract_my_values(*matrix_state, localtraceinc_vec, lm);
+  std::vector<double> localtraceinc_vec = Core::FE::extract_values(*matrix_state, lm);
 
   // convert local trace increments to Core::LinAlg::SerialDenseVector
   Core::LinAlg::SerialDenseVector localtraceinc(nfaces_ * (1 + nsd_) * shapesface_->nfdofs_);

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem_coupling_impl_slave_element.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem_coupling_impl_slave_element.cpp
@@ -53,7 +53,7 @@ namespace Discret
           FOUR_C_THROW("Cannot get state vector %s", disp_statename_.c_str());
 
         // extract local values of the global vector
-        Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+        mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
         for (unsigned inode = 0; inode < slave_nen_; ++inode)  // number of nodes
         {
@@ -93,8 +93,7 @@ namespace Discret
           FOUR_C_THROW("Cannot get state vector %s", vel_statename_.c_str());
 
         // extract local values of the global vectors
-        std::vector<double> mymatrix(lm.size());
-        Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+        std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
         for (unsigned inode = 0; inode < slave_nen_; ++inode)  // number of nodes
         {
@@ -127,8 +126,7 @@ namespace Discret
           FOUR_C_THROW("Cannot get state vector %s", veln_statename_.c_str());
 
         // extract local values of the global vectors
-        std::vector<double> mymatrix(lm.size());
-        Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+        std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
         for (unsigned inode = 0; inode < slave_nen_; ++inode)  // number of nodes
         {
@@ -245,8 +243,7 @@ namespace Discret
         if (matrix_state == nullptr) FOUR_C_THROW("Cannot get state vector %s", state.c_str());
 
         // extract local values of the global vectors
-        std::vector<double> mymatrix(lm.size());
-        Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+        std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
         for (unsigned inode = 0; inode < slave_nen_; ++inode)  // number of nodes
         {
@@ -279,8 +276,7 @@ namespace Discret
         if (matrix_state == nullptr) FOUR_C_THROW("Cannot get state vector %s", state.c_str());
 
         // extract local values of the global vectors
-        std::vector<double> mymatrix(lm.size());
-        Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+        std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
         for (unsigned inode = 0; inode < slave_nen_; ++inode)  // number of nodes
         {

--- a/src/fluid_ele/4C_fluid_ele_evaluate.cpp
+++ b/src/fluid_ele/4C_fluid_ele_evaluate.cpp
@@ -163,10 +163,8 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
             FOUR_C_THROW("Cannot get state vectors 'velnp' and/or 'scanp'");
 
           // extract local values from the global vectors
-          std::vector<double> myvelpre(lm.size());
-          std::vector<double> mysca(lm.size());
-          Core::FE::extract_my_values(*velnp, myvelpre, lm);
-          Core::FE::extract_my_values(*scanp, mysca, lm);
+          std::vector<double> myvelpre = Core::FE::extract_values(*velnp, lm);
+          std::vector<double> mysca = Core::FE::extract_values(*scanp, lm);
 
           // integrate mean values
           const Core::FE::CellType distype = this->shape();
@@ -222,8 +220,8 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
           // extract local values from global vectors
           std::vector<double> myvelpre(lm.size());
           std::vector<double> mysca(lm.size());
-          Core::FE::extract_my_values(*velnp, myvelpre, lm);
-          Core::FE::extract_my_values(*scanp, mysca, lm);
+          myvelpre = Core::FE::extract_values(*velnp, lm);
+          mysca = Core::FE::extract_values(*scanp, lm);
 
           // get factor for equation of state
           const double eosfac = params.get<double>("eos factor", 100000.0 / 287.0);
@@ -283,8 +281,7 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
             discretization.get_state("u and p (trial)");
         if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'vel'");
         // extract local values from the global vectors
-        std::vector<double> myvel(lm.size());
-        Core::FE::extract_my_values(*vel, myvel, lm);
+        std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
 
         std::vector<double> tmp_temp(lm.size());
         std::vector<double> mytemp(nen);
@@ -297,7 +294,7 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
           std::shared_ptr<const Core::LinAlg::Vector<double>> temp =
               discretization.get_state("T (trial)");
           if (temp == nullptr) FOUR_C_THROW("Cannot get state vectors 'temp'");
-          Core::FE::extract_my_values(*temp, tmp_temp, lm);
+          tmp_temp = Core::FE::extract_values(*temp, lm);
 
           for (int i = 0; i < nen; i++) mytemp[i] = tmp_temp[nsd + (i * (nsd + 1))];
 
@@ -543,10 +540,8 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
         }
 
         // extract local values from the global vectors
-        std::vector<double> myvel(lm.size());
-        Core::FE::extract_my_values(*velnp, myvel, lm);
-        std::vector<double> myfsvel(lm.size());
-        Core::FE::extract_my_values(*fsvelnp, myfsvel, lm);
+        std::vector<double> myvel = Core::FE::extract_values(*velnp, lm);
+        std::vector<double> myfsvel = Core::FE::extract_values(*fsvelnp, lm);
 
         // pointer to class FluidEleParameter (access to the general parameter)
         Discret::Elements::FluidEleParameterStd* fldpara =
@@ -597,11 +592,10 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
           FOUR_C_THROW("Cannot get state vectors");
         }
         // extract local values from the global vectors
-        std::vector<double> myvel(lm.size());
-        Core::FE::extract_my_values(*vel, myvel, lm);
+        std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
         std::vector<double> tmp_sca(lm.size());
         std::vector<double> mysca(nen);
-        Core::FE::extract_my_values(*sca, tmp_sca, lm);
+        tmp_sca = Core::FE::extract_values(*sca, lm);
         for (int i = 0; i < nen; i++) mysca[i] = tmp_sca[nsd + (i * (nsd + 1))];
         // get thermodynamic pressure
         double thermpress = params.get<double>("thermpress at n+alpha_F/n+1", 0.0);

--- a/src/fluid_ele/4C_fluid_ele_evaluate_utils.hpp
+++ b/src/fluid_ele/4C_fluid_ele_evaluate_utils.hpp
@@ -3088,8 +3088,7 @@ namespace FLD
         FOUR_C_THROW("Cannot get state vector 'dispnp'");
       }
 
-      std::vector<double> mydispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp,mydispnp,lm);
+      std::vector<double> mydispnp = Core::FE::extract_values(*dispnp, lm);
 
       // extract velocity part from "mygridvelaf" and get
       // set element displacements
@@ -3144,8 +3143,7 @@ namespace FLD
         FOUR_C_THROW("Cannot get state vector 'dispnp'");
       }
 
-      std::vector<double> mydispnp(lm.size());
-      Core::FE::extract_my_values(*dispnp, mydispnp, lm);
+      std::vector<double> mydispnp = Core::FE::extract_values(*dispnp, lm);
 
       // extract velocity part from "mygridvelaf" and get
       // set element displacements

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
@@ -663,8 +663,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     actele->location_vector(*nurbsdis, lm, lmowner, lmstride);
 
     // extract local values from global vector
-    std::vector<double> myvelnp(lm.size());
-    Core::FE::extract_my_values(*(nurbsdis->get_state("velnp")), myvelnp, lm);
+    std::vector<double> myvelnp = Core::FE::extract_values(*(nurbsdis->get_state("velnp")), lm);
 
     // create Matrix objects
     Core::LinAlg::Matrix<3, 27> evelnp;
@@ -691,8 +690,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     if (withscatra_)
     {
       // extract local values from global vector
-      std::vector<double> myscanp(lm.size());
-      Core::FE::extract_my_values(*(nurbsdis->get_state("scanp")), myscanp, lm);
+      std::vector<double> myscanp = Core::FE::extract_values(*(nurbsdis->get_state("scanp")), lm);
 
       // insert data into element array (scalar field is stored at pressure dofs)
       for (int i = 0; i < 27; ++i)
@@ -716,8 +714,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
       std::shared_ptr<const Core::LinAlg::Vector<double>> phinp =
           scatranurbsdis->get_state("phinp_for_statistics");
       if (phinp == nullptr) FOUR_C_THROW("Cannot get state vector 'phinp' for statistics");
-      std::vector<double> myphinp(scatralm.size());
-      Core::FE::extract_my_values(*phinp, myphinp, scatralm);
+      std::vector<double> myphinp = Core::FE::extract_values(*phinp, scatralm);
 
       // fill all element arrays
       for (int i = 0; i < nen; ++i)

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -704,8 +704,7 @@ void FLD::XFluid::extract_node_vectors(XFEM::DiscretizationXFEM& dis,
     const Core::Nodes::Node* node = dis.l_col_node(lid);
     std::vector<int> lm;
     dis.initial_dof(node, lm);  // initial dofs!
-    std::vector<double> mydisp;
-    Core::FE::extract_my_values(dispnp_col, mydisp, lm);
+    std::vector<double> mydisp = Core::FE::extract_values(dispnp_col, lm);
     if (mydisp.size() < 3) FOUR_C_THROW("we need at least 3 dofs here");
 
     Core::LinAlg::Matrix<3, 1> currpos;

--- a/src/fluid_xfluid/4C_fluid_xfluid_outputservice.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_outputservice.cpp
@@ -663,13 +663,12 @@ void FLD::XFluidOutputServiceGmsh::gmsh_output_element(
     actele->location_vector(discret, la, false);
   }
 
-  std::vector<double> m(la[0].lm_.size());
-  Core::FE::extract_my_values(vel, m, la[0].lm_);
+  std::vector<double> m = Core::FE::extract_values(vel, la[0].lm_);
 
   std::vector<double> m_acc(la[0].lm_.size());
   if (acc_output)
   {
-    Core::FE::extract_my_values(*acc, m_acc, la[0].lm_);
+    m_acc = Core::FE::extract_values(*acc, la[0].lm_);
   }
 
   const bool ale_output(dispnp != nullptr);
@@ -677,7 +676,7 @@ void FLD::XFluidOutputServiceGmsh::gmsh_output_element(
   std::vector<double> m_disp(la[0].lm_.size());
   if (ale_output)
   {
-    Core::FE::extract_my_values(*dispnp, m_disp, la[0].lm_);
+    m_disp = Core::FE::extract_values(*dispnp, la[0].lm_);
   }
 
   int numnode = 0;
@@ -791,13 +790,12 @@ void FLD::XFluidOutputServiceGmsh::gmsh_output_volume_cell(
   // get element location vector, dirichlet flags and ownerships
   actele->location_vector(discret, nds, la, false);
 
-  std::vector<double> m(la[0].lm_.size());
-  Core::FE::extract_my_values(velvec, m, la[0].lm_);
+  std::vector<double> m = Core::FE::extract_values(velvec, la[0].lm_);
 
   std::vector<double> m_acc(la[0].lm_.size());
   if (acc_output)
   {
-    Core::FE::extract_my_values(*accvec, m_acc, la[0].lm_);
+    m_acc = Core::FE::extract_values(*accvec, la[0].lm_);
   }
 
   Core::LinAlg::SerialDenseMatrix vel(3, actele->num_node());

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_dirichletneumann_volcoupl.cpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_dirichletneumann_volcoupl.cpp
@@ -357,8 +357,7 @@ void FSI::VolCorrector::correct_vol_displacements_para_space(
       for (int idof = 0; idof < dim_; idof++) dofsFSI.push_back(temp[idof]);
 
       // extract local values of the global vectors
-      std::vector<double> FSIdisp(dofsFSI.size());
-      Core::FE::extract_my_values(DofColMapDummy, FSIdisp, dofsFSI);
+      std::vector<double> FSIdisp = Core::FE::extract_values(DofColMapDummy, dofsFSI);
 
       std::vector<int> temp2 = fluidale->fluid_field()->discretization()->dof(fluidnode);
       std::vector<int> dofs;

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -412,10 +412,9 @@ std::map<int, Core::LinAlg::Matrix<3, 1>> FSI::Utils::SlideAleUtils::current_str
         lm.reserve(3);
         // extract global dof ids
         interfacedis.dof(node, lm);
-        std::vector<double> mydisp(3);
         Core::LinAlg::Matrix<3, 1> currpos;
 
-        Core::FE::extract_my_values(reddisp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(reddisp, lm);
 
         for (int a = 0; a < 3; a++)
         {

--- a/src/geometry_pair/4C_geometry_pair_element_faces.cpp
+++ b/src/geometry_pair/4C_geometry_pair_element_faces.cpp
@@ -51,8 +51,7 @@ void GEOMETRYPAIR::FaceElementTemplate<Surface, ScalarType>::set_state(
     const std::unordered_map<int, std::shared_ptr<GEOMETRYPAIR::FaceElement>>& face_elements)
 {
   // Get all displacements for the current face / patch.
-  std::vector<double> patch_displacement;
-  Core::FE::extract_my_values(*displacement, patch_displacement, patch_dof_gid_);
+  std::vector<double> patch_displacement = Core::FE::extract_values(*displacement, patch_dof_gid_);
 
   // Create the full length FAD types.
   face_position_ = GEOMETRYPAIR::InitializeElementData<Surface, ScalarType>::initialize(
@@ -250,8 +249,8 @@ void GEOMETRYPAIR::FaceElementPatchTemplate<Surface, ScalarType>::set_state(
     const std::unordered_map<int, std::shared_ptr<GEOMETRYPAIR::FaceElement>>& face_elements)
 {
   // Get all displacements for the current face / patch.
-  std::vector<double> patch_displacement;
-  Core::FE::extract_my_values(*displacement, patch_displacement, this->patch_dof_gid_);
+  std::vector<double> patch_displacement =
+      Core::FE::extract_values(*displacement, this->patch_dof_gid_);
 
   // Create the full length FAD types.
   this->face_position_ = GEOMETRYPAIR::InitializeElementData<Surface, ScalarType>::initialize(
@@ -549,8 +548,8 @@ void GEOMETRYPAIR::FaceElementTemplateExtendedVolume<Surface, ScalarType, Volume
     const std::unordered_map<int, std::shared_ptr<GEOMETRYPAIR::FaceElement>>& face_elements)
 {
   // Get all displacements for the current face / volume.
-  std::vector<double> volume_displacement;
-  Core::FE::extract_my_values(*displacement, volume_displacement, this->patch_dof_gid_);
+  std::vector<double> volume_displacement =
+      Core::FE::extract_values(*displacement, this->patch_dof_gid_);
 
   // Create the full length FAD types.
   std::vector<ScalarType> patch_displacement_fad(Volume::n_dof_);

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -381,7 +381,7 @@ void ScaTra::LevelSetAlgorithm::apply_contact_point_boundary_condition()
               std::vector<double> myconvel(lmvel.size());
 
               // extract local values from global vector
-              Core::FE::extract_my_values(*convel, myconvel, lmvel);
+              myconvel = Core::FE::extract_values(*convel, lmvel);
 
               // determine number of velocity related dofs per node
               const int numveldofpernode = lmvel.size() / nen;

--- a/src/levelset/4C_levelset_intersection_utils.cpp
+++ b/src/levelset/4C_levelset_intersection_utils.cpp
@@ -336,7 +336,7 @@ void ScaTra::LevelSet::Intersection::prepare_cut(const Core::Elements::Element* 
   lmowner.clear();
   lmstride.clear();
   ele->location_vector(scatradis, lm, lmowner, lmstride);
-  Core::FE::extract_my_values(phicol, phi_nodes, lm);
+  phi_nodes = Core::FE::extract_values(phicol, lm);
 
   // define nodal ID's
   node_ids.resize(numnode, 0.0);

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -3116,8 +3116,7 @@ void Mat::constraint_mixture_output_to_gmsh(
     std::vector<int> lmstride;
     actele->location_vector(dis, lm, lmowner, lmstride);
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp = dis.get_state("displacement");
-    std::vector<double> mydisp(lm.size(), 0);
-    Core::FE::extract_my_values(*disp, mydisp, lm);
+    std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
     std::shared_ptr<Core::Mat::Material> mat = actele->material();
     Mat::ConstraintMixture* grow = static_cast<Mat::ConstraintMixture*>(mat.get());

--- a/src/membrane/4C_membrane_evaluate.cpp
+++ b/src/membrane/4C_membrane_evaluate.cpp
@@ -136,8 +136,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       Core::LinAlg::Matrix<numdof_, numdof_>* matptr = nullptr;
       if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -155,8 +154,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       Core::LinAlg::Matrix<numdof_, numdof_>* matptr = nullptr;
       if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -174,8 +172,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       mem_nlnstiffmass(lm, mydisp, nullptr, nullptr, &elevec1, nullptr, nullptr, params,
           Inpar::Solid::stress_none, Inpar::Solid::strain_none);
@@ -191,8 +188,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       update_element(mydisp, params, *material());
     }
     break;
@@ -216,8 +212,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       std::shared_ptr<std::vector<char>> stressdata = nullptr;
       std::shared_ptr<std::vector<char>> straindata = nullptr;
@@ -308,8 +303,7 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // get reference configuration and determine current configuration
       Core::LinAlg::Matrix<numnod_, noddof_> xrefe(true);
@@ -562,8 +556,7 @@ int Discret::Elements::Membrane<distype>::evaluate_neumann(Teuchos::ParameterLis
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement new");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
-  std::vector<double> mydisp(lm.size());
-  Core::FE::extract_my_values(*disp, mydisp, lm);
+  std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
   // get reference configuration and determine current configuration
   Core::LinAlg::Matrix<numnod_, noddof_> xrefe(true);

--- a/src/membrane/4C_membrane_scatra_evaluate.cpp
+++ b/src/membrane/4C_membrane_scatra_evaluate.cpp
@@ -41,9 +41,7 @@ void Discret::Elements::MembraneScatra<distype>::pre_evaluate(Teuchos::Parameter
       if (scalarnp == nullptr) FOUR_C_THROW("can not get state vector %s", scalarfield.c_str());
 
       // extract local values of the global vectors
-      std::vector<double> myscalar(la[1].lm_.size(), 0.0);
-
-      Core::FE::extract_my_values(*scalarnp, myscalar, la[1].lm_);
+      std::vector<double> myscalar = Core::FE::extract_values(*scalarnp, la[1].lm_);
 
       // element vector for k-th scalar
       std::vector<Core::LinAlg::Matrix<Membrane<distype>::numnod_, 1>> elescalar(numscal);

--- a/src/mortar/4C_mortar_interface.cpp
+++ b/src/mortar/4C_mortar_interface.cpp
@@ -2061,12 +2061,11 @@ void Mortar::Interface::set_state(
       {
         auto* node = dynamic_cast<Mortar::Node*>(idiscret_->l_col_node(i));
         const int numdof = node->num_dof();
-        std::vector<double> mydisp(numdof);
         std::vector<int> lm(numdof);
 
         for (int j = 0; j < numdof; ++j) lm[j] = node->dofs()[j];
 
-        Core::FE::extract_my_values(*global, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*global, lm);
 
         // add mydisp[2]=0 for 2D problems
         if (mydisp.size() < 3) mydisp.resize(3);
@@ -2091,12 +2090,11 @@ void Mortar::Interface::set_state(
       {
         auto* node = dynamic_cast<Mortar::Node*>(idiscret_->g_node(slave_col_nodes()->GID(i)));
         const int numdof = node->num_dof();
-        std::vector<double> mydisp(numdof);
         std::vector<int> lm(numdof);
 
         for (int j = 0; j < numdof; ++j) lm[j] = node->dofs()[j];
 
-        Core::FE::extract_my_values(global, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(global, lm);
 
         // add mydisp[2]=0 for 2D problems
         if (mydisp.size() < 3) mydisp.resize(3);
@@ -2122,12 +2120,11 @@ void Mortar::Interface::set_state(
       {
         auto* node = dynamic_cast<Mortar::Node*>(idiscret_->l_col_node(i));
         const int numdof = node->num_dof();
-        std::vector<double> myolddisp(numdof);
         std::vector<int> lm(numdof);
 
         for (int j = 0; j < numdof; ++j) lm[j] = node->dofs()[j];
 
-        Core::FE::extract_my_values(*global, myolddisp, lm);
+        std::vector<double> myolddisp = Core::FE::extract_values(*global, lm);
 
         // add mydisp[2]=0 for 2D problems
         if (myolddisp.size() < 3) myolddisp.resize(3);

--- a/src/particle_interaction/4C_particle_interaction_dem_adhesion.cpp
+++ b/src/particle_interaction/4C_particle_interaction_dem_adhesion.cpp
@@ -388,8 +388,8 @@ void ParticleInteraction::DEMAdhesion::evaluate_particle_wall_adhesion()
     if (walldatastate->get_vel_col() != nullptr)
     {
       // get nodal velocities
-      std::vector<double> nodal_vel(numnodes * 3);
-      Core::FE::extract_my_values(*walldatastate->get_vel_col(), nodal_vel, lmele);
+      std::vector<double> nodal_vel =
+          Core::FE::extract_values(*walldatastate->get_vel_col(), lmele);
 
       // determine velocity of wall contact point j
       for (int node = 0; node < numnodes; ++node)

--- a/src/particle_interaction/4C_particle_interaction_dem_contact.cpp
+++ b/src/particle_interaction/4C_particle_interaction_dem_contact.cpp
@@ -694,8 +694,8 @@ void ParticleInteraction::DEMContact::evaluate_particle_wall_contact()
     if (walldatastate->get_vel_col() != nullptr)
     {
       // get nodal velocities
-      std::vector<double> nodal_vel(numnodes * 3);
-      Core::FE::extract_my_values(*walldatastate->get_vel_col(), nodal_vel, lmele);
+      std::vector<double> nodal_vel =
+          Core::FE::extract_values(*walldatastate->get_vel_col(), lmele);
 
       // determine velocity of wall contact point j
       for (int node = 0; node < numnodes; ++node)

--- a/src/particle_interaction/4C_particle_interaction_sph_density.cpp
+++ b/src/particle_interaction/4C_particle_interaction_sph_density.cpp
@@ -634,8 +634,8 @@ void ParticleInteraction::SPHDensityBase::continuity_equation_particle_wall_cont
     if (walldatastate->get_vel_col() != nullptr)
     {
       // get nodal velocities
-      std::vector<double> nodal_vel(numnodes * 3);
-      Core::FE::extract_my_values(*walldatastate->get_vel_col(), nodal_vel, lmele);
+      std::vector<double> nodal_vel =
+          Core::FE::extract_values(*walldatastate->get_vel_col(), lmele);
 
       // determine velocity of wall contact point j
       for (int node = 0; node < numnodes; ++node)

--- a/src/particle_interaction/4C_particle_interaction_sph_momentum.cpp
+++ b/src/particle_interaction/4C_particle_interaction_sph_momentum.cpp
@@ -701,8 +701,8 @@ void ParticleInteraction::SPHMomentum::momentum_equation_particle_wall_contribut
     if (walldatastate->get_vel_col() != nullptr)
     {
       // get nodal velocities
-      std::vector<double> nodal_vel(numnodes * 3);
-      Core::FE::extract_my_values(*walldatastate->get_vel_col(), nodal_vel, lmele);
+      std::vector<double> nodal_vel =
+          Core::FE::extract_values(*walldatastate->get_vel_col(), lmele);
 
       // determine velocity of wall contact point j
       for (int node = 0; node < numnodes; ++node)

--- a/src/particle_interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
+++ b/src/particle_interaction/4C_particle_interaction_sph_rigid_particle_contact.cpp
@@ -281,8 +281,8 @@ void ParticleInteraction::SPHRigidParticleContactElastic::
     if (walldatastate->get_vel_col() != nullptr)
     {
       // get nodal velocities
-      std::vector<double> nodal_vel(numnodes * 3);
-      Core::FE::extract_my_values(*walldatastate->get_vel_col(), nodal_vel, lmele);
+      std::vector<double> nodal_vel =
+          Core::FE::extract_values(*walldatastate->get_vel_col(), lmele);
 
       // determine velocity of wall contact point j
       for (int node = 0; node < numnodes; ++node)

--- a/src/particle_interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
+++ b/src/particle_interaction/4C_particle_interaction_sph_virtual_wall_particle.cpp
@@ -196,8 +196,8 @@ void ParticleInteraction::SPHVirtualWallParticle::init_states_at_wall_contact_po
     if (walldatastate->get_acc_col() != nullptr)
     {
       // get nodal accelerations
-      std::vector<double> nodal_acc(numnodes * 3);
-      Core::FE::extract_my_values(*walldatastate->get_acc_col(), nodal_acc, lmele);
+      std::vector<double> nodal_acc =
+          Core::FE::extract_values(*walldatastate->get_acc_col(), lmele);
 
       // determine acceleration of wall contact point j
       for (int node = 0; node < numnodes; ++node)

--- a/src/particle_wall/4C_particle_wall.cpp
+++ b/src/particle_wall/4C_particle_wall.cpp
@@ -411,7 +411,7 @@ void PARTICLEWALL::WallHandlerBase::determine_col_wall_ele_nodal_pos(
         FOUR_C_THROW("dof gid=%d not in dof column map!", lm_wall[i]);
 #endif
 
-    Core::FE::extract_my_values(*walldatastate_->get_disp_col(), nodal_disp, lm_wall);
+    nodal_disp = Core::FE::extract_values(*walldatastate_->get_disp_col(), lm_wall);
   }
 
   // iterate over nodes of current column wall element

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_linebased.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_linebased.cpp
@@ -957,8 +957,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::get_ele_segment_len
   std::shared_ptr<const Core::LinAlg::Vector<double>> curr_seg_lengths =
       arterydis_->get_state(1, "curr_seg_lengths");
 
-  std::vector<double> seglengths(maxnumsegperartele_);
-  Core::FE::extract_my_values(*curr_seg_lengths, seglengths, seglengthdofs);
+  std::vector<double> seglengths = Core::FE::extract_values(*curr_seg_lengths, seglengthdofs);
 
   return seglengths;
 }

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_pair.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_pair.cpp
@@ -797,10 +797,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
       variablemanager_->extract_element_and_node_values(*element2_, *contdis, la_cont, ele2pos_, 0);
 
       // get contelephinp_ and artelephinp_
-      Core::FE::extract_my_values(
-          *contdis->get_state("phinp_fluid"), contelephinp_, la_cont[0].lm_);
-      Core::FE::extract_my_values(
-          *artdis->get_state("one_d_artery_pressure"), artelephinp_, la_art[0].lm_);
+      contelephinp_ = Core::FE::extract_values(*contdis->get_state("phinp_fluid"), la_cont[0].lm_);
+      artelephinp_ =
+          Core::FE::extract_values(*artdis->get_state("one_d_artery_pressure"), la_art[0].lm_);
 
       // extract velocity of solid phase
       extract_solid_vel(*contdis);
@@ -854,9 +853,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
       variablemanager_->extract_element_and_node_values(*element2_, *contdis, la_cont, ele2pos_, 2);
 
       // get contelephinp_ and artelephinp_
-      Core::FE::extract_my_values(*contdis->get_state("phinp"), contelephinp_, la_cont[0].lm_);
-      Core::FE::extract_my_values(
-          *artdis->get_state("one_d_artery_phinp"), artelephinp_, la_art[0].lm_);
+      contelephinp_ = Core::FE::extract_values(*contdis->get_state("phinp"), la_cont[0].lm_);
+      artelephinp_ =
+          Core::FE::extract_values(*artdis->get_state("one_d_artery_phinp"), la_art[0].lm_);
 
       // extract artery pressure
       std::shared_ptr<const Core::LinAlg::Vector<double>> artpressnp =

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -147,20 +147,16 @@ int Discret::Elements::AcinusImpl<distype>::evaluate(RedAcinus* ele, Teuchos::Pa
     FOUR_C_THROW("Cannot get state vectors 'pnp', 'on', and/or 'pnm''");
 
   // Extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // Extract local values from the global vectors
-  std::vector<double> mypn(lm.size());
-  Core::FE::extract_my_values(*on, mypn, lm);
+  std::vector<double> mypn = Core::FE::extract_values(*on, lm);
 
   // Extract local values from the global vectors
-  std::vector<double> mypnm(lm.size());
-  Core::FE::extract_my_values(*pnm, mypnm, lm);
+  std::vector<double> mypnm = Core::FE::extract_values(*pnm, lm);
 
   // Extract local values from the global vectors
-  std::vector<double> myial(lm.size());
-  Core::FE::extract_my_values(*ial, myial, lm);
+  std::vector<double> myial = Core::FE::extract_values(*ial, lm);
 
   // Create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(elemVecdim);
@@ -294,8 +290,7 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
   if (pnp == nullptr) FOUR_C_THROW("Cannot get state vectors 'pnp'");
 
   // Extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // Create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(numnode);
@@ -707,16 +702,13 @@ void Discret::Elements::AcinusImpl<distype>::calc_flow_rates(RedAcinus* ele,
     FOUR_C_THROW("Cannot get state vectors 'pnp', 'on', and/or 'pnm''");
 
   // Extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // Extract local values from the global vectors
-  std::vector<double> mypn(lm.size());
-  Core::FE::extract_my_values(*on, mypn, lm);
+  std::vector<double> mypn = Core::FE::extract_values(*on, lm);
 
   // Extract local values from the global vectors
-  std::vector<double> mypnm(lm.size());
-  Core::FE::extract_my_values(*pnm, mypnm, lm);
+  std::vector<double> mypnm = Core::FE::extract_values(*pnm, lm);
 
   // Create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(elemVecdim);
@@ -826,8 +818,7 @@ void Discret::Elements::AcinusImpl<distype>::get_coupled_values(RedAcinus* ele,
   if (pnp == nullptr) FOUR_C_THROW("Cannot get state vectors 'pnp'");
 
   // extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(numnode);

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -606,16 +606,13 @@ int Discret::Elements::AirwayImpl<distype>::evaluate(RedAirway* ele, Teuchos::Pa
     FOUR_C_THROW("Cannot get state vectors 'pnp', 'on', and/or 'pnm''");
 
   // extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // extract local values from the global vectors
-  std::vector<double> mypn(lm.size());
-  Core::FE::extract_my_values(*on, mypn, lm);
+  std::vector<double> mypn = Core::FE::extract_values(*on, lm);
 
   // extract local values from the global vectors
-  std::vector<double> mypnm(lm.size());
-  Core::FE::extract_my_values(*pnm, mypnm, lm);
+  std::vector<double> mypnm = Core::FE::extract_values(*pnm, lm);
 
   // create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(elemVecdim);
@@ -864,8 +861,7 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
   if (on == nullptr) FOUR_C_THROW("Cannot get state vectors 'on'");
 
   // extract local values from the global vectors
-  std::vector<double> mypn(lm.size());
-  Core::FE::extract_my_values(*on, mypn, lm);
+  std::vector<double> mypn = Core::FE::extract_values(*on, lm);
 
   // create objects for element arrays
   Core::LinAlg::SerialDenseVector epn(numnode);
@@ -1177,16 +1173,13 @@ void Discret::Elements::AirwayImpl<distype>::calc_flow_rates(RedAirway* ele,
     FOUR_C_THROW("Cannot get state vectors 'pnp', 'on', and/or 'pnm''");
 
   // extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // extract local values from the global vectors
-  std::vector<double> mypn(lm.size());
-  Core::FE::extract_my_values(*on, mypn, lm);
+  std::vector<double> mypn = Core::FE::extract_values(*on, lm);
 
   // extract local values from the global vectors
-  std::vector<double> mypnm(lm.size());
-  Core::FE::extract_my_values(*pnm, mypnm, lm);
+  std::vector<double> mypnm = Core::FE::extract_values(*pnm, lm);
 
   // create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(elemVecdim);
@@ -1346,8 +1339,7 @@ void Discret::Elements::AirwayImpl<distype>::get_coupled_values(RedAirway* ele,
   if (pnp == nullptr) FOUR_C_THROW("Cannot get state vectors 'pnp'");
 
   // extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(numnode);

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -77,8 +77,7 @@ int Discret::Elements::InterAcinarDepImpl<distype>::evaluate(RedInterAcinarDep* 
       discretization.get_state("intr_ac_link");
 
   // Extract local values from the global vectors
-  std::vector<double> myial(lm.size());
-  Core::FE::extract_my_values(*ial, myial, lm);
+  std::vector<double> myial = Core::FE::extract_values(*ial, lm);
 
   // Calculate the system matrix for inter-acinar linkers
   sysmat(myial, elemat1_epetra, elevec1_epetra);
@@ -170,8 +169,7 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
   if (pnp == nullptr) FOUR_C_THROW("Cannot get state vectors 'pnp'");
 
   // Extract local values from the global vectors
-  std::vector<double> mypnp(lm.size());
-  Core::FE::extract_my_values(*pnp, mypnp, lm);
+  std::vector<double> mypnp = Core::FE::extract_values(*pnp, lm);
 
   // Create objects for element arrays
   Core::LinAlg::SerialDenseVector epnp(numnode);

--- a/src/rigidsphere/4C_rigidsphere_evaluate.cpp
+++ b/src/rigidsphere/4C_rigidsphere_evaluate.cpp
@@ -54,8 +54,7 @@ int Discret::Elements::Rigidsphere::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       std::shared_ptr<const Core::LinAlg::Vector<double>> vel;
       std::vector<double> myvel(lm.size());
@@ -94,15 +93,13 @@ int Discret::Elements::Rigidsphere::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // get element velocity
       std::shared_ptr<const Core::LinAlg::Vector<double>> vel =
           discretization.get_state("velocity");
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
 
       if (act == Core::Elements::struct_calc_brownianforce)
         calc_brownian_forces_and_stiff(params, myvel, mydisp, nullptr, &elevec1);
@@ -341,8 +338,7 @@ Core::GeometricSearch::BoundingVolume Discret::Elements::Rigidsphere::get_boundi
   // Get the element displacements.
   std::vector<int> lm, lmowner, lmstride;
   this->location_vector(discret, lm, lmowner, lmstride);
-  std::vector<double> mydisp(lm.size());
-  Core::FE::extract_my_values(result_data_dofbased, mydisp, lm);
+  std::vector<double> mydisp = Core::FE::extract_values(result_data_dofbased, lm);
 
   // Add reference position.
   if (mydisp.size() != 3)

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.cpp
@@ -127,7 +127,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcLoma<distype, probdim>::calc_loma_t
   std::vector<double> myconvel(lmvel.size());
 
   // extract local values of the global vectors
-  Core::FE::extract_my_values(*convel, myconvel, lmvel);
+  myconvel = Core::FE::extract_values(*convel, lmvel);
 
   // rotate the vector field in the case of rotationally symmetric boundary conditions
   my::rotsymmpbc_->rotate_my_values_if_necessary(myconvel);

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.cpp
@@ -148,8 +148,7 @@ int Discret::Elements::ScaTraEleBoundaryCalcPoro<distype, probdim>::evaluate_act
 
         if (disp != nullptr)
         {
-          std::vector<double> mydisp(la[ndsdisp].lm_.size());
-          Core::FE::extract_my_values(*disp, mydisp, la[ndsdisp].lm_);
+          std::vector<double> mydisp = Core::FE::extract_values(*disp, la[ndsdisp].lm_);
 
           for (int inode = 0; inode < nen_; ++inode)  // number of nodes
             eporosity_(inode, 0) = mydisp[nsd_ + (inode * (nsd_ele_ + 2))];

--- a/src/scatra_ele/4C_scatra_ele_calc_artery.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_artery.cpp
@@ -164,9 +164,7 @@ void Discret::Elements::ScaTraEleCalcArtery<distype, probdim>::extract_element_a
   {
     std::shared_ptr<const Core::LinAlg::Vector<double>> curr_seg_lengths =
         discretization.get_state(1, "curr_seg_lengths");
-    std::vector<double> seglengths(la[1].lm_.size());
-
-    Core::FE::extract_my_values(*curr_seg_lengths, seglengths, la[1].lm_);
+    std::vector<double> seglengths = Core::FE::extract_values(*curr_seg_lengths, la[1].lm_);
 
     const double curr_ele_length = std::accumulate(seglengths.begin(), seglengths.end(), 0.0);
 

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_NP.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_NP.cpp
@@ -952,8 +952,7 @@ void Discret::Elements::ScaTraEleCalcElchNP<distype>::correction_for_flux_across
     // get dirichlet toggle from the discretization
     std::shared_ptr<const Core::LinAlg::Vector<double>> dctoggle =
         discretization.get_state("dctoggle");
-    std::vector<double> mydctoggle(lm.size());
-    Core::FE::extract_my_values(*dctoggle, mydctoggle, lm);
+    std::vector<double> mydctoggle = Core::FE::extract_values(*dctoggle, lm);
 
     double val = 0.;
     for (unsigned vi = 0; vi < nen_; ++vi)

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond.cpp
@@ -1128,8 +1128,7 @@ void Discret::Elements::ScaTraEleCalcElchDiffCond<distype, probdim>::correction_
   // in this function we check if the actual nodes have a dirichlet value
   std::shared_ptr<const Core::LinAlg::Vector<double>> dctoggle =
       discretization.get_state("dctoggle");
-  std::vector<double> mydctoggle(lm.size());
-  Core::FE::extract_my_values(*dctoggle, mydctoggle, lm);
+  std::vector<double> mydctoggle = Core::FE::extract_values(*dctoggle, lm);
 
   double val = 0.0;
   for (unsigned vi = 0; vi < nen_; ++vi)

--- a/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
@@ -1900,13 +1900,11 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::project_field(
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
       params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("phi");
 
-  std::vector<double> tracephi;
-  Core::FE::extract_my_values(*matrix_state, tracephi, la[nds_var_old].lm_);
+  std::vector<double> tracephi = Core::FE::extract_values(*matrix_state, la[nds_var_old].lm_);
 
   // get node based values!
   matrix_state = params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("intphi");
-  std::vector<double> intphi;
-  Core::FE::extract_my_values(*matrix_state, intphi, la[nds_intvar_old].lm_);
+  std::vector<double> intphi = Core::FE::extract_values(*matrix_state, la[nds_intvar_old].lm_);
   if (intphi.size() != shapes_old->ndofs_ * (nsd_ + 1))
     FOUR_C_THROW(
         "node number not matching: %d vs. %d", intphi.size(), shapes_old->ndofs_ * (nsd_ + 1));

--- a/src/scatra_ele/4C_scatra_ele_calc_poro.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro.cpp
@@ -179,8 +179,7 @@ void Discret::Elements::ScaTraEleCalcPoro<distype>::extract_element_and_node_val
 
     if (disp != nullptr)
     {
-      std::vector<double> mydisp(la[ndsdisp].lm_.size());
-      Core::FE::extract_my_values(*disp, mydisp, la[ndsdisp].lm_);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, la[ndsdisp].lm_);
 
       for (unsigned inode = 0; inode < nen_; ++inode)  // number of nodes
         eporosity_(inode, 0) = mydisp[nsd_ + (inode * (nsd_ + 1))];

--- a/src/scatra_ele/4C_scatra_ele_sti_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_sti_elch.cpp
@@ -80,8 +80,7 @@ void Discret::Elements::ScaTraEleSTIElch<distype>::extract_element_and_node_valu
 
   // extract local nodal values of concentration and electric potential from global state vector
   const std::vector<int>& lm = la[2].lm_;
-  std::vector<double> myelchnp(lm.size());
-  Core::FE::extract_my_values(*elchnp, myelchnp, lm);
+  std::vector<double> myelchnp = Core::FE::extract_values(*elchnp, lm);
   for (int inode = 0; inode < nen_; ++inode)
   {
     econcnp_(inode) = myelchnp[inode * 2];

--- a/src/shell7p/4C_shell7p_ele_calc.cpp
+++ b/src/shell7p/4C_shell7p_ele_calc.cpp
@@ -101,10 +101,8 @@ double Discret::Elements::Shell7pEleCalc<distype>::calculate_internal_energy(
       discretization.get_state("residual displacement");
   if (disp == nullptr || res == nullptr)
     FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // init scale factor for scaled director approach (SDC)
   const double condfac = shell_data_.sdc;
@@ -207,10 +205,8 @@ void Discret::Elements::Shell7pEleCalc<distype>::calculate_stresses_strains(
       discretization.get_state("residual displacement");
   if (disp == nullptr || res == nullptr)
     FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // init gauss point in thickness direction that will be modified via SDC
   double zeta = 0.0;
@@ -314,10 +310,8 @@ void Discret::Elements::Shell7pEleCalc<distype>::evaluate_nonlinear_force_stiffn
       discretization.get_state("residual displacement");
   if (disp == nullptr || res == nullptr)
     FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // init gauss point in thickness direction that will be modified via SDC
   double zeta = 0.0;
@@ -499,8 +493,7 @@ void Discret::Elements::Shell7pEleCalc<distype>::update(Core::Elements::Element&
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement' ");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
 
   // calculate and update inelastic deformation gradient if needed
   if (solid_material.uses_extended_update())

--- a/src/shell7p/4C_shell7p_ele_calc_eas.cpp
+++ b/src/shell7p/4C_shell7p_ele_calc_eas.cpp
@@ -207,10 +207,8 @@ double Discret::Elements::Shell7pEleCalcEas<distype>::calculate_internal_energy(
       discretization.get_state("displacement");
   std::shared_ptr<const Core::LinAlg::Vector<double>> res =
       discretization.get_state("residual displacement");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // init scale factor for scaled director approach (SDC)
   const double condfac = shell_data_.sdc;
@@ -343,10 +341,8 @@ void Discret::Elements::Shell7pEleCalcEas<distype>::calculate_stresses_strains(
       discretization.get_state("displacement");
   std::shared_ptr<const Core::LinAlg::Vector<double>> res =
       discretization.get_state("residual displacement");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // init gauss point in thickness direction that will be modified via SDC
   double zeta = 0.0;
@@ -477,10 +473,8 @@ void Discret::Elements::Shell7pEleCalcEas<distype>::evaluate_nonlinear_force_sti
       discretization.get_state("displacement");
   std::shared_ptr<const Core::LinAlg::Vector<double>> res =
       discretization.get_state("residual displacement");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // init gauss point in thickness direction that will be modified via SDC
   double zeta = 0.0;
@@ -721,8 +715,7 @@ void Discret::Elements::Shell7pEleCalcEas<distype>::recover(Core::Elements::Elem
   std::shared_ptr<const Core::LinAlg::Vector<double>> res =
       discretization.get_state("residual displacement");
   if (res == nullptr) FOUR_C_THROW("Cannot get residual displacement state vector");
-  std::vector<double> residual(dof_index_array.size());
-  Core::FE::extract_my_values(*res, residual, dof_index_array);
+  std::vector<double> residual = Core::FE::extract_values(*res, dof_index_array);
 
   // get access to the interface parameters
   double step_length = interface_ptr.get_step_length();
@@ -778,8 +771,7 @@ void Discret::Elements::Shell7pEleCalcEas<distype>::update(Core::Elements::Eleme
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement' ");
-  std::vector<double> displacement(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacement, dof_index_array);
+  std::vector<double> displacement = Core::FE::extract_values(*disp, dof_index_array);
 
   // No need to update alpha here. Update is called to copy states from t_{n+1} to
   // t_{n} after the time step and output Hence, there are no more Newton iterations that would

--- a/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
+++ b/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
@@ -169,8 +169,7 @@ void Discret::Elements::Shell::evaluate_neumann(Core::Elements::Element& ele,
         // no linearization needed for load in last converged configuration
         loadlin = false;
         const Core::LinAlg::Vector<double>& disp = *discretization.get_state("displacement");
-        std::vector<double> displacements(dof_index_array.size());
-        Core::FE::extract_my_values(disp, displacements, dof_index_array);
+        std::vector<double> displacements = Core::FE::extract_values(disp, dof_index_array);
 
         spatial_configuration<distype>(x_curr, x_refe, displacements, 0);
 
@@ -180,8 +179,7 @@ void Discret::Elements::Shell::evaluate_neumann(Core::Elements::Element& ele,
       case config_spatial:
       {
         const Core::LinAlg::Vector<double>& disp = *discretization.get_state("displacement new");
-        std::vector<double> displacements(dof_index_array.size());
-        Core::FE::extract_my_values(disp, displacements, dof_index_array);
+        std::vector<double> displacements = Core::FE::extract_values(disp, dof_index_array);
 
         spatial_configuration<distype>(x_curr, x_refe, displacements, 0);
 

--- a/src/shell7p/4C_shell7p_ele_scatra_preevaluator.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra_preevaluator.cpp
@@ -73,9 +73,7 @@ void Discret::Elements::Shell::pre_evaluate_scatra(Core::Elements::Element& ele,
       if (scalarnp == nullptr) FOUR_C_THROW("can not get state vector %s", scalarfield.c_str());
 
       // extract local values of the global vectors
-      std::vector<double> myscalar(dof_index_array[1].lm_.size(), 0.0);
-
-      Core::FE::extract_my_values(*scalarnp, myscalar, dof_index_array[1].lm_);
+      std::vector<double> myscalar = Core::FE::extract_values(*scalarnp, dof_index_array[1].lm_);
 
       // element vector for k-th scalar
       std::vector<Core::LinAlg::Matrix<Shell::Internal::num_node<distype>, 1>> elescalar(numscal);

--- a/src/shell7p/4C_shell7p_line_evaluate.cpp
+++ b/src/shell7p/4C_shell7p_line_evaluate.cpp
@@ -29,8 +29,7 @@ int Discret::Elements::Shell7pLine::evaluate_neumann(Teuchos::ParameterList& par
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-  std::vector<double> displacements(dof_index_array.size());
-  Core::FE::extract_my_values(*disp, displacements, dof_index_array);
+  std::vector<double> displacements = Core::FE::extract_values(*disp, dof_index_array);
 
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
@@ -63,8 +63,7 @@ int Discret::Elements::KirchhoffLoveShellNurbs::evaluate(Teuchos::ParameterList&
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       Core::LinAlg::Matrix<9 * 3, 1> displacement(mydisp.data(), true);
 
       // Get reference configuration

--- a/src/so3/4C_so3_hex27_evaluate.cpp
+++ b/src/so3/4C_so3_hex27_evaluate.cpp
@@ -126,10 +126,8 @@ int Discret::Elements::SoHex27::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMDOF_SOH27, NUMDOF_SOH27>* matptr = nullptr;
       if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -164,10 +162,8 @@ int Discret::Elements::SoHex27::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       // create a dummy element matrix to apply linearised EAS-stuff onto
       Core::LinAlg::Matrix<NUMDOF_SOH27, NUMDOF_SOH27> myemat(true);
 
@@ -217,14 +213,10 @@ int Discret::Elements::SoHex27::evaluate(Teuchos::ParameterList& params,
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
       if (acc == nullptr) FOUR_C_THROW("Cannot get state vectors 'acceleration'");
 
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
-      std::vector<double> myacc(lm.size());
-      Core::FE::extract_my_values(*acc, myacc, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
+      std::vector<double> myacc = Core::FE::extract_values(*acc, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       // This matrix is used in the evaluation functions to store the mass matrix. If the action
       // type is Core::Elements::struct_calc_internalinertiaforce we do not want to actually
@@ -301,10 +293,8 @@ int Discret::Elements::SoHex27::evaluate(Teuchos::ParameterList& params,
       if (stressdata == nullptr) FOUR_C_THROW("Cannot get 'stress' data");
       if (straindata == nullptr) FOUR_C_THROW("Cannot get 'strain' data");
       if (plstraindata == nullptr) FOUR_C_THROW("Cannot get 'plastic strain' data");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMGPT_SOH27, Mat::NUM_STRESS_3D> stress;
       Core::LinAlg::Matrix<NUMGPT_SOH27, Mat::NUM_STRESS_3D> strain;
       Core::LinAlg::Matrix<NUMGPT_SOH27, Mat::NUM_STRESS_3D> plstrain;
@@ -360,8 +350,7 @@ int Discret::Elements::SoHex27::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get displacement state");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // build incremental def gradient for every gauss point
       Core::LinAlg::SerialDenseMatrix gpdefgrd(NUMGPT_SOH27, 9);
@@ -429,8 +418,7 @@ int Discret::Elements::SoHex27::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state displacement vector");
 
       // get displacements of this element
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // update element geometry
       Core::LinAlg::Matrix<NUMNOD_SOH27, NUMDIM_SOH27> xrefe;  // material coord. of element

--- a/src/so3/4C_so3_hex8_evaluate.cpp
+++ b/src/so3/4C_so3_hex8_evaluate.cpp
@@ -103,10 +103,8 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMDOF_SOH8, NUMDOF_SOH8>* matptr = nullptr;
       if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -127,10 +125,8 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       // create a dummy element matrix to apply linearised EAS-stuff onto
       Core::LinAlg::Matrix<NUMDOF_SOH8, NUMDOF_SOH8> myemat(true);
 
@@ -162,14 +158,10 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
       if (acc == nullptr) FOUR_C_THROW("Cannot get state vectors 'acceleration'");
 
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
-      std::vector<double> myacc(lm.size());
-      Core::FE::extract_my_values(*acc, myacc, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
+      std::vector<double> myacc = Core::FE::extract_values(*acc, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       // This matrix is used in the evaluation functions to store the mass matrix. If the action
       // type is Core::Elements::struct_calc_internalinertiaforce we do not want to actually
@@ -229,8 +221,7 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
             "Cannot get state vectors \"displacement\" "
             "and/or \"residual displacement\"");
 
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       soh8_recover(lm, myres);
       /* ToDo Probably we have to recover the history information of some special
@@ -276,10 +267,8 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
       if (stressdata == nullptr) FOUR_C_THROW("Cannot get 'stress' data");
       if (straindata == nullptr) FOUR_C_THROW("Cannot get 'strain' data");
       if (plstraindata == nullptr) FOUR_C_THROW("Cannot get 'plastic strain' data");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> stress;
       Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> strain;
       Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> plstrain;
@@ -422,8 +411,7 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       update_element(mydisp, params, *material());
     }
     break;
@@ -460,8 +448,7 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state displacement vector");
 
       // get displacements of this element
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // update element geometry
       Core::LinAlg::Matrix<NUMNOD_SOH8, NUMDIM_SOH8> xrefe;  // material coord. of element
@@ -722,8 +709,7 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get displacement state");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       switch (pstype_)
       {
@@ -797,10 +783,8 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
                 "gpstrainmap", nullptr);
         if (gpstrainmap == nullptr)
           FOUR_C_THROW("no gp strain map available for writing gpstrains");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
-        std::vector<double> myres(lm.size());
-        Core::FE::extract_my_values(*res, myres, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+        std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
         Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> stress;
         Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> strain;
@@ -884,8 +868,7 @@ int Discret::Elements::SoHex8::evaluate(Teuchos::ParameterList& params,
       if (!res) FOUR_C_THROW("Cannot get state vector \"residual displacement\"");
 
       // extract the part for this element
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       soh8_create_eas_backup_state(myres);
 

--- a/src/so3/4C_so3_nurbs27_evaluate.cpp
+++ b/src/so3/4C_so3_nurbs27_evaluate.cpp
@@ -114,10 +114,8 @@ int Discret::Elements::Nurbs::SoNurbs27::evaluate(Teuchos::ParameterList& params
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<81, 81>* matptr = nullptr;
       if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -135,10 +133,8 @@ int Discret::Elements::Nurbs::SoNurbs27::evaluate(Teuchos::ParameterList& params
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       // create a dummy element matrix to apply linearised EAS-stuff onto
       Core::LinAlg::Matrix<81, 81> myemat(true);
       sonurbs27_nlnstiffmass(lm, discretization, mydisp, myres, &myemat, nullptr, &elevec1, params);
@@ -156,10 +152,8 @@ int Discret::Elements::Nurbs::SoNurbs27::evaluate(Teuchos::ParameterList& params
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       sonurbs27_nlnstiffmass(
           lm, discretization, mydisp, myres, &elemat1, &elemat2, &elevec1, params);
@@ -225,8 +219,7 @@ int Discret::Elements::Nurbs::SoNurbs27::evaluate(Teuchos::ParameterList& params
       // need current displacement
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       elevec1_epetra(0) = calc_int_energy(discretization, mydisp, params);
       break;

--- a/src/so3/4C_so3_poro_evaluate.cpp
+++ b/src/so3/4C_so3_poro_evaluate.cpp
@@ -191,7 +191,7 @@ int Discret::Elements::So3Poro<So3Ele, distype>::my_evaluate(Teuchos::ParameterL
             std::vector<double> myephi(la[1].size());
             std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
                 discretization.get_state(1, "porofluid");
-            Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+            myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
             // calculate tangent stiffness matrix
             nonlinear_stiffness_poroelast_pressure_based(
@@ -270,7 +270,7 @@ int Discret::Elements::So3Poro<So3Ele, distype>::my_evaluate(Teuchos::ParameterL
             std::vector<double> myephi(la[1].size());
             std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
                 discretization.get_state(1, "porofluid");
-            Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+            myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
             // calculate tangent stiffness matrix
             nonlinear_stiffness_poroelast_pressure_based(
@@ -339,7 +339,7 @@ int Discret::Elements::So3Poro<So3Ele, distype>::my_evaluate(Teuchos::ParameterL
           std::vector<double> myephi(la[1].size());
           std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
               discretization.get_state(1, "porofluid");
-          Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+          myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
           Core::LinAlg::Matrix<numdim_, numnod_> mydisp(true);
           extract_values_from_global_vector(
@@ -395,7 +395,7 @@ int Discret::Elements::So3Poro<So3Ele, distype>::my_evaluate(Teuchos::ParameterL
           std::vector<double> myephi(la[1].size());
           std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
               discretization.get_state(1, "porofluid");
-          Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+          myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
           // calculate tangent stiffness matrix
           nonlinear_stiffness_poroelast_pressure_based(
@@ -1267,8 +1267,7 @@ void Discret::Elements::So3Poro<So3Ele, distype>::extract_values_from_global_vec
   const int numdofpernode = discretization.num_dof(dofset, nodes()[0]);
 
   // extract local values of the global vectors
-  std::vector<double> mymatrix(lm.size());
-  Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+  std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
   if (numdofpernode == numdim_ + 1)
   {

--- a/src/so3/4C_so3_poro_scatra_evaluate.cpp
+++ b/src/so3/4C_so3_poro_scatra_evaluate.cpp
@@ -27,8 +27,7 @@ void Discret::Elements::So3PoroScatra<So3Ele, distype>::pre_evaluate(Teuchos::Pa
           discretization.get_state(2, "scalar");
 
       // extract local values of the global vectors
-      std::vector<double> myscalar(la[2].lm_.size());
-      Core::FE::extract_my_values(*scalarnp, myscalar, la[2].lm_);
+      std::vector<double> myscalar = Core::FE::extract_values(*scalarnp, la[2].lm_);
 
       if (So3Ele::num_material() < 2)
         FOUR_C_THROW("no second material defined for Wall poro element!");

--- a/src/so3/4C_so3_sh8_evaluate.cpp
+++ b/src/so3/4C_so3_sh8_evaluate.cpp
@@ -141,10 +141,8 @@ int Discret::Elements::SoSh8::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       // decide whether evaluate 'thin' sosh stiff or 'thick' so_hex8 stiff
       if (eastype_ != Discret::Elements::SoHex8::soh8_easmild)
       {
@@ -170,10 +168,8 @@ int Discret::Elements::SoSh8::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       // create a dummy element matrix to apply linearised EAS-stuff onto
       Core::LinAlg::Matrix<NUMDOF_SOH8, NUMDOF_SOH8> myemat(true);
       // decide whether evaluate 'thin' sosh stiff or 'thick' so_hex8 stiff
@@ -207,10 +203,8 @@ int Discret::Elements::SoSh8::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       // decide whether evaluate 'thin' sosh stiff or 'thick' so_hex8 stiff
       if (eastype_ != Discret::Elements::SoHex8::soh8_easmild)
@@ -248,11 +242,9 @@ int Discret::Elements::SoSh8::evaluate(Teuchos::ParameterList& params,
       if (straindata == nullptr) FOUR_C_THROW("Cannot get strain 'data'");
       if (plstraindata == nullptr) FOUR_C_THROW("Cannot get plastic strain 'data'");
 
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> stress;
       Core::LinAlg::Matrix<NUMGPT_SOH8, Mat::NUM_STRESS_3D> strain;
@@ -454,8 +446,7 @@ int Discret::Elements::SoSh8::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state displacement vector");
 
       // get displacements of this element
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
 
       if (is_params_interface())  // new structural time integration

--- a/src/so3/4C_so3_surface_evaluate.cpp
+++ b/src/so3/4C_so3_surface_evaluate.cpp
@@ -142,8 +142,7 @@ int Discret::Elements::StructuralSurface::evaluate_neumann(Teuchos::ParameterLis
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       spatial_configuration(xc, mydisp);
     }
     break;
@@ -170,8 +169,7 @@ int Discret::Elements::StructuralSurface::evaluate_neumann(Teuchos::ParameterLis
           FOUR_C_THROW(
               "Cannot get state vector 'displacement new'\n"
               "Did you forget to set the 'LOADLIN yes' in '--STRUCTURAL DYNAMIC' input section???");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
         spatial_configuration(xc, mydisp);
       }
     }
@@ -615,8 +613,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
         std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
             discretization.get_state("displacementtotal");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacementtotal'");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
         const int numnode = num_node();
         const int numdf = 3;
         Core::LinAlg::SerialDenseMatrix xc(numnode, numdf);
@@ -634,8 +631,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
 
         std::shared_ptr<const Core::LinAlg::Vector<double>> dispincr =
             discretization.get_state("displacementincr");
-        std::vector<double> edispincr(lm.size());
-        Core::FE::extract_my_values(*dispincr, edispincr, lm);
+        std::vector<double> edispincr = Core::FE::extract_values(*dispincr, lm);
         elevector2[0] = 0;
 
         for (int gp = 0; gp < intpoints.nquad; gp++)
@@ -680,16 +676,14 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
         std::shared_ptr<const Core::LinAlg::Vector<double>> dispn =
             discretization.get_state("displacementnp");
         if (dispn == nullptr) FOUR_C_THROW("Cannot get state vector 'displacementnp");
-        std::vector<double> edispn(lm.size());
-        Core::FE::extract_my_values(*dispn, edispn, lm);
+        std::vector<double> edispn = Core::FE::extract_values(*dispn, lm);
         Core::LinAlg::SerialDenseMatrix xcn(numnode, numdf);
         spatial_configuration(xcn, edispn);
 
         std::shared_ptr<const Core::LinAlg::Vector<double>> dispincr =
             discretization.get_state("displacementincr");
         if (dispn == nullptr) FOUR_C_THROW("Cannot get state vector 'displacementincr");
-        std::vector<double> edispincr(lm.size());
-        Core::FE::extract_my_values(*dispincr, edispincr, lm);
+        std::vector<double> edispincr = Core::FE::extract_values(*dispincr, lm);
 
         // integration of the displacements over the surface
         // allocate vector for shape functions and matrix for derivatives
@@ -775,16 +769,14 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispn =
           discretization.get_state("displacementnp");
       if (dispn == nullptr) FOUR_C_THROW("Cannot get state vector 'displacementnp");
-      std::vector<double> edispn(lm.size());
-      Core::FE::extract_my_values(*dispn, edispn, lm);
+      std::vector<double> edispn = Core::FE::extract_values(*dispn, lm);
       Core::LinAlg::SerialDenseMatrix xcn(numnode, numdf);
       spatial_configuration(xcn, edispn);
 
       std::shared_ptr<const Core::LinAlg::Vector<double>> dispincr =
           discretization.get_state("displacementincr");
       if (dispn == nullptr) FOUR_C_THROW("Cannot get state vector 'displacementincr");
-      std::vector<double> edispincr(lm.size());
-      Core::FE::extract_my_values(*dispincr, edispincr, lm);
+      std::vector<double> edispincr = Core::FE::extract_values(*dispincr, lm);
 
       // integration of the displacements over the surface
       // allocate vector for shape functions and matrix for derivatives
@@ -858,8 +850,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
         std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
             discretization.get_state("displacement");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
         const int numdim = 3;
         Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
         spatial_configuration(xscurr, mydisp);
@@ -875,8 +866,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numdim = 3;
       Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
       spatial_configuration(xscurr, mydisp);
@@ -936,8 +926,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
         std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
             discretization.get_state("displacement");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
         const int numdim = 3;
         Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
         spatial_configuration(xscurr, mydisp);
@@ -1002,8 +991,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numdim = 3;
       Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
       spatial_configuration(xscurr, mydisp);
@@ -1027,8 +1015,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numdim = 3;
       Core::LinAlg::SerialDenseMatrix xscurr(num_node(), numdim);  // material coord. of element
       spatial_configuration(xscurr, mydisp);
@@ -1063,8 +1050,7 @@ int Discret::Elements::StructuralSurface::evaluate(Teuchos::ParameterList& param
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       build_normals_at_nodes(elevector1, mydisp, false);
     }
     break;
@@ -1525,8 +1511,7 @@ void Discret::Elements::StructuralSurface::calculate_surface_porosity(
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-  std::vector<double> mydisp(lmpar.size());
-  Core::FE::extract_my_values(*disp, mydisp, lmpar);
+  std::vector<double> mydisp = Core::FE::extract_values(*disp, lmpar);
 
   // update element geometry
   Core::LinAlg::SerialDenseMatrix xrefe(numdim, nenparent);  // material coord. of element
@@ -1551,8 +1536,7 @@ void Discret::Elements::StructuralSurface::calculate_surface_porosity(
       discretization.get_state(1, "fluidvel");
   if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'fluidvel'");
   // extract local values of the global vectors
-  std::vector<double> myvelpres(la[1].lm_.size());
-  Core::FE::extract_my_values(*velnp, myvelpres, la[1].lm_);
+  std::vector<double> myvelpres = Core::FE::extract_values(*velnp, la[1].lm_);
 
   Core::LinAlg::SerialDenseVector mypres(numnode);
   for (int inode = 0; inode < numnode; ++inode)  // number of nodes

--- a/src/so3/4C_so3_tet10_evaluate.cpp
+++ b/src/so3/4C_so3_tet10_evaluate.cpp
@@ -129,10 +129,8 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMDOF_SOTET10, NUMDOF_SOTET10>* matptr = nullptr;
       if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -154,10 +152,8 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       std::vector<double> mydispmat(lm.size(), 0.0);
       // create a dummy element matrix to apply linearised EAS-stuff onto
       Core::LinAlg::Matrix<NUMDOF_SOTET10, NUMDOF_SOTET10> myemat(true);
@@ -191,14 +187,10 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
       if (acc == nullptr) FOUR_C_THROW("Cannot get state vectors 'acceleration'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
-      std::vector<double> myacc(lm.size());
-      Core::FE::extract_my_values(*acc, myacc, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
+      std::vector<double> myacc = Core::FE::extract_values(*acc, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       std::vector<double> mydispmat(lm.size(), 0.0);
 
@@ -224,10 +216,8 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
       if (stressdata == nullptr) FOUR_C_THROW("Cannot get 'stress' data");
       if (straindata == nullptr) FOUR_C_THROW("Cannot get 'strain' data");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMGPT_SOTET10, Mat::NUM_STRESS_3D> stress;
       Core::LinAlg::Matrix<NUMGPT_SOTET10, Mat::NUM_STRESS_3D> strain;
       auto iostress = params.get<Inpar::Solid::StressType>("iostress", Inpar::Solid::stress_none);
@@ -278,8 +268,7 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       update_element(mydisp, params, *material());
     }
     break;
@@ -290,8 +279,7 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get displacement state");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       switch (pstype_)
       {
@@ -355,8 +343,7 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state displacement vector");
 
       // get displacements of this element
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // update element geometry
       Core::LinAlg::Matrix<NUMNOD_SOTET10, NUMDIM_SOTET10> xrefe;  // material coord. of element
@@ -483,10 +470,8 @@ int Discret::Elements::SoTet10::evaluate(Teuchos::ParameterList& params,
                 "gpstrainmap", nullptr);
         if (gpstrainmap == nullptr)
           FOUR_C_THROW("no gp strain map available for writing gpstrains");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
-        std::vector<double> myres(lm.size());
-        Core::FE::extract_my_values(*res, myres, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+        std::vector<double> myres = Core::FE::extract_values(*res, lm);
         Core::LinAlg::Matrix<NUMGPT_SOTET10, Mat::NUM_STRESS_3D> stress;
         Core::LinAlg::Matrix<NUMGPT_SOTET10, Mat::NUM_STRESS_3D> strain;
         auto iostress = params.get<Inpar::Solid::StressType>("iostress", Inpar::Solid::stress_none);

--- a/src/so3/4C_so3_tet4_evaluate.cpp
+++ b/src/so3/4C_so3_tet4_evaluate.cpp
@@ -154,10 +154,8 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       //      Core::LinAlg::Matrix<NUMDOF_SOTET4,NUMDOF_SOTET4>* matptr = nullptr;
       //      if (elemat1.is_initialized()) matptr = &elemat1;
 
@@ -180,10 +178,8 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       std::vector<double> mydispmat(lm.size(), 0.0);
       // create a dummy element matrix to apply linearised EAS-stuff onto
       Core::LinAlg::Matrix<NUMDOF_SOTET4, NUMDOF_SOTET4> myemat(true);  // to zero
@@ -214,14 +210,10 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
       if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
       if (acc == nullptr) FOUR_C_THROW("Cannot get state vectors 'acceleration'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myvel(lm.size());
-      Core::FE::extract_my_values(*vel, myvel, lm);
-      std::vector<double> myacc(lm.size());
-      Core::FE::extract_my_values(*acc, myacc, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myvel = Core::FE::extract_values(*vel, lm);
+      std::vector<double> myacc = Core::FE::extract_values(*acc, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       std::vector<double> mydispmat(lm.size(), 0.0);
 
@@ -248,10 +240,8 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
       if (stressdata == nullptr) FOUR_C_THROW("Cannot get 'stress' data");
       if (straindata == nullptr) FOUR_C_THROW("Cannot get 'strain' data");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       Core::LinAlg::Matrix<NUMGPT_SOTET4, Mat::NUM_STRESS_3D> stress(true);  // set to zero
       Core::LinAlg::Matrix<NUMGPT_SOTET4, Mat::NUM_STRESS_3D> strain(true);
       auto iostress = params.get<Inpar::Solid::StressType>("iostress", Inpar::Solid::stress_none);
@@ -285,8 +275,7 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get displacement state");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       switch (pstype_)
       {
@@ -344,8 +333,7 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state displacement vector");
 
       // get displacements of this element
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       /* ============================================================================*/
       // element geometry
@@ -514,8 +502,7 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       if (solid_material()->uses_extended_update())
       {
@@ -594,10 +581,8 @@ int Discret::Elements::SoTet4::evaluate(Teuchos::ParameterList& params,
                 "gpstrainmap", nullptr);
         if (gpstrainmap == nullptr)
           FOUR_C_THROW("no gp strain map available for writing gpstrains");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
-        std::vector<double> myres(lm.size());
-        Core::FE::extract_my_values(*res, myres, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+        std::vector<double> myres = Core::FE::extract_values(*res, lm);
         Core::LinAlg::Matrix<NUMGPT_SOTET4, Mat::NUM_STRESS_3D> stress;
         Core::LinAlg::Matrix<NUMGPT_SOTET4, Mat::NUM_STRESS_3D> strain;
         auto iostress = params.get<Inpar::Solid::StressType>("iostress", Inpar::Solid::stress_none);

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_eas_helpers.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_eas_helpers.hpp
@@ -11,9 +11,12 @@
 #include "4C_config.hpp"
 
 #include "4C_fem_general_cell_type_traits.hpp"
+#include "4C_fem_general_extract_values.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_generators.hpp"
 #include "4C_solid_3D_ele_calc_lib.hpp"
+
+#include <cstring>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -163,11 +166,11 @@ namespace Discret::Elements
       const Core::FE::Discretization& discretization, const std::vector<int>& lm)
   {
     auto residual_from_dis = discretization.get_state("residual displacement");
-    std::vector<double> residual(lm.size());
-    Core::FE::extract_my_values(*residual_from_dis, residual, lm);
+    const std::array residual =
+        Core::FE::extract_values_as_array<Discret::Elements::num_dof_per_ele<celltype>>(
+            *residual_from_dis, lm);
     Core::LinAlg::Matrix<Discret::Elements::num_dof_per_ele<celltype>, 1> displ_inc(false);
-    for (int i = 0; i < Discret::Elements::num_dof_per_ele<celltype>; ++i)
-      displ_inc(i) = residual[i];
+    std::memcpy(displ_inc.data(), residual.data(), sizeof(double) * residual.size());
 
     return displ_inc;
   }

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
@@ -149,9 +149,9 @@ namespace Discret::Elements
    * @param disp (in) : Vector of nodal displacements of the element
    * @return ElementNodes<celltype>
    */
-  template <Core::FE::CellType celltype>
-  ElementNodes<celltype> evaluate_element_nodes(
-      const Core::Elements::Element& ele, const std::vector<double>& disp)
+  template <Core::FE::CellType celltype, std::ranges::contiguous_range R>
+    requires std::ranges::sized_range<R>
+  ElementNodes<celltype> evaluate_element_nodes(const Core::Elements::Element& ele, const R& disp)
   {
     Discret::Elements::ElementNodes<celltype> element_nodes;
     for (int i = 0; i < Internal::num_nodes<celltype>; ++i)
@@ -183,8 +183,9 @@ namespace Discret::Elements
   {
     const Core::LinAlg::Vector<double>& displacements = *discretization.get_state("displacement");
 
-    std::vector<double> mydisp(lm.size());
-    Core::FE::extract_my_values(displacements, mydisp, lm);
+    constexpr unsigned num_dofs = Core::FE::num_nodes<celltype> * Core::FE::dim<celltype>;
+    std::array<double, num_dofs> mydisp =
+        Core::FE::extract_values_as_array<num_dofs>(displacements, lm);
 
     Discret::Elements::ElementNodes<celltype> element_nodes =
         evaluate_element_nodes<celltype>(ele, mydisp);

--- a/src/solid_3D_ele/4C_solid_3D_ele_evaluate.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_evaluate.cpp
@@ -29,10 +29,7 @@ namespace
       const Core::FE::Discretization& discretization, const std::vector<int>& lm)
   {
     const Core::LinAlg::Vector<double>& acceleration = *discretization.get_state("acceleration");
-    std::vector<double> my_acceleration(lm.size());
-    Core::FE::extract_my_values(acceleration, my_acceleration, lm);
-
-    return my_acceleration;
+    return Core::FE::extract_values(acceleration, lm);
   }
 
   void evaluate_inertia_force(const Core::LinAlg::SerialDenseMatrix& mass_matrix,

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_lib.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_lib.hpp
@@ -88,8 +88,7 @@ namespace Discret::Elements
     const int numdofpernode = discretization.num_dof(dofset, ele.nodes()[0]);
 
     // extract local values of the global vectors
-    std::vector<double> mymatrix(lm.size());
-    Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+    const std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
     if (numdofpernode == Internal::num_dim<celltype> + 1)
     {
@@ -388,8 +387,8 @@ namespace Discret::Elements
   inline FluidVariables<celltype> get_fluid_variables(const Core::Elements::Element& ele,
       const Core::FE::Discretization& discretization, const Core::Elements::LocationArray& la)
   {
-    std::vector<double> fluid_ephi(la[1].lm_.size());
-    Core::FE::extract_my_values(*(discretization.get_state(1, "fluidvel")), fluid_ephi, la[1].lm_);
+    const std::vector<double> fluid_ephi =
+        Core::FE::extract_values(*(discretization.get_state(1, "fluidvel")), la[1].lm_);
 
     FluidVariables<celltype> fluid_variables{};
     for (unsigned int inode = 0; inode < Internal::num_nodes<celltype>; ++inode)  // number of nodes

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
@@ -49,10 +49,11 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::evaluate_nonlin
   if (force_vector != nullptr) force.emplace(*force_vector, true);
 
   // get primary variables of multiphase porous medium flow
-  std::vector<double> fluidmultiphase_ephi(la[1].size());
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
       discretization.get_state(1, "porofluid");
-  Core::FE::extract_my_values(*matrix_state, fluidmultiphase_ephi, la[1].lm_);
+  const std::vector<double> fluidmultiphase_ephi =
+      Core::FE::extract_values(*matrix_state, la[1].lm_);
+
 
   // Initialize variables of multiphase porous medium flow
   const int nummultifluiddofpernode = porofluidmat.num_mat();
@@ -172,10 +173,9 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<
     Core::LinAlg::SerialDenseMatrix& stiffness_matrix)
 {
   // get primary variables of multiphase porous medium flow
-  std::vector<double> fluidmultiphase_ephi(la[1].size());
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
       discretization.get_state(1, "porofluid");
-  Core::FE::extract_my_values(*matrix_state, fluidmultiphase_ephi, la[1].lm_);
+  std::vector<double> fluidmultiphase_ephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
   // Initialize variables of multiphase porous medium flow
   const int nummultifluiddofpernode = porofluidmat.num_mat();

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.cpp
@@ -163,8 +163,7 @@ namespace
 
     if (quantities_np == nullptr) FOUR_C_THROW("Cannot get state vector '%s' ", field_name.c_str());
 
-    auto my_quantities = std::vector<double>(la[*field_index].lm_.size(), 0.0);
-    Core::FE::extract_my_values(*quantities_np, my_quantities, la[*field_index].lm_);
+    const auto my_quantities = Core::FE::extract_values(*quantities_np, la[*field_index].lm_);
 
     return get_element_quantities<celltype, is_scalar>(num_scalars, my_quantities);
   }

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -463,8 +463,7 @@ void Solid::MonitorDbc::get_area(double area[], const Core::Conditions::Conditio
 
     for (unsigned i = 0; i < num_fnodes; ++i) discret.dof(fele, fnodes[i], fele_dofs);
 
-    std::vector<double> mydispn;
-    Core::FE::extract_my_values(dispn_col, mydispn, fele_dofs);
+    std::vector<double> mydispn = Core::FE::extract_values(dispn_col, fele_dofs);
 
     xyze_ref.reshape(DIM, num_fnodes);
     xyze_curr.reshape(DIM, num_fnodes);
@@ -562,8 +561,7 @@ double Solid::MonitorDbc::get_reaction_moment(Core::LinAlg::Matrix<DIM, 1>& rmom
 
     for (unsigned i = 0; i < DIM; ++i) node_gid[i] = discret_ptr_->dof(node, i);
 
-    std::vector<double> mydisp;
-    Core::FE::extract_my_values(*dispn, mydisp, node_gid);
+    std::vector<double> mydisp = Core::FE::extract_values(*dispn, node_gid);
     for (unsigned i = 0; i < DIM; ++i) node_position(i) = node->x()[i] + mydisp[i];
 
     // Get the reaction force at this node. This force will only contain non-zero values at the DOFs

--- a/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
@@ -191,7 +191,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
             discretization.get_state("temperature");
         if (tempnp == nullptr) FOUR_C_THROW("Cannot get state vector 'tempnp'");
 
-        Core::FE::extract_my_values(*tempnp, mytempnp, la[0].lm_);
+        mytempnp = Core::FE::extract_values(*tempnp, la[0].lm_);
         // build the element temperature
         Core::LinAlg::Matrix<nen_, 1> etemp(mytempnp.data(), true);  // view only!
         etemp_.update(etemp);                                        // copy
@@ -210,7 +210,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
             discretization.get_state("old temperature");
         if (tempn == nullptr) FOUR_C_THROW("Cannot get state vector 'tempn'");
 
-        Core::FE::extract_my_values(*tempn, mytempn, la[0].lm_);
+        mytempn = Core::FE::extract_values(*tempn, la[0].lm_);
         // build the element temperature
         Core::LinAlg::Matrix<nen_, 1> etemp(mytempn.data(), true);  // view only!
         etemp_.update(etemp);                                       // copy
@@ -271,7 +271,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
             discretization.get_state(1, "displacement");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
         // extract the displacements
-        Core::FE::extract_my_values(*disp, mydisp, la[1].lm_);
+        mydisp = Core::FE::extract_values(*disp, la[1].lm_);
 
         // and now check if there is a convection heat transfer boundary condition
         calculate_nln_convection_fint_cond(ele,  // current boundary element
@@ -412,7 +412,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
                 discretization.get_state("temperature");
             if (tempnp == nullptr) FOUR_C_THROW("Cannot get state vector 'tempnp'");
 
-            Core::FE::extract_my_values(*tempnp, mytempnp, la[0].lm_);
+            mytempnp = Core::FE::extract_values(*tempnp, la[0].lm_);
             // build the element temperature
             Core::LinAlg::Matrix<nen_, 1> etemp(mytempnp.data(), true);  // view only!
             etemp_.update(etemp);                                        // copy
@@ -431,7 +431,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
                 discretization.get_state("old temperature");
             if (tempn == nullptr) FOUR_C_THROW("Cannot get state vector 'tempn'");
 
-            Core::FE::extract_my_values(*tempn, mytempn, la[0].lm_);
+            mytempn = Core::FE::extract_values(*tempn, la[0].lm_);
             // build the element temperature
             Core::LinAlg::Matrix<nen_, 1> etemp(mytempn.data(), true);  // view only!
             etemp_.update(etemp);                                       // copy
@@ -460,7 +460,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
             discretization.get_state(1, "displacement");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
         // extract the displacements
-        Core::FE::extract_my_values(*disp, mydisp, la[1].lm_);
+        mydisp = Core::FE::extract_values(*disp, la[1].lm_);
 
         // and now check if there is a convection heat transfer boundary condition
         calculate_nln_convection_fint_cond(ele,  // current boundary element

--- a/src/thermo/src/element/4C_thermo_ele_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.cpp
@@ -161,7 +161,7 @@ int Discret::Elements::TemperImpl<distype>::evaluate(
     std::shared_ptr<const Core::LinAlg::Vector<double>> tempnp =
         discretization.get_state(0, "temperature");
     if (tempnp == nullptr) FOUR_C_THROW("Cannot get state vector 'tempnp'");
-    Core::FE::extract_my_values(*tempnp, mytempnp, la[0].lm_);
+    mytempnp = Core::FE::extract_values(*tempnp, la[0].lm_);
     // build the element temperature
     Core::LinAlg::Matrix<nen_ * numdofpernode_, 1> etempn(mytempnp.data(), true);  // view only!
     etempn_.update(etempn);                                                        // copy
@@ -173,7 +173,7 @@ int Discret::Elements::TemperImpl<distype>::evaluate(
     std::shared_ptr<const Core::LinAlg::Vector<double>> tempn =
         discretization.get_state(0, "last temperature");
     if (tempn == nullptr) FOUR_C_THROW("Cannot get state vector 'tempn'");
-    Core::FE::extract_my_values(*tempn, mytempn, la[0].lm_);
+    mytempn = Core::FE::extract_values(*tempn, la[0].lm_);
     // build the element temperature
     Core::LinAlg::Matrix<nen_ * numdofpernode_, 1> etemp(mytempn.data(), true);  // view only!
     etemp_.update(etemp);                                                        // copy
@@ -388,7 +388,7 @@ int Discret::Elements::TemperImpl<distype>::evaluate(
           if (ratem == nullptr) FOUR_C_THROW("Cannot get mid-temprate state vector for fcap");
           std::vector<double> myratem((la[0].lm_).size());
           // fill the vector myratem with the global values of ratem
-          Core::FE::extract_my_values(*ratem, myratem, la[0].lm_);
+          myratem = Core::FE::extract_values(*ratem, la[0].lm_);
           // build the element mid-temperature rates
           Core::LinAlg::Matrix<nen_ * numdofpernode_, 1> eratem(
               myratem.data(), true);  // view only!
@@ -650,7 +650,7 @@ int Discret::Elements::TemperImpl<distype>::evaluate_neumann(const Core::Element
     std::shared_ptr<const Core::LinAlg::Vector<double>> tempnp =
         discretization.get_state("temperature");
     if (tempnp == nullptr) FOUR_C_THROW("Cannot get state vector 'tempnp'");
-    Core::FE::extract_my_values(*tempnp, mytempnp, lm);
+    mytempnp = Core::FE::extract_values(*tempnp, lm);
     Core::LinAlg::Matrix<nen_ * numdofpernode_, 1> etemp(mytempnp.data(), true);  // view only!
     etempn_.update(etemp);                                                        // copy
   }
@@ -2665,14 +2665,14 @@ void Discret::Elements::TemperImpl<distype>::extract_disp_vel(
         discretization.get_state(1, "displacement");
     if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
     // extract the displacements
-    Core::FE::extract_my_values(*disp, mydisp, la[1].lm_);
+    mydisp = Core::FE::extract_values(*disp, la[1].lm_);
 
     // get the velocities
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel =
         discretization.get_state(1, "velocity");
     if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
     // extract the displacements
-    Core::FE::extract_my_values(*vel, myvel, la[1].lm_);
+    myvel = Core::FE::extract_values(*vel, la[1].lm_);
   }
 }
 

--- a/src/torsion3/4C_torsion3_evaluate.cpp
+++ b/src/torsion3/4C_torsion3_evaluate.cpp
@@ -95,8 +95,7 @@ int Discret::Elements::Torsion3::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       t3_energy(params, mydisp, &elevec1);
     }
@@ -117,14 +116,12 @@ int Discret::Elements::Torsion3::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       // get residual displacements
       std::shared_ptr<const Core::LinAlg::Vector<double>> res =
           discretization.get_state("residual displacement");
       if (res == nullptr) FOUR_C_THROW("Cannot get state vectors 'residual displacement'");
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       /*first displacement vector is modified for proper element evaluation in case of periodic
        *boundary conditions; in case that no periodic boundary conditions are to be applied the

--- a/src/truss3/4C_truss3_evaluate.cpp
+++ b/src/truss3/4C_truss3_evaluate.cpp
@@ -569,7 +569,7 @@ void Discret::Elements::Truss3::extract_elemental_variables(Core::Elements::Loca
 
   auto disp = discretization.get_state("displacement");
   if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
-  Core::FE::extract_my_values(*disp, disp_ele, la[0].lm_);
+  disp_ele = Core::FE::extract_values(*disp, la[0].lm_);
 
   if (ele_state.find("disp") == ele_state.end())
     ele_state.emplace(std::make_pair("disp", disp_ele));

--- a/src/truss3/4C_truss3_scatra.cpp
+++ b/src/truss3/4C_truss3_scatra.cpp
@@ -347,7 +347,7 @@ void Discret::Elements::Truss3Scatra::extract_elemental_variables(Core::Elements
     phi_ele.clear();
     auto phi = discretization.get_state(2, "MicroCon");
     if (phi == nullptr) FOUR_C_THROW("Cannot get state vector 'MicroCon'");
-    Core::FE::extract_my_values(*phi, phi_ele, la[2].lm_);
+    phi_ele = Core::FE::extract_values(*phi, la[2].lm_);
   }
   // get nodal phi from micro state
   else if (discretization.has_state(1, "scalarfield"))
@@ -356,7 +356,7 @@ void Discret::Elements::Truss3Scatra::extract_elemental_variables(Core::Elements
     phi_ele.clear();
     auto phi = discretization.get_state(1, "scalarfield");
     if (phi == nullptr) FOUR_C_THROW("Cannot get state vectors 'scalar'");
-    Core::FE::extract_my_values(*phi, phi_ele, la[1].lm_);
+    phi_ele = Core::FE::extract_values(*phi, la[1].lm_);
   }
   else
     FOUR_C_THROW("Cannot find state vector");

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -2605,8 +2605,8 @@ void TSI::Monolithic::calculate_necking_tsi_results()
   // extract axial displacements (here z-displacements) of top surface
   if (structure_field()->discretization()->dof_row_map()->MyGID(one_dof_in_dbc_global.at(0)))
   {
-    Core::FE::extract_my_values(
-        *(structure_field()->dispnp()), top_disp_local, one_dof_in_dbc_global);
+    top_disp_local =
+        Core::FE::extract_values(*(structure_field()->dispnp()), one_dof_in_dbc_global);
   }
 
   // initialise the top displacement
@@ -2642,7 +2642,7 @@ void TSI::Monolithic::calculate_necking_tsi_results()
   necking_radius.at(0) = 0.0;
   if (necking_radius_dof.at(0) != -1)
   {
-    Core::FE::extract_my_values(*(structure_field()->dispnp()), necking_radius, necking_radius_dof);
+    necking_radius = Core::FE::extract_values(*(structure_field()->dispnp()), necking_radius_dof);
   }
 
   // sum necking deformations in the global variable necking_radius_global
@@ -2677,9 +2677,8 @@ void TSI::Monolithic::calculate_necking_tsi_results()
   temperature.at(0) = 0.0;
   if (neck_temperature_dof.at(0) != -1)
   {
-    Core::FE::extract_my_values(*(thermo_field()->tempnp()),  // global (i)
-        temperature,                                          // local (o)
-        neck_temperature_dof                                  // global ids to be extracted
+    temperature = Core::FE::extract_values(*(thermo_field()->tempnp()),  // global (i)
+        neck_temperature_dof  // global ids to be extracted
     );
   }
   // sum necking temperatures in the variable temperature_global
@@ -2712,10 +2711,10 @@ void TSI::Monolithic::calculate_necking_tsi_results()
   top_temperature_local.at(0) = 0.0;
   if (top_temperature_dof.at(0) != -1.)
   {
-    Core::FE::extract_my_values(*(thermo_field()->tempnp()),  // global vector (i)
-        top_temperature_local,  // local, i.e. at specific position (o)
-        top_temperature_dof     // global ids to be extracted
-    );
+    top_temperature_local =
+        Core::FE::extract_values(*(thermo_field()->tempnp()),  // global vector (i)
+            top_temperature_dof                                // global ids to be extracted
+        );
   }
 
   // sum top-temperatures in the variable top_temperature_global

--- a/src/w1/4C_w1_evaluate.cpp
+++ b/src/w1/4C_w1_evaluate.cpp
@@ -154,10 +154,8 @@ int Discret::Elements::Wall1::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       // special case: geometrically linear
       if (kintype_ == Inpar::Solid::KinemType::linear)
@@ -186,10 +184,8 @@ int Discret::Elements::Wall1::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
 
       // special case: geometrically linear
       if (kintype_ == Inpar::Solid::KinemType::linear)
@@ -215,10 +211,8 @@ int Discret::Elements::Wall1::evaluate(Teuchos::ParameterList& params,
           discretization.get_state("residual displacement");
       if (disp == nullptr || res == nullptr)
         FOUR_C_THROW("Cannot get state vectors 'displacement' and/or residual");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       // create a dummy element matrix (initialised to zero)
       // This matrix is not utterly useless. It is used to apply EAS-stuff in a linearised manner
       // onto the internal force vector.
@@ -252,10 +246,8 @@ int Discret::Elements::Wall1::evaluate(Teuchos::ParameterList& params,
             "Cannot get state vectors \"displacement\" "
             "and/or \"residual displacement\"");
       }
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       w1_recover(lm, mydisp, myres);
       /* ToDo Probably we have to recover the history information of some special
        * materials as well.                                 hiermeier 04/2016  */
@@ -321,10 +313,8 @@ int Discret::Elements::Wall1::evaluate(Teuchos::ParameterList& params,
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors 'displacement'");
       if (stressdata == nullptr) FOUR_C_THROW("Cannot get stress 'data'");
       if (straindata == nullptr) FOUR_C_THROW("Cannot get strain 'data'");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
-      std::vector<double> myres(lm.size());
-      Core::FE::extract_my_values(*res, myres, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
+      std::vector<double> myres = Core::FE::extract_values(*res, lm);
       const Core::FE::IntegrationPoints2D intpoints(gaussrule_);
       Core::LinAlg::SerialDenseMatrix stress(intpoints.nquad, Wall1::numstr_);
       Core::LinAlg::SerialDenseMatrix strain(intpoints.nquad, Wall1::numstr_);
@@ -362,8 +352,7 @@ int Discret::Elements::Wall1::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vectors");
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
       // determine energies
       energy(params, lm, mydisp, &elevec1, actmat);

--- a/src/w1/4C_w1_line_evaluate.cpp
+++ b/src/w1/4C_w1_line_evaluate.cpp
@@ -122,8 +122,7 @@ int Discret::Elements::Wall1Line::evaluate_neumann(Teuchos::ParameterList& param
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
         discretization.get_state("displacement");
     if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-    std::vector<double> mydisp(lm.size());
-    Core::FE::extract_my_values(*disp, mydisp, lm);
+    std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
     for (int i = 0; i < numnod; ++i)
     {
@@ -142,8 +141,7 @@ int Discret::Elements::Wall1Line::evaluate_neumann(Teuchos::ParameterList& param
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
         discretization.get_state("displacement new");
     if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
-    std::vector<double> mydisp(lm.size());
-    Core::FE::extract_my_values(*disp, mydisp, lm);
+    std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
     for (int i = 0; i < numnod; ++i)
     {
@@ -459,8 +457,7 @@ int Discret::Elements::Wall1Line::evaluate(Teuchos::ParameterList& params,
         std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
             discretization.get_state("displacement");
         if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disp, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
         const int numnod = num_node();
         Core::LinAlg::SerialDenseMatrix xsrefe(
             numnod, Wall1::numdim_);  // material coord. of element
@@ -488,8 +485,7 @@ int Discret::Elements::Wall1Line::evaluate(Teuchos::ParameterList& params,
         std::shared_ptr<const Core::LinAlg::Vector<double>> disptotal =
             discretization.get_state("displacementtotal");
         if (disptotal == nullptr) FOUR_C_THROW("Cannot get state vector 'displacementtotal'");
-        std::vector<double> mydisp(lm.size());
-        Core::FE::extract_my_values(*disptotal, mydisp, lm);
+        std::vector<double> mydisp = Core::FE::extract_values(*disptotal, lm);
         const int numnod = num_node();
         Core::LinAlg::SerialDenseMatrix xsrefe(
             Wall1::numdim_, numnod);  // material coord. of element
@@ -518,8 +514,7 @@ int Discret::Elements::Wall1Line::evaluate(Teuchos::ParameterList& params,
 
         std::shared_ptr<const Core::LinAlg::Vector<double>> dispincr =
             discretization.get_state("displacementincr");
-        std::vector<double> edispincr(lm.size());
-        Core::FE::extract_my_values(*dispincr, edispincr, lm);
+        std::vector<double> edispincr = Core::FE::extract_values(*dispincr, lm);
 
         elevector2[0] = 0;
 
@@ -561,8 +556,7 @@ int Discret::Elements::Wall1Line::evaluate(Teuchos::ParameterList& params,
       {
         FOUR_C_THROW("Cannot get state vector 'displacement'");
       }
-      std::vector<double> mydisp(lm.size());
-      Core::FE::extract_my_values(*disp, mydisp, lm);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
       const int numnod = num_node();
       Core::LinAlg::SerialDenseMatrix xsrefe(numnod, Wall1::numdim_);  // material coord. of element
       Core::LinAlg::SerialDenseMatrix xscurr(numnod, Wall1::numdim_);  // material coord. of element
@@ -649,8 +643,7 @@ int Discret::Elements::Wall1Line::evaluate(Teuchos::ParameterList& params,
       std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
           discretization.get_state("displacement");
       if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement'");
-      std::vector<double> mydisp(lmpar.size());
-      Core::FE::extract_my_values(*disp, mydisp, lmpar);
+      std::vector<double> mydisp = Core::FE::extract_values(*disp, lmpar);
 
       // update element geometry
       Core::LinAlg::SerialDenseMatrix xrefe(numdim, nenparent);  // material coord. of element
@@ -674,8 +667,7 @@ int Discret::Elements::Wall1Line::evaluate(Teuchos::ParameterList& params,
           discretization.get_state(1, "fluidvel");
       if (velnp == nullptr) FOUR_C_THROW("Cannot get state vector 'fluidvel'");
       // extract local values of the global vectors
-      std::vector<double> myvelpres(la[1].lm_.size());
-      Core::FE::extract_my_values(*velnp, myvelpres, la[1].lm_);
+      std::vector<double> myvelpres = Core::FE::extract_values(*velnp, la[1].lm_);
 
       Core::LinAlg::SerialDenseVector mypres(numnode);
       for (int inode = 0; inode < numnode; ++inode)  // number of nodes

--- a/src/w1/4C_w1_poro_evaluate.cpp
+++ b/src/w1/4C_w1_poro_evaluate.cpp
@@ -38,8 +38,7 @@ void Discret::Elements::Wall1Poro<distype>::pre_evaluate(Teuchos::ParameterList&
             discretization.get_state(2, "scalar");
 
         // extract local values of the global vectors
-        std::vector<double> myscalar(la[2].lm_.size());
-        Core::FE::extract_my_values(*scalarnp, myscalar, la[2].lm_);
+        std::vector<double> myscalar = Core::FE::extract_values(*scalarnp, la[2].lm_);
 
         if (num_material() < 3) FOUR_C_THROW("no third material defined for Wall poro element!");
         std::shared_ptr<Core::Mat::Material> scatramat = material(2);
@@ -263,7 +262,7 @@ int Discret::Elements::Wall1Poro<distype>::my_evaluate(Teuchos::ParameterList& p
             std::vector<double> myephi(la[1].size());
             std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
                 discretization.get_state(1, "porofluid");
-            Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+            myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
             // calculate tangent stiffness matrix
             nonlinear_stiffness_poroelast_pressure_based(
@@ -333,7 +332,7 @@ int Discret::Elements::Wall1Poro<distype>::my_evaluate(Teuchos::ParameterList& p
             std::vector<double> myephi(la[1].size());
             std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
                 discretization.get_state(1, "porofluid");
-            Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+            myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
             // calculate tangent stiffness matrix
             nonlinear_stiffness_poroelast_pressure_based(
@@ -391,7 +390,7 @@ int Discret::Elements::Wall1Poro<distype>::my_evaluate(Teuchos::ParameterList& p
           std::vector<double> myephi(la[1].size());
           std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
               discretization.get_state(1, "porofluid");
-          Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+          myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
           Core::LinAlg::Matrix<numdim_, numnod_> mydisp(true);
           extract_values_from_global_vector(
@@ -448,7 +447,7 @@ int Discret::Elements::Wall1Poro<distype>::my_evaluate(Teuchos::ParameterList& p
           std::vector<double> myephi(la[1].size());
           std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
               discretization.get_state(1, "porofluid");
-          Core::FE::extract_my_values(*matrix_state, myephi, la[1].lm_);
+          myephi = Core::FE::extract_values(*matrix_state, la[1].lm_);
 
           // calculate tangent stiffness matrix
           nonlinear_stiffness_poroelast_pressure_based(
@@ -2394,8 +2393,7 @@ void Discret::Elements::Wall1Poro<distype>::extract_values_from_global_vector(
   const int numdofpernode = discretization.num_dof(dofset, nodes()[0]);
 
   // extract local values of the global vectors
-  std::vector<double> mymatrix(lm.size());
-  Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+  std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
   if (numdofpernode == numdim_ + 1)
   {

--- a/src/w1/4C_w1_scatra_evaluate.cpp
+++ b/src/w1/4C_w1_scatra_evaluate.cpp
@@ -40,8 +40,7 @@ void Discret::Elements::Wall1Scatra::pre_evaluate(Teuchos::ParameterList& params
       if (phinp == nullptr) FOUR_C_THROW("pre_evaluate: Cannot get state vector 'phinp' ");
 
       // extract local values of the global vectors
-      std::vector<double> myphi(la[1].lm_.size());
-      Core::FE::extract_my_values(*phinp, myphi, la[1].lm_);
+      std::vector<double> myphi = Core::FE::extract_values(*phinp, la[1].lm_);
 
       double meanphi = 0.0;
       for (int i = 0; i < numnode; ++i)

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -562,8 +562,7 @@ void XFEM::LevelSetCoupling::map_cutter_to_bg_vector(Core::FE::Discretization& s
       if (static_cast<int>(lm_target.size()) != 1)
         FOUR_C_THROW("we expect a unique dof per node here!");
 
-      std::vector<double> val_source;
-      Core::FE::extract_my_values(source_vec_dofbased, val_source, lm_source);
+      std::vector<double> val_source = Core::FE::extract_values(source_vec_dofbased, lm_source);
 
       // set to a dofrowmap based vector!
       const int lid_target = target_vec_dofbased.Map().LID(lm_target[0]);
@@ -590,8 +589,7 @@ XFEM::LevelSetCoupling::get_level_set_field_as_node_row_vector()
     std::vector<int> lm_source;
     bg_dis_->dof(bg_nds_phi_, node, lm_source);
 
-    std::vector<double> val_source;
-    Core::FE::extract_my_values(*phinp_, val_source, lm_source);
+    std::vector<double> val_source = Core::FE::extract_values(*phinp_, lm_source);
 
     if (val_source.size() != 1) FOUR_C_THROW("we expect only one dof");
 

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -2453,7 +2453,7 @@ void XFEM::MeshCouplingFSI::estimate_nitsche_trace_max_eigenvalue(Core::Elements
   std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp = coupl_dis_->get_state("dispnp");
   if (dispnp == nullptr) FOUR_C_THROW("Cannot get state vector 'dispnp'");
 
-  Core::FE::extract_my_values(*dispnp, eledisp, la[0].lm_);
+  eledisp = Core::FE::extract_values(*dispnp, la[0].lm_);
   (*ele_to_max_eigenvalue_)[ele->id()] = solidfaceele->estimate_nitsche_trace_max_eigenvalue(
       eledisp);  // this is (E/h) ...basically :-)
 }

--- a/src/xfem/4C_xfem_interface_utils.cpp
+++ b/src/xfem/4C_xfem_interface_utils.cpp
@@ -1048,12 +1048,10 @@ void XFEM::Utils::evaluate_stateat_gp(const Core::Elements::Element* sele,
     const std::string& state, Core::LinAlg::Matrix<3, 1>& vel_s)
 {
   vel_s.clear();
-
-  std::vector<double> ivel;
   Core::Elements::LocationArray las(1);
   sele->location_vector(discret, las, false);
   std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state = discret.get_state(state);
-  Core::FE::extract_my_values(*matrix_state, ivel, las[0].lm_);
+  std::vector<double> ivel = Core::FE::extract_values(*matrix_state, las[0].lm_);
 
   // 4 // evaluate slave velocity at guasspoint
   if (sele->shape() == Core::FE::CellType::quad4)

--- a/src/xfem/4C_xfem_mesh_projector.cpp
+++ b/src/xfem/4C_xfem_mesh_projector.cpp
@@ -79,7 +79,7 @@ void XFEM::MeshProjector::set_source_position_vector(
     {
       // get the current displacement
       sourcedis_->dof(node, 0, src_dofs);
-      Core::FE::extract_my_values(*sourcedisp, mydisp, src_dofs);
+      mydisp = Core::FE::extract_values(*sourcedisp, src_dofs);
     }
 
     for (int d = 0; d < 3; ++d) src_nodepositions_n_[node->id()](d) = node->x()[d] + mydisp.at(d);
@@ -226,7 +226,7 @@ void XFEM::MeshProjector::project(std::map<int, std::set<int>>& projection_nodeT
     {
       // get the current displacement
       targetdis_->dof(node, 0, tar_dofs);
-      Core::FE::extract_my_values(*targetdisp, mydisp, tar_dofs);
+      mydisp = Core::FE::extract_values(*targetdisp, tar_dofs);
     }
 
     Core::LinAlg::Matrix<3, 1> pos;
@@ -370,7 +370,7 @@ bool XFEM::MeshProjector::check_position_and_project(const Core::Elements::Eleme
       {
         if (source_statevecs_[iv] == nullptr) continue;
 
-        Core::FE::extract_my_values(*source_statevecs_[iv], myval, src_dofs);
+        myval = Core::FE::extract_values(*source_statevecs_[iv], src_dofs);
         for (unsigned isd = 0; isd < numdofpernode; ++isd)
         {
           interpolatedvec(isd + offset) += myval[isd] * shp(in);
@@ -621,7 +621,7 @@ void XFEM::MeshProjector::gmsh_output(
       {
         // get the current displacement
         targetdis_->dof(actnode, 0, tar_dofs);
-        Core::FE::extract_my_values(*targetdisp, mydisp, tar_dofs);
+        mydisp = Core::FE::extract_values(*targetdisp, tar_dofs);
         for (unsigned isd = 0; isd < 3; ++isd)
         {
           pos(isd, 0) += mydisp[isd];

--- a/src/xfem/4C_xfem_utils.cpp
+++ b/src/xfem/4C_xfem_utils.cpp
@@ -32,8 +32,7 @@ void XFEM::Utils::extract_node_vectors(Core::FE::Discretization& dis,
     const Core::Nodes::Node* node = dis.l_col_node(lid);
     std::vector<int> lm;
     dis.dof(node, lm);
-    std::vector<double> mydisp;
-    Core::FE::extract_my_values(*dispcol, mydisp, lm);
+    std::vector<double> mydisp = Core::FE::extract_values(*dispcol, lm);
     if (mydisp.size() < 3) FOUR_C_THROW("we need at least 3 dofs here");
 
     Core::LinAlg::Matrix<3, 1> currpos;
@@ -157,8 +156,8 @@ void XFEM::Utils::extract_quantity_at_element(Core::LinAlg::SerialDenseMatrix::B
     FOUR_C_THROW("assume a unique level-set dof in cutterdis-Dofset per node");
   }
 
-  std::vector<double> local_vector(nsd * numnode);
-  Core::FE::extract_my_values(global_col_vector, local_vector, la[nds_vector].lm_);
+  std::vector<double> local_vector =
+      Core::FE::extract_values(global_col_vector, la[nds_vector].lm_);
 
   if (local_vector.size() != nsd * numnode)
     FOUR_C_THROW("wrong size of (potentially resized) local matrix!");
@@ -176,8 +175,7 @@ void XFEM::Utils::extract_quantity_at_node(Core::LinAlg::SerialDenseMatrix::Base
   const std::vector<int> lm = dis.dof(nds_vector, node);
   if (lm.size() != 1) FOUR_C_THROW("assume a unique level-set dof in cutterdis-Dofset");
 
-  std::vector<double> local_vector(nsd);
-  Core::FE::extract_my_values(global_col_vector, local_vector, lm);
+  std::vector<double> local_vector = Core::FE::extract_values(global_col_vector, lm);
 
   if (local_vector.size() != nsd) FOUR_C_THROW("wrong size of (potentially resized) local matrix!");
 

--- a/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
+++ b/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
@@ -302,7 +302,7 @@ void XFEM::XFluidContactComm::get_states(const int fluidele_id, const std::vecto
     fluidele->location_vector(*fluiddis_, fluid_nds, la_f, false);
     std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
         fluiddis_->get_state("velaf");
-    Core::FE::extract_my_values(*matrix_state, velpres, la_f[0].lm_);
+    velpres = Core::FE::extract_values(*matrix_state, la_f[0].lm_);
 
     std::vector<int> lmdisp;
     lmdisp.resize(fluid_nds.size() * 3);
@@ -313,7 +313,7 @@ void XFEM::XFluidContactComm::get_states(const int fluidele_id, const std::vecto
         for (int dof = 0; dof < 3; ++dof) lmdisp[n * 3 + dof] = la_f[0].lm_[n * 4 + dof];
       std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state_disp =
           fluiddis_->get_state("dispnp");
-      Core::FE::extract_my_values(*matrix_state_disp, disp, lmdisp);
+      disp = Core::FE::extract_values(*matrix_state_disp, lmdisp);
     }
   }
   {
@@ -321,7 +321,7 @@ void XFEM::XFluidContactComm::get_states(const int fluidele_id, const std::vecto
     sele->location_vector(*mc_[mcidx_]->get_cutter_dis(), la_s, false);
     std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
         mc_[mcidx_]->get_cutter_dis()->get_state("ivelnp");
-    Core::FE::extract_my_values(*matrix_state, ivel, la_s[0].lm_);
+    ivel = Core::FE::extract_values(*matrix_state, la_s[0].lm_);
   }
   static std::vector<double> ipfvel;
   if (isporo_)
@@ -330,7 +330,7 @@ void XFEM::XFluidContactComm::get_states(const int fluidele_id, const std::vecto
     sele->location_vector(*mcfpi_ps_pf_->get_cutter_dis(), la_s, false);
     std::shared_ptr<const Core::LinAlg::Vector<double>> matrix_state =
         mcfpi_ps_pf_->get_cutter_dis()->get_state("ivelnp");
-    Core::FE::extract_my_values(*matrix_state, ipfvel, la_s[0].lm_);
+    ipfvel = Core::FE::extract_values(*matrix_state, la_s[0].lm_);
   }
 
   // 2 // get element xyze

--- a/src/xfem/4C_xfem_xfluid_timeInt.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.cpp
@@ -1898,13 +1898,12 @@ bool XFEM::XFluidTimeInt::within_space_time_side(
     Core::LinAlg::Matrix<3, 1> x_new(node.x().data());
 
     std::vector<int> lm;
-    std::vector<double> mydisp_old;
     std::vector<double> mydisp_new;
 
     cutter_dis->dof(&node, lm);
 
-    Core::FE::extract_my_values(*idisp_old, mydisp_old, lm);
-    Core::FE::extract_my_values(*idisp_new, mydisp_new, lm);
+    std::vector<double> mydisp_old = Core::FE::extract_values(*idisp_old, lm);
+    mydisp_new = Core::FE::extract_values(*idisp_new, lm);
 
     // add displacements
     x_old(0) += mydisp_old.at(0);

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
@@ -488,9 +488,9 @@ void XFEM::XfluidTimeintBase::call_x_to_xi_coords(
     std::vector<double> mydispnp(la[0].lm_.size());
 
     if (state == "dispnp")
-      Core::FE::extract_my_values(*dispnp_, mydispnp, la[0].lm_);
+      mydispnp = Core::FE::extract_values(*dispnp_, la[0].lm_);
     else if (state == "dispn")
-      Core::FE::extract_my_values(*dispn_, mydispnp, la[0].lm_);
+      mydispnp = Core::FE::extract_values(*dispn_, la[0].lm_);
     else
       FOUR_C_THROW("XFEM::XfluidTimeintBase::call_x_to_xi_coords: Undefined state!");
 
@@ -608,8 +608,7 @@ void XFEM::XfluidTimeintBase::eval_shape_and_deriv(
       element->location_vector(*discret_, nds, la, false);
 
       // extract local values of the global vectors
-      std::vector<double> mydispnp(la[0].lm_.size());
-      Core::FE::extract_my_values(*dispnp_, mydispnp, la[0].lm_);
+      std::vector<double> mydispnp = Core::FE::extract_values(*dispnp_, la[0].lm_);
 
       for (int inode = 0; inode < nen; ++inode)  // number of nodes
       {
@@ -1154,8 +1153,7 @@ void XFEM::XfluidStd::get_gp_values_t(Core::Elements::Element* ele,  ///< pointe
 
 
   // extract local values of the global vectors
-  std::vector<double> mymatrix(lm.size());
-  Core::FE::extract_my_values(*vel_vec, mymatrix, lm);
+  std::vector<double> mymatrix = Core::FE::extract_values(*vel_vec, lm);
 
   for (int inode = 0; inode < numnode; ++inode)  // number of nodes
   {
@@ -1671,8 +1669,7 @@ void XFEM::XfluidStd::project_and_trackback(TimeIntData& data)
     if (matrix_state == nullptr) FOUR_C_THROW("Cannot get state vector %s", state.c_str());
 
     // extract local values of the global vectors
-    std::vector<double> mymatrix(lm.size());
-    Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+    std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
     // add the displacement of the interface
     for (int idim = 0; idim < 3; ++idim)  // number of dimensions
@@ -2286,8 +2283,7 @@ void XFEM::XfluidStd::addeidisp(
   if (matrix_state == nullptr) FOUR_C_THROW("Cannot get state vector %s", state.c_str());
 
   // extract local values of the global vectors
-  std::vector<double> mymatrix(lm.size());
-  Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+  std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
   for (int inode = 0; inode < nen; ++inode)  // number of nodes
   {
@@ -3076,8 +3072,7 @@ void XFEM::XfluidStd::project_on_point(
   if (matrix_state == nullptr) FOUR_C_THROW("Cannot get state vector %s", state.c_str());
 
   // extract local values of the global vectors
-  std::vector<double> mymatrix(lm.size());
-  Core::FE::extract_my_values(*matrix_state, mymatrix, lm);
+  std::vector<double> mymatrix = Core::FE::extract_values(*matrix_state, lm);
 
   // add the displacement of the interface
   for (int idim = 0; idim < 3; ++idim)  // number of dimensions

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.hpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.hpp
@@ -713,8 +713,7 @@ namespace XFEM
       if (vel_vec == nullptr) FOUR_C_THROW("vector is null");
 
       // extract local values of the global vectors
-      std::vector<double> mymatrix(lm.size());
-      Core::FE::extract_my_values(*vel_vec, mymatrix, lm);
+      std::vector<double> mymatrix = Core::FE::extract_values(*vel_vec, lm);
 
       for (int inode = 0; inode < numnode; ++inode)  // number of nodes
       {


### PR DESCRIPTION
Until now, extracting the local dofs always looks like this:

```c++
    std::vector<double> disp;
    Core::FE::extract_my_values(global_displacements, disp, global_ids);
```

With this PR, we can simply write

```c++
    const std::vector<double> disp = Core::FE::extract_values(global_displacements, global_ids);
```
(allow const-variables, easier readable).

* Commit 1: Implements the function in Core
* Commit 2: Applies it in solid_3D_ele
* Commit 3: Replaces it everywhere
