### PR TITLE
[NOX] Remove "Modified" parameter list

### DIFF
--- a/src/contact/4C_contact_paramsinterface.hpp
+++ b/src/contact/4C_contact_paramsinterface.hpp
@@ -63,9 +63,6 @@ namespace CONTACT
     //! get the current step length
     virtual double get_step_length() const = 0;
 
-    //! get number of linear system corrections (modified Newton approach)
-    virtual int get_number_of_modified_newton_corrections() const = 0;
-
     //! get the is_default_step indicator
     virtual bool is_default_step() const = 0;
 

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -82,35 +82,6 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   }
   steepestdescent.move_into_collection(list);
 
-  // sub-sub-sub-list "Modified Newton"
-  Core::Utils::SectionSpecs modnewton{newton, "Modified"};
-  {
-    Core::Utils::double_parameter("Initial Primal Diagonal Correction", 1.0e-4,
-        "Initial correction factor for the diagonal of the primal block.", modnewton);
-
-    Core::Utils::double_parameter("Minimal Primal Diagonal Correction", 1.0e-20,
-        "Minimal correction factor for the diagonal of the primal block.", modnewton);
-
-    Core::Utils::double_parameter("Maximal Primal Diagonal Correction", 1.0e+40,
-        "Maximal correction factor for the diagonal of the primal block.", modnewton);
-
-    Core::Utils::double_parameter("Primal Reduction Factor", 1.0 / 3.0,
-        "Reduction factor for the adaption of the primal diagonal correction.", modnewton);
-
-    Core::Utils::double_parameter("Primal Accretion Factor", 8.0,
-        "Accretion factor for the adaption of the primal diagonal correction.", modnewton);
-
-    Core::Utils::double_parameter("Primal High Accretion Factor", 100.0,
-        "High accretion factor for the adaption of the primal diagonal correction.", modnewton);
-
-    Core::Utils::bool_parameter("Catch Floating Point Exceptions", "No",
-        "Set to true, if"
-        "floating point exceptions during the linear solver call should be "
-        "caught by the algorithm.",
-        modnewton);
-  }
-  modnewton.move_into_collection(list);
-
   // sub-list "Pseudo Transient"
   Core::Utils::SectionSpecs ptc{snox, "Pseudo Transient"};
 

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -223,7 +223,7 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::runPostIterate(const ::NOX::Solver:
 {
   double step = 0.0;
   const bool isdefaultstep = get_step(step, solver);
-  const int num_corrs = get_number_of_modified_newton_corrections(solver);
+  const int num_corrs = 0;
 
   impl_.model_eval().run_post_iterate(solver, step, isdefaultstep, num_corrs);
 }
@@ -299,21 +299,6 @@ bool NOX::Nln::PrePostOp::IMPLICIT::Generic::get_step(
   }
 
   return isdefaultstep;
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-int NOX::Nln::PrePostOp::IMPLICIT::Generic::get_number_of_modified_newton_corrections(
-    const ::NOX::Solver::Generic& solver) const
-{
-  int number_of_corr = 0;
-  const Teuchos::ParameterList& pmod =
-      solver.getList().sublist("Direction").sublist("Newton").sublist("Modified");
-
-  if (pmod.isParameter("Number of Corrections"))
-    number_of_corr = pmod.get<int>("Number of Corrections");
-
-  return number_of_corr;
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -223,9 +223,8 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::runPostIterate(const ::NOX::Solver:
 {
   double step = 0.0;
   const bool isdefaultstep = get_step(step, solver);
-  const int num_corrs = 0;
 
-  impl_.model_eval().run_post_iterate(solver, step, isdefaultstep, num_corrs);
+  impl_.model_eval().run_post_iterate(solver, step, isdefaultstep);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.hpp
@@ -301,9 +301,6 @@ namespace NOX
           /// get the step length
           bool get_step(double& step, const ::NOX::Solver::Generic& solver) const;
 
-          /// get the number of necessary system corrections in case of a mod newton direction
-          int get_number_of_modified_newton_corrections(const ::NOX::Solver::Generic& solver) const;
-
          private:
           //! reference to the Solid::IMPLICIT::Generic object (read-only)
           const Solid::IMPLICIT::Generic& impl_;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -169,7 +169,6 @@ Solid::ModelEvaluator::Data::Data()
       delta_time_(-1.0),
       step_length_(-1.0),
       is_default_step_(true),
-      num_corr_mod_newton_(0),
       corr_type_(NOX::Nln::CorrectionType::vague),
       timintfactor_disp_(-1.0),
       timintfactor_vel_(-1.0),

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -271,13 +271,6 @@ namespace Solid
         return corr_type_;
       }
 
-      /// get number of system modifications in case of a mod. Newton direction method
-      int get_number_of_modified_newton_corrections() const
-      {
-        check_init_setup();
-        return num_corr_mod_newton_;
-      }
-
       //!@name set routines which can be called inside of the element [derived]
       //! @{
 
@@ -477,12 +470,6 @@ namespace Solid
       inline void set_is_default_step(const bool& is_default_step)
       {
         is_default_step_ = is_default_step;
-      }
-
-      /// set the number of system corrections in case of a mod. Newton direction method
-      inline void set_number_of_modified_newton_corrections(const int num_corr)
-      {
-        num_corr_mod_newton_ = num_corr;
       }
 
       /// set the current system correction type of the non-linear solver
@@ -870,9 +857,6 @@ namespace Solid
        *  Only important for the internal elementwise update. */
       bool is_default_step_;
 
-      /// number of system corrections (modified Newton direction method)
-      int num_corr_mod_newton_;
-
       /// system correction type (e.g. in case of a SOC step, see the
       /// NOX::Nln::Inner::StatusTest::Filter method)
       NOX::Nln::CorrectionType corr_type_;
@@ -1137,13 +1121,6 @@ namespace Solid
       {
         check_init();
         return str_data_ptr_->get_correction_type();
-      }
-
-      /// derived
-      int get_number_of_modified_newton_corrections() const override
-      {
-        check_init();
-        return str_data_ptr_->get_number_of_modified_newton_corrections();
       }
 
       /*! \brief Get the current active predictor type

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
@@ -584,12 +584,11 @@ void Solid::ModelEvaluatorManager::run_pre_compute_x(const Core::LinAlg::Vector<
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::ModelEvaluatorManager::run_post_iterate(const ::NOX::Solver::Generic& solver,
-    const double step, const bool isdefaultstep, const int num_corrs) const
+void Solid::ModelEvaluatorManager::run_post_iterate(
+    const ::NOX::Solver::Generic& solver, const double step, const bool isdefaultstep) const
 {
   eval_data_ptr_->set_is_default_step(isdefaultstep);
   eval_data_ptr_->set_step_length(step);
-  eval_data_ptr_->set_number_of_modified_newton_corrections(num_corrs);
 
   for (const auto& me_iter : *me_vec_ptr_) me_iter->run_post_iterate(solver);
 }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
@@ -420,8 +420,8 @@ namespace Solid
     /*! \brief Executed at the end of the ::NOX::Solver::Step() (f.k.a. Iterate()) method
      *
      *  \author hiermeier \date 03/17 */
-    void run_post_iterate(const ::NOX::Solver::Generic& solver, const double step,
-        const bool isdefaultstep, const int num_corrs) const;
+    void run_post_iterate(
+        const ::NOX::Solver::Generic& solver, const double step, const bool isdefaultstep) const;
 
     /*! \brief Executed at the beginning of the ::NOX::Solver::solve() method
      *


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
The `Modified` parameter list we internally add to NOX breaks the new structure time integration tests with the current Trilinos development branch. To my knowledge and in-depth search in the input files, these options are not used at all, neither in NOX nor in our own code?!
In addition the `Modified` list is only retrieved once in `get_number_of_modified_newton_corrections()`, but the relevant parameter is never found and thus this function always returns 0 (also based on the coverage report). With this PR I propose to just delete the parameter list and the related function, there's no benefit in keeping it.

## Related Issues and Merge Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Closes #405 