### PR TITLE
InputSpec: allow for arbitrarily nested vectors and maps

### DIFF
--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -11,6 +11,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_input_types.hpp"
 #include "4C_utils_demangle.hpp"
 #include "4C_utils_exceptions.hpp"
 
@@ -30,22 +31,6 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::IO
 {
-  /**
-   * A type that either contains a value of type T or nothing. This type is useful to
-   * represent the absence of a value marked by "none" in the input file. The type is just an alias
-   * for std::optional<T> to more precisely convey the intended meaning.
-   */
-  template <typename T>
-  using Noneable = std::optional<T>;
-
-  /**
-   * A constant to represent the absence of a value in the input file. The constant is templated
-   * on the type of the value inside the Noneable to properly handle cases where a Noneable is
-   * itself stored inside a std::optional type.
-   */
-  template <typename T>
-  inline constexpr auto none = Noneable<T>{std::nullopt};
-
   /**
    * A container to store dynamic input parameters. The container can store arbitrary types of
    * parameters. Parameters can be grouped in sub-containers.

--- a/src/core/io/src/4C_io_input_types.hpp
+++ b/src/core/io/src/4C_io_input_types.hpp
@@ -1,0 +1,132 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_IO_INPUT_TYPES_HPP
+#define FOUR_C_IO_INPUT_TYPES_HPP
+
+#include "4C_config.hpp"
+
+#include <filesystem>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::IO
+{
+  /**
+   * A type that either contains a value of type T or nothing. This type is useful to
+   * represent the absence of a value marked by "none" in the input file. The type is just an alias
+   * for std::optional<T> to more precisely convey the intended meaning.
+   */
+  template <typename T>
+  using Noneable = std::optional<T>;
+
+  /**
+   * A constant to represent the absence of a value in the input file. The constant is templated
+   * on the type of the value inside the Noneable to properly handle cases where a Noneable is
+   * itself stored inside a std::optional type.
+   */
+  template <typename T>
+  inline constexpr auto none = Noneable<T>{std::nullopt};
+
+  namespace Internal
+  {
+    template <typename T>
+    struct SupportedTypeHelper : std::false_type
+    {
+    };
+
+    template <typename T>
+    concept SupportedTypePrimitives =
+        std::same_as<T, int> || std::same_as<T, double> || std::same_as<T, bool> ||
+        std::same_as<T, std::string> || std::same_as<T, std::filesystem::path>;
+
+    template <SupportedTypePrimitives T>
+    struct SupportedTypeHelper<T> : std::true_type
+    {
+    };
+
+    template <typename T>
+    struct SupportedTypeHelper<std::vector<T>> : SupportedTypeHelper<T>
+    {
+    };
+
+    template <typename U>
+    struct SupportedTypeHelper<std::map<std::string, U>> : SupportedTypeHelper<U>
+    {
+    };
+
+    template <typename T>
+    struct SupportedTypeHelper<Noneable<T>> : SupportedTypeHelper<T>
+    {
+    };
+
+    template <typename T>
+    struct RankHelper
+    {
+      static constexpr std::size_t value = 0;
+    };
+
+    template <typename T>
+    struct RankHelper<std::vector<T>>
+    {
+      static constexpr std::size_t value = 1 + RankHelper<T>::value;
+    };
+
+    template <typename T>
+    struct RankHelper<std::map<std::string, T>>
+    {
+      static constexpr std::size_t value = 1 + RankHelper<T>::value;
+    };
+
+    template <typename T>
+    concept IsStdArray = requires {
+      typename T::value_type;
+      std::tuple_size<T>::value;
+    };
+  }  // namespace Internal
+
+  /**
+   * We deliberately limit ourselves to a few generally useful types. While it would not be too
+   * difficult to support all the fundamental and container types that C++ provides, this would
+   * likely lead to more confusion for users than it would provide benefits. After all, when
+   * consuming the parsed input, the user will have to use the exact type of the parameter. Also,
+   * input file formats are often not able to distinguish fundamental types like `double` and
+   * `float` and there is little benefit in supporting both in the input mechanism. Any conversion
+   * between types can be done in the user code, which usually entails additional validation and
+   * error handling anyway.
+   *
+   * The supported types are:
+   * - `int`
+   * - `double`
+   * - `bool`
+   * - `std::string`
+   * - `std::filesystem::path`
+   * - `Noneable<T>`, where `T` is one of the supported types
+   * - `std::vector<T>`, where `T` is one of the supported types
+   * - `std::map<std::string, T>`, where `T` is one of the supported types
+   */
+  template <typename T>
+  concept SupportedType = Internal::SupportedTypeHelper<T>::value;
+
+  /**
+   * Determine the rank of a type, i.e., how many levels of nested containers are present.
+   */
+  template <SupportedType T>
+  constexpr std::size_t rank()
+  {
+    return Internal::RankHelper<T>::value;
+  }
+
+}  // namespace Core::IO
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/io/src/4C_io_yaml.cpp
+++ b/src/core/io/src/4C_io_yaml.cpp
@@ -27,6 +27,21 @@ ryml::Tree Core::IO::init_yaml_tree_with_exceptions()
   return ryml::Tree{cb};
 }
 
+void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const std::string& value)
+{
+  node << ryml::to_csubstr(value);
+}
+
+void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const bool& value)
+{
+  node << (value ? "true" : "false");
+}
+
+void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const std::filesystem::path& value)
+{
+  node << value.string();
+}
+
 void Core::IO::read_value_from_yaml(Core::IO::ConstYamlNodeRef node, double& value)
 {
   FOUR_C_ASSERT_ALWAYS(node.node.has_val(), "Expected a value node.");

--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -127,20 +127,11 @@ namespace Core::IO
     node << value;
   }
 
-  inline void emit_value_as_yaml(ryml::NodeRef node, const std::string& value)
-  {
-    node << ryml::to_csubstr(value);
-  }
+  void emit_value_as_yaml(ryml::NodeRef node, const std::string& value);
 
-  inline void emit_value_as_yaml(ryml::NodeRef node, const bool& value)
-  {
-    node << (value ? "true" : "false");
-  }
+  void emit_value_as_yaml(ryml::NodeRef node, const bool& value);
 
-  inline void emit_value_as_yaml(ryml::NodeRef node, const std::filesystem::path& value)
-  {
-    node << value.string();
-  }
+  void emit_value_as_yaml(ryml::NodeRef node, const std::filesystem::path& value);
 
   template <typename T>
   void emit_value_as_yaml(ryml::NodeRef node, const std::optional<T>& value)
@@ -156,27 +147,10 @@ namespace Core::IO
   }
 
   template <typename T>
-  void emit_value_as_yaml(ryml::NodeRef node, const std::map<std::string, T>& value)
-  {
-    node |= ryml::MAP;
-    for (const auto& [key, v] : value)
-    {
-      auto child = node.append_child();
-      child << ryml::key(key);
-      emit_value_as_yaml(child, v);
-    }
-  }
+  void emit_value_as_yaml(ryml::NodeRef node, const std::map<std::string, T>& value);
 
   template <typename T>
-  void emit_value_as_yaml(ryml::NodeRef node, const std::vector<T>& value)
-  {
-    node |= ryml::SEQ | ryml::FLOW_SL;
-    for (const auto& v : value)
-    {
-      auto child = node.append_child();
-      emit_value_as_yaml(child, v);
-    }
-  }
+  void emit_value_as_yaml(ryml::NodeRef node, const std::vector<T>& value);
 
   template <YamlSupportedType T>
   void read_value_from_yaml(ConstYamlNodeRef node, T& value)
@@ -251,6 +225,31 @@ namespace Core::IO
     }
   }
 }  // namespace Core::IO
+
+
+
+template <typename T>
+void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const std::map<std::string, T>& value)
+{
+  node |= ryml::MAP;
+  for (const auto& [key, v] : value)
+  {
+    auto child = node.append_child();
+    child << ryml::key(key);
+    emit_value_as_yaml(child, v);
+  }
+}
+
+template <typename T>
+void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const std::vector<T>& value)
+{
+  node |= ryml::SEQ | ryml::FLOW_SL;
+  for (const auto& v : value)
+  {
+    auto child = node.append_child();
+    emit_value_as_yaml(child, v);
+  }
+}
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/core/io/tests/4C_io_value_parser_test.cpp
+++ b/src/core/io/tests/4C_io_value_parser_test.cpp
@@ -233,7 +233,7 @@ namespace
     std::string_view in("1 2 3 4 5 6 7 8 9");
     Core::IO::ValueParser parser(in);
 
-    auto nested_vectors = parser.read<std::vector<std::vector<int>>>(3, 3);
+    auto nested_vectors = parser.read<std::vector<std::vector<int>>>({3, 3});
 
     EXPECT_EQ(nested_vectors.size(), 3);
     for (size_t i = 0; i < 3; ++i)
@@ -250,7 +250,7 @@ namespace
     std::string_view in("key1 1 2 key2 2 3 key3 3 4");
     Core::IO::ValueParser parser(in);
 
-    auto map = parser.read<std::map<std::string, std::vector<int>>>(3, 2);
+    auto map = parser.read<std::map<std::string, std::vector<int>>>({3, 2});
 
     EXPECT_EQ(map.size(), 3);
     EXPECT_EQ(map.at("key1"), (std::vector{1, 2}));

--- a/src/xfem/4C_xfem_xfluid_timeInt.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.cpp
@@ -66,7 +66,6 @@ XFEM::XFluidTimeInt::XFluidTimeInt(
       timeint_scheme_(xfluid_timintapproach),
       node_to_reconstr_method_(node_to_reconstr_method),
       reconstr_method_to_node_(reconstr_method_to_node),
-      step_(step),
       xfluid_timint_check_interfacetips_(xfluid_timint_check_interfacetips),
       xfluid_timint_check_sliding_on_surface_(xfluid_timint_check_sliding_on_surface)
 {

--- a/src/xfem/4C_xfem_xfluid_timeInt.hpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.hpp
@@ -290,9 +290,6 @@ namespace XFEM
                                 /// marker for reconstruction method of single nodal dofsets used
                                 /// for export in parallel
 
-    // global timestep
-    int step_;
-
     // name check interfacetips in timeintegration
     bool xfluid_timint_check_interfacetips_;
 


### PR DESCRIPTION
The initial implementation only contained vectors of primitive types. This PR extends this to allow nested vectors and maps, either with dynamic sizes, fixed sizes, or the dat-style size read from another parameter (the `NUMxxx` parameters).