### PR TITLE
Remove `innerTests` from `SingleStep` solver

### DIFF
--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_factory.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_factory.cpp
@@ -52,7 +52,7 @@ Teuchos::RCP<::NOX::Solver::Generic> NOX::Nln::Solver::Factory::build_solver(
   }
   else if (method == "Single Step")
   {
-    solver = Teuchos::make_rcp<NOX::Nln::Solver::SingleStep>(grp, innerTests, params);
+    solver = Teuchos::make_rcp<NOX::Nln::Solver::SingleStep>(grp, params);
   }
   else if (not nlnGlobalData.is_constrained())
   {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_singlestep.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_singlestep.cpp
@@ -28,17 +28,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::Solver::SingleStep::SingleStep(const Teuchos::RCP<::NOX::Abstract::Group>& grp,
-    const Teuchos::RCP<NOX::Nln::Inner::StatusTest::Generic>& innerTests,
     const Teuchos::RCP<Teuchos::ParameterList>& params)
     : ::NOX::Solver::SingleStep(grp, params)
-{
-  // call own init() after base init() was called.
-  init(*innerTests);
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-void NOX::Nln::Solver::SingleStep::init(NOX::Nln::Inner::StatusTest::Generic& innerTests)
 {
   nIter = 0;
   status = ::NOX::StatusTest::Unconverged;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_singlestep.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_singlestep.hpp
@@ -42,7 +42,6 @@ namespace NOX
           for description
          */
         SingleStep(const Teuchos::RCP<::NOX::Abstract::Group>& grp,
-            const Teuchos::RCP<NOX::Nln::Inner::StatusTest::Generic>& innerTests,
             const Teuchos::RCP<Teuchos::ParameterList>& params);
 
         [[nodiscard]] ::NOX::StatusTest::StatusType getStatus() const override;
@@ -51,9 +50,6 @@ namespace NOX
         [[nodiscard]] const ::NOX::Utils& get_utils() const;
 
        protected:
-        //! initialize additional variables after base class initialization
-        void init(NOX::Nln::Inner::StatusTest::Generic& innerTests);
-
         void printUpdate() override;
       };  // class SingleStep
     }  // namespace Solver


### PR DESCRIPTION
## Description
With the debug version of Trilinos `StepSolver` crashed attempting to dereference null pointer `innerTests`. Since `innerTests` variable is not used anyway, I just removed it.
