### PR TITLE
Extract InputParameterContainer::add to own header

### DIFF
--- a/src/core/io/src/4C_io_input_parameter_container.cpp
+++ b/src/core/io/src/4C_io_input_parameter_container.cpp
@@ -5,9 +5,9 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
-#include "4C_io_input_parameter_container.hpp"
+#include "4C_io_input_parameter_container.templates.hpp"
 
-#include "4C_linalg_vector.hpp"
+#include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -131,6 +131,21 @@ Core::IO::InputParameterContainer::get_type_actions()
   return type_actions;
 }
 
+// Explicit instantiation of the template functions.
 
+template void Core::IO::InputParameterContainer::add(const std::string& name, const int& data);
+template void Core::IO::InputParameterContainer::add(const std::string& name, const double& data);
+template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::string& data);
+template void Core::IO::InputParameterContainer::add(const std::string& name, const bool& data);
+
+template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<int>& data);
+template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<double>& data);
+template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<std::string>& data);
+template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<bool>& data);
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -13,8 +13,7 @@
 
 #include "4C_utils_demangle.hpp"
 #include "4C_utils_exceptions.hpp"
-
-#include <Teuchos_ParameterList.hpp>
+#include "4C_utils_parameter_list.fwd.hpp"
 
 #include <any>
 #include <functional>
@@ -282,12 +281,6 @@ namespace Core::IO::Internal::InputParameterContainerImplementation
 }  // namespace Core::IO::Internal::InputParameterContainerImplementation
 
 
-template <typename T>
-void Core::IO::InputParameterContainer::add(const std::string& name, const T& data)
-{
-  entries_[name] = {.data = std::any{data}};
-  ensure_type_action_registered<T>();
-}
 
 template <typename T>
 const T& Core::IO::InputParameterContainer::get(const std::string& name) const
@@ -319,20 +312,6 @@ const T* Core::IO::InputParameterContainer::get_if(const std::string& name) cons
   else
   {
     return nullptr;
-  }
-}
-
-template <typename T>
-void Core::IO::InputParameterContainer::ensure_type_action_registered()
-{
-  auto& type_actions = get_type_actions();
-  if (!type_actions.contains(typeid(T)))
-  {
-    type_actions[typeid(T)] = {
-        .print = Internal::InputParameterContainerImplementation::PrintHelper<T>{},
-        .write_to_pl = [](Teuchos::ParameterList& pl, const std::string& name, const std::any& data)
-        { pl.set<T>(name, std::any_cast<T>(data)); },
-    };
   }
 }
 

--- a/src/core/io/src/4C_io_input_parameter_container.templates.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.templates.hpp
@@ -1,0 +1,66 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_IO_INPUT_PARAMETER_CONTAINER_TEMPLATES_HPP
+#define FOUR_C_IO_INPUT_PARAMETER_CONTAINER_TEMPLATES_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_io_input_parameter_container.hpp"
+
+#include <Teuchos_ParameterList.hpp>
+
+FOUR_C_NAMESPACE_OPEN
+
+// The add() function requires expensive-to-include Teuchos headers, but it is rarely needed, since
+// most user code only reads from the InputParameterContainer. Therefore, we put the implementation
+// into this special templates file.
+
+template <typename T>
+void Core::IO::InputParameterContainer::add(const std::string& name, const T& data)
+{
+  entries_[name] = {.data = std::any{data}};
+  ensure_type_action_registered<T>();
+}
+
+template <typename T>
+void Core::IO::InputParameterContainer::ensure_type_action_registered()
+{
+  auto& type_actions = get_type_actions();
+  if (!type_actions.contains(typeid(T)))
+  {
+    type_actions[typeid(T)] = {
+        .print = Internal::InputParameterContainerImplementation::PrintHelper<T>{},
+        .write_to_pl = [](Teuchos::ParameterList& pl, const std::string& name, const std::any& data)
+        { pl.set<T>(name, std::any_cast<T>(data)); },
+    };
+  }
+}
+
+// --- Declare that these templates are instantiated for some types --- //
+
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const int& data);
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const double& data);
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::string& data);
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const bool& data);
+
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<int>& data);
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<double>& data);
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<std::string>& data);
+extern template void Core::IO::InputParameterContainer::add(
+    const std::string& name, const std::vector<bool>& data);
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -10,7 +10,7 @@
 
 #include "4C_config.hpp"
 
-#include "4C_io_input_parameter_container.hpp"
+#include "4C_io_input_parameter_container.templates.hpp"
 #include "4C_io_input_spec.hpp"
 #include "4C_io_value_parser.hpp"
 #include "4C_io_yaml.hpp"

--- a/src/core/io/tests/4C_io_input_parameter_container_test.cpp
+++ b/src/core/io/tests/4C_io_input_parameter_container_test.cpp
@@ -7,7 +7,9 @@
 
 #include <gtest/gtest.h>
 
-#include "4C_io_input_parameter_container.hpp"
+#include "4C_io_input_parameter_container.templates.hpp"
+
+#include <Teuchos_ParameterList.hpp>
 
 namespace
 {

--- a/unittests/mat/4C_electrode_test.cpp
+++ b/unittests/mat/4C_electrode_test.cpp
@@ -12,6 +12,7 @@
 #include "4C_global_data_read.hpp"
 #include "4C_global_legacy_module.hpp"
 #include "4C_io_input_file.hpp"
+#include "4C_io_input_parameter_container.templates.hpp"
 #include "4C_mat_electrode.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_utils_singleton_owner.hpp"

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "4C_global_data.hpp"
+#include "4C_io_input_parameter_container.templates.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_mat_elast_couptransverselyisotropic.hpp"


### PR DESCRIPTION
The `InputParameterContainer` was the most expensive include due to the transitive include of `Teuchos::ParameterList`. I moved the `add` method to a `.templates.hpp` which we rarely need to include since we mostly want to `get()`.