### PR TITLE
CI: make 4C upload and download more flexible

### DIFF
--- a/.github/actions/download_4C_build/action.yml
+++ b/.github/actions/download_4C_build/action.yml
@@ -4,6 +4,9 @@ inputs:
   build-job:
     description: Name of the build-job
     required: true
+  destination:
+    description: Path to extract the build
+    required: true
 runs:
   using: composite
   steps:
@@ -14,5 +17,9 @@ runs:
     - name: Extract 4C build
       shell: bash
       run: |
-        tar -xf $GITHUB_WORKSPACE/4C_build.tar -C /
+        mkdir -p $DESTINATION
+        cd $DESTINATION
+        tar -xf $GITHUB_WORKSPACE/4C_build.tar
         rm $GITHUB_WORKSPACE/4C_build.tar
+      env:
+        DESTINATION: ${{ inputs.destination }}

--- a/.github/actions/upload_4C_build/action.yml
+++ b/.github/actions/upload_4C_build/action.yml
@@ -13,7 +13,11 @@ runs:
   steps:
     - name: Package build directory
       shell: bash
-      run: tar -cf $GITHUB_WORKSPACE/4C_build.tar $GITHUB_WORKSPACE/build
+      run: |
+        cd $BUILD_DIRECTORY
+        tar -cf $GITHUB_WORKSPACE/4C_build.tar .
+      env:
+        BUILD_DIRECTORY: ${{ inputs.build-directory }}
     - name: Upload build folder
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -70,6 +70,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: gcc13_assertions_build
+          destination: ${{ github.workspace }}/build
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
@@ -154,6 +155,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: clang18_build
+          destination: ${{ github.workspace }}/build
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: gcc13_coverage_build
+          destination: ${{ github.workspace }}/build
       - name: Run all tests and collect raw coverage data
         run: | # Note: Collect raw coverage data in a file distict for each process
           cd $GITHUB_WORKSPACE/build
@@ -119,6 +120,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: gcc13_coverage_build
+          destination: ${{ github.workspace }}/build
       - name: Setup developer environment for testing
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: gcc13_assertions_build
+          destination: ${{ github.workspace }}/build
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
@@ -145,6 +146,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: clang18_build
+          destination: ${{ github.workspace }}/build
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
@@ -229,6 +231,7 @@ jobs:
       - uses: ./.github/actions/download_4C_build
         with:
           build-job: gcc13_asan_build
+          destination: ${{ github.workspace }}/build
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build


### PR DESCRIPTION
With the help of @amgebauer we realized that the upload of  a 4C build performed in the actions is suboptimal as it previously used absolute paths. This will not work when the build is reused in a different environment, but it isn't very clear even in the present use case. This PR packages the build relative to the build dir and extracts it to a parameterized destination.