### PR TITLE
Clean up mortar input parameters

### DIFF
--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -72,10 +72,9 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       mortar);
 
   Core::Utils::string_to_integral_parameter<Inpar::Mortar::MeshRelocation>("MESH_RELOCATION",
-      "Initial", "Type of mesh relocation",
-      tuple<std::string>("Initial", "initial", "Every_Timestep", "every_timestep", "No", "no"),
-      tuple<Inpar::Mortar::MeshRelocation>(relocation_initial, relocation_initial,
-          relocation_timestep, relocation_timestep, relocation_none, relocation_none),
+      "Initial", "Type of mesh relocation", tuple<std::string>("Initial", "Every_Timestep", "None"),
+      tuple<Inpar::Mortar::MeshRelocation>(
+          relocation_initial, relocation_timestep, relocation_none),
       mortar);
 
   Core::Utils::string_to_integral_parameter<Inpar::Mortar::AlgorithmType>("ALGORITHM", "Mortar",

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -148,11 +148,8 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       "Minimum no. of elements per processor for parallel redistribution", parallelRedist);
 
   Core::Utils::string_to_integral_parameter<ParallelRedist>("PARALLEL_REDIST", "Static",
-      "Type of redistribution algorithm",
-      tuple<std::string>("None", "none", "No", "no", "Static", "static", "Dynamic", "dynamic"),
-      tuple<ParallelRedist>(ParallelRedist::redist_none, ParallelRedist::redist_none,
-          ParallelRedist::redist_none, ParallelRedist::redist_none, ParallelRedist::redist_static,
-          ParallelRedist::redist_static, ParallelRedist::redist_dynamic,
+      "Type of redistribution algorithm", tuple<std::string>("None", "Static", "Dynamic"),
+      tuple<ParallelRedist>(ParallelRedist::redist_none, ParallelRedist::redist_static,
           ParallelRedist::redist_dynamic),
       parallelRedist);
 

--- a/tests/input_files/contact2D_binning_redist_dynamic.dat
+++ b/tests/input_files/contact2D_binning_redist_dynamic.dat
@@ -66,7 +66,7 @@ SEARCH_USE_AUX_POS              Yes
 LM_QUAD                         undefined
 CROSSPOINTS                     No
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 NUMGP_PER_DIM                   0

--- a/tests/input_files/contact2D_binning_redist_none.dat
+++ b/tests/input_files/contact2D_binning_redist_none.dat
@@ -66,7 +66,7 @@ SEARCH_USE_AUX_POS              Yes
 LM_QUAD                         undefined
 CROSSPOINTS                     No
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 NUMGP_PER_DIM                   0

--- a/tests/input_files/contact2D_binning_redist_static.dat
+++ b/tests/input_files/contact2D_binning_redist_static.dat
@@ -66,7 +66,7 @@ SEARCH_USE_AUX_POS              Yes
 LM_QUAD                         undefined
 CROSSPOINTS                     No
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 NUMGP_PER_DIM                   0

--- a/tests/input_files/contact2D_cpp_vertex_on_vertex_new_struc.dat
+++ b/tests/input_files/contact2D_cpp_vertex_on_vertex_new_struc.dat
@@ -79,7 +79,7 @@ LM_DUAL_CONSISTENT   none
 ALGORITHM            mortar
 LM_QUAD              quad
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               UMFPACK

--- a/tests/input_files/contact2D_ele_based_new_struc.dat
+++ b/tests/input_files/contact2D_ele_based_new_struc.dat
@@ -64,7 +64,7 @@ SEARCH_PARAM                    0.3
 INTTYPE                         elements
 NUMGP_PER_DIM                   3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST dynamic
+PARALLEL_REDIST Dynamic
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact2D_meshtying.dat
+++ b/tests/input_files/contact2D_meshtying.dat
@@ -52,7 +52,7 @@ SEARCH_ALGORITHM     Binarytree
 SEARCH_PARAM         0.5
 LM_SHAPEFCN          pg
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      dynamic
+PARALLEL_REDIST      Dynamic
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               Superlu

--- a/tests/input_files/contact2D_multibody.dat
+++ b/tests/input_files/contact2D_multibody.dat
@@ -67,7 +67,7 @@ LM_SHAPEFCN                     Standard
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact2D_nurbs9_pg_frict.dat
+++ b/tests/input_files/contact2D_nurbs9_pg_frict.dat
@@ -57,7 +57,7 @@ NUMGP_PER_DIM                   5
 LM_QUAD                         quad
 LM_DUAL_CONSISTENT              none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 --------------------------------------------------------------------SOLVER 1
 NAME                            Struct_Solver
 SOLVER                          Superlu

--- a/tests/input_files/contact2D_nurbs9_std_new_struc.dat
+++ b/tests/input_files/contact2D_nurbs9_std_new_struc.dat
@@ -69,7 +69,7 @@ NUMGP_PER_DIM                   5
 LM_QUAD                         quad
 LM_DUAL_CONSISTENT              none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 --------------------------------------------------------------------SOLVER 1
 NAME                            Struct_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact2D_patch_bound.dat
+++ b/tests/input_files/contact2D_patch_bound.dat
@@ -63,7 +63,7 @@ ALGORITHM                       mortar
 LM_QUAD                         quad
 CROSSPOINTS                     Yes
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Direct_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact2D_patch_bound_new_struct.dat
+++ b/tests/input_files/contact2D_patch_bound_new_struct.dat
@@ -63,7 +63,7 @@ LM_DUAL_CONSISTENT   none
 ALGORITHM            mortar
 LM_QUAD              quad
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact2D_self.dat
+++ b/tests/input_files/contact2D_self.dat
@@ -57,7 +57,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.5
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact2D_self_new_struct.dat
+++ b/tests/input_files/contact2D_self_new_struct.dat
@@ -57,7 +57,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.5
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact2D_self_saddlepoint.dat
+++ b/tests/input_files/contact2D_self_saddlepoint.dat
@@ -75,7 +75,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.5
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact2D_simpler.dat
+++ b/tests/input_files/contact2D_simpler.dat
@@ -68,7 +68,7 @@ LM_SHAPEFCN                     Standard
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact2D_slidingblock_coulomb.dat
+++ b/tests/input_files/contact2D_slidingblock_coulomb.dat
@@ -64,7 +64,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact3D_bin_strat.dat
+++ b/tests/input_files/contact3D_bin_strat.dat
@@ -59,7 +59,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 MAX_BALANCE_EVAL_TIME           1.0
 GHOSTING_STRATEGY               binning
 ----------------------------------------------------------SOLVER 1

--- a/tests/input_files/contact3D_bin_strat_new_struct.dat
+++ b/tests/input_files/contact3D_bin_strat_new_struct.dat
@@ -59,7 +59,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 MAX_BALANCE_EVAL_TIME           1.0
 GHOSTING_STRATEGY               binning
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/contact3D_blocked_system_ilu_precon.dat
+++ b/tests/input_files/contact3D_blocked_system_ilu_precon.dat
@@ -63,7 +63,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 OUTPUT_INTERFACES               Yes

--- a/tests/input_files/contact3D_dual_lts.dat
+++ b/tests/input_files/contact3D_dual_lts.dat
@@ -52,7 +52,7 @@ INTTYPE              segments
 LM_DUAL_CONSISTENT   none
 ALGORITHM            lts
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               Superlu

--- a/tests/input_files/contact3D_dual_lts_new_struct.dat
+++ b/tests/input_files/contact3D_dual_lts_new_struct.dat
@@ -52,7 +52,7 @@ INTTYPE              segments
 LM_DUAL_CONSISTENT   none
 ALGORITHM            lts
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               Superlu

--- a/tests/input_files/contact3D_lin_GPTSpenalty.dat
+++ b/tests/input_files/contact3D_lin_GPTSpenalty.dat
@@ -54,7 +54,7 @@ SEARCH_PARAM                    0.3
 ALGORITHM                       gpts
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ----------------------------------------------------------SOLVER 1
 NAME                            Direct_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact3D_lin_GPTSpenalty_new_struct.dat
+++ b/tests/input_files/contact3D_lin_GPTSpenalty_new_struct.dat
@@ -55,7 +55,7 @@ SEARCH_PARAM                    0.3
 ALGORITHM                       gpts
 TRIANGULATION                   center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/contact3D_lin_ltl_new_struc.dat
+++ b/tests/input_files/contact3D_lin_ltl_new_struc.dat
@@ -56,7 +56,7 @@ INTTYPE              segments
 LM_DUAL_CONSISTENT   all
 ALGORITHM            ltl
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               Superlu

--- a/tests/input_files/contact3D_lts_ll_new_struc.dat
+++ b/tests/input_files/contact3D_lts_ll_new_struc.dat
@@ -60,7 +60,7 @@ INTTYPE              segments
 LM_DUAL_CONSISTENT   all
 ALGORITHM            mortar
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               Superlu

--- a/tests/input_files/contact3D_nitsche_hex8_nonsym_ele.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_nonsym_ele.dat
@@ -49,7 +49,7 @@ NUMGP_PER_DIM        2
 LM_SHAPEFCN          std
 INTTYPE              Elements
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 SOLVER                         UMFPACK
 ---------------------------------------------------------MATERIALS

--- a/tests/input_files/contact3D_nitsche_hex8_nonsym_ele_new_struct.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_nonsym_ele_new_struct.dat
@@ -50,7 +50,7 @@ NUMGP_PER_DIM        2
 LM_SHAPEFCN          std
 INTTYPE              Elements
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 SOLVER                         UMFPACK
 ----------------------------------------------------------SOLVER 2

--- a/tests/input_files/contact3D_nitsche_hex8_skew_segm.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_segm.dat
@@ -49,7 +49,7 @@ SEARCH_PARAM         0.3e1
 NUMGP_PER_DIM        7
 LM_SHAPEFCN          std
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 SOLVER                         UMFPACK
 ---------------------------------------------------------MATERIALS

--- a/tests/input_files/contact3D_nitsche_hex8_skew_segm_new_struct.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_segm_new_struct.dat
@@ -50,7 +50,7 @@ SEARCH_PARAM         0.3e1
 NUMGP_PER_DIM        7
 LM_SHAPEFCN          std
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 SOLVER                         UMFPACK
 ----------------------------------------------------------SOLVER 2

--- a/tests/input_files/contact3D_nitsche_hex8_skew_segm_newtonLS_new_struc.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_segm_newtonLS_new_struc.dat
@@ -50,7 +50,7 @@ SEARCH_PARAM         0.3e1
 NUMGP_PER_DIM        3
 LM_SHAPEFCN          std
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 -------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/contact3D_nitsche_hex8_skew_tresca.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_skew_tresca.dat
@@ -45,7 +45,7 @@ INTTYPE                   elements
 NUMGP_PER_DIM             1
 SEARCH_PARAM              0.3
 LM_DUAL_CONSISTENT        none
-// PARALLEL_REDIST           no
+// PARALLEL_REDIST           None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               UMFPACK

--- a/tests/input_files/contact3D_nitsche_hex8_sym_coulomb.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_sym_coulomb.dat
@@ -45,7 +45,7 @@ NUMGP_PER_DIM             7
 SEARCH_PARAM              0.3
 LM_DUAL_CONSISTENT        none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST           dynamic
+PARALLEL_REDIST           Dynamic
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER              UMFPACK

--- a/tests/input_files/contact3D_nitsche_hex8_sym_coulomb_new_struc.dat
+++ b/tests/input_files/contact3D_nitsche_hex8_sym_coulomb_new_struc.dat
@@ -52,7 +52,7 @@ NUMGP_PER_DIM             7
 SEARCH_PARAM              0.3
 LM_DUAL_CONSISTENT        none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST           dynamic
+PARALLEL_REDIST           Dynamic
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER              UMFPACK

--- a/tests/input_files/contact3D_nurbs27_pg.dat
+++ b/tests/input_files/contact3D_nurbs27_pg.dat
@@ -59,7 +59,7 @@ NUMGP_PER_DIM                   5
 LM_QUAD                         quad
 LM_DUAL_CONSISTENT              none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 --------------------------------------------------------------------SOLVER 1
 NAME                            Struct_Solver
 SOLVER                          Superlu

--- a/tests/input_files/contact3D_patch_unbiased_self_nitsche_skew.dat
+++ b/tests/input_files/contact3D_patch_unbiased_self_nitsche_skew.dat
@@ -29,7 +29,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -------------------------------------------------STRUCTURAL DYNAMIC
 INT_STRATEGY                    Standard

--- a/tests/input_files/contact3D_roundrobin_ghost.dat
+++ b/tests/input_files/contact3D_roundrobin_ghost.dat
@@ -58,7 +58,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 GHOSTING_STRATEGY               round_robin
 ----------------------------------------------------------SOLVER 1
 NAME                            Direct_Solver

--- a/tests/input_files/contact3D_roundrobin_ghost_new_struc.dat
+++ b/tests/input_files/contact3D_roundrobin_ghost_new_struc.dat
@@ -58,7 +58,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 GHOSTING_STRATEGY               round_robin
 --------------------------------------------------------------------SOLVER 1
 NAME                            Direct_Solver

--- a/tests/input_files/contact3D_sp_dual_simple.dat
+++ b/tests/input_files/contact3D_sp_dual_simple.dat
@@ -63,7 +63,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 OUTPUT_INTERFACES               Yes

--- a/tests/input_files/contact3D_sp_std_braess_sarazin.dat
+++ b/tests/input_files/contact3D_sp_std_braess_sarazin.dat
@@ -63,7 +63,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 OUTPUT_INTERFACES               Yes

--- a/tests/input_files/contact3D_sp_std_simple.dat
+++ b/tests/input_files/contact3D_sp_std_simple.dat
@@ -63,7 +63,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 OUTPUT_INTERFACES               Yes

--- a/tests/input_files/contact3D_sp_std_uzawa.dat
+++ b/tests/input_files/contact3D_sp_std_uzawa.dat
@@ -63,7 +63,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 OUTPUT_INTERFACES               Yes

--- a/tests/input_files/contact3D_tet4_hex8.dat
+++ b/tests/input_files/contact3D_tet4_hex8.dat
@@ -54,7 +54,7 @@ SEARCH_PARAM                    0.8
 INTTYPE                         elements
 NUMGP_PER_DIM                   3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          Superlu

--- a/tests/input_files/contact3D_tet4_hex8_new_struct.dat
+++ b/tests/input_files/contact3D_tet4_hex8_new_struct.dat
@@ -51,7 +51,7 @@ SEARCH_PARAM                    0.8
 INTTYPE                         elements
 NUMGP_PER_DIM                   3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 dynamic
+PARALLEL_REDIST                 Dynamic
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          Superlu

--- a/tests/input_files/contact3D_unbiased_self_hex8_nitsche.dat
+++ b/tests/input_files/contact3D_unbiased_self_hex8_nitsche.dat
@@ -39,7 +39,7 @@ ALGORITHM                       gpts
 NUMGP_PER_DIM                   7
 TRIANGULATION                   Center
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact3D_unbiased_self_hex8_nitsche_new_struct.dat
+++ b/tests/input_files/contact3D_unbiased_self_hex8_nitsche_new_struct.dat
@@ -46,7 +46,7 @@ ALGORITHM                       gpts
 NUMGP_PER_DIM                   3
 TRIANGULATION                   Center
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
+++ b/tests/input_files/contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
@@ -46,7 +46,7 @@ ALGORITHM                       gpts
 NUMGP_PER_DIM                   2
 INTTYPE                         Elements
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/ehl2D_block_sqz.dat
+++ b/tests/input_files/ehl2D_block_sqz.dat
@@ -56,7 +56,7 @@ INTTYPE                         Elements
 NUMGP_PER_DIM                   2
 TRIANGULATION                   Center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ---------------------------------------------------LUBRICATION DYNAMIC
 MAXTIME                         1.0
 NUMSTEP                         3000

--- a/tests/input_files/ehl3D_block_sqz.dat
+++ b/tests/input_files/ehl3D_block_sqz.dat
@@ -56,7 +56,7 @@ INTTYPE                         Elements
 NUMGP_PER_DIM                   2
 TRIANGULATION                   Center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ---------------------------------------------------LUBRICATION DYNAMIC
 MAXTIME                         1.0
 NUMSTEP                         3000

--- a/tests/input_files/ehl3d_cyl_mono.dat
+++ b/tests/input_files/ehl3d_cyl_mono.dat
@@ -56,7 +56,7 @@ INTTYPE                         Elements
 NUMGP_PER_DIM                   2
 TRIANGULATION                   Center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ---------------------------------------------------LUBRICATION DYNAMIC
 MAXTIME                         1.0
 NUMSTEP                         3000

--- a/tests/input_files/ehl3d_cyl_mono_averaged.dat
+++ b/tests/input_files/ehl3d_cyl_mono_averaged.dat
@@ -56,7 +56,7 @@ INTTYPE                         Elements
 NUMGP_PER_DIM                   2
 TRIANGULATION                   Center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ---------------------------------------------------LUBRICATION DYNAMIC
 MAXTIME                         1.0
 NUMSTEP                         3000

--- a/tests/input_files/ehl3d_cyl_part.dat
+++ b/tests/input_files/ehl3d_cyl_part.dat
@@ -56,7 +56,7 @@ INTTYPE                         Elements
 NUMGP_PER_DIM                   2
 TRIANGULATION                   Center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ---------------------------------------------------LUBRICATION DYNAMIC
 MAXTIME                         1.0
 NUMSTEP                         3000

--- a/tests/input_files/ehl3d_mixed.dat
+++ b/tests/input_files/ehl3d_mixed.dat
@@ -60,7 +60,7 @@ INTTYPE                         Elements_BS
 NUMGP_PER_DIM                   2
 TRIANGULATION                   Center
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ---------------------------------------------------LUBRICATION DYNAMIC
 MAXTIME                         1.0e2
 NUMSTEP                         3000

--- a/tests/input_files/ehl_bearing_barus.dat
+++ b/tests/input_files/ehl_bearing_barus.dat
@@ -68,7 +68,7 @@ SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    1
 INTTYPE                         Elements
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 3
 NAME                            Direct_Solver
 SOLVER                          Superlu

--- a/tests/input_files/ehl_bearing_roeland.dat
+++ b/tests/input_files/ehl_bearing_roeland.dat
@@ -68,7 +68,7 @@ SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.5
 INTTYPE                         Elements
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 3
 NAME                            Direct_Solver
 SOLVER                          Superlu

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_bubnov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_bubnov_lmmaster.dat
@@ -35,7 +35,7 @@ LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_bubnov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_bubnov_lmmaster.dat
@@ -33,7 +33,7 @@ EQUPOT                          divi
 COUPLINGTYPE                    CondensedMortar_Bubnov
 LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov.dat
@@ -34,7 +34,7 @@ COUPLINGTYPE                    CondensedMortar_Petrov
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov.dat
@@ -32,7 +32,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    CondensedMortar_Petrov
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov_lmmaster.dat
@@ -33,7 +33,7 @@ EQUPOT                          divi
 COUPLINGTYPE                    CondensedMortar_Petrov
 LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_condensed_petrov_lmmaster.dat
@@ -35,7 +35,7 @@ LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov.dat
@@ -34,7 +34,7 @@ COUPLINGTYPE                    SaddlePointMortar_Bubnov
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov.dat
@@ -32,7 +32,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    SaddlePointMortar_Bubnov
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov_lmmaster.dat
@@ -33,7 +33,7 @@ EQUPOT                          divi
 COUPLINGTYPE                    SaddlePointMortar_Bubnov
 LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_bubnov_lmmaster.dat
@@ -35,7 +35,7 @@ LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov.dat
@@ -32,7 +32,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    SaddlePointMortar_Petrov
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov.dat
@@ -34,7 +34,7 @@ COUPLINGTYPE                    SaddlePointMortar_Petrov
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov_lmmaster.dat
@@ -33,7 +33,7 @@ EQUPOT                          divi
 COUPLINGTYPE                    SaddlePointMortar_Petrov
 LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov_lmmaster.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_saddlepoint_petrov_lmmaster.dat
@@ -35,7 +35,7 @@ LMSIDE                          master
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard.dat
@@ -33,7 +33,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard.dat
@@ -35,7 +35,7 @@ COUPLINGTYPE                    StandardMortar
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_BGS-AMG_3x3.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_BGS-AMG_3x3.dat
@@ -39,7 +39,7 @@ COUPLINGTYPE                    StandardMortar
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          Belos
 AZPREC                          AMGnxn

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_BGS-AMG_3x3.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_BGS-AMG_3x3.dat
@@ -37,7 +37,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_redist.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_redist.dat
@@ -32,7 +32,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_redist_BGS-AMG_3x3.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_mortar_standard_redist_BGS-AMG_3x3.dat
@@ -37,7 +37,7 @@ EQUPOT                          divi
 ---------------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          Belos
 AZPREC                          AMGnxn

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_nts_standard.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_nts_standard.dat
@@ -35,7 +35,7 @@ NTSPROJTOL                      2.e-2
 -------------------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/elch_3D_tet4_s2i_butlervolmer_nts_standard.dat
+++ b/tests/input_files/elch_3D_tet4_s2i_butlervolmer_nts_standard.dat
@@ -33,7 +33,7 @@ EQUPOT                          divi
 COUPLINGTYPE                    StandardNodeToSegment
 NTSPROJTOL                      2.e-2
 -------------------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------------------------------------------SOLVER 1

--- a/tests/input_files/elch_NonMatchingMesh_20x80.dat
+++ b/tests/input_files/elch_NonMatchingMesh_20x80.dat
@@ -36,7 +36,7 @@ EQUPOT                          ENC
 LM_SHAPEFCN                     Dual
 MESH_RELOCATION                 Initial
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK

--- a/tests/input_files/elch_NonMatchingMesh_20x80.dat
+++ b/tests/input_files/elch_NonMatchingMesh_20x80.dat
@@ -34,7 +34,7 @@ TEMPERATURE                     11604.506                       // abused as a s
 EQUPOT                          ENC
 ---------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
-MESH_RELOCATION                 initial
+MESH_RELOCATION                 Initial
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 static
 GHOSTING_STRATEGY               redundant_all

--- a/tests/input_files/elch_NonMatchingMesh_20x80_pdeElim_ionTransport_Laplace.dat
+++ b/tests/input_files/elch_NonMatchingMesh_20x80_pdeElim_ionTransport_Laplace.dat
@@ -36,7 +36,7 @@ EQUPOT                          ENC_PDE_ELIM
 ONLYPOTENTIAL                   yes
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 GHOSTING_STRATEGY               redundant_all

--- a/tests/input_files/elch_NonMatchingMesh_20x80_pdeElim_ionTransport_Laplace.dat
+++ b/tests/input_files/elch_NonMatchingMesh_20x80_pdeElim_ionTransport_Laplace.dat
@@ -38,7 +38,7 @@ ONLYPOTENTIAL                   yes
 LM_SHAPEFCN                     Dual
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK

--- a/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Bmat.dat
+++ b/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Bmat.dat
@@ -72,7 +72,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Fluid_Solver

--- a/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Smat.dat
+++ b/tests/input_files/f2_ShearFlow_NonMatchingMesh_4x16_Con_Smat.dat
@@ -73,7 +73,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Meshtying_Solver

--- a/tests/input_files/f3_beltrami_8x8_meshtying_ale.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_ale.dat
@@ -74,7 +74,7 @@ CROSSPOINTS                     no
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   2

--- a/tests/input_files/f3_beltrami_8x8_meshtying_ale_euler.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_ale_euler.dat
@@ -74,7 +74,7 @@ CROSSPOINTS                     no
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   2

--- a/tests/input_files/f3_beltrami_8x8_meshtying_bmat.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_bmat.dat
@@ -62,7 +62,7 @@ CROSSPOINTS             no
 SEARCH_ALGORITHM        Binarytree
 SEARCH_PARAM            0.3
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/f3_beltrami_8x8_meshtying_bmat_merged.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_bmat_merged.dat
@@ -59,7 +59,7 @@ CROSSPOINTS               no
 SEARCH_ALGORITHM          Binarytree
 SEARCH_PARAM              0.3
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   2

--- a/tests/input_files/f3_beltrami_8x8_meshtying_smat.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_smat.dat
@@ -66,7 +66,7 @@ LM_SHAPEFCN             Dual
 LM_QUAD                 quad
 CROSSPOINTS             no
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   2

--- a/tests/input_files/f3_beltrami_8x8_meshtying_smat_velcoupled.dat
+++ b/tests/input_files/f3_beltrami_8x8_meshtying_smat_velcoupled.dat
@@ -60,7 +60,7 @@ CROSSPOINTS               no
 SEARCH_ALGORITHM          Binarytree
 SEARCH_PARAM              0.3
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   2

--- a/tests/input_files/f3_channel_meshtying_DCmaster.dat
+++ b/tests/input_files/f3_channel_meshtying_DCmaster.dat
@@ -72,7 +72,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 -------------------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/fbi_meshtying_bmat.dat
+++ b/tests/input_files/fbi_meshtying_bmat.dat
@@ -53,7 +53,7 @@ CROSSPOINTS             no
 SEARCH_ALGORITHM        Binarytree
 SEARCH_PARAM            0.5
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                         1

--- a/tests/input_files/fbi_meshtying_smat.dat
+++ b/tests/input_files/fbi_meshtying_smat.dat
@@ -54,7 +54,7 @@ CROSSPOINTS             no
 SEARCH_ALGORITHM        Binarytree
 SEARCH_PARAM            0.5
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   2

--- a/tests/input_files/fsi_dc_part_mtrait_ost_ga.dat
+++ b/tests/input_files/fsi_dc_part_mtrait_ost_ga.dat
@@ -85,7 +85,7 @@ RELAX                           0.825
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 NAME                            Ale_Solver

--- a/tests/input_files/fsi_fp_mono_mtrfs_ga_ga.dat
+++ b/tests/input_files/fsi_fp_mono_mtrfs_ga_ga.dat
@@ -80,7 +80,7 @@ THERM_TEMPGRAD                  None
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------------PROBLEM TYPE
 PROBLEMTYPE                      Fluid_Structure_Interaction

--- a/tests/input_files/fsi_fp_mono_mtrfs_ga_ga_sp.dat
+++ b/tests/input_files/fsi_fp_mono_mtrfs_ga_ga_sp.dat
@@ -69,7 +69,7 @@ TOL_VEL_RES_L2                  1e-10
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------------PROBLEM TYPE
 PROBLEMTYPE                      Fluid_Structure_Interaction

--- a/tests/input_files/fsi_fp_mono_mtrfs_ost_ga.dat
+++ b/tests/input_files/fsi_fp_mono_mtrfs_ost_ga.dat
@@ -81,7 +81,7 @@ THERM_TEMPGRAD                  None
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------------PROBLEM TYPE
 PROBLEMTYPE                      Fluid_Structure_Interaction

--- a/tests/input_files/fsi_fp_mono_mtrfs_ost_ga_sp.dat
+++ b/tests/input_files/fsi_fp_mono_mtrfs_ost_ga_sp.dat
@@ -67,7 +67,7 @@ TOL_VEL_RES_L2                  1e-10
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------------PROBLEM TYPE
 PROBLEMTYPE                      Fluid_Structure_Interaction

--- a/tests/input_files/fsi_fp_mono_mtrss_ga_ga.dat
+++ b/tests/input_files/fsi_fp_mono_mtrss_ga_ga.dat
@@ -84,7 +84,7 @@ THERM_TEMPGRAD                  None
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------------PROBLEM TYPE
 PROBLEMTYPE                      Fluid_Structure_Interaction

--- a/tests/input_files/fsi_fp_mono_mtrss_ost_ga.dat
+++ b/tests/input_files/fsi_fp_mono_mtrss_ost_ga.dat
@@ -78,7 +78,7 @@ THERM_TEMPGRAD                  None
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------------PROBLEM TYPE
 PROBLEMTYPE                      Fluid_Structure_Interaction

--- a/tests/input_files/fsi_ow3D_mtr_drt.dat
+++ b/tests/input_files/fsi_ow3D_mtr_drt.dat
@@ -81,7 +81,7 @@ SHAPEFCT                        Polynomial
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 INT_STRATEGY                    Standard

--- a/tests/input_files/fsi_ves_mono_mtrfs_ost_ost_slidcurr.dat
+++ b/tests/input_files/fsi_ves_mono_mtrfs_ost_ost_slidcurr.dat
@@ -31,7 +31,7 @@ VERBOSITY                       standard
 LM_SHAPEFCN                     Dual
 MESH_RELOCATION                 Initial
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/fsi_ves_mono_mtrfs_ost_ost_slidcurr.dat
+++ b/tests/input_files/fsi_ves_mono_mtrfs_ost_ost_slidcurr.dat
@@ -29,7 +29,7 @@ FILESTEPS                       1000
 VERBOSITY                       standard
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
-MESH_RELOCATION                 initial
+MESH_RELOCATION                 Initial
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 No
 GHOSTING_STRATEGY               redundant_all

--- a/tests/input_files/fsi_ves_mono_mtrfs_ost_ost_slidrot.dat
+++ b/tests/input_files/fsi_ves_mono_mtrfs_ost_ost_slidrot.dat
@@ -29,7 +29,7 @@ FILESTEPS                       1000
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/fsi_ves_mono_mtrss_ost_ost_slidcurr.dat
+++ b/tests/input_files/fsi_ves_mono_mtrss_ost_ost_slidcurr.dat
@@ -30,7 +30,7 @@ VERBOSITY                       standard
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/fsi_ves_mono_mtrss_ost_ost_slidrot.dat
+++ b/tests/input_files/fsi_ves_mono_mtrss_ost_ost_slidrot.dat
@@ -31,7 +31,7 @@ VERBOSITY                       standard
 LM_SHAPEFCN                     Dual
 MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/fsi_ves_mono_mtrss_ost_ost_slidrot.dat
+++ b/tests/input_files/fsi_ves_mono_mtrss_ost_ost_slidrot.dat
@@ -29,7 +29,7 @@ FILESTEPS                       1000
 VERBOSITY                       standard
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 GHOSTING_STRATEGY               redundant_all

--- a/tests/input_files/meshtying2D_nurbs9_dual.dat
+++ b/tests/input_files/meshtying2D_nurbs9_dual.dat
@@ -67,7 +67,7 @@ NUMGP_PER_DIM                   3
 LM_QUAD                         quad
 LM_DUAL_CONSISTENT              none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Struct_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying2D_nurbs9_dual_new_struct.dat
+++ b/tests/input_files/meshtying2D_nurbs9_dual_new_struct.dat
@@ -68,7 +68,7 @@ NUMGP_PER_DIM                   3
 LM_QUAD                         quad
 LM_DUAL_CONSISTENT              none
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Struct_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying2D_structure_crosspoints.dat
+++ b/tests/input_files/meshtying2D_structure_crosspoints.dat
@@ -41,7 +41,7 @@ LINEAR_SOLVER                   2
 CROSSPOINTS                     Yes
 OUTPUT_INTERFACES               Yes
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying2D_structure_crosspoints_new_struct.dat
+++ b/tests/input_files/meshtying2D_structure_crosspoints_new_struct.dat
@@ -40,7 +40,7 @@ LINEAR_SOLVER                   2
 -------------------------------------------------------------MORTAR COUPLING
 CROSSPOINTS                     Yes
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying3D_patch_bound.dat
+++ b/tests/input_files/meshtying3D_patch_bound.dat
@@ -59,7 +59,7 @@ LM_QUAD              quad
 NUMGP_PER_DIM        12
 TRIANGULATION        Delaunay
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 NAME                 Structure_Solver
 SOLVER               Superlu

--- a/tests/input_files/meshtying3D_sp_dual_simple.dat
+++ b/tests/input_files/meshtying3D_sp_dual_simple.dat
@@ -62,7 +62,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION

--- a/tests/input_files/meshtying3D_sp_std_braess_sarazin.dat
+++ b/tests/input_files/meshtying3D_sp_std_braess_sarazin.dat
@@ -62,7 +62,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION

--- a/tests/input_files/meshtying3D_sp_std_simple.dat
+++ b/tests/input_files/meshtying3D_sp_std_simple.dat
@@ -62,7 +62,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION

--- a/tests/input_files/meshtying3D_sp_std_uzawa.dat
+++ b/tests/input_files/meshtying3D_sp_std_uzawa.dat
@@ -62,7 +62,7 @@ SEARCH_ALGORITHM                BinaryTree
 SEARCH_PARAM                    0.3
 SEARCH_USE_AUX_POS              Yes
 LM_DUAL_CONSISTENT              boundary
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ALGORITHM                       Mortar
 INTTYPE                         Segments
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION

--- a/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_initial.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_initial.dat
@@ -37,7 +37,7 @@ SYSTEM                          Saddlepoint
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Standard
 ALGORITHM                       mortar
-MESH_RELOCATION                 initial
+MESH_RELOCATION                 Initial
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_no.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_meshrelocation_no.dat
@@ -37,7 +37,7 @@ SYSTEM                          Saddlepoint
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Standard
 ALGORITHM                       mortar
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_initial.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_initial.dat
@@ -38,7 +38,7 @@ SYSTEM                          Saddlepoint
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Standard
 ALGORITHM                       mortar
-MESH_RELOCATION                 initial
+MESH_RELOCATION                 Initial
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_no.dat
+++ b/tests/input_files/meshtying3D_structure_stdlagr_new_struct_meshrelocation_no.dat
@@ -38,7 +38,7 @@ SYSTEM                          Saddlepoint
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Standard
 ALGORITHM                       mortar
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 --------------------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/mfsi_ow3D_mtr_drt.dat
+++ b/tests/input_files/mfsi_ow3D_mtr_drt.dat
@@ -91,7 +91,7 @@ GENAVG                          TrLike
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 No
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK

--- a/tests/input_files/new_solidporo_pressure_velocity_based_ele_3D_hex8_nopenetration.dat
+++ b/tests/input_files/new_solidporo_pressure_velocity_based_ele_3D_hex8_nopenetration.dat
@@ -55,7 +55,7 @@ RESULTSEVERY                     1
 LINEAR_SOLVER                   1
 CONTIPARTINT                    yes
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 --------------------------------------------------------------------SOLVER 2

--- a/tests/input_files/new_solidporo_pressure_velocity_based_nitsche_contact3D_twoelem.dat
+++ b/tests/input_files/new_solidporo_pressure_velocity_based_nitsche_contact3D_twoelem.dat
@@ -72,7 +72,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/new_solidporo_pressure_velocity_based_nitsche_contact3D_twoelem_wonopen_new_struc.dat
+++ b/tests/input_files/new_solidporo_pressure_velocity_based_nitsche_contact3D_twoelem_wonopen_new_struc.dat
@@ -46,7 +46,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/old_solid_ele_contact3D_nitsche_hex8_skew_segm_new_struct.dat
+++ b/tests/input_files/old_solid_ele_contact3D_nitsche_hex8_skew_segm_new_struct.dat
@@ -50,7 +50,7 @@ SEARCH_PARAM         0.3e1
 NUMGP_PER_DIM        7
 LM_SHAPEFCN          std
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      none
+PARALLEL_REDIST      None
 ----------------------------------------------------------SOLVER 1
 SOLVER                         UMFPACK
 ----------------------------------------------------------SOLVER 2

--- a/tests/input_files/old_solid_ele_contact3D_unbiased_self_hex8_nitsche_new_struct.dat
+++ b/tests/input_files/old_solid_ele_contact3D_unbiased_self_hex8_nitsche_new_struct.dat
@@ -46,7 +46,7 @@ ALGORITHM                       gpts
 NUMGP_PER_DIM                   3
 TRIANGULATION                   Center
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/old_solid_ele_contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
+++ b/tests/input_files/old_solid_ele_contact3D_unbiased_self_tet4_nitsche_ele_new_struct.dat
@@ -46,7 +46,7 @@ ALGORITHM                       gpts
 NUMGP_PER_DIM                   2
 INTTYPE                         Elements
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------------------SOLVER 1
 NAME                            Structure_Solver

--- a/tests/input_files/poro_2D_contact_closed_bound.dat
+++ b/tests/input_files/poro_2D_contact_closed_bound.dat
@@ -46,7 +46,7 @@ MESH_RELOCATION                 Initial
 INTTYPE                         Segments
 NUMGP_PER_DIM                   0
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_2D_quad4_meshtying.dat
+++ b/tests/input_files/poro_2D_quad4_meshtying.dat
@@ -72,7 +72,7 @@ SYSTEM                          condlm
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 --------------------------------------------------------------------SOLVER 2

--- a/tests/input_files/poro_2D_quad4_nopen.dat
+++ b/tests/input_files/poro_2D_quad4_nopen.dat
@@ -69,7 +69,7 @@ TOLRES_PORO                     1e-10
 VECTORNORM_RESF                 L2
 VECTORNORM_INC                  L2
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 ---------------------------------------------------------------FLUID DYNAMIC
 LINEAR_SOLVER                   1
 TIMEINTEGR                      One_Step_Theta

--- a/tests/input_files/poro_2D_quad4_poroporocontact.dat
+++ b/tests/input_files/poro_2D_quad4_poroporocontact.dat
@@ -87,7 +87,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_2D_quad4_porosolid_mt_patchtest.dat
+++ b/tests/input_files/poro_2D_quad4_porosolid_mt_patchtest.dat
@@ -72,7 +72,7 @@ SYSTEM                          condlm
 -------------------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 --------------------------------------------------------------------SOLVER 2

--- a/tests/input_files/poro_3D_hex8_nopenetration.dat
+++ b/tests/input_files/poro_3D_hex8_nopenetration.dat
@@ -55,7 +55,7 @@ RESULTSEVERY                     1
 LINEAR_SOLVER                   1
 CONTIPARTINT                    yes
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 --------------------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 --------------------------------------------------------------------SOLVER 2

--- a/tests/input_files/poro_new_solid_nitsche_contact3D_twoelem.dat
+++ b/tests/input_files/poro_new_solid_nitsche_contact3D_twoelem.dat
@@ -72,7 +72,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_new_solid_nitsche_contact3D_twoelem_new_struc.dat
+++ b/tests/input_files/poro_new_solid_nitsche_contact3D_twoelem_new_struc.dat
@@ -45,7 +45,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_scatra_contact3D_two_cubes.dat
+++ b/tests/input_files/poro_scatra_contact3D_two_cubes.dat
@@ -67,7 +67,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_master
 ---------------------------------------------------CONTACT DYNAMIC
 LINEAR_SOLVER                   1

--- a/tests/input_files/poro_solid_contact3D_twoelem.dat
+++ b/tests/input_files/poro_solid_contact3D_twoelem.dat
@@ -71,7 +71,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_solid_contact3D_twoelem_wonopen.dat
+++ b/tests/input_files/poro_solid_contact3D_twoelem_wonopen.dat
@@ -70,7 +70,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem.dat
@@ -72,7 +72,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem_twosided.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem_twosided.dat
@@ -73,7 +73,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem_twosided_new_struc.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem_twosided_new_struc.dat
@@ -46,7 +46,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem_wonopen.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem_wonopen.dat
@@ -73,7 +73,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/poro_solid_nitsche_contact3D_twoelem_wonopen_new_struc.dat
+++ b/tests/input_files/poro_solid_nitsche_contact3D_twoelem_wonopen_new_struc.dat
@@ -46,7 +46,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   16
 TRIANGULATION                   Center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 MAX_BALANCE_EVAL_TIME           2
 MIN_ELEPROC                     0
 GHOSTING_STRATEGY               redundant_master

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov.dat
@@ -25,7 +25,7 @@ LINEAR_SOLVER                   1
 ------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    CondensedMortar_Bubnov
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov.dat
@@ -27,7 +27,7 @@ COUPLINGTYPE                    CondensedMortar_Bubnov
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov_lmmaster.dat
@@ -28,7 +28,7 @@ LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_bubnov_lmmaster.dat
@@ -26,7 +26,7 @@ LINEAR_SOLVER                   1
 COUPLINGTYPE                    CondensedMortar_Bubnov
 LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov.dat
@@ -27,7 +27,7 @@ COUPLINGTYPE                    CondensedMortar_Petrov
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov.dat
@@ -25,7 +25,7 @@ LINEAR_SOLVER                   1
 ------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    CondensedMortar_Petrov
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov_lmmaster.dat
@@ -28,7 +28,7 @@ LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_condensed_petrov_lmmaster.dat
@@ -26,7 +26,7 @@ LINEAR_SOLVER                   1
 COUPLINGTYPE                    CondensedMortar_Petrov
 LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov.dat
@@ -27,7 +27,7 @@ COUPLINGTYPE                    SaddlePointMortar_Bubnov
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov.dat
@@ -25,7 +25,7 @@ LINEAR_SOLVER                   1
 ------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    SaddlePointMortar_Bubnov
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov_lmmaster.dat
@@ -26,7 +26,7 @@ LINEAR_SOLVER                   1
 COUPLINGTYPE                    SaddlePointMortar_Bubnov
 LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_bubnov_lmmaster.dat
@@ -28,7 +28,7 @@ LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov.dat
@@ -27,7 +27,7 @@ COUPLINGTYPE                    SaddlePointMortar_Petrov
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov.dat
@@ -25,7 +25,7 @@ LINEAR_SOLVER                   1
 ------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    SaddlePointMortar_Petrov
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov_lmmaster.dat
@@ -28,7 +28,7 @@ LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov_lmmaster.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_saddlepoint_petrov_lmmaster.dat
@@ -26,7 +26,7 @@ LINEAR_SOLVER                   1
 COUPLINGTYPE                    SaddlePointMortar_Petrov
 LMSIDE                          master
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_standard.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_standard.dat
@@ -25,7 +25,7 @@ LINEAR_SOLVER                   1
 ------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_standard.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_standard.dat
@@ -27,7 +27,7 @@ COUPLINGTYPE                    StandardMortar
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_standard_redist.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_mortar_standard_redist.dat
@@ -20,7 +20,7 @@ LINEAR_SOLVER                   1
 ------------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_nts_standard.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_nts_standard.dat
@@ -28,7 +28,7 @@ NTSPROJTOL                      4.e-3
 ----------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------------------SOLVER 1
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_nts_standard.dat
+++ b/tests/input_files/scatra_3D_tet4_hex8_s2i_constperm_nts_standard.dat
@@ -26,7 +26,7 @@ LINEAR_SOLVER                   1
 COUPLINGTYPE                    StandardNodeToSegment
 NTSPROJTOL                      4.e-3
 ----------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 No
+MESH_RELOCATION                 None
 ----------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none
 -----------------------------------------------------------SOLVER 1

--- a/tests/input_files/scatra_NonMatchingMesh_20x80_linear_bmat_merged.dat
+++ b/tests/input_files/scatra_NonMatchingMesh_20x80_linear_bmat_merged.dat
@@ -45,7 +45,7 @@ EXPLPREDICT                     Yes
 LM_SHAPEFCN                     Dual
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------SOLVER 1
 NAME                            Sca_Tra_Solver

--- a/tests/input_files/scatra_NonMatchingMesh_20x80_linear_bmat_merged.dat
+++ b/tests/input_files/scatra_NonMatchingMesh_20x80_linear_bmat_merged.dat
@@ -43,7 +43,7 @@ ITEMAX                          2
 EXPLPREDICT                     Yes
 ---------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 static
 GHOSTING_STRATEGY               redundant_all

--- a/tests/input_files/scatra_NonMatchingMesh_20x80_smat.dat
+++ b/tests/input_files/scatra_NonMatchingMesh_20x80_smat.dat
@@ -45,7 +45,7 @@ EXPLPREDICT                     Yes
 LM_SHAPEFCN                     Dual
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------SOLVER 1
 NAME                            Sca_Tra_Solver

--- a/tests/input_files/scatra_NonMatchingMesh_20x80_smat.dat
+++ b/tests/input_files/scatra_NonMatchingMesh_20x80_smat.dat
@@ -43,7 +43,7 @@ ITEMAX                          2
 EXPLPREDICT                     Yes
 ---------------------------------------------------MORTAR COUPLING
 LM_SHAPEFCN                     Dual
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 static
 GHOSTING_STRATEGY               redundant_all

--- a/tests/input_files/ssi_3D_hex8_quad4_meshtying.dat
+++ b/tests/input_files/ssi_3D_hex8_quad4_meshtying.dat
@@ -75,7 +75,7 @@ SEARCH_PARAM                    0.3
 MESH_RELOCATION                 Initial
 INTTYPE                         elements
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 ----------------------------------------------------------SOLVER 1
 NAME                            Sca_Tra_Solver
 SOLVER                          UMFPACK

--- a/tests/input_files/ssi_3D_hex8_quad4_meshtying.dat
+++ b/tests/input_files/ssi_3D_hex8_quad4_meshtying.dat
@@ -72,7 +72,7 @@ FIELDCOUPLING                   boundary_nonmatching
 LM_SHAPEFCN                     dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
-MESH_RELOCATION                 initial
+MESH_RELOCATION                 Initial
 INTTYPE                         elements
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 none

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
@@ -39,7 +39,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_2x2.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_2x2.dat
@@ -39,7 +39,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_3x3.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_3x3.dat
@@ -40,7 +40,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
@@ -39,7 +39,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_and_meshtying_elch_s2i_butlervolmer.dat
+++ b/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_and_meshtying_elch_s2i_butlervolmer.dat
@@ -58,7 +58,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   3
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
+++ b/tests/input_files/ssi_mono_3D_3blocks_nitsche_contact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
@@ -54,7 +54,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   3
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_mono_3D_3blocks_nitsche_unbiased_selfcontact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
+++ b/tests/input_files/ssi_mono_3D_3blocks_nitsche_unbiased_selfcontact_elch_s2i_butlervolmer_linaniso_liniso_growthlaw.dat
@@ -56,7 +56,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   3
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 GHOSTING_STRATEGY               redundant_all
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no

--- a/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
+++ b/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm.dat
@@ -42,7 +42,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
+++ b/tests/input_files/ssi_twoway_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_linearperm.dat
@@ -42,7 +42,7 @@ INTTYPE                         Segments
 NUMGP_PER_DIM                   1
 TRIANGULATION                   center
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 none
+PARALLEL_REDIST                 None
 -----------------------------------------------STRUCT NOX/Printing
 Inner Iteration = no
 Outer Iteration = yes

--- a/tests/input_files/sti_mono_3D_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
@@ -30,7 +30,7 @@ EQUPOT                          divi
 -----------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 -------------------------------------------------------STI DYNAMIC

--- a/tests/input_files/sti_mono_3D_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
@@ -32,7 +32,7 @@ COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 -------------------------------------------------------STI DYNAMIC
 SCATRATIMINTTYPE                Elch
 THERMO_INITIALFIELD             field_by_function

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard.dat
@@ -34,7 +34,7 @@ EQUPOT                          divi
 -----------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 -------------------------------------------------------STI DYNAMIC

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard.dat
@@ -36,7 +36,7 @@ COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 -------------------------------------------------------STI DYNAMIC
 SCATRATIMINTTYPE                Elch
 THERMO_INITIALFIELD             field_by_function

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_2x2.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_2x2.dat
@@ -37,7 +37,7 @@ COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 -------------------------------------------------------STI DYNAMIC
 SCATRATIMINTTYPE                Elch
 THERMO_INITIALFIELD             field_by_function

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_2x2.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_2x2.dat
@@ -35,7 +35,7 @@ EQUPOT                          divi
 -----------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 -------------------------------------------------------STI DYNAMIC

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
@@ -34,7 +34,7 @@ EQUPOT                          divi
 -----------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 -------------------------------------------------------STI DYNAMIC

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
@@ -36,7 +36,7 @@ COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 -------------------------------------------------------STI DYNAMIC
 SCATRATIMINTTYPE                Elch
 THERMO_INITIALFIELD             field_by_function

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_2x2.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_2x2.dat
@@ -37,7 +37,7 @@ COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 -------------------------------------------------------STI DYNAMIC
 SCATRATIMINTTYPE                Elch
 THERMO_INITIALFIELD             field_by_function

--- a/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_2x2.dat
+++ b/tests/input_files/sti_mono_3D_tet4_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_2x2.dat
@@ -35,7 +35,7 @@ EQUPOT                          divi
 -----------------------------SCALAR TRANSPORT DYNAMIC/S2I COUPLING
 COUPLINGTYPE                    StandardMortar
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 -------------------------------------------------------STI DYNAMIC

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_4x4.dat
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_4x4.dat
@@ -24,7 +24,7 @@ MATRIXTYPE                      block_condition
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------SCALAR TRANSPORT DYNAMIC/NONLINEAR
 ITEMAX                          2
 ----------------------------SCALAR TRANSPORT DYNAMIC/STABILIZATION

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_4x4.dat
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_condensed_mortar_standard_BGS-AMG_4x4.dat
@@ -22,7 +22,7 @@ CALCFLUX_BOUNDARY               total
 LINEAR_SOLVER                   2
 MATRIXTYPE                      block_condition
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------SCALAR TRANSPORT DYNAMIC/NONLINEAR

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
@@ -23,7 +23,7 @@ LINEAR_SOLVER                   1
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 ----------------------------SCALAR TRANSPORT DYNAMIC/STABILIZATION
 STABTYPE                        no_stabilization
 DEFINITION_TAU                  Zero

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard.dat
@@ -21,7 +21,7 @@ INITIALFIELD                    field_by_condition
 CALCFLUX_BOUNDARY               total
 LINEAR_SOLVER                   1
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 ----------------------------SCALAR TRANSPORT DYNAMIC/STABILIZATION

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_4x4.dat
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_4x4.dat
@@ -24,7 +24,7 @@ MATRIXTYPE                      block_condition
 ---------------------------------------------------MORTAR COUPLING
 MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 no
+PARALLEL_REDIST                 None
 --------------------------------SCALAR TRANSPORT DYNAMIC/NONLINEAR
 ITEMAX                          2
 ----------------------------SCALAR TRANSPORT DYNAMIC/STABILIZATION

--- a/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_4x4.dat
+++ b/tests/input_files/sti_mono_3D_tet4_hex8_elch_s2i_butlervolmerpeltier_adiabatic_mortar_standard_BGS-AMG_4x4.dat
@@ -22,7 +22,7 @@ CALCFLUX_BOUNDARY               total
 LINEAR_SOLVER                   2
 MATRIXTYPE                      block_condition
 ---------------------------------------------------MORTAR COUPLING
-MESH_RELOCATION                 no
+MESH_RELOCATION                 None
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
 PARALLEL_REDIST                 no
 --------------------------------SCALAR TRANSPORT DYNAMIC/NONLINEAR

--- a/tests/input_files/thermo3D_meshtying_nurbs.dat
+++ b/tests/input_files/thermo3D_meshtying_nurbs.dat
@@ -22,7 +22,7 @@ SHAPEFCT                        Nurbs
 -------------------------------------------------------------MORTAR COUPLING
 SEARCH_PARAM         0.3
 INTTYPE              Segments
-MESH_RELOCATION      no
+MESH_RELOCATION      None
 LM_QUAD              quad
 // REDUNDANT_STORAGE    master
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION

--- a/tests/input_files/thermo3D_meshtying_nurbs.dat
+++ b/tests/input_files/thermo3D_meshtying_nurbs.dat
@@ -26,7 +26,7 @@ MESH_RELOCATION      None
 LM_QUAD              quad
 // REDUNDANT_STORAGE    master
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      No
+PARALLEL_REDIST      None
 ----------------------------------------------------THERMAL DYNAMIC
 ADAPTCONV                       No
 DIVERCONT                       continue

--- a/tests/input_files/tsi_contact3D_conduction.dat
+++ b/tests/input_files/tsi_contact3D_conduction.dat
@@ -27,7 +27,7 @@ LINEAR_SOLVER        1
 SEARCH_PARAM         0.3
 INTTYPE              Segments
 --------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      No
+PARALLEL_REDIST      None
 ---------------------------------------------------------TSI CONTACT
 HEATTRANSSLAVE       10
 HEATTRANSMASTER      10

--- a/tests/input_files/tsi_meshtying_nurbs.dat
+++ b/tests/input_files/tsi_meshtying_nurbs.dat
@@ -24,7 +24,7 @@ SHAPEFCT                        Nurbs
 -------------------------------------------------------------MORTAR COUPLING
 SEARCH_PARAM         0.3
 INTTYPE              Segments
-MESH_RELOCATION      no
+MESH_RELOCATION      None
 LM_QUAD              quad
 // REDUNDANT_STORAGE    master
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION

--- a/tests/input_files/tsi_meshtying_nurbs.dat
+++ b/tests/input_files/tsi_meshtying_nurbs.dat
@@ -28,7 +28,7 @@ MESH_RELOCATION      None
 LM_QUAD              quad
 // REDUNDANT_STORAGE    master
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST      No
+PARALLEL_REDIST      None
 ----------------------------------------------------THERMAL DYNAMIC
 ADAPTCONV                       No
 DIVERCONT                       continue

--- a/tests/input_files/volmortar2D_fsi.dat
+++ b/tests/input_files/volmortar2D_fsi.dat
@@ -66,7 +66,7 @@ LM_SHAPEFCN                     Dual
 SEARCH_ALGORITHM                Binarytree
 SEARCH_PARAM                    0.3
 -------------------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST                 static
+PARALLEL_REDIST                 Static
 GHOSTING_STRATEGY               redundant_all
 ----------------------------------------------------------VOLMORTAR COUPLING
 INTTYPE                         segments

--- a/tests/input_files/weakly_compressible_fsi_fp_part_ga_ga.dat
+++ b/tests/input_files/weakly_compressible_fsi_fp_part_ga_ga.dat
@@ -66,7 +66,7 @@ LM_SHAPEFCN           Dual
 SEARCH_ALGORITHM      Binarytree
 SEARCH_PARAM          0.3
 ---------------------------MORTAR COUPLING/PARALLEL REDISTRIBUTION
-PARALLEL_REDIST       static
+PARALLEL_REDIST       Static
 GHOSTING_STRATEGY     redundant_all
 ------------------------------------------------VOLMORTAR COUPLING
 COUPLINGTYPE          consint


### PR DESCRIPTION
⚠️ BREAKING CHANGE in input parameters 

## Description and Context

Two mortar input parameters have been modified:

`MESH_RELOCATION` :
- Use `None` and nothing else to deactivate
- Only allow one spelling for each input value

`PARALLEL_REDIST` :
- Use `None` and nothing else to deactivate
- Only allow one spelling for each input value

To not allow multiple spellings for the same value has been on my list for a long time already.

## Related Issues and Merge Requests

This came up due to #420.