### PR TITLE
Make bool params take a bool default value

### DIFF
--- a/src/adapter/4C_adapter_fld_base_algorithm.cpp
+++ b/src/adapter/4C_adapter_fld_base_algorithm.cpp
@@ -1356,12 +1356,10 @@ void Adapter::FluidBaseAlgorithm::set_general_parameters(
   fluidtimeparams->set<std::string>("form of convective term", fdyn.get<std::string>("CONVFORM"));
 
   // -------------------------- potential nonlinear boundary conditions
-  fluidtimeparams->set<std::string>(
-      "Nonlinear boundary conditions", fdyn.get<std::string>("NONLINEARBC"));
+  fluidtimeparams->set("Nonlinear boundary conditions", fdyn.get<bool>("NONLINEARBC"));
 
   // ------------------------------------ potential reduced_D 3D coupling method
-  fluidtimeparams->set<std::string>(
-      "Strong 3D_redD coupling", fdyn.get<std::string>("STRONG_REDD_3D_COUPLING_TYPE"));
+  fluidtimeparams->set("Strong 3D_redD coupling", fdyn.get<bool>("STRONG_REDD_3D_COUPLING_TYPE"));
 
   //--------------------------------------  mesh tying for fluid
   fluidtimeparams->set<Inpar::FLUID::MeshTying>(

--- a/src/ale/4C_ale_input.cpp
+++ b/src/ale/4C_ale_input.cpp
@@ -33,10 +33,10 @@ void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           springs_material, springs_spatial),
       adyn);
 
-  Core::Utils::bool_parameter("ASSESSMESHQUALITY", "no",
+  Core::Utils::bool_parameter("ASSESSMESHQUALITY", false,
       "Evaluate element quality measure according to [Oddy et al. 1988]", adyn);
 
-  Core::Utils::bool_parameter("UPDATEMATRIX", "no",
+  Core::Utils::bool_parameter("UPDATEMATRIX", false,
       "Update stiffness matrix in every time step (only for linear/material strategies)", adyn);
 
   Core::Utils::int_parameter("MAXITER", 1, "Maximum number of newton iterations.", adyn);

--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -34,25 +34,25 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       beamcontact);
 
   Core::Utils::bool_parameter(
-      "BEAMS_NEWGAP", "No", "choose between original or enhanced gapfunction", beamcontact);
+      "BEAMS_NEWGAP", false, "choose between original or enhanced gapfunction", beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_SEGCON", "No",
+  Core::Utils::bool_parameter("BEAMS_SEGCON", false,
       "choose between beam contact with and without subsegment generation", beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_DEBUG", "No",
+  Core::Utils::bool_parameter("BEAMS_DEBUG", false,
       "This flag can be used for testing purposes. When it is switched on, some sanity checks are "
       "not performed!",
       beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_INACTIVESTIFF", "No",
+  Core::Utils::bool_parameter("BEAMS_INACTIVESTIFF", false,
       "Always apply contact stiffness in first Newton step for pairs which have active in last "
       "time step",
       beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_BTSOL", "No",
+  Core::Utils::bool_parameter("BEAMS_BTSOL", false,
       "decide, if also the contact between beams and solids is possible", beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_ENDPOINTPENALTY", "No",
+  Core::Utils::bool_parameter("BEAMS_ENDPOINTPENALTY", false,
       "Additional consideration of endpoint-line and endpoint-endpoint contacts", beamcontact);
 
   Core::Utils::string_to_integral_parameter<BeamContact::Smoothing>("BEAMS_SMOOTHING", "None",
@@ -130,7 +130,7 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<BeamContact::OctreeType>(boct_none, boct_none, boct_aabb, boct_cobb, boct_spbb),
       beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_ADDITEXT", "Yes",
+  Core::Utils::bool_parameter("BEAMS_ADDITEXT", true,
       "Switch between No==multiplicative extrusion factor and Yes==additive extrusion factor",
       beamcontact);
   Core::Utils::string_parameter("BEAMS_EXTVAL", "-1.0",
@@ -149,7 +149,7 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs beamcontact_vtk_sublist{beamcontact, "RUNTIME VTK OUTPUT"};
 
   // whether to write visualization output for beam contact
-  Core::Utils::bool_parameter("VTK_OUTPUT_BEAM_CONTACT", "No",
+  Core::Utils::bool_parameter("VTK_OUTPUT_BEAM_CONTACT", false,
       "write visualization output for beam contact", beamcontact_vtk_sublist);
 
   // output interval regarding steps: write output every INTERVAL_STEPS steps
@@ -157,15 +157,15 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "write visualization output at runtime every INTERVAL_STEPS steps", beamcontact_vtk_sublist);
 
   // whether to write output in every iteration of the nonlinear solver
-  Core::Utils::bool_parameter("EVERY_ITERATION", "No",
+  Core::Utils::bool_parameter("EVERY_ITERATION", false,
       "write output in every iteration of the nonlinear solver", beamcontact_vtk_sublist);
 
   // whether to write visualization output for contact forces
-  Core::Utils::bool_parameter("CONTACT_FORCES", "No",
+  Core::Utils::bool_parameter("CONTACT_FORCES", false,
       "write visualization output for contact forces", beamcontact_vtk_sublist);
 
   // whether to write visualization output for gaps
-  Core::Utils::bool_parameter("GAPS", "No", "write visualization output for gap, i.e. penetration",
+  Core::Utils::bool_parameter("GAPS", false, "write visualization output for gap, i.e. penetration",
       beamcontact_vtk_sublist);
 
   beamcontact_vtk_sublist.move_into_collection(list);

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -19,7 +19,7 @@ void BrownianDynamics::set_valid_parameters(std::map<std::string, Core::IO::Inpu
   Core::Utils::SectionSpecs browniandyn_list{"BROWNIAN DYNAMICS"};
 
   Core::Utils::bool_parameter(
-      "BROWNDYNPROB", "No", "switch Brownian dynamics on/off", browniandyn_list);
+      "BROWNDYNPROB", false, "switch Brownian dynamics on/off", browniandyn_list);
 
   // Reading double parameter for viscosity of background fluid
   Core::Utils::double_parameter("VISCOSITY", 0.0, "viscosity", browniandyn_list);

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.cpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.cpp
@@ -20,19 +20,12 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::Utils
 {
-  void bool_parameter(std::string const& paramName, std::string const& value,
+  void bool_parameter(std::string const& paramName, bool default_value,
       std::string const& docString, SectionSpecs& section_specs)
   {
-    // Check that value in lower-case is either "true" or "false", case insensitive
-    const std::string value_lower = Core::Utils::to_lower(value);
-    FOUR_C_ASSERT_ALWAYS(value_lower == "yes" || value_lower == "no",
-        "Invalid value for boolean parameter '" + paramName + "': " + value);
-    bool sane_default = value_lower == "yes";
-
     section_specs.specs.emplace_back(Core::IO::InputSpecBuilders::entry<bool>(
-        paramName, {.description = docString, .default_value = sane_default}));
+        paramName, {.description = docString, .default_value = default_value}));
   }
-
 
   void int_parameter(std::string const& paramName, int const value, std::string const& docString,
       SectionSpecs& section_specs)

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
@@ -60,9 +60,12 @@ namespace Core
           Teuchos::tuple<std::string>(value_name), Teuchos::tuple<EnumType>(value), &list);
     }
 
-    /// local wrapper to test multiple versions of "Yes", "YES", etc
-    void bool_parameter(std::string const& paramName, std::string const& value,
+    /// temporary helper around InputSpecBuilders::entry<bool>
+    void bool_parameter(std::string const& paramName, bool default_value,
         std::string const& docString, SectionSpecs& section_specs);
+    // fail if users provide a string literal as default value
+    void bool_parameter(std::string const& paramName, const char* default_value,
+        std::string const& docString, SectionSpecs& section_specs) = delete;
 
     /// local wrapper for Teuchos::setIntParameter() that allows only integers
     void int_parameter(std::string const& paramName, int const value, std::string const& docString,

--- a/src/cut/4C_cut_input.cpp
+++ b/src/cut/4C_cut_input.cpp
@@ -65,14 +65,14 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 
   // Specify is Cutsides are triangulated
   Core::Utils::bool_parameter(
-      "SPLIT_CUTSIDES", "Yes", "Split Quad4 CutSides into Tri3-Subtriangles?", cut_general);
+      "SPLIT_CUTSIDES", true, "Split Quad4 CutSides into Tri3-Subtriangles?", cut_general);
 
   // Do the Selfcut before standard CUT
-  Core::Utils::bool_parameter("DO_SELFCUT", "Yes", "Do the SelfCut?", cut_general);
+  Core::Utils::bool_parameter("DO_SELFCUT", true, "Do the SelfCut?", cut_general);
 
   // Do meshcorrection in Selfcut
   Core::Utils::bool_parameter(
-      "SELFCUT_DO_MESHCORRECTION", "Yes", "Do meshcorrection in the SelfCut?", cut_general);
+      "SELFCUT_DO_MESHCORRECTION", true, "Do meshcorrection in the SelfCut?", cut_general);
 
   // Selfcut meshcorrection multiplicator
   Core::Utils::int_parameter("SELFCUT_MESHCORRECTION_MULTIPLICATOR", 30,
@@ -86,7 +86,7 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
       cut_general);
 
   // Integrate inside volume cells
-  Core::Utils::bool_parameter("INTEGRATE_INSIDE_CELLS", "Yes",
+  Core::Utils::bool_parameter("INTEGRATE_INSIDE_CELLS", true,
       "Should the integration be done on inside cells", cut_general);
 
   cut_general.move_into_collection(list);

--- a/src/fluid/4C_fluid_DbcHDG.cpp
+++ b/src/fluid/4C_fluid_DbcHDG.cpp
@@ -264,10 +264,9 @@ void FLD::Utils::DbcHdgFluid::do_dirichlet_condition(const Teuchos::ParameterLis
           Teuchos::ParameterList params = Global::Problem::instance()->fluid_dynamic_params();
 
           // check whether the imposition of the average pressure is requested
-          const auto dopressavgbc =
-              Teuchos::getIntegralValue<Inpar::FLUID::PressAvgBc>(params, "PRESSAVGBC");
+          const auto dopressavgbc = Teuchos::get<bool>(params, "PRESSAVGBC");
 
-          if (dopressavgbc == Inpar::FLUID::yes_pressure_average_bc)
+          if (dopressavgbc)
           {
             double pressureavgBC = 0.0;
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -150,9 +150,7 @@ void FLD::FluidImplicitTimeInt::init()
   // -------------------------------------------------------------------
   // flag for potential nonlinear boundary conditions
   // -------------------------------------------------------------------
-  nonlinearbc_ = false;
-  if (params_->get<std::string>("Nonlinear boundary conditions", "no") == "yes")
-    nonlinearbc_ = true;
+  nonlinearbc_ = params_->get<bool>("Nonlinear boundary conditions", false);
 
   discret_->compute_null_space_if_necessary(solver_->params(), true);
 

--- a/src/fluid/4C_fluid_timint_red.cpp
+++ b/src/fluid/4C_fluid_timint_red.cpp
@@ -66,9 +66,7 @@ void FLD::TimIntRedModels::init()
   // Initialize the reduced models
   // -------------------------------------------------------------------
 
-  strong_redD_3d_coupling_ = false;
-  if (params_->get<std::string>("Strong 3D_redD coupling", "no") == "yes")
-    strong_redD_3d_coupling_ = true;
+  strong_redD_3d_coupling_ = params_->get<bool>("Strong 3D_redD coupling", false);
 
   {
     ART_timeInt_ = dyn_art_net_drt(true);

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -53,7 +53,7 @@ namespace Inpar
           sublist_IO_monitor_structure_dbc);
 
       // whether to write output in every iteration of the nonlinear solver
-      Core::Utils::bool_parameter("WRITE_HEADER", "No",
+      Core::Utils::bool_parameter("WRITE_HEADER", false,
           "write information about monitored boundary condition to output file",
           sublist_IO_monitor_structure_dbc);
 

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -54,7 +54,7 @@ namespace Inpar
           sublist_IO_VTK_structure);
 
       // whether to write output in every iteration of the nonlinear solver
-      Core::Utils::bool_parameter("EVERY_ITERATION", "No",
+      Core::Utils::bool_parameter("EVERY_ITERATION", false,
           "write output in every iteration of the nonlinear solver", sublist_IO_VTK_structure);
 
       // virtual time increment that is added for each nonlinear output state

--- a/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
@@ -32,39 +32,39 @@ namespace Inpar
 
         // whether to write output for fluid
         Core::Utils::bool_parameter(
-            "OUTPUT_FLUID", "No", "write fluid output", sublist_IO_output_fluid);
+            "OUTPUT_FLUID", false, "write fluid output", sublist_IO_output_fluid);
 
         // whether to write velocity state
         Core::Utils::bool_parameter(
-            "VELOCITY", "No", "write velocity output", sublist_IO_output_fluid);
+            "VELOCITY", false, "write velocity output", sublist_IO_output_fluid);
 
         // whether to write pressure state
         Core::Utils::bool_parameter(
-            "PRESSURE", "No", "write pressure output", sublist_IO_output_fluid);
+            "PRESSURE", false, "write pressure output", sublist_IO_output_fluid);
 
         // whether to write acceleration state
         Core::Utils::bool_parameter(
-            "ACCELERATION", "No", "write acceleration output", sublist_IO_output_fluid);
+            "ACCELERATION", false, "write acceleration output", sublist_IO_output_fluid);
 
         // whether to write displacement state
         Core::Utils::bool_parameter(
-            "DISPLACEMENT", "No", "write displacement output", sublist_IO_output_fluid);
+            "DISPLACEMENT", false, "write displacement output", sublist_IO_output_fluid);
 
         // whether to write displacement state
         Core::Utils::bool_parameter(
-            "GRIDVELOCITY", "No", "write grid velocity output", sublist_IO_output_fluid);
+            "GRIDVELOCITY", false, "write grid velocity output", sublist_IO_output_fluid);
 
         // whether to write element owner
         Core::Utils::bool_parameter(
-            "ELEMENT_OWNER", "No", "write element owner", sublist_IO_output_fluid);
+            "ELEMENT_OWNER", false, "write element owner", sublist_IO_output_fluid);
 
         // whether to write element GIDs
         Core::Utils::bool_parameter(
-            "ELEMENT_GID", "No", "write 4C internal element GIDs", sublist_IO_output_fluid);
+            "ELEMENT_GID", false, "write 4C internal element GIDs", sublist_IO_output_fluid);
 
         // whether to write node GIDs
         Core::Utils::bool_parameter(
-            "NODE_GID", "No", "write 4C internal node GIDs", sublist_IO_output_fluid);
+            "NODE_GID", false, "write 4C internal node GIDs", sublist_IO_output_fluid);
 
         sublist_IO_output_fluid.move_into_collection(list);
       }

--- a/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
@@ -32,80 +32,80 @@ namespace Inpar
         Core::Utils::SectionSpecs sublist_IO_output_beams{sublist_IO_VTK_structure, "BEAMS"};
 
         // whether to write special output for beam elements
-        Core::Utils::bool_parameter("OUTPUT_BEAMS", "No", "write special output for beam elements",
+        Core::Utils::bool_parameter("OUTPUT_BEAMS", false, "write special output for beam elements",
             sublist_IO_output_beams);
 
         // whether to write displacement state
         Core::Utils::bool_parameter(
-            "DISPLACEMENT", "No", "write displacement output", sublist_IO_output_beams);
+            "DISPLACEMENT", false, "write displacement output", sublist_IO_output_beams);
 
         // use absolute positions or initial positions for vtu geometry (i.e. point coordinates)
         // 'absolute positions' requires writing geometry in every output step (default for now)
-        Core::Utils::bool_parameter("USE_ABSOLUTE_POSITIONS", "Yes",
+        Core::Utils::bool_parameter("USE_ABSOLUTE_POSITIONS", true,
             "use absolute positions or initial positions for vtu geometry (i.e. point coordinates)",
             sublist_IO_output_beams);
 
         // write internal (elastic) energy of element
-        Core::Utils::bool_parameter("INTERNAL_ENERGY_ELEMENT", "No",
+        Core::Utils::bool_parameter("INTERNAL_ENERGY_ELEMENT", false,
             "write internal (elastic) energy for each element", sublist_IO_output_beams);
 
         // write kinetic energy of element
-        Core::Utils::bool_parameter("KINETIC_ENERGY_ELEMENT", "No",
+        Core::Utils::bool_parameter("KINETIC_ENERGY_ELEMENT", false,
             "write kinetic energy for each element", sublist_IO_output_beams);
 
         // write triads as three orthonormal base vectors at every visualization point
-        Core::Utils::bool_parameter("TRIAD_VISUALIZATIONPOINT", "No",
+        Core::Utils::bool_parameter("TRIAD_VISUALIZATIONPOINT", false,
             "write triads at every visualization point", sublist_IO_output_beams);
 
         // write material cross-section strains at the Gauss points:
         // axial & shear strains, twist & curvatures
-        Core::Utils::bool_parameter("STRAINS_GAUSSPOINT", "No",
+        Core::Utils::bool_parameter("STRAINS_GAUSSPOINT", false,
             "write material cross-section strains at the Gauss points", sublist_IO_output_beams);
 
         // write material cross-section strains at the visualization points:
         // axial & shear strains, twist & curvatures
-        Core::Utils::bool_parameter("STRAINS_CONTINUOUS", "No",
+        Core::Utils::bool_parameter("STRAINS_CONTINUOUS", false,
             "write material cross-section strains at the visualization points",
             sublist_IO_output_beams);
 
         // write material cross-section stresses at the Gauss points:
         // axial and shear forces, torque and bending moments
-        Core::Utils::bool_parameter("MATERIAL_FORCES_GAUSSPOINT", "No",
+        Core::Utils::bool_parameter("MATERIAL_FORCES_GAUSSPOINT", false,
             "write material cross-section stresses at the Gauss points", sublist_IO_output_beams);
 
         // write material cross-section stresses at the visualization points:
         // axial and shear forces, torque and bending moments
-        Core::Utils::bool_parameter("MATERIAL_FORCES_CONTINUOUS", "No",
+        Core::Utils::bool_parameter("MATERIAL_FORCES_CONTINUOUS", false,
             "write material cross-section stresses at the visualization points",
             sublist_IO_output_beams);
 
         // write spatial cross-section stresses at the Gauss points:
         // axial and shear forces, torque and bending moments
-        Core::Utils::bool_parameter("SPATIAL_FORCES_GAUSSPOINT", "No",
+        Core::Utils::bool_parameter("SPATIAL_FORCES_GAUSSPOINT", false,
             "write material cross-section stresses at the Gauss points", sublist_IO_output_beams);
 
         // write element filament numbers and type
-        Core::Utils::bool_parameter("BEAMFILAMENTCONDITION", "No", "write element filament numbers",
-            sublist_IO_output_beams);
+        Core::Utils::bool_parameter("BEAMFILAMENTCONDITION", false,
+            "write element filament numbers", sublist_IO_output_beams);
 
         // write element and network orientation parameter
-        Core::Utils::bool_parameter("ORIENTATION_PARAMETER", "No", "write element filament numbers",
-            sublist_IO_output_beams);
+        Core::Utils::bool_parameter("ORIENTATION_PARAMETER", false,
+            "write element filament numbers", sublist_IO_output_beams);
 
         // write crossection forces of periodic RVE
-        Core::Utils::bool_parameter("RVE_CROSSSECTION_FORCES", "No",
+        Core::Utils::bool_parameter("RVE_CROSSSECTION_FORCES", false,
             " get sum of all internal forces of  ", sublist_IO_output_beams);
 
         // write reference length of beams
         Core::Utils::bool_parameter(
-            "REF_LENGTH", "No", "write reference length of all beams", sublist_IO_output_beams);
+            "REF_LENGTH", false, "write reference length of all beams", sublist_IO_output_beams);
 
         // write element GIDs
         Core::Utils::bool_parameter(
-            "ELEMENT_GID", "No", "write the 4C internal element GIDs", sublist_IO_output_beams);
+            "ELEMENT_GID", false, "write the 4C internal element GIDs", sublist_IO_output_beams);
 
         // write element ghosting information
-        Core::Utils::bool_parameter("ELEMENT_GHOSTING", "No",
+        Core::Utils::bool_parameter("ELEMENT_GHOSTING", false,
             "write which processors ghost the elements", sublist_IO_output_beams);
 
         // number of subsegments along a single beam element for visualization

--- a/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
@@ -33,41 +33,41 @@ namespace Inpar
 
         // whether to write output for structure
         Core::Utils::bool_parameter(
-            "OUTPUT_STRUCTURE", "No", "write structure output", sublist_IO_VTK_structure);
+            "OUTPUT_STRUCTURE", false, "write structure output", sublist_IO_VTK_structure);
 
         // whether to write displacement state
         Core::Utils::bool_parameter(
-            "DISPLACEMENT", "No", "write displacement output", sublist_IO_VTK_structure);
+            "DISPLACEMENT", false, "write displacement output", sublist_IO_VTK_structure);
 
         // whether to write velocity state
         Core::Utils::bool_parameter(
-            "VELOCITY", "No", "write velocity output", sublist_IO_VTK_structure);
+            "VELOCITY", false, "write velocity output", sublist_IO_VTK_structure);
 
         Core::Utils::bool_parameter(
-            "ACCELERATION", "No", "write acceleration output", sublist_IO_VTK_structure);
+            "ACCELERATION", false, "write acceleration output", sublist_IO_VTK_structure);
 
         // whether to write element owner
         Core::Utils::bool_parameter(
-            "ELEMENT_OWNER", "No", "write element owner", sublist_IO_VTK_structure);
+            "ELEMENT_OWNER", false, "write element owner", sublist_IO_VTK_structure);
 
         // whether to write element GIDs
         Core::Utils::bool_parameter(
-            "ELEMENT_GID", "No", "write 4C internal element GIDs", sublist_IO_VTK_structure);
+            "ELEMENT_GID", false, "write 4C internal element GIDs", sublist_IO_VTK_structure);
 
         // write element ghosting information
-        Core::Utils::bool_parameter("ELEMENT_GHOSTING", "No",
+        Core::Utils::bool_parameter("ELEMENT_GHOSTING", false,
             "write which processors ghost the elements", sublist_IO_VTK_structure);
 
         // whether to write node GIDs
         Core::Utils::bool_parameter(
-            "NODE_GID", "No", "write 4C internal node GIDs", sublist_IO_VTK_structure);
+            "NODE_GID", false, "write 4C internal node GIDs", sublist_IO_VTK_structure);
 
         // write element material IDs
-        Core::Utils::bool_parameter("ELEMENT_MAT_ID", "No",
+        Core::Utils::bool_parameter("ELEMENT_MAT_ID", false,
             "Output of the material id of each element", sublist_IO_VTK_structure);
 
         // whether to write stress and / or strain data
-        Core::Utils::bool_parameter("STRESS_STRAIN", "No",
+        Core::Utils::bool_parameter("STRESS_STRAIN", false,
             "Write element stress and / or strain  data. The type of stress / strain has to be "
             "selected in the --IO input section",
             sublist_IO_VTK_structure);

--- a/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
@@ -39,24 +39,24 @@ namespace Inpar
           sublist_IO_VTP_structure);
 
       // whether to write output in every iteration of the nonlinear solver
-      Core::Utils::bool_parameter("EVERY_ITERATION", "No",
+      Core::Utils::bool_parameter("EVERY_ITERATION", false,
           "write output in every iteration of the nonlinear solver", sublist_IO_VTP_structure);
 
       // write owner at every visualization point
       Core::Utils::bool_parameter(
-          "OWNER", "No", "write owner of every point", sublist_IO_VTP_structure);
+          "OWNER", false, "write owner of every point", sublist_IO_VTP_structure);
 
       // write orientation at every visualization point
-      Core::Utils::bool_parameter("ORIENTATIONANDLENGTH", "No", "write orientation at every point",
+      Core::Utils::bool_parameter("ORIENTATIONANDLENGTH", false, "write orientation at every point",
           sublist_IO_VTP_structure);
 
       // write number of bonds at every visualization point
       Core::Utils::bool_parameter(
-          "NUMBEROFBONDS", "No", "write number of bonds of every point", sublist_IO_VTP_structure);
+          "NUMBEROFBONDS", false, "write number of bonds of every point", sublist_IO_VTP_structure);
 
       // write force actin in linker
       Core::Utils::bool_parameter(
-          "LINKINGFORCE", "No", "write force acting in linker", sublist_IO_VTP_structure);
+          "LINKINGFORCE", false, "write force acting in linker", sublist_IO_VTP_structure);
 
       sublist_IO_VTP_structure.move_into_collection(list);
     }

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -101,7 +101,7 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
     //        coupled.
     // - Yes: The beam and solid states at the restart configuration are coupled. This allows to
     //        pre-deform the structures and then couple them.
-    Core::Utils::bool_parameter("COUPLE_RESTART_STATE", "No",
+    Core::Utils::bool_parameter("COUPLE_RESTART_STATE", false,
         "Enable / disable the coupling of the restart configuration.",
         beam_to_solid_volume_mestying);
 
@@ -149,20 +149,20 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
       beam_to_solid_volume_mestying, "RUNTIME VTK OUTPUT"};
   {
     // Whether to write visualization output at all for btsvmt.
-    Core::Utils::bool_parameter("WRITE_OUTPUT", "No",
+    Core::Utils::bool_parameter("WRITE_OUTPUT", false,
         "Enable / disable beam-to-solid volume mesh tying output.",
         beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("NODAL_FORCES", "No",
+    Core::Utils::bool_parameter("NODAL_FORCES", false,
         "Enable / disable output of the resulting nodal forces due to beam to solid interaction.",
         beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", "No",
+    Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", false,
         "Enable / disable output of the discrete Lagrange multipliers at the node of the Lagrange "
         "multiplier shape functions.",
         beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", "No",
+    Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", false,
         "Enable / disable output of the continuous Lagrange multipliers function along the beam.",
         beam_to_solid_volume_mestying_output);
 
@@ -174,15 +174,15 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
         "circumference",
         beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("SEGMENTATION", "No",
+    Core::Utils::bool_parameter("SEGMENTATION", false,
         "Enable / disable output of segmentation points.", beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("INTEGRATION_POINTS", "No",
+    Core::Utils::bool_parameter("INTEGRATION_POINTS", false,
         "Enable / disable output of used integration points. If the contact method has 'forces' at "
         "the integration point, they will also be output.",
         beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("UNIQUE_IDS", "No",
+    Core::Utils::bool_parameter("UNIQUE_IDS", false,
         "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
         beam_to_solid_volume_mestying_output);
   }
@@ -232,8 +232,8 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
         "Penalty parameter for beam-to-solid surface meshtying", beam_to_solid_surface_mestying);
 
     // Parameters for rotational coupling.
-    Core::Utils::bool_parameter("ROTATIONAL_COUPLING", "No", "Enable / disable rotational coupling",
-        beam_to_solid_surface_mestying);
+    Core::Utils::bool_parameter("ROTATIONAL_COUPLING", false,
+        "Enable / disable rotational coupling", beam_to_solid_surface_mestying);
     Core::Utils::double_parameter("ROTATIONAL_COUPLING_PENALTY_PARAMETER", 0.0,
         "Penalty parameter for beam-to-solid surface rotational meshtying",
         beam_to_solid_surface_mestying);
@@ -328,38 +328,38 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
       beam_to_solid_surface, "RUNTIME VTK OUTPUT"};
   {
     // Whether to write visualization output at all.
-    Core::Utils::bool_parameter("WRITE_OUTPUT", "No",
+    Core::Utils::bool_parameter("WRITE_OUTPUT", false,
         "Enable / disable beam-to-solid volume mesh tying output.", beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("NODAL_FORCES", "No",
+    Core::Utils::bool_parameter("NODAL_FORCES", false,
         "Enable / disable output of the resulting nodal forces due to beam to solid interaction.",
         beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("AVERAGED_NORMALS", "No",
+    Core::Utils::bool_parameter("AVERAGED_NORMALS", false,
         "Enable / disable output of averaged nodal normals on the surface.",
         beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", "No",
+    Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", false,
         "Enable / disable output of the discrete Lagrange multipliers at the node of the Lagrange "
         "multiplier shape functions.",
         beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", "No",
+    Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", false,
         "Enable / disable output of the continuous Lagrange multipliers function along the beam.",
         beam_to_solid_surface_output);
 
     Core::Utils::int_parameter("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS", 5,
         "Number of segments for continuous mortar output", beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("SEGMENTATION", "No",
+    Core::Utils::bool_parameter("SEGMENTATION", false,
         "Enable / disable output of segmentation points.", beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("INTEGRATION_POINTS", "No",
+    Core::Utils::bool_parameter("INTEGRATION_POINTS", false,
         "Enable / disable output of used integration points. If the contact method has 'forces' at "
         "the integration point, they will also be output.",
         beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("UNIQUE_IDS", "No",
+    Core::Utils::bool_parameter("UNIQUE_IDS", false,
         "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
         beam_to_solid_surface_output);
   }

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -54,7 +54,7 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
   Core::Utils::SectionSpecs crosslinking{beaminteraction, "CROSSLINKING"};
 
   // remove this some day
-  Core::Utils::bool_parameter("CROSSLINKER", "No", "Crosslinker in problem", crosslinking);
+  Core::Utils::bool_parameter("CROSSLINKER", false, "Crosslinker in problem", crosslinking);
 
   // bounding box for initial random crosslinker position
   Core::Utils::string_parameter("INIT_LINKER_BOUNDINGBOX", "1e12 1e12 1e12 1e12 1e12 1e12",
@@ -104,7 +104,7 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
 
   Core::Utils::SectionSpecs spherebeamlink{beaminteraction, "SPHERE BEAM LINK"};
 
-  Core::Utils::bool_parameter("SPHEREBEAMLINKING", "No", "Integrins in problem", spherebeamlink);
+  Core::Utils::bool_parameter("SPHEREBEAMLINKING", false, "Integrins in problem", spherebeamlink);
 
   // Reading double parameter for contraction rate for active linker
   Core::Utils::double_parameter("CONTRACTIONRATE", 0.0,

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -73,8 +73,8 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
   Core::Utils::int_parameter(
       "NUM_GAUSSPOINTS", 10, "Number of Gauss points used per integration segment", beampotential);
 
-  Core::Utils::bool_parameter(
-      "AUTOMATIC_DIFFERENTIATION", "No", "apply automatic differentiation via FAD?", beampotential);
+  Core::Utils::bool_parameter("AUTOMATIC_DIFFERENTIATION", false,
+      "apply automatic differentiation via FAD?", beampotential);
 
   Core::Utils::string_to_integral_parameter<MasterSlaveChoice>("CHOICE_MASTER_SLAVE",
       "smaller_eleGID_is_slave",
@@ -84,11 +84,11 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
           MasterSlaveChoice::smaller_eleGID_is_slave, MasterSlaveChoice::higher_eleGID_is_slave),
       beampotential);
 
-  Core::Utils::bool_parameter("BEAMPOT_BTSOL", "No",
+  Core::Utils::bool_parameter("BEAMPOT_BTSOL", false,
       "decide, whether potential-based interaction between beams and solids is considered",
       beampotential);
 
-  Core::Utils::bool_parameter("BEAMPOT_BTSPH", "No",
+  Core::Utils::bool_parameter("BEAMPOT_BTSPH", false,
       "decide, whether potential-based interaction between beams and spheres is considered",
       beampotential);
 
@@ -120,7 +120,7 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
 
 
   // whether to write visualization output for beam contact
-  Core::Utils::bool_parameter("VTK_OUTPUT_BEAM_POTENTIAL", "No",
+  Core::Utils::bool_parameter("VTK_OUTPUT_BEAM_POTENTIAL", false,
       "write visualization output for potential-based beam interactions",
       beampotential_output_sublist);
 
@@ -129,24 +129,24 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
       "write output at runtime every INTERVAL_STEPS steps", beampotential_output_sublist);
 
   // whether to write output in every iteration of the nonlinear solver
-  Core::Utils::bool_parameter("EVERY_ITERATION", "No",
+  Core::Utils::bool_parameter("EVERY_ITERATION", false,
       "write output in every iteration of the nonlinear solver", beampotential_output_sublist);
 
   // whether to write visualization output for forces
   Core::Utils::bool_parameter(
-      "FORCES", "No", "write visualization output for forces", beampotential_output_sublist);
+      "FORCES", false, "write visualization output for forces", beampotential_output_sublist);
 
   // whether to write visualization output for moments
   Core::Utils::bool_parameter(
-      "MOMENTS", "No", "write visualization output for moments", beampotential_output_sublist);
+      "MOMENTS", false, "write visualization output for moments", beampotential_output_sublist);
 
   // whether to write visualization output for forces/moments separately for each element pair
-  Core::Utils::bool_parameter("WRITE_FORCE_MOMENT_PER_ELEMENTPAIR", "No",
+  Core::Utils::bool_parameter("WRITE_FORCE_MOMENT_PER_ELEMENTPAIR", false,
       "write visualization output for forces/moments separately for each element pair",
       beampotential_output_sublist);
 
   // whether to write out the UIDs (uid_0_beam_1_gid, uid_1_beam_2_gid, uid_2_gp_id)
-  Core::Utils::bool_parameter("WRITE_UIDS", "No",
+  Core::Utils::bool_parameter("WRITE_UIDS", false,
       "write out the unique ID's for each visualization point,i.e., master and slave beam element "
       "global ID (uid_0_beam_1_gid, uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
       beampotential_output_sublist);

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -32,7 +32,7 @@ void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", andyn);
 
   Core::Utils::bool_parameter(
-      "SOLVESCATRA", "no", "Flag to (de)activate solving scalar transport in blood", andyn);
+      "SOLVESCATRA", false, "Flag to (de)activate solving scalar transport in blood", andyn);
 
   // number of linear solver used for arterial dynamics
   Core::Utils::int_parameter(
@@ -211,8 +211,8 @@ void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::SectionSpecs biofilmcontrol{"BIOFILM CONTROL"};
 
   Core::Utils::bool_parameter(
-      "BIOFILMGROWTH", "No", "Scatra algorithm for biofilm growth", biofilmcontrol);
-  Core::Utils::bool_parameter("AVGROWTH", "No",
+      "BIOFILMGROWTH", false, "Scatra algorithm for biofilm growth", biofilmcontrol);
+  Core::Utils::bool_parameter("AVGROWTH", false,
       "The calculation of growth parameters is based on averaged values", biofilmcontrol);
   Core::Utils::double_parameter(
       "FLUXCOEF", 0.0, "Coefficient for growth due to scalar flux", biofilmcontrol);
@@ -229,7 +229,7 @@ void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::int_parameter(
       "BIONUMSTEP", 0, "Maximum number of steps for biofilm growth", biofilmcontrol);
   Core::Utils::bool_parameter(
-      "OUTPUT_GMSH", "No", "Do you want to write Gmsh postprocessing files?", biofilmcontrol);
+      "OUTPUT_GMSH", false, "Do you want to write Gmsh postprocessing files?", biofilmcontrol);
 
   biofilmcontrol.move_into_collection(list);
 }
@@ -280,12 +280,12 @@ void Inpar::ReducedLung::set_valid_parameters(std::map<std::string, Core::IO::In
       "number of linear solver used for reduced dim arterial dynamics", redawdyn);
 
   Core::Utils::bool_parameter(
-      "SOLVESCATRA", "no", "Flag to (de)activate solving scalar transport in blood", redawdyn);
+      "SOLVESCATRA", false, "Flag to (de)activate solving scalar transport in blood", redawdyn);
 
-  Core::Utils::bool_parameter("COMPAWACINTER", "no",
+  Core::Utils::bool_parameter("COMPAWACINTER", false,
       "Flag to (de)activate computation of airway-acinus interdependency", redawdyn);
 
-  Core::Utils::bool_parameter("CALCV0PRESTRESS", "no",
+  Core::Utils::bool_parameter("CALCV0PRESTRESS", false,
       "Flag to (de)activate initial acini volume adjustment with pre-stress condition", redawdyn);
 
   Core::Utils::double_parameter("TRANSPULMPRESS", 800.0,

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -28,11 +28,11 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
       cardvasc0dstruct);
   Core::Utils::double_parameter("TIMINT_THETA", 0.5,
       "theta for one-step-theta time-integration scheme of Cardiovascular0D", cardvasc0dstruct);
-  Core::Utils::bool_parameter("RESTART_WITH_CARDVASC0D", "No",
+  Core::Utils::bool_parameter("RESTART_WITH_CARDVASC0D", false,
       "Must be chosen if a non-cardiovascular0d simulation is to be restarted as "
       "cardiovascular0d-structural coupled problem.",
       cardvasc0dstruct);
-  Core::Utils::bool_parameter("ENHANCED_OUTPUT", "No",
+  Core::Utils::bool_parameter("ENHANCED_OUTPUT", false,
       "Set to yes for enhanced output (like e.g. derivative information)", cardvasc0dstruct);
 
   // linear solver id used for monolithic 0D cardiovascular-structural problems
@@ -50,7 +50,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
       "EPS_PERIODIC", 1.0e-16, "tolerance for periodic state", cardvasc0dstruct);
 
   Core::Utils::bool_parameter(
-      "PTC_3D0D", "No", "Set to yes for doing PTC 2x2 block system.", cardvasc0dstruct);
+      "PTC_3D0D", false, "Set to yes for doing PTC 2x2 block system.", cardvasc0dstruct);
 
   Core::Utils::double_parameter("K_PTC", 0.0,
       "PTC parameter: 0 means normal Newton, ->infty means steepest desc", cardvasc0dstruct);

--- a/src/inpar/4C_inpar_contact.cpp
+++ b/src/inpar/4C_inpar_contact.cpp
@@ -24,7 +24,7 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::int_parameter(
       "LINEAR_SOLVER", -1, "number of linear solver used for meshtying and contact", scontact);
 
-  Core::Utils::bool_parameter("RESTART_WITH_CONTACT", "No",
+  Core::Utils::bool_parameter("RESTART_WITH_CONTACT", false,
       "Must be chosen if a non-contact simulation is to be restarted with contact", scontact);
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::AdhesionType>("ADHESION", "None",
@@ -39,11 +39,11 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
           friction_none, friction_stick, friction_tresca, friction_coulomb),
       scontact);
 
-  Core::Utils::bool_parameter("FRLESS_FIRST", "No",
+  Core::Utils::bool_parameter("FRLESS_FIRST", false,
       "If chosen the first time step of a newly in contact slave node is regarded as frictionless",
       scontact);
 
-  Core::Utils::bool_parameter("GP_SLIP_INCR", "No",
+  Core::Utils::bool_parameter("GP_SLIP_INCR", false,
       "If chosen the slip increment is computed gp-wise which results to a non-objective quantity, "
       "but this would be consistent to wear and tsi calculations.",
       scontact);
@@ -77,20 +77,20 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       "Tolerance of constraint norm for Uzawa solution strategy", scontact);
 
   Core::Utils::bool_parameter(
-      "SEMI_SMOOTH_NEWTON", "Yes", "If chosen semi-smooth Newton concept is applied", scontact);
+      "SEMI_SMOOTH_NEWTON", true, "If chosen semi-smooth Newton concept is applied", scontact);
 
   Core::Utils::double_parameter(
       "SEMI_SMOOTH_CN", 1.0, "Weighting factor cn for semi-smooth PDASS", scontact);
   Core::Utils::double_parameter(
       "SEMI_SMOOTH_CT", 1.0, "Weighting factor ct for semi-smooth PDASS", scontact);
 
-  Core::Utils::bool_parameter("CONTACTFORCE_ENDTIME", "No",
+  Core::Utils::bool_parameter("CONTACTFORCE_ENDTIME", false,
       "If chosen, the contact force is not evaluated at the generalized midpoint, but at the end "
       "of the time step",
       scontact);
 
   Core::Utils::bool_parameter(
-      "VELOCITY_UPDATE", "No", "If chosen, velocity update method is applied", scontact);
+      "VELOCITY_UPDATE", false, "If chosen, velocity update method is applied", scontact);
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::EmOutputType>("EMOUTPUT", "None",
       "Type of energy and momentum output",
@@ -101,7 +101,7 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       scontact);
 
   Core::Utils::bool_parameter(
-      "INITCONTACTBYGAP", "No", "Initialize init contact by weighted gap vector", scontact);
+      "INITCONTACTBYGAP", false, "Initialize init contact by weighted gap vector", scontact);
 
   Core::Utils::double_parameter("INITCONTACTGAPVALUE", 0.0,
       "Value for initialization of init contact set with gap vector", scontact);
@@ -134,13 +134,13 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       "CONTACT_REGULARIZATION", "no", "use regularized contact", tuple<std::string>("no", "tanh"),
       tuple<Inpar::CONTACT::Regularization>(reg_none, reg_tanh), scontact);
 
-  Core::Utils::bool_parameter("NONSMOOTH_GEOMETRIES", "No",
+  Core::Utils::bool_parameter("NONSMOOTH_GEOMETRIES", false,
       "If chosen the contact algorithm combines mortar and nts formulations. This is needed if "
       "contact between entities of different geometric dimension (such as contact between surfaces "
       "and lines, or lines and nodes) can occur",
       scontact);
 
-  Core::Utils::bool_parameter("NONSMOOTH_CONTACT_SURFACE", "No",
+  Core::Utils::bool_parameter("NONSMOOTH_CONTACT_SURFACE", false,
       "This flag is used to alter the criterion for the evaluation of the so-called qualified "
       "vectors in the case of a self contact scenario. This is needed as the standard criterion is "
       "only valid for smooth surfaces and thus has to be altered, if the surface that is defined "
@@ -154,11 +154,11 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       "Non-smooth contact: angle between cpp normal and element normal: end transition (NTS)",
       scontact);
 
-  Core::Utils::bool_parameter("CPP_NORMALS", "No",
+  Core::Utils::bool_parameter("CPP_NORMALS", false,
       "If chosen the nodal normal field is created as averaged CPP normal field.", scontact);
 
   Core::Utils::bool_parameter(
-      "TIMING_DETAILS", "No", "Enable and print detailed contact timings to screen.", scontact);
+      "TIMING_DETAILS", false, "Enable and print detailed contact timings to screen.", scontact);
 
   // --------------------------------------------------------------------------
   Core::Utils::double_parameter(
@@ -172,11 +172,11 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       tuple<Inpar::CONTACT::NitscheWeighting>(NitWgt_slave, NitWgt_master, NitWgt_harmonic),
       scontact);
 
-  Core::Utils::bool_parameter("NITSCHE_PENALTY_ADAPTIVE", "yes",
+  Core::Utils::bool_parameter("NITSCHE_PENALTY_ADAPTIVE", true,
       "adapt penalty parameter after each converged time step", scontact);
 
-  Core::Utils::bool_parameter(
-      "REGULARIZED_NORMAL_CONTACT", "No", "add a regularized normal contact formulation", scontact);
+  Core::Utils::bool_parameter("REGULARIZED_NORMAL_CONTACT", false,
+      "add a regularized normal contact formulation", scontact);
   Core::Utils::double_parameter(
       "REGULARIZATION_THICKNESS", -1., "maximum contact penetration", scontact);
   Core::Utils::double_parameter("REGULARIZATION_STIFFNESS", -1.,

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -31,7 +31,7 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", ehldyn);
   Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", ehldyn);
   Core::Utils::bool_parameter(
-      "DIFFTIMESTEPSIZE", "No", "use different step size for lubrication and solid", ehldyn);
+      "DIFFTIMESTEPSIZE", false, "use different step size for lubrication and solid", ehldyn);
   Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", ehldyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ehldyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ehldyn);
@@ -48,11 +48,11 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       tuple<SolutionSchemeOverFields>(ehl_IterStagg, ehl_Monolithic), ehldyn);
 
   // set unprojectable nodes to zero pressure via Dirichlet condition
-  Core::Utils::bool_parameter("UNPROJ_ZERO_DBC", "No",
+  Core::Utils::bool_parameter("UNPROJ_ZERO_DBC", false,
       "set unprojectable nodes to zero pressure via Dirichlet condition", ehldyn);
 
   // use dry contact model
-  Core::Utils::bool_parameter("DRY_CONTACT_MODEL", "No",
+  Core::Utils::bool_parameter("DRY_CONTACT_MODEL", false,
       "set unprojectable nodes to zero pressure via Dirichlet condition", ehldyn);
 
 
@@ -101,7 +101,7 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "LINEAR_SOLVER", -1, "number of linear solver used for monolithic EHL problems", ehldynmono);
 
   // convergence criteria adaptivity of monolithic EHL solver
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution", ehldynmono);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
@@ -109,7 +109,7 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       ehldynmono);
 
   Core::Utils::bool_parameter(
-      "INFNORMSCALING", "yes", "Scale blocks of matrix with row infnorm?", ehldynmono);
+      "INFNORMSCALING", true, "Scale blocks of matrix with row infnorm?", ehldynmono);
 
   ehldynmono.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -46,7 +46,7 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "MOLARVOLUME", 0.0, "Molar volume for electrode shape change computations", elchcontrol);
   Core::Utils::double_parameter("MOVBOUNDARYTHETA", 0.0,
       "One-step-theta factor in electrode shape change computations", elchcontrol);
-  Core::Utils::bool_parameter("GALVANOSTATIC", "No", "flag for galvanostatic mode", elchcontrol);
+  Core::Utils::bool_parameter("GALVANOSTATIC", false, "flag for galvanostatic mode", elchcontrol);
   Core::Utils::string_to_integral_parameter<Inpar::ElCh::ApproxElectResist>(
       "GSTAT_APPROX_ELECT_RESIST", "relation_pot_cur", "relation of potential and current flow",
       tuple<std::string>("relation_pot_cur", "effective_length_with_initial_cond",
@@ -76,18 +76,18 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           equpot_poisson, equpot_laplace, equpot_divi),
       elchcontrol);
   Core::Utils::bool_parameter(
-      "DIFFCOND_FORMULATION", "No", "Activation of diffusion-conduction formulation", elchcontrol);
-  Core::Utils::bool_parameter("INITPOTCALC", "No",
+      "DIFFCOND_FORMULATION", false, "Activation of diffusion-conduction formulation", elchcontrol);
+  Core::Utils::bool_parameter("INITPOTCALC", false,
       "Automatically calculate initial field for electric potential", elchcontrol);
-  Core::Utils::bool_parameter("ONLYPOTENTIAL", "no",
+  Core::Utils::bool_parameter("ONLYPOTENTIAL", false,
       "Coupling of general ion transport equation with Laplace equation", elchcontrol);
-  Core::Utils::bool_parameter("COUPLE_BOUNDARY_FLUXES", "Yes",
+  Core::Utils::bool_parameter("COUPLE_BOUNDARY_FLUXES", true,
       "Coupling of lithium-ion flux density and electric current density at Dirichlet and Neumann "
       "boundaries",
       elchcontrol);
   Core::Utils::double_parameter(
       "CYCLING_TIMESTEP", -1., "modified time step size for CCCV cell cycling", elchcontrol);
-  Core::Utils::bool_parameter("ELECTRODE_INFO_EVERY_STEP", "No",
+  Core::Utils::bool_parameter("ELECTRODE_INFO_EVERY_STEP", false,
       "the cell voltage, SOC, and C-Rate will be written to the csv file every step, even if "
       "RESULTSEVERY is not 1",
       elchcontrol);
@@ -99,8 +99,8 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs elchdiffcondcontrol{elchcontrol, "DIFFCOND"};
 
   Core::Utils::bool_parameter(
-      "CURRENT_SOLUTION_VAR", "No", "Current as a solution variable", elchdiffcondcontrol);
-  Core::Utils::bool_parameter("MAT_DIFFCOND_DIFFBASED", "Yes",
+      "CURRENT_SOLUTION_VAR", false, "Current as a solution variable", elchdiffcondcontrol);
+  Core::Utils::bool_parameter("MAT_DIFFCOND_DIFFBASED", true,
       "Coupling terms of chemical diffusion for current equation are based on t and kappa",
       elchdiffcondcontrol);
 
@@ -133,11 +133,11 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs sclcontrol{elchcontrol, "SCL"};
 
   Core::Utils::bool_parameter(
-      "ADD_MICRO_MACRO_COUPLING", "No", "flag for micro macro coupling with scls", sclcontrol);
-  Core::Utils::bool_parameter("COUPLING_OUTPUT", "No",
+      "ADD_MICRO_MACRO_COUPLING", false, "flag for micro macro coupling with scls", sclcontrol);
+  Core::Utils::bool_parameter("COUPLING_OUTPUT", false,
       "write coupled node gids and node coordinates to csv file", sclcontrol);
   Core::Utils::bool_parameter(
-      "INITPOTCALC", "No", "calculate initial potential field?", sclcontrol);
+      "INITPOTCALC", false, "calculate initial potential field?", sclcontrol);
   Core::Utils::int_parameter("SOLVER", -1, "solver for coupled SCL problem", sclcontrol);
   Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
       "type of global system matrix in global system of equations",

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -81,11 +81,11 @@ void Inpar::EleMag::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     // Error calculation
     Core::Utils::bool_parameter(
-        "CALCERR", "No", "Calc the error wrt ERRORFUNCNO?", electromagneticdyn);
+        "CALCERR", false, "Calc the error wrt ERRORFUNCNO?", electromagneticdyn);
 
     // Post process solution?
     Core::Utils::bool_parameter(
-        "POSTPROCESS", "No", "Postprocess solution? (very slow)", electromagneticdyn);
+        "POSTPROCESS", false, "Postprocess solution? (very slow)", electromagneticdyn);
   }
 
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fbi.cpp
+++ b/src/inpar/4C_inpar_fbi.cpp
@@ -90,31 +90,31 @@ void Inpar::FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       beam_to_fluid_meshtying, "RUNTIME VTK OUTPUT"};
 
   // Whether to write visualization output at all for beam to fluid meshtying.
-  Core::Utils::bool_parameter("WRITE_OUTPUT", "No",
+  Core::Utils::bool_parameter("WRITE_OUTPUT", false,
       "Enable / disable beam-to-fluid mesh tying output.", beam_to_fluid_meshtying_output);
 
-  Core::Utils::bool_parameter("NODAL_FORCES", "No",
+  Core::Utils::bool_parameter("NODAL_FORCES", false,
       "Enable / disable output of the resulting nodal forces due to beam to Fluid interaction.",
       beam_to_fluid_meshtying_output);
 
-  Core::Utils::bool_parameter("SEGMENTATION", "No",
+  Core::Utils::bool_parameter("SEGMENTATION", false,
       "Enable / disable output of segmentation points.", beam_to_fluid_meshtying_output);
 
-  Core::Utils::bool_parameter("INTEGRATION_POINTS", "No",
+  Core::Utils::bool_parameter("INTEGRATION_POINTS", false,
       "Enable / disable output of used integration points. If the meshtying method has 'forces' at "
       "the integration point, they will also be output.",
       beam_to_fluid_meshtying_output);
 
-  Core::Utils::bool_parameter("CONSTRAINT_VIOLATION", "No",
+  Core::Utils::bool_parameter("CONSTRAINT_VIOLATION", false,
       "Enable / disable output of the constraint violation into a output_name.penalty csv file.",
       beam_to_fluid_meshtying_output);
 
-  Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", "No",
+  Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", false,
       "Enable / disable output of the discrete Lagrange multipliers at the node of the Lagrange "
       "multiplier shape functions.",
       beam_to_fluid_meshtying_output);
 
-  Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", "No",
+  Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", false,
       "Enable / disable output of the continuous Lagrange multipliers function along the beam.",
       beam_to_fluid_meshtying_output);
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -98,7 +98,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Norm for convergence check (relative increments and absolute residuals)",
       tuple<std::string>("L_2_norm"), tuple<Inpar::FLUID::ItNorm>(fncc_L2), fdyn);
 
-  Core::Utils::bool_parameter("INCONSISTENT_RESIDUAL", "No",
+  Core::Utils::bool_parameter("INCONSISTENT_RESIDUAL", false,
       "do not evaluate residual after solution has converged (->faster)", fdyn);
 
   {
@@ -136,13 +136,13 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "OSEENFIELDFUNCNO", -1, "function number of Oseen advective field", fdyn);
 
   Core::Utils::bool_parameter(
-      "LIFTDRAG", "No", "Calculate lift and drag forces along specified boundary", fdyn);
+      "LIFTDRAG", false, "Calculate lift and drag forces along specified boundary", fdyn);
 
   std::vector<std::string> convform_valid_input = {"convective", "conservative"};
   Core::Utils::string_parameter(
       "CONVFORM", "convective", "form of convective term", fdyn, convform_valid_input);
 
-  Core::Utils::bool_parameter("NONLINEARBC", "no",
+  Core::Utils::bool_parameter("NONLINEARBC", false,
       "Flag to activate check for potential nonlinear boundary conditions", fdyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
@@ -156,7 +156,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "scheme for determination of gridvelocity from displacements",
       tuple<std::string>("BE", "BDF2", "OST"), tuple<Inpar::FLUID::Gridvel>(BE, BDF2, OST), fdyn);
 
-  Core::Utils::bool_parameter("ALLDOFCOUPLED", "Yes", "all dof (incl. pressure) are coupled", fdyn);
+  Core::Utils::bool_parameter("ALLDOFCOUPLED", true, "all dof (incl. pressure) are coupled", fdyn);
 
   {
     Teuchos::Tuple<std::string, 16> name;
@@ -219,17 +219,17 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter("VARVISCFUNCNO", -1,
       "Function for calculation of a variable viscosity for the weakly compressible problem", fdyn);
 
-  Core::Utils::bool_parameter("PRESSAVGBC", "no",
+  Core::Utils::bool_parameter("PRESSAVGBC", false,
       "Flag to (de)activate imposition of boundary condition for the considered element average "
       "pressure",
       fdyn);
 
   Core::Utils::double_parameter("REFMACH", 1.0, "Reference Mach number", fdyn);
 
-  Core::Utils::bool_parameter("BLOCKMATRIX", "No",
+  Core::Utils::bool_parameter("BLOCKMATRIX", false,
       "Indicates if system matrix should be assembled into a sparse block matrix type.", fdyn);
 
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution", fdyn);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
@@ -237,14 +237,14 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       fdyn);
 
   Core::Utils::bool_parameter(
-      "INFNORMSCALING", "no", "Scale blocks of matrix with row infnorm?", fdyn);
+      "INFNORMSCALING", false, "Scale blocks of matrix with row infnorm?", fdyn);
 
-  Core::Utils::bool_parameter("GMSH_OUTPUT", "No", "write output to gmsh files", fdyn);
+  Core::Utils::bool_parameter("GMSH_OUTPUT", false, "write output to gmsh files", fdyn);
   Core::Utils::bool_parameter(
-      "COMPUTE_DIVU", "No", "Compute divergence of velocity field at the element center", fdyn);
-  Core::Utils::bool_parameter("COMPUTE_EKIN", "No",
+      "COMPUTE_DIVU", false, "Compute divergence of velocity field at the element center", fdyn);
+  Core::Utils::bool_parameter("COMPUTE_EKIN", false,
       "Compute kinetic energy at the end of each time step and write it to file.", fdyn);
-  Core::Utils::bool_parameter("NEW_OST", "No",
+  Core::Utils::bool_parameter("NEW_OST", false,
       "Solve the Navier-Stokes equation with the new One Step Theta algorithm",
       fdyn);  // TODO: To be removed.
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", fdyn);
@@ -266,7 +266,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::double_parameter(
       "START_THETA", 1.0, "Time integration factor for starting scheme", fdyn);
 
-  Core::Utils::bool_parameter("STRONG_REDD_3D_COUPLING_TYPE", "no",
+  Core::Utils::bool_parameter("STRONG_REDD_3D_COUPLING_TYPE", false,
       "Flag to (de)activate potential Strong 3D redD coupling", fdyn);
 
   Core::Utils::int_parameter(
@@ -282,7 +282,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           ),
       fdyn);
 
-  Core::Utils::bool_parameter("OFF_PROC_ASSEMBLY", "No",
+  Core::Utils::bool_parameter("OFF_PROC_ASSEMBLY", false,
       "Do not evaluate ghosted elements but communicate them --> faster if element call is "
       "expensive",
       fdyn);
@@ -323,11 +323,11 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           stabtype_nostab, stabtype_residualbased, stabtype_edgebased, stabtype_pressureprojection),
       fdyn_stab);
 
-  Core::Utils::bool_parameter("INCONSISTENT", "No",
+  Core::Utils::bool_parameter("INCONSISTENT", false,
       "residual based without second derivatives (i.e. only consistent for tau->0, but faster)",
       fdyn_stab);
 
-  Core::Utils::bool_parameter("Reconstruct_Sec_Der", "No",
+  Core::Utils::bool_parameter("Reconstruct_Sec_Der", false,
       "residual computed with a reconstruction of the second derivatives via projection or "
       "superconvergent patch recovery",
       fdyn_stab);
@@ -346,9 +346,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       tuple<Transient>(inertia_stab_drop, inertia_stab_keep, inertia_stab_keep_complete),
       fdyn_stab);
 
-  Core::Utils::bool_parameter("PSPG", "Yes", "Flag to (de)activate PSPG stabilization.", fdyn_stab);
-  Core::Utils::bool_parameter("SUPG", "Yes", "Flag to (de)activate SUPG stabilization.", fdyn_stab);
-  Core::Utils::bool_parameter("GRAD_DIV", "Yes", "Flag to (de)activate grad-div term.", fdyn_stab);
+  Core::Utils::bool_parameter("PSPG", true, "Flag to (de)activate PSPG stabilization.", fdyn_stab);
+  Core::Utils::bool_parameter("SUPG", true, "Flag to (de)activate SUPG stabilization.", fdyn_stab);
+  Core::Utils::bool_parameter("GRAD_DIV", true, "Flag to (de)activate grad-div term.", fdyn_stab);
 
   Core::Utils::string_to_integral_parameter<VStab>("VSTAB", "no_vstab",
       "Flag to (de)activate viscous term in residual-based stabilization. Options: "
@@ -458,7 +458,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   // these parameters active additional terms in loma continuity equation
   // which might be identified as SUPG-/cross- and Reynolds-stress term
-  Core::Utils::bool_parameter("LOMA_CONTI_SUPG", "No",
+  Core::Utils::bool_parameter("LOMA_CONTI_SUPG", false,
       "Flag to (de)activate SUPG stabilization in loma continuity equation.", fdyn_stab);
 
   Core::Utils::string_to_integral_parameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
@@ -551,7 +551,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   //! special least-squares condition for pseudo 2D examples where pressure level is determined via
   //! Krylov-projection
-  Core::Utils::bool_parameter("PRES_KRYLOV_2Dz", "No",
+  Core::Utils::bool_parameter("PRES_KRYLOV_2Dz", false,
       "residual based without second derivatives (i.e. only consistent for tau->0, but faster)",
       fdyn_edge_based_stab);
 
@@ -606,7 +606,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::SectionSpecs fdyn_porostab{fdyn, "POROUS-FLOW STABILIZATION"};
 
   Core::Utils::bool_parameter(
-      "STAB_BIOT", "No", "Flag to (de)activate BIOT stabilization.", fdyn_porostab);
+      "STAB_BIOT", false, "Flag to (de)activate BIOT stabilization.", fdyn_porostab);
   Core::Utils::double_parameter("STAB_BIOT_SCALING", 1.0,
       "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
       fdyn_porostab);
@@ -623,11 +623,11 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       tuple<Inpar::FLUID::StabType>(stabtype_nostab, stabtype_residualbased, stabtype_edgebased),
       fdyn_porostab);
 
-  Core::Utils::bool_parameter("INCONSISTENT", "No",
+  Core::Utils::bool_parameter("INCONSISTENT", false,
       "residual based without second derivatives (i.e. only consistent for tau->0, but faster)",
       fdyn_porostab);
 
-  Core::Utils::bool_parameter("Reconstruct_Sec_Der", "No",
+  Core::Utils::bool_parameter("Reconstruct_Sec_Der", false,
       "residual computed with a reconstruction of the second derivatives via projection or "
       "superconvergent patch recovery",
       fdyn_porostab);
@@ -645,11 +645,11 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       fdyn_porostab);
 
   Core::Utils::bool_parameter(
-      "PSPG", "Yes", "Flag to (de)activate PSPG stabilization.", fdyn_porostab);
+      "PSPG", true, "Flag to (de)activate PSPG stabilization.", fdyn_porostab);
   Core::Utils::bool_parameter(
-      "SUPG", "Yes", "Flag to (de)activate SUPG stabilization.", fdyn_porostab);
+      "SUPG", true, "Flag to (de)activate SUPG stabilization.", fdyn_porostab);
   Core::Utils::bool_parameter(
-      "GRAD_DIV", "Yes", "Flag to (de)activate grad-div term.", fdyn_porostab);
+      "GRAD_DIV", true, "Flag to (de)activate grad-div term.", fdyn_porostab);
 
   Core::Utils::string_to_integral_parameter<VStab>("VSTAB", "no_vstab",
       "Flag to (de)activate viscous term in residual-based stabilization.",
@@ -726,7 +726,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   // these parameters active additional terms in loma continuity equation
   // which might be identified as SUPG-/cross- and Reynolds-stress term
-  Core::Utils::bool_parameter("LOMA_CONTI_SUPG", "No",
+  Core::Utils::bool_parameter("LOMA_CONTI_SUPG", false,
       "Flag to (de)activate SUPG stabilization in loma continuity equation.", fdyn_porostab);
 
   Core::Utils::string_to_integral_parameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
@@ -794,12 +794,12 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "SAMPLING_STOP", 1, "Time step when sampling shall be stopped", fdyn_turbu);
   Core::Utils::int_parameter("DUMPING_PERIOD", 1,
       "Period of time steps after which statistical data shall be dumped", fdyn_turbu);
-  Core::Utils::bool_parameter("SUBGRID_DISSIPATION", "No",
+  Core::Utils::bool_parameter("SUBGRID_DISSIPATION", false,
       "Flag to (de)activate estimation of subgrid-scale dissipation (only for seclected flows).",
       fdyn_turbu);
   Core::Utils::bool_parameter(
-      "OUTMEAN", "No", "Flag to (de)activate averaged paraview output", fdyn_turbu);
-  Core::Utils::bool_parameter("TURBMODEL_LS", "Yes",
+      "OUTMEAN", false, "Flag to (de)activate averaged paraview output", fdyn_turbu);
+  Core::Utils::bool_parameter("TURBMODEL_LS", true,
       "Flag to (de)activate turbulence model in level-set equation", fdyn_turbu);
 
   //----------------------------------------------------------------------
@@ -936,7 +936,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // filtering with xfem
   //--------------
 
-  Core::Utils::bool_parameter("EXCLUDE_XFEM", "No",
+  Core::Utils::bool_parameter("EXCLUDE_XFEM", false,
       "Flag to (de)activate XFEM dofs in calculation of fine-scale velocity.", fdyn_turbu);
 
   fdyn_turbu.move_into_collection(list);
@@ -953,10 +953,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Constant for the compressible Smagorinsky model: isotropic part of subgrid-stress tensor. "
       "About 0.09 or 0.0066. Ci will not be squared!",
       fdyn_turbsgv);
-  Core::Utils::bool_parameter("C_SMAGORINSKY_AVERAGED", "No",
+  Core::Utils::bool_parameter("C_SMAGORINSKY_AVERAGED", false,
       "Flag to (de)activate averaged Smagorinksy constant", fdyn_turbsgv);
   Core::Utils::bool_parameter(
-      "C_INCLUDE_CI", "No", "Flag to (de)inclusion of Yoshizawa model", fdyn_turbsgv);
+      "C_INCLUDE_CI", false, "Flag to (de)inclusion of Yoshizawa model", fdyn_turbsgv);
   // remark: following Moin et al. 1991, the extension of the dynamic Smagorinsky model to
   // compressibel flow
   //        also contains a model for the isotropic part of the subgrid-stress tensor according to
@@ -988,7 +988,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // sublist with additional input parameters for Smagorinsky model
   Core::Utils::SectionSpecs fdyn_wallmodel{fdyn, "WALL MODEL"};
 
-  Core::Utils::bool_parameter("X_WALL", "No", "Flag to switch on the xwall model", fdyn_wallmodel);
+  Core::Utils::bool_parameter("X_WALL", false, "Flag to switch on the xwall model", fdyn_wallmodel);
 
 
   std::vector<std::string> tauw_type_valid_input = {"constant", "between_steps"};
@@ -1046,7 +1046,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter(
       "GP_Wall_Parallel", 3, "Gauss points in wall parallel direction", fdyn_wallmodel);
 
-  Core::Utils::bool_parameter("Treat_Tauw_on_Dirichlet_Inflow", "No",
+  Core::Utils::bool_parameter("Treat_Tauw_on_Dirichlet_Inflow", false,
       "Flag to treat residual on Dirichlet inflow nodes for calculation of wall shear stress",
       fdyn_wallmodel);
 
@@ -1078,7 +1078,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "aggregation.",
       fdyn_turbmfs);
 
-  Core::Utils::bool_parameter("CALC_N", "No",
+  Core::Utils::bool_parameter("CALC_N", false,
       "Flag to (de)activate calculation of N from the Reynolds number.", fdyn_turbmfs);
 
   Core::Utils::double_parameter("N", 1.0, "Set grid to viscous scale ratio.", fdyn_turbmfs);
@@ -1110,7 +1110,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       fdyn_turbmfs);
 
   Core::Utils::bool_parameter(
-      "NEAR_WALL_LIMIT", "No", "Flag to (de)activate near-wall limit.", fdyn_turbmfs);
+      "NEAR_WALL_LIMIT", false, "Flag to (de)activate near-wall limit.", fdyn_turbmfs);
 
   std::vector<std::string> evaluation_b_valid_input = {"element_center", "integration_point"};
   std::string evaluation_b_doc =
@@ -1136,12 +1136,12 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Modelparameter of multifractal subgrid-scales for scalar transport.", fdyn_turbmfs);
 
   Core::Utils::bool_parameter(
-      "ADAPT_CSGS_PHI", "No", "Flag to (de)activate adaption of CsgsD to CsgsB.", fdyn_turbmfs);
+      "ADAPT_CSGS_PHI", false, "Flag to (de)activate adaption of CsgsD to CsgsB.", fdyn_turbmfs);
 
-  Core::Utils::bool_parameter("NEAR_WALL_LIMIT_CSGS_PHI", "No",
+  Core::Utils::bool_parameter("NEAR_WALL_LIMIT_CSGS_PHI", false,
       "Flag to (de)activate near-wall limit for scalar field.", fdyn_turbmfs);
 
-  Core::Utils::bool_parameter("CONSISTENT_FLUID_RESIDUAL", "No",
+  Core::Utils::bool_parameter("CONSISTENT_FLUID_RESIDUAL", false,
       "Flag to (de)activate the consistency term for residual-based stabilization.", fdyn_turbmfs);
 
   Core::Utils::double_parameter("C_DIFF", 1.0,
@@ -1149,11 +1149,11 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Usually equal cnu.",
       fdyn_turbmfs);
 
-  Core::Utils::bool_parameter("SET_FINE_SCALE_VEL", "No",
+  Core::Utils::bool_parameter("SET_FINE_SCALE_VEL", false,
       "Flag to set fine-scale velocity for parallel nightly tests.", fdyn_turbmfs);
 
   // activate cross- and Reynolds-stress terms in loma continuity equation
-  Core::Utils::bool_parameter("LOMA_CONTI", "No",
+  Core::Utils::bool_parameter("LOMA_CONTI", false,
       "Flag to (de)activate cross- and Reynolds-stress terms in loma continuity equation.",
       fdyn_turbmfs);
 
@@ -1162,7 +1162,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs fdyn_turbinf{fdyn, "TURBULENT INFLOW"};
 
-  Core::Utils::bool_parameter("TURBULENTINFLOW", "No",
+  Core::Utils::bool_parameter("TURBULENTINFLOW", false,
       "Flag to (de)activate potential separate turbulent inflow section", fdyn_turbinf);
 
   Core::Utils::string_to_integral_parameter<InitialField>("INITIALINFLOWFIELD", "zero_field",
@@ -1260,7 +1260,7 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
 
   Core::Utils::SectionSpecs lomacontrol{"LOMA CONTROL"};
 
-  Core::Utils::bool_parameter("MONOLITHIC", "no", "monolithic solver", lomacontrol);
+  Core::Utils::bool_parameter("MONOLITHIC", false, "monolithic solver", lomacontrol);
   Core::Utils::int_parameter("NUMSTEP", 24, "Total number of time steps", lomacontrol);
   Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", lomacontrol);
   Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", lomacontrol);
@@ -1275,7 +1275,7 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::string_parameter("CONSTHERMPRESS", "Yes",
       "treatment of thermodynamic pressure in time", lomacontrol, constthermpress_valid_input);
 
-  Core::Utils::bool_parameter("SGS_MATERIAL_UPDATE", "no",
+  Core::Utils::bool_parameter("SGS_MATERIAL_UPDATE", false,
       "update material by adding subgrid-scale scalar field", lomacontrol);
 
   // number of linear solver used for LOMA solver

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -142,10 +142,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::string_parameter(
       "CONVFORM", "convective", "form of convective term", fdyn, convform_valid_input);
 
-  std::vector<std::string> nonlinearbc_valid_input = {"no", "yes"};
-  Core::Utils::string_parameter("NONLINEARBC", "no",
-      "Flag to activate check for potential nonlinear boundary conditions", fdyn,
-      nonlinearbc_valid_input);
+  Core::Utils::bool_parameter("NONLINEARBC", "no",
+      "Flag to activate check for potential nonlinear boundary conditions", fdyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
       "Flag to (de)activate mesh tying algorithm",
@@ -221,20 +219,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter("VARVISCFUNCNO", -1,
       "Function for calculation of a variable viscosity for the weakly compressible problem", fdyn);
 
-  {
-    Teuchos::Tuple<std::string, 2> name;
-    Teuchos::Tuple<Inpar::FLUID::PressAvgBc, 2> label;
-
-    name[0] = "no";
-    label[0] = no_pressure_average_bc;
-    name[1] = "yes";
-    label[1] = yes_pressure_average_bc;
-
-    Core::Utils::string_to_integral_parameter<Inpar::FLUID::PressAvgBc>("PRESSAVGBC", "no",
-        "Flag to (de)activate imposition of boundary condition for the considered element average "
-        "pressure",
-        name, label, fdyn);
-  }
+  Core::Utils::bool_parameter("PRESSAVGBC", "no",
+      "Flag to (de)activate imposition of boundary condition for the considered element average "
+      "pressure",
+      fdyn);
 
   Core::Utils::double_parameter("REFMACH", 1.0, "Reference Mach number", fdyn);
 
@@ -278,10 +266,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::double_parameter(
       "START_THETA", 1.0, "Time integration factor for starting scheme", fdyn);
 
-  std::vector<std::string> strong_redd_3d_coupling_valid_input = {"no", "yes"};
-  Core::Utils::string_parameter("STRONG_REDD_3D_COUPLING_TYPE", "no",
-      "Flag to (de)activate potential Strong 3D redD coupling", fdyn,
-      strong_redd_3d_coupling_valid_input);
+  Core::Utils::bool_parameter("STRONG_REDD_3D_COUPLING_TYPE", "no",
+      "Flag to (de)activate potential Strong 3D redD coupling", fdyn);
 
   Core::Utils::int_parameter(
       "VELGRAD_PROJ_SOLVER", -1, "Number of linear solver used for L2 projection", fdyn);

--- a/src/inpar/4C_inpar_fluid.hpp
+++ b/src/inpar/4C_inpar_fluid.hpp
@@ -297,13 +297,6 @@ namespace Inpar
       channel_weakly_compressible,
     };
 
-    /// average pressure boundary condition for hdg
-    enum PressAvgBc
-    {
-      no_pressure_average_bc,
-      yes_pressure_average_bc
-    };
-
     /// meshtying algorithm
     enum MeshTying
     {

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -31,12 +31,12 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::string_to_integral_parameter<FpsiCouplingType>("COUPALGO", "fpsi_monolithic_plain",
       "Iteration Scheme over the fields", name, label, fpsidyn);
 
-  Core::Utils::bool_parameter("SHAPEDERIVATIVES", "No",
+  Core::Utils::bool_parameter("SHAPEDERIVATIVES", false,
       "Include linearization with respect to mesh movement in Navier Stokes equation.\n"
       "Supported in monolithic FPSI for now.",
       fpsidyn);
 
-  Core::Utils::bool_parameter("USESHAPEDERIVATIVES", "No",
+  Core::Utils::bool_parameter("USESHAPEDERIVATIVES", false,
       "Add linearization with respect to mesh movement in Navier Stokes equation to stiffness "
       "matrix.\n"
       "Supported in monolithic FPSI for now.",
@@ -48,7 +48,7 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<Inpar::FPSI::PartitionedCouplingMethod>(RobinNeumann, monolithic, nocoupling), fpsidyn);
 
   Core::Utils::bool_parameter(
-      "SECONDORDER", "No", "Second order coupling at the interface.", fpsidyn);
+      "SECONDORDER", false, "Second order coupling at the interface.", fpsidyn);
 
   // Iterationparameters
   Core::Utils::string_parameter("RESTOL", "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8",
@@ -87,12 +87,12 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>("And", "Or"), tuple<Inpar::FPSI::BinaryOp>(bop_and, bop_or), fpsidyn);
 
-  Core::Utils::bool_parameter("LineSearch", "No",
+  Core::Utils::bool_parameter("LineSearch", false,
       "adapt increment in case of non-monotonic residual convergence or residual oscillations",
       fpsidyn);
 
   Core::Utils::bool_parameter(
-      "FDCheck", "No", "perform FPSIFDCheck() finite difference check", fpsidyn);
+      "FDCheck", false, "perform FPSIFDCheck() finite difference check", fpsidyn);
 
   // number of linear solver used for poroelasticity
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -30,7 +30,7 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<Inpar::ScaTra::SolverType>(
           Inpar::ScaTra::solvertype_linear_incremental, Inpar::ScaTra::solvertype_nonlinear),
       fs3idyn);
-  Core::Utils::bool_parameter("INF_PERM", "yes", "Flag for infinite permeability", fs3idyn);
+  Core::Utils::bool_parameter("INF_PERM", true, "Flag for infinite permeability", fs3idyn);
   std::vector<std::string> consthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
   Core::Utils::string_parameter("CONSTHERMPRESS", "Yes",
       "treatment of thermodynamic pressure in time", fs3idyn, consthermpress_valid_input);
@@ -83,7 +83,7 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       fs3idyn);
 
   // Restart from FSI instead of FS3I
-  Core::Utils::bool_parameter("RESTART_FROM_PART_FSI", "No",
+  Core::Utils::bool_parameter("RESTART_FROM_PART_FSI", false,
       "restart from partitioned fsi problem (e.g. from prestress calculations) instead of fs3i",
       fs3idyn);
 

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -73,14 +73,14 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   std::string debugoutput_doc =
       "Output of unconverged interface values during FSI iteration. There will be a new control "
       "file for each time step. This might be helpful to understand the coupling iteration.";
-  Core::Utils::bool_parameter("DEBUGOUTPUT", "No", debugoutput_doc, fsidyn);
+  Core::Utils::bool_parameter("DEBUGOUTPUT", false, debugoutput_doc, fsidyn);
 
-  Core::Utils::bool_parameter("MATCHGRID_FLUIDALE", "Yes", "is matching grid (fluid-ale)", fsidyn);
+  Core::Utils::bool_parameter("MATCHGRID_FLUIDALE", true, "is matching grid (fluid-ale)", fsidyn);
 
   Core::Utils::bool_parameter(
-      "MATCHGRID_STRUCTALE", "Yes", "is matching grid (structure-ale)", fsidyn);
+      "MATCHGRID_STRUCTALE", true, "is matching grid (structure-ale)", fsidyn);
 
-  Core::Utils::bool_parameter("MATCHALL", "Yes",
+  Core::Utils::bool_parameter("MATCHALL", true,
       "is matching grid (fluid-ale) and is full fluid-ale (without euler part)", fsidyn);
 
   Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", fsidyn);
@@ -88,11 +88,11 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", fsidyn);
 
-  Core::Utils::bool_parameter("RESTART_FROM_PART_FSI", "No",
+  Core::Utils::bool_parameter("RESTART_FROM_PART_FSI", false,
       "restart from partitioned fsi (e.g. from prestress calculations) instead of monolithic fsi",
       fsidyn);
 
-  Core::Utils::bool_parameter("SECONDORDER", "No",
+  Core::Utils::bool_parameter("SECONDORDER", false,
       "Second order displacement-velocity conversion at the interface.", fsidyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::FSI::SlideALEProj>("SLIDEALEPROJ", "None",
@@ -175,7 +175,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       fsiadapt);
 
   Core::Utils::bool_parameter(
-      "TIMEADAPTON", "No", "Activate or deactivate time step size adaptivity", fsiadapt);
+      "TIMEADAPTON", false, "Activate or deactivate time step size adaptivity", fsiadapt);
 
   fsiadapt.move_into_collection(list);
 
@@ -203,13 +203,13 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "Nonlinear tolerance for lung/constraint/fluid-fluid FSI",
       fsimono);  // ToDo remove
 
-  Core::Utils::bool_parameter("ENERGYFILE", "No",
+  Core::Utils::bool_parameter("ENERGYFILE", false,
       "Write artificial interface energy due to temporal discretization to file", fsimono);
 
   Core::Utils::bool_parameter(
-      "FSIAMGANALYZE", "No", "run analysis on fsiamg multigrid scheme", fsimono);
+      "FSIAMGANALYZE", false, "run analysis on fsiamg multigrid scheme", fsimono);
 
-  Core::Utils::bool_parameter("INFNORMSCALING", "Yes", "Scale Blocks with row infnorm?", fsimono);
+  Core::Utils::bool_parameter("INFNORMSCALING", true, "Scale Blocks with row infnorm?", fsimono);
 
   Core::Utils::int_parameter(
       "ITEMAX", 100, "Maximum allowed number of nonlinear iterations", fsimono);
@@ -253,14 +253,14 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "Number of iterations in one time step reusing the preconditioner before rebuilding it",
       fsimono);
 
-  Core::Utils::bool_parameter("REBUILDPRECEVERYSTEP", "Yes",
+  Core::Utils::bool_parameter("REBUILDPRECEVERYSTEP", true,
       "Enforce rebuilding the preconditioner at the beginning of every time step", fsimono);
 
-  Core::Utils::bool_parameter("SHAPEDERIVATIVES", "No",
+  Core::Utils::bool_parameter("SHAPEDERIVATIVES", false,
       "Include linearization with respect to mesh movement in Navier Stokes equation.", fsimono);
 
   Core::Utils::bool_parameter(
-      "SYMMETRICPRECOND", "No", "Symmetric block GS preconditioner or ordinary GS", fsimono);
+      "SYMMETRICPRECOND", false, "Symmetric block GS preconditioner or ordinary GS", fsimono);
 
   // monolithic preconditioner parameter
 
@@ -378,7 +378,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::FSI::CoupVarPart::vel),
       fsipart);
 
-  Core::Utils::bool_parameter("DIVPROJECTION", "no",
+  Core::Utils::bool_parameter("DIVPROJECTION", false,
       "Project velocity into divergence-free subspace for partitioned fsi", fsipart);
 
   Core::Utils::int_parameter("ITEMAX", 100, "Maximum number of iterations over fields", fsipart);

--- a/src/inpar/4C_inpar_geometric_search.cpp
+++ b/src/inpar/4C_inpar_geometric_search.cpp
@@ -25,7 +25,7 @@ void Inpar::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO
       "radius in all directions (+ and -).",
       boundingvolumestrategy);
 
-  Core::Utils::bool_parameter("WRITE_GEOMETRIC_SEARCH_VISUALIZATION", "no",
+  Core::Utils::bool_parameter("WRITE_GEOMETRIC_SEARCH_VISUALIZATION", false,
       "If visualization output for the geometric search should be written", boundingvolumestrategy);
 
   boundingvolumestrategy.move_into_collection(list);

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -20,23 +20,23 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
 
   Core::Utils::SectionSpecs io{"IO"};
 
-  Core::Utils::bool_parameter("OUTPUT_GMSH", "No", "", io);
-  Core::Utils::bool_parameter("OUTPUT_ROT", "No", "", io);
-  Core::Utils::bool_parameter("OUTPUT_SPRING", "No", "", io);
-  Core::Utils::bool_parameter("OUTPUT_BIN", "yes", "Do you want to have binary output?", io);
+  Core::Utils::bool_parameter("OUTPUT_GMSH", false, "", io);
+  Core::Utils::bool_parameter("OUTPUT_ROT", false, "", io);
+  Core::Utils::bool_parameter("OUTPUT_SPRING", false, "", io);
+  Core::Utils::bool_parameter("OUTPUT_BIN", true, "Do you want to have binary output?", io);
 
   // Output every iteration (for debugging purposes)
-  Core::Utils::bool_parameter("OUTPUT_EVERY_ITER", "no",
+  Core::Utils::bool_parameter("OUTPUT_EVERY_ITER", false,
       "Do you desire structural displ. output every Newton iteration", io);
   Core::Utils::int_parameter(
       "OEI_FILE_COUNTER", 0, "Add an output name affix by introducing a additional number", io);
 
   Core::Utils::bool_parameter(
-      "ELEMENT_MAT_ID", "No", "Output of the material id of each element", io);
+      "ELEMENT_MAT_ID", false, "Output of the material id of each element", io);
 
   // Structural output
-  Core::Utils::bool_parameter("STRUCT_ELE", "Yes", "Output of element properties", io);
-  Core::Utils::bool_parameter("STRUCT_DISP", "Yes", "Output of displacements", io);
+  Core::Utils::bool_parameter("STRUCT_ELE", true, "Output of element properties", io);
+  Core::Utils::bool_parameter("STRUCT_DISP", true, "Output of displacements", io);
   Core::Utils::string_to_integral_parameter<Inpar::Solid::StressType>("STRUCT_STRESS", "No",
       "Output of stress",
       tuple<std::string>("No", "no", "NO", "Yes", "yes", "YES", "Cauchy", "cauchy", "2PK", "2pk"),
@@ -79,8 +79,8 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
           Inpar::Solid::optquantity_none, Inpar::Solid::optquantity_none,
           Inpar::Solid::optquantity_membranethickness),
       io);
-  Core::Utils::bool_parameter("STRUCT_SURFACTANT", "No", "", io);
-  Core::Utils::bool_parameter("STRUCT_JACOBIAN_MATLAB", "No", "", io);
+  Core::Utils::bool_parameter("STRUCT_SURFACTANT", false, "", io);
+  Core::Utils::bool_parameter("STRUCT_JACOBIAN_MATLAB", false, "", io);
   Core::Utils::string_to_integral_parameter<Inpar::Solid::ConditionNumber>(
       "STRUCT_CONDITION_NUMBER", "none",
       "Compute the condition number of the structural system matrix and write it to a text file.",
@@ -89,11 +89,11 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
           Inpar::Solid::ConditionNumber::max_min_ev_ratio, Inpar::Solid::ConditionNumber::one_norm,
           Inpar::Solid::ConditionNumber::inf_norm, Inpar::Solid::ConditionNumber::none),
       io);
-  Core::Utils::bool_parameter("FLUID_STRESS", "No", "", io);
-  Core::Utils::bool_parameter("FLUID_WALL_SHEAR_STRESS", "No", "", io);
-  Core::Utils::bool_parameter("FLUID_ELEDATA_EVERY_STEP", "No", "", io);
-  Core::Utils::bool_parameter("FLUID_NODEDATA_FIRST_STEP", "No", "", io);
-  Core::Utils::bool_parameter("THERM_TEMPERATURE", "No", "", io);
+  Core::Utils::bool_parameter("FLUID_STRESS", false, "", io);
+  Core::Utils::bool_parameter("FLUID_WALL_SHEAR_STRESS", false, "", io);
+  Core::Utils::bool_parameter("FLUID_ELEDATA_EVERY_STEP", false, "", io);
+  Core::Utils::bool_parameter("FLUID_NODEDATA_FIRST_STEP", false, "", io);
+  Core::Utils::bool_parameter("THERM_TEMPERATURE", false, "", io);
   Core::Utils::string_to_integral_parameter<Thermo::HeatFluxType>("THERM_HEATFLUX", "None", "",
       tuple<std::string>("None", "No", "NO", "no", "Current", "Initial"),
       tuple<Thermo::HeatFluxType>(Thermo::heatflux_none, Thermo::heatflux_none,
@@ -111,18 +111,18 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
       "FILESTEPS", 1000, "Amount of timesteps written to a single result file", io);
   Core::Utils::int_parameter("STDOUTEVERY", 1, "Print to screen every n step", io);
 
-  Core::Utils::bool_parameter("WRITE_TO_SCREEN", "Yes", "Write screen output", io);
-  Core::Utils::bool_parameter("WRITE_TO_FILE", "No", "Write the output into a file", io);
+  Core::Utils::bool_parameter("WRITE_TO_SCREEN", true, "Write screen output", io);
+  Core::Utils::bool_parameter("WRITE_TO_FILE", false, "Write the output into a file", io);
 
   Core::Utils::bool_parameter(
-      "WRITE_INITIAL_STATE", "yes", "Do you want to write output for initial state ?", io);
-  Core::Utils::bool_parameter("WRITE_FINAL_STATE", "no",
+      "WRITE_INITIAL_STATE", true, "Do you want to write output for initial state ?", io);
+  Core::Utils::bool_parameter("WRITE_FINAL_STATE", false,
       "Enforce to write output/restart data at the final state regardless of the other "
       "output/restart intervals",
       io);
 
   Core::Utils::bool_parameter(
-      "PREFIX_GROUP_ID", "No", "Put a <GroupID>: in front of every line", io);
+      "PREFIX_GROUP_ID", false, "Put a <GroupID>: in front of every line", io);
   Core::Utils::int_parameter(
       "LIMIT_OUTP_TO_PROC", -1, "Only the specified procs will write output", io);
   Core::Utils::string_to_integral_parameter<FourC::Core::IO::Verbositylevel>("VERBOSITY", "verbose",
@@ -145,7 +145,7 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
 
   // Output every iteration (for debugging purposes)
   Core::Utils::bool_parameter(
-      "OUTPUT_EVERY_ITER", "No", "Do you wish output every Newton iteration?", io_every_iter);
+      "OUTPUT_EVERY_ITER", false, "Do you wish output every Newton iteration?", io_every_iter);
 
   Core::Utils::int_parameter("RUN_NUMBER", -1,
       "Create a new folder for different runs of the same simulation. "
@@ -158,7 +158,7 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
       "be written.",
       io_every_iter);
 
-  Core::Utils::bool_parameter("WRITE_OWNER_EACH_NEWTON_ITER", "No",
+  Core::Utils::bool_parameter("WRITE_OWNER_EACH_NEWTON_ITER", false,
       "If yes, the ownership "
       "of elements and nodes are written each Newton step, instead of only once"
       "per time/load step.",

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -32,7 +32,7 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::ScaTra::calcerror_no_ls, Inpar::ScaTra::calcerror_initial_field),
       levelsetcontrol);
 
-  Core::Utils::bool_parameter("EXTRACT_INTERFACE_VEL", "No",
+  Core::Utils::bool_parameter("EXTRACT_INTERFACE_VEL", false,
       "replace computed velocity at nodes of given distance of interface by approximated interface "
       "velocity",
       levelsetcontrol);
@@ -54,12 +54,12 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::ScaTra::reinitaction_ellipticeq),
       ls_reinit);
 
-  Core::Utils::bool_parameter("REINIT_INITIAL", "No",
+  Core::Utils::bool_parameter("REINIT_INITIAL", false,
       "Has level set field to be reinitialized before first time step?", ls_reinit);
   Core::Utils::int_parameter("REINITINTERVAL", 1, "reinitialization interval", ls_reinit);
 
   // parameters for signed distance reinitialization
-  Core::Utils::bool_parameter("REINITBAND", "No",
+  Core::Utils::bool_parameter("REINITBAND", false,
       "reinitialization only within a band around the interface, or entire domain?", ls_reinit);
   Core::Utils::double_parameter("REINITBANDWIDTH", 1.0,
       "level-set value defining band width for reinitialization", ls_reinit);
@@ -142,7 +142,7 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
       tuple<std::string>("newton", "fixed_point"),
       tuple<Inpar::ScaTra::LinReinit>(Inpar::ScaTra::newton, Inpar::ScaTra::fixed_point),
       ls_reinit);
-  Core::Utils::bool_parameter("CORRECTOR_STEP", "yes",
+  Core::Utils::bool_parameter("CORRECTOR_STEP", true,
       "correction of interface position via volume constraint according to Sussman & Fatemi",
       ls_reinit);
   Core::Utils::double_parameter("CONVTOL_REINIT", -1.0,
@@ -150,7 +150,7 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
       ls_reinit);
 
   Core::Utils::bool_parameter(
-      "REINITVOLCORRECTION", "No", "volume correction after reinitialization", ls_reinit);
+      "REINITVOLCORRECTION", false, "volume correction after reinitialization", ls_reinit);
 
   Core::Utils::double_parameter(
       "PENALTY_PARA", -1.0, "penalty parameter for elliptic reinitialization", ls_reinit);
@@ -163,11 +163,11 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
       ls_reinit);
 
   Core::Utils::bool_parameter(
-      "PROJECTION", "yes", "use L2-projection for grad phi and related quantities", ls_reinit);
+      "PROJECTION", true, "use L2-projection for grad phi and related quantities", ls_reinit);
   Core::Utils::double_parameter(
       "PROJECTION_DIFF", 0.0, "use diffusive term for L2-projection", ls_reinit);
   Core::Utils::bool_parameter(
-      "LUMPING", "no", "use lumped mass matrix for L2-projection", ls_reinit);
+      "LUMPING", false, "use lumped mass matrix for L2-projection", ls_reinit);
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::DiffFunc>("DIFF_FUNC", "hyperbolic",
       "function for diffusivity",

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -48,7 +48,7 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::double_parameter(
       "SEARCH_PARAM", 0.3, "Radius / Bounding volume inflation for contact search", mortar);
 
-  Core::Utils::bool_parameter("SEARCH_USE_AUX_POS", "Yes",
+  Core::Utils::bool_parameter("SEARCH_USE_AUX_POS", true,
       "If chosen auxiliary position is used for computing dops", mortar);
 
   Core::Utils::string_to_integral_parameter<Inpar::Mortar::LagMultQuad>("LM_QUAD", "undefined",
@@ -59,7 +59,7 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           lagmult_pwlin, lagmult_pwlin, lagmult_lin, lagmult_lin, lagmult_const),
       mortar);
 
-  Core::Utils::bool_parameter("CROSSPOINTS", "No",
+  Core::Utils::bool_parameter("CROSSPOINTS", false,
       "If chosen, multipliers are removed from crosspoints / edge nodes", mortar);
 
   Core::Utils::string_to_integral_parameter<Inpar::Mortar::ConsistentDualType>("LM_DUAL_CONSISTENT",
@@ -105,10 +105,10 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           triangulation_center, triangulation_center),
       mortar);
 
-  Core::Utils::bool_parameter("RESTART_WITH_MESHTYING", "No",
+  Core::Utils::bool_parameter("RESTART_WITH_MESHTYING", false,
       "Must be chosen if a non-meshtying simulation is to be restarted with meshtying", mortar);
 
-  Core::Utils::bool_parameter("OUTPUT_INTERFACES", "No",
+  Core::Utils::bool_parameter("OUTPUT_INTERFACES", false,
       "Write output for each mortar interface separately.\nThis is an additional feature, purely "
       "to enhance visualization. Currently, this is limited to solid meshtying and contact w/o "
       "friction.",
@@ -120,7 +120,7 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   // parameters for parallel redistribution of mortar interfaces
   Core::Utils::SectionSpecs parallelRedist{mortar, "PARALLEL REDISTRIBUTION"};
 
-  Core::Utils::bool_parameter("EXPLOIT_PROXIMITY", "Yes",
+  Core::Utils::bool_parameter("EXPLOIT_PROXIMITY", true,
       "Exploit information on geometric proximity to split slave interface into close and "
       "non-close parts and redistribute them independently. [Contact only]",
       parallelRedist);
@@ -157,7 +157,7 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           ParallelRedist::redist_dynamic),
       parallelRedist);
 
-  Core::Utils::bool_parameter("PRINT_DISTRIBUTION", "Yes",
+  Core::Utils::bool_parameter("PRINT_DISTRIBUTION", true,
       "Print details of the parallel distribution, i.e. number of nodes/elements for each rank.",
       parallelRedist);
 

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -48,7 +48,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // write ghosted particles
   Core::Utils::bool_parameter(
-      "WRITE_GHOSTED_PARTICLES", "no", "write ghosted particles (debug feature)", particledyn);
+      "WRITE_GHOSTED_PARTICLES", false, "write ghosted particles (debug feature)", particledyn);
 
   // time loop control
   Core::Utils::double_parameter("TIMESTEP", 0.01, "time step size", particledyn);
@@ -67,7 +67,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // transfer particles to new bins every time step
   Core::Utils::bool_parameter(
-      "TRANSFER_EVERY", "no", "transfer particles to new bins every time step", particledyn);
+      "TRANSFER_EVERY", false, "transfer particles to new bins every time step", particledyn);
 
   // considered particle phases with dynamic load balance weighting factor
   Core::Utils::string_parameter("PHASE_TO_DYNLOADBALFAC", "none",
@@ -95,12 +95,13 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // flags defining considered states of particle wall
   Core::Utils::bool_parameter(
-      "PARTICLE_WALL_MOVING", "no", "consider a moving particle wall", particledyn);
+      "PARTICLE_WALL_MOVING", false, "consider a moving particle wall", particledyn);
   Core::Utils::bool_parameter(
-      "PARTICLE_WALL_LOADED", "no", "consider loading on particle wall", particledyn);
+      "PARTICLE_WALL_LOADED", false, "consider loading on particle wall", particledyn);
 
   // consider rigid body motion
-  Core::Utils::bool_parameter("RIGID_BODY_MOTION", "no", "consider rigid body motion", particledyn);
+  Core::Utils::bool_parameter(
+      "RIGID_BODY_MOTION", false, "consider rigid body motion", particledyn);
 
   Core::Utils::double_parameter("RIGID_BODY_PHASECHANGE_RADIUS", -1.0,
       "search radius for neighboring rigid bodies in case of phase change", particledyn);
@@ -157,7 +158,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::SectionSpecs particledynsph{particledyn, "SPH"};
 
   // write particle-wall interaction output
-  Core::Utils::bool_parameter("WRITE_PARTICLE_WALL_INTERACTION", "no",
+  Core::Utils::bool_parameter("WRITE_PARTICLE_WALL_INTERACTION", false,
       "write particle-wall interaction output", particledynsph);
 
   // type of smoothed particle hydrodynamics kernel
@@ -256,7 +257,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       particledynsph);
 
   Core::Utils::bool_parameter(
-      "TEMPERATUREGRADIENT", "no", "evaluate temperature gradient", particledynsph);
+      "TEMPERATUREGRADIENT", false, "evaluate temperature gradient", particledynsph);
 
   // type of heat source
   Core::Utils::string_to_integral_parameter<HeatSourceType>("HEATSOURCETYPE", "NoHeatSource",
@@ -274,7 +275,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // evaporation induced heat loss
   Core::Utils::bool_parameter(
-      "VAPOR_HEATLOSS", "no", "evaluate evaporation induced heat loss", particledynsph);
+      "VAPOR_HEATLOSS", false, "evaluate evaporation induced heat loss", particledynsph);
   Core::Utils::double_parameter(
       "VAPOR_HEATLOSS_LATENTHEAT", 0.0, "latent heat in heat loss formula", particledynsph);
   Core::Utils::double_parameter("VAPOR_HEATLOSS_ENTHALPY_REFTEMP", 0.0,
@@ -286,7 +287,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // evaporation induced recoil pressure
   Core::Utils::bool_parameter(
-      "VAPOR_RECOIL", "no", "evaluate evaporation induced recoil pressure", particledynsph);
+      "VAPOR_RECOIL", false, "evaluate evaporation induced recoil pressure", particledynsph);
   Core::Utils::double_parameter("VAPOR_RECOIL_BOILINGTEMPERATURE", 0.0,
       "boiling temperature in recoil pressure formula", particledynsph);
   Core::Utils::double_parameter(
@@ -324,14 +325,14 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // interface viscosity
   Core::Utils::bool_parameter(
-      "INTERFACE_VISCOSITY", "no", "evaluate interface viscosity", particledynsph);
+      "INTERFACE_VISCOSITY", false, "evaluate interface viscosity", particledynsph);
   Core::Utils::double_parameter("INTERFACE_VISCOSITY_LIQUIDGAS", 0.0,
       "artificial viscosity on liquid-gas interface", particledynsph);
   Core::Utils::double_parameter("INTERFACE_VISCOSITY_SOLIDLIQUID", 0.0,
       "artificial viscosity on solid-liquid interface", particledynsph);
 
   // barrier force
-  Core::Utils::bool_parameter("BARRIER_FORCE", "no", "evaluate barrier force", particledynsph);
+  Core::Utils::bool_parameter("BARRIER_FORCE", false, "evaluate barrier force", particledynsph);
   Core::Utils::double_parameter(
       "BARRIER_FORCE_DISTANCE", 0.0, "barrier force distance", particledynsph);
   Core::Utils::double_parameter(
@@ -430,10 +431,10 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
 
   // write particle energy output
   Core::Utils::bool_parameter(
-      "WRITE_PARTICLE_ENERGY", "no", "write particle energy output", particledyndem);
+      "WRITE_PARTICLE_ENERGY", false, "write particle energy output", particledyndem);
 
   // write particle-wall interaction output
-  Core::Utils::bool_parameter("WRITE_PARTICLE_WALL_INTERACTION", "no",
+  Core::Utils::bool_parameter("WRITE_PARTICLE_WALL_INTERACTION", false,
       "write particle-wall interaction output", particledyndem);
 
   // type of normal contact law
@@ -513,7 +514,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "$|g| < (\\text{DAMP_REG_FAC} \\cdot r_{\\min})$",
       particledyndem);
   Core::Utils::bool_parameter(
-      "TENSION_CUTOFF", "yes", "evaluate tension cutoff of normal contact force", particledyndem);
+      "TENSION_CUTOFF", true, "evaluate tension cutoff of normal contact force", particledyndem);
 
   Core::Utils::double_parameter("POISSON_RATIO", -1.0, "poisson ratio", particledyndem);
   Core::Utils::double_parameter("YOUNG_MODULUS", -1.0, "young's modulus", particledyndem);
@@ -530,11 +531,11 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "ADHESION_MAX_CONTACT_PRESSURE", 0.0, "adhesion maximum contact pressure", particledyndem);
   Core::Utils::double_parameter(
       "ADHESION_MAX_CONTACT_FORCE", 0.0, "adhesion maximum contact force", particledyndem);
-  Core::Utils::bool_parameter("ADHESION_USE_MAX_CONTACT_FORCE", "no",
+  Core::Utils::bool_parameter("ADHESION_USE_MAX_CONTACT_FORCE", false,
       "use maximum contact force instead of maximum contact pressure", particledyndem);
 
   Core::Utils::bool_parameter(
-      "ADHESION_VDW_CURVE_SHIFT", "no", "shifts van-der-Waals-curve to g = 0", particledyndem);
+      "ADHESION_VDW_CURVE_SHIFT", false, "shifts van-der-Waals-curve to g = 0", particledyndem);
 
   Core::Utils::double_parameter(
       "ADHESION_HAMAKER", -1.0, "hamaker constant of van-der-Waals interaction", particledyndem);

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -56,7 +56,7 @@ void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "tolerance of relative interface force increments in partitioned iterations", pasidyn);
 
   Core::Utils::bool_parameter(
-      "IGNORE_CONV_CHECK", "no", "ignore convergence check and proceed simulation", pasidyn);
+      "IGNORE_CONV_CHECK", false, "ignore convergence check and proceed simulation", pasidyn);
 
   // parameters for relaxation
   Core::Utils::double_parameter("STARTOMEGA", 1.0, "fixed relaxation parameter", pasidyn);

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -113,18 +113,18 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
       poroelastdyn);
 
   Core::Utils::bool_parameter(
-      "SECONDORDER", "Yes", "Second order coupling at the interface.", poroelastdyn);
+      "SECONDORDER", true, "Second order coupling at the interface.", poroelastdyn);
 
-  Core::Utils::bool_parameter("CONTIPARTINT", "No",
+  Core::Utils::bool_parameter("CONTIPARTINT", false,
       "Partial integration of porosity gradient in continuity equation", poroelastdyn);
 
-  Core::Utils::bool_parameter("CONTACT_NO_PENETRATION", "No",
+  Core::Utils::bool_parameter("CONTACT_NO_PENETRATION", false,
       "No-Penetration Condition on active contact surface in case of poro contact problem!",
       poroelastdyn);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", "Yes", "is matching grid", poroelastdyn);
+  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", poroelastdyn);
 
-  Core::Utils::bool_parameter("CONVECTIVE_TERM", "No", "convective term ", poroelastdyn);
+  Core::Utils::bool_parameter("CONVECTIVE_TERM", false, "convective term ", poroelastdyn);
 
   // number of linear solver used for poroelasticity
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,

--- a/src/inpar/4C_inpar_porofluidmultiphase.cpp
+++ b/src/inpar/4C_inpar_porofluidmultiphase.cpp
@@ -53,7 +53,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasedyn);
 
   // convergence criteria adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution",
       porofluidmultiphasedyn);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
@@ -73,20 +73,20 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasedyn);
   Core::Utils::double_parameter("FDCHECKTOL", 1.e-6,
       "relative tolerance for finite difference check", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("SKIPINITDER", "yes",
+  Core::Utils::bool_parameter("SKIPINITDER", true,
       "Flag to skip computation of initial time derivative", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_SATANDPRESS", "yes",
+  Core::Utils::bool_parameter("OUTPUT_SATANDPRESS", true,
       "Flag if output of saturations and pressures should be calculated", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_SOLIDPRESS", "yes",
+  Core::Utils::bool_parameter("OUTPUT_SOLIDPRESS", true,
       "Flag if output of solid pressure should be calculated", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_POROSITY", "yes",
+  Core::Utils::bool_parameter("OUTPUT_POROSITY", true,
       "Flag if output of porosity should be calculated", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_PHASE_VELOCITIES", "yes",
+  Core::Utils::bool_parameter("OUTPUT_PHASE_VELOCITIES", true,
       "Flag if output of phase velocities should be calculated", porofluidmultiphasedyn);
 
   // Biot stabilization
   Core::Utils::bool_parameter(
-      "STAB_BIOT", "No", "Flag to (de)activate BIOT stabilization.", porofluidmultiphasedyn);
+      "STAB_BIOT", false, "Flag to (de)activate BIOT stabilization.", porofluidmultiphasedyn);
   Core::Utils::double_parameter("STAB_BIOT_SCALING", 1.0,
       "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
       porofluidmultiphasedyn);
@@ -145,7 +145,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
 
   // coupling with 1D artery network active
   Core::Utils::bool_parameter(
-      "ARTERY_COUPLING", "No", "Coupling with 1D blood vessels.", porofluidmultiphasedyn);
+      "ARTERY_COUPLING", false, "Coupling with 1D blood vessels.", porofluidmultiphasedyn);
 
   Core::Utils::double_parameter("STARTING_DBC_TIME_END", -1.0,
       "End time for the starting Dirichlet BC.", porofluidmultiphasedyn);
@@ -211,13 +211,13 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       "SCALEREAC_CONT", "0", "scale for coupling (porofluid part)", porofluidmultiphasemshtdyn);
 
   // Flag if artery elements are evaluated in reference or current configuration
-  Core::Utils::bool_parameter("EVALUATE_IN_REF_CONFIG", "yes",
+  Core::Utils::bool_parameter("EVALUATE_IN_REF_CONFIG", true,
       "Flag if artery elements are evaluated in reference or current configuration",
       porofluidmultiphasemshtdyn);
 
   // Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of embedded artery
   // elements
-  Core::Utils::bool_parameter("LATERAL_SURFACE_COUPLING", "no",
+  Core::Utils::bool_parameter("LATERAL_SURFACE_COUPLING", false,
       "Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of embedded artery "
       "elements",
       porofluidmultiphasemshtdyn);
@@ -235,16 +235,16 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasemshtdyn);
 
   // Flag if blood vessel volume fraction should be output
-  Core::Utils::bool_parameter("OUTPUT_BLOODVESSELVOLFRAC", "no",
+  Core::Utils::bool_parameter("OUTPUT_BLOODVESSELVOLFRAC", false,
       "Flag if output of blood vessel volume fraction should be calculated",
       porofluidmultiphasemshtdyn);
 
   // Flag if summary of coupling-pairs should be printed
-  Core::Utils::bool_parameter("PRINT_OUT_SUMMARY_PAIRS", "no",
+  Core::Utils::bool_parameter("PRINT_OUT_SUMMARY_PAIRS", false,
       "Flag if summary of coupling-pairs should be printed", porofluidmultiphasemshtdyn);
 
   // Flag if free-hanging elements (after blood vessel collapse) should be deleted
-  Core::Utils::bool_parameter("DELETE_FREE_HANGING_ELES", "no",
+  Core::Utils::bool_parameter("DELETE_FREE_HANGING_ELES", false,
       "Flag if free-hanging elements (after blood vessel collapse) should be deleted",
       porofluidmultiphasemshtdyn);
 

--- a/src/inpar/4C_inpar_poromultiphase.cpp
+++ b/src/inpar/4C_inpar_poromultiphase.cpp
@@ -37,7 +37,7 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
   // here the computation of the structure can be skipped, this is helpful if only fluid-scatra
   // coupling should be calculated
   Core::Utils::bool_parameter(
-      "SOLVE_STRUCTURE", "yes", "Flag to skip computation of structural field", poromultiphasedyn);
+      "SOLVE_STRUCTURE", true, "Flag to skip computation of structural field", poromultiphasedyn);
 
 
   // Coupling strategy for solvers
@@ -49,7 +49,7 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
 
   // coupling with 1D artery network active
   Core::Utils::bool_parameter(
-      "ARTERY_COUPLING", "No", "Coupling with 1D blood vessels.", poromultiphasedyn);
+      "ARTERY_COUPLING", false, "Coupling with 1D blood vessels.", poromultiphasedyn);
 
   poromultiphasedyn.move_into_collection(list);
 
@@ -105,7 +105,7 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
       poromultiphasedynmono);
 
   // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution",
       poromultiphasedynmono);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.001,

--- a/src/inpar/4C_inpar_poromultiphase_scatra.cpp
+++ b/src/inpar/4C_inpar_poromultiphase_scatra.cpp
@@ -51,7 +51,7 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
 
   // coupling with 1D artery network active
   Core::Utils::bool_parameter(
-      "ARTERY_COUPLING", "No", "Coupling with 1D blood vessels.", poromultiphasescatradyn);
+      "ARTERY_COUPLING", false, "Coupling with 1D blood vessels.", poromultiphasescatradyn);
 
   // no convergence of coupling scheme
   Core::Utils::string_to_integral_parameter<DivContAct>("DIVERCONT", "stop",
@@ -82,7 +82,7 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
       poromultiphasescatradynmono);
 
   // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution",
       poromultiphasescatradynmono);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.001,

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -104,7 +104,7 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
           Monolithic, Part_ScatraToPoro, Part_PoroToScatra, Part_TwoWay),
       poroscatradyn);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", "Yes", "is matching grid", poroscatradyn);
+  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", poroscatradyn);
 
   poroscatradyn.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -41,7 +41,7 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       s2icoupling);
 
   // flag for evaluation of interface linearizations and residuals on slave side only
-  Core::Utils::bool_parameter("SLAVEONLY", "No",
+  Core::Utils::bool_parameter("SLAVEONLY", false,
       "flag for evaluation of interface linearizations and residuals on slave side only",
       s2icoupling);
 
@@ -84,10 +84,10 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "growth",
       s2icoupling);
 
-  Core::Utils::bool_parameter("MESHTYING_CONDITIONS_INDEPENDENT_SETUP", "No",
+  Core::Utils::bool_parameter("MESHTYING_CONDITIONS_INDEPENDENT_SETUP", false,
       "mesh tying for different conditions should be setup independently", s2icoupling);
 
-  Core::Utils::bool_parameter("OUTPUT_INTERFACE_FLUX", "No",
+  Core::Utils::bool_parameter("OUTPUT_INTERFACE_FLUX", false,
       "evaluate integral of coupling flux on slave side for each s2i condition and write it to csv "
       "file",
       s2icoupling);

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -108,7 +108,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::int_parameter(
       "INITFUNCNO", -1, "function number for scalar transport initial field", scatradyn);
 
-  Core::Utils::bool_parameter("SPHERICALCOORDS", "No", "use of spherical coordinates", scatradyn);
+  Core::Utils::bool_parameter("SPHERICALCOORDS", false, "use of spherical coordinates", scatradyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::CalcError>("CALCERROR", "No",
       "compute error compared to analytical solution",
@@ -127,7 +127,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<std::string>("No", "total", "diffusive"),
       tuple<Inpar::ScaTra::FluxType>(flux_none, flux_total, flux_diffusive), scatradyn);
 
-  Core::Utils::bool_parameter("CALCFLUX_DOMAIN_LUMPED", "Yes",
+  Core::Utils::bool_parameter("CALCFLUX_DOMAIN_LUMPED", true,
       "perform approximate domain flux calculation involving matrix lumping", scatradyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FluxType>("CALCFLUX_BOUNDARY", "No",
@@ -136,7 +136,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<Inpar::ScaTra::FluxType>(flux_none, flux_total, flux_diffusive, flux_convective),
       scatradyn);
 
-  Core::Utils::bool_parameter("CALCFLUX_BOUNDARY_LUMPED", "Yes",
+  Core::Utils::bool_parameter("CALCFLUX_BOUNDARY_LUMPED", true,
       "perform approximate boundary flux calculation involving matrix lumping", scatradyn);
 
   Core::Utils::string_parameter("WRITEFLUX_IDS", "-1",
@@ -150,13 +150,13 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           outputscalars_condition, outputscalars_entiredomain_condition),
       scatradyn);
   Core::Utils::bool_parameter(
-      "OUTPUTSCALARSMEANGRAD", "No", "Output of mean gradient of scalars", scatradyn);
+      "OUTPUTSCALARSMEANGRAD", false, "Output of mean gradient of scalars", scatradyn);
   Core::Utils::bool_parameter(
-      "OUTINTEGRREAC", "No", "Output of integral reaction values", scatradyn);
+      "OUTINTEGRREAC", false, "Output of integral reaction values", scatradyn);
   Core::Utils::bool_parameter(
-      "OUTPUT_GMSH", "No", "Do you want to write Gmsh postprocessing files?", scatradyn);
+      "OUTPUT_GMSH", false, "Do you want to write Gmsh postprocessing files?", scatradyn);
 
-  Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", "No",
+  Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", false,
       "Do you want to write the state solution to Matlab file?", scatradyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ConvForm>("CONVFORM", "convective",
@@ -164,13 +164,13 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<Inpar::ScaTra::ConvForm>(convform_convective, convform_conservative), scatradyn);
 
   Core::Utils::bool_parameter(
-      "NEUMANNINFLOW", "no", "Flag to (de)activate potential Neumann inflow term(s)", scatradyn);
+      "NEUMANNINFLOW", false, "Flag to (de)activate potential Neumann inflow term(s)", scatradyn);
 
-  Core::Utils::bool_parameter("CONV_HEAT_TRANS", "no",
+  Core::Utils::bool_parameter("CONV_HEAT_TRANS", false,
       "Flag to (de)activate potential convective heat transfer boundary conditions", scatradyn);
 
   Core::Utils::bool_parameter(
-      "SKIPINITDER", "no", "Flag to skip computation of initial time derivative", scatradyn);
+      "SKIPINITDER", false, "Flag to skip computation of initial time derivative", scatradyn);
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FSSUGRDIFF>("FSSUGRDIFF", "No",
       "fine-scale subgrid diffusivity",
@@ -180,7 +180,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       scatradyn);
 
   // flag for output of performance statistics associated with nonlinear solver into *.csv file
-  Core::Utils::bool_parameter("ELECTROMAGNETICDIFFUSION", "No",
+  Core::Utils::bool_parameter("ELECTROMAGNETICDIFFUSION", false,
       "flag to activate electromagnetic diffusion problems", scatradyn);
 
   // Current density source function for EMD problems
@@ -230,7 +230,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   // flag for natural convection effects
   Core::Utils::bool_parameter(
-      "NATURAL_CONVECTION", "No", "Include natural convection effects", scatradyn);
+      "NATURAL_CONVECTION", false, "Include natural convection effects", scatradyn);
 
   // parameters for finite difference check
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FdCheck>("FDCHECK", "none",
@@ -263,33 +263,33 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   // parameter for using p-adpativity and semi-implicit evaluation of the reaction term (at the
   // moment only used for HDG and cardiac monodomain problems)
-  Core::Utils::bool_parameter("PADAPTIVITY", "no", "Flag to (de)activate p-adativity", scatradyn);
+  Core::Utils::bool_parameter("PADAPTIVITY", false, "Flag to (de)activate p-adativity", scatradyn);
   Core::Utils::double_parameter("PADAPTERRORTOL", 1e-6,
       "The error tolerance to calculate the variation of the elemental degree", scatradyn);
   Core::Utils::double_parameter("PADAPTERRORBASE", 1.66,
       "The error tolerance base to calculate the variation of the elemental degree", scatradyn);
   Core::Utils::int_parameter(
       "PADAPTDEGREEMAX", 4, "The max. degree of the shape functions", scatradyn);
-  Core::Utils::bool_parameter("SEMIIMPLICIT", "no",
+  Core::Utils::bool_parameter("SEMIIMPLICIT", false,
       "Flag to (de)activate semi-implicit calculation of the reaction term", scatradyn);
 
   // flag for output of performance statistics associated with linear solver into *.csv file
-  Core::Utils::bool_parameter("OUTPUTLINSOLVERSTATS", "No",
+  Core::Utils::bool_parameter("OUTPUTLINSOLVERSTATS", false,
       "flag for output of performance statistics associated with linear solver into csv file",
       scatradyn);
 
   // flag for output of performance statistics associated with nonlinear solver into *.csv file
-  Core::Utils::bool_parameter("OUTPUTNONLINSOLVERSTATS", "No",
+  Core::Utils::bool_parameter("OUTPUTNONLINSOLVERSTATS", false,
       "flag for output of performance statistics associated with nonlinear solver into csv file",
       scatradyn);
 
   // flag for point-based null space calculation
   Core::Utils::bool_parameter(
-      "NULLSPACE_POINTBASED", "No", "flag for point-based null space calculation", scatradyn);
+      "NULLSPACE_POINTBASED", false, "flag for point-based null space calculation", scatradyn);
 
   // flag for adaptive time stepping
   Core::Utils::bool_parameter(
-      "ADAPTIVE_TIMESTEPPING", "No", "flag for adaptive time stepping", scatradyn);
+      "ADAPTIVE_TIMESTEPPING", false, "flag for adaptive time stepping", scatradyn);
 
   scatradyn.move_into_collection(list);
 
@@ -306,14 +306,14 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       "Convergence check tolerance for outer loop in partitioned coupling schemes (natural "
       "convection, multi-scale simulations etc.)",
       scatra_nonlin);
-  Core::Utils::bool_parameter("EXPLPREDICT", "no",
+  Core::Utils::bool_parameter("EXPLPREDICT", false,
       "do an explicit predictor step before starting nonlinear iteration", scatra_nonlin);
   Core::Utils::double_parameter("ABSTOLRES", 1e-14,
       "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
       scatra_nonlin);
 
   // convergence criteria adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution",
       scatra_nonlin);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
@@ -336,10 +336,10 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   // this parameter governs whether subgrid-scale velocity is included
   Core::Utils::bool_parameter(
-      "SUGRVEL", "no", "potential incorporation of subgrid-scale velocity", scatradyn_stab);
+      "SUGRVEL", false, "potential incorporation of subgrid-scale velocity", scatradyn_stab);
 
   // this parameter governs whether all-scale subgrid diffusivity is included
-  Core::Utils::bool_parameter("ASSUGRDIFF", "no",
+  Core::Utils::bool_parameter("ASSUGRDIFF", false,
       "potential incorporation of all-scale subgrid diffusivity (a.k.a. discontinuity-capturing) "
       "term",
       scatradyn_stab);
@@ -460,7 +460,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   // Flag for external force
   Core::Utils::bool_parameter(
-      "EXTERNAL_FORCE", "No", "Flag to activate external force", scatradyn_external_force);
+      "EXTERNAL_FORCE", false, "Flag to activate external force", scatradyn_external_force);
 
   // Function ID for external force
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -63,7 +63,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     Core::Utils::double_parameter("Forcing Term Maximum Tolerance", 0.01, "", newton);
     Core::Utils::double_parameter("Forcing Term Alpha", 1.5, "used only by \"Type 2\"", newton);
     Core::Utils::double_parameter("Forcing Term Gamma", 0.9, "used only by \"Type 2\"", newton);
-    Core::Utils::bool_parameter("Rescue Bad Newton Solve", "Yes",
+    Core::Utils::bool_parameter("Rescue Bad Newton Solve", true,
         "If set to true, we will use "
         "the computed direction even if the linear solve does not achieve the tolerance "
         "specified by the forcing term",
@@ -166,7 +166,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "A multiplier between zero and one that reduces the step size between line search "
         "iterations",
         backtrack);
-    Core::Utils::bool_parameter("Allow Exceptions", "No",
+    Core::Utils::bool_parameter("Allow Exceptions", false,
         "Set to true, if exceptions during the force evaluation and backtracking routine should be "
         "allowed.",
         backtrack);
@@ -218,12 +218,12 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     Core::Utils::double_parameter(
         "Alpha Factor", 1.0e-4, "Parameter choice for sufficient decrease condition", polynomial);
-    Core::Utils::bool_parameter("Force Interpolation", "No",
+    Core::Utils::bool_parameter("Force Interpolation", false,
         "Set to true if at least one interpolation step should be used. The default is false which "
         "means that the line search will stop if the default step length satisfies the convergence "
         "criteria",
         polynomial);
-    Core::Utils::bool_parameter("Use Counters", "Yes",
+    Core::Utils::bool_parameter("Use Counters", true,
         "Set to true if we should use counters and then output the result to the parameter list as "
         "described in Output Parameters",
         polynomial);
@@ -269,7 +269,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "Choice to use for the sufficient decrease condition", morethuente,
         sufficient_decrease_condition_valid_input);
 
-    Core::Utils::bool_parameter("Optimize Slope Calculation", "No",
+    Core::Utils::bool_parameter("Optimize Slope Calculation", false,
         "Boolean value. If set to true the value of $s^T J^T F$ is estimated using a "
         "directional derivative in a call to ::NOX::LineSearch::Common::computeSlopeWithOutJac. "
         "If false the slope computation is computed with the "
@@ -309,16 +309,16 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs printing{snox, "Printing"};
 
   {
-    Core::Utils::bool_parameter("Error", "No", "", printing);
-    Core::Utils::bool_parameter("Warning", "Yes", "", printing);
-    Core::Utils::bool_parameter("Outer Iteration", "Yes", "", printing);
-    Core::Utils::bool_parameter("Inner Iteration", "Yes", "", printing);
-    Core::Utils::bool_parameter("Parameters", "No", "", printing);
-    Core::Utils::bool_parameter("Details", "No", "", printing);
-    Core::Utils::bool_parameter("Outer Iteration StatusTest", "Yes", "", printing);
-    Core::Utils::bool_parameter("Linear Solver Details", "No", "", printing);
-    Core::Utils::bool_parameter("Test Details", "No", "", printing);
-    Core::Utils::bool_parameter("Debug", "No", "", printing);
+    Core::Utils::bool_parameter("Error", false, "", printing);
+    Core::Utils::bool_parameter("Warning", true, "", printing);
+    Core::Utils::bool_parameter("Outer Iteration", true, "", printing);
+    Core::Utils::bool_parameter("Inner Iteration", true, "", printing);
+    Core::Utils::bool_parameter("Parameters", false, "", printing);
+    Core::Utils::bool_parameter("Details", false, "", printing);
+    Core::Utils::bool_parameter("Outer Iteration StatusTest", true, "", printing);
+    Core::Utils::bool_parameter("Linear Solver Details", false, "", printing);
+    Core::Utils::bool_parameter("Test Details", false, "", printing);
+    Core::Utils::bool_parameter("Debug", false, "", printing);
   }
   printing.move_into_collection(list);
 
@@ -355,7 +355,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   {
     // convergence criteria adaptivity
-    Core::Utils::bool_parameter("Adaptive Control", "No",
+    Core::Utils::bool_parameter("Adaptive Control", false,
         "Switch on adaptive control of linear solver tolerance for nonlinear solution",
         linearSolver);
     Core::Utils::double_parameter("Adaptive Control Objective", 0.1,
@@ -363,12 +363,12 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "nonlinear convergence limit",
         linearSolver);
     Core::Utils::bool_parameter(
-        "Zero Initial Guess", "Yes", "Zero out the delta X vector if requested.", linearSolver);
-    Core::Utils::bool_parameter("Computing Scaling Manually", "No",
+        "Zero Initial Guess", true, "Zero out the delta X vector if requested.", linearSolver);
+    Core::Utils::bool_parameter("Computing Scaling Manually", false,
         "Allows the manually scaling of your linear system (not supported at the moment).",
         linearSolver);
-    Core::Utils::bool_parameter("Output Solver Details", "Yes",
-        "Switch the linear solver output on and off.", linearSolver);
+    Core::Utils::bool_parameter(
+        "Output Solver Details", true, "Switch the linear solver output on and off.", linearSolver);
   }
   linearSolver.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -33,11 +33,11 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", ssidyn);
   Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", ssidyn);
   Core::Utils::bool_parameter(
-      "DIFFTIMESTEPSIZE", "No", "use different step size for scatra and solid", ssidyn);
+      "DIFFTIMESTEPSIZE", false, "use different step size for scatra and solid", ssidyn);
   Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", ssidyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ssidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ssidyn);
-  Core::Utils::bool_parameter("SCATRA_FROM_RESTART_FILE", "No",
+  Core::Utils::bool_parameter("SCATRA_FROM_RESTART_FILE", false,
       "read scatra result from restart files (use option 'restartfromfile' during execution of "
       "4C)",
       ssidyn);
@@ -84,16 +84,16 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       ssidyn);
 
   // Restart from Structure problem instead of SSI
-  Core::Utils::bool_parameter("RESTART_FROM_STRUCTURE", "no",
+  Core::Utils::bool_parameter("RESTART_FROM_STRUCTURE", false,
       "restart from structure problem (e.g. from prestress calculations) instead of ssi", ssidyn);
 
   // Adaptive time stepping
   Core::Utils::bool_parameter(
-      "ADAPTIVE_TIMESTEPPING", "no", "flag for adaptive time stepping", ssidyn);
+      "ADAPTIVE_TIMESTEPPING", false, "flag for adaptive time stepping", ssidyn);
 
   // do redistribution by binning of solid mechanics discretization (scatra dis is cloned from solid
   // dis for volume_matching and volumeboundary_matching)
-  Core::Utils::bool_parameter("REDISTRIBUTE_SOLID", "No",
+  Core::Utils::bool_parameter("REDISTRIBUTE_SOLID", false,
       "redistribution by binning of solid mechanics discretization", ssidyn);
 
   ssidyn.move_into_collection(list);
@@ -177,7 +177,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Core::LinAlg::EquilibrationMethod::symmetry),
       ssidynmono);
 
-  Core::Utils::bool_parameter("PRINT_MAT_RHS_MAP_MATLAB", "no",
+  Core::Utils::bool_parameter("PRINT_MAT_RHS_MAP_MATLAB", false,
       "print system matrix, rhs vector, and full map to matlab readable file after solution of "
       "time step",
       ssidynmono);
@@ -200,9 +200,9 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ssidynmanifold{ssidyn, "MANIFOLD"};
 
   Core::Utils::bool_parameter(
-      "ADD_MANIFOLD", "no", "activate additional manifold?", ssidynmanifold);
+      "ADD_MANIFOLD", false, "activate additional manifold?", ssidynmanifold);
 
-  Core::Utils::bool_parameter("MESHTYING_MANIFOLD", "no",
+  Core::Utils::bool_parameter("MESHTYING_MANIFOLD", false,
       "activate meshtying between all manifold fields in case they intersect?", ssidynmanifold);
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("INITIALFIELD",
@@ -218,7 +218,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::int_parameter(
       "LINEAR_SOLVER", -1, "linear solver for scalar transport on manifold", ssidynmanifold);
 
-  Core::Utils::bool_parameter("OUTPUT_INFLOW", "no",
+  Core::Utils::bool_parameter("OUTPUT_INFLOW", false,
       "write output of inflow of scatra manifold - scatra coupling into scatra manifold to csv "
       "file",
       ssidynmanifold);
@@ -229,7 +229,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   /* parameters for SSI with elch */
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs ssidynelch{ssidyn, "ELCH"};
-  Core::Utils::bool_parameter("INITPOTCALC", "No",
+  Core::Utils::bool_parameter("INITPOTCALC", false,
       "Automatically calculate initial field for electric potential", ssidynelch);
 
   ssidynelch.move_into_collection(list);

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -33,7 +33,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", sstidyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", sstidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", sstidyn);
-  Core::Utils::bool_parameter("SCATRA_FROM_RESTART_FILE", "No",
+  Core::Utils::bool_parameter("SCATRA_FROM_RESTART_FILE", false,
       "read scatra result from restart files (use option 'restartfromfile' during execution of "
       "4C)",
       sstidyn);
@@ -47,7 +47,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "time integration scheme for ssi problems",
       tuple<std::string>("Elch"), tuple<ScaTraTimIntType>(ScaTraTimIntType::elch), sstidyn);
   Core::Utils::bool_parameter(
-      "ADAPTIVE_TIMESTEPPING", "no", "flag for adaptive time stepping", sstidyn);
+      "ADAPTIVE_TIMESTEPPING", false, "flag for adaptive time stepping", sstidyn);
 
   sstidyn.move_into_collection(list);
 
@@ -110,7 +110,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           Core::LinAlg::EquilibrationMethod::rowsandcolumns_maindiag,
           Core::LinAlg::EquilibrationMethod::symmetry),
       sstidynmono);
-  Core::Utils::bool_parameter("EQUILIBRATION_INIT_SCATRA", "no",
+  Core::Utils::bool_parameter("EQUILIBRATION_INIT_SCATRA", false,
       "use equilibration method of ScaTra to equilibrate initial calculation of potential",
       sstidynmono);
 

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -62,7 +62,7 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "THERMO_LINEAR_SOLVER", -1, "ID of linear solver for temperature field", stidyn);
 
   // flag for double condensation of linear equations associated with temperature field
-  Core::Utils::bool_parameter("THERMO_CONDENSATION", "No",
+  Core::Utils::bool_parameter("THERMO_CONDENSATION", false,
       "flag for double condensation of linear equations associated with temperature field", stidyn);
 
   stidyn.move_into_collection(list);

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -30,7 +30,7 @@ namespace Inpar
           tuple<Solid::IntegrationStrategy>(int_old, int_standard), sdyn);
 
       Core::Utils::bool_parameter(
-          "TIME_ADAPTIVITY", "No", "Enable adaptive time integration", sdyn);
+          "TIME_ADAPTIVITY", false, "Enable adaptive time integration", sdyn);
 
       Core::Utils::string_to_integral_parameter<Solid::DynamicType>("DYNAMICTYPE", "GenAlpha",
           "type of the specific dynamic time integration scheme",
@@ -67,7 +67,7 @@ namespace Inpar
           "RESEVERYERGY", 0, "write system energies every requested step", sdyn);
       Core::Utils::int_parameter(
           "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", sdyn);
-      Core::Utils::bool_parameter("CALC_ACC_ON_RESTART", "No",
+      Core::Utils::bool_parameter("CALC_ACC_ON_RESTART", false,
           "Compute the initial state for a restart dynamics analysis", sdyn);
       Core::Utils::int_parameter("OUTPUT_STEP_OFFSET", 0,
           "An offset added to the current step to shift the steps to be written.", sdyn);
@@ -187,7 +187,7 @@ namespace Inpar
 
 
       Core::Utils::bool_parameter(
-          "LOADLIN", "No", "Use linearization of external follower load in Newton", sdyn);
+          "LOADLIN", false, "Use linearization of external follower load in Newton", sdyn);
 
       Core::Utils::string_to_integral_parameter<Solid::MassLin>("MASSLIN", "No",
           "Application of nonlinear inertia terms",
@@ -196,7 +196,7 @@ namespace Inpar
               ml_none, ml_none, ml_standard, ml_standard, ml_rotations, ml_rotations),
           sdyn);
 
-      Core::Utils::bool_parameter("NEGLECTINERTIA", "No", "Neglect inertia", sdyn);
+      Core::Utils::bool_parameter("NEGLECTINERTIA", false, "Neglect inertia", sdyn);
 
       // Since predictor "none" would be misleading, the usage of no predictor is called vague.
       Core::Utils::string_to_integral_parameter<Solid::PredEnum>("PREDICT", "ConstDis",
@@ -222,7 +222,7 @@ namespace Inpar
           tuple<Solid::ConSolveAlgo>(consolve_uzawa, consolve_simple, consolve_direct), sdyn);
 
       // convergence criteria adaptivity
-      Core::Utils::bool_parameter("ADAPTCONV", "No",
+      Core::Utils::bool_parameter("ADAPTCONV", false,
           "Switch on adaptive control of linear solver tolerance for nonlinear solution", sdyn);
       Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
           "The linear solver shall be this much better than the current nonlinear residual in the "
@@ -230,9 +230,9 @@ namespace Inpar
           sdyn);
 
       Core::Utils::bool_parameter(
-          "LUMPMASS", "No", "Lump the mass matrix for explicit time integration", sdyn);
+          "LUMPMASS", false, "Lump the mass matrix for explicit time integration", sdyn);
 
-      Core::Utils::bool_parameter("MODIFIEDEXPLEULER", "Yes",
+      Core::Utils::bool_parameter("MODIFIEDEXPLEULER", true,
           "Use the modified explicit Euler time integration scheme", sdyn);
 
       // linear solver id used for structural problems
@@ -333,7 +333,7 @@ namespace Inpar
           jep);
 
       Core::Utils::bool_parameter(
-          "LUMPMASS", "No", "Lump the mass matrix for explicit time integration", jep);
+          "LUMPMASS", false, "Lump the mass matrix for explicit time integration", jep);
 
       Core::Utils::string_to_integral_parameter<Inpar::Solid::DampKind>("DAMPING", "No",
           "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M + K_DAMP x K, "
@@ -375,7 +375,7 @@ namespace Inpar
       /*----------------------------------------------------------------------*/
       /* parameters for error evaluation */
       Core::Utils::SectionSpecs errorevaluator{sdyn, "ERROR EVALUATION"};
-      Core::Utils::bool_parameter("EVALUATE_ERROR_ANALYTICAL_REFERENCE", "No",
+      Core::Utils::bool_parameter("EVALUATE_ERROR_ANALYTICAL_REFERENCE", false,
           "Calculate error with respect to analytical solution defined by a function",
           errorevaluator);
       Core::Utils::int_parameter("ANALYTICAL_DISPLACEMENT_FUNCTION", -1,

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -29,7 +29,7 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           IterStaggAitkenIrons, IterStaggFixedRel, Monolithic),
       tsidyn);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", "Yes", "is matching grid", tsidyn);
+  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", tsidyn);
 
   // output type
   Core::Utils::int_parameter(
@@ -91,7 +91,7 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "LINEAR_SOLVER", -1, "number of linear solver used for monolithic TSI problems", tsidynmono);
 
   // convergence criteria adaptivity of monolithic TSI solver
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution", tsidynmono);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
@@ -99,16 +99,17 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       tsidynmono);
 
   Core::Utils::bool_parameter(
-      "INFNORMSCALING", "yes", "Scale blocks of matrix with row infnorm?", tsidynmono);
+      "INFNORMSCALING", true, "Scale blocks of matrix with row infnorm?", tsidynmono);
 
   // merge TSI block matrix to enable use of direct solver in monolithic TSI
   // default: "No", i.e. use block matrix
-  Core::Utils::bool_parameter("MERGE_TSI_BLOCK_MATRIX", "No", "Merge TSI block matrix", tsidynmono);
+  Core::Utils::bool_parameter(
+      "MERGE_TSI_BLOCK_MATRIX", false, "Merge TSI block matrix", tsidynmono);
 
   // in case of monolithic TSI nodal values (displacements, temperatures and
   // reaction forces) at fix points of the body can be calculated
   // default: "No", i.e. nothing is calculated
-  Core::Utils::bool_parameter("CALC_NECKING_TSI_VALUES", "No",
+  Core::Utils::bool_parameter("CALC_NECKING_TSI_VALUES", false,
       "Calculate nodal values for evaluation and validation of necking", tsidynmono);
 
   Core::Utils::string_to_integral_parameter<LineSearch>("TSI_LINE_SEARCH", "none",
@@ -163,7 +164,7 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::CONTACT::NitWgt_physical),
       tsic);
 
-  Core::Utils::bool_parameter("NITSCHE_PENALTY_ADAPTIVE_TSI", "yes",
+  Core::Utils::bool_parameter("NITSCHE_PENALTY_ADAPTIVE_TSI", true,
       "adapt penalty parameter after each converged time step", tsic);
 
   Core::Utils::double_parameter(

--- a/src/inpar/4C_inpar_validparameters.cpp
+++ b/src/inpar/4C_inpar_validparameters.cpp
@@ -128,7 +128,7 @@ std::map<std::string, Core::IO::InputSpec> Input::valid_parameters()
 
   Core::Utils::SectionSpecs nurbs_param{"NURBS"};
 
-  Core::Utils::bool_parameter("DO_LS_DBC_PROJECTION", "No",
+  Core::Utils::bool_parameter("DO_LS_DBC_PROJECTION", false,
       "Determines if a projection is needed for least square Dirichlet boundary conditions.",
       nurbs_param);
 

--- a/src/inpar/4C_inpar_volmortar.cpp
+++ b/src/inpar/4C_inpar_volmortar.cpp
@@ -65,9 +65,9 @@ void Inpar::VolMortar::set_valid_parameters(std::map<std::string, Core::IO::Inpu
       volmortar);
 
   Core::Utils::bool_parameter(
-      "MESH_INIT", "No", "If chosen, mesh initialization procedure is performed", volmortar);
+      "MESH_INIT", false, "If chosen, mesh initialization procedure is performed", volmortar);
 
-  Core::Utils::bool_parameter("KEEP_EXTENDEDGHOSTING", "Yes",
+  Core::Utils::bool_parameter("KEEP_EXTENDEDGHOSTING", true,
       "If chosen, extended ghosting is kept for simulation", volmortar);
 
   volmortar.move_into_collection(list);

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -24,7 +24,7 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<std::string>("None", "none", "Archard", "archard"),
       tuple<WearLaw>(wear_none, wear_none, wear_archard, wear_archard), wear);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", "Yes", "is matching grid", wear);
+  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", wear);
 
   Core::Utils::string_to_integral_parameter<WearShape>("WEAR_SHAPEFCN", "std",
       "Type of employed set of shape functions for wear",
@@ -40,7 +40,7 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "WEAR_TIMERATIO", 1.0, "Time step ratio between wear and spatial time scale", wear);
   Core::Utils::double_parameter("SSSLIP", 1.0, "Fixed slip for steady state wear", wear);
 
-  Core::Utils::bool_parameter("SSWEAR", "No", "flag for steady state wear", wear);
+  Core::Utils::bool_parameter("SSWEAR", false, "flag for steady state wear", wear);
 
   Core::Utils::string_to_integral_parameter<WearSide>("WEAR_SIDE", "slave",
       "Definition of wear side",

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -23,22 +23,22 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs xfem_general{"XFEM GENERAL"};
 
   // OUTPUT options
-  Core::Utils::bool_parameter("GMSH_DEBUG_OUT", "No",
+  Core::Utils::bool_parameter("GMSH_DEBUG_OUT", false,
       "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_DEBUG_OUT_SCREEN", "No",
+  Core::Utils::bool_parameter("GMSH_DEBUG_OUT_SCREEN", false,
       "Do you want to be informed, if Gmsh output is written?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_SOL_OUT", "No",
+  Core::Utils::bool_parameter("GMSH_SOL_OUT", false,
       "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_TIMINT_OUT", "No",
+  Core::Utils::bool_parameter("GMSH_TIMINT_OUT", false,
       "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_EOS_OUT", "No",
+  Core::Utils::bool_parameter("GMSH_EOS_OUT", false,
       "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_DISCRET_OUT", "No",
+  Core::Utils::bool_parameter("GMSH_DISCRET_OUT", false,
       "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_CUT_OUT", "No",
+  Core::Utils::bool_parameter("GMSH_CUT_OUT", false,
       "Do you want to write extended Gmsh output for each timestep?", xfem_general);
   Core::Utils::bool_parameter(
-      "PRINT_OUTPUT", "No", "Is the output of the cut process desired?", xfem_general);
+      "PRINT_OUTPUT", false, "Is the output of the cut process desired?", xfem_general);
 
   Core::Utils::int_parameter(
       "MAX_NUM_DOFSETS", 3, "Maximum number of volumecells in the XFEM element", xfem_general);
@@ -75,13 +75,13 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs xfluid_general{xfluid_dyn, "GENERAL"};
 
   // Do we use more than one fluid discretization?
-  Core::Utils::bool_parameter("XFLUIDFLUID", "no", "Use an embedded fluid patch.", xfluid_general);
+  Core::Utils::bool_parameter("XFLUIDFLUID", false, "Use an embedded fluid patch.", xfluid_general);
 
   // How many monolithic steps we keep the fluidfluid-boundary fixed
   Core::Utils::int_parameter(
       "RELAXING_ALE_EVERY", 1, "Relaxing Ale after how many monolithic steps", xfluid_general);
 
-  Core::Utils::bool_parameter("RELAXING_ALE", "yes",
+  Core::Utils::bool_parameter("RELAXING_ALE", true,
       "switch on/off for relaxing Ale in monolithic fluid-fluid-fsi", xfluid_general);
 
   Core::Utils::double_parameter(
@@ -138,7 +138,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_Proj_AND_GHOST_by_Proj_or_Copy_or_GP),
       xfluid_general);
 
-  Core::Utils::bool_parameter("ALE_XFluid", "no", "XFluid is Ale Fluid?", xfluid_general);
+  Core::Utils::bool_parameter("ALE_XFluid", false, "XFluid is Ale Fluid?", xfluid_general);
 
   // for new OST-implementation: which interface terms to be evaluated for previous time step
   Core::Utils::string_to_integral_parameter<InterfaceTermsPreviousState>(
@@ -153,10 +153,10 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           ),
       xfluid_general);
 
-  Core::Utils::bool_parameter("XFLUID_TIMEINT_CHECK_INTERFACETIPS", "Yes",
+  Core::Utils::bool_parameter("XFLUID_TIMEINT_CHECK_INTERFACETIPS", true,
       "Xfluid TimeIntegration Special Check if node has changed the side!", xfluid_general);
 
-  Core::Utils::bool_parameter("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE", "Yes",
+  Core::Utils::bool_parameter("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE", true,
       "Xfluid TimeIntegration Special Check if node is sliding on surface!", xfluid_general);
 
   xfluid_general.move_into_collection(list);
@@ -292,15 +292,15 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           ),
       xfluid_stab);
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_STAB", "no",
+  Core::Utils::bool_parameter("GHOST_PENALTY_STAB", false,
       "switch on/off ghost penalty interface stabilization", xfluid_stab);
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_TRANSIENT_STAB", "no",
+  Core::Utils::bool_parameter("GHOST_PENALTY_TRANSIENT_STAB", false,
       "switch on/off ghost penalty transient interface stabilization", xfluid_stab);
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_2nd_STAB", "no",
+  Core::Utils::bool_parameter("GHOST_PENALTY_2nd_STAB", false,
       "switch on/off ghost penalty interface stabilization for 2nd order derivatives", xfluid_stab);
-  Core::Utils::bool_parameter("GHOST_PENALTY_2nd_STAB_NORMAL", "no",
+  Core::Utils::bool_parameter("GHOST_PENALTY_2nd_STAB_NORMAL", false,
       "switch between ghost penalty interface stabilization for 2nd order derivatives in normal or "
       "all spatial directions",
       xfluid_stab);
@@ -321,17 +321,17 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       xfluid_stab);
 
 
-  Core::Utils::bool_parameter("XFF_EOS_PRES_EMB_LAYER", "no",
+  Core::Utils::bool_parameter("XFF_EOS_PRES_EMB_LAYER", false,
       "switch on/off edge-based pressure stabilization on interface-contributing elements of the "
       "embedded fluid",
       xfluid_stab);
 
-  Core::Utils::bool_parameter("IS_PSEUDO_2D", "no",
+  Core::Utils::bool_parameter("IS_PSEUDO_2D", false,
       "modify viscous interface stabilization due to the vanishing polynomial in third dimension "
       "when using strong Dirichlet conditions to block polynomials in one spatial dimension",
       xfluid_stab);
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_ADD_INNER_FACES", "no",
+  Core::Utils::bool_parameter("GHOST_PENALTY_ADD_INNER_FACES", false,
       "Apply ghost penalty stabilization also for inner faces if this is possible due to the "
       "dofsets",
       xfluid_stab);
@@ -345,7 +345,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "ITEMIN", 1, "How many iterations are performed minimal", xfsi_monolithic);
   Core::Utils::int_parameter(
       "ITEMAX_OUTER", 5, "How many outer iterations are performed maximal", xfsi_monolithic);
-  Core::Utils::bool_parameter("ND_NEWTON_DAMPING", "no",
+  Core::Utils::bool_parameter("ND_NEWTON_DAMPING", false,
       "Activate Newton damping based on residual and increment", xfsi_monolithic);
   Core::Utils::double_parameter("ND_MAX_DISP_ITERINC", -1.0,
       "Maximal displacement increment to apply full newton --> otherwise damp newton",
@@ -369,7 +369,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::int_parameter("CUT_EVALUATE_MINITER", 0,
       "Minimal number of nonlinear iterations, before the CUT is potentially not evaluated",
       xfsi_monolithic);
-  Core::Utils::bool_parameter("EXTRAPOLATE_TO_ZERO", "no",
+  Core::Utils::bool_parameter("EXTRAPOLATE_TO_ZERO", false,
       "the extrapolation of the fluid stress in the contact zone is relaxed to zero after a "
       "certain distance",
       xfsi_monolithic);
@@ -377,7 +377,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "factor of element size, when transition between FPSI and PSCI is started!", xfsi_monolithic);
   Core::Utils::double_parameter("POROCONTACTFPSI_FULLPCFRACTION", 0.0,
       "ration of gap/(POROCONTACTFPSI_HFRACTION*h) when full PSCI is started!", xfsi_monolithic);
-  Core::Utils::bool_parameter("USE_PORO_PRESSURE", "yes",
+  Core::Utils::bool_parameter("USE_PORO_PRESSURE", true,
       "the extrapolation of the fluid stress in the contact zone is relaxed to zero after a "
       "certtain distance",
       xfsi_monolithic);

--- a/src/lubrication/src/4C_lubrication_input.cpp
+++ b/src/lubrication/src/4C_lubrication_input.cpp
@@ -49,12 +49,12 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "HFUNCNO", -1, "function number for lubrication height field", lubricationdyn);
 
   Core::Utils::bool_parameter(
-      "OUTMEAN", "No", "Output of mean values for scalars and density", lubricationdyn);
+      "OUTMEAN", false, "Output of mean values for scalars and density", lubricationdyn);
 
   Core::Utils::bool_parameter(
-      "OUTPUT_GMSH", "No", "Do you want to write Gmsh postprocessing files?", lubricationdyn);
+      "OUTPUT_GMSH", false, "Do you want to write Gmsh postprocessing files?", lubricationdyn);
 
-  Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", "No",
+  Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", false,
       "Do you want to write the state solution to Matlab file?", lubricationdyn);
 
   /// linear solver id used for lubrication problems
@@ -69,7 +69,7 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "CONVTOL", 1e-13, "Tolerance for convergence check", lubricationdyn);
 
   // convergence criteria adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution",
       lubricationdyn);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
@@ -106,17 +106,17 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "ROUGHNESS_STD_DEVIATION", 0., "standard deviation of surface roughness", lubricationdyn);
 
   /// use modified reynolds equ.
-  Core::Utils::bool_parameter("MODIFIED_REYNOLDS_EQU", "No",
+  Core::Utils::bool_parameter("MODIFIED_REYNOLDS_EQU", false,
       "the lubrication problem will use the modified reynolds equ. in order to consider surface"
       " roughness",
       lubricationdyn);
 
   /// Flag for considering the Squeeze term in Reynolds Equation
-  Core::Utils::bool_parameter("ADD_SQUEEZE_TERM", "No",
+  Core::Utils::bool_parameter("ADD_SQUEEZE_TERM", false,
       "the squeeze term will also be considered in the Reynolds Equation", lubricationdyn);
 
   /// Flag for considering the pure Reynolds Equation
-  Core::Utils::bool_parameter("PURE_LUB", "No", "the problem is pure lubrication", lubricationdyn);
+  Core::Utils::bool_parameter("PURE_LUB", false, "the problem is pure lubrication", lubricationdyn);
 
   lubricationdyn.move_into_collection(list);
 }

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -94,7 +94,7 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
       tuple<PredEnum>(pred_vague, pred_consttemp, pred_consttemprate, pred_tangtemp), tdyn);
 
   // convergence criteria solver adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", "No",
+  Core::Utils::bool_parameter("ADAPTCONV", false,
       "Switch on adaptive control of linear solver tolerance for nonlinear solution", tdyn);
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
@@ -102,7 +102,7 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
       tdyn);
 
   Core::Utils::bool_parameter(
-      "LUMPCAPA", "No", "Lump the capacity matrix for explicit time integration", tdyn);
+      "LUMPCAPA", false, "Lump the capacity matrix for explicit time integration", tdyn);
 
   // number of linear solver used for thermal problems
   Core::Utils::int_parameter(
@@ -151,29 +151,29 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
     Core::Utils::SectionSpecs sublist_vtk_output{tdyn, "RUNTIME VTK OUTPUT"};
 
     // whether to write output for thermo
-    Core::Utils::bool_parameter("OUTPUT_THERMO", "No", "write thermo output", sublist_vtk_output);
+    Core::Utils::bool_parameter("OUTPUT_THERMO", false, "write thermo output", sublist_vtk_output);
 
     // whether to write temperature state
     Core::Utils::bool_parameter(
-        "TEMPERATURE", "No", "write temperature output", sublist_vtk_output);
+        "TEMPERATURE", false, "write temperature output", sublist_vtk_output);
 
     // whether to write heatflux state
-    Core::Utils::bool_parameter("HEATFLUX", "No", "write heatflux output", sublist_vtk_output);
+    Core::Utils::bool_parameter("HEATFLUX", false, "write heatflux output", sublist_vtk_output);
 
     // whether to write temperature gradient state
     Core::Utils::bool_parameter(
-        "TEMPGRAD", "No", "write temperature gradient output", sublist_vtk_output);
+        "TEMPGRAD", false, "write temperature gradient output", sublist_vtk_output);
 
     // whether to write element owner
-    Core::Utils::bool_parameter("ELEMENT_OWNER", "No", "write element owner", sublist_vtk_output);
+    Core::Utils::bool_parameter("ELEMENT_OWNER", false, "write element owner", sublist_vtk_output);
 
     // whether to write element GIDs
     Core::Utils::bool_parameter(
-        "ELEMENT_GID", "No", "write 4C internal element GIDs", sublist_vtk_output);
+        "ELEMENT_GID", false, "write 4C internal element GIDs", sublist_vtk_output);
 
     // whether to write node GIDs
     Core::Utils::bool_parameter(
-        "NODE_GID", "No", "write 4C internal node GIDs", sublist_vtk_output);
+        "NODE_GID", false, "write 4C internal node GIDs", sublist_vtk_output);
 
     sublist_vtk_output.move_into_collection(list);
   }
@@ -183,10 +183,10 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
     Core::Utils::SectionSpecs sublist_csv_output{tdyn, "RUNTIME CSV OUTPUT"};
 
     // whether to write csv output for thermo
-    Core::Utils::bool_parameter("OUTPUT_THERMO", "No", "write thermo output", sublist_csv_output);
+    Core::Utils::bool_parameter("OUTPUT_THERMO", false, "write thermo output", sublist_csv_output);
 
     // whether to write energy state
-    Core::Utils::bool_parameter("ENERGY", "No", "write energy output", sublist_csv_output);
+    Core::Utils::bool_parameter("ENERGY", false, "write energy output", sublist_csv_output);
 
     sublist_csv_output.move_into_collection(list);
   }


### PR DESCRIPTION
@mayrmt I was too slow to push this; now you pushed #426, #425, #424. But I think we have almost no overlap :crossed_fingers: 

- First commit fixes "NONLINEARBC", "STRONG_REDD_3D_COUPLING_TYPE", and "PRESSAVGBC". 
- Second commit moves the signature of `bool_parameter` to take a bool value. 
- ~Third commit is an alternative to a commit in #424 as it changes `BEAMS_DAMPING` to a bool.~ Dropped

Part of #420 