### PR TITLE
Change terminology from dat file to input file in comments and error messages

### DIFF
--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -88,7 +88,7 @@ namespace
            "\t\tx must be 0 and 1 for the respective run\n"
         << "\n"
         << "\t<dat_name>\n"
-        << "\t\tName of the input file, including the suffix (Usually *.dat)\n"
+        << "\t\tName of the input file, including the suffix\n"
         << "\n"
         << "\t<output_name>\n"
         << "\t\tPrefix of your output files.\n"

--- a/doc/readthedocs/introduction_solvers.rst
+++ b/doc/readthedocs/introduction_solvers.rst
@@ -258,8 +258,8 @@ Future prospects
 **Switch from ML to MueLu**
 
    In the near future there will be a major change with respect to the preconditioners.
-   This will affect also the th einput parameters,
-   and even the input style, which will then rather depend on separate solver parameter files than parameters in the .dat file.
+   This will affect also the input parameters,
+   and even the input style, which will then rather depend on separate solver parameter files than parameters in the input file.
 
 Further reading
 ^^^^^^^^^^^^^^^

--- a/doc/readthedocs/postprocessing.rst
+++ b/doc/readthedocs/postprocessing.rst
@@ -50,7 +50,7 @@ and did not provide the direct vtk output (see :ref:`above <directvtkoutput>`).
 .. Note::
     When using the |FOURC| post processing script ``post_processor``,
     be aware that derived quantities like e.g. stresses and strains are not automatically extracted from the simulation results!
-    Presumed you set the proper flags in the \*.dat file (i.e. the quantities were actually calculated),
+    Presumed you set the proper flags in the input file (i.e. the quantities were actually calculated),
     you still have to set the ``--stress`` etc. options of the post processing script to extract these quantities from the simulation results.
 
 You always have to provide the control file,

--- a/src/adapter/4C_adapter_fld_base_algorithm.hpp
+++ b/src/adapter/4C_adapter_fld_base_algorithm.hpp
@@ -55,7 +55,7 @@ namespace Adapter
     //! values specified in given problem-dependent ParameterList)
     /**
      * \note In this function the linear solver object is generated. For pure fluid problems or
-     * fluid meshtying (no block matrix) the FLUID SOLVER block from the 4C dat file is used.
+     * fluid meshtying (no block matrix) the FLUID SOLVER block from the 4C input file is used.
      * For fluid meshtying (block matrix) the MESHTYING SOLVER block is used as main solver object
      * with a block preconditioner (BGS or SIMPLE type). The block preconditioners use the
      * information form the FLUID SOLVER and the FLUID PRESSURE SOLVER block for the velocity and

--- a/src/adapter/4C_adapter_str_structure.cpp
+++ b/src/adapter/4C_adapter_str_structure.cpp
@@ -119,7 +119,7 @@ void Adapter::StructureBaseAlgorithm::create_tim_int(const Teuchos::ParameterLis
   Teuchos::ParameterList& nox = xparams->sublist("NOX");
   nox = snox;
 
-  // Check if for chosen Rayleigh damping the regarding parameters are given explicitly in the .dat
+  // Check if for chosen Rayleigh damping the regarding parameters are given explicitly in the input
   // file
   if (Teuchos::getIntegralValue<Inpar::Solid::DampKind>(sdyn, "DAMPING") ==
       Inpar::Solid::damp_rayleigh)

--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -663,7 +663,7 @@ void Adapter::StructureBaseAlgorithmNew::set_params(Teuchos::ParameterList& iofl
   sdyn_->set<int>("RESTARTEVERY", prbdyn_->get<int>("RESTARTEVERY"));
   sdyn_->set<int>("RESULTSEVERY", prbdyn_->get<int>("RESULTSEVERY"));
 
-  // Check if for chosen Rayleigh damping the regarding parameters are given explicitly in the .dat
+  // Check if for chosen Rayleigh damping the regarding parameters are given explicitly in the input
   // file
   if (Teuchos::getIntegralValue<Inpar::Solid::DampKind>(*sdyn_, "DAMPING") ==
       Inpar::Solid::damp_rayleigh)

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.cpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.cpp
@@ -552,7 +552,7 @@ int CONSTRAINTS::SUBMODELEVALUATOR::RveMultiPointConstraintManager::build_linear
       << Core::IO::endl
       << "-------------------------------------------" << Core::IO::endl;
   Core::IO::cout(Core::IO::verbose)
-      << "Reading linear coupled eq. from .dat file" << Core::IO::endl;
+      << "Reading linear coupled eq. from input file" << Core::IO::endl;
   Core::IO::cout(Core::IO::verbose)
       << "linear MPC condition count: " << point_linear_coupled_equation_conditions_.size()
       << Core::IO::endl;

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.hpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.hpp
@@ -67,7 +67,7 @@ namespace CONSTRAINTS::SUBMODELEVALUATOR
         line_periodic_rve_conditions_, surface_periodic_rve_conditions_;
 
     //! Tolerance for the opposing edge node search
-    double node_search_toler_ = 0.25;  // #ToDo: Add .dat parameter
+    double node_search_toler_ = 0.25;  // #ToDo: Add input parameter
 
     //! Parameter List for the rveType
     Teuchos::ParameterList mpc_parameter_list_;

--- a/src/core/fem/src/condition/4C_fem_condition_definition.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_definition.hpp
@@ -43,12 +43,12 @@ namespace Core::Conditions
   /// definition of a valid condition in 4C input
   /*!
 
-    A ConditionDefinition is the definition of a condition dat file
+    A ConditionDefinition is the definition of a condition input file
     section. This definition includes the knowledge what this section looks
     like, how to read it and how to write it. In particular given a
-    ConditionDefinition object it is possible to (a) write an empty dat file
-    section that describes this condition, (b) read a dat file and create
-    Core::Conditions::Condition objects for each line in this section and (c) write the dat
+    ConditionDefinition object it is possible to (a) write an empty input file
+    section that describes this condition, (b) read an input file and create
+    Core::Conditions::Condition objects for each line in this section and (c) write the input
     file section filled with all corresponding conditions from a given
     Core::FE::Discretization.
 
@@ -66,7 +66,7 @@ namespace Core::Conditions
    public:
     /// construction of a condition definition
     /*!
-      \param sectionname name of dat file section
+      \param sectionname name of input file section
       \param conditionname name of conditions in Core::FE::Discretization
       \param description description of condition type
       \param condtype type of conditions to be build
@@ -96,7 +96,7 @@ namespace Core::Conditions
     void read(Core::IO::InputFile& input,
         std::multimap<int, std::shared_ptr<Core::Conditions::Condition>>& cmap) const;
 
-    /// print my dat file section
+    /// print my input file section
     std::ostream& print(std::ostream& stream);
 
     /// name of my section in input file

--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -127,7 +127,7 @@ namespace Core::FE
 
   The initialization of a discretization is a major effort since the parallel
   distribution needs to be established. Normally the discretization is read from
-  a dat-file with the help of Discret::InputFile and related classes. The
+  an input file with the help of Discret::InputFile and related classes. The
   discretization class comes with a bunch of helper method for its setup phase.
 
   <h3>Filled-State</h3>

--- a/src/core/fem/src/dofset/4C_fem_dofset_definedmapping_wrapper.hpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_definedmapping_wrapper.hpp
@@ -64,7 +64,7 @@ namespace Core::DOFSets
 
   \endcode
 
-  See also the example '.dat'-file 'immersed_cell_biochemo_mechano_pureProtrusion_h8' in
+  See also the example input file 'immersed_cell_biochemo_mechano_pureProtrusion_h8' in
   the 4C 'Input' folder.
 
 

--- a/src/core/fem/src/general/element/4C_fem_general_element_definition.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element_definition.hpp
@@ -23,7 +23,7 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::Elements
 {
-  /// Collection of valid element dat file line definitions
+  /// Collection of valid element input file line definitions
   /*!
     The actual definition is done by each element's type class.
    */

--- a/src/core/fem/src/general/element/4C_fem_general_elementtype.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_elementtype.hpp
@@ -34,7 +34,7 @@ namespace Core::FE
 /// Subclass of ParObjectType that adds element type specific methods
 /*!
   Element types need to be initialized. Furthermore, there is a pre_evaluate
-  method and the ability to read elements from dat files. And finally the
+  method and the ability to read elements from input files. And finally the
   element specific setup of null spaces for multi grid preconditioning is
   here, too.
 
@@ -54,13 +54,13 @@ namespace Core::Elements
     ElementType();
 
    public:
-    /// setup the dat file input line definitions for this type of element
+    /// setup the input file input line definitions for this type of element
     virtual void setup_element_definition(
         std::map<std::string, std::map<std::string, Core::IO::InputSpec>>& definitions)
     {
     }
 
-    /// create an element from a dat file specifier
+    /// create an element from an input file specifier
     virtual std::shared_ptr<Element> create(
         const std::string eletype, const std::string eledistype, const int id, const int owner)
     {

--- a/src/core/io/src/4C_io_elementreader.hpp
+++ b/src/core/io/src/4C_io_elementreader.hpp
@@ -32,7 +32,7 @@ namespace Core::IO
     \brief helper class to read the elements of a discretization
 
     Together with MeshReader this class constitutes a (almost) parallel
-    and efficient reading mechanism for discretizations from dat files.
+    and efficient reading mechanism for discretizations from input files.
 
     We face the following problem:
 
@@ -154,7 +154,7 @@ namespace Core::IO
     /// discretization name
     std::string name_;
 
-    /// the main dat file reader
+    /// the main input file reader
     Core::IO::InputFile& input_;
 
     /// my comm

--- a/src/core/io/src/4C_io_gridgenerator.cpp
+++ b/src/core/io/src/4C_io_gridgenerator.cpp
@@ -153,7 +153,7 @@ namespace Core::IO::GridGenerator
           -1, nummynewele, mynewele.data(), 0, Core::Communication::as_epetra_comm(comm));
     }
 
-    // Build an input line that matches what is expected from a dat file.
+    // Build an input line that matches what is expected from an input file.
     // Prepend the distype which is not part of the user-supplied arguments but must be parsed.
     // The distype is followed by nodal ids, which are set to dummy values of -1 here.
     const std::string argument_line = std::invoke(

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -342,7 +342,7 @@ void Core::IO::read_design(InputFile& input, const std::string& name,
       FOUR_C_THROW("Illegal line in section '%s': '%*s'", marker.c_str(), s.size(), s.data());
     }
 
-    if (nname == "NODE")  // plain old reading of the design nodes from the .dat-file
+    if (nname == "NODE")  // plain old reading of the design nodes from the input file
     {
       stream >> nodeid >> dname >> dobj;
       topology[dobj - 1].insert(nodeid - 1);
@@ -425,7 +425,7 @@ void Core::IO::read_design(InputFile& input, const std::string& name,
         for (int init = 0; init < 9; ++init) box_specifications.push_back(0.0);
         if (Core::Communication::my_mpi_rank(input.get_comm()) == 0)  // Reading is done by proc 0
         {
-          // get original domain section from the *.dat-file
+          // get original domain section from the input file
           std::string dommarker = disname + " DOMAIN";
           std::transform(dommarker.begin(), dommarker.end(), dommarker.begin(), ::toupper);
 

--- a/src/core/io/src/4C_io_meshreader.hpp
+++ b/src/core/io/src/4C_io_meshreader.hpp
@@ -27,7 +27,7 @@ namespace Core::IO
     \brief helper class to read a mesh
 
     This is an interface for handling node, element and domain readers
-    and to set up a discretization from a dat file which is fill_complete().
+    and to set up a discretization from an input file which is fill_complete().
    */
   class MeshReader
   {
@@ -109,7 +109,7 @@ namespace Core::IO
 
    private:
     /*!
-    \brief Read pre-generated mesh from dat-file and generate related FillCompleted()
+    \brief Read pre-generated mesh from input file and generate related FillCompleted()
     discretizations
 
     \param[in/out] max_node_id Maximum node id in a given discretization. To be used as global

--- a/src/core/io/src/4C_io_pstream.hpp
+++ b/src/core/io/src/4C_io_pstream.hpp
@@ -64,8 +64,8 @@ namespace Core::IO
     virtual ~Pstream();
 
     /// configure the output. Must be called before Core::IO::cout can be used. Is
-    /// currently called in the global problem using the params specified in the
-    /// IO section of the .dat-file.
+    /// currently called indat the global problem using the params specified in the
+    /// IO section of the input file.
     void setup(const bool writetoscreen,       ///< bool whether output is written to screen
         const bool writetofile,                ///< bool whether output is written to file
         const bool prefixgroupID,              ///< bool whether group ID is prefixed in each line

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -194,7 +194,7 @@ Core::LinearSolver::AmGnxnInterface::AmGnxnInterface(Teuchos::ParameterList& par
   }
   else
     FOUR_C_THROW(
-        "\"%s\" is an invalid value for \"AMGNXN_TYPE\". Fix your .dat", amgnxn_type.c_str());
+        "\"%s\" is an invalid value for \"AMGNXN_TYPE\". Fix your input file", amgnxn_type.c_str());
 
 
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
@@ -137,7 +137,7 @@ int Core::LinearSolver::IterativeSolver<MatrixType, VectorType>::solve()
   else
   {
     if (Core::Communication::my_mpi_rank(comm_) == 0)
-      std::cout << "WARNING: The linear solver input parameters from the .dat file will be "
+      std::cout << "WARNING: The linear solver input parameters from the input file will be "
                    "depreciated soon. Switch to an appropriate xml-file version."
                 << std::endl;
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -415,9 +415,9 @@ Teuchos::ParameterList Core::LinAlg::Solver::translate_solver_parameters(
   switch (Teuchos::getIntegralValue<Core::LinearSolver::SolverType>(inparams, "SOLVER"))
   {
     case Core::LinearSolver::SolverType::undefined:
-      std::cout << "undefined solver! Set " << inparams.name() << "  in your dat file!"
+      std::cout << "undefined solver! Set " << inparams.name() << "  in your input file!"
                 << std::endl;
-      FOUR_C_THROW("fix your dat file");
+      FOUR_C_THROW("fix your input file");
       break;
     case Core::LinearSolver::SolverType::umfpack:
       outparams.set("solver", "umfpack");

--- a/src/cut/4C_cut_cutwizard.cpp
+++ b/src/cut/4C_cut_cutwizard.cpp
@@ -124,7 +124,7 @@ void Cut::CutWizard::set_options(
   intersection_->set_find_positions(positions);
   intersection_->set_nodal_dof_set_strategy(nodal_dofset_strategy);
 
-  // Initialize Cut Parameters based on dat file section CUT GENERAL
+  // Initialize Cut Parameters based on input file section CUT GENERAL
   intersection_->get_options().init_by_paramlist(cutparams);
 
   is_set_options_ = true;

--- a/src/cut/4C_cut_options.cpp
+++ b/src/cut/4C_cut_options.cpp
@@ -12,7 +12,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-/// Initializes Cut Parameters by Parameterlist (typically from *.dat-file section CUT GENERAL)
+/// Initializes Cut Parameters by Parameterlist (typically from input file section CUT GENERAL)
 void Cut::Options::init_by_paramlist(const Teuchos::ParameterList& cutparams)
 {
   geomintersect_floattype_ =

--- a/src/cut/4C_cut_options.hpp
+++ b/src/cut/4C_cut_options.hpp
@@ -49,7 +49,7 @@ namespace Cut
     {
     }
 
-    /// Initializes Cut Parameters by Parameterlist (typically from *.dat-file section CUT
+    /// Initializes Cut Parameters by Parameterlist (typically from input file section CUT
     /// GENERAL)
     void init_by_paramlist(const Teuchos::ParameterList& cutparams);
 

--- a/src/elemag/4C_elemag_timeint.hpp
+++ b/src/elemag/4C_elemag_timeint.hpp
@@ -210,7 +210,7 @@ namespace EleMag
     /*!
     \brief Output routine
 
-    This routine outputs the computed global and local solutions to the output ".dat" file.
+    This routine outputs the computed global and local solutions to the output file.
     */
     virtual void output();
     // void output();

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -2089,21 +2089,21 @@ void FLD::FluidImplicitTimeInt::setup_krylov_space_projection(Core::Conditions::
   // confirm that mode flags are number of nodal dofs
   const int nummodes = kspcond->parameters().get<int>("NUMMODES");
   if (nummodes != (numdim_ + 1))
-    FOUR_C_THROW("Expecting numdim_+1 modes in Krylov projection definition. Check dat-file!");
+    FOUR_C_THROW("Expecting numdim_+1 modes in Krylov projection definition. Check input file!");
 
-  // get vector of mode flags as given in dat-file
+  // get vector of mode flags as given in input file
   const auto& modeflags = kspcond->parameters().get<std::vector<int>>("ONOFF");
 
-  // confirm that only the pressure mode is selected for Krylov projection in dat-file
+  // confirm that only the pressure mode is selected for Krylov projection in input file
   for (int rr = 0; rr < numdim_; ++rr)
   {
     if ((modeflags[rr]) != 0)
     {
-      FOUR_C_THROW("Expecting only an undetermined pressure. Check dat-file!");
+      FOUR_C_THROW("Expecting only an undetermined pressure. Check input file!");
     }
   }
   if ((modeflags[numdim_]) != 1)
-    FOUR_C_THROW("Expecting an undetermined pressure. Check dat-file!");
+    FOUR_C_THROW("Expecting an undetermined pressure. Check input file!");
   std::vector<int> activemodeids(1, numdim_);
 
   // allocate kspsplitter_
@@ -2112,7 +2112,7 @@ void FLD::FluidImplicitTimeInt::setup_krylov_space_projection(Core::Conditions::
 
   kspsplitter_->setup(*discret_);
 
-  // get from dat-file definition how weights are to be computed
+  // get from input file definition how weights are to be computed
   const auto* weighttype = &kspcond->parameters().get<std::string>("WEIGHTVECDEF");
 
   // set flag for projection update true only if ALE and integral weights
@@ -2144,7 +2144,7 @@ void FLD::FluidImplicitTimeInt::update_krylov_space_projection()
 
     const std::string* weighttype = projector_->weight_type();
     std::shared_ptr<Core::LinAlg::Vector<double>> w0_update = nullptr;
-    // compute w_ as defined in dat-file
+    // compute w_ as defined in input file
     if (*weighttype == "pointvalues")
     {
       /*

--- a/src/fluid/4C_fluid_utils.cpp
+++ b/src/fluid/4C_fluid_utils.cpp
@@ -557,7 +557,7 @@ void FLD::Utils::lift_drag(const std::shared_ptr<const Core::FE::Discretization>
     // vector with lift&drag forces after communication
     liftdragvals = std::make_shared<std::map<int, std::vector<double>>>();
 
-    for (unsigned i = 0; i < ldconds.size(); ++i)  // loop L&D conditions (i.e. lines in .dat file)
+    for (unsigned i = 0; i < ldconds.size(); ++i)
     {
       // get label of present lift_drag condition
       const int label = ldconds[i]->parameters().get<int>("label");
@@ -585,7 +585,7 @@ void FLD::Utils::lift_drag(const std::shared_ptr<const Core::FE::Discretization>
     }
 
     // sort data
-    for (unsigned i = 0; i < ldconds.size(); ++i)  // loop L&D conditions (i.e. lines in .dat file)
+    for (unsigned i = 0; i < ldconds.size(); ++i)
     {
       // get label of present lift_drag condition
       const int label = ldconds[i]->parameters().get<int>("label");

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -2760,21 +2760,21 @@ void FLD::XFluid::setup_krylov_space_projection(Core::Conditions::Condition* ksp
   // confirm that mode flags are number of nodal dofs
   const int nummodes = kspcond->parameters().get<int>("NUMMODES");
   if (nummodes != (numdim_ + 1))
-    FOUR_C_THROW("Expecting numdim_+1 modes in Krylov projection definition. Check dat-file!");
+    FOUR_C_THROW("Expecting numdim_+1 modes in Krylov projection definition. Check input file!");
 
-  // get vector of mode flags as given in dat-file
+  // get vector of mode flags as given in input file
   const auto* modeflags = &kspcond->parameters().get<std::vector<int>>("ONOFF");
 
-  // confirm that only the pressure mode is selected for Krylov projection in dat-file
+  // confirm that only the pressure mode is selected for Krylov projection in input file
   for (int rr = 0; rr < numdim_; ++rr)
   {
     if (((*modeflags)[rr]) != 0)
     {
-      FOUR_C_THROW("Expecting only an undetermined pressure. Check dat-file!");
+      FOUR_C_THROW("Expecting only an undetermined pressure. Check input file!");
     }
   }
   if (((*modeflags)[numdim_]) != 1)
-    FOUR_C_THROW("Expecting an undetermined pressure. Check dat-file!");
+    FOUR_C_THROW("Expecting an undetermined pressure. Check input file!");
   std::vector<int> activemodeids(1, numdim_);
 
   // allocate kspsplitter_
@@ -2783,7 +2783,7 @@ void FLD::XFluid::setup_krylov_space_projection(Core::Conditions::Condition* ksp
 
   kspsplitter_->setup(*discret_);
 
-  // get from dat-file definition how weights are to be computed
+  // get from input file definition how weights are to be computed
   const std::string* weighttype = &kspcond->parameters().get<std::string>("WEIGHTVECDEF");
 
   // set flag for projection update true only if ALE and integral weights
@@ -2821,12 +2821,12 @@ void FLD::XFluid::update_krylov_space_projection()
 
     const std::string* weighttype = projector_->weight_type();
 
-    // compute w_ as defined in dat-file
+    // compute w_ as defined in input file
     if (*weighttype == "pointvalues")
     {
       // Smart xfluid people put FOUR_C_THROW here. I guess they had there reasons. KN
       FOUR_C_THROW(
-          "Pointvalues for weights is not supported for xfluid, choose integration in dat-file");
+          "Pointvalues for weights is not supported for xfluid, choose integration in input file");
 
       /*
       // export to vector to normalize against

--- a/src/fpsi/4C_fpsi_monolithic.cpp
+++ b/src/fpsi/4C_fpsi_monolithic.cpp
@@ -237,14 +237,16 @@ FPSI::Monolithic::Monolithic(MPI_Comm comm, const Teuchos::ParameterList& fpsidy
       Inpar::Solid::PredEnum::pred_constdis)
     FOUR_C_THROW(
         "No Structural Predictor for FPSI implemented at the moment, choose <PREDICT = ConstDis> "
-        "in you .dat file! \n --> Or feel free to add the missing terms coming from the predictors "
+        "in you input file! \n --> Or feel free to add the missing terms coming from the "
+        "predictors "
         "to 4C!");
 
   const Teuchos::ParameterList& fdynparams = Global::Problem::instance()->fluid_dynamic_params();
   if (fdynparams.get<std::string>("PREDICTOR") != "steady_state")
     FOUR_C_THROW(
         "No Fluid Predictor for FPSI implemented at the moment, choose <PREDICTOR = steady_state> "
-        "in you .dat file! \n --> Or feel free to add the missing terms coming from the predictors "
+        "in you input file! \n --> Or feel free to add the missing terms coming from the "
+        "predictors "
         "to 4C!");
 
   active_FD_check_ = false;  // to avoid adding RHS of firstiter moreoften!
@@ -632,7 +634,7 @@ void FPSI::Monolithic::create_linear_solver()
     std::cout << " uses the structural solver and fluid solver blocks" << std::endl;
     std::cout << " for building the internal inverses" << std::endl;
     std::cout << " Remove the old BGS PRECONDITIONER BLOCK entries " << std::endl;
-    std::cout << " in the dat files!" << std::endl;
+    std::cout << " in the input files!" << std::endl;
     std::cout << "!!!!!!!!!!!!!!!!!!!!!! ATTENTION !!!!!!!!!!!!!!!!!!!!!" << std::endl;
     FOUR_C_THROW("Iterative solver expected");
   }

--- a/src/fpsi/4C_fpsi_monolithic_plain.cpp
+++ b/src/fpsi/4C_fpsi_monolithic_plain.cpp
@@ -453,7 +453,7 @@ void FPSI::MonolithicPlain::setup_system_matrix(Core::LinAlg::BlockSparseMatrixB
             mat.matrix(structure_block_, ale_i_block_), false, true);
       }
     }
-    else  // if shapederivatives = no in FluidDynamics section in dat-file
+    else  // if shapederivatives = no in FluidDynamics section in input file
     {
       std::cout << "WARNING: Linearization with respect to mesh motion of fluid subproblem is "
                    "switched off!"

--- a/src/global_data/4C_global_data.hpp
+++ b/src/global_data/4C_global_data.hpp
@@ -82,7 +82,7 @@ namespace Global
    *
    * Global problem instance that keeps the discretizations
    * The global problem represents the input file passed to 4C. This class organizes the reading of
-   * a dat file (utilizing the InputFile of course). That is way, in all but the most eccentric
+   * an input file (utilizing the InputFile of course). That is way, in all but the most eccentric
    * cases there will be exactly one object of this class during a 4C run. This object contains all
    * parameters read from the input file as well as any material definitions and even all the
    * discretizations.

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -2113,7 +2113,7 @@ void Global::read_conditions(Global::Problem& problem, Core::IO::InputFile& inpu
   {
     std::multimap<int, std::shared_ptr<Core::Conditions::Condition>> cond;
 
-    // read conditions from dat file
+    // read conditions from the input file
     condition.read(input, cond);
 
     // add nodes to conditions

--- a/src/mat/4C_mat_anisotropy_extension_default.hpp
+++ b/src/mat/4C_mat_anisotropy_extension_default.hpp
@@ -33,11 +33,11 @@ namespace Mat
     /// @{
     //! Fibers defined in material on element basis
     static constexpr int INIT_MODE_ELEMENT_EXTERNAL = 0;
-    //! Fibers defined in dat file on element basis
+    //! Fibers defined in input file on element basis
     static constexpr int INIT_MODE_ELEMENT_FIBERS = 1;
     //! Fibers defined in material on Gauss point basis
     static constexpr int INIT_MODE_NODAL_EXTERNAL = 4;
-    //! Fibers defined in dat file on Gauss point basis
+    //! Fibers defined in input file on Gauss point basis
     static constexpr int INIT_MODE_NODAL_FIBERS = 3;
     /// @}
 

--- a/src/mat/4C_mat_crystal_plasticity.cpp
+++ b/src/mat/4C_mat_crystal_plasticity.cpp
@@ -325,7 +325,7 @@ void Mat::CrystalPlasticity::setup(int numgp, const Core::IO::InputParameterCont
   // parameters according to chosen lattice type
   this->setup_lattice_vectors();
 
-  //  read Lattice orientation matrix from .dat file
+  //  read Lattice orientation matrix from input file
   this->setup_lattice_orientation(container);
 
   // rotate lattice vectors according to lattice orientation
@@ -1097,7 +1097,7 @@ void Mat::CrystalPlasticity::setup_lattice_vectors()
 }
 
 /*---------------------------------------------------------------------------------*
- | Read Lattice orientation matrix from .dat file                                    |
+ | Read Lattice orientation matrix from input file                                    |
  *---------------------------------------------------------------------------------*/
 
 void Mat::CrystalPlasticity::setup_lattice_orientation(

--- a/src/mat/4C_mat_crystal_plasticity.hpp
+++ b/src/mat/4C_mat_crystal_plasticity.hpp
@@ -232,7 +232,7 @@ namespace Mat
     //! type
     void setup_lattice_vectors();
 
-    //! read lattice orientation matrix from .dat file
+    //! read lattice orientation matrix from an input file
     void setup_lattice_orientation(const Core::IO::InputParameterContainer& container);
 
     //! update internal variables

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -87,8 +87,7 @@ Mat::PAR::GrowthRemodelElastHyper::GrowthRemodelElastHyper(
   if (cylinder_ != -1 && cylinder_ != 1 && cylinder_ != 2 && cylinder_ != 3)
     FOUR_C_THROW(
         "The parameter CYLINDER has to be either 1, 2 or 3. If you have defined a fiber direction "
-        "in your"
-        ".dat file then just skip this parameter");
+        "in your input file then just skip this parameter");
 }
 
 /*----------------------------------------------------------------------*/
@@ -485,7 +484,7 @@ void Mat::GrowthRemodelElastHyper::setup_axi_cir_rad_structural_tensor(
     // radial structural tensor in "stress-like" Voigt notation
     Core::LinAlg::Voigt::Stresses::matrix_to_vector(arad_m_, aradv_);
   }
-  // Cylinder flag defined in .dat file, dummy AXI, CIR and RAD directions are written till
+  // Cylinder flag defined in input file, dummy AXI, CIR and RAD directions are written till
   // location of element center in reference configuration is available
   else if (params_->cylinder_ == 1 || params_->cylinder_ == 2 || params_->cylinder_ == 3)
   {
@@ -495,11 +494,11 @@ void Mat::GrowthRemodelElastHyper::setup_axi_cir_rad_structural_tensor(
     arad_m_(2, 2) = 1.0;
     aradv_(2) = 1.0;
   }
-  // No AXI CIR RAD-direction defined in .dat file and additionally no cylinder flag was set
+  // No AXI CIR RAD-direction defined in input file and additionally no cylinder flag was set
   else
     FOUR_C_THROW(
         "Homogenized Constrained Mixture Model can so far only be used by defining AXI-, CIR- and "
-        "RAD-direction in the .dat file or by defining the Cylinder flag!");
+        "RAD-direction in the input file or by defining the Cylinder flag!");
 }
 
 

--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -68,7 +68,7 @@ namespace
   {
     double operator()(const ActivationMapType*& map) const
     {
-      // use one-based element ids in the pattern file (corresponding to the ones in the dat-file)
+      // use one-based element ids in the pattern file (corresponding to the ones in the input file)
       return Mat::Utils::Muscle::evaluate_time_space_dependent_active_stress_by_map(
           Popt_, *map, t_tot_, eleGID_ + 1);
     }

--- a/src/mat/4C_mat_viscoelasthyper.cpp
+++ b/src/mat/4C_mat_viscoelasthyper.cpp
@@ -866,7 +866,7 @@ void Mat::ViscoElastHyper::evaluate_visco_gen_max(Core::LinAlg::Matrix<6, 1>* st
     // get time algorithmic parameters
     // NOTE: dt can be zero (in restart of STI) for Generalized Maxwell model
     // there is no special treatment required. Adaptation for Kelvin-Voigt were necessary.
-    double dt = params.get<double>("delta time");  // TIMESTEP in the .dat file
+    double dt = params.get<double>("delta time");  // TIMESTEP in the input file
 
     // evaluate scalars to compute
     // Q^(n+1) = tau/(tau+theta*dt) [(tau-dt+theta*dt)/tau Q + beta(S^(n+1) - S^n)]
@@ -908,7 +908,7 @@ void Mat::ViscoElastHyper::evaluate_visco_gen_max(Core::LinAlg::Matrix<6, 1>* st
     // get time algorithmic parameters
     // NOTE: dt can be zero (in restart of STI) for Generalized Maxwell model
     // there is no special treatment required. Adaptation for Kelvin-Voigt were necessary.
-    double dt = params.get<double>("delta time");  // TIMESTEP in the .dat file
+    double dt = params.get<double>("delta time");  // TIMESTEP in the input file
     // evaluate scalars to compute
     // Q_(n+1)=\exp(2*(-dt/(2*tau)))*Q_n+exp(-dt/(2*tau))*beta*(S_(n+1)-S_n)
 
@@ -1074,7 +1074,7 @@ void Mat::ViscoElastHyper::evaluate_visco_generalized_gen_max(Core::LinAlg::Matr
       // get time algorithmic parameters
       // NOTE: dt can be zero (in restart of STI) for Generalized Maxwell model
       // there is no special treatment required. Adaptation for Kelvin-Voigt were necessary.
-      double dt = params.get<double>("delta time");  // TIMESTEP in the .dat file
+      double dt = params.get<double>("delta time");  // TIMESTEP in the input file
 
       // evaluate scalars to compute
       // Q^(n+1) = tau/(tau+theta*dt) [(tau-dt+theta*dt)/tau Q + beta(S^(n+1) - S^n)]

--- a/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.cpp
+++ b/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.cpp
@@ -59,7 +59,7 @@ Mat::Elastic::PAR::StructuralTensorParameter::StructuralTensorParameter(
     FOUR_C_THROW(
         "You chose structural tensor strategy 'ByDistributionFunction' but you forgot to specify "
         "the 'DISTR' parameter.\n"
-        "Check the definitions of anisotropic materials in your .dat file.");
+        "Check the definitions of anisotropic materials in your input file.");
   else if (distr_type == "none" and
            (strategy_type_ == strategy_type_standard or
                strategy_type_ == strategy_type_dispersedtransverselyisotropic))

--- a/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.hpp
+++ b/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.hpp
@@ -46,7 +46,7 @@ namespace Mat
        * We assume only one symmetry for the distribution function \rho(M), i.e.:
        * \rho(M) = \rho(-M) .
        *
-       * Example input line in .dat file:
+       * Example input line in input file:
        * MAT 2 ELAST_IsoAnisoExpo  K1 1.0E6 K2 100.0 GAMMA 0.0 K1COMP 0.0 K2COMP 0.0 STR_TENS_ID
        * 100 MAT 100 ELAST_StructuralTensor STRATEGY ByDistributionFunction DISTR vonMisesFisher C1
        * 500.0

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke.cpp
@@ -46,7 +46,7 @@ void Mat::Elastic::CoupAnisoNeoHooke::setup(
   // warning message
   std::cout << "Material does not respect a stress free reference state" << std::endl;
 
-  // path if fibers aren't given in .dat file
+  // path if fibers aren't given in input file
   if (params_->init_ == 0)
   {
     // fibers aligned in YZ-plane with gamma around Z in global cartesian cosy
@@ -55,7 +55,7 @@ void Mat::Elastic::CoupAnisoNeoHooke::setup(
     set_fiber_vecs(-1.0, Id, Id);
   }
 
-  // path if fibers are given in .dat file
+  // path if fibers are given in input file
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
@@ -51,7 +51,7 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::unpack_summand(
 void Mat::Elastic::CoupAnisoNeoHookeVarProp::setup(
     int numgp, const Core::IO::InputParameterContainer& container)
 {
-  // path if fibers aren't given in .dat file
+  // path if fibers aren't given in input file
   if (params_->init_ == 0)
   {
     // fibers aligned in YZ-plane with gamma around Z in global cartesian cosy
@@ -92,7 +92,7 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::setup(
     set_fiber_vecs(-1.0, locsys, Id);
   }
 
-  // path if fibers are given in .dat file
+  // path if fibers are given in input file
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature

--- a/src/mat/elast/4C_mat_elast_coupanisopow.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisopow.cpp
@@ -45,7 +45,7 @@ void Mat::Elastic::CoupAnisoPow::unpack_summand(Core::Communication::UnpackBuffe
 void Mat::Elastic::CoupAnisoPow::setup(
     int numgp, const Core::IO::InputParameterContainer& container)
 {
-  // path if fibers aren't given in .dat file
+  // path if fibers aren't given in input file
   if (params_->init_ == 0)
   {
     // fibers aligned in YZ-plane with gamma around Z in global cartesian cosy
@@ -54,7 +54,7 @@ void Mat::Elastic::CoupAnisoPow::setup(
     set_fiber_vecs(-1.0, Id, Id);
   }
 
-  // path if fibers are given in .dat file
+  // path if fibers are given in input file
   else if (params_->init_ == 1)
   {
     std::ostringstream ss;

--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
@@ -56,7 +56,7 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
 {
   switch (params_->init_)
   {
-    // path if fibers aren't given in .dat file
+    // path if fibers aren't given in input file
     case 0:
     {
       // fibers aligned in YZ-plane with gamma around Z in global cartesian cosy
@@ -66,7 +66,7 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
 
       break;
     }
-    // path if fibers are given in .dat file
+    // path if fibers are given in input file
     case 1:
     {
       std::ostringstream ss;

--- a/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
+++ b/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
@@ -56,7 +56,7 @@ void Mat::Elastic::IsoAnisoExpo::setup(
     set_fiber_vecs(-1.0, Id, Id);
   }
 
-  // path if fibers are given in .dat file
+  // path if fibers are given in input file
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature

--- a/src/particle_engine/4C_particle_engine_particlereader.hpp
+++ b/src/particle_engine/4C_particle_engine_particlereader.hpp
@@ -24,7 +24,7 @@ namespace Core::IO
 namespace PARTICLEENGINE
 {
   /**
-   * Read particles from a dat file. The particles are read from the section
+   * Read particles from an input file. The particles are read from the section
    * with name @p section_name.
    */
   void read_particles(Core::IO::InputFile& input, const std::string& section_name,

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -676,7 +676,7 @@ void PoroElast::Monolithic::create_linear_solver()
     std::cout << " uses the structural solver and fluid solver blocks" << std::endl;
     std::cout << " for building the internal inverses" << std::endl;
     std::cout << " Remove the old BGS PRECONDITIONER BLOCK entries " << std::endl;
-    std::cout << " in the dat files!" << std::endl;
+    std::cout << " in the input files!" << std::endl;
     std::cout << "!!!!!!!!!!!!!!!!!!!!!! ATTENTION !!!!!!!!!!!!!!!!!!!!!" << std::endl;
     FOUR_C_THROW("Iterative solver expected");
   }

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils_clonestrategy.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils_clonestrategy.cpp
@@ -194,15 +194,13 @@ void PoroElastScaTra::Utils::PoroScatraCloneStrategy::set_element_data(
   if (impltype == Inpar::ScaTra::impltype_undefined)
     FOUR_C_THROW(
         "PoroScatraCloneStrategy copies scatra discretization from structure discretization, but "
-        "the "
-        "STRUCTURE elements that are defined in the .dat file are either not meant to be copied "
-        "to scatra elements "
-        "or the ImplType is set 'Undefined' which is not meaningful for the created scatra "
-        "discretization! "
+        "the STRUCTURE elements that are defined in the input file are either not meant to be "
+        "copied "
+        "to scatra elements or the ImplType is set 'Undefined' which is not meaningful for the "
+        "created scatra discretization! "
         "Use SOLIDSCATRA, WALLSCATRA, SHELLSCATRA, SOLIDPOROSCATRA, SOLIDPOROP1SCATRA, "
-        "SOLIDPORO_PRESSURE_BASED"
-        "WALLPOROSCATRA or "
-        "WALLPOROP1SCATRA Elements with meaningful ImplType instead!");
+        "SOLIDPORO_PRESSURE_BASED, WALLPOROSCATRA or WALLPOROP1SCATRA Elements with meaningful "
+        "ImplType instead!");
 
   trans->set_impl_type(impltype);
 }

--- a/src/porofluidmultiphase/4C_porofluidmultiphase_utils.cpp
+++ b/src/porofluidmultiphase/4C_porofluidmultiphase_utils.cpp
@@ -75,7 +75,7 @@ void POROFLUIDMULTIPHASE::Utils::setup_material(
   // initialize material map
   std::map<int, int> matmap;
   {
-    // get the cloning material map from the .dat file
+    // get the cloning material map from the input file
     std::map<std::pair<std::string, std::string>, std::map<int, int>> clonefieldmatmap =
         Global::Problem::instance()->cloning_material_map();
     if (clonefieldmatmap.size() < 1)

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
@@ -22,22 +22,13 @@ FOUR_C_NAMESPACE_OPEN
  *---------------------------------------------------------------------- *
  *-----------------------------------------------------------------------*/
 
-/*----------------------------------------------------------------------*
- | instantiate global instance                               vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhaseType Discret::Elements::PoroFluidMultiPhaseType::instance_;
 
-/*----------------------------------------------------------------------*
- | instance access method                                   vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhaseType& Discret::Elements::PoroFluidMultiPhaseType::instance()
 {
   return instance_;
 }
 
-/*----------------------------------------------------------------------*
- | create an element from data                              vuong 08/16 |
- *----------------------------------------------------------------------*/
 Core::Communication::ParObject* Discret::Elements::PoroFluidMultiPhaseType::create(
     Core::Communication::UnpackBuffer& buffer)
 {
@@ -47,9 +38,6 @@ Core::Communication::ParObject* Discret::Elements::PoroFluidMultiPhaseType::crea
   return object;
 }
 
-/*----------------------------------------------------------------------*
- |  create an element from a dat file specifier             vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::shared_ptr<Core::Elements::Element> Discret::Elements::PoroFluidMultiPhaseType::create(
     const std::string eletype, const std::string eledistype, const int id, const int owner)
 {
@@ -62,9 +50,6 @@ std::shared_ptr<Core::Elements::Element> Discret::Elements::PoroFluidMultiPhaseT
   return nullptr;
 }
 
-/*----------------------------------------------------------------------*
- |  create an empty element                                vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::shared_ptr<Core::Elements::Element> Discret::Elements::PoroFluidMultiPhaseType::create(
     const int id, const int owner)
 {
@@ -73,9 +58,6 @@ std::shared_ptr<Core::Elements::Element> Discret::Elements::PoroFluidMultiPhaseT
   return ele;
 }
 
-/*----------------------------------------------------------------------------*
- |  nodal block information to create a null space description    vuong 08/16 |
- *----------------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhaseType::nodal_block_information(
     Core::Elements::Element* dwele, int& numdf, int& dimns, int& nv, int& np)
 {
@@ -83,19 +65,13 @@ void Discret::Elements::PoroFluidMultiPhaseType::nodal_block_information(
   dimns = numdf;
   nv = numdf;
 }
-/*----------------------------------------------------------------------*
- |  do the null space computation                            vuong 08/16 |
- *----------------------------------------------------------------------*/
+
 Core::LinAlg::SerialDenseMatrix Discret::Elements::PoroFluidMultiPhaseType::compute_null_space(
     Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
 {
   return FLD::compute_fluid_null_space(node, numdof, dimnsp);
 }
 
-/*----------------------------------------------------------------------*
- |  setup the dat file input line definitions for this type of element   |
- |                                                           vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhaseType::setup_element_definition(
     std::map<std::string, std::map<std::string, Core::IO::InputSpec>>& definitions)
 {
@@ -160,24 +136,15 @@ void Discret::Elements::PoroFluidMultiPhaseType::setup_element_definition(
  *---------------------------------------------------------------------- *
  *-----------------------------------------------------------------------*/
 
-/*----------------------------------------------------------------------*
- | instantiate global instance                               vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhaseBoundaryType
     Discret::Elements::PoroFluidMultiPhaseBoundaryType::instance_;
 
-/*----------------------------------------------------------------------*
- | instance access method                                   vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhaseBoundaryType&
 Discret::Elements::PoroFluidMultiPhaseBoundaryType::instance()
 {
   return instance_;
 }
 
-/*----------------------------------------------------------------------*
- |  create an empty element                                vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::shared_ptr<Core::Elements::Element> Discret::Elements::PoroFluidMultiPhaseBoundaryType::create(
     const int id, const int owner)
 {
@@ -192,9 +159,6 @@ std::shared_ptr<Core::Elements::Element> Discret::Elements::PoroFluidMultiPhaseB
   return nullptr;
 }
 
-/*----------------------------------------------------------------------*
- |  init the element (public)                                           |
- *----------------------------------------------------------------------*/
 int Discret::Elements::PoroFluidMultiPhaseType::initialize(Core::FE::Discretization& dis)
 {
   for (int i = 0; i < dis.num_my_col_elements(); ++i)
@@ -215,29 +179,17 @@ int Discret::Elements::PoroFluidMultiPhaseType::initialize(Core::FE::Discretizat
  *---------------------------------------------------------------------- *
  *-----------------------------------------------------------------------*/
 
-/*----------------------------------------------------------------------*
- |  create an empty element                                vuong 08/16 |
- *------------------------------------------------------ ----------------*/
 Discret::Elements::PoroFluidMultiPhase::PoroFluidMultiPhase(int id, int owner)
     : Core::Elements::Element(id, owner), distype_(Core::FE::CellType::dis_none), numdofpernode_(-1)
 {
-  return;
 }
 
-/*----------------------------------------------------------------------*
- |  copy-ctor (public)                                      vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhase::PoroFluidMultiPhase(
     const Discret::Elements::PoroFluidMultiPhase& old)
     : Core::Elements::Element(old), distype_(old.distype_), numdofpernode_(old.numdofpernode_)
 {
-  return;
 }
 
-/*--------------------------------------------------------------------------*
- |  Deep copy this instance of PoroFluidMultiPhase and return pointer to it  |
- |                                                 (public) vuong 08/16      |
- *---------------------------------------------------------------------------*/
 Core::Elements::Element* Discret::Elements::PoroFluidMultiPhase::clone() const
 {
   Discret::Elements::PoroFluidMultiPhase* newelement =
@@ -245,29 +197,16 @@ Core::Elements::Element* Discret::Elements::PoroFluidMultiPhase::clone() const
   return newelement;
 }
 
-/*----------------------------------------------------------------------*
- |  Return the shape of a PoroFluidMultiPhase element          (public) |
- |                                                          vuong 08/16 |
- *----------------------------------------------------------------------*/
 Core::FE::CellType Discret::Elements::PoroFluidMultiPhase::shape() const { return distype_; }
 
-/*----------------------------------------------------------------------*
- |  Initialize element                                      (protected) |
- |                                                          vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhase::initialize()
 {
   std::shared_ptr<Mat::FluidPoroMultiPhase> actmat =
       std::dynamic_pointer_cast<Mat::FluidPoroMultiPhase>(material());
 
   actmat->initialize();
-  return;
 }
 
-/*----------------------------------------------------------------------*
- |  Pack data                                                  (public) |
- |                                                          vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhase::pack(Core::Communication::PackBuffer& data) const
 {
   // pack type of this instance of ParObject
@@ -280,15 +219,8 @@ void Discret::Elements::PoroFluidMultiPhase::pack(Core::Communication::PackBuffe
   // add internal data
   add_to_pack(data, distype_);
   add_to_pack(data, numdofpernode_);
-
-  return;
 }
 
-
-/*----------------------------------------------------------------------*
- |  Unpack data                                                (public) |
- |                                                          vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhase::unpack(Core::Communication::UnpackBuffer& buffer)
 {
   Core::Communication::extract_and_assert_id(buffer, unique_par_object_id());
@@ -299,43 +231,23 @@ void Discret::Elements::PoroFluidMultiPhase::unpack(Core::Communication::UnpackB
   // extract internal data
   extract_from_pack(buffer, distype_);
   extract_from_pack(buffer, numdofpernode_);
-
-
-
-  return;
 }
 
-/*----------------------------------------------------------------------*
- |  Return number of lines of this element (public)         vuong 08/16 |
- *----------------------------------------------------------------------*/
 int Discret::Elements::PoroFluidMultiPhase::num_line() const
 {
   return Core::FE::get_number_of_element_lines(distype_);
 }
 
-
-/*----------------------------------------------------------------------*
- |  Return number of surfaces of this element (public)      vuong 08/16 |
- *----------------------------------------------------------------------*/
 int Discret::Elements::PoroFluidMultiPhase::num_surface() const
 {
   return Core::FE::get_number_of_element_surfaces(distype_);
 }
 
-
-/*----------------------------------------------------------------------*
- | Return number of volumes of this element (public)        vuong 08/16 |
- *----------------------------------------------------------------------*/
 int Discret::Elements::PoroFluidMultiPhase::num_volume() const
 {
   return Core::FE::get_number_of_element_volumes(distype_);
 }
 
-
-
-/*----------------------------------------------------------------------*
- |  print this element (public)                             vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhase::print(std::ostream& os) const
 {
   os << "PoroFluidMultiPhase element";
@@ -348,10 +260,6 @@ void Discret::Elements::PoroFluidMultiPhase::print(std::ostream& os) const
   return;
 }
 
-
-/*----------------------------------------------------------------------*
- |  get vector of lines            (public)                 vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::vector<std::shared_ptr<Core::Elements::Element>>
 Discret::Elements::PoroFluidMultiPhase::lines()
 {
@@ -359,10 +267,6 @@ Discret::Elements::PoroFluidMultiPhase::lines()
       *this);
 }
 
-
-/*----------------------------------------------------------------------*
- |  get vector of surfaces (public)                         vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::vector<std::shared_ptr<Core::Elements::Element>>
 Discret::Elements::PoroFluidMultiPhase::surfaces()
 {
@@ -370,9 +274,6 @@ Discret::Elements::PoroFluidMultiPhase::surfaces()
       PoroFluidMultiPhase>(*this);
 }
 
-/*----------------------------------------------------------------------*
- | read element input                                       vuong 08/16 |
- *----------------------------------------------------------------------*/
 bool Discret::Elements::PoroFluidMultiPhase::read_element(const std::string& eletype,
     const std::string& distype, const Core::IO::InputParameterContainer& container)
 {
@@ -386,9 +287,6 @@ bool Discret::Elements::PoroFluidMultiPhase::read_element(const std::string& ele
   return true;
 }
 
-/*----------------------------------------------------------------------*
- |  create material class (public)                          vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhase::set_material(
     const int index, std::shared_ptr<Core::Mat::Material> mat)
 {
@@ -408,8 +306,6 @@ void Discret::Elements::PoroFluidMultiPhase::set_material(
   else
     FOUR_C_THROW(
         "PoroFluidMultiPhase element got unsupported material type %d", mat->material_type());
-
-  return;
 }
 
 /*----------------------------------------------------------------------*
@@ -418,10 +314,6 @@ void Discret::Elements::PoroFluidMultiPhase::set_material(
  *---------------------------------------------------------------------- *
  *-----------------------------------------------------------------------*/
 
-
-/*----------------------------------------------------------------------*
- |  ctor (public)                                           vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhaseBoundary::PoroFluidMultiPhaseBoundary(int id, int owner,
     int nnode, const int* nodeids, Core::Nodes::Node** nodes,
     Discret::Elements::PoroFluidMultiPhase* parent, const int lsurface)
@@ -433,9 +325,6 @@ Discret::Elements::PoroFluidMultiPhaseBoundary::PoroFluidMultiPhaseBoundary(int 
   return;
 }
 
-/*----------------------------------------------------------------------*
- |  copy-ctor (public)                                      vuong 08/16 |
- *----------------------------------------------------------------------*/
 Discret::Elements::PoroFluidMultiPhaseBoundary::PoroFluidMultiPhaseBoundary(
     const Discret::Elements::PoroFluidMultiPhaseBoundary& old)
     : Core::Elements::FaceElement(old)
@@ -443,9 +332,6 @@ Discret::Elements::PoroFluidMultiPhaseBoundary::PoroFluidMultiPhaseBoundary(
   return;
 }
 
-/*----------------------------------------------------------------------*
- |  Deep copy this instance return pointer to it   (public) vuong 08/16 |
- *----------------------------------------------------------------------*/
 Core::Elements::Element* Discret::Elements::PoroFluidMultiPhaseBoundary::clone() const
 {
   Discret::Elements::PoroFluidMultiPhaseBoundary* newelement =
@@ -453,17 +339,11 @@ Core::Elements::Element* Discret::Elements::PoroFluidMultiPhaseBoundary::clone()
   return newelement;
 }
 
-/*----------------------------------------------------------------------*
- |  Return shape of this element                   (public) vuong 08/16 |
- *----------------------------------------------------------------------*/
 Core::FE::CellType Discret::Elements::PoroFluidMultiPhaseBoundary::shape() const
 {
   return Core::FE::get_shape_of_boundary_element(num_node(), parent_element()->shape());
 }
 
-/*----------------------------------------------------------------------*
- |  Pack data (public)                                      vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhaseBoundary::pack(
     Core::Communication::PackBuffer& data) const
 {
@@ -474,9 +354,6 @@ void Discret::Elements::PoroFluidMultiPhaseBoundary::pack(
   return;
 }
 
-/*----------------------------------------------------------------------*
- |  Unpack data (public)                                    vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhaseBoundary::unpack(
     Core::Communication::UnpackBuffer& buffer)
 {
@@ -488,10 +365,6 @@ void Discret::Elements::PoroFluidMultiPhaseBoundary::unpack(
 }
 
 
-
-/*----------------------------------------------------------------------*
- |  print this element (public)                             vuong 08/16 |
- *----------------------------------------------------------------------*/
 void Discret::Elements::PoroFluidMultiPhaseBoundary::print(std::ostream& os) const
 {
   os << "PoroFluidMultiPhaseBoundary element";
@@ -502,34 +375,22 @@ void Discret::Elements::PoroFluidMultiPhaseBoundary::print(std::ostream& os) con
   return;
 }
 
-/*----------------------------------------------------------------------*
- | Return number of lines of boundary element (public)      vuong 08/16 |
- *----------------------------------------------------------------------*/
 int Discret::Elements::PoroFluidMultiPhaseBoundary::num_line() const
 {
   return Core::FE::get_number_of_element_lines(shape());
 }
 
-/*----------------------------------------------------------------------*
- |  Return number of surfaces of boundary element (public)  vuong 08/16 |
- *----------------------------------------------------------------------*/
 int Discret::Elements::PoroFluidMultiPhaseBoundary::num_surface() const
 {
   return Core::FE::get_number_of_element_surfaces(shape());
 }
 
-/*----------------------------------------------------------------------*
- |  get vector of lines (public)                            vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::vector<std::shared_ptr<Core::Elements::Element>>
 Discret::Elements::PoroFluidMultiPhaseBoundary::lines()
 {
   FOUR_C_THROW("Lines of PoroFluidMultiPhaseBoundary not implemented");
 }
 
-/*----------------------------------------------------------------------*
- |  get vector of lines (public)                            vuong 08/16 |
- *----------------------------------------------------------------------*/
 std::vector<std::shared_ptr<Core::Elements::Element>>
 Discret::Elements::PoroFluidMultiPhaseBoundary::surfaces()
 {

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.hpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.hpp
@@ -32,7 +32,7 @@ namespace Discret
       /// create an element from data
       Core::Communication::ParObject* create(Core::Communication::UnpackBuffer& buffer) override;
 
-      /// create an element from a dat file specifier
+      /// create an element from an input file specifier
       std::shared_ptr<Core::Elements::Element> create(const std::string eletype,
           const std::string eledistype, const int id, const int owner) override;
 
@@ -47,7 +47,7 @@ namespace Discret
       Core::LinAlg::SerialDenseMatrix compute_null_space(
           Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
 
-      /// setup the dat file input line definitions for this type of element
+      /// setup the input file input line definitions for this type of element
       void setup_element_definition(
           std::map<std::string, std::map<std::string, Core::IO::InputSpec>>& definitions) override;
 

--- a/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
+++ b/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
@@ -634,7 +634,7 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::create_linear_solver(
     std::cout << " uses the structural solver and fluid solver blocks" << std::endl;
     std::cout << " for building the internal inverses" << std::endl;
     std::cout << " Remove the old BGS PRECONDITIONER BLOCK entries " << std::endl;
-    std::cout << " in the dat files!" << std::endl;
+    std::cout << " in the input files!" << std::endl;
     std::cout << "!!!!!!!!!!!!!!!!!!!!!! ATTENTION !!!!!!!!!!!!!!!!!!!!!" << std::endl;
     FOUR_C_THROW("Iterative solver expected");
   }

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
@@ -287,7 +287,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::create_linear_s
     std::cout << " uses the structural solver and fluid solver blocks" << std::endl;
     std::cout << " for building the internal inverses" << std::endl;
     std::cout << " Remove the old BGS PRECONDITIONER BLOCK entries " << std::endl;
-    std::cout << " in the dat files!" << std::endl;
+    std::cout << " in the input files!" << std::endl;
     std::cout << "!!!!!!!!!!!!!!!!!!!!!! ATTENTION !!!!!!!!!!!!!!!!!!!!!" << std::endl;
     FOUR_C_THROW("Iterative solver expected");
   }

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -2384,7 +2384,7 @@ void EnsightWriter::write_coordinates_for_polynomial_shapefunctions(
       for (int inode = 0; inode < proc0map->NumGlobalElements(); ++inode)
       {
         write(geofile, proc0map->GID(inode) + 1);
-        // gid+1 delivers the node numbering of the *.dat file starting with 1
+        // gid+1 delivers the node numbering of the input file starting with 1
       }
     }
     // now write the coordinate information

--- a/src/post/4C_post_ensight_writer_nurbs.cpp
+++ b/src/post/4C_post_ensight_writer_nurbs.cpp
@@ -1380,7 +1380,7 @@ void EnsightWriter::write_coordinates_for_nurbs_shapefunctions(
       for (int inode = 0; inode < proc0map->NumGlobalElements(); ++inode)
       {
         write(geofile, static_cast<float>(proc0map->GID(inode)) + 1);
-        // gid+1 delivers the node numbering of the *.dat file starting with 1
+        // gid+1 delivers the node numbering of the input file starting with 1
       }
     }
     // now write the coordinate information

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -397,10 +397,10 @@ void Airway::RedAirwayImplicitTimeInt::integrate(
 
 
 /*-----------------------------------------------------------------------------*
- | Prestress the lung to a given transpulmonary pressure given in the .dat file|
- | This will shink the lung before the first timestep in such a way that the   |
- | volume of each acinus reaches the given volume in the .dat file when p_tp is|
- | applied                                                        roth 05/2015 |
+ | Prestress the lung to a given transpulmonary pressure given in the input file|
+ | This will shink the lung before the first timestep in such a way that the    |
+ | volume of each acinus reaches the given volume in the input file when p_tp is|
+ | applied                                                                      |
  *-----------------------------------------------------------------------------*/
 void Airway::RedAirwayImplicitTimeInt::compute_vol0_for_pre_stress()
 {
@@ -449,7 +449,7 @@ void Airway::RedAirwayImplicitTimeInt::compute_vol0_for_pre_stress()
           // getParams and setParams
           auto* acini_ele = dynamic_cast<Discret::Elements::RedAcinus*>(discret_->g_element(GID));
           const auto acinus_params = acini_ele->get_acinus_params();
-          // get original value for aciuns volume (entered in dat file)
+          // get original value for aciuns volume (entered in input file)
           double val = acinus_params.volume_init;
           // calculate new value for aciuns volume with alpha and set in element parameters
           val = val / alpha;
@@ -474,9 +474,6 @@ void Airway::RedAirwayImplicitTimeInt::compute_vol0_for_pre_stress()
   }
 }
 
-/*-----------------------------------------------------------------------------*
- |                                                                roth 02/2016 |
- *-----------------------------------------------------------------------------*/
 void Airway::RedAirwayImplicitTimeInt::compute_nearest_acinus(
     const Core::FE::Discretization& search_discret, std::set<int>* elecolset,
     std::set<int>* nodecolset, std::shared_ptr<Core::LinAlg::Vector<double>> airway_acinus_dep)

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -3288,7 +3288,7 @@ double ScaTra::ScaTraTimIntElch::get_current_temperature() const
 {
   double temperature(-1.0);
 
-  // if no function is defined we use the value set in the dat-file
+  // if no function is defined we use the value set in the input file
   if (temperature_funct_num_ == -1)
     temperature = elchparams_->get<double>("TEMPERATURE");
   else

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -2338,7 +2338,7 @@ void ScaTra::ScaTraTimIntImpl::update_iter(const Core::LinAlg::Vector<double>& i
 void ScaTra::ScaTraTimIntImpl::setup_krylov_space_projection(Core::Conditions::Condition* kspcond)
 {
   // previously, scatra was able to define actual modes that formed a
-  // nullspace. factors when assigned to scalars in the dat file. it could
+  // nullspace. factors when assigned to scalars in the input file. it could
   // take several scatra Krylov conditions each forming one mode like:
   // 4.0*c_1 + 2.0*c_2 = const
   // since this was never used, not even in ELCH-problems, and for the sake of
@@ -2356,13 +2356,13 @@ void ScaTra::ScaTraTimIntImpl::setup_krylov_space_projection(Core::Conditions::C
   {
     FOUR_C_THROW(
         "Expecting as many mode flags as nodal dofs in Krylov projection definition. Check "
-        "dat-file!");
+        "input file!");
   }
 
-  // get vector of mode flags as given in dat-file
+  // get vector of mode flags as given in input file
   const auto* modeflags = &kspcond->parameters().get<std::vector<int>>("ONOFF");
 
-  // count actual active modes selected in dat-file
+  // count actual active modes selected in input file
   std::vector<int> activemodeids;
   for (int rr = 0; rr < num_dof_per_node(); ++rr)
   {
@@ -2372,7 +2372,7 @@ void ScaTra::ScaTraTimIntImpl::setup_krylov_space_projection(Core::Conditions::C
     }
   }
 
-  // get from dat-file definition how weights are to be computed
+  // get from input file definition how weights are to be computed
   const auto* weighttype = &kspcond->parameters().get<std::string>("WEIGHTVECDEF");
 
   // set flag for projection update true only if ALE and integral weights
@@ -2401,7 +2401,7 @@ void ScaTra::ScaTraTimIntImpl::update_krylov_space_projection()
   c->PutScalar(0.0);
 
   const std::string* weighttype = projector_->weight_type();
-  // compute w_ as defined in dat-file
+  // compute w_ as defined in input file
   if (*weighttype == "pointvalues")
   {
     FOUR_C_THROW("option pointvalues not implemented");

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
@@ -265,7 +265,7 @@ void NOX::Nln::GlobalData::set_status_test_parameters()
 {
   Teuchos::ParameterList& statusTestParams = nlnparams_->sublist("Status Test", true);
 
-  // check if the status test was already set via the dat-file
+  // check if the status test was already set via the input file
   if (statusTestParams.isSublist("Outer Status Test") and
       statusTestParams.sublist("Outer Status Test").numParams() != 0)
     return;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.hpp
@@ -139,7 +139,7 @@ namespace NOX
 
       /*! \brief set printing parameters
        *
-       * translate dat file input into NOX input */
+       * translate input file input into NOX input */
       void set_printing_parameters();
 
       //! set solver option parameters

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -342,7 +342,7 @@ void SSI::SSIBase::init_discretizations(MPI_Comm comm, const std::string& struct
     if (fieldcoupling_ == Inpar::SSI::FieldCoupling::volume_match)
     {
       FOUR_C_THROW(
-          "Reading a TRANSPORT discretization from the .dat file for the input parameter "
+          "Reading a TRANSPORT discretization from the input file for the input parameter "
           "'FIELDCOUPLING volume_matching' in the SSI CONTROL section is not supported! As this "
           "coupling relies on matching node (and sometimes element) IDs, the ScaTra discretization "
           "is cloned from the structure discretization. Delete the ScaTra discretization from your "
@@ -366,9 +366,10 @@ void SSI::SSIBase::init_discretizations(MPI_Comm comm, const std::string& struct
           Inpar::ScaTra::impltype_undefined)
       {
         FOUR_C_THROW(
-            "A TRANSPORT discretization is read from the .dat file, which is fine since the scatra "
+            "A TRANSPORT discretization is read from the input file, which is fine since the "
+            "scatra "
             "discretization is not cloned from the structure discretization. But in the STRUCTURE "
-            "ELEMENTS section of the .dat file an ImplType that is NOT 'Undefined' is prescribed "
+            "ELEMENTS section of the input file an ImplType that is NOT 'Undefined' is prescribed "
             "which does not make sense if you don't want to clone the structure discretization. "
             "Change the ImplType to 'Undefined' or decide to clone the scatra discretization from "
             "the structure discretization.");

--- a/src/ssi/4C_ssi_clonestrategy.cpp
+++ b/src/ssi/4C_ssi_clonestrategy.cpp
@@ -96,7 +96,7 @@ void SSI::ScatraStructureCloneStrategy::set_element_data(
     {
       FOUR_C_THROW(
           "ScatraStructureCloneStrategy copies scatra discretization from structure "
-          "discretization, but the STRUCTURE elements that are defined in the .dat file are "
+          "discretization, but the STRUCTURE elements that are defined in the input file are "
           "either not meant to be copied to scatra elements or the ImplType is set 'Undefined' "
           "which is not meaningful for the created scatra discretization! Use SOLIDSCATRA, "
           "WALLSCATRA, SHELLSCATRA or TRUSS3SCATRA elements with meaningful ImplType instead!");

--- a/src/ssti/4C_ssti_utils.cpp
+++ b/src/ssti/4C_ssti_utils.cpp
@@ -725,7 +725,8 @@ void SSTI::SSTIScatraStructureCloneStrategy::set_element_data(
     {
       FOUR_C_THROW(
           "ScatraStructureCloneStrategy copies scatra discretization from structure "
-          "discretization, but the STRUCTURE elements that are defined in the .dat file are either "
+          "discretization, but the STRUCTURE elements that are defined in the input file are "
+          "either "
           "not meant to be copied to scatra elements or the ImplType is set 'Undefined' which is "
           "not meaningful for the created scatra discretization! Use SOLIDSCATRA, WALLSCATRA or "
           "SHELLSCATRA elements with meaningful ImplType instead!");

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -1009,7 +1009,7 @@ void MultiScale::MicroStatic::static_homogenization(Core::LinAlg::Matrix<6, 1>* 
     // get the solver number used for structural solver
     const int linsolvernumber = 9;
 
-    // TODO: insert input parameter from dat file for solver block Belos
+    // TODO: insert input parameter from input file for solver block Belos
 
     // get solver parameter list of linear solver
     const Teuchos::ParameterList& solverparams =

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -749,14 +749,14 @@ void Solid::TimIntImpl::predict_tang_dis_consist_vel_acc()
  *--------------------------------------------------------------------------*/
 void Solid::TimIntImpl::setup_krylov_space_projection(Core::Conditions::Condition* kspcond)
 {
-  // get number of mode flags in dat-file
+  // get number of mode flags in input file
   const int nummodes = kspcond->parameters().get<int>("NUMMODES");
 
   // get rigid body mode flags - number and order as in ComputeNullspace
   // e.g. for a 3-D solid: [transx transy transz rotx roty rotz]
   const auto* modeflags = &kspcond->parameters().get<std::vector<int>>("ONOFF");
 
-  // get actual active mode ids given in dat-file
+  // get actual active mode ids given in input file
   std::vector<int> activemodeids;
   for (int rr = 0; rr < nummodes; ++rr)
   {
@@ -766,7 +766,7 @@ void Solid::TimIntImpl::setup_krylov_space_projection(Core::Conditions::Conditio
     }
   }
 
-  // get from dat-file definition how weights are to be computed
+  // get from input file definition how weights are to be computed
   const std::string* weighttype = &kspcond->parameters().get<std::string>("WEIGHTVECDEF");
 
   // since we only use total Lagrange, no update necessary.

--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
@@ -49,7 +49,7 @@ void Solid::TimeInt::Explicit::setup()
   enum Inpar::Solid::NonlinSolTech nlnSolverType = data_sdyn().get_nln_solver_type();
   if (nlnSolverType != Inpar::Solid::soltech_singlestep)
   {
-    std::cout << "WARNING!!!Nonlinear solver for explicit dynamics is given (in the dat file) as "
+    std::cout << "WARNING!!!Nonlinear solver for explicit dynamics is given (in the input file) as "
               << Inpar::Solid::nonlin_sol_tech_string(nlnSolverType)
               << ". This is not compatible. singlestep solver will be selected." << std::endl;
     nlnSolverType = Inpar::Solid::soltech_singlestep;

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -232,7 +232,7 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_meshtying_co
           FOUR_C_THROW(
               "You have chosen an iterative linear solver. For mortar/Contact in saddlepoint "
               "formulation you have to choose a block preconditioner such as SIMPLE. Choose "
-              "Teko or MueLu in the SOLVER %i block in your dat file.",
+              "Teko or MueLu in the SOLVER %i block in your input file.",
               lin_solver_id);
       }
 

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_fullnewton.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_fullnewton.cpp
@@ -78,7 +78,7 @@ void Solid::Nln::SOLVER::FullNewton::set_full_newton_params()
   // STATUS TEST
   // ---------------------------------------------------------------------------
   /* This is only necessary for the special case, that you use no xml-file for
-   * the definition of your convergence tests, but you use the dat-file instead.
+   * the definition of your convergence tests, but you use the input file instead.
    */
   if (not is_xml_status_test_file(data_sdyn().get_nox_params().sublist("Status Test")))
   {

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_ptc.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_ptc.cpp
@@ -94,7 +94,7 @@ void Solid::Nln::SOLVER::PseudoTransient::set_pseudo_transient_params()
   // STATUS TEST
   // ---------------------------------------------------------------------------
   /* This is only necessary for the special case, that you use no xml-file for
-   * the definition of your convergence tests, but you use the dat-file instead.
+   * the definition of your convergence tests, but you use the input file instead.
    */
   if (not is_xml_status_test_file(data_sdyn().get_nox_params().sublist("Status Test")))
   {

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
@@ -49,7 +49,7 @@ void Solid::Nln::SOLVER::SingleStep::set_single_step_params()
   // STATUS TEST
   // ---------------------------------------------------------------------------
   /* This is only necessary for the special case, that you use no xml-file for
-   * the definition of your convergence tests, but you use the dat-file instead.
+   * the definition of your convergence tests, but you use the input file instead.
    */
   if (not is_xml_status_test_file(data_sdyn().get_nox_params().sublist("Status Test")))
   {

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.hpp
@@ -34,7 +34,7 @@ namespace Solid
   {
     namespace SOLVER
     {
-      //! Check if a xml status test file is specified in the dat file
+      //! Check if a xml status test file is specified in the input file
       bool is_xml_status_test_file(const Teuchos::ParameterList& pstatus);
 
       /*! \brief Create quantity types
@@ -56,7 +56,7 @@ namespace Solid
       /*! \brief Create a status test parameter list
        *
        *  A status test parameter list for the outer status test is created. The
-       *  information comes from the dat file. Actually we consider only convergence
+       *  information comes from the input file. Actually we consider only convergence
        *  tests which were already in 4C before the NOX framework was introduced.
        *
        *  Feel free to extend the given framework, to generalize it or to use a xml
@@ -80,7 +80,7 @@ namespace Solid
        * parameter list
        *
        *  Maybe the current implementation needs a short explanation:
-       *  You can specify different combinations in your dat-file. Let's concentrate on
+       *  You can specify different combinations in your input file. Let's concentrate on
        *  the NormF case and imagine the following status test settings:
        *
        *  NORMCOMBI_RESFINCO           AND        (RESIDUAL and PRESSURE)
@@ -100,11 +100,11 @@ namespace Solid
        *
        *  If you want a different behavior, please use a xml file instead.
        *
-       *  One last note: In the case you want to commit your dat-file as a test case, your algorithm
-       *  should not use any OR-combination, since the goal of your algorithm should be to reduce
-       * the whole residual. If you think a part of your residual can not be reduced in a sufficient
-       * way, think again and if it stays your opinion, do not check it (by using a xml-file for
-       * example). This makes things easier to read and understand. If you use only
+       *  One last note: In the case you want to commit your input file as a test case, your
+       * algorithm should not use any OR-combination, since the goal of your algorithm should be to
+       * reduce the whole residual. If you think a part of your residual can not be reduced in a
+       * sufficient way, think again and if it stays your opinion, do not check it (by using a
+       * xml-file for example). This makes things easier to read and understand. If you use only
        * AND-combinations, you can use the QUANTITY parameter list name option for NormF, NormWRMS
        * and NormUpdate tests. See the NOX::Nln::StatusTest::Factory for more information.
        *

--- a/src/thermo/src/element/4C_thermo_ele_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.cpp
@@ -546,7 +546,7 @@ int Discret::Elements::TemperImpl<distype>::evaluate(
   }
 
   //==================================================================================
-  // allowing the predictor TangTemp in .dat --> can be decisive in compressible case!
+  // allowing the predictor TangTemp in input file --> can be decisive in compressible case!
   else if (action == Thermo::calc_thermo_reset_istep)
   {
     // we have to have a thermo-capable material here -> throw error if not

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -264,7 +264,7 @@ void TSI::Monolithic::create_linear_solver()
     std::cout << " uses the structural solver and thermal solver blocks" << std::endl;
     std::cout << " for building the internal inverses" << std::endl;
     std::cout << " Remove the old BGS PRECONDITIONER BLOCK entries " << std::endl;
-    std::cout << " in the dat files!" << std::endl;
+    std::cout << " in the input files!" << std::endl;
     std::cout << "!!!!!!!!!!!!!!!!!!!!!! ATTENTION !!!!!!!!!!!!!!!!!!!!!" << std::endl;
     FOUR_C_THROW("Iterative solver expected");
   }


### PR DESCRIPTION
## Description and Context
Generalize the terminology to use `input file` instead of `dat file` in comments and error messages.
I did not yet change any occurences in pre-exodus and the documentation.

## Related Issues and Merge Requests
--