### PR TITLE
Fix MPI_COMM nullptr

### DIFF
--- a/src/adapter/4C_adapter_coupling_nonlin_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_nonlin_mortar.cpp
@@ -39,7 +39,7 @@ Adapter::CouplingNonLinMortar::CouplingNonLinMortar(int spatial_dimension,
     : Coupling::Adapter::CouplingMortar(
           spatial_dimension, mortar_coupling_params, contact_dynamic_params, shape_function_type),
       issetup_(false),
-      comm_(nullptr),
+      comm_(MPI_COMM_NULL),
       myrank_(-1),
       slavenoderowmap_(nullptr),
       DLin_(nullptr),

--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -295,7 +295,7 @@ namespace Core::Communication
         lpidgpid_(lpidgpid),
         lcomm_(lcomm),
         gcomm_(gcomm),
-        subcomm_(nullptr),
+        subcomm_(MPI_COMM_NULL),
         np_type_(npType)
   {
     return;

--- a/src/core/io/src/4C_io_pstream.cpp
+++ b/src/core/io/src/4C_io_pstream.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_mpi_utils.hpp"
 
+#include <mpi.h>
 #include <Teuchos_oblackholestream.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -25,7 +26,7 @@ namespace Core::IO
  *----------------------------------------------------------------------*/
 Core::IO::Pstream::Pstream()
     : is_initialized_(false),
-      comm_(nullptr),
+      comm_(MPI_COMM_NULL),
       targetpid_(-2),
       writetoscreen_(false),
       writetofile_(false),
@@ -124,7 +125,7 @@ void Core::IO::Pstream::close()
   if (not is_initialized_) return;
 
   is_initialized_ = false;
-  comm_ = nullptr;
+  comm_ = MPI_COMM_NULL;
   targetpid_ = -2;
   writetoscreen_ = false;
   writetofile_ = false;

--- a/src/cut/4C_cut_combintersection.cpp
+++ b/src/cut/4C_cut_combintersection.cpp
@@ -8,7 +8,6 @@
 #include "4C_cut_combintersection.hpp"
 
 #include "4C_cut_levelsetintersection.hpp"
-#include "4C_cut_levelsetside.hpp"
 #include "4C_cut_meshintersection.hpp"
 #include "4C_cut_tolerance.hpp"  // for EXTENDED_CUT_DEBUG_OUTPUT
 

--- a/src/cut/4C_cut_levelsetintersection.cpp
+++ b/src/cut/4C_cut_levelsetintersection.cpp
@@ -7,24 +7,12 @@
 
 #include "4C_cut_levelsetintersection.hpp"
 
-#include "4C_comm_mpi_utils.hpp"
-#include "4C_cut_levelsetside.hpp"
 #include "4C_cut_side.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-Cut::LevelSetIntersection::LevelSetIntersection(MPI_Comm comm, bool create_side)
-    : ParentIntersection(Core::Communication::my_mpi_rank(comm)), side_(nullptr), comm_(comm)
-{
-  if (create_side) add_cut_side(1);
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 Cut::LevelSetIntersection::LevelSetIntersection(int myrank, bool create_side)
     : ParentIntersection(myrank), side_(nullptr), comm_(nullptr)
 {
@@ -101,7 +89,6 @@ void Cut::LevelSetIntersection::cut_mesh(bool screenoutput)
 
     if (myrank_ == 0 and screenoutput)
     {
-      if (comm_) Core::Communication::barrier(comm_);
       t_diff = Teuchos::Time::wallTime() - t_start;
 
       printf("success! ( %10.4e secs )", t_diff);
@@ -117,7 +104,6 @@ void Cut::LevelSetIntersection::cut_mesh(bool screenoutput)
 
     if (myrank_ == 0 and screenoutput)
     {
-      if (comm_) Core::Communication::barrier(comm_);
       t_diff = Teuchos::Time::wallTime() - t_start;
 
       printf("success! ( %10.4e secs )", t_diff);
@@ -133,7 +119,6 @@ void Cut::LevelSetIntersection::cut_mesh(bool screenoutput)
 
     if (myrank_ == 0 and screenoutput)
     {
-      if (comm_) Core::Communication::barrier(comm_);
       t_diff = Teuchos::Time::wallTime() - t_start;
 
       printf("success! ( %10.4e secs )", t_diff);
@@ -149,7 +134,6 @@ void Cut::LevelSetIntersection::cut_mesh(bool screenoutput)
 
     if (myrank_ == 0 and screenoutput)
     {
-      if (comm_) Core::Communication::barrier(comm_);
       t_diff = Teuchos::Time::wallTime() - t_start;
 
       printf("success! ( %10.4e secs )", t_diff);
@@ -199,7 +183,6 @@ void Cut::LevelSetIntersection::cut(bool include_inner, bool screenoutput, VCell
 
     if (myrank_ == 0 and screenoutput)
     {
-      if (comm_) Core::Communication::barrier(comm_);
       t_diff = Teuchos::Time::wallTime() - t_start;
 
       printf("success! ( %10.4e secs )", t_diff);
@@ -215,7 +198,6 @@ void Cut::LevelSetIntersection::cut(bool include_inner, bool screenoutput, VCell
 
     if (myrank_ == 0 and screenoutput)
     {
-      if (comm_) Core::Communication::barrier(comm_);
       t_diff = Teuchos::Time::wallTime() - t_start;
 
       printf("success! ( %10.4e secs )\n\n", t_diff);

--- a/src/cut/4C_cut_levelsetintersection.hpp
+++ b/src/cut/4C_cut_levelsetintersection.hpp
@@ -37,8 +37,6 @@ namespace Cut
 
 
    public:
-    LevelSetIntersection(MPI_Comm comm, bool create_side = true);
-
     /// constructor for LevelSetIntersection class
     LevelSetIntersection(int myrank = -1, bool create_side = true);
 

--- a/src/levelset/4C_levelset_intersection_utils.cpp
+++ b/src/levelset/4C_levelset_intersection_utils.cpp
@@ -89,7 +89,7 @@ void ScaTra::LevelSet::Intersection::get_zero_level_set(const Core::LinAlg::Vect
     // ------------------------------------------------------------------------
     // Prepare cut
     // ------------------------------------------------------------------------
-    Cut::LevelSetIntersection levelset(scatradis.get_comm());
+    Cut::LevelSetIntersection levelset(Core::Communication::my_mpi_rank(scatradis.get_comm()));
     Core::LinAlg::SerialDenseMatrix xyze;
     std::vector<double> phi_nodes;
     std::vector<int> nids;

--- a/src/mortar/4C_mortar_interface.cpp
+++ b/src/mortar/4C_mortar_interface.cpp
@@ -46,7 +46,7 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------------*/
 Mortar::InterfaceDataContainer::InterfaceDataContainer()
     : id_(-1),
-      comm_(nullptr),
+      comm_(MPI_COMM_NULL),
       redistributed_(false),
       idiscret_(nullptr),
       dim_(-1),

--- a/src/mortar/4C_mortar_strategy_base.cpp
+++ b/src/mortar/4C_mortar_strategy_base.cpp
@@ -26,7 +26,7 @@ FOUR_C_NAMESPACE_OPEN
 Mortar::StrategyDataContainer::StrategyDataContainer()
     : probdofs_(nullptr),
       probnodes_(nullptr),
-      comm_(nullptr),
+      comm_(MPI_COMM_NULL),
       scontact_(),
       dim_(0),
       alphaf_(0.0),

--- a/src/mortar/4C_mortar_strategy_factory.cpp
+++ b/src/mortar/4C_mortar_strategy_factory.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Mortar::STRATEGY::Factory::Factory()
-    : discret_ptr_(nullptr), isinit_(false), issetup_(false), comm_ptr_(nullptr), dim_(-1)
+    : discret_ptr_(nullptr), isinit_(false), issetup_(false), comm_(MPI_COMM_NULL), dim_(-1)
 {
   // empty
 }
@@ -45,7 +45,7 @@ void Mortar::STRATEGY::Factory::setup(const int dim)
   check_init();
 
   // get a copy of the underlying structural communicator
-  comm_ptr_ = discret_ptr_->get_comm();
+  comm_ = discret_ptr_->get_comm();
 
   // get the problem dimension
   dim_ = dim;
@@ -90,7 +90,7 @@ const Core::FE::Discretization& Mortar::STRATEGY::Factory::discret() const
 MPI_Comm Mortar::STRATEGY::Factory::get_comm() const
 {
   check_init_setup();
-  return comm_ptr_;
+  return comm_;
 }
 
 /*----------------------------------------------------------------------*

--- a/src/mortar/4C_mortar_strategy_factory.hpp
+++ b/src/mortar/4C_mortar_strategy_factory.hpp
@@ -158,7 +158,7 @@ namespace Mortar
 
       //!@}
       //! pointer to a COPY of the structural communicator
-      MPI_Comm comm_ptr_;
+      MPI_Comm comm_;
 
       int dim_;
     };  // namespace STRATEGY

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -40,7 +40,7 @@ Solid::TimeInt::BaseDataGlobalState::BaseDataGlobalState()
       datasdyn_(nullptr),
       dim_(Global::Problem::instance()->n_dim()),
       discret_(nullptr),
-      comm_(nullptr),
+      comm_(MPI_COMM_NULL),
       my_rank_(-1),
       timenp_(0.0),
       timen_(nullptr),

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -186,7 +186,7 @@ Solid::ModelEvaluator::Data::Data()
       io_ptr_(nullptr),
       gstate_ptr_(nullptr),
       timint_ptr_(nullptr),
-      comm_ptr_(nullptr),
+      comm_(MPI_COMM_NULL),
       beam_data_ptr_(nullptr),
       contact_data_ptr_(nullptr),
       model_ptr_(nullptr)
@@ -203,7 +203,7 @@ void Solid::ModelEvaluator::Data::init(
   io_ptr_ = timint_ptr->get_data_io_ptr();
   gstate_ptr_ = timint_ptr->get_data_global_state_ptr();
   timint_ptr_ = timint_ptr;
-  comm_ptr_ = timint_ptr->get_data_global_state().get_comm_ptr();
+  comm_ = timint_ptr->get_data_global_state().get_comm_ptr();
   isinit_ = true;
 }
 
@@ -334,7 +334,7 @@ void Solid::ModelEvaluator::Data::collect_norm_types_over_all_procs(
 
   const quantity_norm_type_map mynormtypes(normtypes);
   quantity_norm_type_map& gnormtypes = const_cast<quantity_norm_type_map&>(normtypes);
-  collect_data(comm_ptr_, mynormtypes, gnormtypes);
+  collect_data(comm_, mynormtypes, gnormtypes);
 }
 
 /*----------------------------------------------------------------------------*
@@ -383,7 +383,7 @@ void Solid::ModelEvaluator::Data::sum_into_my_update_norm(
     const double* my_update_values, const double* my_new_sol_values, const double& step_length,
     const int& owner)
 {
-  if (owner != Core::Communication::my_mpi_rank(comm_ptr_)) return;
+  if (owner != Core::Communication::my_mpi_rank(comm_)) return;
   // --- standard update norms
   enum ::NOX::Abstract::Vector::NormType normtype = ::NOX::Abstract::Vector::TwoNorm;
   if (get_update_norm_type(qtype, normtype))
@@ -405,7 +405,7 @@ void Solid::ModelEvaluator::Data::sum_into_my_previous_sol_norm(
     const enum NOX::Nln::StatusTest::QuantityType& qtype, const int& numentries,
     const double* my_old_sol_values, const int& owner)
 {
-  if (owner != Core::Communication::my_mpi_rank(comm_ptr_)) return;
+  if (owner != Core::Communication::my_mpi_rank(comm_)) return;
 
   enum ::NOX::Abstract::Vector::NormType normtype = ::NOX::Abstract::Vector::TwoNorm;
   if (not get_update_norm_type(qtype, normtype)) return;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -967,7 +967,7 @@ namespace Solid
       std::shared_ptr<const Solid::TimeInt::Base> timint_ptr_;
 
       //! read-only access to the epetra communicator
-      MPI_Comm comm_ptr_;
+      MPI_Comm comm_;
 
       //! beam data container pointer
       std::shared_ptr<BeamData> beam_data_ptr_;

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -26,7 +26,7 @@ XFEM::MultiFieldMapExtractor::MultiFieldMapExtractor()
     : isinit_(false),
       issetup_(false),
       max_num_reserved_dofs_per_node_(0),
-      comm_(nullptr),
+      comm_(MPI_COMM_NULL),
       slave_discret_vec_(0),
       element_map_extractor_(nullptr),
       idiscret_(nullptr),

--- a/tests/cut_test/cut_test_main.cpp
+++ b/tests/cut_test/cut_test_main.cpp
@@ -443,6 +443,9 @@ int main(int argc, char** argv)
 
   std::map<std::string, testfunct> functable;
 
+  Core::IO::cout.setup(
+      false, false, false, Core::IO::standard, MPI_COMM_WORLD, 0, 0, "dummyFilePrefix");
+
   // these tests were generated from the real computation
   // all of then expreience the same problem:
   // "Could not find reference plane with all gausspoints inside!" in

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_volume_segmentation_test.cpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_volume_segmentation_test.cpp
@@ -310,7 +310,7 @@ namespace
 
     // Add the relevant nurbs information to the discretization.
     std::shared_ptr<Core::FE::Nurbs::NurbsDiscretization> structdis =
-        std::make_shared<Core::FE::Nurbs::NurbsDiscretization>("structure", nullptr, 3);
+        std::make_shared<Core::FE::Nurbs::NurbsDiscretization>("structure", MPI_COMM_NULL, 3);
     Global::Problem::instance()->add_dis("structure", structdis);
 
     // Get the geometry.


### PR DESCRIPTION
## Description and Context
The 4C build fails when compiling with intel-mpi. This PR fixes the build errors.
- In some places the MPI_COMM was initialized with or assigned a `nullptr`. This works for openmpi as MPI_COMM is a pointer. But for intel-mpi MPI_COMM is an int. Therefore, the nullptr is replaced by the implementation-independent `MPI_COMM_NULL`.
- With MPI_COMM as int, there were two constructors with the same argument types. I removed one of them. The removed constructor was only used in tests.
- I also fixed a bug where only one process would hit an MPI barrier.

## Related Issues and Merge Requests

