### PR TITLE
Enable Noneable in selection

### DIFF
--- a/src/core/io/src/4C_io_input_types.hpp
+++ b/src/core/io/src/4C_io_input_types.hpp
@@ -36,6 +36,15 @@ namespace Core::IO
   template <typename T>
   inline constexpr auto none = Noneable<T>{std::nullopt};
 
+  /**
+   * Concept to check if a type is a Noneable type.
+   */
+  template <typename T>
+  concept IsNoneable = requires(T t) {
+    { t.has_value() } -> std::convertible_to<bool>;
+    { t.value() } -> std::convertible_to<typename T::value_type>;
+  };
+
   namespace Internal
   {
     template <typename T>
@@ -91,6 +100,19 @@ namespace Core::IO
       typename T::value_type;
       std::tuple_size<T>::value;
     };
+
+    template <typename T>
+    struct RemoveNoneableHelper
+    {
+      using type = T;
+    };
+
+    template <typename T>
+      requires IsNoneable<T>
+    struct RemoveNoneableHelper<T>
+    {
+      using type = typename T::value_type;
+    };
   }  // namespace Internal
 
   /**
@@ -124,6 +146,13 @@ namespace Core::IO
   {
     return Internal::RankHelper<T>::value;
   }
+
+  /**
+   * Remove the Noneable wrapper from a type if it is a Noneable type. Otherwise, return the type
+   * itself.
+   */
+  template <typename T>
+  using RemoveNoneable = typename Internal::RemoveNoneableHelper<T>::type;
 
 }  // namespace Core::IO
 

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
@@ -103,10 +103,10 @@ namespace Core
     {
       FOUR_C_ASSERT(
           strings.size() == integrals.size(), "The number of strings and integrals must match.");
-      std::vector<std::pair<std::string, T>> choices;
+      std::map<std::string, T> choices;
       for (int i = 0; i < strings.size(); ++i)
       {
-        choices.emplace_back(strings[i], integrals[i]);
+        choices.emplace(strings[i], integrals[i]);
       }
 
       auto default_it = std::find(strings.begin(), strings.end(), defaultValue);

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -50,7 +50,7 @@ namespace Discret::Elements::SolidPoroPressureBasedInternal
               },
               {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                               "kinematics (large displacements)"}),
-          selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_pairs(),
+          selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
       });

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -54,7 +54,7 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
           parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
           parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
           parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
-          selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_pairs(),
+          selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
       });

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_utils.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_utils.hpp
@@ -34,14 +34,15 @@ namespace Discret::Elements
         Inpar::ScaTra::ImplType::impltype_undefined};
   }
 
-  inline std::vector<std::pair<std::string, Inpar::ScaTra::ImplType>> get_impltype_inpar_pairs()
+  inline std::map<std::string, Inpar::ScaTra::ImplType> get_impltype_inpar_map()
   {
     constexpr auto supported_impl_types = get_supported_impl_types();
-    std::vector<std::pair<std::string, Inpar::ScaTra::ImplType>> impltype_map(
-        supported_impl_types.size());
+    std::map<std::string, Inpar::ScaTra::ImplType> impltype_map;
 
-    std::ranges::transform(supported_impl_types, impltype_map.begin(),
-        [](auto type) { return std::make_pair(Inpar::ScaTra::impltype_to_string(type), type); });
+    for (const auto& impltype : supported_impl_types)
+    {
+      impltype_map[Inpar::ScaTra::impltype_to_string(impltype)] = impltype;
+    }
 
     return impltype_map;
   }


### PR DESCRIPTION
Based on a discussion here: https://github.com/4C-multiphysics/4C/pull/424#issuecomment-2676743683

I have a feeling that the internals of the `selection` implementation can be moved to `EntrySpec` soon. This PR also helped to clarify some types a little more.