### PR TITLE
Enable all sections in JSON schema

### DIFF
--- a/apps/global_full/CMakeLists.txt
+++ b/apps/global_full/CMakeLists.txt
@@ -33,15 +33,28 @@ add_custom_command(
   COMMENT "Creating symbolic link"
   )
 
-# Create a json schema file for the input
-add_custom_command(
-  TARGET ${FOUR_C_EXECUTABLE_NAME}
-  POST_BUILD
-  COMMAND
-    ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS} "$<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>" -p >
-    ${CMAKE_BINARY_DIR}/4C_metadata.yaml
-  COMMAND
-    ${FOUR_C_PYTHON_VENV_BUILD}/bin/python ${PROJECT_SOURCE_DIR}/utilities/create_json_schema.py
-    ${CMAKE_BINARY_DIR}/4C_metadata.yaml ${CMAKE_BINARY_DIR}/4C_schema.json
-  COMMENT "Creating schema file for input"
-  )
+if(Python3_VERSION VERSION_GREATER_EQUAL "3.10")
+  # Create a json schema file for the input
+  add_custom_command(
+    TARGET ${FOUR_C_EXECUTABLE_NAME}
+    POST_BUILD
+    COMMAND
+      ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS} "$<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>" -p
+      > ${CMAKE_BINARY_DIR}/4C_metadata.yaml
+    COMMAND
+      ${FOUR_C_PYTHON_VENV_BUILD}/bin/python ${PROJECT_SOURCE_DIR}/utilities/create_json_schema.py
+      ${CMAKE_BINARY_DIR}/4C_metadata.yaml ${CMAKE_BINARY_DIR}/4C_schema.json
+    COMMENT "Creating JSON schema file for input"
+    )
+else()
+  message(
+    WARNING "Your python version ${Python3_VERSION} is too old to generate the JSON schema file"
+    )
+  add_custom_command(
+    TARGET ${FOUR_C_EXECUTABLE_NAME}
+    POST_BUILD
+    COMMAND
+      ${CMAKE_COMMAND} -E echo
+      "Skipping metadata and JSON schema generation due to outdated python version"
+    )
+endif()

--- a/cmake/python/requirements.txt
+++ b/cmake/python/requirements.txt
@@ -1,5 +1,5 @@
 # for creating the yaml schemata during build:
-pyyaml
+ruamel.yaml
 # for testing:
 numpy
 vtk

--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -5,169 +5,592 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-"""Create json schema from 4C yaml file."""
-import yaml
-import warnings
+"""Create JSON schema for YAML validation."""
+
 import json
 import argparse
+from pathlib import Path
 
-FOURC_TO_JSON_SCHEMA_DICT = {
-    "double": "number",
-    "int": "integer",
-    "bool": "boolean",
-    "string": "string",
-}
+from metadata_utils import (
+    NotSet,
+    NAMED_TYPES,
+    MISSING_DESCRIPTION,
+    FOURC_BASE_TYPES_TO_JSON_SCHEMA_DICT,
+    Primitive,
+    Vector,
+    Map,
+    Selection,
+    Group,
+    List,
+    All_Of,
+    One_Of,
+    metadata_object_from_file,
+)
+from dataclasses import asdict
 
 
-def map_property_to_json_schema(
-    properties_original: dict,
-    key_original: str,
-    properties_schema: dict,
-    key_schema: str,
-    filter=lambda x: x,
-    optional: bool = False,
+def json_schema(
+    *,
+    schema_type="object",
+    title=None,
+    description=MISSING_DESCRIPTION,
+    noneable=False,
+    default=NotSet(),
+    enum=None,
+    const=NotSet(),
+    properties=None,
+    required=None,
+    oneOf=None,
+    minProperties=None,
+    maxProperties=None,
+    patternProperties=None,
+    additionalProperties=False,
+    items=None,
+    minItems=None,
+    maxItems=None,
 ):
-    value = properties_original.pop(key_original, None)
-    if value is None:
-        if not optional:
-            raise ValueError(f"Value {key_original} was not provided!")
-    else:
-        properties_schema[key_schema] = filter(value)
+    """Create JSON schema dict."""
+
+    def set_if_not_none(schema, name, value):
+        if value is not None:
+            schema[name] = value
+
+    def set_if_true(schema, name, value):
+        if value:
+            schema[name] = value
+
+    def set_if_set(schema, name, value):
+        if not isinstance(value, NotSet):
+            schema[name] = value
+
+    schema = {}
+
+    # Properties for any kind of schema
+    set_if_not_none(schema, "title", title)
+    schema["description"] = description or MISSING_DESCRIPTION
+    set_if_not_none(schema, "type", schema_type)
+    if schema_type:
+        if noneable:
+            schema["type"] = [schema_type, "null"]
+        else:
+            schema["type"] = schema_type
+    set_if_true(schema, "enum", enum)
+
+    # Allow None since it could be a desired value
+    set_if_set(schema, "const", const)
+    set_if_set(schema, "default", default)
+
+    # Objects
+    if schema_type == "object":
+        set_if_true(schema, "required", required)
+        set_if_true(schema, "properties", properties)
+        set_if_true(schema, "oneOf", oneOf)
+        if not additionalProperties:
+            schema["additionalProperties"] = False
+        set_if_true(schema, "patternProperties", patternProperties)
+        set_if_not_none(schema, "minProperties", minProperties)
+        set_if_not_none(schema, "maxProperties", maxProperties)
+
+    # Arrays
+    if schema_type == "array":
+        set_if_not_none(schema, "items", items)
+        set_if_not_none(schema, "maxItems", maxItems)
+        set_if_not_none(schema, "minItems", minItems)
+
+    return schema
 
 
-def create_properties_dict(properties_entry: dict) -> dict:
-    """Generate properties dict for one option.
-
-    Args:
-        properties_entry (dict): 4C exported dict
-
-    Returns:
-        dict: properties dict for the JSON schema
-    """
-    properties = {}
-
-    # Loop over the definitions of the properties
-    for key, value in properties_entry.items():
-
-        # Check if the obtains contains the type
-        if "type" not in value.keys():
-            raise Exception(f"Ups could not load {key}: {value}")
-
-        description = value.pop("description", "No description yet")
-
-        # Add default to the description if provided
-        if "default" in value:
-            description += f"\nDefault: {value['default']}"
-
-        properties[key] = {"description": description}
-        properties[key]["title"] = f"{key} ({value['type']})"
-        map_property_to_json_schema(
-            value, "type", properties[key], "type", filter=FOURC_TO_JSON_SCHEMA_DICT.get
-        )
-        map_property_to_json_schema(
-            value, "valid options", properties[key], "enum", optional=True
-        )
-
-        # Defaults are ready to go, but currently not properly provided!
-        # For now we do not export them!
-        # map_property_to_json_schema(value, "default", properties[key], "default", optional=True)
-
-    return properties
-
-
-def is_parent_section(section_name: str, section_names: list) -> bool:
-    """Check if the section is a parent section.
-
-    Args:
-        section_name (str): name of the section
-        section_names (list): list of valid section names
-
-    Returns:
-        bool: True if it is a parent section
-    """
-    for name in section_names:
-        if name.startswith(section_name + "/"):
-            return True
-
-    return False
-
-
-def create_json_schema(fourc_metadata: dict) -> dict:
-    """Create a JSON schema dict.
+def schema_from_base_type(primitive):
+    """Create schema from Primitive with base type.
 
     Args:
-        fourc_metadata (dict): Metadata exported by 4C
+        primitive (Primitive): Primitive made of base type.
 
     Returns:
-        dict: data for the JSON schema
+        dict: JSON schema data
     """
-    commit_hash = fourc_metadata["metadata"]["commit_hash"]
-    json_schema_dict = {
-        "$id": commit_hash,  # not the best solution but for now it works
-        "$schema": "https://json-schema.org/draft/2020-12/schema",  # Schema standard we use
-        "title": f"4C Schema for commit hash: {commit_hash}",
-        "description": "A schema for 4C yaml input files.",
-        "type": "object",
-    }
-
-    properties_dict = {}
-
-    # Title section
-    properties_dict["TITLE"] = {
-        "title": "Section 'Title'",
-        "description": "You can add a description to your input file here.",
-        "type": "string",
-        "default": f"Using commit hash {commit_hash}",
-    }
-
-    # Includes section
-    properties_dict["INCLUDES"] = {
-        "title": "Section 'INCLUDES'",
-        "description": "Paths to additional input files.",
-        "type": "array",
-        "items": {"type": "string"},
-    }
-
-    json_schema_dict["properties"] = properties_dict
-    return json_schema_dict
+    schema = json_schema(
+        schema_type=FOURC_BASE_TYPES_TO_JSON_SCHEMA_DICT[primitive.type],
+        title=primitive.short_description(),
+        default=primitive.default,
+        noneable=primitive.noneable,
+    )
+    return schema
 
 
-def load_fourc_yaml_and_escape_bools(fourc_yaml_path: str) -> dict:
-    """Load 4C yaml file.
-
-    Since in 4C currently bools are not supported in the inputs, they need some special treatment to avoid converting them to bool while loading. Once this is supported in the code, this functionally can be dropped.
+def schema_from_selection(selection):
+    """Create schema from Selection.
 
     Args:
-        fourc_yaml_path (str): Path to the 4C metadata file
+        selection (Selection): Selection parameter
 
     Returns:
-        dict: loaded options
+        dict: JSON schema data
     """
-    from yaml.constructor import SafeConstructor
-    from yaml.loader import Reader, Scanner, Parser, Composer, Resolver
-
-    class CustomSafeConstructor(SafeConstructor):
-        def add_bool(self, node):
-            return self.construct_scalar(node)
-
-    CustomSafeConstructor.add_constructor(
-        "tag:yaml.org,2002:bool", CustomSafeConstructor.add_bool
+    # One could also do this using a oneOf where the choices are strings with constant values.
+    # This would allow to add a description for each option.
+    schema = json_schema(
+        schema_type=FOURC_BASE_TYPES_TO_JSON_SCHEMA_DICT["string"],
+        title=selection.short_description(),
+        description=selection.description,
+        default=selection.default,
+        enum=list(set(selection.choices)),
     )
 
-    class KeepStringSafeLoader(
-        Reader, Scanner, Parser, Composer, CustomSafeConstructor, Resolver
-    ):
-        def __init__(self, stream):
-            Reader.__init__(self, stream)
-            Scanner.__init__(self)
-            Parser.__init__(self)
-            Composer.__init__(self)
-            CustomSafeConstructor.__init__(self)
-            Resolver.__init__(self)
+    return schema
 
-    with open(fourc_yaml_path, "r", encoding="UTF-8") as f:
-        fourc_metadata = yaml.load(f.read(), KeepStringSafeLoader)
-    return fourc_metadata
+
+def schema_from_group(group):
+    """Create schema from Group.
+
+    Args:
+        group (Group): Group parameter
+
+    Returns:
+        dict: JSON schema data
+    """
+    # Empty group
+    if group.is_empty():
+        title = f"{group.name} (empty group)"
+        schema = json_schema(
+            title=title,
+            description=group.description,
+            properties={},
+            const={},
+            default={},
+        )
+        return schema
+
+    # Use All_of to create the schema
+    metadata_dict = asdict(group)
+    noneable = metadata_dict.pop("noneable", False)
+    metadata_dict.pop("defaultable", False)
+    schema = schema_from_all_of(All_Of(**metadata_dict))
+    schema["title"] = group.short_description()
+    schema["description"] = group.description or MISSING_DESCRIPTION
+    if noneable:
+        schema["type"] = [schema["type"], "null"]
+        schema["title"] = f"{group.name} (group, null)"
+    return schema
+
+
+def array_schema(parameter, items):
+    """Create array schema.
+
+    Args:
+        parameter (Vector, List): Metadata object
+        items (dict): JSON schema for item type of the parameter
+
+    Returns:
+        dict: JSON schema data
+    """
+    schema = json_schema(
+        title=parameter.short_description(),
+        description=parameter.description,
+        schema_type="array",
+        items=items,
+        maxItems=parameter.size,
+        minItems=parameter.size,
+    )
+
+    return schema
+
+
+def schema_from_vector(vector):
+    """Create schema from vector.
+
+    Args:
+        vector (Vector): Vector parameter
+
+    Returns:
+        dict: JSON schema data
+    """
+    items = get_schema(vector.value_type)
+    return array_schema(vector, items)
+
+
+def schema_from_list(list_metadata):
+    """Create schema from list.
+
+    Args:
+        list_metadata (List): List parameter
+
+    Returns:
+        dict: JSON schema data
+    """
+    if isinstance(list_metadata.spec, NAMED_TYPES):
+        schema = json_schema(
+            title=list_metadata.spec.short_description(),
+            description=list_metadata.spec.description,
+            required=[list_metadata.spec.name] if list_metadata.spec.required else None,
+            properties={list_metadata.spec.name: get_schema(list_metadata.spec)},
+        )
+        items = schema
+    # Essentially one_ofs remain
+    else:
+        items = get_schema(list_metadata.spec)
+
+    return array_schema(list_metadata, items)
+
+
+def schema_from_map(map_metadata):
+    """Create schema from map.
+
+    Args:
+        map_metadata (Map): Map parameter
+
+    Returns:
+        dict: JSON schema data
+    """
+    value_schema = get_schema(map_metadata.value_type)
+
+    schema = json_schema(
+        title=map_metadata.short_description(),
+        description=map_metadata.description,
+        patternProperties={"^.*$": value_schema},
+        minProperties=map_metadata.size,
+        maxProperties=map_metadata.size,
+    )
+    return schema
+
+
+def schema_from_one_of(one_of):
+    """Create schema from one_of.
+
+    Args:
+        one_of (One_of): One_of collection
+
+    Returns:
+        dict: JSON schema data
+    """
+    schemas_options = []
+
+    # One_of in One_of
+    if one_of.one_ofs():
+        for v in one_of.one_ofs():
+            properties = schema_from_one_of(v)
+            properties.pop("properties", None)
+            schemas_options.append(properties)
+
+    # named specs
+    if named_specs := one_of.named_specs():
+        named_specs_schema = [object_schema(spec) for spec in named_specs]
+        schemas_options.extend(named_specs_schema)
+
+    # all_of nesting
+    if all_ofs := one_of.all_ofs():
+        for v in all_ofs:
+            properties = schema_from_all_of(v)
+            schemas_options.append(properties)
+
+    if not one_of.name:
+        if specs_names := one_of.parameter_names():
+            one_of.name = " or ".join(specs_names)
+        else:
+            one_of.name = None
+
+    if not one_of.description:
+        if specs_names := one_of.parameter_names():
+            one_of.description = " or ".join(specs_names)
+        else:
+            one_of.description = None
+
+    schema = json_schema(
+        title=one_of.name,
+        description=one_of.description,
+        oneOf=schemas_options,
+        additionalProperties=True,
+    )
+
+    def flatten_one_ofs(schema):
+        """A single oneOf in a oneOf is flatted."""
+        if "oneOf" in schema and len(schema["oneOf"]) == 1:
+            return flatten_one_ofs(schema["oneOf"][0])
+        return schema
+
+    return flatten_one_ofs(schema)
+
+
+def schema_from_all_of(all_of):
+    """Create schema from all_of.
+
+    Args:
+        all_of (All_of): All_of collection
+
+    Returns:
+        dict: JSON schema data
+    """
+
+    all_of = condense_all_of(all_of)
+
+    # Check if is empty
+    if all_of.is_empty():
+        raise ValueError("Empty all_of not possible!")
+
+    # Condensing might remove an unnecessart All_of and transformed it into a One_of
+    if isinstance(all_of, One_Of):
+        return schema_from_one_of(all_of)
+
+    named_specs, one_ofs, all_ofs = all_of.split_specs(pop=True)
+
+    # Sanity checks
+
+    # All_ofs in all_ofs is not possible after condensing
+    if all_ofs:
+        raise TypeError("All_ofs in All_ofs are not possible anymore.")
+
+    # One_ofs and named_specs are not possible after condensing
+    if bool(one_ofs) == bool(named_specs):
+        raise TypeError("One_ofs and named specs together are not possible.")
+
+    # One_ofs
+    if one_ofs:
+        if len(one_ofs) == 1:
+            raise TypeError("A single one_of had to be returned previously")
+        else:
+            raise NotImplementedError(
+                f"Multiple parallel one_ofs not supported found {len(one_ofs)}. If this should become required anyOf in JSON schema files have to be introduced."
+            )
+
+    if named_specs:
+        properties = {}
+        required_properties = []
+        for entry in named_specs:
+            properties[entry.name] = get_schema(entry)
+            if entry.required:
+                required_properties.append(entry.name)
+
+        if not all_of.name:
+            all_of.name = " & ".join(properties.keys())
+
+        if not all_of.description:
+            all_of.description = " & ".join(properties.keys())
+
+        # Return a simple object schema
+        schema = json_schema(
+            title=all_of.name,
+            description=all_of.description,
+            required=required_properties,
+            properties=properties,
+        )
+        return schema
+
+    raise ValueError("Empty all of is not supported!")
+
+
+def get_schema(parameter):
+    """Create schema from parameter.
+
+    Args:
+        parameter (Parameter): Parameter to create a schema for.
+
+    Returns:
+        dict: JSON schema data
+    """
+    schema = {}
+
+    match parameter:
+        case Selection():
+            schema = schema_from_selection(parameter)
+        case Vector():
+            schema = schema_from_vector(parameter)
+        case Map():
+            schema = schema_from_map(parameter)
+        case Primitive():
+            schema = schema_from_base_type(parameter)
+        case Group():
+            schema = schema_from_group(parameter)
+        case List():
+            schema = schema_from_list(parameter)
+        case All_Of():
+            schema = schema_from_all_of(parameter)
+        case One_Of():
+            schema = schema_from_one_of(parameter)
+        case _:
+            raise TypeError(f"Unknown class {type(parameter)} for entry: {parameter}")
+
+    return schema
+
+
+def create_json_schema(schema_data, schema_id, schema_path):
+    """Create JSON schema file.
+
+    Args:
+        schema_data (dict): Schema data
+        schema_id (str): Id of the schema
+        schema_path (str, pathlib.Path): Path to JSON schema
+    """
+    schema = {}
+    schema["$id"] = schema_id
+    schema["$schema"] = "https://json-schema.org/draft/2020-12/schema"
+    schema.update(schema_data)
+
+    Path(schema_path).write_text(json.dumps(schema, indent=2), encoding="utf-8")
+
+
+def object_schema(named_spec):
+    """Create object schema for a single named spec.
+
+    Args:
+        named_spec (Parameter): Named spec to objectify
+
+    Returns:
+        dict: JSON schema data
+    """
+    schema = json_schema(
+        title=named_spec.short_description(),
+        description=named_spec.description,
+        required=[named_spec.name] if named_spec.required else None,
+        properties={named_spec.name: get_schema(named_spec)},
+    )
+    return schema
+
+
+def add_named_specs(parameter, named_specs):
+    """Add named specs to parameter.
+
+    Args:
+        parameter (Parameter): Parameter to add the named specs to
+        named_specs (list): Named specs to add
+
+    Returns:
+        Parameter: parameter with the additional specs
+    """
+    # Adding specs to a named specs turns them into an all_of
+    if isinstance(parameter, NAMED_TYPES):
+        return All_Of(specs=[parameter] + named_specs)
+
+    if isinstance(parameter, All_Of):
+
+        # Only named specs already
+        if not parameter.one_ofs() and not parameter.all_ofs():
+            parameter.specs.extend(named_specs)
+            return parameter
+
+        # Make sure it only contains a single all_of
+        parameter = condense_all_of(parameter)
+
+        # Check if it was transformed into a single oneof
+        if isinstance(parameter, One_Of):
+            return add_named_specs(parameter, named_specs)
+
+        if parameter.all_ofs():
+            raise ValueError("oh no")
+
+        # Add the named_specs of the all_of to the new named_specs
+        named_specs += parameter.named_specs(pop=True)
+
+        # Only remaining stuff is one_ofs
+        for i, spec in enumerate(parameter.specs):
+            parameter.specs[i] = add_named_specs(spec, named_specs)
+        return parameter
+
+    if isinstance(parameter, One_Of):
+        for i, spec in enumerate(parameter.specs):
+            parameter.specs[i] = add_named_specs(spec, named_specs)
+        return parameter
+
+    raise TypeError(f"Unknown metadata type {type(parameter)}: {parameter}")
+
+
+def condense_all_of(all_of):
+    """Condense All_ofs.
+
+    The all_ofs in the metadata file are not natively supported in JSON schemas. Therefore, they are condensed by pushing named specs down to their options and avoid the mix of named specs and one_ofs.
+
+    Args:
+        all_of (All_of): All_of collection to condense.
+
+    Returns:
+        All_of or One_of: Condensed collection
+    """
+    # Empty all_of
+    if all_of.is_empty():
+        raise ValueError("Empty all_ofs are not allowed!")
+
+    named_specs, one_ofs, all_ofs = all_of.split_specs()
+
+    # Either only one_ofs or only named specs, easy
+    if not all_ofs and (bool(one_ofs) != bool(named_specs)):
+        return all_of
+
+    # Extract the specs
+    named_specs, one_ofs, all_ofs = all_of.split_specs(pop=True)
+
+    # Ensure all the all_ofs a condensed and combine them into one all_of
+    for ao in all_ofs:
+
+        ao = condense_all_of(ao)
+        if isinstance(ao, One_Of):
+            raise TypeError(
+                "All_of was converted into a One_of. This is not possible!."
+            )
+
+        new_named_specs, new_one_ofs, new_all_ofs = ao.split(pop=True)
+
+        # Update the named specs
+        named_specs += new_named_specs
+
+        # update the one_ofs
+        one_ofs += new_one_ofs
+
+        if new_all_ofs:
+            raise TypeError("No new all_ofs possible!")
+
+    # No all_of left
+    all_ofs = None
+
+    if not one_ofs:
+        raise TypeError(
+            "There have to be one_ofs if this stage of the function is reached!"
+        )
+
+    # Add the named specs to the one_ofs
+    for i, one_of in enumerate(one_ofs):
+        one_ofs[i] = add_named_specs(one_of, named_specs)
+
+    # If the only entry is a single one_of, return the one_of
+    if len(one_ofs) == 1:
+        return one_ofs[0]
+
+    raise ValueError("This case should not be possible.")
+
+
+def schema_for_description_section(section_name):
+    """Create JSON schema for the description section.
+
+    Args:
+        section_name (str): Name of the description section
+
+    Returns:
+        dict: JSON schema data
+    """
+    # Allow any type
+    schema = json_schema(
+        title=section_name + " (no schema)",
+        description=MISSING_DESCRIPTION + " (no schema)",
+        additionalProperties=True,
+        schema_type=None,
+    )
+    return schema
+
+
+def main(metadata_path, json_schema_path):
+    """Generate JSON schema from metadata file.
+
+    Args:
+        metadata_path (str, pathlib.Path): 4C emitted metadata file path
+        json_schema_path (str, pathlib.Path): JSON schema file path
+    """
+    metadata_4C, title_section, code_metadata = metadata_object_from_file(metadata_path)
+    schema = get_schema(metadata_4C)
+    schema["properties"].update(
+        {title_section: schema_for_description_section(title_section)}
+    )
+    schema["patternProperties"] = {
+        "^FUNCT[1-9][0-9]*$": schema["properties"].pop("FUNCT<n>")
+    }
+    create_json_schema(schema, code_metadata["commit_hash"], json_schema_path)
 
 
 if __name__ == "__main__":
@@ -180,12 +603,4 @@ if __name__ == "__main__":
     parser.add_argument("json_schema_path", help="Path for the JSON schema.")
     args = parser.parse_args()
 
-    # Load the yaml file exported by 4C
-    fourc_metadata = load_fourc_yaml_and_escape_bools(args.fourc_metadata_yaml_path)
-
-    # create the json schema dict
-    json_schema_dict = create_json_schema(fourc_metadata)
-
-    # Export the JSON schema
-    with open(args.json_schema_path, "w", encoding="UTF-8") as f:
-        json.dump(json_schema_dict, f, indent=1)
+    main(args.fourc_metadata_yaml_path, args.json_schema_path)

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -1,0 +1,332 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""Utilities to handle 4C metadata files."""
+from dataclasses import dataclass, field
+from pathlib import Path
+from ruamel.yaml import YAML
+
+
+# In order to allow None as defaults
+class NotSet:
+    def __str__(self):
+        return "NOTSET singleton"
+
+
+MISSING_DESCRIPTION = "No description yet."
+FOURC_BASE_TYPES_TO_JSON_SCHEMA_DICT = {
+    "double": "number",
+    "int": "integer",
+    "bool": "boolean",
+    "string": "string",
+    "path": "string",
+}
+
+
+@dataclass
+class Parameter:
+    """Base parameter."""
+
+    name: str = None
+    type: str = None
+    required: bool = False
+    description: str = None
+
+
+@dataclass
+class Primitive(Parameter):
+    """Primitive parameter."""
+
+    default: int = NotSet()
+    noneable: bool = False
+
+    def short_description(self):
+        """Create short description."""
+        description = ""
+        if self.name:
+            description += self.name + " "
+        if self.noneable:
+            description += f"({self.type} or null)"
+        else:
+            description += f"({self.type})"
+        return description
+
+
+@dataclass
+class Vector(Primitive):
+    """Vector parameter."""
+
+    size: int = None
+    value_type: str = None
+
+    def __post_init__(self):
+        # If dict create object
+        if isinstance(self.value_type, dict):
+            self.value_type = _metadata_object_from_dict(self.value_type)
+
+
+@dataclass
+class Map(Primitive):
+    """Map parameter."""
+
+    size: int = None
+    value_type: str = None
+
+    def __post_init__(self):
+        # If dict create object
+        if isinstance(self.value_type, dict):
+            self.value_type = _metadata_object_from_dict(self.value_type)
+
+
+@dataclass
+class Selection(Primitive):
+    """Selection parameter."""
+
+    choices: list = field(default_factory=list)
+
+    def __post_init__(self):
+        for i, choice in enumerate(self.choices):
+            if isinstance(choice, dict):
+                self.choices[i] = choice["name"]
+
+
+@dataclass
+class Collection(Parameter):
+    """Collection parameter."""
+
+    def __post_init__(self):
+        self.type = self._type
+        for i, spec in enumerate(self.specs):
+            if isinstance(spec, dict):
+                spec = _metadata_object_from_dict(spec)
+                self.specs[i] = spec
+
+        self.specs = sorted(self.specs, key=lambda x: x.name)
+
+    def one_ofs(self, pop=False):
+        """Get all one_ofs.
+
+        Args:
+            pop (bool, optional): Delete entries from specs. Defaults to False.
+
+        Returns:
+            list: one_ofs specs
+        """
+        ids = []
+        specs = []
+        for i, k in enumerate(self.specs):
+            if isinstance(k, One_Of):
+                specs.append(k)
+            else:
+                ids.append(i)
+
+        if pop:
+            self.specs = [self.specs[i] for i in ids]
+        return specs
+
+    def all_ofs(self, pop=False):
+        """Get all all_ofs.
+
+        Args:
+            pop (bool, optional): Delete entries from specs. Defaults to False.
+
+        Returns:
+            list: all_ofs specs
+        """
+        ids = []
+        specs = []
+        for i, k in enumerate(self.specs):
+            if type(k) == All_Of:
+                specs.append(k)
+            else:
+                ids.append(i)
+
+        if pop:
+            self.specs = [self.specs[i] for i in ids]
+        return specs
+
+    def named_specs(self, pop=False):
+        """Get all named specs.
+
+        Specs that are not one_of or all_of
+
+        Args:
+            pop (bool, optional): Delete entries from specs. Defaults to False.
+
+        Returns:
+            list: named specs
+        """
+        ids = []
+        specs = []
+        for i, k in enumerate(self.specs):
+            if isinstance(k, (Primitive, Group, List)):
+                specs.append(k)
+            else:
+                ids.append(i)
+
+        if pop:
+            self.specs = [self.specs[i] for i in ids]
+        return specs
+
+    def split_specs(self, pop=False):
+        """Split specs into named specs, one_ofs and all_ofs
+
+        Args:
+            pop (bool, optional): Delete entries from specs. Defaults to False.
+
+        Returns:
+            tuple of lists: named_specs, one_ofs and all_ofs
+        """
+        return self.named_specs(pop), self.one_ofs(pop), self.all_ofs(pop)
+
+    def parameter_names(self):
+        """Names of the named specs.
+
+        Returns:
+            list: names of the named specs.
+        """
+        return [k.name for k in self.named_specs()]
+
+    def is_empty(self):
+        """Check for no entries.
+
+        Returns:
+            bool: True for no entries
+        """
+        return not bool(self.specs)
+
+
+@dataclass
+class One_Of(Collection):
+    """One_of collection."""
+
+    specs: list = field(default_factory=list)
+    name: str = ""
+    _type = "one_of"
+
+
+@dataclass
+class All_Of(Collection):
+    """All_of collection."""
+
+    specs: list = field(default_factory=list)
+    name: str = ""
+    _type = "all_of"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if len(self.one_ofs()) > 1:
+            raise ValueError("More than one One_of is not supported.")
+
+
+@dataclass
+class Group(Collection):
+    """Group."""
+
+    specs: list = field(default_factory=list)
+    name: str = None
+    noneable: bool = False
+    defaultable: bool = False
+    _type = "group"
+
+    def short_description(self):
+        """Create short description."""
+        return f"{self.name} ({self.type})"
+
+
+@dataclass
+class List(Parameter):
+    """List."""
+
+    size: int = None
+    spec: Parameter = None
+    _type = "list"
+
+    def __post_init__(self):
+        self.type = self._type
+        if isinstance(self.spec, dict):
+            self.spec = _metadata_object_from_dict(self.spec)
+
+    def short_description(self):
+        """Create short description."""
+        return f"{self.name} ({self.type})"
+
+
+# Named objects
+NAMED_TYPES = (Primitive, List, Group)
+
+
+def _metadata_object_from_dict(metadata_dict):
+    """Create metadata object from dict.
+
+    Args:
+        metadata_dict (dict): Dictionary with the metadata
+
+    Returns:
+        Parameter: Metadata object
+    """
+    match metadata_dict["type"]:
+        # Primitives
+        case _ if metadata_dict["type"] in FOURC_BASE_TYPES_TO_JSON_SCHEMA_DICT:
+            cls = Primitive
+        case "selection":
+            cls = Selection
+        case "vector":
+            cls = Vector
+        case "map":
+            cls = Map
+        # Collections
+        case "group":
+            cls = Group
+        case "list":
+            cls = List
+        case "all_of":
+            cls = All_Of
+        case "one_of":
+            cls = One_Of
+        case _:
+            raise TypeError(
+                f"Unknown type '{metadata_dict['type']}' for {metadata_dict}."
+            )
+
+    return cls(**metadata_dict)
+
+
+def metadata_object_from_file(metadata_4C_path):
+    """Load metadata from file and create metadata object.
+
+    Args:
+        metadata_4C_path (str, pathlib.Path): Path to metadata file.
+
+    Returns:
+        tuple: All_of and description section name and 4C code metadata
+    """
+    metadata = YAML().load(Path(metadata_4C_path).read_text())
+
+    # Title section
+    description_section_name = metadata["metadata"]["description_section_name"]
+    metadata_description = f"Schema for 4C\nCommit hash: {metadata['metadata']['commit_hash']}\nVersion: {metadata['metadata']['version']}"
+
+    # Legacy section
+    sections = metadata["sections"]
+    legacy_sections = [
+        {
+            "name": name,
+            "description": name + f" [legacy section] ",
+            "type": "vector",
+            "value_type": {"type": "string"},
+        }
+        for name in metadata["legacy_string_sections"]
+    ]
+
+    # Combine sections with legacy sections
+    all_of = All_Of(
+        description=metadata_description,
+        specs=sections + legacy_sections,
+        name="Sections",
+    )
+    return all_of, description_section_name, metadata["metadata"]


### PR DESCRIPTION
## Description and Context
This PR enables JSON schemas for all sections
- The python YAML library is changed to ruamel.yaml to allow for YAML 1.2
- The metadata functionality is split into two parts `metadata_utils.py` (creates ptython objects, will also be used for documentation etc) and the script that actually creates the schema
- I used inheritance to keep the dataclasses well interfaced (@sebproell don't worry, in python they are chill)
- Compared to the previous iteration, the script is much more complex. This is due to the fact that all sections are supported now, allowing for nesting information
- This change requires python 3.10, shouldn't be a problem since ubuntu 24.04 will ship with 3.12

To test the schema file, I converted all the .dat input test files to YAML and checked if they were valid. The validation was successful for all the files, except the ones using NURBS with `something KNOTVECTORS` since
```yaml
STRUCTURE KNOTVECTORS:
  - NURBS_DIMENSION 3
  - BEGIN NURBSPATCH
  - ID 1
  - NUMKNOTS 8
  - DEGREE 2
  - TYPE Interpolated
  - +0.000000000000
  - +0.000000000000
  - +0.000000000000
 ```
the last three entries are not strings as expected (can also be seen by the syntax highlighting on gh). Here a valid approach looks like this:
 ```yaml
STRUCTURE KNOTVECTORS:
  - NURBS_DIMENSION 3
  - BEGIN NURBSPATCH
  - ID 1
  - NUMKNOTS 8
  - DEGREE 2
  - TYPE Interpolated
  - "+0.000000000000"
  - "+0.000000000000"
  - "+0.000000000000"
 ```

## Related Issues and Merge Requests
Closes #319 
