### PR TITLE
Fix Noneable for containers

### DIFF
--- a/src/core/io/src/4C_io_input_types.hpp
+++ b/src/core/io/src/4C_io_input_types.hpp
@@ -87,6 +87,13 @@ namespace Core::IO
     };
 
     template <typename T>
+    struct RankHelper<Noneable<T>>
+    {
+      // Noneable is not considered a container, so it does not increase the rank.
+      static constexpr std::size_t value = RankHelper<T>::value;
+    };
+
+    template <typename T>
     concept IsStdArray = requires {
       typename T::value_type;
       std::tuple_size<T>::value;

--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -132,17 +132,7 @@ namespace Core::IO
   void emit_value_as_yaml(ryml::NodeRef node, const std::filesystem::path& value);
 
   template <typename T>
-  void emit_value_as_yaml(ryml::NodeRef node, const std::optional<T>& value)
-  {
-    if (value.has_value())
-    {
-      emit_value_as_yaml(node, value.value());
-    }
-    else
-    {
-      node = "null";
-    }
-  }
+  void emit_value_as_yaml(ryml::NodeRef node, const std::optional<T>& value);
 
   template <typename T>
   void emit_value_as_yaml(ryml::NodeRef node, const std::map<std::string, T>& value);
@@ -224,7 +214,18 @@ namespace Core::IO
   }
 }  // namespace Core::IO
 
-
+template <typename T>
+void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const std::optional<T>& value)
+{
+  if (value.has_value())
+  {
+    emit_value_as_yaml(node, value.value());
+  }
+  else
+  {
+    node = "null";
+  }
+}
 
 template <typename T>
 void Core::IO::emit_value_as_yaml(ryml::NodeRef node, const std::map<std::string, T>& value)


### PR DESCRIPTION
Fixes ` parameter<Noneable<std::vector<int>>>` which did not work before. Added to test as well.

Required for #437 