### PR TITLE
Replace most parameters with .required = false with better constructs

### DIFF
--- a/src/bele/4C_bele_bele3.cpp
+++ b/src/bele/4C_bele_bele3.cpp
@@ -97,27 +97,27 @@ void Discret::Elements::Bele3Type::setup_element_definition(
 
   defs3["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
-      parameter<int>("MAT", {.required = false}),
+      parameter<Noneable<int>>("MAT"),
   });
 
   defs3["TRI6"] = all_of({
       parameter<std::vector<int>>("TRI6", {.size = 6}),
-      parameter<int>("MAT", {.required = false}),
+      parameter<Noneable<int>>("MAT"),
   });
 
   defs3["QUAD4"] = all_of({
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
-      parameter<int>("MAT", {.required = false}),
+      parameter<Noneable<int>>("MAT"),
   });
 
   defs3["QUAD8"] = all_of({
       parameter<std::vector<int>>("QUAD8", {.size = 8}),
-      parameter<int>("MAT", {.required = false}),
+      parameter<Noneable<int>>("MAT"),
   });
 
   defs3["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
-      parameter<int>("MAT", {.required = false}),
+      parameter<Noneable<int>>("MAT"),
   });
 }
 
@@ -265,10 +265,10 @@ bool Discret::Elements::Bele3::read_element(const std::string& eletype, const st
     const Core::IO::InputParameterContainer& container)
 {
   // check if material is defined
-  int material = container.get_or("MAT", -1);
-  if (material != -1)
+  auto material_id = container.get<Core::IO::Noneable<int>>("MAT");
+  if (material_id)
   {
-    set_material(0, Mat::factory(material));
+    set_material(0, Mat::factory(*material_id));
   }
   return true;
 }

--- a/src/core/utils/src/functions/4C_utils_function.cpp
+++ b/src/core/utils/src/functions/4C_utils_function.cpp
@@ -218,7 +218,11 @@ Core::Utils::try_create_symbolic_function_of_space_time(
   bool found_function_of_space_time(false);
   for (const auto& ith_function_lin_def : parameters)
   {
-    ignore_errors_in([&]() { maxcomp = ith_function_lin_def.get<int>("COMPONENT"); });
+    // We need to use get_if since we call this function for lines that are completely wrong.
+    // This will go away when the functions are restructured.
+    auto* comp = ith_function_lin_def.get_if<IO::Noneable<int>>("COMPONENT");
+    if (comp) maxcomp = comp->value_or(maxcomp);
+
     ignore_errors_in([&]() { maxvar = ith_function_lin_def.get<int>("VARIABLE"); });
     if (ith_function_lin_def.get_if<std::string>("SYMBOLIC_FUNCTION_OF_SPACE_TIME") != nullptr)
       found_function_of_space_time = true;
@@ -239,8 +243,7 @@ Core::Utils::try_create_symbolic_function_of_space_time(
     const auto& functcomp = parameters[n];
 
     // check the validity of the n-th component
-    int compid = 0;
-    ignore_errors_in([&]() { compid = functcomp.get<int>("COMPONENT"); });
+    const int compid = functcomp.get<IO::Noneable<int>>("COMPONENT").value_or(0);
     if (compid != n) FOUR_C_THROW("expected COMPONENT %d but got COMPONENT %d", n, compid);
 
 

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -83,7 +83,7 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
 
   auto spec = one_of({
       all_of({
-          parameter<int>("COMPONENT", {.required = false}),
+          parameter<Noneable<int>>("COMPONENT", {.default_value = none<int>}),
           parameter<std::string>("SYMBOLIC_FUNCTION_OF_SPACE_TIME"),
       }),
 

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -121,9 +121,11 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
 
       all_of({
           parameter<std::string>("VARFUNCTION"),
-          parameter<int>("NUMCONSTANTS", {.required = false}),
-          parameter<std::map<std::string, double>>(
-              "CONSTANTS", {.required = false, .size = from_parameter<int>("NUMCONSTANTS")}),
+          parameter<Noneable<int>>("NUMCONSTANTS", {.default_value = none<int>}),
+          parameter<std::map<std::string, double>>("CONSTANTS",
+              {.default_value = std::map<std::string, double>{},
+                  .size = [](const IO::InputParameterContainer& container)
+                  { return container.get<Noneable<int>>("NUMCONSTANTS").value_or(0); }}),
       }),
   });
 

--- a/src/elemag/4C_elemag_diff_ele.cpp
+++ b/src/elemag/4C_elemag_diff_ele.cpp
@@ -103,14 +103,14 @@ void Discret::Elements::ElemagDiffType::setup_element_definition(
       parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   defs["TET4"] = all_of({
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   // 2D elements
@@ -118,21 +118,21 @@ void Discret::Elements::ElemagDiffType::setup_element_definition(
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   defs["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   defs["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 }
 

--- a/src/elemag/4C_elemag_ele.cpp
+++ b/src/elemag/4C_elemag_ele.cpp
@@ -97,14 +97,14 @@ void Discret::Elements::ElemagType::setup_element_definition(
       parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   defs["TET4"] = all_of({
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   // 2D elements
@@ -112,21 +112,21 @@ void Discret::Elements::ElemagType::setup_element_definition(
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   defs["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 
   defs["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<int>("DEG"),
-      parameter<int>("SPC"),
+      parameter<bool>("SPC"),
   });
 }
 
@@ -222,7 +222,7 @@ bool Discret::Elements::Elemag::read_element(const std::string& eletype, const s
   set_material(0, Mat::factory(material_id));
   degree_ = container.get<int>("DEG");
 
-  completepol_ = container.get<int>("SPC");
+  completepol_ = container.get<bool>("SPC");
 
   // set discretization type (setOptimalgaussrule is pushed into element
   // routine)

--- a/src/fluid_ele/4C_fluid_ele_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.cpp
@@ -137,7 +137,7 @@ void Discret::Elements::FluidHDGType ::setup_element_definition(
     defs_hdg[key] = all_of({
         fluid_line_def,
         parameter<int>("DEG"),
-        parameter<int>("SPC", {.required = false}),
+        parameter<Noneable<bool>>("SPC", {.default_value = none<bool>}),
     });
   }
 }
@@ -225,7 +225,7 @@ bool Discret::Elements::FluidHDG::read_element(const std::string& eletype,
   bool success = Fluid::read_element(eletype, distype, container);
   degree_ = container.get<int>("DEG");
 
-  completepol_ = container.get_or<int>("SPC", false);
+  completepol_ = container.get<Core::IO::Noneable<bool>>("SPC").value_or(false);
 
   return success;
 }

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
@@ -99,7 +99,7 @@ void Discret::Elements::FluidHDGWeakCompType ::setup_element_definition(
     defs_hdg[key] = all_of({
         fluid_line_def,
         parameter<int>("DEG"),
-        parameter<int>("SPC", {.required = false}),
+        parameter<Noneable<bool>>("SPC", {.default_value = none<bool>}),
     });
   }
 }
@@ -178,7 +178,7 @@ bool Discret::Elements::FluidHDGWeakComp::read_element(const std::string& eletyp
   bool success = Fluid::read_element(eletype, distype, container);
   degree_ = container.get<int>("DEG");
 
-  completepol_ = container.get_or<int>("SPC", false);
+  completepol_ = container.get<Core::IO::Noneable<bool>>("SPC").value_or(false);
 
   return success;
 }

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -133,7 +133,7 @@ void Inpar::EleMag::set_valid_conditions(
     cond.add_component(parameter<std::vector<int>>(
         "ONOFF", {.description = "", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(parameter<std::vector<Noneable<int>>>(
-        "FUNCT", {.description = "", .required = false, .size = from_parameter<int>("NUMDOF")}));
+        "FUNCT", {.description = "", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(parameter<std::vector<double>>(
         "VAL", {.description = "", .size = from_parameter<int>("NUMDOF")}));
 

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -456,8 +456,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       selection<std::string>("BOOLEANTYPE",
           {"none", "cut", "union", "difference", "sym_difference"},
           {.description = "define which boolean operator is used for combining this level-set "
-                          "field with the previous one with smaller coupling id",
-              .required = false}),
+                          "field with the previous one with smaller coupling id"}),
       parameter<bool>(
           "COMPLEMENTARY", {.description = "define which complementary operator is applied "
                                            "after combining the level-set field with a boolean "

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -396,7 +396,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       parameter<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<Noneable<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
-      selection<std::string>("TAG", {"none", "monitor_reaction"}, {.required = false}),
+      selection<std::string>("TAG", {"none", "monitor_reaction"}, {.default_value = "none"}),
   });
 
   auto neumanncomponents = all_of({

--- a/src/mat/4C_mat_anisotropy_cylinder_coordinate_system_manager.cpp
+++ b/src/mat/4C_mat_anisotropy_cylinder_coordinate_system_manager.cpp
@@ -36,9 +36,9 @@ void Mat::CylinderCoordinateSystemManager::unpack(Core::Communication::UnpackBuf
 void Mat::CylinderCoordinateSystemManager::read_from_element_line_definition(
     const Core::IO::InputParameterContainer& container)
 {
-  if (container.get_if<std::vector<double>>("RAD") != nullptr and
-      container.get_if<std::vector<double>>("AXI") != nullptr and
-      container.get_if<std::vector<double>>("CIR") != nullptr)
+  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
   {
     read_anisotropy_fiber(container, "RAD", radial_);
     read_anisotropy_fiber(container, "AXI", axial_);

--- a/src/mat/4C_mat_anisotropy_utils.cpp
+++ b/src/mat/4C_mat_anisotropy_utils.cpp
@@ -19,7 +19,10 @@ FOUR_C_NAMESPACE_OPEN
 void Mat::read_anisotropy_fiber(const Core::IO::InputParameterContainer& container,
     std::string specifier, Core::LinAlg::Matrix<3, 1>& fiber_vector)
 {
-  auto fiber = container.get<std::vector<double>>(std::move(specifier));
+  const auto& fiber_opt =
+      container.get<Core::IO::Noneable<std::vector<double>>>(std::move(specifier));
+  FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
+  const auto& fiber = *fiber_opt;
 
   double f1norm = 0.;
   // normalization

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -369,9 +369,15 @@ void Mat::ConstraintMixture::setup(int numgp, const Core::IO::InputParameterCont
   a4_ = std::make_shared<std::vector<Core::LinAlg::Matrix<3, 1>>>(numgp);
 
   // read local (cylindrical) cosy-directions at current element
-  auto rad = container.get<std::vector<double>>("RAD");
-  auto axi = container.get<std::vector<double>>("AXI");
-  auto cir = container.get<std::vector<double>>("CIR");
+  auto rad_opt = container.get<Core::IO::Noneable<std::vector<double>>>("RAD");
+  auto axi_opt = container.get<Core::IO::Noneable<std::vector<double>>>("AXI");
+  auto cir_opt = container.get<Core::IO::Noneable<std::vector<double>>>("CIR");
+  FOUR_C_ASSERT_ALWAYS(rad_opt && axi_opt && cir_opt, "Require RAD, AXI and CIR parameters.");
+
+  const auto& rad = *rad_opt;
+  const auto& axi = *axi_opt;
+  const auto& cir = *cir_opt;
+
 
   Core::LinAlg::Matrix<3, 3> locsys;
   // basis is local cosy with third vec e3 = circumferential dir and e2 = axial dir

--- a/src/mat/4C_mat_crystal_plasticity.cpp
+++ b/src/mat/4C_mat_crystal_plasticity.cpp
@@ -1104,11 +1104,11 @@ void Mat::CrystalPlasticity::setup_lattice_orientation(
     const Core::IO::InputParameterContainer& container)
 {
   // extract fiber vectors as columns of the rotation matrix
-  const auto* fiber1 = container.get_if<std::vector<double>>("FIBER1");
-  const auto* fiber2 = container.get_if<std::vector<double>>("FIBER2");
-  const auto* fiber3 = container.get_if<std::vector<double>>("FIBER3");
+  const auto& fiber1 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1");
+  const auto& fiber2 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2");
+  const auto& fiber3 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER3");
 
-  if (fiber1 != nullptr and fiber2 != nullptr and fiber3 != nullptr)
+  if (fiber1 and fiber2 and fiber3)
   {
     // assemble rotation matrix
     for (int i = 0; i < 3; i++)

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -458,9 +458,9 @@ void Mat::GrowthRemodelElastHyper::setup_axi_cir_rad_structural_tensor(
     const Core::IO::InputParameterContainer& container)
 {
   // CIR-AXI-RAD nomenclature
-  if (container.get_if<std::vector<double>>("RAD") != nullptr and
-      container.get_if<std::vector<double>>("AXI") != nullptr and
-      container.get_if<std::vector<double>>("CIR") != nullptr)
+  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
   {
     // Read in of data
     // read local (cylindrical) cosy-directions at current element
@@ -522,7 +522,9 @@ void Mat::GrowthRemodelElastHyper::setup_aniso_growth_tensors()
 void Mat::GrowthRemodelElastHyper::read_dir(const Core::IO::InputParameterContainer& container,
     const std::string& specifier, Core::LinAlg::Matrix<3, 1>& dir)
 {
-  auto fiber = container.get<std::vector<double>>(specifier);
+  const auto& fiber_opt = container.get<Core::IO::Noneable<std::vector<double>>>(specifier);
+  FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
+  const auto& fiber = *fiber_opt;
 
   double fnorm = 0.;
   // normalization

--- a/src/mat/4C_mat_membrane_active_strain.cpp
+++ b/src/mat/4C_mat_membrane_active_strain.cpp
@@ -409,9 +409,9 @@ void Mat::MembraneActiveStrain::setup_fiber_vectors(
   Core::LinAlg::Matrix<3, 1> dir;
 
   // CIR-AXI-RAD nomenclature
-  if (container.get_if<std::vector<double>>("RAD") != nullptr and
-      container.get_if<std::vector<double>>("AXI") != nullptr and
-      container.get_if<std::vector<double>>("CIR") != nullptr)
+  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
   {
     // Axial direction
     read_dir(container, "AXI", dir);
@@ -426,8 +426,8 @@ void Mat::MembraneActiveStrain::setup_fiber_vectors(
     fibervecs_.push_back(dir);
   }
   // FIBER nomenclature
-  else if (container.get_if<std::vector<double>>("FIBER1") != nullptr and
-           container.get_if<std::vector<double>>("FIBER2") != nullptr)
+  else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() and
+           container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2").has_value())
   {
     for (int i = 1; i < 3; ++i)
     {
@@ -474,7 +474,9 @@ void Mat::MembraneActiveStrain::setup_fiber_vectors(
 void Mat::MembraneActiveStrain::read_dir(const Core::IO::InputParameterContainer& container,
     std::string specifier, Core::LinAlg::Matrix<3, 1>& dir)
 {
-  std::vector<double> fiber = container.get<std::vector<double>>(specifier);
+  const auto& fiber_opt = container.get<Core::IO::Noneable<std::vector<double>>>(specifier);
+  FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
+  const auto& fiber = *fiber_opt;
 
   double fnorm = 0.;
   // normalization

--- a/src/mat/4C_mat_myocard.cpp
+++ b/src/mat/4C_mat_myocard.cpp
@@ -247,13 +247,11 @@ void Mat::Myocard::setup(const Core::LinAlg::Matrix<2, 1>& fiber1)
 
 void Mat::Myocard::setup(const Core::IO::InputParameterContainer& container)
 {
-  std::vector<double> fiber1(3);
-  if (container.get_if<std::vector<double>>("FIBER1") != nullptr)
+  if (const auto& fiber1 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1");
+      fiber1.has_value())
   {
     diff_at_ele_center_ = true;
-    fiber1 = container.get<std::vector<double>>("FIBER1");
-
-    setup_diffusion_tensor(fiber1);
+    setup_diffusion_tensor(*fiber1);
   }
 }
 

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -343,12 +343,12 @@ void Mat::PlasticElastHyper::setup(int numgp, const Core::IO::InputParameterCont
     FOUR_C_THROW("no visco-elasticity in PlasticElastHyper...yet(?)");
 
   // check if either zero or three fiber directions are given
-  if ((container.get_if<std::vector<double>>("FIBER1") == nullptr ||
-          container.get_if<std::vector<double>>("FIBER2") == nullptr ||
-          container.get_if<std::vector<double>>("FIBER3") == nullptr) &&
-      (container.get_if<std::vector<double>>("FIBER1") != nullptr ||
-          container.get_if<std::vector<double>>("FIBER2") != nullptr ||
-          container.get_if<std::vector<double>>("FIBER3") != nullptr))
+  if ((!container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() ||
+          !container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() ||
+          !container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value()) &&
+      (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() ||
+          container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2").has_value() ||
+          container.get<Core::IO::Noneable<std::vector<double>>>("FIBER3").has_value()))
     FOUR_C_THROW("so3 expects no fibers or 3 fiber directions");
 
   // plastic anisotropy
@@ -441,14 +441,14 @@ void Mat::PlasticElastHyper::setup_hill_plasticity(
     std::vector<Core::LinAlg::Matrix<3, 1>> directions(3);
 
     // compute fiber directions
-    const auto* fiber1 = container.get_if<std::vector<double>>("FIBER1");
-    const auto* fiber2 = container.get_if<std::vector<double>>("FIBER2");
-    const auto* fiber3 = container.get_if<std::vector<double>>("FIBER3");
+    const auto& fiber1 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1");
+    const auto& fiber2 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2");
+    const auto& fiber3 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER3");
 
     std::size_t dir_index = 0;
-    for (const auto* fiber : {fiber1, fiber2, fiber3})
+    for (const auto& fiber : {fiber1, fiber2, fiber3})
     {
-      if (fiber != nullptr)
+      if (fiber)
       {
         double fnorm = 0.;
         // normalization

--- a/src/mat/4C_mat_viscoanisotropic.cpp
+++ b/src/mat/4C_mat_viscoanisotropic.cpp
@@ -209,9 +209,14 @@ void Mat::ViscoAnisotropic::setup(int numgp, const Core::IO::InputParameterConta
   const double gamma = (params_->gamma_ * M_PI) / 180.;  // convert
 
   // read local (cylindrical) cosy-directions at current element
-  auto rad = container.get<std::vector<double>>("RAD");
-  auto axi = container.get<std::vector<double>>("AXI");
-  auto cir = container.get<std::vector<double>>("CIR");
+  auto rad_opt = container.get<Core::IO::Noneable<std::vector<double>>>("RAD");
+  auto axi_opt = container.get<Core::IO::Noneable<std::vector<double>>>("AXI");
+  auto cir_opt = container.get<Core::IO::Noneable<std::vector<double>>>("CIR");
+  FOUR_C_ASSERT_ALWAYS(rad_opt && axi_opt && cir_opt, "Require RAD, AXI and CIR parameters.");
+
+  const auto& rad = *rad_opt;
+  const auto& axi = *axi_opt;
+  const auto& cir = *cir_opt;
 
   Core::LinAlg::Matrix<3, 3> locsys;
   // basis is local cosy with third vec e3 = circumferential dir and e2 = axial dir

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke.cpp
@@ -59,9 +59,9 @@ void Mat::Elastic::CoupAnisoNeoHooke::setup(
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature
-    if (container.get_if<std::vector<double>>("RAD") != nullptr and
-        container.get_if<std::vector<double>>("AXI") != nullptr and
-        container.get_if<std::vector<double>>("CIR") != nullptr)
+    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -73,7 +73,7 @@ void Mat::Elastic::CoupAnisoNeoHooke::setup(
     }
 
     // FIBER1 nomenclature
-    else if (container.get_if<std::vector<double>>("FIBER1") != nullptr)
+    else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value())
     {
       // Read in of fiber data and setting fiber data
       read_fiber(container, "FIBER1", a_);

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
@@ -96,9 +96,9 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::setup(
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature
-    if (container.get_if<std::vector<double>>("RAD") != nullptr and
-        container.get_if<std::vector<double>>("AXI") != nullptr and
-        container.get_if<std::vector<double>>("CIR") != nullptr)
+    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -110,7 +110,7 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::setup(
     }
 
     // FIBER1 nomenclature
-    else if (container.get_if<std::vector<double>>("FIBER1") != nullptr)
+    else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value())
     {
       // Read in of fiber data and setting fiber data
       read_fiber(container, "FIBER1", a_);

--- a/src/mat/elast/4C_mat_elast_coupanisopow.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisopow.cpp
@@ -61,9 +61,9 @@ void Mat::Elastic::CoupAnisoPow::setup(
     ss << params_->fibernumber_;
     std::string fibername = "FIBER" + ss.str();  // FIBER Name
     // CIR-AXI-RAD nomenclature
-    if (container.get_if<std::vector<double>>("RAD") != nullptr and
-        container.get_if<std::vector<double>>("AXI") != nullptr and
-        container.get_if<std::vector<double>>("CIR") != nullptr)
+    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -74,7 +74,7 @@ void Mat::Elastic::CoupAnisoPow::setup(
       set_fiber_vecs(0.0, locsys, Id);
     }
     // FIBERi nomenclature
-    else if (container.get_if<std::vector<double>>(fibername) != nullptr)
+    else if (container.get<Core::IO::Noneable<std::vector<double>>>(fibername).has_value())
     {
       // Read in of data
       read_fiber(container, fibername, a_);

--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
@@ -73,9 +73,9 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
       ss << params_->fiber_gid_;
       std::string fibername = "FIBER" + ss.str();  // FIBER Name
       // CIR-AXI-RAD nomenclature
-      if (container.get_if<std::vector<double>>("RAD") != nullptr and
-          container.get_if<std::vector<double>>("AXI") != nullptr and
-          container.get_if<std::vector<double>>("CIR") != nullptr)
+      if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+          container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+          container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
       {
         // Read in of data
         Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -86,7 +86,7 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
         set_fiber_vecs(0.0, locsys, Id);
       }
       // FIBERi nomenclature
-      else if (container.get_if<std::vector<double>>(fibername) != nullptr)
+      else if (container.get<Core::IO::Noneable<std::vector<double>>>(fibername).has_value())
       {
         // Read in of data
         read_fiber(container, fibername, a_);

--- a/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
+++ b/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
@@ -60,9 +60,9 @@ void Mat::Elastic::IsoAnisoExpo::setup(
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature
-    if (container.get_if<std::vector<double>>("RAD") != nullptr and
-        container.get_if<std::vector<double>>("AXI") != nullptr and
-        container.get_if<std::vector<double>>("CIR") != nullptr)
+    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
+        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -75,7 +75,7 @@ void Mat::Elastic::IsoAnisoExpo::setup(
     }
 
     // FIBER1 nomenclature
-    else if (container.get_if<std::vector<double>>("FIBER1") != nullptr)
+    else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value())
     {
       // Read in of data
       read_fiber(container, "FIBER1", a_);

--- a/src/mat/elast/4C_mat_elast_summand.cpp
+++ b/src/mat/elast/4C_mat_elast_summand.cpp
@@ -338,7 +338,9 @@ void Mat::Elastic::Summand::unpack(Core::Communication::UnpackBuffer& buffer) { 
 void Mat::Elastic::Summand::read_fiber(const Core::IO::InputParameterContainer& container,
     const std::string& specifier, Core::LinAlg::Matrix<3, 1>& fiber_vector)
 {
-  auto fiber1 = container.get<std::vector<double>>(specifier);
+  const auto& fiber_opt = container.get<Core::IO::Noneable<std::vector<double>>>(specifier);
+  FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
+  const auto& fiber1 = *fiber_opt;
 
   double f1norm = 0.;
   // normalization

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -79,12 +79,18 @@ void Discret::Elements::MembraneTri3Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 
@@ -154,12 +160,18 @@ void Discret::Elements::MembraneTri6Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 
@@ -229,12 +241,18 @@ void Discret::Elements::MembraneQuad4Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 
@@ -304,12 +322,18 @@ void Discret::Elements::MembraneQuad9Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -98,147 +98,168 @@ void Discret::Elements::TransportType::setup_element_definition(
       parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["HEX20"] = all_of({
       parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["HEX27"] = all_of({
       parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["NURBS27"] = all_of({
       parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["NURBS8"] = all_of({
       parameter<std::vector<int>>("NURBS8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["TET4"] = all_of({
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["TET10"] = all_of({
       parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["WEDGE6"] = all_of({
       parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["WEDGE15"] = all_of({
       parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["PYRAMID5"] = all_of({
       parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["QUAD4"] = all_of({
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["QUAD8"] = all_of({
       parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["TRI6"] = all_of({
       parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["NURBS4"] = all_of({
       parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["NURBS9"] = all_of({
       parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["LINE2"] = all_of({
       parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["LINE3"] = all_of({
       parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["NURBS2"] = all_of({
       parameter<std::vector<int>>("NURBS2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defs["NURBS3"] = all_of({
       parameter<std::vector<int>>("NURBS3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 

--- a/src/scatra_ele/4C_scatra_ele_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.cpp
@@ -138,7 +138,7 @@ void Discret::Elements::ScaTraHDGType ::setup_element_definition(
     defs[key] = all_of({
         scatra_line_def,
         parameter<int>("DEG"),
-        parameter<int>("SPC", {.required = false}),
+        parameter<Noneable<bool>>("SPC", {.default_value = none<bool>}),
     });
   }
 }
@@ -348,7 +348,7 @@ bool Discret::Elements::ScaTraHDG::read_element(const std::string& eletype,
   degree_ = container.get<int>("DEG");
   degree_old_ = degree_;
 
-  completepol_ = container.get_or<int>("SPC", false);
+  completepol_ = container.get<Core::IO::Noneable<bool>>("SPC").value_or(false);
 
   return success;
 }

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -90,12 +90,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defsgeneral["QUAD8"] = all_of({
@@ -105,12 +111,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defsgeneral["QUAD9"] = all_of({
@@ -120,12 +132,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defsgeneral["TRI3"] = all_of({
@@ -133,12 +151,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 
   defsgeneral["TRI6"] = all_of({
@@ -146,12 +170,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -97,7 +97,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<std::string>("TYPE", {.required = false}),
+      parameter<std::string>("TYPE"),
   });
 
   defsgeneral["QUAD8"] = all_of({
@@ -119,7 +119,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<std::string>("TYPE", {.required = false}),
+      parameter<std::string>("TYPE"),
   });
 
   defsgeneral["QUAD9"] = all_of({
@@ -141,7 +141,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<std::string>("TYPE", {.required = false}),
+      parameter<std::string>("TYPE"),
   });
 
   defsgeneral["TRI3"] = all_of({
@@ -161,7 +161,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<std::string>("TYPE", {.required = false}),
+      parameter<std::string>("TYPE"),
   });
 
   defsgeneral["TRI6"] = all_of({
@@ -181,7 +181,7 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<std::string>("TYPE", {.required = false}),
+      parameter<std::string>("TYPE"),
   });
 }
 

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -85,12 +85,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<std::string>("TYPE", {.required = false}),
   });
 
@@ -101,12 +107,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<std::string>("TYPE", {.required = false}),
   });
 
@@ -117,12 +129,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<std::string>("TYPE", {.required = false}),
   });
 
@@ -131,12 +149,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<std::string>("TYPE", {.required = false}),
   });
 
@@ -145,12 +169,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<std::string>("TYPE", {.required = false}),
   });
 }

--- a/src/so3/4C_so3_hex27.cpp
+++ b/src/so3/4C_so3_hex27.cpp
@@ -85,12 +85,18 @@ void Discret::Elements::SoHex27Type::setup_element_definition(
       parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<double>("STRENGTH", {.required = false}),
       parameter<double>("GROWTHTRIG", {.required = false}),
   });

--- a/src/so3/4C_so3_hex27.cpp
+++ b/src/so3/4C_so3_hex27.cpp
@@ -97,8 +97,6 @@ void Discret::Elements::SoHex27Type::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<double>("STRENGTH", {.required = false}),
-      parameter<double>("GROWTHTRIG", {.required = false}),
   });
 }
 

--- a/src/so3/4C_so3_hex8.cpp
+++ b/src/so3/4C_so3_hex8.cpp
@@ -96,12 +96,18 @@ void Discret::Elements::SoHex8Type::setup_element_definition(
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<double>("STRENGTH", {.required = false}),
       parameter<double>("GROWTHTRIG", {.required = false}),
   });

--- a/src/so3/4C_so3_hex8.cpp
+++ b/src/so3/4C_so3_hex8.cpp
@@ -108,8 +108,6 @@ void Discret::Elements::SoHex8Type::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<double>("STRENGTH", {.required = false}),
-      parameter<double>("GROWTHTRIG", {.required = false}),
   });
 }
 

--- a/src/so3/4C_so3_poro.cpp
+++ b/src/so3/4C_so3_poro.cpp
@@ -200,9 +200,9 @@ void Discret::Elements::So3Poro<So3Ele, distype>::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISODIR" + std::to_string(dim + 1);
-    if (container.get_if<std::vector<double>>(definition_name) != nullptr)
-      anisotropic_permeability_directions_[dim] =
-          container.get<std::vector<double>>(definition_name);
+    if (const auto& dir = container.get<Core::IO::Noneable<std::vector<double>>>(definition_name);
+        dir.has_value())
+      anisotropic_permeability_directions_[dim] = *dir;
   }
 }
 
@@ -214,9 +214,10 @@ void Discret::Elements::So3Poro<So3Ele, distype>::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISONODALCOEFFS" + std::to_string(dim + 1);
-    if (container.get_if<std::vector<double>>(definition_name) != nullptr)
-      anisotropic_permeability_nodal_coeffs_[dim] =
-          container.get<std::vector<double>>(definition_name);
+    if (const auto* coeffs =
+            container.get_if<Core::IO::Noneable<std::vector<double>>>(definition_name);
+        coeffs && coeffs->has_value())
+      anisotropic_permeability_nodal_coeffs_[dim] = coeffs->value();
   }
 }
 

--- a/src/so3/4C_so3_poro_eletypes.cpp
+++ b/src/so3/4C_so3_poro_eletypes.cpp
@@ -69,12 +69,18 @@ void Discret::Elements::SoHex8PoroType::setup_element_definition(
 
   defs["HEX8"] = all_of({
       defs_hex8["HEX8"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 8}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS2", {.required = false, .size = 8}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS3", {.required = false, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>, .size = 8}),
   });
 }
 
@@ -149,12 +155,18 @@ void Discret::Elements::SoTet4PoroType::setup_element_definition(
 
   defs["TET4"] = all_of({
       defs_tet4["TET4"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 4}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS2", {.required = false, .size = 4}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS3", {.required = false, .size = 4}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 4}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 4}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>, .size = 4}),
   });
 }
 
@@ -228,9 +240,12 @@ void Discret::Elements::SoHex27PoroType::setup_element_definition(
 
   defs["HEX27"] = all_of({
       defs_hex27["HEX27"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 
@@ -304,9 +319,12 @@ void Discret::Elements::SoTet10PoroType::setup_element_definition(
 
   defs["TET10"] = all_of({
       defs_tet10["TET10"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 
@@ -378,9 +396,12 @@ void Discret::Elements::SoNurbs27PoroType::setup_element_definition(
 
   defs["NURBS27"] = all_of({
       defs_nurbs27["NURBS27"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_sh8.cpp
+++ b/src/so3/4C_so3_sh8.cpp
@@ -93,8 +93,6 @@ void Discret::Elements::SoSh8Type::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<double>("STRENGTH", {.required = false}),
-      parameter<double>("GROWTHTRIG", {.required = false}),
   });
 }
 

--- a/src/so3/4C_so3_sh8.cpp
+++ b/src/so3/4C_so3_sh8.cpp
@@ -81,12 +81,18 @@ void Discret::Elements::SoSh8Type::setup_element_definition(
       parameter<std::string>("EAS"),
       parameter<std::string>("ANS"),
       parameter<std::string>("THICKDIR"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<double>("STRENGTH", {.required = false}),
       parameter<double>("GROWTHTRIG", {.required = false}),
   });

--- a/src/so3/4C_so3_tet10.cpp
+++ b/src/so3/4C_so3_tet10.cpp
@@ -90,12 +90,18 @@ void Discret::Elements::SoTet10Type::setup_element_definition(
       parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<double>("STRENGTH", {.required = false}),
       parameter<double>("GROWTHTRIG", {.required = false}),
   });

--- a/src/so3/4C_so3_tet10.cpp
+++ b/src/so3/4C_so3_tet10.cpp
@@ -102,8 +102,6 @@ void Discret::Elements::SoTet10Type::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<double>("STRENGTH", {.required = false}),
-      parameter<double>("GROWTHTRIG", {.required = false}),
   });
 }
 

--- a/src/so3/4C_so3_tet4.cpp
+++ b/src/so3/4C_so3_tet4.cpp
@@ -96,12 +96,18 @@ void Discret::Elements::SoTet4Type::setup_element_definition(
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<double>("GROWTHTRIG", {.required = false}),
   });
 }

--- a/src/so3/4C_so3_tet4.cpp
+++ b/src/so3/4C_so3_tet4.cpp
@@ -108,7 +108,6 @@ void Discret::Elements::SoTet4Type::setup_element_definition(
           "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
       parameter<Noneable<std::vector<double>>>(
           "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<double>("GROWTHTRIG", {.required = false}),
   });
 }
 

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -62,12 +62,18 @@ namespace
             },
             {.description = "The technology used for prestressing",
                 .default_value = Discret::Elements::PrestressTechnology::none}),
-        parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
     });
   }
 }  // namespace

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -51,9 +51,12 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
               },
               {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                               "kinematics (large displacements)"}),
-          parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 3}),
-          parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 3}),
-          parameter<std::vector<double>>("POROANISODIR3", {.required = false, .size = 3}),
+          parameter<Noneable<std::vector<double>>>(
+              "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
+          parameter<Noneable<std::vector<double>>>(
+              "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
+          parameter<Noneable<std::vector<double>>>(
+              "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
           selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
@@ -79,9 +82,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::hex8>(),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 8}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS2", {.required = false, .size = 8}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS3", {.required = false, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>, .size = 8}),
   });
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex27)] =
@@ -92,9 +98,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::tet4)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::tet4>(),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 8}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS2", {.required = false, .size = 8}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS3", {.required = false, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>, .size = 8}),
   });
 
 
@@ -245,8 +254,8 @@ void Discret::Elements::SolidPoroPressureVelocityBased::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISODIR" + std::to_string(dim + 1);
-    anisotropic_permeability_property_.directions_[dim] =
-        container.get_or<std::vector<double>>(definition_name, std::vector<double>(3, 0.0));
+    const auto& dir = container.get<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    anisotropic_permeability_property_.directions_[dim] = dir ? *dir : std::vector<double>(3, 0.0);
   }
 }
 
@@ -257,8 +266,13 @@ void Discret::Elements::SolidPoroPressureVelocityBased::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISONODALCOEFFS" + std::to_string(dim + 1);
-    anisotropic_permeability_property_.nodal_coeffs_[dim] = container.get_or<std::vector<double>>(
-        definition_name, std::vector<double>(this->num_node(), 0.0));
+
+    if (const auto* coeffs =
+            container.get_if<Core::IO::Noneable<std::vector<double>>>(definition_name);
+        coeffs && coeffs->has_value())
+      anisotropic_permeability_property_.nodal_coeffs_[dim] = coeffs->value();
+    else
+      anisotropic_permeability_property_.nodal_coeffs_[dim] = std::vector<double>(8, 0.0);
   }
 }
 

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -54,12 +54,18 @@ namespace
             },
             {.description = "The technology used for prestressing",
                 .default_value = Discret::Elements::PrestressTechnology::none}),
-        parameter<std::vector<double>>("RAD", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("AXI", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("CIR", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("FIBER1", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("FIBER2", {.required = false, .size = 3}),
-        parameter<std::vector<double>>("FIBER3", {.required = false, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<Noneable<std::vector<double>>>(
+            "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
 
     });
   }

--- a/src/w1/4C_w1_poro.cpp
+++ b/src/w1/4C_w1_poro.cpp
@@ -186,9 +186,9 @@ void Discret::Elements::Wall1Poro<distype>::
   for (int dim = 0; dim < 2; ++dim)
   {
     std::string definition_name = "POROANISODIR" + std::to_string(dim + 1);
-    if (container.get_if<std::vector<double>>(definition_name) != nullptr)
-      anisotropic_permeability_directions_[dim] =
-          container.get<std::vector<double>>(definition_name);
+    if (const auto& dir = container.get<Core::IO::Noneable<std::vector<double>>>(definition_name);
+        dir.has_value())
+      anisotropic_permeability_directions_[dim] = *dir;
   }
 }
 
@@ -200,9 +200,10 @@ void Discret::Elements::Wall1Poro<distype>::
   for (int dim = 0; dim < 2; ++dim)
   {
     std::string definition_name = "POROANISONODALCOEFFS" + std::to_string(dim + 1);
-    if (container.get_if<std::vector<double>>(definition_name) != nullptr)
-      anisotropic_permeability_nodal_coeffs_[dim] =
-          container.get<std::vector<double>>(definition_name);
+    if (const auto* coeffs =
+            container.get_if<Core::IO::Noneable<std::vector<double>>>(definition_name);
+        coeffs && coeffs->has_value())
+      anisotropic_permeability_nodal_coeffs_[dim] = coeffs->value();
   }
 }
 

--- a/src/w1/4C_w1_poro_eletypes.cpp
+++ b/src/w1/4C_w1_poro_eletypes.cpp
@@ -66,10 +66,14 @@ void Discret::Elements::WallQuad4PoroType::setup_element_definition(
 
   defs["QUAD4"] = all_of({
       defs_wall["QUAD4"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 4}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS2", {.required = false, .size = 4}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 4}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 4}),
   });
 }
 
@@ -139,8 +143,10 @@ void Discret::Elements::WallQuad9PoroType::setup_element_definition(
 
   defs["QUAD9"] = all_of({
       defs_wall["QUAD9"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
   });
 }
 
@@ -211,8 +217,10 @@ void Discret::Elements::WallNurbs4PoroType::setup_element_definition(
 
   defs["NURBS4"] = all_of({
       defs_wall["NURBS4"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
   });
 }
 
@@ -283,8 +291,10 @@ void Discret::Elements::WallNurbs9PoroType::setup_element_definition(
 
   defs["NURBS9"] = all_of({
       defs_wall["NURBS9"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
   });
 }
 
@@ -355,10 +365,14 @@ void Discret::Elements::WallTri3PoroType::setup_element_definition(
 
   defs["TRI3"] = all_of({
       defs_wall["TRI3"],
-      parameter<std::vector<double>>("POROANISODIR1", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISODIR2", {.required = false, .size = 2}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS1", {.required = false, .size = 3}),
-      parameter<std::vector<double>>("POROANISONODALCOEFFS2", {.required = false, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<Noneable<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 3}),
   });
 }
 

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -395,7 +395,14 @@ namespace
 
       // define setup parameter for InelasticDefGradTransvIsotropElastViscoplast
       Core::IO::InputParameterContainer setup_transv_isotrop_elast_viscoplast;
-      setup_transv_isotrop_elast_viscoplast.add("FIBER1", std::vector<double>{0.0, 0.0, 1.0});
+      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
+          "FIBER1", std::vector<double>{0.0, 0.0, 1.0});
+      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
+          "RAD", Core::IO::none<std::vector<double>>);
+      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
+          "AXI", Core::IO::none<std::vector<double>>);
+      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
+          "CIR", Core::IO::none<std::vector<double>>);
 
       // call setup method for InelasticDefGradTransvIsotropElastViscoplast
       transv_isotrop_elast_viscoplast_->setup(8, setup_transv_isotrop_elast_viscoplast);


### PR DESCRIPTION
This PR replaces most occurrences of `.required = false` by:
- removing outdated paramters
- making parameters required, or
- making parameters `Noneable`

I need to discuss a few remaining occurrences with a few people. So this is only the first part but can be merged already.

Part of #437 