### PR TITLE
Remove CONTACT_REGULARIZATION

### DIFF
--- a/src/contact/4C_contact_abstract_data_container.cpp
+++ b/src/contact/4C_contact_abstract_data_container.cpp
@@ -66,7 +66,6 @@ CONTACT::AbstractStrategyDataContainer::AbstractStrategyDataContainer()
       isselfcontact_(false),
       friction_(false),
       non_smooth_contact_(false),
-      regularized_(false),
       dualquadslavetrafo_(false),
       trafo_(nullptr),
       invtrafo_(nullptr),

--- a/src/contact/4C_contact_abstract_data_container.hpp
+++ b/src/contact/4C_contact_abstract_data_container.hpp
@@ -477,10 +477,6 @@ namespace CONTACT
     bool& is_non_smooth_contact() { return non_smooth_contact_; };
     bool is_non_smooth_contact() const { return non_smooth_contact_; };
 
-    //! return flag for regularized contact
-    bool& is_regularized() { return regularized_; };
-    bool is_regularized() const { return regularized_; };
-
     //! return flag indicating whether trafo should be applied
     bool& is_dual_quad_slave_trafo() { return dualquadslavetrafo_; };
     bool is_dual_quad_slave_trafo() const { return dualquadslavetrafo_; };
@@ -737,9 +733,6 @@ namespace CONTACT
 
     //! flag for non-smooth contact
     bool non_smooth_contact_;
-
-    //! flag for regularized contact
-    bool regularized_;
 
     //! flag indicating whether trafo should be applied
     bool dualquadslavetrafo_;

--- a/src/contact/4C_contact_abstract_strategy.cpp
+++ b/src/contact/4C_contact_abstract_strategy.cpp
@@ -100,7 +100,6 @@ CONTACT::AbstractStrategy::AbstractStrategy(
       isselfcontact_(data_ptr->is_self_contact()),
       friction_(data_ptr->is_friction()),
       nonSmoothContact_(data_ptr->is_non_smooth_contact()),
-      regularized_(data_ptr->is_regularized()),
       dualquadslavetrafo_(data_ptr->is_dual_quad_slave_trafo()),
       trafo_(data_ptr->trafo_ptr()),
       invtrafo_(data_ptr->inv_trafo_ptr()),
@@ -128,10 +127,6 @@ CONTACT::AbstractStrategy::AbstractStrategy(
 
   // set nonsmooth contact status
   if (params().get<bool>("NONSMOOTH_GEOMETRIES")) nonSmoothContact_ = true;
-
-  if (Teuchos::getIntegralValue<Inpar::CONTACT::Regularization>(
-          params(), "CONTACT_REGULARIZATION") != Inpar::CONTACT::reg_none)
-    regularized_ = true;
 
   // initialize storage fields for parallel redistribution
   unbalanceEvaluationTime_.clear();

--- a/src/contact/4C_contact_abstract_strategy.hpp
+++ b/src/contact/4C_contact_abstract_strategy.hpp
@@ -1678,9 +1678,6 @@ namespace CONTACT
     //! Flag for non-smooth contact algorithm
     bool& nonSmoothContact_;
 
-    //! Flag for regularized contact
-    bool& regularized_;
-
     /*! \brief Flag indicating whether transformation should be applied
      *
      * \todo Which transformation?

--- a/src/contact/4C_contact_lagrange_strategy.hpp
+++ b/src/contact/4C_contact_lagrange_strategy.hpp
@@ -398,22 +398,6 @@ namespace CONTACT
         const Core::LinAlg::Vector<double>& fs, const Core::LinAlg::Vector<double>& fm);
 
     /*!
-    \brief do additional matrix manipulations for regularization scaling
-
-    */
-    void do_regularization_scaling(bool aset, bool iset, Core::LinAlg::SparseMatrix& invda,
-        Core::LinAlg::SparseMatrix& kan, Core::LinAlg::SparseMatrix& kam,
-        Core::LinAlg::SparseMatrix& kai, Core::LinAlg::SparseMatrix& kaa,
-        Core::LinAlg::Vector<double>& fa, Core::LinAlg::SparseMatrix& kteffnew,
-        Core::LinAlg::Vector<double>& feffnew);
-
-    /*!
-    \brief calculate regularization scaling and apply it to matrixes
-
-    */
-    void evaluate_regularization_scaling(Core::LinAlg::Vector<double>& gact);
-
-    /*!
     \brief Saving reference state is required for penalty support (LTL)
 
     */

--- a/src/contact/4C_contact_manager.cpp
+++ b/src/contact/4C_contact_manager.cpp
@@ -787,20 +787,6 @@ bool CONTACT::Manager::read_and_check_input(Teuchos::ParameterList& cparams) con
     // Hopefully coming soon, when Coulomb and Tresca are combined. Until then, throw error.
     FOUR_C_THROW("Frictionless first contact step with Tresca's law not yet implemented");
 
-  if (Teuchos::getIntegralValue<Inpar::CONTACT::Regularization>(
-          contact, "CONTACT_REGULARIZATION") != Inpar::CONTACT::reg_none &&
-      Teuchos::getIntegralValue<Inpar::CONTACT::SolvingStrategy>(contact, "STRATEGY") !=
-          Inpar::CONTACT::solution_lagmult)
-    FOUR_C_THROW(
-        "Regularized Contact just available for Dual Mortar Contact with Lagrangean "
-        "Multiplier!");
-
-  if (Teuchos::getIntegralValue<Inpar::CONTACT::Regularization>(
-          contact, "CONTACT_REGULARIZATION") != Inpar::CONTACT::reg_none &&
-      Teuchos::getIntegralValue<Inpar::CONTACT::FrictionType>(contact, "FRICTION") !=
-          Inpar::CONTACT::friction_none)
-    FOUR_C_THROW("Regularized Contact for contact with friction not implemented yet!");
-
   // *********************************************************************
   // warnings
   // *********************************************************************

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -195,22 +195,6 @@ void CONTACT::STRATEGY::Factory::read_and_check_input(Teuchos::ParameterList& pa
     // hopefully coming soon, when Coulomb and Tresca are combined
     FOUR_C_THROW("Frictionless first contact step with Tresca's law not yet implemented");
 
-  if (Teuchos::getIntegralValue<Inpar::CONTACT::Regularization>(
-          contact, "CONTACT_REGULARIZATION") != Inpar::CONTACT::reg_none &&
-      Teuchos::getIntegralValue<Inpar::CONTACT::SolvingStrategy>(contact, "STRATEGY") !=
-          Inpar::CONTACT::solution_lagmult)
-  {
-    FOUR_C_THROW(
-        "Regularized Contact just available for Dual Mortar Contact with Lagrangean "
-        "Multiplier!");
-  }
-
-  if (Teuchos::getIntegralValue<Inpar::CONTACT::Regularization>(
-          contact, "CONTACT_REGULARIZATION") != Inpar::CONTACT::reg_none &&
-      Teuchos::getIntegralValue<Inpar::CONTACT::FrictionType>(contact, "FRICTION") !=
-          Inpar::CONTACT::friction_none)
-    FOUR_C_THROW("Regularized Contact for contact with friction not implemented yet!");
-
   // ---------------------------------------------------------------------
   // warnings
   // ---------------------------------------------------------------------

--- a/src/inpar/4C_inpar_contact.cpp
+++ b/src/inpar/4C_inpar_contact.cpp
@@ -122,11 +122,6 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       tuple<std::string>("ntt", "xyz"),
       tuple<Inpar::CONTACT::ConstraintDirection>(constr_ntt, constr_xyz), scontact);
 
-  Core::Utils::string_to_integral_parameter<Inpar::CONTACT::Regularization>(
-      "CONTACT_REGULARIZATION", "none", "use regularized contact",
-      tuple<std::string>("none", "tanh"), tuple<Inpar::CONTACT::Regularization>(reg_none, reg_tanh),
-      scontact);
-
   Core::Utils::bool_parameter("NONSMOOTH_GEOMETRIES", false,
       "If chosen the contact algorithm combines mortar and nts formulations. This is needed if "
       "contact between entities of different geometric dimension (such as contact between surfaces "

--- a/src/inpar/4C_inpar_contact.hpp
+++ b/src/inpar/4C_inpar_contact.hpp
@@ -99,12 +99,6 @@ namespace Inpar
       constr_xyz     ///< global Cartesian coordinates
     };
 
-    enum Regularization
-    {
-      reg_none,  ///< no regularization is applied
-      reg_tanh   ///< regularization with tanh smoothing is applied
-    };
-
     /// Local definition of problemtype to avoid use of globalproblem.H
     enum Problemtype
     {


### PR DESCRIPTION
## Description and Context

This feature has been added 10 years ago. Today, it is

- unclear what it is supposed to do,
- untested,
- broken with an overflow error.

We have been doing robust contact simulations without for several years, so apparently it is not super important.

All in all, there seems not to be much value in keeping it, so it is removed.

## Related Issues and Pull Requests

- I looked into this parameter due to #420.
- Closes #422