### PR TITLE
Update documentation,analysis guide->linearsolvers

### DIFF
--- a/doc/readthedocs/introduction_solvers.rst
+++ b/doc/readthedocs/introduction_solvers.rst
@@ -32,17 +32,19 @@ At this point, the linear algebra library *Trilinos* is heavily used, which prov
    Sparse Linear Algebra
 
 **Amesos/Amesos2**:
-   Direct Solvers (UMFPACK, Superlu)
+   Direct Solvers (internal solver KLU/KLU2, external solvers UMFPACK, Superlu)
 
-**AztecOO/Belos**:
+**Belos**:
    Iterative Solvers (CG, GMRES)
 
 **Ifpack**:
-   Preconditioner (ILU, ICHOL, GS)
+   Preconditioner (ILU)
 
-**ML/MueLu**:
-   Multigrid-Preconditioner
+**MueLu**:
+   Algebraic Multigrid-Preconditioner
 
+**Teko**:
+    Block Preconditioner
 
 The solvers are called in the solver sections::
 
@@ -56,10 +58,94 @@ in which all details for a specific solver are defined.
 The parameter ``SOLVER`` defines the solver to be used.
 Most of the solvers require additional parameters. These are explained in the following.
 
+Solvers for coupled problems (aka multiphysics)
+-------------------------------------------------
 
+Sequential solution:
+^^^^^^^^^^^^^^^^^^^^^
+
+If a :ref:`multiphysics problem <multifieldproblems>` is to be solved,
+each physics involved can be solved one after the other, and the interaction then leads to an iterative procedure,
+where the influence of one field to the other hopefully converges to a common solution.
+From a solver's point of view, the solution is achieved by running the solver of each single field problem independent of others.
+Therefore, those problems are solved like single *physics* problems using the methods given below.
+One solver has to be defined for each *physics*, but the definition in the input file can be one for several solvers.
+
+For example, a structural analysis sequentially coupled with scalar transport needs two solvers, handling the respective physics:
+
+::
+
+    ------------------------------------------------------PROBLEM TYPE
+    PROBLEMTYPE                      Structure_Scalar_Interaction
+    ------------------------------------------------STRUCTURAL DYNAMIC
+    LINEAR_SOLVER                   1
+    ...
+    ------------------------------------------SCALAR TRANSPORT DYNAMIC
+    LINEAR_SOLVER                   2
+    ...
+    ----------------------------------------------------------SOLVER 1
+    SOLVER                          UMFPACK
+    ----------------------------------------------------------SOLVER 2
+    SOLVER                          UMFPACK
+
+For the case above, actually, one could also use ``SOLVER 1`` for both physics, two solvers of the same kind would then still be used.
+
+
+Monolithic solution:
+^^^^^^^^^^^^^^^^^^^^^
+
+If, on the other hand, the interaction of the physical fields is strong, the iterative procedure may converge only slowly (if at all),
+thus a so-called *monolithic solution*, solving all degrees of freedom simultaneously is beneficial.
+This solution type will be described in the following:
+
+The degrees of freedom of all physics appear in the linear system.
+Since the stiffness factors of the different physics may be different by orders of magnitude,
+and the coupling between the physics may again have a different magnitude,
+the linear system may be particularly ill-conditioned.
+
+For the monolithic solution of the multiphysics problem, an additional solver is needed for the monolithic approach,
+e.g., again for the SSI problem:
+
+::
+
+     ------------------------------------------------------PROBLEM TYPE
+     PROBLEMTYPE                      Structure_Scalar_Interaction
+     ------------------------------------------------STRUCTURAL DYNAMIC
+     LINEAR_SOLVER                   1
+     ...
+     ------------------------------------------SCALAR TRANSPORT DYNAMIC
+     LINEAR_SOLVER                   1
+     ...
+     --------------------------------------------SSI CONTROL/MONOLITHIC
+     LINEAR_SOLVER                   2
+     ----------------------------------------------------------SOLVER 1
+     SOLVER                          UMFPACK
+     ----------------------------------------------------------SOLVER 2
+     SOLVER                          Belos
+     AZPREC                          AMGnxn
+     AMGNXN_TYPE                     XML
+     AMGNXN_XML_FILE                 ssi_mono_3D_27hex8_scatra_BGS-AMG_2x2.xml
+
+Here, we have used the same solver type (a direct solver) for each physics, and for the coupling we used an iterative solver (Belos).
+The situation is similar, when fluid-structure or thermo-structure coupling is employed.
+The iterative solver used for the coupling is particularly suited for this kind of mathematics, where the coupled degrees of freedom are given in a so-called block structure.
+The solver settings are explained in detail below.
+
+Special case: Contact
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Even though contact does not involve several physics directly, they can be treated as a coupled problem:
+
+- Contact with penalty: basically still solid mechanics (probably a bit more ill-conditioned)
+- Contact with lagrange multipliers: There is a block structure in the system.
+  If an iterative solver is used, the preconditioner needs to know about it.
+
+
+Solver Interfaces
+-------------------
 
 Direct solver
--------------
+^^^^^^^^^^^^^^
 
 In principle, the direct solver identifies :math:`x` by calculating the inverse of :math:`\mathbf{A}`: :math:`x = \mathbf{A}^{-1} b`.
 
@@ -75,10 +161,16 @@ the iterative solver will be significantly faster.
 In addition, the iterative solver is more memory efficient, so it can solve larger system with a computer equipped with low memory.
 
 The benefit of the direct solver is that there are no parameters, which one has to provide,
-since the direct solver does not care about the underlying physics.
+since the direct solver does not care about the underlying physics. The definition in the input file is simply
+
+::
+
+     ----------------------------------------------------------SOLVER 1
+     SOLVER                          UMFPACK
+
 
 Iterative solver
------------------
+^^^^^^^^^^^^^^^^^^
 
 The iterative solver can be used for any size of equation systems, but is the more efficient the larger the problem is.
 If a good parameter set for the solver is chosen, it scales linearly with the size of the system,
@@ -94,122 +186,149 @@ Instead, this solution method solves the equation :math:`\mathbf{A} x_k = b`  wi
    x_{k+1} = \mathbf{P}(x_k, \mathbf{A} x_k, b) \, ,
 
 such that :math:`x_k \rightarrow x \mbox{ for } k \rightarrow \infty`.
-Slow progress if :math:`x_0` is not chosen properly. Preconditioner helps by solving
+Slow progress if :math:`x_0` is not chosen properly. A preconditioner helps by solving
 :math:`\mathbf{P}^{-1} \mathbf{A} x = \mathbf{P}^{-1} b`.
 Ideally :math:`\mathbf{P}^{-1} = \mathbf{A}` (gives the solution for *x*),
 but :math:`\mathbf{P}` should be cheap to calculate.
 The larger the problem is, the higher is the benefit of iterative solvers.
 
-Solver interface
-^^^^^^^^^^^^^^^^
-
 The current solver is based on Trilinos' **Belos** package, which is the successor of AztecOO.
 This package provides a bunch of KRYLOV solvers, e.g.
 
-   - CG for symmetric problems,
-   - GMRES (also for unsymmetric problems)
-   - BICGSTAB (??)
+   - CG (conjugate gradient method) for symmetric problems,
+   - GMRES (Generalised Minimal Residual Method, also for unsymmetric problems)
+   - BICGSTAB (Biconjugate gradient stabilized method)
 
-The parameters are very similar to the AztecOO package,
-and therefore further information on specific details can be found in the official `AztecOO user guide <https://trilinos.github.io/pdfs/AztecOOUserGuide.pdf>`_.
-Since an iterative method approximates the correct solution iteratively,
-a residual criterion (here ``AZCONV``), a tolerance (``AZTOL``),
-and the maximum number of iterations ``AZITER`` must be given.
-The default of ``AZCONV`` (AZ_r0) is reasonable, while the default for the maximum number of iterations (1000) is rather high.
 
-In addition, the parameter ``AZSUB`` is important, if the default algorithm, GMRES, is used:
-Krylov solvers build up a subspace of vectors, and they should be rebuilt after a number of iterations. The default of 50 is reasonable.
-
-These parameters are defined in the following way:
+Originally, the parameters have been defined in the solver sections; however, this is deprecated now.
+In order to narrow down the size of the input file, all parameters for the iterative solver are now given in an extra xml File, which is included by the parameter
+``SOLVER_XML_FILE``.
+Thus, the solver section may also consist of
 
 ::
 
    -----------SOLVER 1
-   SOLVER  Belos
-   AZSOLVE [CG|GMRES|BICGSTAB]
-   AZCONV  [AZ_r0|AZ_rhs|AZ_Anorm|AZ_noscaled|AZ_sol|AZ_weighted]
-   AZITER  <number>
+   SOLVER           Belos
+   SOLVER_XML_FILE  gmres_template.xml
+   ...
 
-
+One can find a number of template solver xml files in ``<source-dir>/tests/input-files/xml/linear_solver/*.xml``.
+Further parameter are necessary for the preconditioner, where a number of choices are available, see below.
 
 Preconditioners
 ^^^^^^^^^^^^^^^^
 
-The choice and design of the preconditioner highly affect performance. Within Belos one can choose between
+The choice and design of the preconditioner highly affect performance.
+Within Belos one can choose between the following four preconditioners:
 
 -	ILU
--	Algebraic Multigrid (AMG) methods
+-	MueLu
+-   Teko
+-   AMGnxn
 
-**ILU** (incomplete LU method)
+ILU is the easiest one to use with very few parameters; however, perfect scalability is not achieved with this method.
+For better performance use **MueLu** for single physics and **Teko** or **AMGnxn** for multiphysics problems.
+You'll find templates of parameter files for various problems in the subdirectories of ``<>source-dir>/tests/input-files/xml/...``.
 
-Perfect scalability is not achieved with this method, but is has the advantage of being less complex.
-
-ILU comes with a single parameter: ``IFPACKGFILL``.
-The default, ``IFPACKGFILL 0``, will not include further elements in the preconditioner P (same sparcity pattern)
-setup will be faster, approximation is worse
-``IFPACKGFILL = 1 .. n``: The higher the more elements are included, sparcity decreases (a level of 12 might be a full matrix, like a direct solver)
-**Remark** One should probably not go beyond 3, maybe start with 0) Only for very strong ill-conditioning one should go towards 3.
+The preconditioner is chosen by the parameter ``AZPREC`` within the ``SOLVER n`` section.
+Note that the parameter to define the xml-file for further preconditioner-parameters is different for each preconditioner.
+The solver sections appear in the following way:
 
 ::
 
    -----------SOLVER 1
-   AZPREC       ILU
-   IFPACKGFILL  [0 .. 12]
+   SOLVER           Belos
+   SOLVER_XML_FILE  gmres_template.xml
+   AZPREC           ILU
+   IFPACK_XML_FILE <path/to/your/ifpack_parameters.xml>
+   -----------SOLVER 2
+   SOLVER           Belos
+   NAME             algebraic_multigrid_solver
+   SOLVER_XML_FILE  gmres_template.xml
+   AZPREC           MueLu
+   MUELU_XML_FILE  <path/to/your/multigrid_parameters.xml>
+   -----------SOLVER 3
+   SOLVER           Belos
+   NAME             block_multigrid_solver
+   SOLVER_XML_FILE  gmres_template.xml
+   AZPREC           Teko
+   TEKO_XML_FILE   <path/to/your/block_preconditioner_parameters.xml>
+   -----------SOLVER 4
+   SOLVER           Belos
+   NAME             block_multigrid_solver
+   SOLVER_XML_FILE  gmres_template.xml
+   AZPREC           AMGnxn
+   AMGNXN_TYPE      XML
+   AMGNXN_XML_FILE  <source-dir>/tests/input-files/*_AMG_*.xml
 
-**Algebraic Multigrid (AMG) methods**
+The xml files are named after problem types for which they are most suited.
+It is highly recommended to first use these defaults before tweaking the parameters.
 
-The current recommendation is the trilinos ML preconditioner, for further information on this, see [Gee07]_.
 
-*Theory:*
+ILU (incomplete LU method) comes with a single parameter, therefore only a single xml file is contained in the respective directory:
+``<>source-dir>/tests/input-files/xml/preconditioner/ifpack.xml``.
+In this file, the so-called fill level is set up by ``fact: level-of-fill``, and it contains the default value 0 there.
+With lower values, the setup will be faster, but the approximation is worse.
+The higher the more elements are included, sparcity decreases (a level of 12 might be a full matrix, like a direct solver).
 
-The trick is to apply a cheap transfer method to get from the complete system to a smaller one (coarsening/aggregation of the system).
-The method to be used is given in `ML_COARSEN`.
-In order to get a preconditioner matrix of the same size as the original matrix, of course,
-the aggregation must be used in the opposite direction afterwards.
-The default method is UC (uncoupled), which is a good choice as well.
+The current recommendation is to use one of the three more sophisticated preconditioners currently available.
+All these preconditioners have a number of parameters that can be chosen;
+however, a recommended set of parameters for various problems are given in respective xml files.
 
-The coarsening reduces the size by a factor `ML_AGG_SIZE`.
-It defines how many lines are comprised to one (good choices are 27 for 3D, 9 for 2D, and 3 for 1D problems).
+In general, the xml file for the multigrid preconditioners usually contains the divisions
+
+- general
+- aggregation
+- smoothing
+- repartitioning
+
+For preconditioning of large systems, the trick is to apply a cheap transfer method to get from the complete system to a smaller one (coarsening/aggregation of the system).
+Here, coarsening means the generation of a smaller system size, will aggregation is the reverse procedure to come to the original matrix size.
+The coarsening reduces the size by comprised a number of lines into one; common choices are 27 for 3D, 9 for 2D, and 3 for 1D problems, which is conducted by default.
+
+The overall multigrid algorithm is defined in the general section by ``multigrid algorithm``, which can have the values
+``sa`` (Classic smoothed aggregation, default), ``pg`` (prolongator smoothing) among others.
 
 A smoother is used twice (pre- and post-smoother) for each level of aggregation to reduce the error frequencies in your solution vector.
 Multiple transfer operations are applied in sequence, since only high frequency components can be tackled by smoothing,
 while the low frequency errors are still there.
 The restriction operator restricts the current error to the coarser grid.
 At some point (let say if 10000 dofs are left) the system has a size where one can apply the direct solver.
-This number is given by `ML_MAXCOARSESIZE`.
-That is, when the number of remaining dofs is smaller than `ML_MAXCOARSESIZE`, no more coarsening is conducted.
+This number is given by ``coarse:: max size`` in the general section of the xml file.
+That is, when the number of remaining dofs is smaller than the given size, no more coarsening is conducted.
 It should be larger than the default of 1000, let say, 5000-10000.
-Also, the maximum number of coarsenings is given by `ML_MAXLEVEL` (maxlevel should always be high enough).
+Also, the maximum number of coarsenings is given by ``max levels``. This number should always be high enough to get down to the max size, the default is 10.
 
-One may define three different smoothers:
-`ML_SMOOTHERFINE` (for the first / fine level);
-`Ml_SMOOTHERMED` (for all intermediate levels);
-`Ml_SMOOTHERMED` (probably always a direct solver like UMFPACK).
+After reaching the coarsest level, the remaining system is solved by a (direct) solver.
+The parameter to setup the direct solver is ``coarse: type``,
+and it can have the values ``SuperLU`` (default), ``SuplerLU_dist`` (the parallel version of SuperLU), ``KLU`` (an internal direct solver in trilinos) or ``Umfpack``.
+(After changing to Amesos2, the internal server will be KLU2).
 
-While many solvers can be used, five of them are most popular: SGS (symmetric Gauss Seidel), Jacobi, Chebychev, ILU, MLS.
+The smoother to be used is set up by ``smoother: type`` with the possible values ``CHEBYSHEV``, ``RELAXATION`` (default), ``ILUT``, or ``RILUK``
+While many solvers can be used, five of them are most popular: SGS (symmetric Gauss Seidel), Jacobi, Chebyshev, ILU, MLS.
 Besides that, particularly for the coarsest smoother, a direct solver can be used, as (Umfpack, SuperLU, KLU).
 
-*Chebychev smoother:*
-   This is a polynomial smoother. The degree of the polynomial is given by `ML_SMOTIMES`.
-   A lower degree is faster (not much), but higher is more accurate; one may use 3, 6 or even 9 [very high])
+*Chebyshev smoother:*
+   This is a polynomial smoother. The degree of the polynomial is given by `smoother: sweeps` (default is 2).
+   A lower degree is faster (not much), but higher is more accurate; reasonable values may go up to 9 (very high)
 
-*Relaxation method (e.g. SGS):*
-   For this kind of smoothers, `ML_SMOTIMES` is providing the number of sweeps for each smoothening.
+*Relaxation method:*
+   The relaxation smoother comes with a number of additional parameters inside a special section , particularly the type: ``relaxation: type``,
+   which can be ``Jacobi``, ``Gauss-Seidel``, ``Symmetric Gauss-Seidel`` among others. The polynomial degree can be setup here by ``relaxation: sweeps``.
    This one is rather for fluid dynamics problems.
 
-*ILU:*
-   Here, `ML_SMOTIMES` will be interpreted as the FILL level.
+*ILUT, RILUK:*
+   These are local (processor-based) incomplete factorization methods.
 
-Damping helps with convergence, and it can be appliedto any of the smoothers,
-see `ML_DAMPFINE`, `ML_DAMPMED`, `ML_DAMPCOARSE`.
-A value of 1 cancels damping, 0 means maximum damping.
+For understanding the multigrid preconditioner better, the interested reader is referred to a :download:`presentation held by Max Firmbach in 2022 <figures/TGM_LinearSolvers.pdf>`.
+
+Damping helps with convergence, and it can be applied to any of the smoothers by ``smoother: damping factor``.
+A value of 1 (default) cancels damping, 0 means maximum damping.
 Too much damping increases the iterations, thus, usually it should be between 1 and 0.5.
 A little bit of damping will probably improve convergence (also from the beginning).
 
-`ML_PROLONG_SMO` is the main parameter to control the prolongation.
-Transfer operator from coarse to fine
-(a tentative prolongator is created by constant interpolation, then try to improve the constant to linear interpolation).
-``ML_PROLONG_SMO 1.33`` is a good value for structural, scatra, thermo problems. Different choice would be 1 (maybe for fluids).
+For the multigrid preconditioner, one can also find a :download:`comprehensive documentation <https://trilinos.github.io/pdfs/mueluguide.pdf>`
+on the trilinos website, explaining all the parameters, their meaning and the default values.
 
 .. list-table::
    :header-rows: 1
@@ -222,52 +341,4 @@ Transfer operator from coarse to fine
      - symm
    * - Contact
      - unsymm
-
-
-Coupled problems:
-^^^^^^^^^^^^^^^^^^
-
-If a :ref:`multiphysics problem <multifieldproblems>` is to be solved, they can be solved sequentially, and the interaction then leads to an iterative procedure,
-where the influence of one field to the other hopefully converges to a common solution.
-From a solver's point of view, the solution is achieved by running the solver of each single field problem independent of others.
-Therefore, those problems are solved using the methods given above.
-
-If, on the other hand, the interaction of the physical fields is strong, the iterative procedure may converge only slowly (if at all),
-thus a monolithic solution, solving all degrees of freedom simultaneously is beneficial.
-This so-called *monolithic solution* will be described in the following:
-
-**Monolithic solution:** all degrees of freedom appear in the linear system.
-Since the stiffness factors of the different physics may be different by orders of magnitude,
-and the coupling between the physics may again have a different magnitude,
-the linear system may be particularly ill-conditioned.
-On the other hand, **sequential solutions** are handled like single field problems from the solver point of view.
-
-*Monolithic solvers for multiphysics problems:*
-
-Contact with penalty: basically still solid mechanics (probably a bit more ill-conditioned)
-Contact with lagrange multipliers and other problems: block structure in the system, and the preconditioner needs to know about it.
-If you have a block structure (e.g. TSI monolithic): e.g. Block Gauss Seidel 2 by 2 (BGS2x2),
-one has to invert the different blocks together.
-In BGS you need to invert the different blocks, you need to provide for preconditioner for each block,
-which is specified in the other solver sections.
-You need to define a preconditioner in the structural and the thermo solver.
-
-Future prospects
-^^^^^^^^^^^^^^^^
-
-**Switch from ML to MueLu**
-
-   In the near future there will be a major change with respect to the preconditioners.
-   This will affect also the input parameters,
-   and even the input style, which will then rather depend on separate solver parameter files than parameters in the input file.
-
-Further reading
-^^^^^^^^^^^^^^^
-
-.. figure:: figures/TGM_LinearSolvers.pdf
-   :width: 400px
-   :align: center
-
-   A presentation held by Max Firmbach in 2022
-
 

--- a/doc/readthedocs/problemtypes.rst
+++ b/doc/readthedocs/problemtypes.rst
@@ -126,21 +126,6 @@ Fluid_XFEM
 The element types used are given in xxx. The number of degrees of freedom
 
 
-Inverse_Analysis
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**General**
-
-.. ToDo::
-
-   No information about this special problem type.
-
-**Elements and Degrees of freedom**
-
-The element types used are given in :ref:`STRUCTURE ELEMENTS<structureelements>`.
-The number of degrees of freedom
-
-
 Level_Set
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -317,11 +302,6 @@ Fluid_Structure_Interaction
 
 One has to define solvers for the following dynamics:
 
-Fluid_Structure_Interaction_Lung
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One has to define solvers for the following dynamics:
-
 Fluid_Structure_Interaction_RedModels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -338,11 +318,6 @@ Fluid_XFEM_LevelSet
 One has to define solvers for the following dynamics:
 
 Gas_Fluid_Structure_Interaction
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-One has to define solvers for the following dynamics:
-
-Immersed_FSI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 One has to define solvers for the following dynamics:

--- a/doc/readthedocs/references.rst
+++ b/doc/readthedocs/references.rst
@@ -1,7 +1,6 @@
 References
 ===========
 
-.. [Gee07] M. Gee, C.M. Siefert, J.J. Hu, R.S. Tuminaro, M.G. Sala: ML 5.0 Smoothed Aggregation User's Guide, SAND2006-2649, Sandia Nat. Lab, 2007.
 
 .. [Wall99] W.A. Wall, PhD thesis, 1999 (available under ``/lnm/literature/1999/``)
 


### PR DESCRIPTION
## Description and Context

Even though I am not the expert on linear solvers, I saw that this section is particularly outdated (change from ML to MueLu is not covered, parameters that do not exist were still mentioned, etc.), and tried to update it.
All the experts, please check the content, so that it becomes a valuable resource of knowledge.
I know that we probably have to update it again soon, when we finally switch to Tpetra and Amesos2, but at least it gives some details to the current version.

## Related Issues and Pull Requests

Needs: PR #400 
Related to: Issue #365 , Discussion #408

# Interested parties
@maxfirmbach @dharinib98 @mayrmt 