### PR TITLE
Add compression level as optional parameter to vtk output

### DIFF
--- a/src/core/io/src/4C_io_visualization_parameters.cpp
+++ b/src/core/io/src/4C_io_visualization_parameters.cpp
@@ -29,6 +29,10 @@ Core::IO::VisualizationParameters Core::IO::visualization_parameters_factory(
   parameters.data_format_ = Teuchos::getIntegralValue<OutputDataFormat>(
       visualization_output_parameter_list, "OUTPUT_DATA_FORMAT");
 
+  // Compression level
+  parameters.compression_level_ = Teuchos::getIntegralValue<LibB64::CompressionLevel>(
+      visualization_output_parameter_list, "COMPRESSION_LEVEL");
+
   // Number of digits to reserve for time step count
   parameters.digits_for_time_step_ =
       visualization_output_parameter_list.get<int>("TIMESTEP_RESERVE_DIGITS");

--- a/src/core/io/src/4C_io_visualization_parameters.hpp
+++ b/src/core/io/src/4C_io_visualization_parameters.hpp
@@ -11,6 +11,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_vtk_writer_base.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 #include <string>
@@ -44,6 +45,9 @@ namespace Core::IO
   {
     //! Enum containing the type of output data format, i.e., binary or ascii.
     OutputDataFormat data_format_;
+
+    //! Level of compression used when writing output.
+    LibB64::CompressionLevel compression_level_;
 
     //! Base output directory
     std::string directory_name_;

--- a/src/core/io/src/4C_io_visualization_writer_vtu_per_rank.cpp
+++ b/src/core/io/src/4C_io_visualization_writer_vtu_per_rank.cpp
@@ -24,7 +24,7 @@ Core::IO::VisualizationWriterVtuPerRank::VisualizationWriterVtuPerRank(
           std::pow(10, Core::IO::get_total_digits_to_reserve_in_time_step(parameters)),
           parameters.directory_name_, (parameters.file_name_prefix_ + "-vtk-files"),
           visualization_data_name_, parameters.restart_from_name_, parameters.restart_time_,
-          parameters.data_format_ == OutputDataFormat::binary)
+          parameters.data_format_ == OutputDataFormat::binary, parameters.compression_level_)
 {
 }
 
@@ -32,9 +32,9 @@ Core::IO::VisualizationWriterVtuPerRank::VisualizationWriterVtuPerRank(
  *
  */
 void Core::IO::VisualizationWriterVtuPerRank::initialize_time_step(
-    const double visualziation_time, const int visualization_step)
+    const double visualization_time, const int visualization_step)
 {
-  vtu_writer_.reset_time_and_time_step(visualziation_time, visualization_step);
+  vtu_writer_.reset_time_and_time_step(visualization_time, visualization_step);
 
   vtu_writer_.initialize_vtk_file_streams_for_new_geometry_and_or_time_step();
   vtu_writer_.write_vtk_headers();

--- a/src/core/io/src/4C_io_visualization_writer_vtu_per_rank.hpp
+++ b/src/core/io/src/4C_io_visualization_writer_vtu_per_rank.hpp
@@ -35,7 +35,7 @@ namespace Core::IO
      * @brief Initialize the current time step (derived)
      */
     void initialize_time_step(
-        const double visualziation_time, const int visualization_step) override;
+        const double visualization_time, const int visualization_step) override;
 
     /**
      * @brief Write all fields contained in the field data map to disk (derived)

--- a/src/core/io/src/4C_io_vtk_writer_base.cpp
+++ b/src/core/io/src/4C_io_vtk_writer_base.cpp
@@ -182,7 +182,8 @@ VtkWriterBase::VtkWriterBase(unsigned int myrank, unsigned int num_processors,
     unsigned int max_number_timesteps_to_be_written,
     const std::string& path_existing_working_directory,
     const std::string& name_new_vtk_subdirectory, const std::string& geometry_name,
-    const std::string& restart_name, const double restart_time, bool write_binary_output)
+    const std::string& restart_name, double restart_time, bool write_binary_output,
+    LibB64::CompressionLevel compression_level)
     : currentPhase_(VAGUE),
       num_timestep_digits_(LibB64::ndigits(max_number_timesteps_to_be_written)),
       num_processor_digits_(LibB64::ndigits(num_processors)),
@@ -192,6 +193,7 @@ VtkWriterBase::VtkWriterBase(unsigned int myrank, unsigned int num_processors,
       is_restart_(restart_time > 0.0),
       cycle_(std::numeric_limits<int>::max()),
       write_binary_output_(write_binary_output),
+      compression_level_(compression_level),
       myrank_(myrank),
       numproc_(num_processors)
 {
@@ -496,7 +498,7 @@ void VtkWriterBase::write_data_array_this_processor(
   {
     filestream << " format=\"binary\">\n";
 
-    LibB64::write_compressed_block(data, filestream);
+    LibB64::write_compressed_block(data, filestream, compression_level_);
   }
   else
   {

--- a/src/core/io/src/4C_io_vtu_writer.cpp
+++ b/src/core/io/src/4C_io_vtu_writer.cpp
@@ -24,10 +24,11 @@ VtuWriter::VtuWriter(unsigned int myrank, unsigned int num_processors,
     unsigned int max_number_timesteps_to_be_written,
     const std::string& path_existing_working_directory,
     const std::string& name_new_vtk_subdirectory, const std::string& geometry_name,
-    const std::string& restart_name, const double restart_time, bool write_binary_output)
+    const std::string& restart_name, double restart_time, bool write_binary_output,
+    LibB64::CompressionLevel compression_level)
     : VtkWriterBase(myrank, num_processors, max_number_timesteps_to_be_written,
           path_existing_working_directory, name_new_vtk_subdirectory, geometry_name, restart_name,
-          restart_time, write_binary_output)
+          restart_time, write_binary_output, compression_level)
 {
   // empty constructor
 }
@@ -140,7 +141,7 @@ void VtuWriter::write_geometry_unstructured_grid(const std::vector<double>& poin
   if (write_binary_output_)
   {
     currentout_ << " format=\"binary\">\n";
-    LibB64::write_compressed_block(point_coordinates, currentout_);
+    LibB64::write_compressed_block(point_coordinates, currentout_, compression_level_);
   }
   else
   {
@@ -178,7 +179,7 @@ void VtuWriter::write_geometry_unstructured_grid(const std::vector<double>& poin
   if (write_binary_output_)
   {
     currentout_ << " format=\"binary\">\n";
-    LibB64::write_compressed_block(point_cell_connectivity, currentout_);
+    LibB64::write_compressed_block(point_cell_connectivity, currentout_, compression_level_);
   }
   else
   {
@@ -200,7 +201,7 @@ void VtuWriter::write_geometry_unstructured_grid(const std::vector<double>& poin
   if (write_binary_output_)
   {
     currentout_ << " format=\"binary\">\n";
-    LibB64::write_compressed_block(cell_offset, currentout_);
+    LibB64::write_compressed_block(cell_offset, currentout_, compression_level_);
   }
   else
   {
@@ -220,7 +221,7 @@ void VtuWriter::write_geometry_unstructured_grid(const std::vector<double>& poin
   if (write_binary_output_)
   {
     currentout_ << " format=\"binary\">\n";
-    LibB64::write_compressed_block(cell_types, currentout_);
+    LibB64::write_compressed_block(cell_types, currentout_, compression_level_);
   }
   else
   {
@@ -238,7 +239,7 @@ void VtuWriter::write_geometry_unstructured_grid(const std::vector<double>& poin
     if (write_binary_output_)
     {
       currentout_ << " format=\"binary\">\n";
-      LibB64::write_compressed_block(face_connectivity, currentout_);
+      LibB64::write_compressed_block(face_connectivity, currentout_, compression_level_);
     }
     else
     {
@@ -252,7 +253,7 @@ void VtuWriter::write_geometry_unstructured_grid(const std::vector<double>& poin
     if (write_binary_output_)
     {
       currentout_ << " format=\"binary\">\n";
-      LibB64::write_compressed_block(face_offset, currentout_);
+      LibB64::write_compressed_block(face_offset, currentout_, compression_level_);
     }
     else
     {

--- a/src/core/io/src/4C_io_vtu_writer.hpp
+++ b/src/core/io/src/4C_io_vtu_writer.hpp
@@ -33,7 +33,8 @@ class VtuWriter : public VtkWriterBase
       unsigned int max_number_timesteps_to_be_written,
       const std::string& path_existing_working_directory,
       const std::string& name_new_vtk_subdirectory, const std::string& geometry_name,
-      const std::string& restart_name, double restart_time, bool write_binary_output);
+      const std::string& restart_name, double restart_time, bool write_binary_output,
+      LibB64::CompressionLevel compression_level);
 
   //! write the geometry defining this unstructured grid
   void write_geometry_unstructured_grid(const std::vector<double>& point_coordinates,

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -47,6 +47,14 @@ namespace Inpar
               Core::IO::OutputDataFormat::binary, Core::IO::OutputDataFormat::ascii),
           sublist_IO_VTK_structure);
 
+      // compression level of written output
+      Core::Utils::string_to_integral_parameter<LibB64::CompressionLevel>("COMPRESSION_LEVEL",
+          "best_speed", "Specify the compression level of written vtk output.",
+          tuple<std::string>("best_compression", "best_speed", "no_compression"),
+          tuple<LibB64::CompressionLevel>(LibB64::CompressionLevel::best_compression,
+              LibB64::CompressionLevel::best_speed, LibB64::CompressionLevel::no_compression),
+          sublist_IO_VTK_structure);
+
       // specify the maximum digits in the number of time steps that shall be written
       Core::Utils::int_parameter("TIMESTEP_RESERVE_DIGITS", 5,
           "Specify the maximum digits in the number of time steps that shall be written. This only "


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

So far, the compression level of binary runtime vtk output is strictly set to the maximum compression possible in zlib. This PR makes the compression level an optional parameter that can be set in the input file. The default compression level is further changed to the best speed possible in zlib. 

New line in input file:
<pre>
-------------------------------------------------------IO/RUNTIME VTK OUTPUT
OUTPUT_DATA_FORMAT               binary
COMPRESSION_LEVEL                best_compression
</pre>

Options for `COMPRESSION_LEVEL`:
- best_compression (current default)
- best_speed (new default)
- no_compression (probably irrelevant anyways)

### Why change to best speed?

The possible speedup when writing output with `best_speed` seems much more advantageous than the smaller output file size achieved with `best_compression`.
I tested the output with a few large `reduced_lung` examples. Output writing is around six times faster with `best_speed` compared to `best_compression`. The generated files are only around 3-5% larger, which I find negligible.

I don't know if that's the general case, but in @c-p-schmidt's experience, this should be beneficial in most places.