### PR TITLE
Use std::optional instead of Noneable

### DIFF
--- a/src/art_net/4C_art_net_art_terminal_bc.cpp
+++ b/src/art_net/4C_art_net_art_terminal_bc.cpp
@@ -66,7 +66,7 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     // -----------------------------------------------------------------
     // Read in the bc curve information
     // -----------------------------------------------------------------
-    const auto& curve = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+    const auto& curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
     double curvefac = 1.0;
     const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 
@@ -546,7 +546,7 @@ void Arteries::Utils::solve_reflective_terminal(Core::FE::Discretization& actdis
   // -------------------------------------------------------------------
   // Read in the bc curve information
   // -------------------------------------------------------------------
-  const auto& curve = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+  const auto& curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
   double curvefac = 1.0;
   const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 
@@ -625,7 +625,7 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
   // -------------------------------------------------------------------
   // Read in the bc curve information
   // -------------------------------------------------------------------
-  const auto& curve = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+  const auto& curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
   double curvefac = 1.0;
   const auto& vals = condition->parameters().get<std::vector<double>>("VAL");
 

--- a/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
@@ -264,7 +264,7 @@ int Discret::Elements::Beam3eb::evaluate_neumann(Teuchos::ParameterList& params,
     time = params.get("total time", -1.0);
 
   // find out whether we will use a time curve and get the factor
-  const auto tmp_funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto tmp_funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // get values and switches from the condition
   // "ONOFF" is related to the first 6 flags of a line Neumann condition in the input file;

--- a/src/beam3/4C_beam3_kirchhoff.hpp
+++ b/src/beam3/4C_beam3_kirchhoff.hpp
@@ -890,7 +890,7 @@ namespace Discret
           const Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, double>&
               disp_totlag,
           const Core::LinAlg::Matrix<6, 1, double>& load_vector_neumann,
-          const std::vector<Core::IO::Noneable<int>>& function_numbers, double time) const;
+          const std::vector<std::optional<int>>& function_numbers, double time) const;
 
       /** \brief evaluate contributions to element residual vector from line Neumann condition
        *
@@ -900,7 +900,7 @@ namespace Discret
       void evaluate_line_neumann_forces(
           Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, T>& force_ext,
           const Core::LinAlg::Matrix<6, 1, double>& load_vector_neumann,
-          const std::vector<Core::IO::Noneable<int>>& function_numbers, double time) const;
+          const std::vector<std::optional<int>>& function_numbers, double time) const;
 
       /** \brief evaluate all contributions from brownian dynamics (thermal & viscous
        * forces/moments)

--- a/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
+++ b/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
@@ -2114,7 +2114,7 @@ int Discret::Elements::Beam3k::evaluate_neumann(Teuchos::ParameterList& params,
   if (condition.type() == Core::Conditions::PointNeumannEB)
   {
     // find out whether we will use a time curve and get the factor
-    const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
     // amplitude of load curve at current time called
     std::vector<double> functtimefac(6, 1.0);
 
@@ -2159,7 +2159,7 @@ int Discret::Elements::Beam3k::evaluate_neumann(Teuchos::ParameterList& params,
     // funct is related to the 6 "FUNCT" fields after the val field of the Neumann condition
     // in the input file; funct gives the number of the function defined in the section FUNCT
     const auto function_numbers =
-        condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+        condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
     // Check if distributed moment load is applied and throw error
     for (unsigned int idof = 3; idof < 6; ++idof)
@@ -2437,7 +2437,7 @@ void Discret::Elements::Beam3k::evaluate_line_neumann(Core::LinAlg::SerialDenseV
     Core::LinAlg::SerialDenseMatrix* stiffmat,
     const Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, double>& disp_totlag,
     const Core::LinAlg::Matrix<6, 1, double>& load_vector_neumann,
-    const std::vector<Core::IO::Noneable<int>>& function_numbers, double time) const
+    const std::vector<std::optional<int>>& function_numbers, double time) const
 {
   if (not use_fad_)
   {
@@ -2527,7 +2527,7 @@ template <unsigned int nnodecl, typename T>
 void Discret::Elements::Beam3k::evaluate_line_neumann_forces(
     Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, T>& force_ext,
     const Core::LinAlg::Matrix<6, 1, double>& load_vector_neumann,
-    const std::vector<Core::IO::Noneable<int>>& function_numbers, double time) const
+    const std::vector<std::optional<int>>& function_numbers, double time) const
 {
   std::vector<Core::LinAlg::Matrix<3, 3>> Gref(2);
 
@@ -3932,16 +3932,16 @@ Discret::Elements::Beam3k::evaluate_stiff_matrix_analytic_from_point_neumann_mom
 template void Discret::Elements::Beam3k::evaluate_line_neumann<2>(Core::LinAlg::SerialDenseVector&,
     Core::LinAlg::SerialDenseMatrix*,
     const Core::LinAlg::Matrix<6 * 2 + BEAM3K_COLLOCATION_POINTS, 1, double>&,
-    const Core::LinAlg::Matrix<6, 1, double>&, const std::vector<Core::IO::Noneable<int>>&,
+    const Core::LinAlg::Matrix<6, 1, double>&, const std::vector<std::optional<int>>&,
     double) const;
 
 template void Discret::Elements::Beam3k::evaluate_line_neumann_forces<2, double>(
     Core::LinAlg::Matrix<6 * 2 + BEAM3K_COLLOCATION_POINTS, 1, double>&,
-    const Core::LinAlg::Matrix<6, 1, double>&, const std::vector<Core::IO::Noneable<int>>&,
+    const Core::LinAlg::Matrix<6, 1, double>&, const std::vector<std::optional<int>>&,
     double) const;
 template void Discret::Elements::Beam3k::evaluate_line_neumann_forces<2, FAD>(
     Core::LinAlg::Matrix<6 * 2 + BEAM3K_COLLOCATION_POINTS, 1, FAD>&,
-    const Core::LinAlg::Matrix<6, 1, double>&, const std::vector<Core::IO::Noneable<int>>&,
+    const Core::LinAlg::Matrix<6, 1, double>&, const std::vector<std::optional<int>>&,
     double) const;
 
 template void Discret::Elements::Beam3k::evaluate_translational_damping<double, 2, 2, 3>(

--- a/src/beam3/4C_beam3_reissner_evaluate.cpp
+++ b/src/beam3/4C_beam3_reissner_evaluate.cpp
@@ -592,7 +592,7 @@ int Discret::Elements::Beam3r::evaluate_neumann(Teuchos::ParameterList& params,
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
   // funct is related to the numdf "FUNCT" fields after the val field of the Neumann condition
   // in the input file; funct gives the number of the function defined in the section FUNCT
-  const auto functions = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto functions = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // integration points in parameter space and weights
   double xi = 0.0;

--- a/src/beaminteraction/4C_beaminteraction_beam_to_beam_potential_pair.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_beam_potential_pair.cpp
@@ -238,14 +238,14 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  auto function_number = linechargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  auto function_number = linechargeconds_[0]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     q1 *= Global::Problem::instance()
               ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value())
               .evaluate(time_);
 
-  function_number = linechargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  function_number = linechargeconds_[1]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     q2 *= Global::Problem::instance()
@@ -619,14 +619,14 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  auto function_number = linechargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  auto function_number = linechargeconds_[0]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     q1 *= Global::Problem::instance()
               ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value())
               .evaluate(time_);
 
-  function_number = linechargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  function_number = linechargeconds_[1]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     q2 *= Global::Problem::instance()
@@ -1204,14 +1204,14 @@ void BeamInteraction::BeamToBeamPotentialPair<numnodes, numnodalvalues, T>::
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  auto function_number = linechargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  auto function_number = linechargeconds_[0]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     rho1 *= Global::Problem::instance()
                 ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value())
                 .evaluate(time_);
 
-  function_number = linechargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  function_number = linechargeconds_[1]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     rho2 *= Global::Problem::instance()

--- a/src/beaminteraction/4C_beaminteraction_beam_to_sphere_potential_pair.cpp
+++ b/src/beaminteraction/4C_beaminteraction_beam_to_sphere_potential_pair.cpp
@@ -249,14 +249,14 @@ void BeamInteraction::BeamToSpherePotentialPair<numnodes,
 
   // evaluate function in time if specified in line charge conditions
   // TODO allow for functions in space, i.e. varying charge along beam centerline
-  auto function_number = chargeconds_[0]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  auto function_number = chargeconds_[0]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() && function_number.value() > 0)
     q1 *= Global::Problem::instance()
               ->function_by_id<Core::Utils::FunctionOfTime>(function_number.value())
               .evaluate(time_);
 
-  function_number = chargeconds_[1]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  function_number = chargeconds_[1]->parameters().get<std::optional<int>>("FUNCT");
 
   if (function_number.has_value() and function_number.value() > 0)
     q2 *= Global::Problem::instance()

--- a/src/bele/4C_bele_bele3.cpp
+++ b/src/bele/4C_bele_bele3.cpp
@@ -97,27 +97,27 @@ void Discret::Elements::Bele3Type::setup_element_definition(
 
   defs3["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
-      parameter<Noneable<int>>("MAT"),
+      parameter<std::optional<int>>("MAT"),
   });
 
   defs3["TRI6"] = all_of({
       parameter<std::vector<int>>("TRI6", {.size = 6}),
-      parameter<Noneable<int>>("MAT"),
+      parameter<std::optional<int>>("MAT"),
   });
 
   defs3["QUAD4"] = all_of({
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
-      parameter<Noneable<int>>("MAT"),
+      parameter<std::optional<int>>("MAT"),
   });
 
   defs3["QUAD8"] = all_of({
       parameter<std::vector<int>>("QUAD8", {.size = 8}),
-      parameter<Noneable<int>>("MAT"),
+      parameter<std::optional<int>>("MAT"),
   });
 
   defs3["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
-      parameter<Noneable<int>>("MAT"),
+      parameter<std::optional<int>>("MAT"),
   });
 }
 
@@ -265,7 +265,7 @@ bool Discret::Elements::Bele3::read_element(const std::string& eletype, const st
     const Core::IO::InputParameterContainer& container)
 {
   // check if material is defined
-  auto material_id = container.get<Core::IO::Noneable<int>>("MAT");
+  auto material_id = container.get<std::optional<int>>("MAT");
   if (material_id)
   {
     set_material(0, Mat::factory(*material_id));

--- a/src/bele/4C_bele_bele3_line_evaluate.cpp
+++ b/src/bele/4C_bele_bele3_line_evaluate.cpp
@@ -93,7 +93,7 @@ int Discret::Elements::Bele3Line::evaluate_neumann(Teuchos::ParameterList& param
   // (assumed to be constant on element boundary)
   const auto& onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto& val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto& functions = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto& functions = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // set number of nodes
   const size_t iel = this->num_node();

--- a/src/cardiovascular0d/4C_cardiovascular0d_arterialproxdist.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_arterialproxdist.cpp
@@ -104,7 +104,7 @@ void Utils::Cardiovascular0DArterialProxDist::evaluate(Teuchos::ParameterList& p
 
     // find out whether we will use a time curve and get the factor
     const auto curvenum =
-        cardiovascular0dcond_[condID]->parameters().get<Core::IO::Noneable<int>>("p_at_crv");
+        cardiovascular0dcond_[condID]->parameters().get<std::optional<int>>("p_at_crv");
     double curvefac_np = 1.0;
 
     if (curvenum.has_value() && curvenum.value() > 0 && time >= 0)

--- a/src/constraint/4C_constraint.cpp
+++ b/src/constraint/4C_constraint.cpp
@@ -240,7 +240,7 @@ void CONSTRAINTS::Constraint::evaluate_constraint(Teuchos::ParameterList& params
       }
 
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
-      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
+      const auto curvenum = cond->parameters().get<std::optional<int>>("curve");
       double curvefac = 1.0;
       if (curvenum.has_value() && curvenum.value() > 0)
       {

--- a/src/constraint/4C_constraint_multipointconstraint2.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint2.cpp
@@ -370,7 +370,7 @@ void CONSTRAINTS::MPConstraint2::evaluate_constraint(std::shared_ptr<Core::FE::D
       }
 
       // Load curve business
-      const auto curvenum = cond.parameters().get<Core::IO::Noneable<int>>("curve");
+      const auto curvenum = cond.parameters().get<std::optional<int>>("curve");
       double curvefac = 1.0;
       if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
       {

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -456,7 +456,7 @@ void CONSTRAINTS::MPConstraint3::evaluate_constraint(std::shared_ptr<Core::FE::D
       }
 
       // loadcurve business
-      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
+      const auto curvenum = cond->parameters().get<std::optional<int>>("curve");
       double curvefac = 1.0;
       if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
       {
@@ -533,7 +533,7 @@ void CONSTRAINTS::MPConstraint3::initialize_constraint(Core::FE::Discretization&
     Core::LinAlg::assemble(systemvector, elevector3, constrlm, constrowner);
 
     // loadcurve business
-    const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
+    const auto curvenum = cond->parameters().get<std::optional<int>>("curve");
     double curvefac = 1.0;
     if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
     {

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -411,7 +411,7 @@ void CONSTRAINTS::MPConstraint3Penalty::evaluate_constraint(
             Core::Communication::my_mpi_rank(disc->get_comm()), eid, err);
 
       // loadcurve business
-      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
+      const auto curvenum = cond->parameters().get<std::optional<int>>("curve");
       double curvefac = 1.0;
       if (curvenum.has_value() && curvenum.value() > 0 && time >= 0.0)
       {

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -204,7 +204,7 @@ void CONSTRAINTS::ConstraintPenalty::evaluate_constraint(Teuchos::ParameterList&
       }
 
       // Evaluate loadcurve if defined. Put current load factor in parameterlist
-      const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("curve");
+      const auto curvenum = cond->parameters().get<std::optional<int>>("curve");
       double curvefac = 1.0;
       if (curvenum.has_value() && curvenum.value() > 0)
       {

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -230,7 +230,7 @@ CONSTRAINTS::SpringDashpot::SpringDashpot(std::shared_ptr<Core::FE::Discretizati
       stiff_comp_((spring_->parameters().get<std::vector<double>>("STIFF"))[0]),
       offset_((spring_->parameters().get<std::vector<double>>("DISPLOFFSET"))[0]),
       viscosity_((spring_->parameters().get<std::vector<double>>("VISCO"))[0]),
-      coupling_(spring_->parameters().get<Core::IO::Noneable<int>>("COUPLING").value_or(-1)),
+      coupling_(spring_->parameters().get<std::optional<int>>("COUPLING").value_or(-1)),
       nodes_(spring_->get_nodes()),
       area_(),
       gap0_(),

--- a/src/contact/4C_contact_manager.cpp
+++ b/src/contact/4C_contact_manager.cpp
@@ -142,7 +142,7 @@ CONTACT::Manager::Manager(Core::FE::Discretization& discret, double alphaf)
 
     // In case of MultiScale contact this is the id of the interface's constitutive contact law
     auto maybe_contactconstitutivelawid =
-        currentgroup[0]->parameters().get<Core::IO::Noneable<int>>("ConstitutiveLawID");
+        currentgroup[0]->parameters().get<std::optional<int>>("ConstitutiveLawID");
     auto contactconstitutivelawid = maybe_contactconstitutivelawid.value_or(-1);
 
     bool foundit = false;

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -678,7 +678,7 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
 
     // In case of MultiScale contact this is the id of the interface's constitutive contact law
     auto contactconstitutivelaw_id =
-        currentgroup[0]->parameters().get<Core::IO::Noneable<int>>("ConstitutiveLawID");
+        currentgroup[0]->parameters().get<std::optional<int>>("ConstitutiveLawID");
 
     // Initialize a flag to check for MIRCO contact consitutive law
     bool mircolaw = false;

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
@@ -119,8 +119,7 @@ void Core::Conditions::LocsysManager::update(const double time,
         typelocsys_[i] = currlocsys->type();
 
         const auto rotangle = currlocsys->parameters().get<std::vector<double>>("ROTANGLE");
-        const auto funct =
-            currlocsys->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+        const auto funct = currlocsys->parameters().get<std::vector<std::optional<int>>>("FUNCT");
         const auto useUpdatedNodePos = currlocsys->parameters().get<int>("USEUPDATEDNODEPOS");
         const std::vector<int>* nodes = currlocsys->get_nodes();
         const auto useConsistentNodeNormal =

--- a/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
@@ -195,7 +195,7 @@ void Core::FE::Discretization::evaluate_neumann(Teuchos::ParameterList& params,
     }
     const std::vector<int>* nodeids = cond->get_nodes();
     if (!nodeids) FOUR_C_THROW("PointNeumann condition does not have nodal cloud");
-    const auto& tmp_funct = cond->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto& tmp_funct = cond->parameters().get<std::vector<std::optional<int>>>("FUNCT");
     const auto& onoff = cond->parameters().get<std::vector<int>>("ONOFF");
     const auto& val = cond->parameters().get<std::vector<double>>("VAL");
 
@@ -406,7 +406,7 @@ void Core::FE::Discretization::evaluate_condition(Teuchos::ParameterList& params
         // to the condition geometry
 
         // Evaluate Loadcurve if defined. Put current load factor in parameter list
-        const auto* curve = cond->parameters().get_if<Core::IO::Noneable<int>>("curve");
+        const auto* curve = cond->parameters().get_if<std::optional<int>>("curve");
 
         double curvefac = 1.0;
         if (curve)

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
@@ -439,7 +439,7 @@ void Core::FE::Utils::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterLis
   if (!nodeids) FOUR_C_THROW("Dirichlet condition does not have nodal cloud");
 
   // get curves, functs, vals, and onoff toggles from the condition
-  const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = cond.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   const auto val = cond.parameters().get<std::vector<double>>("VAL");
   const auto onoff = cond.parameters().get<std::vector<int>>("ONOFF");
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
@@ -235,7 +235,7 @@ void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList
   // get val from condition
   const auto val = cond.parameters().get<std::vector<double>>("VAL");
   // get funct from condition
-  const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = cond.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // loop nodes to identify spatial distributions of Dirichlet boundary conditions
   for (unsigned i = 0; i < nnode; ++i)
@@ -472,7 +472,7 @@ void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& 
   const unsigned nnode = (*nodeids).size();
   // get onoff, funct, and val from condition
   const auto onoff = cond.parameters().get<std::vector<int>>("ONOFF");
-  const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = cond.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   const auto val = cond.parameters().get<std::vector<double>>("VAL");
 
   // determine highest degree of time derivative

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
@@ -219,7 +219,7 @@ void Core::FE::Utils::DbcNurbs::do_dirichlet_condition(const Teuchos::ParameterL
   const std::vector<int>* nodeids = cond.get_nodes();
   if (!nodeids) FOUR_C_THROW("Dirichlet condition does not have nodal cloud");
 
-  const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = cond.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   const auto val = cond.parameters().get<std::vector<double>>("VAL");
 
 
@@ -514,7 +514,7 @@ void Core::FE::Utils::DbcNurbs::do_dirichlet_condition(const Teuchos::ParameterL
 template <Core::FE::CellType distype>
 void Core::FE::Utils::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_boundary(
     Core::Elements::Element& actele, const std::vector<Core::LinAlg::SerialDenseVector>* knots,
-    const std::vector<int>& lm, const std::vector<Core::IO::Noneable<int>>& funct,
+    const std::vector<int>& lm, const std::vector<std::optional<int>>& funct,
     const std::vector<double>& val, const unsigned deg, const double time,
     Core::LinAlg::SerialDenseMatrix& elemass, std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
     const Core::Utils::FunctionManager& function_manager) const
@@ -655,7 +655,7 @@ void Core::FE::Utils::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_boundary(
 template <Core::FE::CellType distype>
 void Core::FE::Utils::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_domain(
     Core::Elements::Element& actele, const std::vector<Core::LinAlg::SerialDenseVector>* knots,
-    const std::vector<int>& lm, const std::vector<Core::IO::Noneable<int>>& funct,
+    const std::vector<int>& lm, const std::vector<std::optional<int>>& funct,
     const std::vector<double>& val, const unsigned deg, const double time,
     Core::LinAlg::SerialDenseMatrix& elemass, std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
     const Core::Utils::FunctionManager& function_manager) const

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
@@ -197,7 +197,7 @@ namespace Core::FE
       template <Core::FE::CellType distype>
       void fill_matrix_and_rhs_for_ls_dirichlet_boundary(Core::Elements::Element& ele,
           const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
-          const std::vector<Core::IO::Noneable<int>>& funct, const std::vector<double>& val,
+          const std::vector<std::optional<int>>& funct, const std::vector<double>& val,
           const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
           std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
           const Core::Utils::FunctionManager& function_manager) const;
@@ -219,7 +219,7 @@ namespace Core::FE
       template <Core::FE::CellType distype>
       void fill_matrix_and_rhs_for_ls_dirichlet_domain(Core::Elements::Element& ele,
           const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
-          const std::vector<Core::IO::Noneable<int>>& funct, const std::vector<double>& val,
+          const std::vector<std::optional<int>>& funct, const std::vector<double>& val,
           const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
           std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
           const Core::Utils::FunctionManager& function_manager) const;

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -599,7 +599,6 @@ namespace Core::IO
             {
                 .description = "Path to files that should be included into this file. "
                                "The paths can be either absolute or relative to the file.",
-                .default_value = std::nullopt,
             });
   }
 

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -595,11 +595,11 @@ namespace Core::IO
         "Section 'INCLUDES' is a reserved section name with special meaning. Please choose a "
         "different name.");
     pimpl_->valid_sections_["INCLUDES"] =
-        InputSpecBuilders::parameter<Noneable<std::vector<std::filesystem::path>>>("INCLUDES",
+        InputSpecBuilders::parameter<std::optional<std::vector<std::filesystem::path>>>("INCLUDES",
             {
                 .description = "Path to files that should be included into this file. "
                                "The paths can be either absolute or relative to the file.",
-                .default_value = none<std::vector<std::filesystem::path>>,
+                .default_value = std::nullopt,
             });
   }
 

--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -220,11 +220,11 @@ namespace Core::IO::Internal::InputParameterContainerImplementation
   };
 
   template <StreamInsertable T>
-  struct PrintHelper<Noneable<T>>
+  struct PrintHelper<std::optional<T>>
   {
     void operator()(std::ostream& os, const std::any& data)
     {
-      auto val = std::any_cast<Noneable<T>>(data);
+      auto val = std::any_cast<std::optional<T>>(data);
       if (val.has_value())
         PrintHelper<T>{}(os, *val);
       else

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -649,7 +649,7 @@ namespace Core::IO
     namespace Internal
     {
       template <SupportedType T>
-      struct EntrySpec
+      struct ParameterSpec
       {
         std::string name;
         using StoredType = T;
@@ -1158,7 +1158,7 @@ namespace Core::IO
 // --- template definitions --- //
 
 template <Core::IO::SupportedType T>
-void Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::parse(
+void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::parse(
     ValueParser& parser, InputParameterContainer& container) const
 {
   if (parser.peek() == name)
@@ -1215,7 +1215,7 @@ void Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::parse(
 
 
 template <Core::IO::SupportedType T>
-bool Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::match(ConstYamlNodeRef node,
+bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::match(ConstYamlNodeRef node,
     InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
   match_entry.type = IO::Internal::MatchEntry::Type::parameter;
@@ -1272,7 +1272,8 @@ bool Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::match(ConstYamlNodeRef
 
 
 template <Core::IO::SupportedType T>
-void Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::emit_metadata(ryml::NodeRef node) const
+void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit_metadata(
+    ryml::NodeRef node) const
 {
   node |= ryml::MAP;
   node["name"] << name;
@@ -1312,7 +1313,7 @@ void Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::emit_metadata(ryml::No
 }
 
 template <Core::IO::SupportedType T>
-bool Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::emit(YamlNodeRef node,
+bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit(YamlNodeRef node,
     const InputParameterContainer& container, const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
@@ -1347,7 +1348,7 @@ bool Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::emit(YamlNodeRef node,
 
 
 template <Core::IO::SupportedType T>
-bool Core::IO::InputSpecBuilders::Internal::EntrySpec<T>::has_correct_size(
+bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::has_correct_size(
     const T& val, const InputParameterContainer& container) const
 {
   if constexpr (rank<T>() == 0)
@@ -1600,7 +1601,7 @@ template <Core::IO::SupportedType T>
 Core::IO::InputSpec Core::IO::InputSpecBuilders::parameter(
     std::string name, ParameterData<T>&& data)
 {
-  return IO::Internal::make_spec(Internal::EntrySpec<T>{.name = name, .data = data},
+  return IO::Internal::make_spec(Internal::ParameterSpec<T>{.name = name, .data = data},
       {
           .name = name,
           .description = data.description,

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -192,8 +192,8 @@ namespace Core::IO
       void operator()(ryml::NodeRef node, size_t* size)
       {
         FOUR_C_ASSERT(node.is_map(), "Expected a map node.");
-        // Pull up the "noneable" aspect. The fact that this type wraps another type is specific
-        // to C++ and not relevant to other tools. Simply knowing that a type can be "none" is
+        // Pull up the std::optional aspect. The fact that this type wraps another type is specific
+        // to C++ and not relevant to other tools. Simply knowing that a type can be empty is
         // enough for them.
         emit_value_as_yaml(node["noneable"], true);
         YamlTypeEmitter<T>{}(node, size);
@@ -330,7 +330,7 @@ namespace Core::IO
 
         /**
          * The total number of specs that make up this spec. This includes the spec itself, meaning,
-         * that the minimum value is 1. This value can used to reserve memory ahead of time.
+         * that the minimum value is 1. This value can be used to reserve memory ahead of time.
          */
         std::size_t n_specs;
       };
@@ -848,10 +848,10 @@ namespace Core::IO
      * // value is given.
      * parameter<double>("my_double", {.default_value = 3.14});
      *
-     * // An alternative way to create this optional int parameter is achieved with a std::optional
-     * // type. This value is optional and by default has an empty value represented by "none" in
-     * // the input file.
-     * parameter<std::optional<int>>("my_int", .default_value = std::nullopt);
+     * // An alternative way to create an optional double parameter is achieved with a
+     * // std::optional type. This value is optional and has an empty value in the input file. You
+     * // cannot set a default value in this case.
+     * parameter<std::optional<my_double>>("my_double");
      *
      * // A vector parameter with a fixed size of 3.
      * parameter<std::vector<double>>("my_vector", {.size = 3});
@@ -875,10 +875,10 @@ namespace Core::IO
      *   }});
      * @endcode
      *
-     * After parsing an InputSpec with fully_parse(), the value of the parameter can be retrieved
-     * from an InputParameterContainer. If `default_value` is set, the parameter is implicitly
-     * optional. In this case, if the parameter is not present in the input file, the default value
-     * will be stored in the container that is filled by the fully_parse() function.
+     * After parsing an InputSpec, the value of the parameter can be retrieved from an
+     * InputParameterContainer. If `default_value` is set, the parameter is implicitly optional. In
+     * this case, if the parameter is not present in the input file, the default value will be
+     * stored in the container.
      *
      * When you decide how to set the `default_value` field or whether to make a parameter optional,
      * consider the following cases:
@@ -896,13 +896,12 @@ namespace Core::IO
      *     parameter that activates or deactivates a feature, e.g., defaulting the EAS element
      *     technology to off might be reasonable.
      *
-     *   - If the parameter is not required, but there is no reasonable default value, wrap the type
-     *     in `std::optional` and set the empty optional state as `default_value`. As an example,
-     *     this may be useful for a damping parameter that, when set, activates damping using
-     *     the provided value. This example demonstrates that the parameter has a double role: its
-     *     presence activates damping and its value determines the damping strength. An often better
-     *     way to selectively activate parameters can be achieved with the group() function,
-     *     especially if a set of parameters is always required together.
+     *   - If the parameter is not required and there is no reasonable default value, wrap the type
+     *     in `std::optional`. As an example, this may be useful for a damping parameter that, when
+     *     set, activates damping using the provided value. This example demonstrates that the
+     *     parameter has a double role: its presence activates damping and its value determines the
+     *     damping strength. An often better way to selectively activate parameters can be achieved
+     *     with the group() function, especially if a set of parameters is always required together.
      *
      * @tparam T The data type of the parameter. Must be a SupportedType.
      *
@@ -932,7 +931,7 @@ namespace Core::IO
     [[nodiscard]] auto from_parameter(const std::string& name);
 
     /**
-     * A parameter whose value is a a selection from a list of choices. For example:
+     * A parameter whose value is a selection from a list of choices. For example:
      *
      * @code
      * selection<int>("my_selection", {{"a", 1}, {"b", 2}, {"c", 3}});
@@ -956,7 +955,7 @@ namespace Core::IO
 
 
     /**
-     * Like the the other selection() function, but the choices are stored as strings and not mapped
+     * Like the other selection() function, but the choices are stored as strings and not mapped
      * to another type.
      *
      * @note Although this function only works with strings, you still need to provide a type for

--- a/src/core/io/tests/4C_io_input_parameter_container_test.cpp
+++ b/src/core/io/tests/4C_io_input_parameter_container_test.cpp
@@ -25,7 +25,7 @@ namespace
     container.add<std::string>("c", "string");
     container.add<bool>("d", true);
     container.add("v", std::vector<int>{1, 2, 3});
-    container.add("n", Core::IO::Noneable<int>{});
+    container.add("n", std::optional<int>{});
     container.group("group").add<std::string>("e", "group string");
     container.group("group").group("deeply").group("nested").add<int>("f", 42);
 
@@ -37,7 +37,7 @@ namespace
     EXPECT_EQ(list.get<std::string>("c"), "string");
     EXPECT_EQ(list.get<bool>("d"), true);
     EXPECT_EQ(list.get<std::vector<int>>("v"), (std::vector<int>{1, 2, 3}));
-    EXPECT_EQ(list.get<Core::IO::Noneable<int>>("n"), Core::IO::none<int>);
+    EXPECT_EQ(list.get<std::optional<int>>("n"), std::nullopt);
     EXPECT_EQ(list.sublist("group").get<std::string>("e"), "group string");
     EXPECT_EQ(list.sublist("group").sublist("deeply").sublist("nested").get<int>("f"), 42);
   }

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -166,16 +166,17 @@ namespace
     }
   }
 
-  TEST(InputSpecTest, Noneable)
+  TEST(InputSpecTest, Optional)
   {
     auto spec = all_of({
         parameter<int>("size"),
-        parameter<std::vector<Noneable<int>>>("vector_none", {.size = from_parameter<int>("size")}),
-        parameter<Noneable<std::vector<int>>>("none_vector",
-            {.default_value = none<std::vector<int>>, .size = from_parameter<int>("size")}),
-        parameter<Noneable<std::string>>("b", {.description = "b"}),
-        parameter<Noneable<double>>("c", {.default_value = 1.0}),
-        parameter<Noneable<int>>("e", {.default_value = none<int>}),
+        parameter<std::vector<std::optional<int>>>(
+            "vector_none", {.size = from_parameter<int>("size")}),
+        parameter<std::optional<std::vector<int>>>(
+            "none_vector", {.default_value = std::nullopt, .size = from_parameter<int>("size")}),
+        parameter<std::optional<std::string>>("b", {.description = "b"}),
+        parameter<std::optional<double>>("c", {.default_value = 1.0}),
+        parameter<std::optional<int>>("e", {.default_value = std::nullopt}),
     });
 
     {
@@ -184,7 +185,7 @@ namespace
       std::string stream("size 3 vector_none 1 2 3 b none none_vector 1 2 3");
       ValueParser parser(stream);
       spec.fully_parse(parser, container);
-      const auto& vector_none = container.get<std::vector<Noneable<int>>>("vector_none");
+      const auto& vector_none = container.get<std::vector<std::optional<int>>>("vector_none");
       EXPECT_EQ(vector_none.size(), 3);
       EXPECT_EQ(vector_none[0].has_value(), true);
       EXPECT_EQ(vector_none[0].value(), 1);
@@ -193,16 +194,16 @@ namespace
       EXPECT_EQ(vector_none[2].has_value(), true);
       EXPECT_EQ(vector_none[2].value(), 3);
 
-      EXPECT_TRUE(container.get<Noneable<std::vector<int>>>("none_vector").has_value());
+      EXPECT_TRUE(container.get<std::optional<std::vector<int>>>("none_vector").has_value());
 
-      const auto& b = container.get<Noneable<std::string>>("b");
+      const auto& b = container.get<std::optional<std::string>>("b");
       EXPECT_EQ(b.has_value(), false);
 
-      const auto& c = container.get<Noneable<double>>("c");
+      const auto& c = container.get<std::optional<double>>("c");
       EXPECT_EQ(c.has_value(), true);
       EXPECT_EQ(c.value(), 1.0);
 
-      const auto& e = container.get<Noneable<int>>("e");
+      const auto& e = container.get<std::optional<int>>("e");
       EXPECT_EQ(e.has_value(), false);
     }
 
@@ -212,7 +213,7 @@ namespace
       std::string stream("size 3 vector_none 1 none 3 b none c none e none none_vector none");
       ValueParser parser(stream);
       spec.fully_parse(parser, container);
-      const auto& a = container.get<std::vector<Noneable<int>>>("vector_none");
+      const auto& a = container.get<std::vector<std::optional<int>>>("vector_none");
       EXPECT_EQ(a.size(), 3);
       EXPECT_EQ(a[0].has_value(), true);
       EXPECT_EQ(a[0].value(), 1);
@@ -220,13 +221,13 @@ namespace
       EXPECT_EQ(a[2].has_value(), true);
       EXPECT_EQ(a[2].value(), 3);
 
-      const auto& b = container.get<Noneable<std::string>>("b");
+      const auto& b = container.get<std::optional<std::string>>("b");
       EXPECT_EQ(b.has_value(), false);
 
-      const auto& c = container.get<Noneable<double>>("c");
+      const auto& c = container.get<std::optional<double>>("c");
       EXPECT_EQ(c.has_value(), false);
 
-      const auto& e = container.get<Noneable<int>>("e");
+      const auto& e = container.get<std::optional<int>>("e");
       EXPECT_EQ(e.has_value(), false);
     }
 
@@ -237,15 +238,15 @@ namespace
       ValueParser parser(stream);
       spec.fully_parse(parser, container);
 
-      const auto& b = container.get<Noneable<std::string>>("b");
+      const auto& b = container.get<std::optional<std::string>>("b");
       EXPECT_EQ(b.has_value(), true);
       EXPECT_EQ(b.value(), "string");
 
-      const auto& c = container.get<Noneable<double>>("c");
+      const auto& c = container.get<std::optional<double>>("c");
       EXPECT_EQ(c.has_value(), true);
       EXPECT_EQ(c.value(), 2.0);
 
-      const auto& e = container.get<Noneable<int>>("e");
+      const auto& e = container.get<std::optional<int>>("e");
       EXPECT_EQ(e.has_value(), true);
       EXPECT_EQ(e.value(), 42);
     }
@@ -324,7 +325,7 @@ namespace
         parameter<int>("a"),
         selection<int>("b", {{"b1", 1}, {"b2", 2}}, {.default_value = 1}),
         selection<std::string>("c", {"c1", "c2"}, {.default_value = "c2"}),
-        selection<Noneable<int>>("d", {{"d1", 1}, {"d2", 2}}, {.default_value = none<int>}),
+        selection<std::optional<int>>("d", {{"d1", 1}, {"d2", 2}}, {.default_value = std::nullopt}),
     });
 
     {
@@ -335,7 +336,7 @@ namespace
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<int>("b"), 2);
       EXPECT_EQ(container.get<std::string>("c"), "c1");
-      EXPECT_EQ(container.get<Noneable<int>>("d").value(), 1);
+      EXPECT_EQ(container.get<std::optional<int>>("d").value(), 1);
     }
 
     {
@@ -346,7 +347,7 @@ namespace
       EXPECT_EQ(container.get<int>("a"), 1);
       EXPECT_EQ(container.get<int>("b"), 1);
       EXPECT_EQ(container.get<std::string>("c"), "c2");
-      EXPECT_EQ(container.get<Noneable<int>>("d").has_value(), false);
+      EXPECT_EQ(container.get<std::optional<int>>("d").has_value(), false);
     }
 
     {
@@ -701,8 +702,8 @@ specs:
   {
     auto spec = all_of({
         parameter<int>("a", {.default_value = 42}),
-        parameter<std::vector<Noneable<double>>>(
-            "b", {.default_value = std::vector<Noneable<double>>{1., none<double>, 3.}, .size = 3}),
+        parameter<std::vector<std::optional<double>>>("b",
+            {.default_value = std::vector<std::optional<double>>{1., std::nullopt, 3.}, .size = 3}),
         one_of({
             all_of({
                 parameter<std::map<std::string, std::string>>(
@@ -720,8 +721,8 @@ specs:
                 {.description = "A group"}),
         }),
         selection<int>("e", {{"e1", 1}, {"e2", 2}}, {.default_value = 1}),
-        selection<Noneable<double>>(
-            "f", {{"f1", 1.0}, {"f2", 2.0}}, {.default_value = none<double>}),
+        selection<std::optional<double>>(
+            "f", {{"f1", 1.0}, {"f2", 2.0}}, {.default_value = std::nullopt}),
         group("group2",
             {
                 parameter<int>("g"),
@@ -961,7 +962,7 @@ specs:
     auto spec = all_of({
         parameter<int>("a"),
         parameter<std::vector<std::string>>("b"),
-        selection<Noneable<int>>("c", {{"c1", 1}, {"c2", 2}}, {.default_value = 1}),
+        selection<std::optional<int>>("c", {{"c1", 1}, {"c2", 2}}, {.default_value = 1}),
         group("group",
             {
                 parameter<int>("d"),
@@ -992,7 +993,7 @@ specs:
       EXPECT_EQ(b.size(), 2);
       EXPECT_EQ(b[0], "b1");
       EXPECT_EQ(b[1], "b2");
-      EXPECT_EQ(container.get<Noneable<int>>("c").value(), 2);
+      EXPECT_EQ(container.get<std::optional<int>>("c").value(), 2);
       EXPECT_EQ(container.group("group").get<int>("d"), 42);
     }
 
@@ -1011,7 +1012,7 @@ b:
 
       InputParameterContainer container;
       spec.match(node, container);
-      EXPECT_EQ(container.get<Noneable<int>>("c").value(), 1);
+      EXPECT_EQ(container.get<std::optional<int>>("c").value(), 1);
       EXPECT_FALSE(container.has_group("group"));
     }
 
@@ -1033,7 +1034,7 @@ group:
 
       InputParameterContainer container;
       spec.match(node, container);
-      EXPECT_FALSE(container.get<Noneable<int>>("c").has_value());
+      EXPECT_FALSE(container.get<std::optional<int>>("c").has_value());
       EXPECT_EQ(container.group("group").get<int>("d"), 42);
     }
 
@@ -1296,9 +1297,9 @@ group:
   TEST(InputSpecTest, MatchYamlNoneable)
   {
     auto spec = all_of({
-        parameter<Noneable<int>>("i", {.default_value = none<int>}),
-        parameter<Noneable<std::string>>("s"),
-        parameter<std::vector<Noneable<double>>>("v", {.size = 3}),
+        parameter<std::optional<int>>("i", {.default_value = std::nullopt}),
+        parameter<std::optional<std::string>>("s"),
+        parameter<std::vector<std::optional<double>>>("v", {.size = 3}),
     });
 
     {
@@ -1313,9 +1314,9 @@ v: [1.0, 2.0, 3.0]
 
       InputParameterContainer container;
       spec.match(node, container);
-      EXPECT_EQ(container.get<Noneable<int>>("i"), 1);
-      EXPECT_EQ(container.get<Noneable<std::string>>("s"), "string");
-      const auto& v = container.get<std::vector<Noneable<double>>>("v");
+      EXPECT_EQ(container.get<std::optional<int>>("i"), 1);
+      EXPECT_EQ(container.get<std::optional<std::string>>("s"), "string");
+      const auto& v = container.get<std::vector<std::optional<double>>>("v");
       EXPECT_EQ(v.size(), 3);
       EXPECT_EQ(v[0], 1.0);
       EXPECT_EQ(v[1], 2.0);
@@ -1334,13 +1335,13 @@ v: [Null, NULL, ~] # all the other spellings that YAML supports
 
       InputParameterContainer container;
       spec.match(node, container);
-      EXPECT_EQ(container.get<Noneable<int>>("i"), none<int>);
-      EXPECT_EQ(container.get<Noneable<std::string>>("s"), none<std::string>);
-      const auto& v = container.get<std::vector<Noneable<double>>>("v");
+      EXPECT_EQ(container.get<std::optional<int>>("i"), std::nullopt);
+      EXPECT_EQ(container.get<std::optional<std::string>>("s"), std::nullopt);
+      const auto& v = container.get<std::vector<std::optional<double>>>("v");
       EXPECT_EQ(v.size(), 3);
-      EXPECT_EQ(v[0], none<double>);
-      EXPECT_EQ(v[1], none<double>);
-      EXPECT_EQ(v[2], none<double>);
+      EXPECT_EQ(v[0], std::nullopt);
+      EXPECT_EQ(v[1], std::nullopt);
+      EXPECT_EQ(v[2], std::nullopt);
     }
   }
 

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -1289,7 +1289,7 @@ group:
     }
   }
 
-  TEST(InputSpecTest, MatchYamlNoneable)
+  TEST(InputSpecTest, MatchYamlOptional)
   {
     auto spec = all_of({
         parameter<std::optional<int>>("i"),

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -181,7 +181,7 @@ Core::LinearSolver::AmGnxnInterface::AmGnxnInterface(Teuchos::ParameterList& par
   if (amgnxn_type == "XML")
   {
     // Parse the whole file
-    auto amgnxn_xml = amglist.get<Core::IO::Noneable<std::filesystem::path>>("AMGNXN_XML_FILE");
+    auto amgnxn_xml = amglist.get<std::optional<std::filesystem::path>>("AMGNXN_XML_FILE");
     if (!amgnxn_xml) FOUR_C_THROW("The input parameter AMGNXN_XML_FILE is 'none'.");
     {
       Teuchos::updateParametersFromXmlFile(

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -253,7 +253,7 @@ Teuchos::ParameterList translate_four_c_to_muelu(
 {
   Teuchos::ParameterList muelulist;
 
-  auto xmlfile = inparams.get<Core::IO::Noneable<std::filesystem::path>>("MUELU_XML_FILE");
+  auto xmlfile = inparams.get<std::optional<std::filesystem::path>>("MUELU_XML_FILE");
   if (xmlfile) muelulist.set("MUELU_XML_FILE", xmlfile->string());
 
   return muelulist;
@@ -266,7 +266,7 @@ Teuchos::ParameterList translate_four_c_to_teko(
 {
   Teuchos::ParameterList tekolist;
 
-  auto xmlfile = inparams.get<Core::IO::Noneable<std::filesystem::path>>("TEKO_XML_FILE");
+  auto xmlfile = inparams.get<std::optional<std::filesystem::path>>("TEKO_XML_FILE");
   if (xmlfile) tekolist.set("TEKO_XML_FILE", xmlfile->string());
 
   return tekolist;
@@ -286,7 +286,7 @@ Teuchos::ParameterList translate_four_c_to_belos(const Teuchos::ParameterList& i
   beloslist.set("ncall", 0);
 
   // try to get an xml file if possible
-  auto xmlfile = inparams.get<Core::IO::Noneable<std::filesystem::path>>("SOLVER_XML_FILE");
+  auto xmlfile = inparams.get<std::optional<std::filesystem::path>>("SOLVER_XML_FILE");
   if (xmlfile)
   {
     beloslist.set("SOLVER_XML_FILE", xmlfile->string());
@@ -390,7 +390,7 @@ Teuchos::ParameterList translate_four_c_to_belos(const Teuchos::ParameterList& i
   if (azprectype == Core::LinearSolver::PreconditionerType::multigrid_nxn)
   {
     Teuchos::ParameterList& amgnxnlist = outparams.sublist("AMGnxn Parameters");
-    auto amgnxn_xml = inparams.get<Core::IO::Noneable<std::filesystem::path>>("AMGNXN_XML_FILE");
+    auto amgnxn_xml = inparams.get<std::optional<std::filesystem::path>>("AMGNXN_XML_FILE");
     amgnxnlist.set("AMGNXN_XML_FILE", amgnxn_xml);
     std::string amgnxn_type = inparams.get<std::string>("AMGNXN_TYPE");
     amgnxnlist.set<std::string>("AMGNXN_TYPE", amgnxn_type);

--- a/src/core/utils/src/functions/4C_utils_function.cpp
+++ b/src/core/utils/src/functions/4C_utils_function.cpp
@@ -220,7 +220,7 @@ Core::Utils::try_create_symbolic_function_of_space_time(
   {
     // We need to use get_if since we call this function for lines that are completely wrong.
     // This will go away when the functions are restructured.
-    auto* comp = ith_function_lin_def.get_if<IO::Noneable<int>>("COMPONENT");
+    auto* comp = ith_function_lin_def.get_if<std::optional<int>>("COMPONENT");
     if (comp) maxcomp = comp->value_or(maxcomp);
 
     ignore_errors_in([&]() { maxvar = ith_function_lin_def.get<int>("VARIABLE"); });
@@ -243,7 +243,7 @@ Core::Utils::try_create_symbolic_function_of_space_time(
     const auto& functcomp = parameters[n];
 
     // check the validity of the n-th component
-    const int compid = functcomp.get<IO::Noneable<int>>("COMPONENT").value_or(0);
+    const int compid = functcomp.get<std::optional<int>>("COMPONENT").value_or(0);
     if (compid != n) FOUR_C_THROW("expected COMPONENT %d but got COMPONENT %d", n, compid);
 
 

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -83,7 +83,7 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
 
   auto spec = one_of({
       all_of({
-          parameter<std::optional<int>>("COMPONENT", {.default_value = std::nullopt}),
+          parameter<std::optional<int>>("COMPONENT"),
           parameter<std::string>("SYMBOLIC_FUNCTION_OF_SPACE_TIME"),
       }),
 
@@ -121,7 +121,7 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
 
       all_of({
           parameter<std::string>("VARFUNCTION"),
-          parameter<std::optional<int>>("NUMCONSTANTS", {.default_value = std::nullopt}),
+          parameter<std::optional<int>>("NUMCONSTANTS"),
           parameter<std::map<std::string, double>>("CONSTANTS",
               {.default_value = std::map<std::string, double>{},
                   .size = [](const IO::InputParameterContainer& container)

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -83,7 +83,7 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
 
   auto spec = one_of({
       all_of({
-          parameter<Noneable<int>>("COMPONENT", {.default_value = none<int>}),
+          parameter<std::optional<int>>("COMPONENT", {.default_value = std::nullopt}),
           parameter<std::string>("SYMBOLIC_FUNCTION_OF_SPACE_TIME"),
       }),
 
@@ -121,11 +121,11 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
 
       all_of({
           parameter<std::string>("VARFUNCTION"),
-          parameter<Noneable<int>>("NUMCONSTANTS", {.default_value = none<int>}),
+          parameter<std::optional<int>>("NUMCONSTANTS", {.default_value = std::nullopt}),
           parameter<std::map<std::string, double>>("CONSTANTS",
               {.default_value = std::map<std::string, double>{},
                   .size = [](const IO::InputParameterContainer& container)
-                  { return container.get<Noneable<int>>("NUMCONSTANTS").value_or(0); }}),
+                  { return container.get<std::optional<int>>("NUMCONSTANTS").value_or(0); }}),
       }),
   });
 

--- a/src/core/utils/src/result_test/4C_utils_result_test.cpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.cpp
@@ -58,7 +58,7 @@ int Core::Utils::ResultTest::compare_values(
   double tolerance = container.get<double>("TOLERANCE");
   // safety check
   if (tolerance <= 0.) FOUR_C_THROW("Tolerance for result test must be strictly positive!");
-  auto name = container.get<IO::Noneable<std::string>>("NAME");
+  auto name = container.get<std::optional<std::string>>("NAME");
 
   // return value (0 if results are correct, 1 if results are not correct)
   int ret = 0;

--- a/src/elemag/4C_elemag_ele_calc.cpp
+++ b/src/elemag/4C_elemag_ele_calc.cpp
@@ -1416,7 +1416,7 @@ void Discret::Elements::ElemagEleCalc<distype>::LocalSolver::compute_absorbing_b
   {
     // Get the user defined functions
     auto* cond = params.getPtr<std::shared_ptr<Core::Conditions::Condition>>("condition");
-    const auto& funct = (*cond)->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto& funct = (*cond)->parameters().get<std::vector<std::optional<int>>>("FUNCT");
     const double time = params.get<double>("time");
 
     Core::LinAlg::SerialDenseVector tempVec1(shapesface_->nfdofs_ * nsd_);

--- a/src/fluid/4C_fluid_DbcHDG.cpp
+++ b/src/fluid/4C_fluid_DbcHDG.cpp
@@ -171,7 +171,7 @@ void FLD::Utils::DbcHdgFluid::do_dirichlet_condition(const Teuchos::ParameterLis
   if (!nodeids) FOUR_C_THROW("Dirichlet condition does not have nodal cloud");
 
   // get curves, functs, vals, and onoff toggles from the condition
-  const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = cond.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   const auto val = cond.parameters().get<std::vector<double>>("VAL");
   const auto onoff = cond.parameters().get<std::vector<int>>("ONOFF");
 

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
@@ -222,7 +222,7 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
   // (assumed to be constant on element boundary)
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   const std::string* type = &condition.parameters().get<std::string>("TYPE");
 
   // get time factor for Neumann term

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
@@ -525,7 +525,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::flow_dep_pressure_bc(
   //  generalized-alpha time-integration scheme -> reset to time n+1)
   const double time =
       fldparatimint_->time() + (1 - fldparatimint_->alpha_f()) * fldparatimint_->dt();
-  const auto curvenum = fdp_cond->parameters().get<Core::IO::Noneable<int>>("curve");
+  const auto curvenum = fdp_cond->parameters().get<std::optional<int>>("curve");
 
   double curvefac = 1.0;
   if (curvenum.has_value() && curvenum.value() > 0 && time >= 0)
@@ -4349,8 +4349,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
 
   // get values and switches from the condition
   // (assumed to be constant on element boundary)
-  const auto functions =
-      hixhybdbc_cond->parameters().get<std::vector<Core::IO::Noneable<int>>>("funct");
+  const auto functions = hixhybdbc_cond->parameters().get<std::vector<std::optional<int>>>("funct");
 
   Core::LinAlg::Matrix<nsd, 1> u_dirich(true);
 

--- a/src/fluid_ele/4C_fluid_ele_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc.cpp
@@ -1432,7 +1432,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::body_force(Discret::Elem
     const auto onoff = myneumcond[0]->parameters().get<std::vector<int>>("ONOFF");
     const auto val = myneumcond[0]->parameters().get<std::vector<double>>("VAL");
     const auto functions =
-        myneumcond[0]->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+        myneumcond[0]->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
     // factor given by spatial function
     double functionfac = 1.0;
@@ -1524,7 +1524,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::body_force(Discret::Elem
     {
       // check for potential time curve
       const auto funct =
-          myscatraneumcond[0]->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+          myscatraneumcond[0]->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
       // initialization of time-curve factor
       double functfac = 0.0;

--- a/src/fluid_ele/4C_fluid_ele_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.cpp
@@ -137,7 +137,7 @@ void Discret::Elements::FluidHDGType ::setup_element_definition(
     defs_hdg[key] = all_of({
         fluid_line_def,
         parameter<int>("DEG"),
-        parameter<Noneable<bool>>("SPC", {.default_value = none<bool>}),
+        parameter<std::optional<bool>>("SPC", {.default_value = std::nullopt}),
     });
   }
 }
@@ -225,7 +225,7 @@ bool Discret::Elements::FluidHDG::read_element(const std::string& eletype,
   bool success = Fluid::read_element(eletype, distype, container);
   degree_ = container.get<int>("DEG");
 
-  completepol_ = container.get<Core::IO::Noneable<bool>>("SPC").value_or(false);
+  completepol_ = container.get<std::optional<bool>>("SPC").value_or(false);
 
   return success;
 }

--- a/src/fluid_ele/4C_fluid_ele_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.cpp
@@ -137,7 +137,7 @@ void Discret::Elements::FluidHDGType ::setup_element_definition(
     defs_hdg[key] = all_of({
         fluid_line_def,
         parameter<int>("DEG"),
-        parameter<std::optional<bool>>("SPC", {.default_value = std::nullopt}),
+        parameter<std::optional<bool>>("SPC"),
     });
   }
 }

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
@@ -99,7 +99,7 @@ void Discret::Elements::FluidHDGWeakCompType ::setup_element_definition(
     defs_hdg[key] = all_of({
         fluid_line_def,
         parameter<int>("DEG"),
-        parameter<std::optional<bool>>("SPC", {.default_value = std::nullopt}),
+        parameter<std::optional<bool>>("SPC"),
     });
   }
 }

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
@@ -99,7 +99,7 @@ void Discret::Elements::FluidHDGWeakCompType ::setup_element_definition(
     defs_hdg[key] = all_of({
         fluid_line_def,
         parameter<int>("DEG"),
-        parameter<Noneable<bool>>("SPC", {.default_value = none<bool>}),
+        parameter<std::optional<bool>>("SPC", {.default_value = std::nullopt}),
     });
   }
 }
@@ -178,7 +178,7 @@ bool Discret::Elements::FluidHDGWeakComp::read_element(const std::string& eletyp
   bool success = Fluid::read_element(eletype, distype, container);
   degree_ = container.get<int>("DEG");
 
-  completepol_ = container.get<Core::IO::Noneable<bool>>("SPC").value_or(false);
+  completepol_ = container.get<std::optional<bool>>("SPC").value_or(false);
 
   return success;
 }

--- a/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
@@ -339,7 +339,7 @@ void FLD::TransferTurbulentInflowCondition::get_data(
   // find out whether we will use a time curve
   if (curve_ == -1)
   {
-    const auto curve = cond->parameters().get<Core::IO::Noneable<int>>("curve");
+    const auto curve = cond->parameters().get<std::optional<int>>("curve");
 
     // set zero based curve number
     curve_ = curve.value_or(-1) - 1;

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -354,7 +354,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("FLUID",
             {
@@ -366,7 +366,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("XFLUID",
             {
@@ -375,7 +375,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("ALE",
             {
@@ -384,7 +384,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("THERMAL",
             {
@@ -393,7 +393,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("LUBRICATION",
             {
@@ -402,7 +402,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("POROFLUIDMULTIPHASE",
             {
@@ -415,7 +415,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("SCATRA",
             {
@@ -427,7 +427,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("SSI",
             {
@@ -441,7 +441,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("SSTI",
             {
@@ -449,7 +449,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("STI",
             {
@@ -457,7 +457,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("RED_AIRWAY",
             {
@@ -469,7 +469,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("ARTNET",
             {
@@ -481,7 +481,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("FSI",
             {
@@ -492,7 +492,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("PARTICLE",
             {
@@ -500,7 +500,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("PARTICLEWALL",
             {
@@ -512,7 +512,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("RIGIDBODY",
             {
@@ -520,7 +520,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("ELECTROMAGNETIC",
             {
@@ -529,7 +529,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
         group("CARDIOVASCULAR0D",
             {
@@ -538,7 +538,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
+                parameter<std::optional<std::string>>("NAME"),
             }),
     });
   }

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -354,7 +354,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("FLUID",
             {
@@ -366,7 +366,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("XFLUID",
             {
@@ -375,7 +375,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("ALE",
             {
@@ -384,7 +384,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("THERMAL",
             {
@@ -393,7 +393,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("LUBRICATION",
             {
@@ -402,7 +402,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("POROFLUIDMULTIPHASE",
             {
@@ -415,7 +415,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("SCATRA",
             {
@@ -427,7 +427,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("SSI",
             {
@@ -441,7 +441,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("SSTI",
             {
@@ -449,7 +449,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("STI",
             {
@@ -457,7 +457,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("RED_AIRWAY",
             {
@@ -469,7 +469,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("ARTNET",
             {
@@ -481,7 +481,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("FSI",
             {
@@ -492,7 +492,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("PARTICLE",
             {
@@ -500,7 +500,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("PARTICLEWALL",
             {
@@ -512,7 +512,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("RIGIDBODY",
             {
@@ -520,7 +520,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("ELECTROMAGNETIC",
             {
@@ -529,7 +529,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
         group("CARDIOVASCULAR0D",
             {
@@ -538,7 +538,7 @@ namespace
                 parameter<std::string>("QUANTITY"),
                 parameter<double>("VALUE"),
                 parameter<double>("TOLERANCE"),
-                parameter<Noneable<std::string>>("NAME", {.default_value = none<std::string>}),
+                parameter<std::optional<std::string>>("NAME", {.default_value = std::nullopt}),
             }),
     });
   }

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -254,10 +254,8 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
     m->add_component(parameter<std::vector<double>>(
         "ROLE", {.description = "role in michaelis-menten like reactions",
                     .size = from_parameter<int>("NUMSCAL")}));
-    m->add_component(parameter<std::optional<std::vector<double>>>(
-        "REACSTART", {.description = "starting point of reaction",
-                         .default_value = std::nullopt,
-                         .size = from_parameter<int>("NUMSCAL")}));
+    m->add_component(parameter<std::optional<std::vector<double>>>("REACSTART",
+        {.description = "starting point of reaction", .size = from_parameter<int>("NUMSCAL")}));
 
     Mat::append_material_definition(matlist, m);
   }
@@ -281,10 +279,8 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
     m->add_component(parameter<std::vector<double>>(
         "ROLE", {.description = "role in michaelis-menten like reactions",
                     .size = from_parameter<int>("NUMSCAL")}));
-    m->add_component(parameter<std::optional<std::vector<double>>>(
-        "REACSTART", {.description = "starting point of reaction",
-                         .default_value = std::nullopt,
-                         .size = from_parameter<int>("NUMSCAL")}));
+    m->add_component(parameter<std::optional<std::vector<double>>>("REACSTART",
+        {.description = "starting point of reaction", .size = from_parameter<int>("NUMSCAL")}));
 
     Mat::append_material_definition(matlist, m);
   }
@@ -3401,7 +3397,6 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
                            .size = from_parameter<int>("NUMSCAL")}));
     m->add_component(parameter<std::optional<std::vector<double>>>(
         "OMEGA_HALF", {.description = "Constant for receptor kinetic law",
-                          .default_value = std::nullopt,
                           .size = from_parameter<int>("NUMSCAL")}));
 
     Mat::append_material_definition(matlist, m);

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -256,7 +256,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
                     .size = from_parameter<int>("NUMSCAL")}));
     m->add_component(parameter<std::optional<std::vector<double>>>(
         "REACSTART", {.description = "starting point of reaction",
-                         .default_value = none<std::vector<double>>,
+                         .default_value = std::nullopt,
                          .size = from_parameter<int>("NUMSCAL")}));
 
     Mat::append_material_definition(matlist, m);
@@ -283,7 +283,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
                     .size = from_parameter<int>("NUMSCAL")}));
     m->add_component(parameter<std::optional<std::vector<double>>>(
         "REACSTART", {.description = "starting point of reaction",
-                         .default_value = none<std::vector<double>>,
+                         .default_value = std::nullopt,
                          .size = from_parameter<int>("NUMSCAL")}));
 
     Mat::append_material_definition(matlist, m);
@@ -3401,7 +3401,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
                            .size = from_parameter<int>("NUMSCAL")}));
     m->add_component(parameter<std::optional<std::vector<double>>>(
         "OMEGA_HALF", {.description = "Constant for receptor kinetic law",
-                          .default_value = none<std::vector<double>>,
+                          .default_value = std::nullopt,
                           .size = from_parameter<int>("NUMSCAL")}));
 
     Mat::append_material_definition(matlist, m);

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -1396,13 +1396,13 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
     m->add_component(parameter<double>("NUE", {.description = "Poisson's ratio"}));
     m->add_component(parameter<double>("DENS", {.description = "mass density"}));
     m->add_component(
-        parameter<double>("YIELD", {.description = "yield stress", .default_value = 0}));
+        parameter<double>("YIELD", {.description = "yield stress", .default_value = 0.}));
     m->add_component(parameter<double>(
-        "ISOHARD", {.description = "isotropic hardening modulus", .default_value = 0}));
+        "ISOHARD", {.description = "isotropic hardening modulus", .default_value = 0.}));
     m->add_component(parameter<double>(
-        "SATHARDENING", {.description = "saturation hardening", .default_value = 0}));
+        "SATHARDENING", {.description = "saturation hardening", .default_value = 0.}));
     m->add_component(parameter<double>(
-        "HARDEXPO", {.description = "linear hardening exponent", .default_value = 0}));
+        "HARDEXPO", {.description = "linear hardening exponent", .default_value = 0.}));
     m->add_component(parameter<double>("VISC", {.description = "VISCOSITY", .default_value = 0.}));
     m->add_component(parameter<double>(
         "RATE_DEPENDENCY", {.description = "rate dependency", .default_value = 0.}));
@@ -1635,7 +1635,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
         {.description = "the list material/potential IDs", .size = from_parameter<int>("NUMMAT")}));
     m->add_component(parameter<double>("DENS", {.description = "material mass density"}));
     m->add_component(parameter<int>("POLYCONVEX",
-        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0.}));
+        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}));
 
     Mat::append_material_definition(matlist, m);
   }
@@ -1653,7 +1653,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
         {.description = "the list material/potential IDs", .size = from_parameter<int>("NUMMAT")}));
     m->add_component(parameter<double>("DENS", {.description = "material mass density"}));
     m->add_component(parameter<int>("POLYCONVEX",
-        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0.}));
+        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}));
 
     Mat::append_material_definition(matlist, m);
   }
@@ -1672,7 +1672,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
     m->add_component(parameter<double>("DENS", {.description = "material mass density"}));
     m->add_component(parameter<double>("INITYIELD", {.description = "initial yield stress"}));
     m->add_component(parameter<int>("POLYCONVEX",
-        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0.}));
+        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}));
     m->add_component(parameter<double>(
         "ISOHARD", {.description = "linear isotropic hardening modulus", .default_value = 0.}));
     m->add_component(parameter<double>("EXPISOHARD",
@@ -1802,7 +1802,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
         {.description = "Taylor-Quinney factor for plastic heat conversion", .default_value = 1.}));
 
     m->add_component(parameter<int>("POLYCONVEX",
-        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0.}));
+        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}));
 
 
     Mat::append_material_definition(matlist, m);
@@ -2665,7 +2665,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
         {.description = "the list material/potential IDs", .size = from_parameter<int>("NUMMAT")}));
     m->add_component(parameter<double>("DENS", {.description = "material mass density"}));
     m->add_component(parameter<int>("POLYCONVEX",
-        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0.}));
+        {.description = "1.0 if polyconvexity of system is checked", .default_value = 0}));
 
     Mat::append_material_definition(matlist, m);
   }
@@ -2728,7 +2728,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
         "PRESTRETCHELASTINAX", {.description = "axial prestretch of elastin matrix"}));
     m->add_component(parameter<double>("THICKNESS",
         {.description = "reference wall thickness of the idealized cylindrical aneurysm [m]",
-            .default_value = -1}));
+            .default_value = -1.}));
     m->add_component(parameter<double>(
         "MEANPRESSURE", {.description = "mean blood pressure [Pa]", .default_value = -1.0}));
     m->add_component(parameter<double>(

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -174,12 +174,12 @@ void Inpar::BeamPotential::set_valid_conditions(
   rigidsphere_potential_charge.add_component(parameter<int>("POTLAW"));
   rigidsphere_potential_charge.add_component(parameter<double>("VAL"));
   rigidsphere_potential_charge.add_component(
-      parameter<Noneable<int>>("FUNCT", {.description = "", .default_value = 0}));
+      parameter<std::optional<int>>("FUNCT", {.description = "", .default_value = 0}));
 
   beam_potential_line_charge.add_component(parameter<int>("POTLAW"));
   beam_potential_line_charge.add_component(parameter<double>("VAL"));
   beam_potential_line_charge.add_component(
-      parameter<Noneable<int>>("FUNCT", {.description = "", .default_value = 0}));
+      parameter<std::optional<int>>("FUNCT", {.description = "", .default_value = 0}));
 
   condlist.push_back(rigidsphere_potential_charge);
   condlist.push_back(beam_potential_line_charge);

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -174,12 +174,12 @@ void Inpar::BeamPotential::set_valid_conditions(
   rigidsphere_potential_charge.add_component(parameter<int>("POTLAW"));
   rigidsphere_potential_charge.add_component(parameter<double>("VAL"));
   rigidsphere_potential_charge.add_component(
-      parameter<std::optional<int>>("FUNCT", {.description = "", .default_value = 0}));
+      parameter<std::optional<int>>("FUNCT", {.description = ""}));
 
   beam_potential_line_charge.add_component(parameter<int>("POTLAW"));
   beam_potential_line_charge.add_component(parameter<double>("VAL"));
   beam_potential_line_charge.add_component(
-      parameter<std::optional<int>>("FUNCT", {.description = "", .default_value = 0}));
+      parameter<std::optional<int>>("FUNCT", {.description = ""}));
 
   condlist.push_back(rigidsphere_potential_charge);
   condlist.push_back(beam_potential_line_charge);

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -111,7 +111,7 @@ void Inpar::ArteryNetwork::set_valid_conditions(
   art_in_bc.add_component(
       parameter<std::vector<double>>("VAL", {.description = "values", .size = 2}));
   art_in_bc.add_component(
-      parameter<std::vector<Noneable<int>>>("curve", {.description = "curve ids", .size = 2}));
+      parameter<std::vector<std::optional<int>>>("curve", {.description = "curve ids", .size = 2}));
 
   condlist.push_back(art_in_bc);
 
@@ -124,7 +124,7 @@ void Inpar::ArteryNetwork::set_valid_conditions(
   art_rf_bc.add_component(
       parameter<std::vector<double>>("VAL", {.description = "value", .size = 1}));
   art_rf_bc.add_component(
-      parameter<std::vector<Noneable<int>>>("curve", {.description = "curve", .size = 1}));
+      parameter<std::vector<std::optional<int>>>("curve", {.description = "curve", .size = 1}));
   condlist.push_back(art_rf_bc);
 
 
@@ -376,9 +376,11 @@ void Inpar::ReducedLung::set_valid_conditions(
   raw_in_bc.add_component(
       parameter<std::vector<double>>("VAL", {.description = "value", .size = 1}));
   raw_in_bc.add_component(
-      parameter<std::vector<Noneable<int>>>("curve", {.description = "curve", .size = 2}));
-  raw_in_bc.add_component(parameter<std::vector<Noneable<int>>>(
-      "funct", {.description = "function id", .default_value = std::vector{none<int>}, .size = 1}));
+      parameter<std::vector<std::optional<int>>>("curve", {.description = "curve", .size = 2}));
+  raw_in_bc.add_component(parameter<std::vector<std::optional<int>>>(
+      "funct", {.description = "function id",
+                   .default_value = std::vector{std::optional<int>{}},
+                   .size = 1}));
 
   condlist.push_back(raw_in_bc);
 
@@ -424,7 +426,7 @@ void Inpar::ReducedLung::set_valid_conditions(
   raw_volPpl_bc.add_component(
       parameter<std::vector<double>>("VAL", {.description = "value", .size = 1}));
   raw_volPpl_bc.add_component(
-      parameter<std::vector<Noneable<int>>>("curve", {.description = "curve", .size = 1}));
+      parameter<std::vector<std::optional<int>>>("curve", {.description = "curve", .size = 1}));
 
   condlist.push_back(raw_volPpl_bc);
 

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -578,7 +578,7 @@ void Inpar::Cardiovascular0D::set_valid_conditions(
   cardiovascular0darterialproxdistcond.add_component(parameter<double>("p_ard_0"));
   cardiovascular0darterialproxdistcond.add_component(parameter<double>("p_at_fac"));
   cardiovascular0darterialproxdistcond.add_component(
-      parameter<Noneable<int>>("p_at_crv", {.description = "curve"}));
+      parameter<std::optional<int>>("p_at_crv", {.description = "curve"}));
   condlist.push_back(cardiovascular0darterialproxdistcond);
 
   /*--------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -317,7 +317,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
     {
       cond.add_component(parameter<int>("ConditionID"));
       cond.add_component(parameter<double>("POT"));
-      cond.add_component(parameter<Noneable<int>>("FUNCT", {.description = ""}));
+      cond.add_component(parameter<std::optional<int>>("FUNCT", {.description = ""}));
       cond.add_component(parameter<int>("NUMSCAL"));
       cond.add_component(parameter<std::vector<int>>(
           "STOICH", {.description = "", .size = from_parameter<int>("NUMSCAL")}));
@@ -358,7 +358,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
     auto electrodedomainkineticscomponents = all_of({
         parameter<int>("ConditionID"),
         parameter<double>("POT"),
-        parameter<Core::IO::Noneable<int>>("FUNCT"),
+        parameter<std::optional<int>>("FUNCT"),
         parameter<int>("NUMSCAL"),
         parameter<std::vector<int>>("STOICH", {.size = from_parameter<int>("NUMSCAL")}),
         parameter<int>("E-"),
@@ -414,14 +414,16 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       cond.add_component(parameter<int>("NUMBER_OF_HALF_CYCLES"));
       cond.add_component(parameter<int>(
           "BEGIN_WITH_CHARGING"));  // Boolean parameter represented by integer parameter
-      cond.add_component(parameter<Noneable<int>>("CONDITION_ID_FOR_CHARGE", {.description = ""}));
       cond.add_component(
-          parameter<Noneable<int>>("CONDITION_ID_FOR_DISCHARGE", {.description = ""}));
+          parameter<std::optional<int>>("CONDITION_ID_FOR_CHARGE", {.description = ""}));
+      cond.add_component(
+          parameter<std::optional<int>>("CONDITION_ID_FOR_DISCHARGE", {.description = ""}));
       cond.add_component(parameter<double>("INIT_RELAX_TIME"));
       cond.add_component(parameter<int>("ADAPTIVE_TIME_STEPPING_INIT_RELAX"));
-      cond.add_component(parameter<Noneable<int>>("NUM_ADD_ADAPT_TIME_STEPS", {.description = ""}));
       cond.add_component(
-          parameter<Noneable<int>>("MIN_TIME_STEPS_DURING_INIT_RELAX", {.description = ""}));
+          parameter<std::optional<int>>("NUM_ADD_ADAPT_TIME_STEPS", {.description = ""}));
+      cond.add_component(
+          parameter<std::optional<int>>("MIN_TIME_STEPS_DURING_INIT_RELAX", {.description = ""}));
 
       // insert condition definitions into global list of valid condition definitions
       condlist.emplace_back(cond);

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -132,7 +132,7 @@ void Inpar::EleMag::set_valid_conditions(
     cond.add_component(parameter<int>("NUMDOF"));
     cond.add_component(parameter<std::vector<int>>(
         "ONOFF", {.description = "", .size = from_parameter<int>("NUMDOF")}));
-    cond.add_component(parameter<std::vector<Noneable<int>>>(
+    cond.add_component(parameter<std::vector<std::optional<int>>>(
         "FUNCT", {.description = "", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(parameter<std::vector<double>>(
         "VAL", {.description = "", .size = from_parameter<int>("NUMDOF")}));

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1303,8 +1303,8 @@ void Inpar::FLUID::set_valid_conditions(
       selection<std::string>("toggle", {"master", "slave"}, {.description = "toggle"}));
   tbc_turb_inflow.add_component(selection<int>("DIRECTION", {{"x", 0}, {"y", 1}, {"z", 2}},
       {.description = "transfer direction", .default_value = 0}));
-  tbc_turb_inflow.add_component(parameter<Noneable<int>>(
-      "curve", {.description = "curve id", .default_value = Core::IO::none<int>}));
+  tbc_turb_inflow.add_component(parameter<std::optional<int>>(
+      "curve", {.description = "curve id", .default_value = std::nullopt}));
 
   condlist.push_back(tbc_turb_inflow);
 
@@ -1340,8 +1340,8 @@ void Inpar::FLUID::set_valid_conditions(
       "ReferencePressure", {.description = " reference pressure outside of boundary"}));
   surfflowdeppressure.add_component(
       parameter<double>("AdiabaticExponent", {.description = "adiabatic exponent"}));
-  surfflowdeppressure.add_component(parameter<Noneable<int>>(
-      "curve", {.description = "curve id", .default_value = Core::IO::none<int>}));
+  surfflowdeppressure.add_component(parameter<std::optional<int>>(
+      "curve", {.description = "curve id", .default_value = std::nullopt}));
 
   condlist.emplace_back(surfflowdeppressure);
 
@@ -1430,9 +1430,9 @@ void Inpar::FLUID::set_valid_conditions(
         parameter<std::vector<double>>("val", {.description = "velocity", .size = 3}));
 
     // and optional spatial functions
-    cond.add_component(parameter<std::vector<Noneable<int>>>(
+    cond.add_component(parameter<std::vector<std::optional<int>>>(
         "funct", {.description = "spatial function",
-                     .default_value = std::vector(3, Core::IO::none<int>),
+                     .default_value = std::vector(3, std::optional<int>{}),
                      .size = 3}));
 
     // characteristic velocity

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1303,8 +1303,8 @@ void Inpar::FLUID::set_valid_conditions(
       selection<std::string>("toggle", {"master", "slave"}, {.description = "toggle"}));
   tbc_turb_inflow.add_component(selection<int>("DIRECTION", {{"x", 0}, {"y", 1}, {"z", 2}},
       {.description = "transfer direction", .default_value = 0}));
-  tbc_turb_inflow.add_component(parameter<std::optional<int>>(
-      "curve", {.description = "curve id", .default_value = std::nullopt}));
+  tbc_turb_inflow.add_component(
+      parameter<std::optional<int>>("curve", {.description = "curve id"}));
 
   condlist.push_back(tbc_turb_inflow);
 
@@ -1340,8 +1340,8 @@ void Inpar::FLUID::set_valid_conditions(
       "ReferencePressure", {.description = " reference pressure outside of boundary"}));
   surfflowdeppressure.add_component(
       parameter<double>("AdiabaticExponent", {.description = "adiabatic exponent"}));
-  surfflowdeppressure.add_component(parameter<std::optional<int>>(
-      "curve", {.description = "curve id", .default_value = std::nullopt}));
+  surfflowdeppressure.add_component(
+      parameter<std::optional<int>>("curve", {.description = "curve id"}));
 
   condlist.emplace_back(surfflowdeppressure);
 

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -205,8 +205,8 @@ void Inpar::Mortar::set_valid_conditions(
         {.description =
                 "optional reference configuration check for non-smooth self contact surfaces",
             .default_value = 0.0}));
-    cond.add_component(parameter<std::optional<int>>("ConstitutiveLawID",
-        {.description = "material id of the constitutive law", .default_value = 0}));
+    cond.add_component(parameter<std::optional<int>>(
+        "ConstitutiveLawID", {.description = "material id of the constitutive law"}));
     condlist.push_back(cond);
   };
 

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -205,7 +205,7 @@ void Inpar::Mortar::set_valid_conditions(
         {.description =
                 "optional reference configuration check for non-smooth self contact surfaces",
             .default_value = 0.0}));
-    cond.add_component(parameter<Noneable<int>>("ConstitutiveLawID",
+    cond.add_component(parameter<std::optional<int>>("ConstitutiveLawID",
         {.description = "material id of the constitutive law", .default_value = 0}));
     condlist.push_back(cond);
   };

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -628,10 +628,10 @@ void Inpar::ScaTra::set_valid_conditions(
     cond.add_component(parameter<double>("coeff", {.description = "heat transfer coefficient h"}));
     cond.add_component(
         parameter<double>("surtemp", {.description = "surrounding (fluid) temperature T_oo"}));
-    cond.add_component(parameter<Noneable<int>>("surtempfunct",
+    cond.add_component(parameter<std::optional<int>>("surtempfunct",
         {.description =
                 "time curve to increase the surrounding (fluid) temperature T_oo in time"}));
-    cond.add_component(parameter<Noneable<int>>("funct",
+    cond.add_component(parameter<std::optional<int>>("funct",
         {.description =
                 "time curve to increase the complete boundary condition, i.e., the heat flux"}));
 

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -102,26 +102,25 @@ namespace Inpar::SOLVER
           list);
 
       list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<Core::IO::Noneable<std::filesystem::path>>(
-              "SOLVER_XML_FILE",
-              {.description = "xml file defining any iterative solver",
-                  .default_value = Core::IO::Noneable<std::filesystem::path>()}));
+          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
+              "SOLVER_XML_FILE", {.description = "xml file defining any iterative solver",
+                                     .default_value = std::optional<std::filesystem::path>()}));
     }
 
     // MueLu options
     {
       list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<Core::IO::Noneable<std::filesystem::path>>(
+          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
               "MUELU_XML_FILE", {.description = "xml file defining any MueLu preconditioner",
-                                    .default_value = Core::IO::Noneable<std::filesystem::path>()}));
+                                    .default_value = std::optional<std::filesystem::path>()}));
     }
 
     // Teko options
     {
       list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<Core::IO::Noneable<std::filesystem::path>>(
+          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
               "TEKO_XML_FILE", {.description = "xml file defining any Teko preconditioner",
-                                   .default_value = Core::IO::Noneable<std::filesystem::path>()}));
+                                   .default_value = std::optional<std::filesystem::path>()}));
     }
 
     // user-given name of solver block (just for beauty)
@@ -134,10 +133,9 @@ namespace Inpar::SOLVER
           "is defined using a xml file",
           list);
       list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<Core::IO::Noneable<std::filesystem::path>>(
-              "AMGNXN_XML_FILE",
-              {.description = "xml file defining the AMGnxn preconditioner",
-                  .default_value = Core::IO::Noneable<std::filesystem::path>()}));
+          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
+              "AMGNXN_XML_FILE", {.description = "xml file defining the AMGnxn preconditioner",
+                                     .default_value = std::optional<std::filesystem::path>()}));
     }
 
     spec = Core::IO::InputSpecBuilders::all_of(std::move(list.specs));

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -103,24 +103,21 @@ namespace Inpar::SOLVER
 
       list.specs.emplace_back(
           Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "SOLVER_XML_FILE", {.description = "xml file defining any iterative solver",
-                                     .default_value = std::optional<std::filesystem::path>()}));
+              "SOLVER_XML_FILE", {.description = "xml file defining any iterative solver"}));
     }
 
     // MueLu options
     {
       list.specs.emplace_back(
           Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "MUELU_XML_FILE", {.description = "xml file defining any MueLu preconditioner",
-                                    .default_value = std::optional<std::filesystem::path>()}));
+              "MUELU_XML_FILE", {.description = "xml file defining any MueLu preconditioner"}));
     }
 
     // Teko options
     {
       list.specs.emplace_back(
           Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "TEKO_XML_FILE", {.description = "xml file defining any Teko preconditioner",
-                                   .default_value = std::optional<std::filesystem::path>()}));
+              "TEKO_XML_FILE", {.description = "xml file defining any Teko preconditioner"}));
     }
 
     // user-given name of solver block (just for beauty)
@@ -134,8 +131,7 @@ namespace Inpar::SOLVER
           list);
       list.specs.emplace_back(
           Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "AMGNXN_XML_FILE", {.description = "xml file defining the AMGnxn preconditioner",
-                                     .default_value = std::optional<std::filesystem::path>()}));
+              "AMGNXN_XML_FILE", {.description = "xml file defining the AMGnxn preconditioner"}));
     }
 
     spec = Core::IO::InputSpecBuilders::all_of(std::move(list.specs));

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -328,8 +328,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     statusTest.specs.emplace_back(
         Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>("XML File",
-            {.description = "Filename of XML file with configuration of nox status test",
-                .default_value = std::optional<std::filesystem::path>()}));
+            {.description = "Filename of XML file with configuration of nox status test"}));
   }
   statusTest.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -327,10 +327,9 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   {
     statusTest.specs.emplace_back(
-        Core::IO::InputSpecBuilders::parameter<Core::IO::Noneable<std::filesystem::path>>(
-            "XML File",
+        Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>("XML File",
             {.description = "Filename of XML file with configuration of nox status test",
-                .default_value = Core::IO::Noneable<std::filesystem::path>()}));
+                .default_value = std::optional<std::filesystem::path>()}));
   }
   statusTest.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -440,7 +440,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         "ONOFF", {.description = "", .size = from_parameter<int>("NUMDOF")}));
     definition.add_component(parameter<std::vector<double>>(
         "VAL", {.description = "", .size = from_parameter<int>("NUMDOF")}));
-    definition.add_component(parameter<std::vector<Noneable<int>>>(
+    definition.add_component(parameter<std::vector<std::optional<int>>>(
         "FUNCT", {.description = "", .size = from_parameter<int>("NUMDOF")}));
   };
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -426,7 +426,7 @@ namespace Inpar
                     {"cursurfnormal",
                         CONSTRAINTS::SpringDashpot::RobinSpringDashpotType::cursurfnormal}},
                 {.description = "Direction of the spring-dashpot boundary conditions"}));
-        cond.add_component(parameter<Noneable<int>>("COUPLING", {.description = ""}));
+        cond.add_component(parameter<std::optional<int>>("COUPLING", {.description = ""}));
         condlist.emplace_back(cond);
       };
 

--- a/src/inpar/4C_inpar_validconditions.cpp
+++ b/src/inpar/4C_inpar_validconditions.cpp
@@ -159,7 +159,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
         "ONOFF", {.description = "onoff", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(parameter<std::vector<double>>(
         "VAL", {.description = "values", .size = from_parameter<int>("NUMDOF")}));
-    cond.add_component(parameter<std::vector<Noneable<int>>>(
+    cond.add_component(parameter<std::vector<std::optional<int>>>(
         "FUNCT", {.description = "function ids", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(selection<std::string>("TYPE",
         {"Live", "Dead", "pseudo_orthopressure", "orthopressure", "PressureGrad"},
@@ -280,7 +280,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
         "ONOFF", {.description = "", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(parameter<std::vector<double>>(
         "VAL", {.description = "", .size = from_parameter<int>("NUMDOF")}));
-    cond.add_component(parameter<std::vector<Noneable<int>>>(
+    cond.add_component(parameter<std::vector<std::optional<int>>>(
         "FUNCT", {.description = "", .size = from_parameter<int>("NUMDOF")}));
 
     // optional
@@ -490,7 +490,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   {
     cond.add_component(parameter<std::vector<double>>("ROTANGLE", {.description = "", .size = 3}));
     cond.add_component(
-        parameter<std::vector<Noneable<int>>>("FUNCT", {.description = "", .size = 3}));
+        parameter<std::vector<std::optional<int>>>("FUNCT", {.description = "", .size = 3}));
     cond.add_component(parameter<int>("USEUPDATEDNODEPOS"));
 
     if (cond.geometry_type() == Core::Conditions::geometry_type_line ||
@@ -610,7 +610,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   volumeconstraint.add_component(parameter<int>("ConditionID"));
   volumeconstraint.add_component(
-      parameter<Noneable<int>>("curve", {.description = "id of the curve"}));
+      parameter<std::optional<int>>("curve", {.description = "id of the curve"}));
   volumeconstraint.add_component(parameter<double>("activeTime"));
   volumeconstraint.add_component(selection<std::string>("projection", {"none", "xy", "yz", "xz"},
       {.description = "projection", .default_value = "none"}));
@@ -628,7 +628,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   volumeconstraintpen.add_component(parameter<int>("ConditionID"));
   volumeconstraintpen.add_component(
-      parameter<Noneable<int>>("curve", {.description = "id of the curve"}));
+      parameter<std::optional<int>>("curve", {.description = "id of the curve"}));
   volumeconstraintpen.add_component(parameter<double>("activeTime"));
   volumeconstraintpen.add_component(parameter<double>("penalty"));
   volumeconstraintpen.add_component(parameter<double>("rho"));
@@ -646,7 +646,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   areaconstraint.add_component(parameter<int>("ConditionID"));
   areaconstraint.add_component(
-      parameter<Noneable<int>>("curve", {.description = "id of the curve"}));
+      parameter<std::optional<int>>("curve", {.description = "id of the curve"}));
   areaconstraint.add_component(parameter<double>("activeTime"));
 
   condlist.push_back(areaconstraint);
@@ -684,7 +684,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
       Core::Conditions::geometry_type_line);
 
   areaconstraint2D.add_component(parameter<int>("ConditionID"));
-  areaconstraint2D.add_component(parameter<Noneable<int>>("curve", {.description = {}}));
+  areaconstraint2D.add_component(parameter<std::optional<int>>("curve", {.description = {}}));
   areaconstraint2D.add_component(parameter<double>("activeTime"));
 
   condlist.push_back(areaconstraint2D);
@@ -709,7 +709,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   nodeonplaneconst3D.add_component(parameter<int>("ConditionID"));
   nodeonplaneconst3D.add_component(parameter<double>("amplitude"));
-  nodeonplaneconst3D.add_component(parameter<Noneable<int>>("curve", {.description = {}}));
+  nodeonplaneconst3D.add_component(parameter<std::optional<int>>("curve", {.description = {}}));
   nodeonplaneconst3D.add_component(parameter<double>("activeTime"));
   nodeonplaneconst3D.add_component(parameter<std::vector<int>>(
       "planeNodes", {.description = "ids of the nodes spanning the plane", .size = 3}));
@@ -728,7 +728,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   nodemasterconst3D.add_component(parameter<int>("ConditionID"));
   nodemasterconst3D.add_component(parameter<double>("amplitude"));
-  nodemasterconst3D.add_component(parameter<Noneable<int>>("curve", {.description = {}}));
+  nodemasterconst3D.add_component(parameter<std::optional<int>>("curve", {.description = {}}));
   nodemasterconst3D.add_component(parameter<double>("activeTime"));
   nodemasterconst3D.add_component(parameter<int>("masterNode"));
   nodemasterconst3D.add_component(
@@ -751,7 +751,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   nodemasterconst3Dpen.add_component(parameter<int>("ConditionID"));
   nodemasterconst3Dpen.add_component(parameter<double>("amplitude"));
-  nodemasterconst3Dpen.add_component(parameter<Noneable<int>>("curve", {.description = {}}));
+  nodemasterconst3Dpen.add_component(parameter<std::optional<int>>("curve", {.description = {}}));
   nodemasterconst3Dpen.add_component(parameter<double>("activeTime"));
   nodemasterconst3Dpen.add_component(parameter<double>("penalty"));
   nodemasterconst3Dpen.add_component(parameter<int>("masterNode"));
@@ -771,7 +771,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   nodeonlineconst2D.add_component(parameter<int>("ConditionID"));
   nodeonlineconst2D.add_component(parameter<double>("amplitude"));
-  nodeonlineconst2D.add_component(parameter<Noneable<int>>("curve", {.description = {}}));
+  nodeonlineconst2D.add_component(parameter<std::optional<int>>("curve", {.description = {}}));
   nodeonlineconst2D.add_component(parameter<int>("constrNode1"));
   nodeonlineconst2D.add_component(parameter<int>("constrNode2"));
   nodeonlineconst2D.add_component(parameter<int>("constrNode3"));

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -635,7 +635,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
 
   xfem_surf_fpi_mono.add_component(parameter<int>("COUPLINGID"));
   xfem_surf_fpi_mono.add_component(
-      parameter<double>("BJ_COEFF", {.description = "", .default_value = 0}));
+      parameter<double>("BJ_COEFF", {.description = "", .default_value = 0.}));
   xfem_surf_fpi_mono.add_component(selection<std::string>(
       "Variant", {"BJ", "BJS"}, {.description = "variant", .default_value = "BJ"}));
   xfem_surf_fpi_mono.add_component(selection<std::string>(

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -395,7 +395,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       parameter<int>("NUMDOF"),
       parameter<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
-      parameter<std::vector<Noneable<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
+      parameter<std::vector<std::optional<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
       selection<std::string>("TAG", {"none", "monitor_reaction"}, {.default_value = "none"}),
   });
 
@@ -403,7 +403,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       parameter<int>("NUMDOF"),
       parameter<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
-      parameter<std::vector<Noneable<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
+      parameter<std::vector<std::optional<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
       selection<std::string>("TYPE",
           {"Live", "Dead", "pseudo_orthopressure", "orthopressure", "PressureGrad"},
           {.default_value = "Live"}),
@@ -516,9 +516,9 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   xfem_levelset_navier_slip.add_component(
       parameter<int>("L2_PROJECTION_SOLVER", {.description = ""}));
   xfem_levelset_navier_slip.add_component(
-      parameter<Noneable<int>>("ROBIN_DIRICHLET_ID", {.description = ""}));
+      parameter<std::optional<int>>("ROBIN_DIRICHLET_ID", {.description = ""}));
   xfem_levelset_navier_slip.add_component(
-      parameter<Noneable<int>>("ROBIN_NEUMANN_ID", {.description = ""}));
+      parameter<std::optional<int>>("ROBIN_NEUMANN_ID", {.description = ""}));
   xfem_levelset_navier_slip.add_component(parameter<double>("SLIPCOEFFICIENT"));
   xfem_levelset_navier_slip.add_component(
       parameter<int>("FUNCT", {.description = "slip function id", .default_value = 0}));
@@ -535,7 +535,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::geometry_type_volume);
 
   xfem_navier_slip_robin_dirch.add_component(
-      parameter<Noneable<int>>("ROBIN_ID", {.description = "robin id"}));
+      parameter<std::optional<int>>("ROBIN_ID", {.description = "robin id"}));
 
   xfem_navier_slip_robin_dirch.add_component(dirichletbundcomponents);
 
@@ -547,7 +547,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::geometry_type_volume);
 
   xfem_navier_slip_robin_neumann.add_component(
-      parameter<Noneable<int>>("ROBIN_ID", {.description = "robin id"}));
+      parameter<std::optional<int>>("ROBIN_ID", {.description = "robin id"}));
 
   xfem_navier_slip_robin_neumann.add_component(neumanncomponents);
 
@@ -701,9 +701,9 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
           "displacement_2ndorder_with_initfunct"},
       {.description = "", .default_value = "funct_interpolated"}));
   xfem_surf_navier_slip.add_component(
-      parameter<Noneable<int>>("ROBIN_DIRICHLET_ID", {.description = ""}));
+      parameter<std::optional<int>>("ROBIN_DIRICHLET_ID", {.description = ""}));
   xfem_surf_navier_slip.add_component(
-      parameter<Noneable<int>>("ROBIN_NEUMANN_ID", {.description = ""}));
+      parameter<std::optional<int>>("ROBIN_NEUMANN_ID", {.description = ""}));
   xfem_surf_navier_slip.add_component(parameter<double>("SLIPCOEFFICIENT"));
   xfem_surf_navier_slip.add_component(
       parameter<int>("FUNCT", {.description = "slip function id", .default_value = 0}));
@@ -721,7 +721,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   //  to have a couplingID. In theory this should not be necessary.
   xfem_navier_slip_robin_dirch_surf.add_component(parameter<int>("COUPLINGID"));
   xfem_navier_slip_robin_dirch_surf.add_component(
-      parameter<Noneable<int>>("ROBIN_ID", {.description = "robin id"}));
+      parameter<std::optional<int>>("ROBIN_ID", {.description = "robin id"}));
 
   // Likely, not necessary. But needed for the current structure.
   xfem_navier_slip_robin_dirch_surf.add_component(selection<std::string>("EVALTYPE",
@@ -743,7 +743,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   //  to have a couplingID. In theory this should not be necessary.
   xfem_navier_slip_robin_neumann_surf.add_component(parameter<int>("COUPLINGID"));
   xfem_navier_slip_robin_neumann_surf.add_component(
-      parameter<Noneable<int>>("ROBIN_ID", {.description = "robin id"}));
+      parameter<std::optional<int>>("ROBIN_ID", {.description = "robin id"}));
 
   xfem_navier_slip_robin_neumann_surf.add_component(neumanncomponents);
 

--- a/src/mat/4C_mat_anisotropy.cpp
+++ b/src/mat/4C_mat_anisotropy.cpp
@@ -88,7 +88,7 @@ void Mat::Anisotropy::read_anisotropy_from_element(
 {
   // This method might be called even though there is no anisotropy possible for the element.
   // In this case, we just return without doing anything.
-  using OptionalFiber = Core::IO::Noneable<std::vector<double>>;
+  using OptionalFiber = std::optional<std::vector<double>>;
   const bool any_fibers_found =
       container.get_if<OptionalFiber>("FIBER1") or container.get_if<OptionalFiber>("RAD") or
       container.get_if<OptionalFiber>("AXI") or container.get_if<OptionalFiber>("CIR");
@@ -96,9 +96,9 @@ void Mat::Anisotropy::read_anisotropy_from_element(
 
 
   // Read coordinate system
-  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+  if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+      container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+      container.get<std::optional<std::vector<double>>>("CIR").has_value())
   {
     // read fibers in RAD AXI CIR notation
     if (!element_cylinder_coordinate_system_manager_)
@@ -118,7 +118,7 @@ void Mat::Anisotropy::read_anisotropy_from_element(
 
       // We count up until we hit a fiber that we do not know about. Thus we need to use the
       // get_if mechanism.
-      auto* fiber_ptr = container.get_if<Core::IO::Noneable<std::vector<double>>>(fiber_name);
+      auto* fiber_ptr = container.get_if<std::optional<std::vector<double>>>(fiber_name);
       if (!fiber_ptr or !fiber_ptr->has_value())
       {
         break;

--- a/src/mat/4C_mat_anisotropy_cylinder_coordinate_system_manager.cpp
+++ b/src/mat/4C_mat_anisotropy_cylinder_coordinate_system_manager.cpp
@@ -36,9 +36,9 @@ void Mat::CylinderCoordinateSystemManager::unpack(Core::Communication::UnpackBuf
 void Mat::CylinderCoordinateSystemManager::read_from_element_line_definition(
     const Core::IO::InputParameterContainer& container)
 {
-  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+  if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+      container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+      container.get<std::optional<std::vector<double>>>("CIR").has_value())
   {
     read_anisotropy_fiber(container, "RAD", radial_);
     read_anisotropy_fiber(container, "AXI", axial_);

--- a/src/mat/4C_mat_anisotropy_utils.cpp
+++ b/src/mat/4C_mat_anisotropy_utils.cpp
@@ -19,8 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 void Mat::read_anisotropy_fiber(const Core::IO::InputParameterContainer& container,
     std::string specifier, Core::LinAlg::Matrix<3, 1>& fiber_vector)
 {
-  const auto& fiber_opt =
-      container.get<Core::IO::Noneable<std::vector<double>>>(std::move(specifier));
+  const auto& fiber_opt = container.get<std::optional<std::vector<double>>>(std::move(specifier));
   FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
   const auto& fiber = *fiber_opt;
 

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -369,9 +369,9 @@ void Mat::ConstraintMixture::setup(int numgp, const Core::IO::InputParameterCont
   a4_ = std::make_shared<std::vector<Core::LinAlg::Matrix<3, 1>>>(numgp);
 
   // read local (cylindrical) cosy-directions at current element
-  auto rad_opt = container.get<Core::IO::Noneable<std::vector<double>>>("RAD");
-  auto axi_opt = container.get<Core::IO::Noneable<std::vector<double>>>("AXI");
-  auto cir_opt = container.get<Core::IO::Noneable<std::vector<double>>>("CIR");
+  auto rad_opt = container.get<std::optional<std::vector<double>>>("RAD");
+  auto axi_opt = container.get<std::optional<std::vector<double>>>("AXI");
+  auto cir_opt = container.get<std::optional<std::vector<double>>>("CIR");
   FOUR_C_ASSERT_ALWAYS(rad_opt && axi_opt && cir_opt, "Require RAD, AXI and CIR parameters.");
 
   const auto& rad = *rad_opt;

--- a/src/mat/4C_mat_crystal_plasticity.cpp
+++ b/src/mat/4C_mat_crystal_plasticity.cpp
@@ -1104,9 +1104,9 @@ void Mat::CrystalPlasticity::setup_lattice_orientation(
     const Core::IO::InputParameterContainer& container)
 {
   // extract fiber vectors as columns of the rotation matrix
-  const auto& fiber1 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1");
-  const auto& fiber2 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2");
-  const auto& fiber3 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER3");
+  const auto& fiber1 = container.get<std::optional<std::vector<double>>>("FIBER1");
+  const auto& fiber2 = container.get<std::optional<std::vector<double>>>("FIBER2");
+  const auto& fiber3 = container.get<std::optional<std::vector<double>>>("FIBER3");
 
   if (fiber1 and fiber2 and fiber3)
   {

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -458,9 +458,9 @@ void Mat::GrowthRemodelElastHyper::setup_axi_cir_rad_structural_tensor(
     const Core::IO::InputParameterContainer& container)
 {
   // CIR-AXI-RAD nomenclature
-  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+  if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+      container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+      container.get<std::optional<std::vector<double>>>("CIR").has_value())
   {
     // Read in of data
     // read local (cylindrical) cosy-directions at current element
@@ -522,7 +522,7 @@ void Mat::GrowthRemodelElastHyper::setup_aniso_growth_tensors()
 void Mat::GrowthRemodelElastHyper::read_dir(const Core::IO::InputParameterContainer& container,
     const std::string& specifier, Core::LinAlg::Matrix<3, 1>& dir)
 {
-  const auto& fiber_opt = container.get<Core::IO::Noneable<std::vector<double>>>(specifier);
+  const auto& fiber_opt = container.get<std::optional<std::vector<double>>>(specifier);
   FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
   const auto& fiber = *fiber_opt;
 

--- a/src/mat/4C_mat_membrane_active_strain.cpp
+++ b/src/mat/4C_mat_membrane_active_strain.cpp
@@ -409,9 +409,9 @@ void Mat::MembraneActiveStrain::setup_fiber_vectors(
   Core::LinAlg::Matrix<3, 1> dir;
 
   // CIR-AXI-RAD nomenclature
-  if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-      container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+  if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+      container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+      container.get<std::optional<std::vector<double>>>("CIR").has_value())
   {
     // Axial direction
     read_dir(container, "AXI", dir);
@@ -426,8 +426,8 @@ void Mat::MembraneActiveStrain::setup_fiber_vectors(
     fibervecs_.push_back(dir);
   }
   // FIBER nomenclature
-  else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() and
-           container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2").has_value())
+  else if (container.get<std::optional<std::vector<double>>>("FIBER1").has_value() and
+           container.get<std::optional<std::vector<double>>>("FIBER2").has_value())
   {
     for (int i = 1; i < 3; ++i)
     {
@@ -474,7 +474,7 @@ void Mat::MembraneActiveStrain::setup_fiber_vectors(
 void Mat::MembraneActiveStrain::read_dir(const Core::IO::InputParameterContainer& container,
     std::string specifier, Core::LinAlg::Matrix<3, 1>& dir)
 {
-  const auto& fiber_opt = container.get<Core::IO::Noneable<std::vector<double>>>(specifier);
+  const auto& fiber_opt = container.get<std::optional<std::vector<double>>>(specifier);
   FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
   const auto& fiber = *fiber_opt;
 

--- a/src/mat/4C_mat_myocard.cpp
+++ b/src/mat/4C_mat_myocard.cpp
@@ -247,7 +247,7 @@ void Mat::Myocard::setup(const Core::LinAlg::Matrix<2, 1>& fiber1)
 
 void Mat::Myocard::setup(const Core::IO::InputParameterContainer& container)
 {
-  if (const auto& fiber1 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1");
+  if (const auto& fiber1 = container.get<std::optional<std::vector<double>>>("FIBER1");
       fiber1.has_value())
   {
     diff_at_ele_center_ = true;

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -343,12 +343,12 @@ void Mat::PlasticElastHyper::setup(int numgp, const Core::IO::InputParameterCont
     FOUR_C_THROW("no visco-elasticity in PlasticElastHyper...yet(?)");
 
   // check if either zero or three fiber directions are given
-  if ((!container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() ||
-          !container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() ||
-          !container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value()) &&
-      (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value() ||
-          container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2").has_value() ||
-          container.get<Core::IO::Noneable<std::vector<double>>>("FIBER3").has_value()))
+  if ((!container.get<std::optional<std::vector<double>>>("FIBER1").has_value() ||
+          !container.get<std::optional<std::vector<double>>>("FIBER1").has_value() ||
+          !container.get<std::optional<std::vector<double>>>("FIBER1").has_value()) &&
+      (container.get<std::optional<std::vector<double>>>("FIBER1").has_value() ||
+          container.get<std::optional<std::vector<double>>>("FIBER2").has_value() ||
+          container.get<std::optional<std::vector<double>>>("FIBER3").has_value()))
     FOUR_C_THROW("so3 expects no fibers or 3 fiber directions");
 
   // plastic anisotropy
@@ -441,9 +441,9 @@ void Mat::PlasticElastHyper::setup_hill_plasticity(
     std::vector<Core::LinAlg::Matrix<3, 1>> directions(3);
 
     // compute fiber directions
-    const auto& fiber1 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1");
-    const auto& fiber2 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER2");
-    const auto& fiber3 = container.get<Core::IO::Noneable<std::vector<double>>>("FIBER3");
+    const auto& fiber1 = container.get<std::optional<std::vector<double>>>("FIBER1");
+    const auto& fiber2 = container.get<std::optional<std::vector<double>>>("FIBER2");
+    const auto& fiber3 = container.get<std::optional<std::vector<double>>>("FIBER3");
 
     std::size_t dir_index = 0;
     for (const auto& fiber : {fiber1, fiber2, fiber3})

--- a/src/mat/4C_mat_viscoanisotropic.cpp
+++ b/src/mat/4C_mat_viscoanisotropic.cpp
@@ -209,9 +209,9 @@ void Mat::ViscoAnisotropic::setup(int numgp, const Core::IO::InputParameterConta
   const double gamma = (params_->gamma_ * M_PI) / 180.;  // convert
 
   // read local (cylindrical) cosy-directions at current element
-  auto rad_opt = container.get<Core::IO::Noneable<std::vector<double>>>("RAD");
-  auto axi_opt = container.get<Core::IO::Noneable<std::vector<double>>>("AXI");
-  auto cir_opt = container.get<Core::IO::Noneable<std::vector<double>>>("CIR");
+  auto rad_opt = container.get<std::optional<std::vector<double>>>("RAD");
+  auto axi_opt = container.get<std::optional<std::vector<double>>>("AXI");
+  auto cir_opt = container.get<std::optional<std::vector<double>>>("CIR");
   FOUR_C_ASSERT_ALWAYS(rad_opt && axi_opt && cir_opt, "Require RAD, AXI and CIR parameters.");
 
   const auto& rad = *rad_opt;

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke.cpp
@@ -59,9 +59,9 @@ void Mat::Elastic::CoupAnisoNeoHooke::setup(
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature
-    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+    if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+        container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+        container.get<std::optional<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -73,7 +73,7 @@ void Mat::Elastic::CoupAnisoNeoHooke::setup(
     }
 
     // FIBER1 nomenclature
-    else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value())
+    else if (container.get<std::optional<std::vector<double>>>("FIBER1").has_value())
     {
       // Read in of fiber data and setting fiber data
       read_fiber(container, "FIBER1", a_);

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
@@ -96,9 +96,9 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::setup(
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature
-    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+    if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+        container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+        container.get<std::optional<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -110,7 +110,7 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::setup(
     }
 
     // FIBER1 nomenclature
-    else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value())
+    else if (container.get<std::optional<std::vector<double>>>("FIBER1").has_value())
     {
       // Read in of fiber data and setting fiber data
       read_fiber(container, "FIBER1", a_);

--- a/src/mat/elast/4C_mat_elast_coupanisopow.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisopow.cpp
@@ -61,9 +61,9 @@ void Mat::Elastic::CoupAnisoPow::setup(
     ss << params_->fibernumber_;
     std::string fibername = "FIBER" + ss.str();  // FIBER Name
     // CIR-AXI-RAD nomenclature
-    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+    if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+        container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+        container.get<std::optional<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -74,7 +74,7 @@ void Mat::Elastic::CoupAnisoPow::setup(
       set_fiber_vecs(0.0, locsys, Id);
     }
     // FIBERi nomenclature
-    else if (container.get<Core::IO::Noneable<std::vector<double>>>(fibername).has_value())
+    else if (container.get<std::optional<std::vector<double>>>(fibername).has_value())
     {
       // Read in of data
       read_fiber(container, fibername, a_);

--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
@@ -73,9 +73,9 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
       ss << params_->fiber_gid_;
       std::string fibername = "FIBER" + ss.str();  // FIBER Name
       // CIR-AXI-RAD nomenclature
-      if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-          container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-          container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+      if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+          container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+          container.get<std::optional<std::vector<double>>>("CIR").has_value())
       {
         // Read in of data
         Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -86,7 +86,7 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
         set_fiber_vecs(0.0, locsys, Id);
       }
       // FIBERi nomenclature
-      else if (container.get<Core::IO::Noneable<std::vector<double>>>(fibername).has_value())
+      else if (container.get<std::optional<std::vector<double>>>(fibername).has_value())
       {
         // Read in of data
         read_fiber(container, fibername, a_);

--- a/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
+++ b/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
@@ -60,9 +60,9 @@ void Mat::Elastic::IsoAnisoExpo::setup(
   else if (params_->init_ == 1)
   {
     // CIR-AXI-RAD nomenclature
-    if (container.get<Core::IO::Noneable<std::vector<double>>>("RAD").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("AXI").has_value() and
-        container.get<Core::IO::Noneable<std::vector<double>>>("CIR").has_value())
+    if (container.get<std::optional<std::vector<double>>>("RAD").has_value() and
+        container.get<std::optional<std::vector<double>>>("AXI").has_value() and
+        container.get<std::optional<std::vector<double>>>("CIR").has_value())
     {
       // Read in of data
       Core::LinAlg::Matrix<3, 3> locsys(true);
@@ -75,7 +75,7 @@ void Mat::Elastic::IsoAnisoExpo::setup(
     }
 
     // FIBER1 nomenclature
-    else if (container.get<Core::IO::Noneable<std::vector<double>>>("FIBER1").has_value())
+    else if (container.get<std::optional<std::vector<double>>>("FIBER1").has_value())
     {
       // Read in of data
       read_fiber(container, "FIBER1", a_);

--- a/src/mat/elast/4C_mat_elast_summand.cpp
+++ b/src/mat/elast/4C_mat_elast_summand.cpp
@@ -338,7 +338,7 @@ void Mat::Elastic::Summand::unpack(Core::Communication::UnpackBuffer& buffer) { 
 void Mat::Elastic::Summand::read_fiber(const Core::IO::InputParameterContainer& container,
     const std::string& specifier, Core::LinAlg::Matrix<3, 1>& fiber_vector)
 {
-  const auto& fiber_opt = container.get<Core::IO::Noneable<std::vector<double>>>(specifier);
+  const auto& fiber_opt = container.get<std::optional<std::vector<double>>>(specifier);
   FOUR_C_ASSERT(fiber_opt.has_value(), "Internal error: fiber vector not found.");
   const auto& fiber1 = *fiber_opt;
 

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -79,18 +79,12 @@ void Discret::Elements::MembraneTri3Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 
@@ -160,18 +154,12 @@ void Discret::Elements::MembraneTri6Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 
@@ -241,18 +229,12 @@ void Discret::Elements::MembraneQuad4Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 
@@ -322,18 +304,12 @@ void Discret::Elements::MembraneQuad9Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -79,18 +79,18 @@ void Discret::Elements::MembraneTri3Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 
@@ -160,18 +160,18 @@ void Discret::Elements::MembraneTri6Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 
@@ -241,18 +241,18 @@ void Discret::Elements::MembraneQuad4Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 
@@ -322,18 +322,18 @@ void Discret::Elements::MembraneQuad9Type::setup_element_definition(
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
       parameter<std::string>("STRESS_STRAIN"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/membrane/4C_membrane_evaluate.cpp
+++ b/src/membrane/4C_membrane_evaluate.cpp
@@ -533,7 +533,7 @@ int Discret::Elements::Membrane<distype>::evaluate_neumann(Teuchos::ParameterLis
     if (onoff[checkdof] != 0) FOUR_C_THROW("membrane pressure on 1st dof only!");
 
   // find out whether we will use time curves and get the factors
-  const auto tmp_funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto tmp_funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   std::vector<double> functfacs(noddof_, 1.0);
   for (int i = 0; i < noddof_; ++i)
   {

--- a/src/membrane/4C_membrane_line_evaluate.cpp
+++ b/src/membrane/4C_membrane_line_evaluate.cpp
@@ -48,7 +48,7 @@ int Discret::Elements::MembraneLine<distype>::evaluate_neumann(Teuchos::Paramete
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto spa_func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto spa_func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   /*
   **    TIME CURVE BUSINESS

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_boundary_calc.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_boundary_calc.cpp
@@ -194,7 +194,7 @@ int Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<distype>::evaluate_neu
   const int numdof = condition.parameters().get<int>("NUMDOF");
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   if (numdofpernode_ != numdof)
     FOUR_C_THROW(

--- a/src/red_airways/4C_red_airways_acinus.cpp
+++ b/src/red_airways/4C_red_airways_acinus.cpp
@@ -73,22 +73,22 @@ void Discret::Elements::RedAcinusType::setup_element_definition(
       parameter<double>("AcinusVolume"),
       parameter<double>("AlveolarDuctVolume"),
       // Maxwell exponential
-      parameter<std::optional<double>>("E1_0", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_LIN", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_EXP", {.default_value = none<double>}),
-      parameter<std::optional<double>>("TAU", {.default_value = none<double>}),
+      parameter<std::optional<double>>("E1_0", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_LIN", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_EXP", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("TAU", {.default_value = std::nullopt}),
       // Maxwell double exponential
-      parameter<std::optional<double>>("E1_01", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_LIN1", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_EXP1", {.default_value = none<double>}),
-      parameter<std::optional<double>>("TAU1", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_02", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_LIN2", {.default_value = none<double>}),
-      parameter<std::optional<double>>("E1_EXP2", {.default_value = none<double>}),
-      parameter<std::optional<double>>("TAU2", {.default_value = none<double>}),
+      parameter<std::optional<double>>("E1_01", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_LIN1", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_EXP1", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("TAU1", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_02", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_LIN2", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_EXP2", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("TAU2", {.default_value = std::nullopt}),
       // VolOgden
-      parameter<std::optional<double>>("KAPPA", {.default_value = none<double>}),
-      parameter<std::optional<double>>("BETA", {.default_value = none<double>}),
+      parameter<std::optional<double>>("KAPPA", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("BETA", {.default_value = std::nullopt}),
   });
 }
 

--- a/src/red_airways/4C_red_airways_acinus.cpp
+++ b/src/red_airways/4C_red_airways_acinus.cpp
@@ -73,22 +73,22 @@ void Discret::Elements::RedAcinusType::setup_element_definition(
       parameter<double>("AcinusVolume"),
       parameter<double>("AlveolarDuctVolume"),
       // Maxwell exponential
-      parameter<std::optional<double>>("E1_0", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_LIN", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_EXP", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("TAU", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_0"),
+      parameter<std::optional<double>>("E1_LIN"),
+      parameter<std::optional<double>>("E1_EXP"),
+      parameter<std::optional<double>>("TAU"),
       // Maxwell double exponential
-      parameter<std::optional<double>>("E1_01", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_LIN1", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_EXP1", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("TAU1", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_02", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_LIN2", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("E1_EXP2", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("TAU2", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("E1_01"),
+      parameter<std::optional<double>>("E1_LIN1"),
+      parameter<std::optional<double>>("E1_EXP1"),
+      parameter<std::optional<double>>("TAU1"),
+      parameter<std::optional<double>>("E1_02"),
+      parameter<std::optional<double>>("E1_LIN2"),
+      parameter<std::optional<double>>("E1_EXP2"),
+      parameter<std::optional<double>>("TAU2"),
       // VolOgden
-      parameter<std::optional<double>>("KAPPA", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("BETA", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("KAPPA"),
+      parameter<std::optional<double>>("BETA"),
   });
 }
 

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -323,10 +323,9 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           Bc = (condition->parameters().get<std::string>("boundarycond"));
 
           const auto vals = condition->parameters().get<std::vector<double>>("VAL");
-          const auto curve =
-              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+          const auto curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
           const auto functions =
-              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("funct");
+              condition->parameters().get<std::vector<std::optional<int>>>("funct");
 
           // Read in the value of the applied BC
           // Get factor of first CURVE
@@ -461,8 +460,7 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             Bc = (condition->parameters().get<std::string>("phase2"));
           }
 
-          const auto curve =
-              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+          const auto curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
           double curvefac = 1.0;
           const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
@@ -507,7 +505,7 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             if (pplCond)
             {
               const auto curve =
-                  pplCond->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+                  pplCond->parameters().get<std::vector<std::optional<int>>>("curve");
               double curvefac = 1.0;
               const auto vals = pplCond->parameters().get<std::vector<double>>("VAL");
 

--- a/src/red_airways/4C_red_airways_airway.cpp
+++ b/src/red_airways/4C_red_airways_airway.cpp
@@ -82,13 +82,13 @@ void Discret::Elements::RedAirwayType::setup_element_definition(
       parameter<double>("WallThickness"),
       parameter<double>("Area"),
       parameter<int>("Generation"),
-      parameter<std::optional<double>>("AirwayColl", {.default_value = none<double>}),
-      parameter<std::optional<double>>("S_Close", {.default_value = none<double>}),
-      parameter<std::optional<double>>("S_Open", {.default_value = none<double>}),
-      parameter<std::optional<double>>("Pcrit_Open", {.default_value = none<double>}),
-      parameter<std::optional<double>>("Pcrit_Close", {.default_value = none<double>}),
-      parameter<std::optional<double>>("Open_Init", {.default_value = none<double>}),
-      parameter<std::optional<double>>("BranchLength", {.default_value = none<double>}),
+      parameter<std::optional<double>>("AirwayColl", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("S_Close", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("S_Open", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("Pcrit_Open", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("Pcrit_Close", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("Open_Init", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("BranchLength", {.default_value = std::nullopt}),
   });
 }
 

--- a/src/red_airways/4C_red_airways_airway.cpp
+++ b/src/red_airways/4C_red_airways_airway.cpp
@@ -82,13 +82,13 @@ void Discret::Elements::RedAirwayType::setup_element_definition(
       parameter<double>("WallThickness"),
       parameter<double>("Area"),
       parameter<int>("Generation"),
-      parameter<std::optional<double>>("AirwayColl", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("S_Close", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("S_Open", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("Pcrit_Open", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("Pcrit_Close", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("Open_Init", {.default_value = std::nullopt}),
-      parameter<std::optional<double>>("BranchLength", {.default_value = std::nullopt}),
+      parameter<std::optional<double>>("AirwayColl"),
+      parameter<std::optional<double>>("S_Close"),
+      parameter<std::optional<double>>("S_Open"),
+      parameter<std::optional<double>>("Pcrit_Open"),
+      parameter<std::optional<double>>("Pcrit_Close"),
+      parameter<std::optional<double>>("Open_Init"),
+      parameter<std::optional<double>>("BranchLength"),
   });
 }
 

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -82,8 +82,7 @@ namespace
       std::string Bc = (condition->parameters().get<std::string>(optionName));
       if (Bc == condType)
       {
-        const auto curve =
-            condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+        const auto curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
         double curvefac = 1.0;
         const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
@@ -945,7 +944,7 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
             //  Val = curve1*val1 + curve2*func
             // -----------------------------------------------------------------
             const auto* curve =
-                condition->parameters().get_if<std::vector<Core::IO::Noneable<int>>>("curve");
+                condition->parameters().get_if<std::vector<std::optional<int>>>("curve");
             const auto vals = condition->parameters().get<std::vector<double>>("VAL");
 
             // get factor of curve1 or curve2
@@ -969,7 +968,7 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
                 [&]()
                 {
                   const auto* functions =
-                      condition->parameters().get_if<std::vector<Core::IO::Noneable<int>>>("funct");
+                      condition->parameters().get_if<std::vector<std::optional<int>>>("funct");
                   if (functions)
                   {
                     if ((*functions)[0].has_value() && (*functions)[0].value() > 0)

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -199,12 +199,11 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           // Get the type of prescribed bc
           Bc = (condition->parameters().get<std::string>("boundarycond"));
 
-          const auto curve =
-              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+          const auto curve = condition->parameters().get<std::vector<std::optional<int>>>("curve");
           double curvefac = 1.0;
           const auto vals = condition->parameters().get<std::vector<double>>("VAL");
           const auto functions =
-              condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("funct");
+              condition->parameters().get<std::vector<std::optional<int>>>("funct");
 
           // Read in the value of the applied BC
           // Get factor of first CURVE
@@ -265,7 +264,7 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
             if (pplCond)
             {
               const auto curve =
-                  pplCond->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve");
+                  pplCond->parameters().get<std::vector<std::optional<int>>>("curve");
               double curvefac = 1.0;
               const auto vals = pplCond->parameters().get<std::vector<double>>("VAL");
 

--- a/src/reduced_lung/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/4C_reduced_lung_main.cpp
@@ -189,7 +189,7 @@ namespace ReducedLung
         const auto* bc_condition = node_in.get_condition("RedAirwayPrescribedCond");
         const std::string bc_type = bc_condition->parameters().get<std::string>("boundarycond");
         const std::optional<int> funct_num =
-            bc_condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve")[0];
+            bc_condition->parameters().get<std::vector<std::optional<int>>>("curve")[0];
         if (bc_type == "pressure")
         {
           if (funct_num.has_value())
@@ -212,7 +212,7 @@ namespace ReducedLung
         const auto* bc_condition = node_out.get_condition("RedAirwayPrescribedCond");
         const std::string bc_type = bc_condition->parameters().get<std::string>("boundarycond");
         const std::optional<int> funct_num =
-            bc_condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("curve")[0];
+            bc_condition->parameters().get<std::vector<std::optional<int>>>("curve")[0];
         if (bc_type == "pressure")
         {
           if (funct_num.has_value())

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -308,10 +308,10 @@ void ScaTra::ScaTraTimIntElch::setup()
             "no CCCV half-cycle boundary conditions!");
       }
       if (!cccvcyclingcondition.parameters()
-              .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_CHARGE")
+              .get<std::optional<int>>("CONDITION_ID_FOR_CHARGE")
               .has_value() or
           !cccvcyclingcondition.parameters()
-              .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_DISCHARGE")
+              .get<std::optional<int>>("CONDITION_ID_FOR_DISCHARGE")
               .has_value())
       {
         FOUR_C_THROW(
@@ -2976,7 +2976,7 @@ void ScaTra::ScaTraTimIntElch::apply_neumann_bc(
             // condition.
             const std::vector<int> onoff = {0, 1};
             const std::vector<double> val = {0.0, condition->parameters().get<double>("CURRENT")};
-            const std::vector<Core::IO::Noneable<int>> funct = {0, 0};
+            const std::vector<std::optional<int>> funct = {0, 0};
             condition->parameters().add("NUMDOF", 2);
             condition->parameters().add("FUNCT", funct);
             condition->parameters().add("ONOFF", onoff);

--- a/src/scatra/4C_scatra_timint_elch_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scheme.cpp
@@ -266,7 +266,7 @@ void ScaTra::ScaTraTimIntElchOST::compute_time_deriv_pot0(const bool init)
   for (int icond = 0; icond < numcond; icond++)
   {
     auto pot0np = cond[icond]->parameters().get<double>("POT");
-    const auto functnum = cond[icond]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+    const auto functnum = cond[icond]->parameters().get<std::optional<int>>("FUNCT");
     auto dlcap = cond[icond]->parameters().get<double>("DL_SPEC_CAP");
 
     if (init)
@@ -827,7 +827,7 @@ void ScaTra::ScaTraTimIntElchGenAlpha::compute_time_deriv_pot0(const bool init)
   for (int icond = 0; icond < numcond; icond++)
   {
     double pot0np = cond[icond]->parameters().get<double>("POT");
-    const auto functnum = cond[icond]->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+    const auto functnum = cond[icond]->parameters().get<std::optional<int>>("FUNCT");
     double dlcap = cond[icond]->parameters().get<double>("DL_SPEC_CAP");
 
     if (init)

--- a/src/scatra/4C_scatra_timint_elch_service.cpp
+++ b/src/scatra/4C_scatra_timint_elch_service.cpp
@@ -25,11 +25,11 @@ ScaTra::CCCVCondition::CCCVCondition(const Core::Conditions::Condition& cccvcycl
       ihalfcycle_(-1),
       initrelaxtime_(cccvcyclingcondition.parameters().get<double>("INIT_RELAX_TIME")),
       min_time_steps_during_init_relax_(cccvcyclingcondition.parameters()
-              .get<Core::IO::Noneable<int>>("MIN_TIME_STEPS_DURING_INIT_RELAX")
+              .get<std::optional<int>>("MIN_TIME_STEPS_DURING_INIT_RELAX")
               .value_or(-1)),
       nhalfcycles_(cccvcyclingcondition.parameters().get<int>("NUMBER_OF_HALF_CYCLES")),
       num_add_adapt_timesteps_(cccvcyclingcondition.parameters()
-              .get<Core::IO::Noneable<int>>("NUM_ADD_ADAPT_TIME_STEPS")
+              .get<std::optional<int>>("NUM_ADD_ADAPT_TIME_STEPS")
               .value_or(-1)),
       num_dofs_(num_dofs),
       phasechanged_(false),
@@ -62,13 +62,13 @@ ScaTra::CCCVCondition::CCCVCondition(const Core::Conditions::Condition& cccvcycl
 
     if (condition->parameters().get<int>("ConditionID") ==
         cccvcyclingcondition.parameters()
-            .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_CHARGE")
+            .get<std::optional<int>>("CONDITION_ID_FOR_CHARGE")
             .value_or(-1))
       halfcycle_charge_ =
           std::make_shared<ScaTra::CCCVHalfCycleCondition>(*condition, adaptivetimestepping);
     if (condition->parameters().get<int>("ConditionID") ==
         cccvcyclingcondition.parameters()
-            .get<Core::IO::Noneable<int>>("CONDITION_ID_FOR_DISCHARGE")
+            .get<std::optional<int>>("CONDITION_ID_FOR_DISCHARGE")
             .value_or(-1))
       halfcycle_discharge_ =
           std::make_shared<ScaTra::CCCVHalfCycleCondition>(*condition, adaptivetimestepping);

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -98,168 +98,168 @@ void Discret::Elements::TransportType::setup_element_definition(
       parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["HEX20"] = all_of({
       parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["HEX27"] = all_of({
       parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["NURBS27"] = all_of({
       parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["NURBS8"] = all_of({
       parameter<std::vector<int>>("NURBS8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["TET4"] = all_of({
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["TET10"] = all_of({
       parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["WEDGE6"] = all_of({
       parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["WEDGE15"] = all_of({
       parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["PYRAMID5"] = all_of({
       parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["QUAD4"] = all_of({
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["QUAD8"] = all_of({
       parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["TRI6"] = all_of({
       parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["NURBS4"] = all_of({
       parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["NURBS9"] = all_of({
       parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["LINE2"] = all_of({
       parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["LINE3"] = all_of({
       parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["NURBS2"] = all_of({
       parameter<std::vector<int>>("NURBS2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 
   defs["NURBS3"] = all_of({
       parameter<std::vector<int>>("NURBS3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -98,168 +98,147 @@ void Discret::Elements::TransportType::setup_element_definition(
       parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["HEX20"] = all_of({
       parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["HEX27"] = all_of({
       parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS27"] = all_of({
       parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS8"] = all_of({
       parameter<std::vector<int>>("NURBS8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TET4"] = all_of({
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TET10"] = all_of({
       parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["WEDGE6"] = all_of({
       parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["WEDGE15"] = all_of({
       parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["PYRAMID5"] = all_of({
       parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["QUAD4"] = all_of({
       parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["QUAD8"] = all_of({
       parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["QUAD9"] = all_of({
       parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TRI3"] = all_of({
       parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TRI6"] = all_of({
       parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS4"] = all_of({
       parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS9"] = all_of({
       parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["LINE2"] = all_of({
       parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["LINE3"] = all_of({
       parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS2"] = all_of({
       parameter<std::vector<int>>("NURBS2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS3"] = all_of({
       parameter<std::vector<int>>("NURBS3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 }
 

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
@@ -510,7 +510,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_neumann
   const int numdof = condition.parameters().get<int>("NUMDOF");
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   if (numdofpernode_ != numdof)
   {
@@ -2129,7 +2129,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
   // get values and spatial functions from condition
   // (assumed to be constant on element boundary)
   const auto& val = (*dbc).parameters().get<std::vector<double>>("VAL");
-  const auto& func = (*dbc).parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto& func = (*dbc).parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // assign boundary value multiplied by time-curve factor
   double dirichval = val[0];

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
@@ -109,7 +109,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
   // access parameters of the condition
   const auto kinetics = cond->parameters().get<int>("KINETIC_MODEL");
   auto pot0 = cond->parameters().get<double>("POT");
-  const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  const auto curvenum = cond->parameters().get<std::optional<int>>("FUNCT");
   const auto nume = cond->parameters().get<int>("E-");
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated
@@ -237,7 +237,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
 
     // access parameters of the condition
     auto pot0 = cond->parameters().get<double>("POT");
-    const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+    const auto curvenum = cond->parameters().get<std::optional<int>>("FUNCT");
     const auto nume = cond->parameters().get<int>("E-");
     const auto e0 = cond->parameters().get<double>("E0");
     const auto c0 = cond->parameters().get<double>("C0");

--- a/src/scatra_ele/4C_scatra_ele_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc.cpp
@@ -860,8 +860,7 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::body_force(
   if (myneumcond.size() == 1)
   {
     // (SPATIAL) FUNCTION BUSINESS
-    const auto funct =
-        myneumcond[0]->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto funct = myneumcond[0]->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
     // get values and switches from the condition
     const auto onoff = myneumcond[0]->parameters().get<std::vector<int>>("ONOFF");

--- a/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
@@ -1325,7 +1325,7 @@ void Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::LocalSolver::compute
   // (assumed to be constant on element boundary)
   const auto onoff = condition->parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition->parameters().get<std::vector<double>>("VAL");
-  const auto func = condition->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto func = condition->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
 
   Core::FE::ShapeValuesFaceParams svfparams(

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
@@ -355,7 +355,7 @@ void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::calc_elch_boundary_
   // access parameters of the condition
   const int kinetics = cond->parameters().get<int>("KINETIC_MODEL");
   double pot0 = cond->parameters().get<double>("POT");
-  const auto functnum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  const auto functnum = cond->parameters().get<std::optional<int>>("FUNCT");
   const int nume = cond->parameters().get<int>("E-");
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
@@ -266,7 +266,7 @@ void Discret::Elements::ScaTraEleCalcElchDiffCond<distype, probdim>::calc_elch_d
   // access parameters of the condition
   const int kinetics = cond->parameters().get<int>("KINETIC_MODEL");
   double pot0 = cond->parameters().get<double>("POT");
-  const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("FUNCT");
+  const auto curvenum = cond->parameters().get<std::optional<int>>("FUNCT");
   const int nume = cond->parameters().get<int>("E-");
   // if zero=1=true, the current flow across the electrode is zero (comparable to do-nothing Neuman
   // condition) but the electrode status is evaluated

--- a/src/scatra_ele/4C_scatra_ele_calc_service_stabilization.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_stabilization.cpp
@@ -965,7 +965,7 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::calc_subgr_velocity(
     const auto onoff = myfluidneumcond[0]->parameters().get<std::vector<int>>("ONOFF");
     const auto val = myfluidneumcond[0]->parameters().get<std::vector<double>>("VAL");
     const auto funct =
-        myfluidneumcond[0]->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+        myfluidneumcond[0]->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
     // factor given by spatial function
     double functfac = 1.0;

--- a/src/scatra_ele/4C_scatra_ele_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.cpp
@@ -137,7 +137,7 @@ void Discret::Elements::ScaTraHDGType ::setup_element_definition(
     defs[key] = all_of({
         scatra_line_def,
         parameter<int>("DEG"),
-        parameter<std::optional<bool>>("SPC", {.default_value = std::nullopt}),
+        parameter<std::optional<bool>>("SPC"),
     });
   }
 }

--- a/src/scatra_ele/4C_scatra_ele_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.cpp
@@ -137,7 +137,7 @@ void Discret::Elements::ScaTraHDGType ::setup_element_definition(
     defs[key] = all_of({
         scatra_line_def,
         parameter<int>("DEG"),
-        parameter<Noneable<bool>>("SPC", {.default_value = none<bool>}),
+        parameter<std::optional<bool>>("SPC", {.default_value = std::nullopt}),
     });
   }
 }
@@ -347,7 +347,7 @@ bool Discret::Elements::ScaTraHDG::read_element(const std::string& eletype,
   degree_ = container.get<int>("DEG");
   degree_old_ = degree_;
 
-  completepol_ = container.get<Core::IO::Noneable<bool>>("SPC").value_or(false);
+  completepol_ = container.get<std::optional<bool>>("SPC").value_or(false);
 
   return success;
 }

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -90,18 +90,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 
   defsgeneral["QUAD8"] = all_of({
@@ -111,18 +111,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 
   defsgeneral["QUAD9"] = all_of({
@@ -132,18 +132,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 
   defsgeneral["TRI3"] = all_of({
@@ -151,18 +151,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 
   defsgeneral["TRI6"] = all_of({
@@ -170,18 +170,18 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -90,18 +90,12 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 
   defsgeneral["QUAD8"] = all_of({
@@ -111,18 +105,12 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 
   defsgeneral["QUAD9"] = all_of({
@@ -132,18 +120,12 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 
   defsgeneral["TRI3"] = all_of({
@@ -151,18 +133,12 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 
   defsgeneral["TRI6"] = all_of({
@@ -170,18 +146,12 @@ void Discret::Elements::Shell7pType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
+++ b/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
@@ -128,8 +128,7 @@ void Discret::Elements::Shell::evaluate_neumann(Core::Elements::Element& ele,
     }
   }
   // get ids of functions of space and time
-  const auto function_ids =
-      condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto function_ids = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // integration loops
   std::array<double, 2> xi_gp;

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -85,18 +85,12 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -107,18 +101,12 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -129,18 +117,12 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -149,18 +131,12 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -169,18 +145,12 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
       parameter<std::string>("TYPE"),
   });
 }

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -85,18 +85,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -107,18 +107,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -129,18 +129,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
       parameter<double>("SDC"),
       parameter<bool>("USE_ANS", {.default_value = false}),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -149,18 +149,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
       parameter<std::string>("TYPE"),
   });
 
@@ -169,18 +169,18 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
       parameter<std::string>("TYPE"),
   });
 }

--- a/src/shell7p/4C_shell7p_line_evaluate.cpp
+++ b/src/shell7p/4C_shell7p_line_evaluate.cpp
@@ -34,7 +34,7 @@ int Discret::Elements::Shell7pLine::evaluate_neumann(Teuchos::ParameterList& par
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto spa_func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto spa_func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // time curve business
   // find out whether we will use a time curve

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
@@ -142,7 +142,7 @@ int Discret::Elements::KirchhoffLoveShellNurbs::evaluate_neumann(Teuchos::Parame
   // get values and switches from the condition
   const auto& onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto& val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto& funct_id = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto& funct_id = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // ensure that the boundary condition has the correct size
   if (onoff.size() != n_nodal_dof)

--- a/src/so3/4C_so3_hex27.cpp
+++ b/src/so3/4C_so3_hex27.cpp
@@ -85,18 +85,18 @@ void Discret::Elements::SoHex27Type::setup_element_definition(
       parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_hex27.cpp
+++ b/src/so3/4C_so3_hex27.cpp
@@ -85,18 +85,12 @@ void Discret::Elements::SoHex27Type::setup_element_definition(
       parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_hex27_evaluate.cpp
+++ b/src/so3/4C_so3_hex27_evaluate.cpp
@@ -551,7 +551,7 @@ int Discret::Elements::SoHex27::evaluate_neumann(Teuchos::ParameterList& params,
   }
 
   // (SPATIAL) FUNCTION BUSINESS
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOH27, 1> xrefegp(false);
 
   /* ============================================================================*

--- a/src/so3/4C_so3_hex8.cpp
+++ b/src/so3/4C_so3_hex8.cpp
@@ -96,18 +96,12 @@ void Discret::Elements::SoHex8Type::setup_element_definition(
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_hex8.cpp
+++ b/src/so3/4C_so3_hex8.cpp
@@ -96,18 +96,18 @@ void Discret::Elements::SoHex8Type::setup_element_definition(
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_hex8_evaluate.cpp
+++ b/src/so3/4C_so3_hex8_evaluate.cpp
@@ -927,7 +927,7 @@ int Discret::Elements::SoHex8::evaluate_neumann(Teuchos::ParameterList& params,
   }
 
   // (SPATIAL) FUNCTION BUSINESS
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOH8, 1> xrefegp(false);
 
   /* ============================================================================*

--- a/src/so3/4C_so3_line_evaluate.cpp
+++ b/src/so3/4C_so3_line_evaluate.cpp
@@ -62,7 +62,7 @@ int Discret::Elements::StructuralLine::evaluate_neumann(Teuchos::ParameterList& 
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto spa_func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto spa_func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   /*
   **    TIME CURVE BUSINESS

--- a/src/so3/4C_so3_nurbs27_evaluate.cpp
+++ b/src/so3/4C_so3_nurbs27_evaluate.cpp
@@ -570,7 +570,7 @@ int Discret::Elements::Nurbs::SoNurbs27::evaluate_neumann(Teuchos::ParameterList
   }
 
   // (SPATIAL) FUNCTION BUSINESS
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SONURBS27, 1> xrefegp(false);
 
   // --------------------------------------------------

--- a/src/so3/4C_so3_poro.cpp
+++ b/src/so3/4C_so3_poro.cpp
@@ -200,7 +200,7 @@ void Discret::Elements::So3Poro<So3Ele, distype>::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISODIR" + std::to_string(dim + 1);
-    if (const auto& dir = container.get<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    if (const auto& dir = container.get<std::optional<std::vector<double>>>(definition_name);
         dir.has_value())
       anisotropic_permeability_directions_[dim] = *dir;
   }
@@ -214,8 +214,7 @@ void Discret::Elements::So3Poro<So3Ele, distype>::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISONODALCOEFFS" + std::to_string(dim + 1);
-    if (const auto* coeffs =
-            container.get_if<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    if (const auto* coeffs = container.get_if<std::optional<std::vector<double>>>(definition_name);
         coeffs && coeffs->has_value())
       anisotropic_permeability_nodal_coeffs_[dim] = coeffs->value();
   }

--- a/src/so3/4C_so3_poro_eletypes.cpp
+++ b/src/so3/4C_so3_poro_eletypes.cpp
@@ -69,18 +69,12 @@ void Discret::Elements::SoHex8PoroType::setup_element_definition(
 
   defs["HEX8"] = all_of({
       defs_hex8["HEX8"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 8}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 8}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS3", {.default_value = std::nullopt, .size = 8}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1", {.size = 8}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2", {.size = 8}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS3", {.size = 8}),
   });
 }
 
@@ -155,18 +149,12 @@ void Discret::Elements::SoTet4PoroType::setup_element_definition(
 
   defs["TET4"] = all_of({
       defs_tet4["TET4"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 4}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 4}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS3", {.default_value = std::nullopt, .size = 4}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1", {.size = 4}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2", {.size = 4}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS3", {.size = 4}),
   });
 }
 
@@ -240,12 +228,9 @@ void Discret::Elements::SoHex27PoroType::setup_element_definition(
 
   defs["HEX27"] = all_of({
       defs_hex27["HEX27"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
   });
 }
 
@@ -319,12 +304,9 @@ void Discret::Elements::SoTet10PoroType::setup_element_definition(
 
   defs["TET10"] = all_of({
       defs_tet10["TET10"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
   });
 }
 
@@ -396,12 +378,9 @@ void Discret::Elements::SoNurbs27PoroType::setup_element_definition(
 
   defs["NURBS27"] = all_of({
       defs_nurbs27["NURBS27"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_poro_eletypes.cpp
+++ b/src/so3/4C_so3_poro_eletypes.cpp
@@ -69,18 +69,18 @@ void Discret::Elements::SoHex8PoroType::setup_element_definition(
 
   defs["HEX8"] = all_of({
       defs_hex8["HEX8"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 8}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 8}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>, .size = 8}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 8}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 8}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.default_value = std::nullopt, .size = 8}),
   });
 }
 
@@ -155,18 +155,18 @@ void Discret::Elements::SoTet4PoroType::setup_element_definition(
 
   defs["TET4"] = all_of({
       defs_tet4["TET4"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 4}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 4}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>, .size = 4}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 4}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 4}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.default_value = std::nullopt, .size = 4}),
   });
 }
 
@@ -240,12 +240,12 @@ void Discret::Elements::SoHex27PoroType::setup_element_definition(
 
   defs["HEX27"] = all_of({
       defs_hex27["HEX27"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 
@@ -319,12 +319,12 @@ void Discret::Elements::SoTet10PoroType::setup_element_definition(
 
   defs["TET10"] = all_of({
       defs_tet10["TET10"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 
@@ -396,12 +396,12 @@ void Discret::Elements::SoNurbs27PoroType::setup_element_definition(
 
   defs["NURBS27"] = all_of({
       defs_nurbs27["NURBS27"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_sh8.cpp
+++ b/src/so3/4C_so3_sh8.cpp
@@ -81,18 +81,12 @@ void Discret::Elements::SoSh8Type::setup_element_definition(
       parameter<std::string>("EAS"),
       parameter<std::string>("ANS"),
       parameter<std::string>("THICKDIR"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_sh8.cpp
+++ b/src/so3/4C_so3_sh8.cpp
@@ -81,18 +81,18 @@ void Discret::Elements::SoSh8Type::setup_element_definition(
       parameter<std::string>("EAS"),
       parameter<std::string>("ANS"),
       parameter<std::string>("THICKDIR"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_surface_evaluate.cpp
+++ b/src/so3/4C_so3_surface_evaluate.cpp
@@ -95,8 +95,7 @@ int Discret::Elements::StructuralSurface::evaluate_neumann(Teuchos::ParameterLis
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto* spa_func =
-      condition.parameters().get_if<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto* spa_func = condition.parameters().get_if<std::vector<std::optional<int>>>("FUNCT");
 
   /*
   **    TIME CURVE BUSINESS

--- a/src/so3/4C_so3_tet10.cpp
+++ b/src/so3/4C_so3_tet10.cpp
@@ -90,18 +90,12 @@ void Discret::Elements::SoTet10Type::setup_element_definition(
       parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_tet10.cpp
+++ b/src/so3/4C_so3_tet10.cpp
@@ -90,18 +90,18 @@ void Discret::Elements::SoTet10Type::setup_element_definition(
       parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_tet10_evaluate.cpp
+++ b/src/so3/4C_so3_tet10_evaluate.cpp
@@ -682,7 +682,7 @@ int Discret::Elements::SoTet10::evaluate_neumann(Teuchos::ParameterList& params,
   }
 
   // (SPATIAL) FUNCTION BUSINESS
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOTET10, 1> xrefegp(false);
 
   /* ============================================================================*

--- a/src/so3/4C_so3_tet4.cpp
+++ b/src/so3/4C_so3_tet4.cpp
@@ -96,18 +96,18 @@ void Discret::Elements::SoTet4Type::setup_element_definition(
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<Noneable<std::vector<double>>>(
-          "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "RAD", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "AXI", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "CIR", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "FIBER3", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_tet4.cpp
+++ b/src/so3/4C_so3_tet4.cpp
@@ -96,18 +96,12 @@ void Discret::Elements::SoTet4Type::setup_element_definition(
       parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
-      parameter<std::optional<std::vector<double>>>(
-          "RAD", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "AXI", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "CIR", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER2", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "FIBER3", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
   });
 }
 

--- a/src/so3/4C_so3_tet4_evaluate.cpp
+++ b/src/so3/4C_so3_tet4_evaluate.cpp
@@ -700,7 +700,7 @@ int Discret::Elements::SoTet4::evaluate_neumann(Teuchos::ParameterList& params,
 
   // (SPATIAL) FUNCTION BUSINESS
   static_assert((NUMGPT_SOTET4 == 1));
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
   Core::LinAlg::Matrix<NUMDIM_SOTET4, 1> xrefegp(false);
 
   /* =============================================================================*

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -62,18 +62,12 @@ namespace
             },
             {.description = "The technology used for prestressing",
                 .default_value = Discret::Elements::PrestressTechnology::none}),
-        parameter<std::optional<std::vector<double>>>(
-            "RAD", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "AXI", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "CIR", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "FIBER1", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "FIBER2", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "FIBER3", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
     });
   }
 }  // namespace

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -62,18 +62,18 @@ namespace
             },
             {.description = "The technology used for prestressing",
                 .default_value = Discret::Elements::PrestressTechnology::none}),
-        parameter<Noneable<std::vector<double>>>(
-            "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "RAD", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "AXI", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "CIR", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "FIBER1", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "FIBER2", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "FIBER3", {.default_value = std::nullopt, .size = 3}),
     });
   }
 }  // namespace

--- a/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
@@ -99,8 +99,7 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
   }
 
   // get ids of functions of space and time
-  const auto& function_ids =
-      condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto& function_ids = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   const ElementNodes<celltype> nodal_coordinates =
       evaluate_element_nodes<celltype>(element, discretization, dof_index_array);

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -52,12 +52,12 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
               },
               {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                               "kinematics (large displacements)"}),
-          parameter<Noneable<std::vector<double>>>(
-              "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 3}),
-          parameter<Noneable<std::vector<double>>>(
-              "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 3}),
-          parameter<Noneable<std::vector<double>>>(
-              "POROANISODIR3", {.default_value = none<std::vector<double>>, .size = 3}),
+          parameter<std::optional<std::vector<double>>>(
+              "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
+          parameter<std::optional<std::vector<double>>>(
+              "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
+          parameter<std::optional<std::vector<double>>>(
+              "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
           selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
@@ -83,15 +83,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::hex8>(),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>,
-                                       .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>,
-                                       .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>,
-                                       .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1",
+          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2",
+          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS3",
+          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
   });
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex27)] =
@@ -102,15 +99,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::tet4)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::tet4>(),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>,
-                                       .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>,
-                                       .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS3", {.default_value = none<std::vector<double>>,
-                                       .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1",
+          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2",
+          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS3",
+          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
   });
 
 
@@ -261,7 +255,7 @@ void Discret::Elements::SolidPoroPressureVelocityBased::
   for (int dim = 0; dim < 3; ++dim)
   {
     std::string definition_name = "POROANISODIR" + std::to_string(dim + 1);
-    const auto& dir = container.get<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    const auto& dir = container.get<std::optional<std::vector<double>>>(definition_name);
     anisotropic_permeability_property_.directions_[dim] = dir ? *dir : std::vector<double>(3, 0.0);
   }
 }
@@ -274,8 +268,7 @@ void Discret::Elements::SolidPoroPressureVelocityBased::
   {
     std::string definition_name = "POROANISONODALCOEFFS" + std::to_string(dim + 1);
 
-    if (const auto* coeffs =
-            container.get_if<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    if (const auto* coeffs = container.get_if<std::optional<std::vector<double>>>(definition_name);
         coeffs && coeffs->has_value())
       anisotropic_permeability_property_.nodal_coeffs_[dim] = coeffs->value();
     else

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -52,12 +52,9 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
               },
               {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                               "kinematics (large displacements)"}),
-          parameter<std::optional<std::vector<double>>>(
-              "POROANISODIR1", {.default_value = std::nullopt, .size = 3}),
-          parameter<std::optional<std::vector<double>>>(
-              "POROANISODIR2", {.default_value = std::nullopt, .size = 3}),
-          parameter<std::optional<std::vector<double>>>(
-              "POROANISODIR3", {.default_value = std::nullopt, .size = 3}),
+          parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
+          parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
+          parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
           selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
@@ -83,12 +80,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::hex8>(),
-      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1",
-          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
-      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2",
-          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
-      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS3",
-          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.size = Core::FE::num_nodes<Core::FE::CellType::hex8>}),
   });
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex27)] =
@@ -99,12 +96,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::setup_element_defini
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::tet4)] = all_of({
       Discret::Elements::SolidPoroPressureVelocityBasedInternal::get_default_input_spec<
           Core::FE::CellType::tet4>(),
-      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1",
-          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
-      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2",
-          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
-      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS3",
-          {.default_value = std::nullopt, .size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS3", {.size = Core::FE::num_nodes<Core::FE::CellType::tet4>}),
   });
 
 

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -54,18 +54,18 @@ namespace
             },
             {.description = "The technology used for prestressing",
                 .default_value = Discret::Elements::PrestressTechnology::none}),
-        parameter<Noneable<std::vector<double>>>(
-            "RAD", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "AXI", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "CIR", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "FIBER1", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "FIBER2", {.default_value = none<std::vector<double>>, .size = 3}),
-        parameter<Noneable<std::vector<double>>>(
-            "FIBER3", {.default_value = none<std::vector<double>>, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "RAD", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "AXI", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "CIR", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "FIBER1", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "FIBER2", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>(
+            "FIBER3", {.default_value = std::nullopt, .size = 3}),
 
     });
   }

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -54,18 +54,12 @@ namespace
             },
             {.description = "The technology used for prestressing",
                 .default_value = Discret::Elements::PrestressTechnology::none}),
-        parameter<std::optional<std::vector<double>>>(
-            "RAD", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "AXI", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "CIR", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "FIBER1", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "FIBER2", {.default_value = std::nullopt, .size = 3}),
-        parameter<std::optional<std::vector<double>>>(
-            "FIBER3", {.default_value = std::nullopt, .size = 3}),
+        parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("FIBER2", {.size = 3}),
+        parameter<std::optional<std::vector<double>>>("FIBER3", {.size = 3}),
 
     });
   }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
@@ -275,7 +275,7 @@ void NOX::Nln::GlobalData::set_status_test_parameters()
       statusTestParams.sublist("Outer Status Test", false);
 
   Teuchos::ParameterList xmlParams;
-  auto xmlfilename = statusTestParams.get<Core::IO::Noneable<std::filesystem::path>>("XML File");
+  auto xmlfilename = statusTestParams.get<std::optional<std::filesystem::path>>("XML File");
 
   // check the input: path to the "Status Test" xml-file
   if (!xmlfilename)

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_utils.cpp
@@ -26,7 +26,7 @@ bool Solid::Nln::SOLVER::is_xml_status_test_file(const Teuchos::ParameterList& p
   bool check = false;
 
   Teuchos::ParameterList pxml;
-  auto xmlfilename = pstatus.get<Core::IO::Noneable<std::filesystem::path>>("XML File");
+  auto xmlfilename = pstatus.get<std::optional<std::filesystem::path>>("XML File");
 
   // check the input: path to the "Status Test" xml-file
   if (xmlfilename)

--- a/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
@@ -145,14 +145,14 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
     // access parameters of the condition
     const std::string* tempstate = &cond->parameters().get<std::string>("temperature_state");
     double coeff = cond->parameters().get<double>("coeff");
-    const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("funct");
+    const auto curvenum = cond->parameters().get<std::optional<int>>("funct");
     const double time = params.get<double>("total time");
 
     // get surrounding temperature T_infty from input file
     double surtemp = cond->parameters().get<double>("surtemp");
     // increase the surrounding temperature T_infty step by step
     // can be scaled with a time curve, get time curve number from input file
-    const auto surtempcurvenum = cond->parameters().get<Core::IO::Noneable<int>>("surtempfunct");
+    const auto surtempcurvenum = cond->parameters().get<std::optional<int>>("surtempfunct");
 
     // find out whether we shall use a time curve for q^_c and get the factor
     double curvefac = 1.0;
@@ -363,15 +363,14 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
         // access parameters of the condition
         const std::string* tempstate = &cond->parameters().get<std::string>("temperature_state");
         double coeff = cond->parameters().get<double>("coeff");
-        const auto curvenum = cond->parameters().get<Core::IO::Noneable<int>>("funct");
+        const auto curvenum = cond->parameters().get<std::optional<int>>("funct");
         const double time = params.get<double>("total time");
 
         // get surrounding temperature T_infty from input file
         double surtemp = cond->parameters().get<double>("surtemp");
         // increase the surrounding temperature T_infty step by step
         // can be scaled with a time curve, get time curve number from input file
-        const auto surtempcurvenum =
-            cond->parameters().get<Core::IO::Noneable<int>>("surtempfunct");
+        const auto surtempcurvenum = cond->parameters().get<std::optional<int>>("surtempfunct");
 
         // find out whether we shall use a time curve for q^_c and get the factor
         double curvefac = 1.0;
@@ -551,7 +550,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate_neumann(const Core::Elements::
   // (assumed to be constant on element boundary)
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto func = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto func = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // integration loop
   for (int iquad = 0; iquad < intpoints.ip().nquad; ++iquad)

--- a/src/thermo/src/element/4C_thermo_ele_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.cpp
@@ -2750,8 +2750,7 @@ void Discret::Elements::TemperImpl<distype>::radiation(
     else if (detJ < 0.0)
       FOUR_C_THROW("NEGATIVE JACOBIAN DETERMINANT");
 
-    const auto funct =
-        myneumcond[0]->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto funct = myneumcond[0]->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
     Core::LinAlg::Matrix<nsd_, 1> xrefegp(false);
     // material/reference co-ordinates of Gauss point

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -219,10 +219,10 @@ void Thermo::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinit
     cond.add_component(parameter<double>("coeff", {.description = "heat transfer coefficient h"}));
     cond.add_component(
         parameter<double>("surtemp", {.description = "surrounding (fluid) temperature T_oo"}));
-    cond.add_component(parameter<Noneable<int>>("surtempfunct",
+    cond.add_component(parameter<std::optional<int>>("surtempfunct",
         {.description =
                 "time curve to increase the surrounding (fluid) temperature T_oo in time"}));
-    cond.add_component(parameter<Noneable<int>>("funct",
+    cond.add_component(parameter<std::optional<int>>("funct",
         {.description =
                 "time curve to increase the complete boundary condition, i.e., the heat flux"}));
     condlist.push_back(cond);

--- a/src/w1/4C_w1_evaluate.cpp
+++ b/src/w1/4C_w1_evaluate.cpp
@@ -405,7 +405,7 @@ int Discret::Elements::Wall1::evaluate_neumann(Teuchos::ParameterList& params,
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // check total time
   double time = -1.0;

--- a/src/w1/4C_w1_line_evaluate.cpp
+++ b/src/w1/4C_w1_line_evaluate.cpp
@@ -65,7 +65,7 @@ int Discret::Elements::Wall1Line::evaluate_neumann(Teuchos::ParameterList& param
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // check total time
   double time = -1.0;

--- a/src/w1/4C_w1_poro.cpp
+++ b/src/w1/4C_w1_poro.cpp
@@ -186,7 +186,7 @@ void Discret::Elements::Wall1Poro<distype>::
   for (int dim = 0; dim < 2; ++dim)
   {
     std::string definition_name = "POROANISODIR" + std::to_string(dim + 1);
-    if (const auto& dir = container.get<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    if (const auto& dir = container.get<std::optional<std::vector<double>>>(definition_name);
         dir.has_value())
       anisotropic_permeability_directions_[dim] = *dir;
   }
@@ -200,8 +200,7 @@ void Discret::Elements::Wall1Poro<distype>::
   for (int dim = 0; dim < 2; ++dim)
   {
     std::string definition_name = "POROANISONODALCOEFFS" + std::to_string(dim + 1);
-    if (const auto* coeffs =
-            container.get_if<Core::IO::Noneable<std::vector<double>>>(definition_name);
+    if (const auto* coeffs = container.get_if<std::optional<std::vector<double>>>(definition_name);
         coeffs && coeffs->has_value())
       anisotropic_permeability_nodal_coeffs_[dim] = coeffs->value();
   }

--- a/src/w1/4C_w1_poro_eletypes.cpp
+++ b/src/w1/4C_w1_poro_eletypes.cpp
@@ -66,14 +66,14 @@ void Discret::Elements::WallQuad4PoroType::setup_element_definition(
 
   defs["QUAD4"] = all_of({
       defs_wall["QUAD4"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 4}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 4}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 4}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 4}),
   });
 }
 
@@ -143,10 +143,10 @@ void Discret::Elements::WallQuad9PoroType::setup_element_definition(
 
   defs["QUAD9"] = all_of({
       defs_wall["QUAD9"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
   });
 }
 
@@ -217,10 +217,10 @@ void Discret::Elements::WallNurbs4PoroType::setup_element_definition(
 
   defs["NURBS4"] = all_of({
       defs_wall["NURBS4"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
   });
 }
 
@@ -291,10 +291,10 @@ void Discret::Elements::WallNurbs9PoroType::setup_element_definition(
 
   defs["NURBS9"] = all_of({
       defs_wall["NURBS9"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
   });
 }
 
@@ -365,14 +365,14 @@ void Discret::Elements::WallTri3PoroType::setup_element_definition(
 
   defs["TRI3"] = all_of({
       defs_wall["TRI3"],
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = none<std::vector<double>>, .size = 2}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = none<std::vector<double>>, .size = 3}),
-      parameter<Noneable<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = none<std::vector<double>>, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>(
+          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 3}),
   });
 }
 

--- a/src/w1/4C_w1_poro_eletypes.cpp
+++ b/src/w1/4C_w1_poro_eletypes.cpp
@@ -66,14 +66,10 @@ void Discret::Elements::WallQuad4PoroType::setup_element_definition(
 
   defs["QUAD4"] = all_of({
       defs_wall["QUAD4"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 4}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 4}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1", {.size = 4}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2", {.size = 4}),
   });
 }
 
@@ -143,10 +139,8 @@ void Discret::Elements::WallQuad9PoroType::setup_element_definition(
 
   defs["QUAD9"] = all_of({
       defs_wall["QUAD9"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 2}),
   });
 }
 
@@ -217,10 +211,8 @@ void Discret::Elements::WallNurbs4PoroType::setup_element_definition(
 
   defs["NURBS4"] = all_of({
       defs_wall["NURBS4"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 2}),
   });
 }
 
@@ -291,10 +283,8 @@ void Discret::Elements::WallNurbs9PoroType::setup_element_definition(
 
   defs["NURBS9"] = all_of({
       defs_wall["NURBS9"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 2}),
   });
 }
 
@@ -365,14 +355,10 @@ void Discret::Elements::WallTri3PoroType::setup_element_definition(
 
   defs["TRI3"] = all_of({
       defs_wall["TRI3"],
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR1", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISODIR2", {.default_value = std::nullopt, .size = 2}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS1", {.default_value = std::nullopt, .size = 3}),
-      parameter<std::optional<std::vector<double>>>(
-          "POROANISONODALCOEFFS2", {.default_value = std::nullopt, .size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 2}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS1", {.size = 3}),
+      parameter<std::optional<std::vector<double>>>("POROANISONODALCOEFFS2", {.size = 3}),
   });
 }
 

--- a/src/w1/4C_w1_poro_p1_evaluate.cpp
+++ b/src/w1/4C_w1_poro_p1_evaluate.cpp
@@ -908,7 +908,7 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate_neumann(Teuchos::Parameter
   // get values and switches from the condition
   const auto onoff = condition.parameters().get<std::vector<int>>("ONOFF");
   const auto val = condition.parameters().get<std::vector<double>>("VAL");
-  const auto funct = condition.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto funct = condition.parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
 
   Core::LinAlg::Matrix<Base::numdim_, Base::numnod_> N_XYZ;

--- a/src/xfem/4C_xfem_coupling_base.cpp
+++ b/src/xfem/4C_xfem_coupling_base.cpp
@@ -559,7 +559,7 @@ void XFEM::CouplingBase::evaluate_function(std::vector<double>& final_values, co
   // get values and switches from the condition
   const auto onoff = cond->parameters().get<std::vector<int>>("ONOFF");
   const auto val = cond->parameters().get<std::vector<double>>("VAL");
-  const auto functions = cond->parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+  const auto functions = cond->parameters().get<std::vector<std::optional<int>>>("FUNCT");
 
   // uniformly distributed random noise
   auto& secondary = const_cast<Core::Conditions::Condition&>(*cond);

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -1240,9 +1240,9 @@ void XFEM::LevelSetCouplingNavierSlip::set_element_conditions()
 
   // Get robin coupling IDs
   const auto maybe_robin_dirichlet_id =
-      cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_DIRICHLET_ID");
+      cond->parameters().get<std::optional<int>>("ROBIN_DIRICHLET_ID");
   const auto maybe_robin_neumann_id =
-      cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_NEUMANN_ID");
+      cond->parameters().get<std::optional<int>>("ROBIN_NEUMANN_ID");
 
   // zero based robin coupling IDs
   robin_dirichlet_id_ = maybe_robin_dirichlet_id.value_or(-1) - 1;
@@ -1422,7 +1422,7 @@ void XFEM::LevelSetCouplingNavierSlip::get_condition_by_robin_id(
   for (size_t i = 0; i < mycond.size(); ++i)
   {
     Core::Conditions::Condition* cond = mycond[i];
-    const auto maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_ID");
+    const auto maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_ID");
     const int id = maybe_id.value_or(-1) - 1;
 
     if (id == coupling_id) mynewcond.push_back(cond);

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1251,7 +1251,7 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions(Core::LinAlg::Ma
   if (eval_dirich_at_gp)
   {
     // evaluate interface velocity (given by weak Dirichlet condition)
-    const auto maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_DIRICHLET_ID");
+    const auto maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_DIRICHLET_ID");
     robin_id = maybe_id.value_or(-1) - 1;
 
     if (robin_id >= 0)
@@ -1269,7 +1269,7 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions(Core::LinAlg::Ma
   }
 
   // evaluate interface traction (given by Neumann condition)
-  const auto maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_NEUMANN_ID");
+  const auto maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_NEUMANN_ID");
   robin_id = maybe_id.value_or(-1) - 1;
 
   if (robin_id >= 0)
@@ -1344,7 +1344,7 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions_old_state(
   //  }
 
   // evaluate interface velocity (given by weak Dirichlet condition)
-  auto maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_DIRICHLET_ID");
+  auto maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_DIRICHLET_ID");
   int robin_id = maybe_id.value_or(-1) - 1;
 
   if (robin_id >= 0)
@@ -1352,7 +1352,7 @@ void XFEM::MeshCouplingNavierSlip::evaluate_coupling_conditions_old_state(
         ivel, x, conditionsmap_robin_dirch_.find(robin_id)->second, time_ - dt_);
 
   // evaluate interface traction (given by Neumann condition)
-  maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_NEUMANN_ID");
+  maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_NEUMANN_ID");
   robin_id = maybe_id.value_or(-1) - 1;
 
   if (robin_id >= 0)
@@ -1394,7 +1394,7 @@ void XFEM::MeshCouplingNavierSlip::create_robin_id_map(
   {
     // Extract its robin id (either dirichlet or neumann)
     const auto maybe_robin_id =
-        conditions_NS[i]->parameters().get<Core::IO::Noneable<int>>(robin_id_name);
+        conditions_NS[i]->parameters().get<std::optional<int>>(robin_id_name);
     const int tmp_robin_id = maybe_robin_id.value_or(-1) - 1;
 
     // Is this robin id active? I.e. is it not 0 or negative?
@@ -1491,7 +1491,7 @@ void XFEM::MeshCouplingNavierSlip::set_condition_specific_parameters()
   for (auto* tmp_cond : conditions_NS)
   {
     const auto maybe_robin_id =
-        tmp_cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_DIRICHLET_ID");
+        tmp_cond->parameters().get<std::optional<int>>("ROBIN_DIRICHLET_ID");
     const auto tmp_robin_id = maybe_robin_id.value_or(-1) - 1;
 
     if (tmp_robin_id >= 0)
@@ -1514,7 +1514,7 @@ void XFEM::MeshCouplingNavierSlip::get_condition_by_robin_id(
   // select the conditions with specified "ROBIN_ID"
   for (auto* cond : mycond)
   {
-    const auto maybe_robin_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_ID");
+    const auto maybe_robin_id = cond->parameters().get<std::optional<int>>("ROBIN_ID");
     const int id_zero_based = maybe_robin_id.value_or(-1) - 1;
 
     if (id_zero_based == coupling_id) mynewcond.push_back(cond);

--- a/src/xfem/4C_xfem_coupling_mesh_coupled_levelset.hpp
+++ b/src/xfem/4C_xfem_coupling_mesh_coupled_levelset.hpp
@@ -69,7 +69,7 @@ namespace XFEM
       if (eval_dirich_at_gp)
       {
         // evaluate interface velocity (given by weak Dirichlet condition)
-        const auto maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_DIRICHLET_ID");
+        const auto maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_DIRICHLET_ID");
         robin_id = maybe_id.value_or(-1) - 1;
         if (robin_id >= 0)
           evaluate_dirichlet_function(
@@ -86,7 +86,7 @@ namespace XFEM
       }
 
       // evaluate interface traction (given by Neumann condition)
-      const auto maybe_id = cond->parameters().get<Core::IO::Noneable<int>>("ROBIN_NEUMANN_ID");
+      const auto maybe_id = cond->parameters().get<std::optional<int>>("ROBIN_NEUMANN_ID");
       robin_id = maybe_id.value_or(-1) - 1;
 
       if (robin_id >= 0)

--- a/src/xfem/4C_xfem_neumann.cpp
+++ b/src/xfem/4C_xfem_neumann.cpp
@@ -115,7 +115,7 @@ void XFEM::evaluate_neumann_standard(
     const std::vector<int>* nodeids = cond.get_nodes();
     if (!nodeids) FOUR_C_THROW("PointNeumann condition does not have nodal cloud");
     const int nnode = (*nodeids).size();
-    const auto funct = cond.parameters().get<std::vector<Core::IO::Noneable<int>>>("FUNCT");
+    const auto funct = cond.parameters().get<std::vector<std::optional<int>>>("FUNCT");
     const auto onoff = cond.parameters().get<std::vector<int>>("ONOFF");
     const auto val = cond.parameters().get<std::vector<double>>("VAL");
 

--- a/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
+++ b/unittests/mat/4C_inelastic_defgrad_factors_test.cpp
@@ -395,14 +395,14 @@ namespace
 
       // define setup parameter for InelasticDefGradTransvIsotropElastViscoplast
       Core::IO::InputParameterContainer setup_transv_isotrop_elast_viscoplast;
-      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
+      setup_transv_isotrop_elast_viscoplast.add<std::optional<std::vector<double>>>(
           "FIBER1", std::vector<double>{0.0, 0.0, 1.0});
-      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
-          "RAD", Core::IO::none<std::vector<double>>);
-      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
-          "AXI", Core::IO::none<std::vector<double>>);
-      setup_transv_isotrop_elast_viscoplast.add<Core::IO::Noneable<std::vector<double>>>(
-          "CIR", Core::IO::none<std::vector<double>>);
+      setup_transv_isotrop_elast_viscoplast.add<std::optional<std::vector<double>>>(
+          "RAD", std::nullopt);
+      setup_transv_isotrop_elast_viscoplast.add<std::optional<std::vector<double>>>(
+          "AXI", std::nullopt);
+      setup_transv_isotrop_elast_viscoplast.add<std::optional<std::vector<double>>>(
+          "CIR", std::nullopt);
 
       // call setup method for InelasticDefGradTransvIsotropElastViscoplast
       transv_isotrop_elast_viscoplast_->setup(8, setup_transv_isotrop_elast_viscoplast);


### PR DESCRIPTION
As outlined in #437, we can do the following things:

- `Noneable` is just `std::optional` now since we no longer have the `.required` field, so there should be no confusion about what this type means.
- When reading `parameter<std::optional<int>>("name")`, you expect that this parameter "name" does not have to be given in the input file and, if indeed not given, its value should be empty. Thus, the code is changed to no longer accept any `.default_value` if your parameter is a `std::optional<T>`.

Closes #437 