### PR TITLE
Clean-up MASSLIN input parameter

### DIFF
--- a/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
@@ -556,7 +556,7 @@ void CONTACT::Beam3cmanager::evaluate(Core::LinAlg::SparseMatrix& stiffmatrix,
   t_start = Teuchos::Time::wallTime();
 
   if (Teuchos::getIntegralValue<Inpar::Solid::MassLin>(sstructdynamic_, "MASSLIN") !=
-      Inpar::Solid::ml_rotations)
+      Inpar::Solid::MassLin::ml_rotations)
   {
     // assemble contact forces into global fres vector
     fres.Update(1.0 - alphaf_, *fc_, 1.0);

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -188,9 +188,8 @@ namespace Inpar
           "LOADLIN", false, "Use linearization of external follower load in Newton", sdyn);
 
       Core::Utils::string_to_integral_parameter<Solid::MassLin>("MASSLIN", "none",
-          "Application of nonlinear inertia terms",
-          tuple<std::string>("none", "standard", "rotations"),
-          tuple<Solid::MassLin>(ml_none, ml_standard, ml_rotations), sdyn);
+          "Application of nonlinear inertia terms", tuple<std::string>("none", "rotations"),
+          tuple<Solid::MassLin>(ml_none, ml_rotations), sdyn);
 
       Core::Utils::bool_parameter("NEGLECTINERTIA", false, "Neglect inertia", sdyn);
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -187,9 +187,11 @@ namespace Inpar
       Core::Utils::bool_parameter(
           "LOADLIN", false, "Use linearization of external follower load in Newton", sdyn);
 
-      Core::Utils::string_to_integral_parameter<Solid::MassLin>("MASSLIN", "none",
+      Core::Utils::string_to_integral_parameter<Inpar::Solid::MassLin>("MASSLIN", "none",
           "Application of nonlinear inertia terms", tuple<std::string>("none", "rotations"),
-          tuple<Solid::MassLin>(ml_none, ml_rotations), sdyn);
+          tuple<Inpar::Solid::MassLin>(
+              Inpar::Solid::MassLin::ml_none, Inpar::Solid::MassLin::ml_rotations),
+          sdyn);
 
       Core::Utils::bool_parameter("NEGLECTINERTIA", false, "Neglect inertia", sdyn);
 

--- a/src/inpar/4C_inpar_structure.hpp
+++ b/src/inpar/4C_inpar_structure.hpp
@@ -356,7 +356,6 @@ namespace Inpar
     enum MassLin
     {
       ml_none,      ///< constant mass matrix
-      ml_standard,  ///< nonlinear inertia terms, translational DoFs
       ml_rotations  ///< nonlinear inertia terms, rotational DoFs
     };
 

--- a/src/inpar/4C_inpar_structure.hpp
+++ b/src/inpar/4C_inpar_structure.hpp
@@ -353,7 +353,7 @@ namespace Inpar
     //!@{
 
     /// have inertia forces to be linearized?
-    enum MassLin
+    enum class MassLin
     {
       ml_none,      ///< constant mass matrix
       ml_rotations  ///< nonlinear inertia terms, rotational DoFs

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -654,7 +654,8 @@ std::shared_ptr<Mat::InelasticDefgradFactors> Mat::InelasticDefgradFactors::fact
 
   // check correct masslin type
   const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
-  if (Teuchos::getIntegralValue<Inpar::Solid::MassLin>(sdyn, "MASSLIN") != Inpar::Solid::ml_none)
+  if (Teuchos::getIntegralValue<Inpar::Solid::MassLin>(sdyn, "MASSLIN") !=
+      Inpar::Solid::MassLin::ml_none)
   {
     FOUR_C_THROW(
         "If you use the material 'InelasticDefgradFactors' please set 'MASSLIN' in the "

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -365,7 +365,7 @@ void Solid::TimInt::create_fields()
   mass_ = std::make_shared<Core::LinAlg::SparseMatrix>(*dof_row_map_view(), 81, false, true);
   if (damping_ != Inpar::Solid::damp_none)
   {
-    if (have_nonlinear_mass() == Inpar::Solid::ml_none)
+    if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
     {
       damp_ = std::make_shared<Core::LinAlg::SparseMatrix>(*dof_row_map_view(), 81, false, true);
     }
@@ -2516,7 +2516,7 @@ void Solid::TimInt::apply_force_external(const double time,
 
 /*----------------------------------------------------------------------*/
 /* check whether we have nonlinear inertia forces or not */
-int Solid::TimInt::have_nonlinear_mass() const
+Inpar::Solid::MassLin Solid::TimInt::have_nonlinear_mass() const
 {
   const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
   auto masslin = Teuchos::getIntegralValue<Inpar::Solid::MassLin>(sdyn, "MASSLIN");
@@ -2564,7 +2564,7 @@ void Solid::TimInt::nonlinear_mass_sanity_check(
         dispnorm, velnorm, accnorm);
   }
 
-  if (have_nonlinear_mass() == Inpar::Solid::ml_rotations and
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_rotations and
       Teuchos::getIntegralValue<Inpar::Solid::PredEnum>(*sdynparams, "PREDICT") !=
           Inpar::Solid::pred_constdis)
   {
@@ -2575,7 +2575,7 @@ void Solid::TimInt::nonlinear_mass_sanity_check(
 
   if (sdynparams != nullptr)
   {
-    if (have_nonlinear_mass() == Inpar::Solid::ml_rotations and
+    if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_rotations and
         Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(*sdynparams, "DYNAMICTYPE") !=
             Inpar::Solid::dyna_genalpha)
     {

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -523,7 +523,7 @@ namespace Solid
     //@{
 
     //! Return bool indicating if we have nonlinear inertia forces
-    int have_nonlinear_mass() const;
+    Inpar::Solid::MassLin have_nonlinear_mass() const;
 
     //! check whether the initial conditions are fulfilled */
     virtual void nonlinear_mass_sanity_check(

--- a/src/structure/4C_structure_timint_expl.cpp
+++ b/src/structure/4C_structure_timint_expl.cpp
@@ -86,7 +86,7 @@ void Solid::TimIntExpl::setup()
     FOUR_C_THROW("Explicit time integration schemes cannot handle local co-ordinate systems");
 
   // explicit time integrators cannot handle nonlinear inertia forces
-  if (have_nonlinear_mass())
+  if (have_nonlinear_mass() != Inpar::Solid::MassLin::ml_none)
     FOUR_C_THROW(
         "Explicit time integration schemes cannot handle nonlinear inertia forces (flag: MASSLIN)");
 

--- a/src/structure/4C_structure_timint_genalpha.cpp
+++ b/src/structure/4C_structure_timint_genalpha.cpp
@@ -150,7 +150,7 @@ void Solid::TimIntGenAlpha::setup()
   // call setup() in base class
   Solid::TimIntImpl::setup();
 
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // determine mass, damping and initial accelerations
     determine_mass_damp_consist_accel();
@@ -221,7 +221,7 @@ void Solid::TimIntGenAlpha::setup()
   pwindk.set("time_step_size", (*dt_)[0]);
   apply_force_stiff_cardiovascular0_d((*time_)[0], (*dis_)(0), fint_, stiff_, pwindk);
 
-  if (have_nonlinear_mass() == Inpar::Solid::ml_none)
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // set initial internal force vector
     apply_force_stiff_internal(
@@ -239,7 +239,8 @@ void Solid::TimIntGenAlpha::setup()
 
     nonlinear_mass_sanity_check(fext_, (*dis_)(0), (*vel_)(0), (*acc_)(0), &sdynparams_);
 
-    if (have_nonlinear_mass() == Inpar::Solid::ml_rotations and !solely_beam3_elements(*discret_))
+    if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_rotations and
+        !solely_beam3_elements(*discret_))
     {
       FOUR_C_THROW(
           "Multiplicative Gen-Alpha time integration scheme only implemented for beam elements so "
@@ -352,7 +353,7 @@ void Solid::TimIntGenAlpha::evaluate_force_stiff_residual(Teuchos::ParameterList
   // ************************** (2) INTERNAL FORCES ***************************
   fintn_->PutScalar(0.0);
   // build new internal forces and stiffness
-  if (have_nonlinear_mass() == Inpar::Solid::ml_none)
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     apply_force_stiff_internal(
         timen_, (*dt_)[0], disn_, disi_, veln_, fintn_, stiff_, params, damp_);
@@ -417,7 +418,7 @@ void Solid::TimIntGenAlpha::evaluate_force_stiff_residual(Teuchos::ParameterList
   // ************************** (3) INERTIA FORCES ***************************
 
   // build new inertia forces and stiffness
-  if (have_nonlinear_mass() == Inpar::Solid::ml_none)
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // build new inertia forces and stiffness
     finertm_->PutScalar(0.0);
@@ -442,7 +443,7 @@ void Solid::TimIntGenAlpha::evaluate_force_stiff_residual(Teuchos::ParameterList
   // ******************** Finally, put everything together ********************
 
   // build residual and tangent matrix for standard case
-  if (have_nonlinear_mass() != Inpar::Solid::ml_rotations)
+  if (have_nonlinear_mass() != Inpar::Solid::MassLin::ml_rotations)
   {
     // build residual
     //    Res = M . A_{n+1-alpha_m}
@@ -510,7 +511,7 @@ void Solid::TimIntGenAlpha::evaluate_force_stiff_residual_relax(Teuchos::Paramet
   evaluate_force_stiff_residual(params);
 
   // overwrite the residual forces #fres_ with interface load
-  if (have_nonlinear_mass() != Inpar::Solid::ml_rotations)
+  if (have_nonlinear_mass() != Inpar::Solid::MassLin::ml_rotations)
   {
     // standard case
     fres_->Update(-1 + alphaf_, *fifc_, 0.0);
@@ -548,7 +549,7 @@ void Solid::TimIntGenAlpha::evaluate_force_residual()
   fintn_->PutScalar(0.0);
 
   // build new internal forces and stiffness
-  if (have_nonlinear_mass() == Inpar::Solid::ml_none)
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     apply_force_internal(timen_, (*dt_)[0], disn_, disi_, veln_, fintn_);
   }
@@ -564,7 +565,7 @@ void Solid::TimIntGenAlpha::evaluate_force_residual()
   // ************************** (3) INERTIAL FORCES ***************************
 
   // build new inertia forces and stiffness
-  if (have_nonlinear_mass() == Inpar::Solid::ml_none)
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // build new inertia forces and stiffness
     finertm_->PutScalar(0.0);
@@ -587,7 +588,7 @@ void Solid::TimIntGenAlpha::evaluate_force_residual()
   // ******************** Finally, put everything together ********************
 
   // build residual and tangent matrix for standard case
-  if (have_nonlinear_mass() != Inpar::Solid::ml_rotations)
+  if (have_nonlinear_mass() != Inpar::Solid::MassLin::ml_rotations)
   {
     // build residual
     //    Res = M . A_{n+1-alpha_m}
@@ -784,7 +785,7 @@ void Solid::TimIntGenAlpha::update_step_element()
   discret_->clear_state();
   discret_->set_state("displacement", (*dis_)(0));
 
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
   }

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -926,7 +926,7 @@ void Solid::TimIntImpl::apply_force_stiff_internal_and_inertial(const double tim
   params.set("timintfac_dis", timintfac_dis);
   params.set("timintfac_vel", timintfac_vel);
 
-  if (have_nonlinear_mass() == Inpar::Solid::ml_rotations)
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_rotations)
   {
     params.set("rot_beta", beta);
     params.set("rot_gamma", gamma);
@@ -4209,7 +4209,7 @@ void Solid::TimIntImpl::use_block_matrix(
     p.set("delta time", (*dt_)[0]);
 
     std::shared_ptr<Core::LinAlg::Vector<double>> finert = nullptr;
-    if (have_nonlinear_mass())
+    if (have_nonlinear_mass() != Inpar::Solid::MassLin::ml_none)
     {
       finert = Core::LinAlg::create_vector(*dof_row_map_view(), true);  // inertial force
       // Note: the following parameters are just dummies, since they are only needed to calculate

--- a/src/structure/4C_structure_timint_ost.cpp
+++ b/src/structure/4C_structure_timint_ost.cpp
@@ -87,7 +87,7 @@ void Solid::TimIntOneStepTheta::setup()
   // call setup() in base class
   Solid::TimIntImpl::setup();
 
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // determine mass, damping and initial accelerations
     determine_mass_damp_consist_accel();
@@ -142,7 +142,7 @@ void Solid::TimIntOneStepTheta::setup()
   pwindk.set("time_step_size", (*dt_)[0]);
   apply_force_stiff_cardiovascular0_d((*time_)[0], (*dis_)(0), fint_, stiff_, pwindk);
 
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // set initial internal force vector
     apply_force_stiff_internal(
@@ -281,7 +281,7 @@ void Solid::TimIntOneStepTheta::evaluate_force_stiff_residual(Teuchos::Parameter
   fintn_->PutScalar(0.0);
 
   // build new internal forces and stiffness
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // ordinary internal force and stiffness
     apply_force_stiff_internal(
@@ -340,7 +340,7 @@ void Solid::TimIntOneStepTheta::evaluate_force_stiff_residual(Teuchos::Parameter
   // ************************** (3) INERTIAL FORCES ***************************
 
   // build new internal forces and stiffness
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // inertial forces #finertt_
     mass_->multiply(false, *acct_, *finertt_);
@@ -436,7 +436,7 @@ void Solid::TimIntOneStepTheta::evaluate_force_residual()
   fintn_->PutScalar(0.0);
 
   // build new internal forces and stiffness
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // ordinary internal force and stiffness
     apply_force_internal(timen_, (*dt_)[0], disn_, disi_, veln_, fintn_);
@@ -449,7 +449,7 @@ void Solid::TimIntOneStepTheta::evaluate_force_residual()
   // ************************** (3) INERTIAL FORCES ***************************
 
   // build new internal forces and stiffness
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     // inertial forces #finertt_
     mass_->multiply(false, *acct_, *finertt_);
@@ -652,7 +652,7 @@ void Solid::TimIntOneStepTheta::update_step_element()
   discret_->clear_state();
   discret_->set_state("displacement", (*dis_)(0));
 
-  if (!have_nonlinear_mass())
+  if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
     discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
   }

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -204,7 +204,7 @@ void Solid::TimeInt::BaseDataGlobalState::setup()
   mass_ = std::make_shared<Core::LinAlg::SparseMatrix>(*dof_row_map_view(), 81, true, true);
   if (datasdyn_->get_damping_type() != Inpar::Solid::damp_none)
   {
-    if (datasdyn_->get_mass_lin_type() == Inpar::Solid::ml_none)
+    if (datasdyn_->get_mass_lin_type() == Inpar::Solid::MassLin::ml_none)
     {
       damp_ = std::make_shared<Core::LinAlg::SparseMatrix>(*dof_row_map_view(), 81, true, true);
     }
@@ -218,7 +218,7 @@ void Solid::TimeInt::BaseDataGlobalState::setup()
   }
 
   if (datasdyn_->get_dynamic_type() == Inpar::Solid::dyna_statics and
-      datasdyn_->get_mass_lin_type() != Inpar::Solid::ml_none)
+      datasdyn_->get_mass_lin_type() != Inpar::Solid::MassLin::ml_none)
     FOUR_C_THROW(
         "Do not set parameter MASSLIN in static simulations as this leads to undesired"
         " evaluation of mass matrix on element level!");

--- a/src/structure_new/src/4C_structure_new_timint_basedatasdyn.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedatasdyn.cpp
@@ -31,7 +31,7 @@ Solid::TimeInt::BaseDataSDyn::BaseDataSDyn()
       damptype_(Inpar::Solid::damp_none),
       dampk_(-1.0),
       dampm_(-1.0),
-      masslintype_(Inpar::Solid::ml_none),
+      masslintype_(Inpar::Solid::MassLin::ml_none),
       lumpmass_(false),
       neglectinertia_(false),
       modeltypes_(nullptr),

--- a/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.cpp
@@ -135,7 +135,7 @@ void Solid::IMPLICIT::GenAlpha::post_setup()
   // check for applicability of classical GenAlpha scheme
   // ---------------------------------------------------------------------------
   // set the constant parameters for the element evaluation
-  if (tim_int().get_data_sdyn().get_mass_lin_type() == Inpar::Solid::ml_rotations)
+  if (tim_int().get_data_sdyn().get_mass_lin_type() == Inpar::Solid::MassLin::ml_rotations)
   {
     FOUR_C_THROW(
         "MASSLIN=ml_rotations is not supported by classical GenAlpha! "

--- a/src/structure_new/src/implicit/4C_structure_new_impl_genalpha_liegroup.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_genalpha_liegroup.cpp
@@ -49,7 +49,8 @@ void Solid::IMPLICIT::GenAlphaLieGroup::post_setup()
 {
   check_init_setup();
 
-  if (sdyn().get_mass_lin_type() != Inpar::Solid::ml_rotations and !sdyn().neglect_inertia())
+  if (sdyn().get_mass_lin_type() != Inpar::Solid::MassLin::ml_rotations and
+      !sdyn().neglect_inertia())
   {
     /* we can use this method for all elements with additive DoFs,
      * but it won't work like this for non-additive rotation vector DoFs */
@@ -298,7 +299,7 @@ void Solid::IMPLICIT::GenAlphaLieGroup::reset_eval_params()
 
   /* in case we have non-additive rotation (pseudo-)vector DOFs, we need to pass
    * the GenAlpha parameters to the beam elements via beam parameter interface */
-  if (tim_int().get_data_sdyn().get_mass_lin_type() == Inpar::Solid::ml_rotations)
+  if (tim_int().get_data_sdyn().get_mass_lin_type() == Inpar::Solid::MassLin::ml_rotations)
   {
     eval_data().get_beam_data().set_beta(beta_);
     eval_data().get_beam_data().set_gamma(gamma_);

--- a/src/structure_new/src/implicit/4C_structure_new_impl_ost.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_ost.cpp
@@ -81,7 +81,8 @@ void Solid::IMPLICIT::OneStepTheta::post_setup()
 {
   check_init_setup();
 
-  if (sdyn().get_mass_lin_type() != Inpar::Solid::ml_rotations and !sdyn().neglect_inertia())
+  if (sdyn().get_mass_lin_type() != Inpar::Solid::MassLin::ml_rotations and
+      !sdyn().neglect_inertia())
   {
     /* we can use this method for all elements with additive DoFs,
      * but it won't work like this for non-additive rotation vector DoFs */

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -43,7 +43,7 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------------*/
 Solid::ModelEvaluator::Structure::Structure()
     : dt_ele_ptr_(nullptr),
-      masslin_type_(Inpar::Solid::ml_none),
+      masslin_type_(Inpar::Solid::MassLin::ml_none),
       stiff_ptr_(nullptr),
       stiff_ptc_ptr_(nullptr),
       dis_incr_ptr_(nullptr),
@@ -423,7 +423,7 @@ bool Solid::ModelEvaluator::Structure::apply_force_stiff_internal()
   // set action types and evaluate matrices/vectors
   static_contributions(eval_mat.data(), eval_vec.data());
   material_damping_contributions(eval_mat.data());
-  if (masslin_type_ != Inpar::Solid::ml_none)
+  if (masslin_type_ != Inpar::Solid::MassLin::ml_none)
     inertial_contributions(eval_mat.data(), eval_vec.data());
 
   // evaluate
@@ -517,7 +517,8 @@ void Solid::ModelEvaluator::Structure::inertial_contributions(
 {
   check_init_setup();
 
-  if (masslin_type_ == Inpar::Solid::ml_none or tim_int().get_data_sdyn_ptr()->neglect_inertia())
+  if (masslin_type_ == Inpar::Solid::MassLin::ml_none or
+      tim_int().get_data_sdyn_ptr()->neglect_inertia())
     return;
 
   // overwrite element action
@@ -536,7 +537,8 @@ void Solid::ModelEvaluator::Structure::inertial_and_viscous_forces()
 {
   check_init_setup();
 
-  if (masslin_type_ == Inpar::Solid::ml_none and !tim_int().get_data_sdyn_ptr()->neglect_inertia())
+  if (masslin_type_ == Inpar::Solid::MassLin::ml_none and
+      !tim_int().get_data_sdyn_ptr()->neglect_inertia())
   {
     // calculate the inertial force at t_{n+1}
     mass().multiply(false, *global_state().get_acc_np(), finertial_np());
@@ -579,14 +581,14 @@ std::shared_ptr<Core::LinAlg::Vector<double>> Solid::ModelEvaluator::Structure::
 {
   switch (masslin_type_)
   {
-    case Inpar::Solid::ml_rotations:
+    case Inpar::Solid::MassLin::ml_rotations:
     {
       finertial_np().PutScalar(0.0);
       // set inertial force
       return global_state().get_finertial_np();
       break;
     }
-    case Inpar::Solid::ml_none:
+    case Inpar::Solid::MassLin::ml_none:
       // do nothing
       break;
     default:
@@ -1591,7 +1593,7 @@ void Solid::ModelEvaluator::Structure::determine_energy(const Core::LinAlg::Vect
   determine_strain_energy(disnp, global);
 
   // global calculation of kinetic energy
-  if (masslin_type_ == Inpar::Solid::ml_none and velnp != nullptr)
+  if (masslin_type_ == Inpar::Solid::MassLin::ml_none and velnp != nullptr)
   {
     double kinetic_energy_times2 = 0.0;
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -580,7 +580,6 @@ std::shared_ptr<Core::LinAlg::Vector<double>> Solid::ModelEvaluator::Structure::
   switch (masslin_type_)
   {
     case Inpar::Solid::ml_rotations:
-    case Inpar::Solid::ml_standard:
     {
       finertial_np().PutScalar(0.0);
       // set inertial force


### PR DESCRIPTION
## Description and Context

- remove obsolete input option (cf. #423)
- convert underlying `enum` to `enum class`

## Related Issues and Pull Requests

Closes #423 