### PR TITLE
Prepare solid poro pressure based for solid poro p1

### DIFF
--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
@@ -88,8 +88,8 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::evaluate_nonlin
             evaluate_inverse_cauchy_green_linearization(
                 cauchygreen, jacobian_mapping, spatial_material_mapping);
 
-        const double volchange = compute_volume_change<celltype>(spatial_material_mapping,
-            jacobian_mapping, ele, discretization, la[0].lm_, kinematictype);
+        const double volchange = compute_volume_change<celltype>(nodal_coordinates.displacements,
+            spatial_material_mapping, jacobian_mapping, ele, kinematictype);
 
         Core::LinAlg::Matrix<1, num_dof_per_ele_> dDetDefGrad_dDisp =
             compute_linearization_of_detdefgrad_wrt_disp<celltype>(
@@ -206,8 +206,8 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<
             evaluate_strain_gradient(jacobian_mapping, spatial_material_mapping);
 
         // volume change (used for porosity law). Same as J in nonlinear theory.
-        const double volchange = compute_volume_change<celltype>(spatial_material_mapping,
-            jacobian_mapping, ele, discretization, la[0].lm_, kinematictype);
+        const double volchange = compute_volume_change<celltype>(nodal_coordinates.displacements,
+            spatial_material_mapping, jacobian_mapping, ele, kinematictype);
 
         std::vector<double> fluidmultiphase_phiAtGP =
             compute_fluid_multiphase_primary_variables_at_gp<celltype>(

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.hpp
@@ -14,7 +14,7 @@
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_utils_gausspoints.hpp"
 #include "4C_solid_poro_3D_ele_calc_interface.hpp"
-#include "4C_solid_poro_3D_ele_calc_lib_io.hpp"
+#include "4C_solid_poro_3D_ele_calc_lib.hpp"
 #include "4C_solid_poro_3D_ele_properties.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -43,16 +43,18 @@ namespace Discret
       void evaluate_nonlinear_force_stiffness(const Core::Elements::Element& ele,
           Mat::StructPoro& porostructmat, Mat::FluidPoro& porofluidmat,
           AnisotropyProperties anisotropy_properties, const Inpar::Solid::KinemType& kinematictype,
-          const Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Teuchos::ParameterList& params, Core::LinAlg::SerialDenseVector* force_vector,
+          const Core::FE::Discretization& discretization,
+          const SolidPoroPrimaryVariables& primary_variables, Teuchos::ParameterList& params,
+          Core::LinAlg::SerialDenseVector* force_vector,
           Core::LinAlg::SerialDenseMatrix* stiffness_matrix,
           Core::LinAlg::SerialDenseMatrix* reactive_matrix);
 
       void evaluate_nonlinear_force_stiffness_od(const Core::Elements::Element& ele,
           Mat::StructPoro& porostructmat, Mat::FluidPoro& porofluidmat,
           AnisotropyProperties anisotropy_properties, const Inpar::Solid::KinemType& kinematictype,
-          const Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Teuchos::ParameterList& params, Core::LinAlg::SerialDenseMatrix* stiffness_matrix);
+          const Core::FE::Discretization& discretization,
+          const SolidPoroPrimaryVariables& primary_variables, Teuchos::ParameterList& params,
+          Core::LinAlg::SerialDenseMatrix* stiffness_matrix);
 
       void poro_setup(
           Mat::StructPoro& porostructmat, const Core::IO::InputParameterContainer& container);
@@ -62,7 +64,7 @@ namespace Discret
       void coupling_stress_poroelast(const Core::Elements::Element& ele,
           Mat::StructPoro& porostructmat, const Inpar::Solid::KinemType& kinematictype,
           const CouplStressIO& couplingstressIO, const Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Teuchos::ParameterList& params);
+          const SolidPoroPrimaryVariables& primary_variables, Teuchos::ParameterList& params);
 
 
 

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_evaluate.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_evaluate.cpp
@@ -9,9 +9,10 @@
 #include "4C_fem_general_cell_type_traits.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_utils_interpolation.hpp"
-#include "4C_mat_structporo.hpp"
+#include "4C_legacy_enum_definitions_element_actions.hpp"
 #include "4C_solid_3D_ele_calc_lib.hpp"
 #include "4C_solid_3D_ele_factory.hpp"
+#include "4C_solid_poro_3D_ele_calc_lib_io.hpp"
 #include "4C_solid_poro_3D_ele_pressure_velocity_based.hpp"
 #include "4C_solid_scatra_3D_ele_factory.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -97,13 +98,15 @@ int Discret::Elements::SolidPoroPressureVelocityBased::evaluate(Teuchos::Paramet
       {
         if (discretization.has_state(1, "fluidvel"))
         {
+          const SolidPoroPrimaryVariables primary_variables =
+              extract_solid_poro_primary_variables(discretization, la, shape());
           std::visit(
               [&](auto& interface)
               {
                 interface->evaluate_nonlinear_force_stiffness(*this, this->struct_poro_material(),
                     this->fluid_poro_material(), this->get_anisotropic_permeability_property(),
-                    this->kinematic_type(), discretization, la, params, &elevec1, &elemat1,
-                    &elemat2);
+                    this->kinematic_type(), discretization, primary_variables, params, &elevec1,
+                    &elemat1, &elemat2);
               },
               solidporo_press_vel_based_calc_variant_);
         }
@@ -125,12 +128,15 @@ int Discret::Elements::SolidPoroPressureVelocityBased::evaluate(Teuchos::Paramet
       {
         if (discretization.has_state(1, "fluidvel"))
         {
+          const SolidPoroPrimaryVariables primary_variables =
+              extract_solid_poro_primary_variables(discretization, la, shape());
           std::visit(
               [&](auto& interface)
               {
                 interface->evaluate_nonlinear_force_stiffness(*this, this->struct_poro_material(),
                     this->fluid_poro_material(), this->get_anisotropic_permeability_property(),
-                    this->kinematic_type(), discretization, la, params, &elevec1, nullptr, nullptr);
+                    this->kinematic_type(), discretization, primary_variables, params, &elevec1,
+                    nullptr, nullptr);
               },
               solidporo_press_vel_based_calc_variant_);
         }
@@ -152,13 +158,15 @@ int Discret::Elements::SolidPoroPressureVelocityBased::evaluate(Teuchos::Paramet
       {
         if (discretization.has_state(1, "fluidvel"))
         {
+          const SolidPoroPrimaryVariables primary_variables =
+              extract_solid_poro_primary_variables(discretization, la, shape());
           std::visit(
               [&](auto& interface)
               {
                 interface->evaluate_nonlinear_force_stiffness(*this, this->struct_poro_material(),
                     this->fluid_poro_material(), this->get_anisotropic_permeability_property(),
-                    this->kinematic_type(), discretization, la, params, &elevec1, &elemat1,
-                    nullptr);
+                    this->kinematic_type(), discretization, primary_variables, params, &elevec1,
+                    &elemat1, nullptr);
               },
               solidporo_press_vel_based_calc_variant_);
         }
@@ -187,12 +195,14 @@ int Discret::Elements::SolidPoroPressureVelocityBased::evaluate(Teuchos::Paramet
     {
       if (discretization.has_state(1, "fluidvel"))
       {
+        const SolidPoroPrimaryVariables primary_variables =
+            extract_solid_poro_primary_variables(discretization, la, shape());
         std::visit(
             [&](auto& interface)
             {
               interface->evaluate_nonlinear_force_stiffness_od(*this, this->struct_poro_material(),
                   this->fluid_poro_material(), this->get_anisotropic_permeability_property(),
-                  this->kinematic_type(), discretization, la, params, &elemat1);
+                  this->kinematic_type(), discretization, primary_variables, params, &elemat1);
             },
             solidporo_press_vel_based_calc_variant_);
       }
@@ -237,14 +247,16 @@ int Discret::Elements::SolidPoroPressureVelocityBased::evaluate(Teuchos::Paramet
 
       if (discretization.has_state(1, "fluidvel"))
       {
+        const SolidPoroPrimaryVariables primary_variables =
+            extract_solid_poro_primary_variables(discretization, la, shape());
         std::visit(
             [&](auto& interface)
             {
               interface->coupling_stress_poroelast(*this, this->struct_poro_material(),
                   this->kinematic_type(),
-                  CouplStressIO{
-                      get_io_couplstress_type(*this, params), get_couplstress_data(*this, params)},
-                  discretization, la, params);
+                  CouplStressIO{.type = get_io_couplstress_type(*this, params),
+                      .mutable_data = get_couplstress_data(*this, params)},
+                  discretization, primary_variables, params);
             },
             solidporo_press_vel_based_calc_variant_);
       }


### PR DESCRIPTION
The first commit generalizes `Core::FE::extract_values()` so that also filtered ranges are accepted.

The second commit generalizes the pressure-velocity based implementation for the extension with the p1 formulation.