### PR TITLE
Update the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,136 +25,37 @@
 to address a plethora of physical problems by means of _computational mechanics_.
 
 Large parts of 4C are based on finite element methods (FEM),
-but alternative discretization methods such as discontinuous Galerkin methods (DG),
+but alternative discretization methods, such as discontinuous Galerkin methods (DG),
 particle methods and mesh-free methods have also been successfully integrated.
 The research software is implemented throughout in object-oriented programming (C++)
 using modern software design and is parallelized with MPI for distributed memory hardware architectures.
 
 **Disclaimer**: 4C is developed for research purposes in the field of numerical method development.
-It is not intended for any use beyond this purpose, and generally should not be used for any form of
-safety-relevant or safety-critical calculations,
+It is not intended for any use beyond this purpose and generally should not be used for any form of
+safety-relevant or safety-critical calculations
 or for an application in association with physical products in particular.
 
-## Required development tools
+- **Website**: https://4C-multiphysics.org
+- **Documentation**: https://4c-multiphysics.github.io/4C/readthedocs/
 
-- **CMake:** 4C supports CMake configuration through CMake presets.
-- **Ninja:** We strongly encourage to work with `ninja` (instead of `make`) for faster compile times.
+## Getting started
 
-## External dependencies
-
-4C heavily relies on the [Trilinos project](https://trilinos.github.io).
-
-Some further third-party libraries (TPLs) are mandatory, e.g.
-
-- CMake (minimum version: 3.30)
-- ParMETIS (recommended version: 4.0.3)
-- SuiteSparse (recommended version: 5.4.0)
-- SuperLUDist (recommended version: 7.2)
-- Qhull (recommended version: 2012.1)
-- CLN (recommended version: 1.3.4)
-
-and some are optional, e.g.
-
-- FFTW
-- [ArborX](https://github.com/arborx/ArborX)
-- [MIRCO](https://github.com/imcs-compsim/MIRCO/)
-
-Maybe, a pre-compiled version of Trilinos and set of TPLs is available at your institute.
-Look into the CMake presets in `presets/` or ask your colleagues for further information.
-
-Some helper scripts to install these TPLs can be found in `dependencies/`.
-
-Additional information can be found in
-the [user documentation](https://4c-multiphysics.github.io/4C/readthedocs/4Csetup.html#external-dependencies).
-
-## Getting up and running
-
-### Create python virtual environment (required for code development in 4C)
-
-For testing and active development, you need to create a python virtual environment once.
-In the source directory,
-execute:
-
+To quickly run 4C, you can use our docker image, where 4C comes pre-compiled.
 ```
-./utilities/set_up_dev_env.sh
+docker run --interactive --tty ghcr.io/4c-multiphysics/4c:main
+/home/user/4C/build/4C ../tests/input_files/<some-input-file>.4C.yaml output_name
 ```
 
-### Configure and Build
-
-4C enforces an out-of-source build, i.e., the build directory may not be the top-level source directory.
-Create a build directory `<path/to/build/dir>` of your choosing.
-
-Navigate into the build directory and run
-
-```bash
-cmake --preset=<name-of-preset> <path/to/source/dir>
-```
-
-A preset name needs to be passed to cmake via the command line argument `--preset`.
-Use `cmake <path/to/source/dir> --list-presets` to get a list of all available presets.
-Define your own presets in a `CMakeUserPresets.json` file.
-
-More information about CMake presets can be found in the [CMake documentation](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html).
-
-#### Build
-
-To build the code on `<numProcs>` processes, run
-
-```bash
-ninja -j <numProcs> full
-```
-
-#### Run the Tests
-
-To verify that the build was successful, run the minimal set of tests via
-
-```bash
-ctest -L minimal
-```
-
-or all tests via
-
-```bash
-ctest
-```
-
-You can use the option `-j <num_threads>` to specify the number of threads to be used for parallel execution.
-
-### Prepare and Run Simulations
-
-After successfully building 4C, the executable `4C` is located in your build directory `<path/to/build/dir>/`.
-It needs to be invoked together with an input (`.dat`) file via
-
-```bash
-<path/to/build/dir>/4C <jobName>.dat <outputName>
-```
-
-where `<jobName>` is the name of the simulation file and `<outputName>` denotes the name of the corresponding output
-file(s).
-A collection of working `.dat` files is located under `tests/input_files/` in the source code repository.
-
-Input files (`*.dat`) can be generated through various mechanisms.
-Please consult our [user guide](https://4c-multiphysics.github.io/4C/readthedocs/index.html) for further information and detailed instructions.
-
-4C can write its simulation output in different formats.
-The [user guide](https://4c-multiphysics.github.io/4C/readthedocs/index.html) outlines the different output format and their necessary steps to actually view the results.
-
-## Where to Ask Questions
-
-If you need help with 4C, feel free to ask questions
-by [creating a GitHub issue](https://github.com/4C-multiphysics/4C/issues). Use an issue template to pre-populate the *Description* field, giving you instructions on submitting the issue.
-
-For more general questions, you can reach us on the [4C Slack workspace](https://join.slack.com/t/4c-multiphysics/shared_invite/zt-1oi61jgdd-5tZuHku3Tb_BH5UBgojbpQ).
+See our [documentation](https://4c-multiphysics.github.io/4C/readthedocs/installation.html) for more information on how to build 4C from source on your machine.
+Consult our [Tutorials](https://4c-multiphysics.github.io/4C/readthedocs/tutorials.html) to get an overview of the general workflow in 4C.
 
 ## Contributing
 
 If you're interested in contributing to 4C, we welcome your collaboration.
-Read [our contributing guidelines](https://github.com/4C-multiphysics/4C/blob/main/CONTRIBUTING.md) carefully for details on
-our workflow, submitting pull requests, etc.
+Please follow [our contributing guidelines](https://github.com/4C-multiphysics/4C/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/4C-multiphysics/4C/blob/main/CODE_OF_CONDUCT.md).
 
-## Code of Conduct
-
-All people and activities in and around 4C are subject to our [Code of Conduct](https://github.com/4C-multiphysics/4C/blob/main/CODE_OF_CONDUCT.md).
+If you need help with 4C, feel free to ask questions
+in the [GitHub discussions](https://github.com/4C-multiphysics/4C/discussions).
 
 ## How to cite 4C
 

--- a/doc/readthedocs/developer_cluster.rst
+++ b/doc/readthedocs/developer_cluster.rst
@@ -7,7 +7,7 @@ In general there are several ways to get the |FOURC| source code to a cluster. I
 
 - Limitations due to firewall settings may emerge.
 - In case you want to commit changes in your repository on a cluster,
-  remember to set up |FOURC| as described in the |FOURC| ``README.md`` or in the :ref:`Setup guide <SetupGuideto4C>`.
+  remember to set up |FOURC| as described in the :ref:`Installation guide <installation>`.
   However, in general, it is recommended to develop code primarily on your workstation.
 
 Method 1: Clone |FOURC| repository from GitHub

--- a/doc/readthedocs/developmentguide.rst
+++ b/doc/readthedocs/developmentguide.rst
@@ -7,10 +7,8 @@ Developer guide
 .. toctree::
     :maxdepth: 2
 
-    4Csetup
     4Ctesting
     codingguidelines
     petra_object_model
     developer_addedinformation
     development_parts
-

--- a/doc/readthedocs/index.rst
+++ b/doc/readthedocs/index.rst
@@ -32,16 +32,19 @@ Content
 
 This guide to |FOURC| is structured as follows:
 
-:ref:`Part I — About 4C<about>`
+:ref:`About 4C<about>`
    Learn about the capabilities and history of |FOURC|.
 
-:ref:`Part II - The 4C Community<4Ccommunity>`
+:ref:`The 4C Community<4Ccommunity>`
    A brief summary of the roles and responsibilities within the |FOURC| community.
 
-:ref:`Part III — Tutorials<tutorials>`
+:ref:`Installation<Installation>`
+   A summary of all requirements of |FOURC| and detailed steps how to build |FOURC|.
+
+:ref:`Tutorials<tutorials>`
    A series of beginner-level tutorials showcases the setup procedure for specific application scenarios.
 
-:ref:`Part IV - Analysis guide<analysisguide>`
+:ref:`Analysis guide<analysisguide>`
    Detailed explanations on the whole tool chain from model generation (pre-processing)
    over running a simulation to the evaluation of results (post-processing) offers deep insight into using |FOURC|
    for advanced simulation scenarios.
@@ -49,16 +52,15 @@ This guide to |FOURC| is structured as follows:
    for the specification of elements, boundary conditions, constitutive laws
    as well as options for linear and nonlinear solvers.
 
-:ref:`Part V - Developer guide<developerguide>`
+:ref:`Developer guide<developerguide>`
    This guide gets you started on actively developing and contributing to |FOURC|.
-   It covers the build process, our CI/CD testing infrastructure,
-   coding guidelines, and useful tools for the daily development of |FOURC|.
+   It covers our CI/CD testing infrastructure, coding guidelines, and useful tools for the daily development of |FOURC|.
 
-:ref:`Part VI - Input Parameter Reference<inputparameterreference>`
+:ref:`Input Parameter Reference<inputparameterreference>`
    A comprehensive list of all input parameters, elements, materials, and boundary conditions
    with short descriptions for each option
 
-:ref:`Part VII - Tools and Scripts<toolsAndScripts>`
+:ref:`Tools and Scripts<toolsAndScripts>`
    A collection of useful scripts for working with |FOURC|
 
 :ref:`Appendix<appendix>`
@@ -71,6 +73,7 @@ This guide to |FOURC| is structured as follows:
 
    about
    4Ccommunity
+   installation
    tutorials
    analysisguide
    developmentguide

--- a/doc/readthedocs/installation.rst
+++ b/doc/readthedocs/installation.rst
@@ -1,7 +1,7 @@
-.. _SetupGuideto4C:
+.. _installation:
 
-Setup Guide
-=============
+Installation
+============
 
 Here you'll find some useful notes on setting up and running |FOURC|.
 
@@ -11,11 +11,6 @@ People around have already ported the code to Windows, but this needs quite a nu
 so it is not advised to try on your own, and the topic will not be covered here.
 Additionally, |FOURC| can be compiled under Windows using the WSL (Windows Subsystem for Linux),
 which provides a complete Linux Environment within the Windows operating system.
-
-You'll find more information about the |FOURC| installation in the
-`README.md <https://github.com/4C-multiphysics/4C/blob/main/README.md>`_ and the
-`CONTRIBUTING.md <https://github.com/4C-multiphysics/4C/blob/main/CONTRIBUTING.md>`_
-files located in the |FOURC| root directory.
 
 Besides the basic setup of the software, the following topics are of particular interest for **all** developers:
 
@@ -38,7 +33,7 @@ So we have to install TPLs first. Here's an list of the |FOURC|-related tools an
 General software development:
 
 - git
-- c++ compiler with c++17 compatibility (e.g. gcc 11)
+- c++ compiler with c++20 compatibility (e.g. gcc 13)
 - MPI installation
 - CMake
 - Ninja

--- a/doc/readthedocs/tut_fluid_preexo.rst
+++ b/doc/readthedocs/tut_fluid_preexo.rst
@@ -5,7 +5,7 @@ Fluid Tutorial with *pre_exodus* and Cubit
 
 For this as for all other tutorials you'll need a complete |FOURC| installation
 as well as access to the pre-processing tool *cubit* and the post-processing tool *paraview*.
-If you did not do so already, install |FOURC| based on the information given in the :ref:`Setup Guide <SetupGuideto4C>`.
+If you did not do so already, install |FOURC| based on the information given in the :ref:`Installation Guide <installation>`.
 
 Introduction
 ------------
@@ -241,4 +241,3 @@ Visualize your results in Paraview
    :align: center
 
    :math:`X`-velocity for a flow past a circular cylinder
-


### PR DESCRIPTION
## Description and Context
Update the `README.md`. I was inspired by the README of [Queens](https://github.com/queens-py/queens).

I also removed the complete setup process of 4C from the README. It was too long, and it duplicates the information from our documentation.

I also moved the setup process to the top level and named it 'Installation'. Technically, it is not an installation of 4C. But I think everyone will understand that this is the page where you find information on how to set up 4C. 

## Related Issues and Pull Requests
Closes #279 
