### PR TITLE
Add CMake option FOUR_C_ENABLE_METADATA_GENERATION

### DIFF
--- a/apps/global_full/CMakeLists.txt
+++ b/apps/global_full/CMakeLists.txt
@@ -32,29 +32,30 @@ add_custom_command(
     ${CMAKE_BINARY_DIR}/${FOUR_C_EXECUTABLE_NAME_LEGACY}
   COMMENT "Creating symbolic link"
   )
-
-if(Python3_VERSION VERSION_GREATER_EQUAL "3.10")
-  # Create a json schema file for the input
-  add_custom_command(
-    TARGET ${FOUR_C_EXECUTABLE_NAME}
-    POST_BUILD
-    COMMAND
-      ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS} "$<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>" -p
-      > ${CMAKE_BINARY_DIR}/4C_metadata.yaml
-    COMMAND
-      ${FOUR_C_PYTHON_VENV_BUILD}/bin/python ${PROJECT_SOURCE_DIR}/utilities/create_json_schema.py
-      ${CMAKE_BINARY_DIR}/4C_metadata.yaml ${CMAKE_BINARY_DIR}/4C_schema.json
-    COMMENT "Creating JSON schema file for input"
-    )
-else()
-  message(
-    WARNING "Your python version ${Python3_VERSION} is too old to generate the JSON schema file"
-    )
-  add_custom_command(
-    TARGET ${FOUR_C_EXECUTABLE_NAME}
-    POST_BUILD
-    COMMAND
-      ${CMAKE_COMMAND} -E echo
-      "Skipping metadata and JSON schema generation due to outdated python version"
-    )
+if(FOUR_C_ENABLE_METADATA_GENERATION)
+  if(Python3_VERSION VERSION_GREATER_EQUAL "3.10")
+    # Create a json schema file for the input
+    add_custom_command(
+      TARGET ${FOUR_C_EXECUTABLE_NAME}
+      POST_BUILD
+      COMMAND
+        ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS} "$<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>"
+        -p > ${CMAKE_BINARY_DIR}/4C_metadata.yaml
+      COMMAND
+        ${FOUR_C_PYTHON_VENV_BUILD}/bin/python ${PROJECT_SOURCE_DIR}/utilities/create_json_schema.py
+        ${CMAKE_BINARY_DIR}/4C_metadata.yaml ${CMAKE_BINARY_DIR}/4C_schema.json
+      COMMENT "Creating JSON schema file for input"
+      )
+  else()
+    message(
+      WARNING "Your python version ${Python3_VERSION} is too old to generate the JSON schema file"
+      )
+    add_custom_command(
+      TARGET ${FOUR_C_EXECUTABLE_NAME}
+      POST_BUILD
+      COMMAND
+        ${CMAKE_COMMAND} -E echo
+        "Skipping metadata and JSON schema generation due to outdated python version"
+      )
+  endif()
 endif()

--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -192,6 +192,12 @@ four_c_process_global_option(
   OFF
   )
 
+four_c_process_global_option(
+  FOUR_C_ENABLE_METADATA_GENERATION
+  "Generate metadata after building 4C. Requires python and invokes 4C."
+  ON
+  )
+
 ##
 # Add potential user flags at the very end
 ##


### PR DESCRIPTION
Allows to turn off metadata and schema generation in environments where it does not work. It stays on by default.

FYI @ppraegla @tnschmid