### PR TITLE
Remove old input interfaces for bool, double and string

### DIFF
--- a/src/ale/4C_ale_input.cpp
+++ b/src/ale/4C_ale_input.cpp
@@ -22,9 +22,11 @@ void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 
   Core::Utils::SectionSpecs adyn{"ALE DYNAMIC"};
 
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "time step size", adyn);
+  adyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.1}));
   Core::Utils::int_parameter("NUMSTEP", 41, "max number of time steps", adyn);
-  Core::Utils::double_parameter("MAXTIME", 4.0, "max simulation time", adyn);
+  adyn.specs.emplace_back(
+      parameter<double>("MAXTIME", {.description = "max simulation time", .default_value = 4.0}));
 
   Core::Utils::string_to_integral_parameter<ALE::AleDynamic>("ALE_TYPE", "solid",
       "ale mesh movement algorithm",
@@ -44,10 +46,12 @@ void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           .default_value = false}));
 
   Core::Utils::int_parameter("MAXITER", 1, "Maximum number of newton iterations.", adyn);
-  Core::Utils::double_parameter(
-      "TOLRES", 1.0e-06, "Absolute tolerance for length scaled L2 residual norm ", adyn);
-  Core::Utils::double_parameter(
-      "TOLDISP", 1.0e-06, "Absolute tolerance for length scaled L2 increment norm ", adyn);
+  adyn.specs.emplace_back(parameter<double>(
+      "TOLRES", {.description = "Absolute tolerance for length scaled L2 residual norm ",
+                    .default_value = 1.0e-06}));
+  adyn.specs.emplace_back(parameter<double>(
+      "TOLDISP", {.description = "Absolute tolerance for length scaled L2 increment norm ",
+                     .default_value = 1.0e-06}));
 
   Core::Utils::int_parameter("NUM_INITSTEP", 0, "", adyn);
   Core::Utils::int_parameter(

--- a/src/ale/4C_ale_input.cpp
+++ b/src/ale/4C_ale_input.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs adyn{"ALE DYNAMIC"};
 
@@ -33,11 +34,14 @@ void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           springs_material, springs_spatial),
       adyn);
 
-  Core::Utils::bool_parameter("ASSESSMESHQUALITY", false,
-      "Evaluate element quality measure according to [Oddy et al. 1988]", adyn);
+  adyn.specs.emplace_back(parameter<bool>("ASSESSMESHQUALITY",
+      {.description = "Evaluate element quality measure according to [Oddy et al. 1988]",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("UPDATEMATRIX", false,
-      "Update stiffness matrix in every time step (only for linear/material strategies)", adyn);
+  adyn.specs.emplace_back(parameter<bool>("UPDATEMATRIX",
+      {.description =
+              "Update stiffness matrix in every time step (only for linear/material strategies)",
+          .default_value = false}));
 
   Core::Utils::int_parameter("MAXITER", 1, "Maximum number of newton iterations.", adyn);
   Core::Utils::double_parameter(

--- a/src/beam3/4C_beam3_kirchhoff.cpp
+++ b/src/beam3/4C_beam3_kirchhoff.cpp
@@ -66,7 +66,6 @@ std::shared_ptr<Core::Elements::Element> Discret::Elements::Beam3kType::create(
  *------------------------------------------------------------------------------------------------*/
 std::shared_ptr<Core::Elements::Element> Discret::Elements::Beam3kType::create(
     const int id, const int owner)
-
 {
   return std::make_shared<Beam3k>(id, owner);
 }

--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -66,37 +66,46 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   beamcontact.specs.emplace_back(parameter<bool>("BEAMS_DAMPING",
       {.description = "Application of a contact damping force", .default_value = false}));
 
-  Core::Utils::double_parameter("BEAMS_BTBPENALTYPARAM", 0.0,
-      "Penalty parameter for beam-to-beam point contact", beamcontact);
-  Core::Utils::double_parameter("BEAMS_BTBLINEPENALTYPARAM", -1.0,
-      "Penalty parameter per unit length for beam-to-beam line contact", beamcontact);
-  Core::Utils::double_parameter(
-      "BEAMS_BTSPENALTYPARAM", 0.0, "Penalty parameter for beam-to-solid contact", beamcontact);
-  Core::Utils::double_parameter(
-      "BEAMS_DAMPINGPARAM", -1000.0, "Damping parameter for contact damping force", beamcontact);
-  Core::Utils::double_parameter("BEAMS_DAMPREGPARAM1", -1000.0,
-      "First (at gap1, with gap1>gap2) regularization parameter for contact damping force",
-      beamcontact);
-  Core::Utils::double_parameter("BEAMS_DAMPREGPARAM2", -1000.0,
-      "Second (at gap2, with gap1>gap2) regularization parameter for contact damping force",
-      beamcontact);
-  Core::Utils::double_parameter("BEAMS_MAXDISISCALEFAC", -1.0,
-      "Scale factor in order to limit maximal iterative displacement increment (resiudal "
-      "displacement)",
-      beamcontact);
-  Core::Utils::double_parameter("BEAMS_MAXDELTADISSCALEFAC", 1.0,
-      "Scale factor in order to limit maximal displacement per time step", beamcontact);
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_BTBPENALTYPARAM",
+      {.description = "Penalty parameter for beam-to-beam point contact", .default_value = 0.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_BTBLINEPENALTYPARAM",
+      {.description = "Penalty parameter per unit length for beam-to-beam line contact",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_BTSPENALTYPARAM",
+      {.description = "Penalty parameter for beam-to-solid contact", .default_value = 0.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_DAMPINGPARAM",
+      {.description = "Damping parameter for contact damping force", .default_value = -1000.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_DAMPREGPARAM1",
+      {.description =
+              "First (at gap1, with gap1>gap2) regularization parameter for contact damping force",
+          .default_value = -1000.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_DAMPREGPARAM2",
+      {.description =
+              "Second (at gap2, with gap1>gap2) regularization parameter for contact damping force",
+          .default_value = -1000.0}));
+  beamcontact.specs.emplace_back(parameter<double>(
+      "BEAMS_MAXDISISCALEFAC", {.description = "Scale factor in order to limit maximal iterative "
+                                               "displacement increment (resiudal displacement)",
+                                   .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_MAXDELTADISSCALEFAC",
+      {.description = "Scale factor in order to limit maximal displacement per time step",
+          .default_value = 1.0}));
 
-  Core::Utils::double_parameter("BEAMS_PERPSHIFTANGLE1", -1.0,
-      "Lower shift angle (in degrees) for penalty scaling of large-angle-contact", beamcontact);
-  Core::Utils::double_parameter("BEAMS_PERPSHIFTANGLE2", -1.0,
-      "Upper shift angle (in degrees) for penalty scaling of large-angle-contact", beamcontact);
-  Core::Utils::double_parameter("BEAMS_PARSHIFTANGLE1", -1.0,
-      "Lower shift angle (in degrees) for penalty scaling of small-angle-contact", beamcontact);
-  Core::Utils::double_parameter("BEAMS_PARSHIFTANGLE2", -1.0,
-      "Upper shift angle (in degrees) for penalty scaling of small-angle-contact", beamcontact);
-  Core::Utils::double_parameter("BEAMS_SEGANGLE", -1.0,
-      "Maximal angle deviation allowed for contact search segmentation", beamcontact);
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PERPSHIFTANGLE1",
+      {.description = "Lower shift angle (in degrees) for penalty scaling of large-angle-contact",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PERPSHIFTANGLE2",
+      {.description = "Upper shift angle (in degrees) for penalty scaling of large-angle-contact",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PARSHIFTANGLE1",
+      {.description = "Lower shift angle (in degrees) for penalty scaling of small-angle-contact",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PARSHIFTANGLE2",
+      {.description = "Upper shift angle (in degrees) for penalty scaling of small-angle-contact",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_SEGANGLE",
+      {.description = "Maximal angle deviation allowed for contact search segmentation",
+          .default_value = -1.0}));
   Core::Utils::int_parameter("BEAMS_NUMINTEGRATIONINTERVAL", 1,
       "Number of integration intervals per element", beamcontact);
 
@@ -107,22 +116,24 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<BeamContact::PenaltyLaw>(pl_lp, pl_qp, pl_lnqp, pl_lpqp, pl_lpcp, pl_lpdqp, pl_lpep),
       beamcontact);
 
-  Core::Utils::double_parameter("BEAMS_PENREGPARAM_G0", -1.0,
-      "First penalty regularization parameter G0 >=0: For gap<G0 contact is active!", beamcontact);
-  Core::Utils::double_parameter("BEAMS_PENREGPARAM_F0", -1.0,
-      "Second penalty regularization parameter F0 >=0: F0 represents the force at the transition "
-      "point between regularized and linear force law!",
-      beamcontact);
-  Core::Utils::double_parameter("BEAMS_PENREGPARAM_C0", -1.0,
-      "Third penalty regularization parameter C0 >=0: C0 has different physical meanings for the "
-      "different penalty laws!",
-      beamcontact);
-  Core::Utils::double_parameter(
-      "BEAMS_GAPSHIFTPARAM", 0.0, "Parameter to shift penalty law!", beamcontact);
-  Core::Utils::double_parameter("BEAMS_BASICSTIFFGAP", -1.0,
-      "For gaps > -BEAMS_BASICSTIFFGAP, only the basic part of the contact linearization is "
-      "applied!",
-      beamcontact);
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PENREGPARAM_G0",
+      {.description =
+              "First penalty regularization parameter G0 >=0: For gap<G0 contact is active!",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PENREGPARAM_F0",
+      {.description = "Second penalty regularization parameter F0 >=0: F0 represents the force at "
+                      "the transition point between regularized and linear force law!",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PENREGPARAM_C0",
+      {.description = "Third penalty regularization parameter C0 >=0: C0 has different physical "
+                      "meanings for the different penalty laws!",
+          .default_value = -1.0}));
+  beamcontact.specs.emplace_back(parameter<double>("BEAMS_GAPSHIFTPARAM",
+      {.description = "Parameter to shift penalty law!", .default_value = 0.0}));
+  beamcontact.specs.emplace_back(parameter<double>(
+      "BEAMS_BASICSTIFFGAP", {.description = "For gaps > -BEAMS_BASICSTIFFGAP, only the basic part "
+                                             "of the contact linearization is applied!",
+                                 .default_value = -1.0}));
 
   // enable octree search and determine type of bounding box (aabb = axis aligned, cobb =
   // cylindrical oriented)

--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs beamcontact{"BEAM CONTACT"};
 
@@ -33,34 +34,37 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<BeamContact::Modelevaluator>(bstr_old, bstr_old, bstr_standard, bstr_standard),
       beamcontact);
 
-  Core::Utils::bool_parameter(
-      "BEAMS_NEWGAP", false, "choose between original or enhanced gapfunction", beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_NEWGAP",
+      {.description = "choose between original or enhanced gapfunction", .default_value = false}));
 
-  Core::Utils::bool_parameter("BEAMS_SEGCON", false,
-      "choose between beam contact with and without subsegment generation", beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_SEGCON",
+      {.description = "choose between beam contact with and without subsegment generation",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("BEAMS_DEBUG", false,
-      "This flag can be used for testing purposes. When it is switched on, some sanity checks are "
-      "not performed!",
-      beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>(
+      "BEAMS_DEBUG", {.description = "This flag can be used for testing purposes. When it is "
+                                     "switched on, some sanity checks are not performed!",
+                         .default_value = false}));
 
-  Core::Utils::bool_parameter("BEAMS_INACTIVESTIFF", false,
-      "Always apply contact stiffness in first Newton step for pairs which have active in last "
-      "time step",
-      beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>(
+      "BEAMS_INACTIVESTIFF", {.description = "Always apply contact stiffness in first Newton step "
+                                             "for pairs which have active in last time step",
+                                 .default_value = false}));
 
-  Core::Utils::bool_parameter("BEAMS_BTSOL", false,
-      "decide, if also the contact between beams and solids is possible", beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_BTSOL",
+      {.description = "decide, if also the contact between beams and solids is possible",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("BEAMS_ENDPOINTPENALTY", false,
-      "Additional consideration of endpoint-line and endpoint-endpoint contacts", beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_ENDPOINTPENALTY",
+      {.description = "Additional consideration of endpoint-line and endpoint-endpoint contacts",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<BeamContact::Smoothing>("BEAMS_SMOOTHING", "None",
       "Application of smoothed tangent field", tuple<std::string>("None", "none", "Cpp", "cpp"),
       tuple<BeamContact::Smoothing>(bsm_none, bsm_none, bsm_cpp, bsm_cpp), beamcontact);
 
-  Core::Utils::bool_parameter(
-      "BEAMS_DAMPING", false, "Application of a contact damping force", beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_DAMPING",
+      {.description = "Application of a contact damping force", .default_value = false}));
 
   Core::Utils::double_parameter("BEAMS_BTBPENALTYPARAM", 0.0,
       "Penalty parameter for beam-to-beam point contact", beamcontact);
@@ -129,9 +133,10 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<BeamContact::OctreeType>(boct_none, boct_none, boct_aabb, boct_cobb, boct_spbb),
       beamcontact);
 
-  Core::Utils::bool_parameter("BEAMS_ADDITEXT", true,
-      "Switch between No==multiplicative extrusion factor and Yes==additive extrusion factor",
-      beamcontact);
+  beamcontact.specs.emplace_back(parameter<bool>(
+      "BEAMS_ADDITEXT", {.description = "Switch between No==multiplicative extrusion factor and "
+                                        "Yes==additive extrusion factor",
+                            .default_value = true}));
   Core::Utils::string_parameter("BEAMS_EXTVAL", "-1.0",
       "extrusion value(s) of the bounding box, Depending on BEAMS_ADDITIVEEXTFAC is either "
       "additive or multiplicative. Give one or two values.",
@@ -148,24 +153,26 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs beamcontact_vtk_sublist{beamcontact, "RUNTIME VTK OUTPUT"};
 
   // whether to write visualization output for beam contact
-  Core::Utils::bool_parameter("VTK_OUTPUT_BEAM_CONTACT", false,
-      "write visualization output for beam contact", beamcontact_vtk_sublist);
+  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>("VTK_OUTPUT_BEAM_CONTACT",
+      {.description = "write visualization output for beam contact", .default_value = false}));
 
   // output interval regarding steps: write output every INTERVAL_STEPS steps
   Core::Utils::int_parameter("INTERVAL_STEPS", -1,
       "write visualization output at runtime every INTERVAL_STEPS steps", beamcontact_vtk_sublist);
 
   // whether to write output in every iteration of the nonlinear solver
-  Core::Utils::bool_parameter("EVERY_ITERATION", false,
-      "write output in every iteration of the nonlinear solver", beamcontact_vtk_sublist);
+  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>(
+      "EVERY_ITERATION", {.description = "write output in every iteration of the nonlinear solver",
+                             .default_value = false}));
 
   // whether to write visualization output for contact forces
-  Core::Utils::bool_parameter("CONTACT_FORCES", false,
-      "write visualization output for contact forces", beamcontact_vtk_sublist);
+  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>("CONTACT_FORCES",
+      {.description = "write visualization output for contact forces", .default_value = false}));
 
   // whether to write visualization output for gaps
-  Core::Utils::bool_parameter("GAPS", false, "write visualization output for gap, i.e. penetration",
-      beamcontact_vtk_sublist);
+  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>(
+      "GAPS", {.description = "write visualization output for gap, i.e. penetration",
+                  .default_value = false}));
 
   beamcontact_vtk_sublist.move_into_collection(list);
 }

--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -148,10 +148,11 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "BEAMS_ADDITEXT", {.description = "Switch between No==multiplicative extrusion factor and "
                                         "Yes==additive extrusion factor",
                             .default_value = true}));
-  Core::Utils::string_parameter("BEAMS_EXTVAL", "-1.0",
-      "extrusion value(s) of the bounding box, Depending on BEAMS_ADDITIVEEXTFAC is either "
-      "additive or multiplicative. Give one or two values.",
-      beamcontact);
+  beamcontact.specs.emplace_back(parameter<std::string>("BEAMS_EXTVAL",
+      {.description = "extrusion value(s) of the bounding box, Depending on BEAMS_ADDITIVEEXTFAC "
+                      "is either  additive or multiplicative. Give one or two values.",
+          .default_value = "-1.0"}));
+
   Core::Utils::int_parameter("BEAMS_TREEDEPTH", 6, "max, tree depth of the octree", beamcontact);
   Core::Utils::int_parameter(
       "BEAMS_BOXESINOCT", 8, "max number of bounding boxes in any leaf octant", beamcontact);

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -55,11 +55,11 @@ void BrownianDynamics::set_valid_parameters(std::map<std::string, Core::IO::Inpu
 
   // values for damping coefficients of beams if they are specified via input file
   // (per unit length, NOT yet multiplied by fluid viscosity)
-  Core::Utils::string_parameter("BEAMS_DAMPING_COEFF_PER_UNITLENGTH", "0.0 0.0 0.0",
-      "values for beam damping coefficients (per unit length and NOT yet multiplied by fluid "
-      "viscosity): "
-      "translational perpendicular/parallel to beam axis, rotational around axis",
-      browniandyn_list);
+  browniandyn_list.specs.emplace_back(parameter<std::string>("BEAMS_DAMPING_COEFF_PER_UNITLENGTH",
+      {.description = "values for beam damping coefficients (per unit length and NOT yet "
+                      "multiplied by fluid viscosity): translational perpendicular/parallel to "
+                      "beam axis, rotational around axis",
+          .default_value = "0.0 0.0 0.0"}));
 
   browniandyn_list.move_into_collection(list);
 }

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -15,11 +15,12 @@ FOUR_C_NAMESPACE_OPEN
 void BrownianDynamics::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs browniandyn_list{"BROWNIAN DYNAMICS"};
 
-  Core::Utils::bool_parameter(
-      "BROWNDYNPROB", false, "switch Brownian dynamics on/off", browniandyn_list);
+  browniandyn_list.specs.emplace_back(parameter<bool>(
+      "BROWNDYNPROB", {.description = "switch Brownian dynamics on/off", .default_value = false}));
 
   // Reading double parameter for viscosity of background fluid
   Core::Utils::double_parameter("VISCOSITY", 0.0, "viscosity", browniandyn_list);

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -23,21 +23,24 @@ void BrownianDynamics::set_valid_parameters(std::map<std::string, Core::IO::Inpu
       "BROWNDYNPROB", {.description = "switch Brownian dynamics on/off", .default_value = false}));
 
   // Reading double parameter for viscosity of background fluid
-  Core::Utils::double_parameter("VISCOSITY", 0.0, "viscosity", browniandyn_list);
+  browniandyn_list.specs.emplace_back(
+      parameter<double>("VISCOSITY", {.description = "viscosity", .default_value = 0.0}));
 
   // Reading double parameter for thermal energy in background fluid (temperature * Boltzmann
   // constant)
-  Core::Utils::double_parameter("KT", 0.0, "thermal energy", browniandyn_list);
+  browniandyn_list.specs.emplace_back(
+      parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}));
 
   // cutoff for random forces, which determines the maximal value
-  Core::Utils::double_parameter("MAXRANDFORCE", -1.0,
-      "Any random force beyond MAXRANDFORCE*(standard dev.) will be omitted and redrawn. "
-      "-1.0 means no bounds.'",
-      browniandyn_list);
+  browniandyn_list.specs.emplace_back(parameter<double>(
+      "MAXRANDFORCE", {.description = "Any random force beyond MAXRANDFORCE*(standard dev.) will "
+                                      "be omitted and redrawn. -1.0 means no bounds.'",
+                          .default_value = -1.0}));
 
   // time interval in which random numbers are constant
-  Core::Utils::double_parameter("TIMESTEP", -1.0,
-      "Within this time interval the random numbers remain constant. -1.0 ", browniandyn_list);
+  browniandyn_list.specs.emplace_back(parameter<double>("TIMESTEP",
+      {.description = "Within this time interval the random numbers remain constant. -1.0 ",
+          .default_value = -1.0}));
 
   // the way how damping coefficient values for beams are specified
   Core::Utils::string_to_integral_parameter<BeamDampingCoefficientSpecificationType>(

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -41,7 +41,6 @@ CONSTRAINTS::ConstrManager::ConstrManager()
       uzawaparam_(0.0),
       issetup_(false),
       isinit_(false)
-
 {
 }
 

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -170,7 +170,6 @@ void CONSTRAINTS::MPConstraint3Penalty::evaluate(Teuchos::ParameterList& params,
   acterror_->PutScalar(0.0);
   std::map<int, std::shared_ptr<Core::FE::Discretization>>::iterator discriter;
   for (discriter = constraintdis_.begin(); discriter != constraintdis_.end(); discriter++)
-
     evaluate_error(*discriter->second, params, *acterror_);
 
   //    std::cout << "current error "<< *acterror_<<std::endl;

--- a/src/contact/4C_contact_interface.cpp
+++ b/src/contact/4C_contact_interface.cpp
@@ -120,8 +120,7 @@ CONTACT::Interface::Interface(const std::shared_ptr<CONTACT::InterfaceDataContai
       smpairs_(interface_data_->sm_int_pairs()),
       smintpairs_(interface_data_->sm_int_pairs()),
       intcells_(interface_data_->int_cells())
-{
-  /* do nothing */
+{ /* do nothing */
 }
 
 /*----------------------------------------------------------------------*

--- a/src/core/fem/src/geometry/4C_fem_geometry_integrationcell.cpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_integrationcell.cpp
@@ -99,8 +99,7 @@ Core::Geo::BoundaryIntCell& Core::Geo::BoundaryIntCell::operator=(
 
 Core::Geo::BoundaryIntCell::BoundaryIntCell(Core::FE::CellType distype, const int& surface_ele_gid)
     : IntCell(distype), surface_ele_gid_(surface_ele_gid), phys_center_(true)
-{
-  /* intentionally left blank */
+{ /* intentionally left blank */
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_every_iteration_writer.cpp
+++ b/src/core/io/src/4C_io_every_iteration_writer.cpp
@@ -32,8 +32,7 @@ Core::IO::EveryIterationWriter::EveryIterationWriter()
       parent_writer_(nullptr),
       interface_(nullptr),
       every_iter_writer_(nullptr)
-{
-  /* empty */
+{ /* empty */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/core/utils/src/functions/4C_utils_functionvariables.cpp
+++ b/src/core/utils/src/functions/4C_utils_functionvariables.cpp
@@ -24,7 +24,6 @@ Core::Utils::ParsedFunctionVariable::ParsedFunctionVariable(
     std::string name, const std::string& buf)
     : FunctionVariable(std::move(name)),
       timefunction_(std::make_shared<Core::Utils::SymbolicExpression<double>>(buf))
-
 {
 }
 

--- a/src/cut/4C_cut_input.cpp
+++ b/src/cut/4C_cut_input.cpp
@@ -19,6 +19,7 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace FourC::Cut;
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs cut_general{"CUT GENERAL"};
 
@@ -64,15 +65,16 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
       cut_general);
 
   // Specify is Cutsides are triangulated
-  Core::Utils::bool_parameter(
-      "SPLIT_CUTSIDES", true, "Split Quad4 CutSides into Tri3-Subtriangles?", cut_general);
+  cut_general.specs.emplace_back(parameter<bool>("SPLIT_CUTSIDES",
+      {.description = "Split Quad4 CutSides into Tri3-Subtriangles?", .default_value = true}));
 
   // Do the Selfcut before standard CUT
-  Core::Utils::bool_parameter("DO_SELFCUT", true, "Do the SelfCut?", cut_general);
+  cut_general.specs.emplace_back(
+      parameter<bool>("DO_SELFCUT", {.description = "Do the SelfCut?", .default_value = true}));
 
   // Do meshcorrection in Selfcut
-  Core::Utils::bool_parameter(
-      "SELFCUT_DO_MESHCORRECTION", true, "Do meshcorrection in the SelfCut?", cut_general);
+  cut_general.specs.emplace_back(parameter<bool>("SELFCUT_DO_MESHCORRECTION",
+      {.description = "Do meshcorrection in the SelfCut?", .default_value = true}));
 
   // Selfcut meshcorrection multiplicator
   Core::Utils::int_parameter("SELFCUT_MESHCORRECTION_MULTIPLICATOR", 30,
@@ -86,8 +88,8 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
       cut_general);
 
   // Integrate inside volume cells
-  Core::Utils::bool_parameter("INTEGRATE_INSIDE_CELLS", true,
-      "Should the integration be done on inside cells", cut_general);
+  cut_general.specs.emplace_back(parameter<bool>("INTEGRATE_INSIDE_CELLS",
+      {.description = "Should the integration be done on inside cells", .default_value = true}));
 
   cut_general.move_into_collection(list);
 }

--- a/src/cut/4C_cut_pointgraph_simple.cpp
+++ b/src/cut/4C_cut_pointgraph_simple.cpp
@@ -191,8 +191,7 @@ void Cut::Impl::SimplePointGraph2D::Graph::split_main_cycles_into_line_cycles()
 Cut::Impl::SimplePointGraph2D::SimplePointGraph2D()
     : Cut::Impl::PointGraph(2),
       graph_2d_(std::dynamic_pointer_cast<SimplePointGraph2D::Graph>(graph_ptr()))
-{
-  /* intentionally left blank */
+{ /* intentionally left blank */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/fluid/4C_fluid_utils_infnormscaling.cpp
+++ b/src/fluid/4C_fluid_utils_infnormscaling.cpp
@@ -109,8 +109,9 @@ void FLD::Utils::FluidInfNormScaling::scale_system(
 
     if (A11->LeftScale(*prowsum_) or
         //      A->RightScale(*pcolsum_) or
-        mat.matrix(1, 0).epetra_matrix()->LeftScale(*prowsum_)  // or
-        // mat.Matrix(0,1).EpetraMatrix()->RightScale(*pcolsum_)
+        mat.matrix(1, 0).epetra_matrix()->LeftScale(
+            *prowsum_)  // or
+                        // mat.Matrix(0,1).EpetraMatrix()->RightScale(*pcolsum_)
     )
       FOUR_C_THROW("fluid scaling failed");
 

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -1397,7 +1397,6 @@ double FLD::Utils::FluidVolumetricSurfaceFlowBc::pressure_calculation(
 double FLD::Utils::FluidVolumetricSurfaceFlowBc::polynomail_velocity(double r, int order)
 {
   return (1.0 - pow(r, double(order)));
-
 }  // FLD::Utils::FluidVolumetricSurfaceFlowBc::PolynomailVelocity
 
 

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -1396,7 +1396,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
     m->add_component(parameter<double>("NUE", {.description = "Poisson's ratio"}));
     m->add_component(parameter<double>("DENS", {.description = "mass density"}));
     m->add_component(
-        parameter<double>("YIELD", {.description = "yield stress", .default_value = 0}));
+        parameter<double>("YIELD", {.description = "yield stress", .default_value = 0.}));
     m->add_component(parameter<double>(
         "ISOHARD", {.description = "isotropic hardening modulus", .default_value = 0}));
     m->add_component(parameter<double>(

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -23,6 +23,7 @@ namespace Inpar
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
     {
       using Teuchos::tuple;
+      using namespace Core::IO::InputSpecBuilders;
 
       // related sublist
       Core::Utils::SectionSpecs sublist_IO{"IO"};
@@ -53,9 +54,9 @@ namespace Inpar
           sublist_IO_monitor_structure_dbc);
 
       // whether to write output in every iteration of the nonlinear solver
-      Core::Utils::bool_parameter("WRITE_HEADER", false,
-          "write information about monitored boundary condition to output file",
-          sublist_IO_monitor_structure_dbc);
+      sublist_IO_monitor_structure_dbc.specs.emplace_back(parameter<bool>("WRITE_HEADER",
+          {.description = "write information about monitored boundary condition to output file",
+              .default_value = false}));
 
       sublist_IO_monitor_structure_dbc.move_into_collection(list);
     }

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -60,9 +60,11 @@ namespace Inpar
               .default_value = false}));
 
       // virtual time increment that is added for each nonlinear output state
-      Core::Utils::double_parameter("EVERY_ITERATION_VIRTUAL_TIME_INCREMENT", 1e-8,
-          "Specify the virtual time increment that is added for each nonlinear output state",
-          sublist_IO_VTK_structure);
+      sublist_IO_VTK_structure.specs.emplace_back(
+          parameter<double>("EVERY_ITERATION_VIRTUAL_TIME_INCREMENT",
+              {.description = "Specify the virtual time increment that is added for each nonlinear "
+                              "output state",
+                  .default_value = 1e-8}));
 
       // specify the maximum digits in the number of iterations that shall be written
       Core::Utils::int_parameter("EVERY_ITERATION_RESERVE_DIGITS", 4,

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -23,6 +23,7 @@ namespace Inpar
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
     {
       using Teuchos::tuple;
+      using namespace Core::IO::InputSpecBuilders;
 
       // related sublist
       Core::Utils::SectionSpecs sublist_IO{"IO"};
@@ -54,8 +55,9 @@ namespace Inpar
           sublist_IO_VTK_structure);
 
       // whether to write output in every iteration of the nonlinear solver
-      Core::Utils::bool_parameter("EVERY_ITERATION", false,
-          "write output in every iteration of the nonlinear solver", sublist_IO_VTK_structure);
+      sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("EVERY_ITERATION",
+          {.description = "write output in every iteration of the nonlinear solver",
+              .default_value = false}));
 
       // virtual time increment that is added for each nonlinear output state
       Core::Utils::double_parameter("EVERY_ITERATION_VIRTUAL_TIME_INCREMENT", 1e-8,

--- a/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
@@ -24,6 +24,7 @@ namespace Inpar
       void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
       {
         using Teuchos::tuple;
+        using namespace Core::IO::InputSpecBuilders;
 
         // related sublist
         Core::Utils::SectionSpecs sublist_IO{"IO"};
@@ -31,40 +32,40 @@ namespace Inpar
         Core::Utils::SectionSpecs sublist_IO_output_fluid{sublist_IO_output, "FLUID"};
 
         // whether to write output for fluid
-        Core::Utils::bool_parameter(
-            "OUTPUT_FLUID", false, "write fluid output", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "OUTPUT_FLUID", {.description = "write fluid output", .default_value = false}));
 
         // whether to write velocity state
-        Core::Utils::bool_parameter(
-            "VELOCITY", false, "write velocity output", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "VELOCITY", {.description = "write velocity output", .default_value = false}));
 
         // whether to write pressure state
-        Core::Utils::bool_parameter(
-            "PRESSURE", false, "write pressure output", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "PRESSURE", {.description = "write pressure output", .default_value = false}));
 
         // whether to write acceleration state
-        Core::Utils::bool_parameter(
-            "ACCELERATION", false, "write acceleration output", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "ACCELERATION", {.description = "write acceleration output", .default_value = false}));
 
         // whether to write displacement state
-        Core::Utils::bool_parameter(
-            "DISPLACEMENT", false, "write displacement output", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "DISPLACEMENT", {.description = "write displacement output", .default_value = false}));
 
         // whether to write displacement state
-        Core::Utils::bool_parameter(
-            "GRIDVELOCITY", false, "write grid velocity output", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "GRIDVELOCITY", {.description = "write grid velocity output", .default_value = false}));
 
         // whether to write element owner
-        Core::Utils::bool_parameter(
-            "ELEMENT_OWNER", false, "write element owner", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}));
 
         // whether to write element GIDs
-        Core::Utils::bool_parameter(
-            "ELEMENT_GID", false, "write 4C internal element GIDs", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>("ELEMENT_GID",
+            {.description = "write 4C internal element GIDs", .default_value = false}));
 
         // whether to write node GIDs
-        Core::Utils::bool_parameter(
-            "NODE_GID", false, "write 4C internal node GIDs", sublist_IO_output_fluid);
+        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
+            "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}));
 
         sublist_IO_output_fluid.move_into_collection(list);
       }

--- a/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
@@ -25,6 +25,7 @@ namespace Inpar
       void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
       {
         using Teuchos::tuple;
+        using namespace Core::IO::InputSpecBuilders;
 
         // related sublist
         Core::Utils::SectionSpecs sublist_IO{"IO"};
@@ -32,81 +33,86 @@ namespace Inpar
         Core::Utils::SectionSpecs sublist_IO_output_beams{sublist_IO_VTK_structure, "BEAMS"};
 
         // whether to write special output for beam elements
-        Core::Utils::bool_parameter("OUTPUT_BEAMS", false, "write special output for beam elements",
-            sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("OUTPUT_BEAMS",
+            {.description = "write special output for beam elements", .default_value = false}));
 
         // whether to write displacement state
-        Core::Utils::bool_parameter(
-            "DISPLACEMENT", false, "write displacement output", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>(
+            "DISPLACEMENT", {.description = "write displacement output", .default_value = false}));
 
         // use absolute positions or initial positions for vtu geometry (i.e. point coordinates)
         // 'absolute positions' requires writing geometry in every output step (default for now)
-        Core::Utils::bool_parameter("USE_ABSOLUTE_POSITIONS", true,
-            "use absolute positions or initial positions for vtu geometry (i.e. point coordinates)",
-            sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>(
+            "USE_ABSOLUTE_POSITIONS", {.description = "use absolute positions or initial positions "
+                                                      "for vtu geometry (i.e. point coordinates)",
+                                          .default_value = true}));
 
         // write internal (elastic) energy of element
-        Core::Utils::bool_parameter("INTERNAL_ENERGY_ELEMENT", false,
-            "write internal (elastic) energy for each element", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("INTERNAL_ENERGY_ELEMENT",
+            {.description = "write internal (elastic) energy for each element",
+                .default_value = false}));
 
         // write kinetic energy of element
-        Core::Utils::bool_parameter("KINETIC_ENERGY_ELEMENT", false,
-            "write kinetic energy for each element", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("KINETIC_ENERGY_ELEMENT",
+            {.description = "write kinetic energy for each element", .default_value = false}));
 
         // write triads as three orthonormal base vectors at every visualization point
-        Core::Utils::bool_parameter("TRIAD_VISUALIZATIONPOINT", false,
-            "write triads at every visualization point", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("TRIAD_VISUALIZATIONPOINT",
+            {.description = "write triads at every visualization point", .default_value = false}));
 
         // write material cross-section strains at the Gauss points:
         // axial & shear strains, twist & curvatures
-        Core::Utils::bool_parameter("STRAINS_GAUSSPOINT", false,
-            "write material cross-section strains at the Gauss points", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("STRAINS_GAUSSPOINT",
+            {.description = "write material cross-section strains at the Gauss points",
+                .default_value = false}));
 
         // write material cross-section strains at the visualization points:
         // axial & shear strains, twist & curvatures
-        Core::Utils::bool_parameter("STRAINS_CONTINUOUS", false,
-            "write material cross-section strains at the visualization points",
-            sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("STRAINS_CONTINUOUS",
+            {.description = "write material cross-section strains at the visualization points",
+                .default_value = false}));
 
         // write material cross-section stresses at the Gauss points:
         // axial and shear forces, torque and bending moments
-        Core::Utils::bool_parameter("MATERIAL_FORCES_GAUSSPOINT", false,
-            "write material cross-section stresses at the Gauss points", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("MATERIAL_FORCES_GAUSSPOINT",
+            {.description = "write material cross-section stresses at the Gauss points",
+                .default_value = false}));
 
         // write material cross-section stresses at the visualization points:
         // axial and shear forces, torque and bending moments
-        Core::Utils::bool_parameter("MATERIAL_FORCES_CONTINUOUS", false,
-            "write material cross-section stresses at the visualization points",
-            sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("MATERIAL_FORCES_CONTINUOUS",
+            {.description = "write material cross-section stresses at the visualization points",
+                .default_value = false}));
 
         // write spatial cross-section stresses at the Gauss points:
         // axial and shear forces, torque and bending moments
-        Core::Utils::bool_parameter("SPATIAL_FORCES_GAUSSPOINT", false,
-            "write material cross-section stresses at the Gauss points", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("SPATIAL_FORCES_GAUSSPOINT",
+            {.description = "write material cross-section stresses at the Gauss points",
+                .default_value = false}));
 
         // write element filament numbers and type
-        Core::Utils::bool_parameter("BEAMFILAMENTCONDITION", false,
-            "write element filament numbers", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("BEAMFILAMENTCONDITION",
+            {.description = "write element filament numbers", .default_value = false}));
 
         // write element and network orientation parameter
-        Core::Utils::bool_parameter("ORIENTATION_PARAMETER", false,
-            "write element filament numbers", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("ORIENTATION_PARAMETER",
+            {.description = "write element filament numbers", .default_value = false}));
 
         // write crossection forces of periodic RVE
-        Core::Utils::bool_parameter("RVE_CROSSSECTION_FORCES", false,
-            " get sum of all internal forces of  ", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("RVE_CROSSSECTION_FORCES",
+            {.description = " get sum of all internal forces of  ", .default_value = false}));
 
         // write reference length of beams
-        Core::Utils::bool_parameter(
-            "REF_LENGTH", false, "write reference length of all beams", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("REF_LENGTH",
+            {.description = "write reference length of all beams", .default_value = false}));
 
         // write element GIDs
-        Core::Utils::bool_parameter(
-            "ELEMENT_GID", false, "write the 4C internal element GIDs", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("ELEMENT_GID",
+            {.description = "write the 4C internal element GIDs", .default_value = false}));
 
         // write element ghosting information
-        Core::Utils::bool_parameter("ELEMENT_GHOSTING", false,
-            "write which processors ghost the elements", sublist_IO_output_beams);
+        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("ELEMENT_GHOSTING",
+            {.description = "write which processors ghost the elements", .default_value = false}));
 
         // number of subsegments along a single beam element for visualization
         Core::Utils::int_parameter("NUMBER_SUBSEGMENTS", 5,

--- a/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
@@ -25,6 +25,7 @@ namespace Inpar
       void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
       {
         using Teuchos::tuple;
+        using namespace Core::IO::InputSpecBuilders;
 
         // related sublist
         Core::Utils::SectionSpecs sublist_IO{"IO"};
@@ -32,45 +33,45 @@ namespace Inpar
         Core::Utils::SectionSpecs sublist_IO_VTK_structure{sublist_IO_VTK, "STRUCTURE"};
 
         // whether to write output for structure
-        Core::Utils::bool_parameter(
-            "OUTPUT_STRUCTURE", false, "write structure output", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
+            "OUTPUT_STRUCTURE", {.description = "write structure output", .default_value = false}));
 
         // whether to write displacement state
-        Core::Utils::bool_parameter(
-            "DISPLACEMENT", false, "write displacement output", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
+            "DISPLACEMENT", {.description = "write displacement output", .default_value = false}));
 
         // whether to write velocity state
-        Core::Utils::bool_parameter(
-            "VELOCITY", false, "write velocity output", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
+            "VELOCITY", {.description = "write velocity output", .default_value = false}));
 
-        Core::Utils::bool_parameter(
-            "ACCELERATION", false, "write acceleration output", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
+            "ACCELERATION", {.description = "write acceleration output", .default_value = false}));
 
         // whether to write element owner
-        Core::Utils::bool_parameter(
-            "ELEMENT_OWNER", false, "write element owner", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
+            "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}));
 
         // whether to write element GIDs
-        Core::Utils::bool_parameter(
-            "ELEMENT_GID", false, "write 4C internal element GIDs", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("ELEMENT_GID",
+            {.description = "write 4C internal element GIDs", .default_value = false}));
 
         // write element ghosting information
-        Core::Utils::bool_parameter("ELEMENT_GHOSTING", false,
-            "write which processors ghost the elements", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("ELEMENT_GHOSTING",
+            {.description = "write which processors ghost the elements", .default_value = false}));
 
         // whether to write node GIDs
-        Core::Utils::bool_parameter(
-            "NODE_GID", false, "write 4C internal node GIDs", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
+            "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}));
 
         // write element material IDs
-        Core::Utils::bool_parameter("ELEMENT_MAT_ID", false,
-            "Output of the material id of each element", sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("ELEMENT_MAT_ID",
+            {.description = "Output of the material id of each element", .default_value = false}));
 
         // whether to write stress and / or strain data
-        Core::Utils::bool_parameter("STRESS_STRAIN", false,
-            "Write element stress and / or strain  data. The type of stress / strain has to be "
-            "selected in the --IO input section",
-            sublist_IO_VTK_structure);
+        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("STRESS_STRAIN",
+            {.description = "Write element stress and / or strain  data. The type of stress / "
+                            "strain has to be selected in the --IO input section",
+                .default_value = false}));
 
         // mode to write gauss point data
         Core::Utils::string_to_integral_parameter<Inpar::Solid::GaussPointDataOutputType>(

--- a/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
@@ -23,6 +23,7 @@ namespace Inpar
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
     {
       using Teuchos::tuple;
+      using namespace Core::IO::InputSpecBuilders;
 
       // related sublist
       Core::Utils::SectionSpecs sublist_IO{"IO"};
@@ -39,24 +40,25 @@ namespace Inpar
           sublist_IO_VTP_structure);
 
       // whether to write output in every iteration of the nonlinear solver
-      Core::Utils::bool_parameter("EVERY_ITERATION", false,
-          "write output in every iteration of the nonlinear solver", sublist_IO_VTP_structure);
+      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>("EVERY_ITERATION",
+          {.description = "write output in every iteration of the nonlinear solver",
+              .default_value = false}));
 
       // write owner at every visualization point
-      Core::Utils::bool_parameter(
-          "OWNER", false, "write owner of every point", sublist_IO_VTP_structure);
+      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>(
+          "OWNER", {.description = "write owner of every point", .default_value = false}));
 
       // write orientation at every visualization point
-      Core::Utils::bool_parameter("ORIENTATIONANDLENGTH", false, "write orientation at every point",
-          sublist_IO_VTP_structure);
+      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>("ORIENTATIONANDLENGTH",
+          {.description = "write orientation at every point", .default_value = false}));
 
       // write number of bonds at every visualization point
-      Core::Utils::bool_parameter(
-          "NUMBEROFBONDS", false, "write number of bonds of every point", sublist_IO_VTP_structure);
+      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>("NUMBEROFBONDS",
+          {.description = "write number of bonds of every point", .default_value = false}));
 
       // write force actin in linker
-      Core::Utils::bool_parameter(
-          "LINKINGFORCE", false, "write force acting in linker", sublist_IO_VTP_structure);
+      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>(
+          "LINKINGFORCE", {.description = "write force acting in linker", .default_value = false}));
 
       sublist_IO_VTP_structure.move_into_collection(list);
     }

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -52,6 +52,7 @@ void Inpar::BeamToSolid::beam_to_solid_interaction_get_string(
 void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs beaminteraction{"BEAM INTERACTION"};
 
@@ -101,9 +102,9 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
     //        coupled.
     // - Yes: The beam and solid states at the restart configuration are coupled. This allows to
     //        pre-deform the structures and then couple them.
-    Core::Utils::bool_parameter("COUPLE_RESTART_STATE", false,
-        "Enable / disable the coupling of the restart configuration.",
-        beam_to_solid_volume_mestying);
+    beam_to_solid_volume_mestying.specs.emplace_back(parameter<bool>("COUPLE_RESTART_STATE",
+        {.description = "Enable / disable the coupling of the restart configuration.",
+            .default_value = false}));
 
     Core::Utils::string_to_integral_parameter<BeamToSolidRotationCoupling>("ROTATION_COUPLING",
         "none", "Type of rotational coupling",
@@ -149,22 +150,24 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
       beam_to_solid_volume_mestying, "RUNTIME VTK OUTPUT"};
   {
     // Whether to write visualization output at all for btsvmt.
-    Core::Utils::bool_parameter("WRITE_OUTPUT", false,
-        "Enable / disable beam-to-solid volume mesh tying output.",
-        beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
+        "WRITE_OUTPUT", {.description = "Enable / disable beam-to-solid volume mesh tying output.",
+                            .default_value = false}));
 
-    Core::Utils::bool_parameter("NODAL_FORCES", false,
-        "Enable / disable output of the resulting nodal forces due to beam to solid interaction.",
-        beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
+        "NODAL_FORCES", {.description = "Enable / disable output of the resulting nodal forces due "
+                                        "to beam to solid interaction.",
+                            .default_value = false}));
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", false,
-        "Enable / disable output of the discrete Lagrange multipliers at the node of the Lagrange "
-        "multiplier shape functions.",
-        beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>("MORTAR_LAMBDA_DISCRET",
+        {.description = "Enable / disable output of the discrete Lagrange multipliers at the node "
+                        "of the Lagrange multiplier shape functions.",
+            .default_value = false}));
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", false,
-        "Enable / disable output of the continuous Lagrange multipliers function along the beam.",
-        beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
+        "MORTAR_LAMBDA_CONTINUOUS", {.description = "Enable / disable output of the continuous "
+                                                    "Lagrange multipliers function along the beam.",
+                                        .default_value = false}));
 
     Core::Utils::int_parameter("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS", 5,
         "Number of segments for continuous mortar output", beam_to_solid_volume_mestying_output);
@@ -174,17 +177,19 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
         "circumference",
         beam_to_solid_volume_mestying_output);
 
-    Core::Utils::bool_parameter("SEGMENTATION", false,
-        "Enable / disable output of segmentation points.", beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
+        "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
+                            .default_value = false}));
 
-    Core::Utils::bool_parameter("INTEGRATION_POINTS", false,
-        "Enable / disable output of used integration points. If the contact method has 'forces' at "
-        "the integration point, they will also be output.",
-        beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>("INTEGRATION_POINTS",
+        {.description = "Enable / disable output of used integration points. If the contact method "
+                        "has 'forces' at the integration point, they will also be output.",
+            .default_value = false}));
 
-    Core::Utils::bool_parameter("UNIQUE_IDS", false,
-        "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
-        beam_to_solid_volume_mestying_output);
+    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>("UNIQUE_IDS",
+        {.description =
+                "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
+            .default_value = false}));
   }
 
   beam_to_solid_volume_mestying_output.move_into_collection(list);
@@ -232,8 +237,8 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
         "Penalty parameter for beam-to-solid surface meshtying", beam_to_solid_surface_mestying);
 
     // Parameters for rotational coupling.
-    Core::Utils::bool_parameter("ROTATIONAL_COUPLING", false,
-        "Enable / disable rotational coupling", beam_to_solid_surface_mestying);
+    beam_to_solid_surface_mestying.specs.emplace_back(parameter<bool>("ROTATIONAL_COUPLING",
+        {.description = "Enable / disable rotational coupling", .default_value = false}));
     Core::Utils::double_parameter("ROTATIONAL_COUPLING_PENALTY_PARAMETER", 0.0,
         "Penalty parameter for beam-to-solid surface rotational meshtying",
         beam_to_solid_surface_mestying);
@@ -328,40 +333,45 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
       beam_to_solid_surface, "RUNTIME VTK OUTPUT"};
   {
     // Whether to write visualization output at all.
-    Core::Utils::bool_parameter("WRITE_OUTPUT", false,
-        "Enable / disable beam-to-solid volume mesh tying output.", beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
+        "WRITE_OUTPUT", {.description = "Enable / disable beam-to-solid volume mesh tying output.",
+                            .default_value = false}));
 
-    Core::Utils::bool_parameter("NODAL_FORCES", false,
-        "Enable / disable output of the resulting nodal forces due to beam to solid interaction.",
-        beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
+        "NODAL_FORCES", {.description = "Enable / disable output of the resulting nodal forces due "
+                                        "to beam to solid interaction.",
+                            .default_value = false}));
 
-    Core::Utils::bool_parameter("AVERAGED_NORMALS", false,
-        "Enable / disable output of averaged nodal normals on the surface.",
-        beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("AVERAGED_NORMALS",
+        {.description = "Enable / disable output of averaged nodal normals on the surface.",
+            .default_value = false}));
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", false,
-        "Enable / disable output of the discrete Lagrange multipliers at the node of the Lagrange "
-        "multiplier shape functions.",
-        beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("MORTAR_LAMBDA_DISCRET",
+        {.description = "Enable / disable output of the discrete Lagrange multipliers at the node "
+                        "of the Lagrange multiplier shape functions.",
+            .default_value = false}));
 
-    Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", false,
-        "Enable / disable output of the continuous Lagrange multipliers function along the beam.",
-        beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
+        "MORTAR_LAMBDA_CONTINUOUS", {.description = "Enable / disable output of the continuous "
+                                                    "Lagrange multipliers function along the beam.",
+                                        .default_value = false}));
 
     Core::Utils::int_parameter("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS", 5,
         "Number of segments for continuous mortar output", beam_to_solid_surface_output);
 
-    Core::Utils::bool_parameter("SEGMENTATION", false,
-        "Enable / disable output of segmentation points.", beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
+        "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
+                            .default_value = false}));
 
-    Core::Utils::bool_parameter("INTEGRATION_POINTS", false,
-        "Enable / disable output of used integration points. If the contact method has 'forces' at "
-        "the integration point, they will also be output.",
-        beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("INTEGRATION_POINTS",
+        {.description = "Enable / disable output of used integration points. If the contact method "
+                        "has 'forces' at the integration point, they will also be output.",
+            .default_value = false}));
 
-    Core::Utils::bool_parameter("UNIQUE_IDS", false,
-        "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
-        beam_to_solid_surface_output);
+    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("UNIQUE_IDS",
+        {.description =
+                "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
+            .default_value = false}));
   }
 
   beam_to_solid_surface_output.move_into_collection(list);

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -90,8 +90,9 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
         "Number of fourier modes to be used for cross-section mortar coupling",
         beam_to_solid_volume_mestying);
 
-    Core::Utils::double_parameter("PENALTY_PARAMETER", 0.0,
-        "Penalty parameter for beam-to-solid volume meshtying", beam_to_solid_volume_mestying);
+    beam_to_solid_volume_mestying.specs.emplace_back(parameter<double>(
+        "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-solid volume meshtying",
+                                 .default_value = 0.0}));
 
     // Add the geometry pair input parameters.
     Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_volume_mestying);
@@ -138,9 +139,11 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
             BeamToSolidMortarShapefunctions::line4),
         beam_to_solid_volume_mestying);
 
-    Core::Utils::double_parameter("ROTATION_COUPLING_PENALTY_PARAMETER", 0.0,
-        "Penalty parameter for rotational coupling in beam-to-solid volume mesh tying",
-        beam_to_solid_volume_mestying);
+    beam_to_solid_volume_mestying.specs.emplace_back(
+        parameter<double>("ROTATION_COUPLING_PENALTY_PARAMETER",
+            {.description =
+                    "Penalty parameter for rotational coupling in beam-to-solid volume mesh tying",
+                .default_value = 0.0}));
   }
 
   beam_to_solid_volume_mestying.move_into_collection(list);
@@ -233,15 +236,17 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
             BeamToSolidMortarShapefunctions::line4),
         beam_to_solid_surface_mestying);
 
-    Core::Utils::double_parameter("PENALTY_PARAMETER", 0.0,
-        "Penalty parameter for beam-to-solid surface meshtying", beam_to_solid_surface_mestying);
+    beam_to_solid_surface_mestying.specs.emplace_back(parameter<double>("PENALTY_PARAMETER",
+        {.description = "Penalty parameter for beam-to-solid surface meshtying",
+            .default_value = 0.0}));
 
     // Parameters for rotational coupling.
     beam_to_solid_surface_mestying.specs.emplace_back(parameter<bool>("ROTATIONAL_COUPLING",
         {.description = "Enable / disable rotational coupling", .default_value = false}));
-    Core::Utils::double_parameter("ROTATIONAL_COUPLING_PENALTY_PARAMETER", 0.0,
-        "Penalty parameter for beam-to-solid surface rotational meshtying",
-        beam_to_solid_surface_mestying);
+    beam_to_solid_surface_mestying.specs.emplace_back(
+        parameter<double>("ROTATIONAL_COUPLING_PENALTY_PARAMETER",
+            {.description = "Penalty parameter for beam-to-solid surface rotational meshtying",
+                .default_value = 0.0}));
     Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceRotationCoupling>(
         "ROTATIONAL_COUPLING_SURFACE_TRIAD", "none", "Construction method for surface triad",
         tuple<std::string>("none", "surface_cross_section_director", "averaged"),
@@ -278,8 +283,9 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
             BeamToSolidConstraintEnforcement::none, BeamToSolidConstraintEnforcement::penalty),
         beam_to_solid_surface_contact);
 
-    Core::Utils::double_parameter("PENALTY_PARAMETER", 0.0,
-        "Penalty parameter for beam-to-solid surface contact", beam_to_solid_surface_contact);
+    beam_to_solid_surface_contact.specs.emplace_back(parameter<double>(
+        "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-solid surface contact",
+                                 .default_value = 0.0}));
 
     Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceContact>("CONTACT_TYPE", "none",
         "How the contact constraints are formulated",
@@ -295,9 +301,10 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
             BeamToSolidSurfaceContactPenaltyLaw::linear_quadratic),
         beam_to_solid_surface_contact);
 
-    Core::Utils::double_parameter("PENALTY_PARAMETER_G0", 0.0,
-        "First penalty regularization parameter G0 >=0: For gap<G0 contact is active",
-        beam_to_solid_surface_contact);
+    beam_to_solid_surface_contact.specs.emplace_back(parameter<double>("PENALTY_PARAMETER_G0",
+        {.description =
+                "First penalty regularization parameter G0 >=0: For gap<G0 contact is active",
+            .default_value = 0.0}));
 
     Core::Utils::string_to_integral_parameter<BeamToSolidSurfaceContactMortarDefinedIn>(
         "MORTAR_CONTACT_DEFINED_IN", "none", "Configuration where the mortar contact is defined",

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -59,8 +59,9 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
       "CROSSLINKER", {.description = "Crosslinker in problem", .default_value = false}));
 
   // bounding box for initial random crosslinker position
-  Core::Utils::string_parameter("INIT_LINKER_BOUNDINGBOX", "1e12 1e12 1e12 1e12 1e12 1e12",
-      "Linker are initially set randomly within this bounding box", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("INIT_LINKER_BOUNDINGBOX",
+      {.description = "Linker are initially set randomly within this bounding box",
+          .default_value = "1e12 1e12 1e12 1e12 1e12 1e12"}));
 
   // time step for stochastic events concerning crosslinking
   crosslinking.specs.emplace_back(parameter<double>(
@@ -75,31 +76,36 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
   crosslinking.specs.emplace_back(
       parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}));
   // number of initial (are set right in the beginning) crosslinker of certain type
-  Core::Utils::string_parameter("MAXNUMINITCROSSLINKERPERTYPE", "0",
-      "number of initial crosslinker of certain type (additional to NUMCROSSLINKERPERTYPE) ",
-      crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>(
+      "MAXNUMINITCROSSLINKERPERTYPE", {.description = "number of initial crosslinker of certain "
+                                                      "type (additional to NUMCROSSLINKERPERTYPE) ",
+                                          .default_value = "0"}));
   // number of crosslinker of certain type
-  Core::Utils::string_parameter(
-      "NUMCROSSLINKERPERTYPE", "0", "number of crosslinker of certain type ", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("NUMCROSSLINKERPERTYPE",
+      {.description = "number of crosslinker of certain type ", .default_value = "0"}));
   // material number characterizing crosslinker type
-  Core::Utils::string_parameter("MATCROSSLINKERPERTYPE", "-1",
-      "material number characterizing crosslinker type ", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("MATCROSSLINKERPERTYPE",
+      {.description = "material number characterizing crosslinker type ", .default_value = "-1"}));
   // maximal number of binding partner per filament binding spot for each binding spot type
-  Core::Utils::string_parameter("MAXNUMBONDSPERFILAMENTBSPOT", "1",
-      "maximal number of bonds per filament binding spot", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("MAXNUMBONDSPERFILAMENTBSPOT",
+      {.description = "maximal number of bonds per filament binding spot", .default_value = "1"}));
   // distance between two binding spots on a filament (same on all filaments)
-  Core::Utils::string_parameter("FILAMENTBSPOTINTERVALGLOBAL", "-1.0",
-      "distance between two binding spots on all filaments", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALGLOBAL",
+      {.description = "distance between two binding spots on all filaments",
+          .default_value = "-1.0"}));
   // distance between two binding spots on a filament (as percentage of current filament length)
-  Core::Utils::string_parameter("FILAMENTBSPOTINTERVALLOCAL", "-1.0",
-      "distance between two binding spots on current filament", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALLOCAL",
+      {.description = "distance between two binding spots on current filament",
+          .default_value = "-1.0"}));
   // start and end for bspots on a filament in arc parameter (same on each filament independent of
   // their length)
-  Core::Utils::string_parameter("FILAMENTBSPOTRANGEGLOBAL", "-1.0 -1.0",
-      "Lower and upper arc parameter bound for binding spots on a filament", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGEGLOBAL",
+      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+          .default_value = "-1.0 -1.0"}));
   // start and end for bspots on a filament in percent of reference filament length
-  Core::Utils::string_parameter("FILAMENTBSPOTRANGELOCAL", "0.0 1.0",
-      "Lower and upper arc parameter bound for binding spots on a filament", crosslinking);
+  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
+      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+          .default_value = "0.0 1.0"}));
 
   crosslinking.move_into_collection(list);
 
@@ -121,24 +127,28 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
       "TIMESTEP", {.description = "time step for stochastic events concerning sphere beam linking "
                                   "(e.g. catch-slip-bond behavior) ",
                       .default_value = -1.0}));
-  Core::Utils::string_parameter(
-      "MAXNUMLINKERPERTYPE", "0", "number of crosslinker of certain type ", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<std::string>("MAXNUMLINKERPERTYPE",
+      {.description = "number of crosslinker of certain type ", .default_value = "0"}));
   // material number characterizing crosslinker type
-  Core::Utils::string_parameter(
-      "MATLINKERPERTYPE", "-1", "material number characterizing crosslinker type ", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<std::string>("MATLINKERPERTYPE",
+      {.description = "material number characterizing crosslinker type ", .default_value = "-1"}));
   // distance between two binding spots on a filament (same on all filaments)
-  Core::Utils::string_parameter("FILAMENTBSPOTINTERVALGLOBAL", "-1.0",
-      "distance between two binding spots on all filaments", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALGLOBAL",
+      {.description = "distance between two binding spots on all filaments",
+          .default_value = "-1.0"}));
   // distance between two binding spots on a filament (as percentage of current filament length)
-  Core::Utils::string_parameter("FILAMENTBSPOTINTERVALLOCAL", "-1.0",
-      "distance between two binding spots on current filament", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALLOCAL",
+      {.description = "distance between two binding spots on current filament",
+          .default_value = "-1.0"}));
   // start and end for bspots on a filament in arc parameter (same on each filament independent of
   // their length)
-  Core::Utils::string_parameter("FILAMENTBSPOTRANGEGLOBAL", "-1.0 -1.0",
-      "Lower and upper arc parameter bound for binding spots on a filament", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGEGLOBAL",
+      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+          .default_value = "-1.0 -1.0"}));
   // start and end for bspots on a filament in percent of reference filament length
-  Core::Utils::string_parameter("FILAMENTBSPOTRANGELOCAL", "0.0 1.0",
-      "Lower and upper arc parameter bound for binding spots on a filament", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
+      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+          .default_value = "0.0 1.0"}));
 
   spherebeamlink.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -29,6 +29,7 @@ void Inpar::BeamInteraction::beam_interaction_conditions_get_all(
 void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs beaminteraction{"BEAM INTERACTION"};
 
@@ -54,7 +55,8 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
   Core::Utils::SectionSpecs crosslinking{beaminteraction, "CROSSLINKING"};
 
   // remove this some day
-  Core::Utils::bool_parameter("CROSSLINKER", false, "Crosslinker in problem", crosslinking);
+  crosslinking.specs.emplace_back(parameter<bool>(
+      "CROSSLINKER", {.description = "Crosslinker in problem", .default_value = false}));
 
   // bounding box for initial random crosslinker position
   Core::Utils::string_parameter("INIT_LINKER_BOUNDINGBOX", "1e12 1e12 1e12 1e12 1e12 1e12",
@@ -104,7 +106,8 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
 
   Core::Utils::SectionSpecs spherebeamlink{beaminteraction, "SPHERE BEAM LINK"};
 
-  Core::Utils::bool_parameter("SPHEREBEAMLINKING", false, "Integrins in problem", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<bool>(
+      "SPHEREBEAMLINKING", {.description = "Integrins in problem", .default_value = false}));
 
   // Reading double parameter for contraction rate for active linker
   Core::Utils::double_parameter("CONTRACTIONRATE", 0.0,

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -63,14 +63,17 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
       "Linker are initially set randomly within this bounding box", crosslinking);
 
   // time step for stochastic events concerning crosslinking
-  Core::Utils::double_parameter("TIMESTEP", -1.0,
-      "time step for stochastic events concerning crosslinking (e.g. diffusion, p_link, p_unlink) ",
-      crosslinking);
+  crosslinking.specs.emplace_back(parameter<double>(
+      "TIMESTEP", {.description = "time step for stochastic events concerning crosslinking (e.g. "
+                                  "diffusion, p_link, p_unlink) ",
+                      .default_value = -1.0}));
   // Reading double parameter for viscosity of background fluid
-  Core::Utils::double_parameter("VISCOSITY", 0.0, "viscosity", crosslinking);
+  crosslinking.specs.emplace_back(
+      parameter<double>("VISCOSITY", {.description = "viscosity", .default_value = 0.0}));
   // Reading double parameter for thermal energy in background fluid (temperature * Boltzmann
   // constant)
-  Core::Utils::double_parameter("KT", 0.0, "thermal energy", crosslinking);
+  crosslinking.specs.emplace_back(
+      parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}));
   // number of initial (are set right in the beginning) crosslinker of certain type
   Core::Utils::string_parameter("MAXNUMINITCROSSLINKERPERTYPE", "0",
       "number of initial crosslinker of certain type (additional to NUMCROSSLINKERPERTYPE) ",
@@ -110,13 +113,14 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
       "SPHEREBEAMLINKING", {.description = "Integrins in problem", .default_value = false}));
 
   // Reading double parameter for contraction rate for active linker
-  Core::Utils::double_parameter("CONTRACTIONRATE", 0.0,
-      "contraction rate of cell (integrin linker) in [microm/s]", spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<double>(
+      "CONTRACTIONRATE", {.description = "contraction rate of cell (integrin linker) in [microm/s]",
+                             .default_value = 0.0}));
   // time step for stochastic events concerning sphere beam linking
-  Core::Utils::double_parameter("TIMESTEP", -1.0,
-      "time step for stochastic events concerning sphere beam linking (e.g. catch-slip-bond "
-      "behavior) ",
-      spherebeamlink);
+  spherebeamlink.specs.emplace_back(parameter<double>(
+      "TIMESTEP", {.description = "time step for stochastic events concerning sphere beam linking "
+                                  "(e.g. catch-slip-bond behavior) ",
+                      .default_value = -1.0}));
   Core::Utils::string_parameter(
       "MAXNUMLINKERPERTYPE", "0", "number of crosslinker of certain type ", spherebeamlink);
   // material number characterizing crosslinker type
@@ -166,8 +170,8 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
       tuple<Inpar::BeamInteraction::Strategy>(bstr_none, bstr_none, bstr_penalty, bstr_penalty),
       beamtospherecontact);
 
-  Core::Utils::double_parameter("PENALTY_PARAMETER", 0.0,
-      "Penalty parameter for beam-to-rigidsphere contact", beamtospherecontact);
+  beamtospherecontact.specs.emplace_back(parameter<double>("PENALTY_PARAMETER",
+      {.description = "Penalty parameter for beam-to-rigidsphere contact", .default_value = 0.0}));
 
   beamtospherecontact.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -24,12 +24,14 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
   /* parameters for potential-based beam interaction */
   Core::Utils::SectionSpecs beampotential{"BEAM POTENTIAL"};
 
-  Core::Utils::string_parameter("POT_LAW_EXPONENT", "1.0",
-      "negative(!) exponent(s)  $m_i$ of potential law "
-      "$\\Phi(r) = \\sum_i (k_i * r^{-m_i}).$",
-      beampotential);
-  Core::Utils::string_parameter("POT_LAW_PREFACTOR", "0.0",
-      "prefactor(s) $k_i$ of potential law $\\Phi(r) = \\sum_i (k_i * r^{-m_i})$.", beampotential);
+  beampotential.specs.emplace_back(parameter<std::string>(
+      "POT_LAW_EXPONENT", {.description = "negative(!) exponent(s)  $m_i$ of potential law  "
+                                          "$\\Phi(r) = \\sum_i (k_i * r^{-m_i}).$",
+                              .default_value = "1.0"}));
+
+  beampotential.specs.emplace_back(parameter<std::string>("POT_LAW_PREFACTOR",
+      {.description = "prefactor(s) $k_i$ of potential law $\\Phi(r) = \\sum_i (k_i * r^{-m_i})$.",
+          .default_value = "0.0"}));
 
   Core::Utils::string_to_integral_parameter<Inpar::BeamPotential::BeamPotentialType>(
       "BEAMPOTENTIAL_TYPE", "Surface",

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -19,6 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for potential-based beam interaction */
   Core::Utils::SectionSpecs beampotential{"BEAM POTENTIAL"};
@@ -73,8 +74,8 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
   Core::Utils::int_parameter(
       "NUM_GAUSSPOINTS", 10, "Number of Gauss points used per integration segment", beampotential);
 
-  Core::Utils::bool_parameter("AUTOMATIC_DIFFERENTIATION", false,
-      "apply automatic differentiation via FAD?", beampotential);
+  beampotential.specs.emplace_back(parameter<bool>("AUTOMATIC_DIFFERENTIATION",
+      {.description = "apply automatic differentiation via FAD?", .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<MasterSlaveChoice>("CHOICE_MASTER_SLAVE",
       "smaller_eleGID_is_slave",
@@ -84,13 +85,15 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
           MasterSlaveChoice::smaller_eleGID_is_slave, MasterSlaveChoice::higher_eleGID_is_slave),
       beampotential);
 
-  Core::Utils::bool_parameter("BEAMPOT_BTSOL", false,
-      "decide, whether potential-based interaction between beams and solids is considered",
-      beampotential);
+  beampotential.specs.emplace_back(parameter<bool>("BEAMPOT_BTSOL",
+      {.description =
+              "decide, whether potential-based interaction between beams and solids is considered",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("BEAMPOT_BTSPH", false,
-      "decide, whether potential-based interaction between beams and spheres is considered",
-      beampotential);
+  beampotential.specs.emplace_back(parameter<bool>("BEAMPOT_BTSPH",
+      {.description =
+              "decide, whether potential-based interaction between beams and spheres is considered",
+          .default_value = false}));
 
   // enable octree search and determine type of bounding box (aabb = axis aligned, spbb = spherical)
   Core::Utils::string_to_integral_parameter<BeamContact::OctreeType>("BEAMPOT_OCTREE", "None",
@@ -120,36 +123,40 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
 
 
   // whether to write visualization output for beam contact
-  Core::Utils::bool_parameter("VTK_OUTPUT_BEAM_POTENTIAL", false,
-      "write visualization output for potential-based beam interactions",
-      beampotential_output_sublist);
+  beampotential_output_sublist.specs.emplace_back(parameter<bool>("VTK_OUTPUT_BEAM_POTENTIAL",
+      {.description = "write visualization output for potential-based beam interactions",
+          .default_value = false}));
 
   // output interval regarding steps: write output every INTERVAL_STEPS steps
   Core::Utils::int_parameter("INTERVAL_STEPS", -1,
       "write output at runtime every INTERVAL_STEPS steps", beampotential_output_sublist);
 
   // whether to write output in every iteration of the nonlinear solver
-  Core::Utils::bool_parameter("EVERY_ITERATION", false,
-      "write output in every iteration of the nonlinear solver", beampotential_output_sublist);
+  beampotential_output_sublist.specs.emplace_back(parameter<bool>(
+      "EVERY_ITERATION", {.description = "write output in every iteration of the nonlinear solver",
+                             .default_value = false}));
 
   // whether to write visualization output for forces
-  Core::Utils::bool_parameter(
-      "FORCES", false, "write visualization output for forces", beampotential_output_sublist);
+  beampotential_output_sublist.specs.emplace_back(parameter<bool>(
+      "FORCES", {.description = "write visualization output for forces", .default_value = false}));
 
   // whether to write visualization output for moments
-  Core::Utils::bool_parameter(
-      "MOMENTS", false, "write visualization output for moments", beampotential_output_sublist);
+  beampotential_output_sublist.specs.emplace_back(parameter<bool>("MOMENTS",
+      {.description = "write visualization output for moments", .default_value = false}));
 
   // whether to write visualization output for forces/moments separately for each element pair
-  Core::Utils::bool_parameter("WRITE_FORCE_MOMENT_PER_ELEMENTPAIR", false,
-      "write visualization output for forces/moments separately for each element pair",
-      beampotential_output_sublist);
+  beampotential_output_sublist.specs.emplace_back(
+      parameter<bool>("WRITE_FORCE_MOMENT_PER_ELEMENTPAIR",
+          {.description =
+                  "write visualization output for forces/moments separately for each element pair",
+              .default_value = false}));
 
   // whether to write out the UIDs (uid_0_beam_1_gid, uid_1_beam_2_gid, uid_2_gp_id)
-  Core::Utils::bool_parameter("WRITE_UIDS", false,
-      "write out the unique ID's for each visualization point,i.e., master and slave beam element "
-      "global ID (uid_0_beam_1_gid, uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
-      beampotential_output_sublist);
+  beampotential_output_sublist.specs.emplace_back(parameter<bool>(
+      "WRITE_UIDS", {.description = "write out the unique ID's for each visualization point,i.e., "
+                                    "master and slave beam element global ID (uid_0_beam_1_gid, "
+                                    "uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
+                        .default_value = false}));
 
   beampotential_output_sublist.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_beampotential.cpp
+++ b/src/inpar/4C_inpar_beampotential.cpp
@@ -51,10 +51,10 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
           strategy_singlelengthspec_smallsepapprox_simple),
       beampotential);
 
-  Core::Utils::double_parameter("CUTOFF_RADIUS", -1.0,
-      "Neglect all potential contributions at separation larger"
-      "than this cutoff radius",
-      beampotential);
+  beampotential.specs.emplace_back(parameter<double>("CUTOFF_RADIUS",
+      {.description =
+              "Neglect all potential contributions at separation largerthan this cutoff radius",
+          .default_value = -1.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::BeamPotential::BeamPotentialRegularizationType>(
       "REGULARIZATION_TYPE", "none", "Type of regularization applied to the force law",
@@ -63,10 +63,9 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
           regularization_linear, regularization_constant, regularization_none, regularization_none),
       beampotential);
 
-  Core::Utils::double_parameter("REGULARIZATION_SEPARATION", -1.0,
-      "Use regularization of force law at separations "
-      "smaller than this separation",
-      beampotential);
+  beampotential.specs.emplace_back(parameter<double>("REGULARIZATION_SEPARATION",
+      {.description = "Use regularization of force law at separations smaller than this separation",
+          .default_value = -1.0}));
 
   Core::Utils::int_parameter("NUM_INTEGRATION_SEGMENTS", 1,
       "Number of integration segments used per beam element", beampotential);
@@ -109,10 +108,10 @@ void Inpar::BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::
   Core::Utils::int_parameter(
       "BEAMPOT_BOXESINOCT", 8, "max number of bounding boxes in any leaf octant", beampotential);
 
-  Core::Utils::double_parameter("POTENTIAL_REDUCTION_LENGTH", -1.0,
-      "Within this length of the master beam end point the potential is smoothly reduced to one "
-      "half to account for infinitely long master beam surrogates.",
-      beampotential);
+  beampotential.specs.emplace_back(parameter<double>("POTENTIAL_REDUCTION_LENGTH",
+      {.description = "Within this length of the master beam end point the potential is smoothly "
+                      "reduced to one half to account for infinitely long master beam surrogates.",
+          .default_value = -1.0}));
 
   beampotential.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_binningstrategy.cpp
+++ b/src/inpar/4C_inpar_binningstrategy.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::BINSTRATEGY::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs binningstrategy{"BINNING STRATEGY"};
 

--- a/src/inpar/4C_inpar_binningstrategy.cpp
+++ b/src/inpar/4C_inpar_binningstrategy.cpp
@@ -28,18 +28,21 @@ void Inpar::BINSTRATEGY::set_valid_parameters(std::map<std::string, Core::IO::In
       "direction",
       binningstrategy);
 
-  Core::Utils::string_parameter("BIN_PER_DIR", "-1 -1 -1",
-      "Number of bins per direction (x, y, z) in particle simulations. Either Define this value or "
-      "BIN_SIZE_LOWER_BOUND",
-      binningstrategy);
+  binningstrategy.specs.emplace_back(parameter<std::string>("BIN_PER_DIR",
+      {.description = "Number of bins per direction (x, y, z) in particle simulations. Either "
+                      "Define this value or  BIN_SIZE_LOWER_BOUND",
+          .default_value = "-1 -1 -1"}));
 
-  Core::Utils::string_parameter("PERIODICONOFF", "0 0 0",
-      "Turn on/off periodic boundary conditions in each spatial direction", binningstrategy);
 
-  Core::Utils::string_parameter("DOMAINBOUNDINGBOX", "1e12 1e12 1e12 1e12 1e12 1e12",
-      "Bounding box for computational domain using binning strategy. Specify diagonal corner "
-      "points",
-      binningstrategy);
+  binningstrategy.specs.emplace_back(parameter<std::string>("PERIODICONOFF",
+      {.description = "Turn on/off periodic boundary conditions in each spatial direction",
+          .default_value = "0 0 0"}));
+
+  binningstrategy.specs.emplace_back(parameter<std::string>(
+      "DOMAINBOUNDINGBOX", {.description = "Bounding box for computational domain using binning "
+                                           "strategy. Specify diagonal corner  points",
+                               .default_value = "1e12 1e12 1e12 1e12 1e12 1e12"}));
+
 
   Core::Utils::string_to_integral_parameter<Core::Binstrategy::WriteBins>("WRITEBINS", "none",
       "Write none, row or column bins for visualization",

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -26,9 +26,11 @@ void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<std::string>("ExpTaylorGalerkin", "Stationary"),
       tuple<TimeIntegrationScheme>(tay_gal, stationary), andyn);
 
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", andyn);
+  andyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
   Core::Utils::int_parameter("NUMSTEP", 0, "Number of Time Steps", andyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", andyn);
+  andyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", andyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", andyn);
 
@@ -62,19 +64,24 @@ void Inpar::ArteryNetwork::set_valid_parameters(std::map<std::string, Core::IO::
   using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs redtisdyn{"COUPLED REDUCED-D AIRWAYS AND TISSUE DYNAMIC"};
-  Core::Utils::double_parameter("CONVTOL_P", 1E-6,
-      "Coupled red_airway and tissue iteration convergence for pressure", redtisdyn);
-  Core::Utils::double_parameter(
-      "CONVTOL_Q", 1E-6, "Coupled red_airway and tissue iteration convergence for flux", redtisdyn);
+  redtisdyn.specs.emplace_back(parameter<double>("CONVTOL_P",
+      {.description = "Coupled red_airway and tissue iteration convergence for pressure",
+          .default_value = 1E-6}));
+  redtisdyn.specs.emplace_back(parameter<double>(
+      "CONVTOL_Q", {.description = "Coupled red_airway and tissue iteration convergence for flux",
+                       .default_value = 1E-6}));
   Core::Utils::int_parameter("MAXITER", 5, "Maximum coupling iterations", redtisdyn);
   Core::Utils::string_to_integral_parameter<Relaxtype3D0D>("RELAXTYPE", "norelaxation",
       "Dynamic Relaxation Type",
       tuple<std::string>("norelaxation", "fixedrelaxation", "Aitken", "SD"),
       tuple<Relaxtype3D0D>(norelaxation, fixedrelaxation, Aitken, SD), redtisdyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", redtisdyn);
+  redtisdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
   Core::Utils::int_parameter("NUMSTEP", 1, "Number of Time Steps", redtisdyn);
-  Core::Utils::double_parameter("MAXTIME", 4.0, "", redtisdyn);
-  Core::Utils::double_parameter("NORMAL", 1.0, "", redtisdyn);
+  redtisdyn.specs.emplace_back(
+      parameter<double>("MAXTIME", {.description = "", .default_value = 4.0}));
+  redtisdyn.specs.emplace_back(
+      parameter<double>("NORMAL", {.description = "", .default_value = 1.0}));
 
   redtisdyn.move_into_collection(list);
 }
@@ -221,18 +228,22 @@ void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputS
   biofilmcontrol.specs.emplace_back(parameter<bool>("AVGROWTH",
       {.description = "The calculation of growth parameters is based on averaged values",
           .default_value = false}));
-  Core::Utils::double_parameter(
-      "FLUXCOEF", 0.0, "Coefficient for growth due to scalar flux", biofilmcontrol);
-  Core::Utils::double_parameter("NORMFORCEPOSCOEF", 0.0,
-      "Coefficient for erosion due to traction normal surface forces", biofilmcontrol);
-  Core::Utils::double_parameter("NORMFORCENEGCOEF", 0.0,
-      "Coefficient for erosion due to compression normal surface forces", biofilmcontrol);
-  Core::Utils::double_parameter("TANGONEFORCECOEF", 0.0,
-      "Coefficient for erosion due to the first tangential surface force", biofilmcontrol);
-  Core::Utils::double_parameter("TANGTWOFORCECOEF", 0.0,
-      "Coefficient for erosion due to the second tangential surface force", biofilmcontrol);
-  Core::Utils::double_parameter(
-      "BIOTIMESTEP", 0.05, "Time step size for biofilm growth", biofilmcontrol);
+  biofilmcontrol.specs.emplace_back(parameter<double>("FLUXCOEF",
+      {.description = "Coefficient for growth due to scalar flux", .default_value = 0.0}));
+  biofilmcontrol.specs.emplace_back(parameter<double>("NORMFORCEPOSCOEF",
+      {.description = "Coefficient for erosion due to traction normal surface forces",
+          .default_value = 0.0}));
+  biofilmcontrol.specs.emplace_back(parameter<double>("NORMFORCENEGCOEF",
+      {.description = "Coefficient for erosion due to compression normal surface forces",
+          .default_value = 0.0}));
+  biofilmcontrol.specs.emplace_back(parameter<double>("TANGONEFORCECOEF",
+      {.description = "Coefficient for erosion due to the first tangential surface force",
+          .default_value = 0.0}));
+  biofilmcontrol.specs.emplace_back(parameter<double>("TANGTWOFORCECOEF",
+      {.description = "Coefficient for erosion due to the second tangential surface force",
+          .default_value = 0.0}));
+  biofilmcontrol.specs.emplace_back(parameter<double>(
+      "BIOTIMESTEP", {.description = "Time step size for biofilm growth", .default_value = 0.05}));
   Core::Utils::int_parameter(
       "BIONUMSTEP", 0, "Maximum number of steps for biofilm growth", biofilmcontrol);
   biofilmcontrol.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
@@ -274,14 +285,17 @@ void Inpar::ReducedLung::set_valid_parameters(std::map<std::string, Core::IO::In
       "Solver type", tuple<std::string>("Linear", "Nonlinear"),
       tuple<RedAirwaysDyntype>(linear, nonlinear), redawdyn);
 
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", redawdyn);
+  redawdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
   Core::Utils::int_parameter("NUMSTEP", 0, "Number of Time Steps", redawdyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", redawdyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", redawdyn);
-  Core::Utils::double_parameter("THETA", 1.0, "One-step-theta time integration factor", redawdyn);
+  redawdyn.specs.emplace_back(parameter<double>(
+      "THETA", {.description = "One-step-theta time integration factor", .default_value = 1.0}));
 
   Core::Utils::int_parameter("MAXITERATIONS", 1, "maximum iteration steps", redawdyn);
-  Core::Utils::double_parameter("TOLERANCE", 1.0E-6, "tolerance", redawdyn);
+  redawdyn.specs.emplace_back(
+      parameter<double>("TOLERANCE", {.description = "tolerance", .default_value = 1.0E-6}));
 
   // number of linear solver used for reduced dimensional airways dynamic
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,
@@ -300,8 +314,9 @@ void Inpar::ReducedLung::set_valid_parameters(std::map<std::string, Core::IO::In
               "Flag to (de)activate initial acini volume adjustment with pre-stress condition",
           .default_value = false}));
 
-  Core::Utils::double_parameter("TRANSPULMPRESS", 800.0,
-      "Transpulmonary pressure needed for recalculation of acini volumes", redawdyn);
+  redawdyn.specs.emplace_back(parameter<double>("TRANSPULMPRESS",
+      {.description = "Transpulmonary pressure needed for recalculation of acini volumes",
+          .default_value = 800.0}));
 
   redawdyn.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
   Core::Utils::SectionSpecs andyn{"ARTERIAL DYNAMIC"};
 
   Core::Utils::string_to_integral_parameter<TimeIntegrationScheme>("DYNAMICTYPE",
@@ -31,8 +32,9 @@ void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", andyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", andyn);
 
-  Core::Utils::bool_parameter(
-      "SOLVESCATRA", false, "Flag to (de)activate solving scalar transport in blood", andyn);
+  andyn.specs.emplace_back(parameter<bool>(
+      "SOLVESCATRA", {.description = "Flag to (de)activate solving scalar transport in blood",
+                         .default_value = false}));
 
   // number of linear solver used for arterial dynamics
   Core::Utils::int_parameter(
@@ -57,6 +59,7 @@ void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 void Inpar::ArteryNetwork::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs redtisdyn{"COUPLED REDUCED-D AIRWAYS AND TISSUE DYNAMIC"};
   Core::Utils::double_parameter("CONVTOL_P", 1E-6,
@@ -210,12 +213,14 @@ void Inpar::ArteryNetwork::set_valid_conditions(
 
 void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
+  using namespace Core::IO::InputSpecBuilders;
   Core::Utils::SectionSpecs biofilmcontrol{"BIOFILM CONTROL"};
 
-  Core::Utils::bool_parameter(
-      "BIOFILMGROWTH", false, "Scatra algorithm for biofilm growth", biofilmcontrol);
-  Core::Utils::bool_parameter("AVGROWTH", false,
-      "The calculation of growth parameters is based on averaged values", biofilmcontrol);
+  biofilmcontrol.specs.emplace_back(parameter<bool>("BIOFILMGROWTH",
+      {.description = "Scatra algorithm for biofilm growth", .default_value = false}));
+  biofilmcontrol.specs.emplace_back(parameter<bool>("AVGROWTH",
+      {.description = "The calculation of growth parameters is based on averaged values",
+          .default_value = false}));
   Core::Utils::double_parameter(
       "FLUXCOEF", 0.0, "Coefficient for growth due to scalar flux", biofilmcontrol);
   Core::Utils::double_parameter("NORMFORCEPOSCOEF", 0.0,
@@ -230,8 +235,8 @@ void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputS
       "BIOTIMESTEP", 0.05, "Time step size for biofilm growth", biofilmcontrol);
   Core::Utils::int_parameter(
       "BIONUMSTEP", 0, "Maximum number of steps for biofilm growth", biofilmcontrol);
-  Core::Utils::bool_parameter(
-      "OUTPUT_GMSH", false, "Do you want to write Gmsh postprocessing files?", biofilmcontrol);
+  biofilmcontrol.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
+      {.description = "Do you want to write Gmsh postprocessing files?", .default_value = false}));
 
   biofilmcontrol.move_into_collection(list);
 }
@@ -257,6 +262,7 @@ void Inpar::BioFilm::set_valid_conditions(
 void Inpar::ReducedLung::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs redawdyn{"REDUCED DIMENSIONAL AIRWAYS DYNAMIC"};
 
@@ -281,14 +287,18 @@ void Inpar::ReducedLung::set_valid_parameters(std::map<std::string, Core::IO::In
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,
       "number of linear solver used for reduced dim arterial dynamics", redawdyn);
 
-  Core::Utils::bool_parameter(
-      "SOLVESCATRA", false, "Flag to (de)activate solving scalar transport in blood", redawdyn);
+  redawdyn.specs.emplace_back(parameter<bool>(
+      "SOLVESCATRA", {.description = "Flag to (de)activate solving scalar transport in blood",
+                         .default_value = false}));
 
-  Core::Utils::bool_parameter("COMPAWACINTER", false,
-      "Flag to (de)activate computation of airway-acinus interdependency", redawdyn);
+  redawdyn.specs.emplace_back(parameter<bool>("COMPAWACINTER",
+      {.description = "Flag to (de)activate computation of airway-acinus interdependency",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("CALCV0PRESTRESS", false,
-      "Flag to (de)activate initial acini volume adjustment with pre-stress condition", redawdyn);
+  redawdyn.specs.emplace_back(parameter<bool>("CALCV0PRESTRESS",
+      {.description =
+              "Flag to (de)activate initial acini volume adjustment with pre-stress condition",
+          .default_value = false}));
 
   Core::Utils::double_parameter("TRANSPULMPRESS", 800.0,
       "Transpulmonary pressure needed for recalculation of acini volumes", redawdyn);

--- a/src/inpar/4C_inpar_cardiac_monodomain.cpp
+++ b/src/inpar/4C_inpar_cardiac_monodomain.cpp
@@ -26,8 +26,10 @@ void Inpar::ElectroPhysiology::set_valid_parameters(
   Core::Utils::int_parameter("WRITEMAXIONICCURRENTS", 0,
       "number of maximal ionic currents to be postprocessed", epcontrol);
 
-  Core::Utils::double_parameter("ACTTHRES", 1.0,
-      "threshold for the potential for computing and postprocessing activation time ", epcontrol);
+  epcontrol.specs.emplace_back(parameter<double>("ACTTHRES",
+      {.description =
+              "threshold for the potential for computing and postprocessing activation time ",
+          .default_value = 1.0}));
 
   epcontrol.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_cardiac_monodomain.cpp
+++ b/src/inpar/4C_inpar_cardiac_monodomain.cpp
@@ -16,6 +16,7 @@ void Inpar::ElectroPhysiology::set_valid_parameters(
     std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs epcontrol{"CARDIAC MONODOMAIN CONTROL"};
 

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -577,8 +577,8 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
 
   Core::Utils::SectionSpecs mor{"MOR"};
 
-  Core::Utils::string_parameter(
-      "POD_MATRIX", "none", "filename of file containing projection matrix", mor);
+  mor.specs.emplace_back(parameter<std::string>("POD_MATRIX",
+      {.description = "filename of file containing projection matrix", .default_value = "none"}));
 
   mor.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs cardvasc0dstruct{"CARDIOVASCULAR 0D-STRUCTURE COUPLING"};
 
@@ -28,12 +29,13 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
       cardvasc0dstruct);
   Core::Utils::double_parameter("TIMINT_THETA", 0.5,
       "theta for one-step-theta time-integration scheme of Cardiovascular0D", cardvasc0dstruct);
-  Core::Utils::bool_parameter("RESTART_WITH_CARDVASC0D", false,
-      "Must be chosen if a non-cardiovascular0d simulation is to be restarted as "
-      "cardiovascular0d-structural coupled problem.",
-      cardvasc0dstruct);
-  Core::Utils::bool_parameter("ENHANCED_OUTPUT", false,
-      "Set to yes for enhanced output (like e.g. derivative information)", cardvasc0dstruct);
+  cardvasc0dstruct.specs.emplace_back(parameter<bool>("RESTART_WITH_CARDVASC0D",
+      {.description = "Must be chosen if a non-cardiovascular0d simulation is to be restarted as "
+                      "cardiovascular0d-structural coupled problem.",
+          .default_value = false}));
+  cardvasc0dstruct.specs.emplace_back(parameter<bool>("ENHANCED_OUTPUT",
+      {.description = "Set to yes for enhanced output (like e.g. derivative information)",
+          .default_value = false}));
 
   // linear solver id used for monolithic 0D cardiovascular-structural problems
   Core::Utils::int_parameter("LINEAR_COUPLED_SOLVER", -1,
@@ -49,8 +51,8 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
   Core::Utils::double_parameter(
       "EPS_PERIODIC", 1.0e-16, "tolerance for periodic state", cardvasc0dstruct);
 
-  Core::Utils::bool_parameter(
-      "PTC_3D0D", false, "Set to yes for doing PTC 2x2 block system.", cardvasc0dstruct);
+  cardvasc0dstruct.specs.emplace_back(parameter<bool>("PTC_3D0D",
+      {.description = "Set to yes for doing PTC 2x2 block system.", .default_value = false}));
 
   Core::Utils::double_parameter("K_PTC", 0.0,
       "PTC parameter: 0 means normal Newton, ->infty means steepest desc", cardvasc0dstruct);

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -22,13 +22,16 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
 
   Core::Utils::SectionSpecs cardvasc0dstruct{"CARDIOVASCULAR 0D-STRUCTURE COUPLING"};
 
-  Core::Utils::double_parameter("TOL_CARDVASC0D_RES", 1.0E-08,
-      "tolerance in the cardiovascular0d error norm for the Newton iteration", cardvasc0dstruct);
-  Core::Utils::double_parameter("TOL_CARDVASC0D_DOFINCR", 1.0E-08,
-      "tolerance in the cardiovascular0d dof increment error norm for the Newton iteration",
-      cardvasc0dstruct);
-  Core::Utils::double_parameter("TIMINT_THETA", 0.5,
-      "theta for one-step-theta time-integration scheme of Cardiovascular0D", cardvasc0dstruct);
+  cardvasc0dstruct.specs.emplace_back(parameter<double>("TOL_CARDVASC0D_RES",
+      {.description = "tolerance in the cardiovascular0d error norm for the Newton iteration",
+          .default_value = 1.0E-08}));
+  cardvasc0dstruct.specs.emplace_back(parameter<double>("TOL_CARDVASC0D_DOFINCR",
+      {.description =
+              "tolerance in the cardiovascular0d dof increment error norm for the Newton iteration",
+          .default_value = 1.0E-08}));
+  cardvasc0dstruct.specs.emplace_back(parameter<double>("TIMINT_THETA",
+      {.description = "theta for one-step-theta time-integration scheme of Cardiovascular0D",
+          .default_value = 0.5}));
   cardvasc0dstruct.specs.emplace_back(parameter<bool>("RESTART_WITH_CARDVASC0D",
       {.description = "Must be chosen if a non-cardiovascular0d simulation is to be restarted as "
                       "cardiovascular0d-structural coupled problem.",
@@ -47,37 +50,45 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
           Inpar::Cardiovascular0D::cardvasc0dsolve_direct),
       cardvasc0dstruct);
 
-  Core::Utils::double_parameter("T_PERIOD", -1.0, "periodic time", cardvasc0dstruct);
-  Core::Utils::double_parameter(
-      "EPS_PERIODIC", 1.0e-16, "tolerance for periodic state", cardvasc0dstruct);
+  cardvasc0dstruct.specs.emplace_back(
+      parameter<double>("T_PERIOD", {.description = "periodic time", .default_value = -1.0}));
+  cardvasc0dstruct.specs.emplace_back(parameter<double>(
+      "EPS_PERIODIC", {.description = "tolerance for periodic state", .default_value = 1.0e-16}));
 
   cardvasc0dstruct.specs.emplace_back(parameter<bool>("PTC_3D0D",
       {.description = "Set to yes for doing PTC 2x2 block system.", .default_value = false}));
 
-  Core::Utils::double_parameter("K_PTC", 0.0,
-      "PTC parameter: 0 means normal Newton, ->infty means steepest desc", cardvasc0dstruct);
+  cardvasc0dstruct.specs.emplace_back(parameter<double>(
+      "K_PTC", {.description = "PTC parameter: 0 means normal Newton, ->infty means steepest desc",
+                   .default_value = 0.0}));
 
   cardvasc0dstruct.move_into_collection(list);
 
   Core::Utils::SectionSpecs cardvasc0dsyspulcirc{
       cardvasc0dstruct, "SYS-PUL CIRCULATION PARAMETERS"};
 
-  Core::Utils::double_parameter("R_arvalve_max_l", 0.0,
-      "maximal left arterial (semilunar) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_arvalve_min_l", 0.0,
-      "minimal left arterial (semilunar) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_atvalve_max_l", 0.0,
-      "maximal left atrial (atrioventricular) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_atvalve_min_l", 0.0,
-      "minimal left atrial (atrioventricular) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_arvalve_max_r", 0.0,
-      "maximal right arterial (semilunar) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_arvalve_min_r", 0.0,
-      "minimal right arterial (semilunar) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_atvalve_max_r", 0.0,
-      "maximal right atrial (atrioventricular) valve resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("R_atvalve_min_r", 0.0,
-      "minimal right atrial (atrioventricular) valve resistance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arvalve_max_l",
+      {.description = "maximal left arterial (semilunar) valve resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arvalve_min_l",
+      {.description = "minimal left arterial (semilunar) valve resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_atvalve_max_l", {.description = "maximal left atrial (atrioventricular) valve resistance",
+                             .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_atvalve_min_l", {.description = "minimal left atrial (atrioventricular) valve resistance",
+                             .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_arvalve_max_r", {.description = "maximal right arterial (semilunar) valve resistance",
+                             .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_arvalve_min_r", {.description = "minimal right arterial (semilunar) valve resistance",
+                             .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_atvalve_max_r", {.description = "maximal right atrial (atrioventricular) valve resistance",
+                             .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_atvalve_min_r", {.description = "minimal right atrial (atrioventricular) valve resistance",
+                             .default_value = 0.0}));
 
   Core::Utils::string_to_integral_parameter<Cardvasc0DAtriumModel>("ATRIUM_MODEL", "0D", "",
       tuple<std::string>("0D", "3D", "prescribed"),
@@ -94,14 +105,14 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
   Core::Utils::int_parameter("Atrium_prescr_E_curve_r", -1,
       "right atrial elastance prescription curve (ONLY for ATRIUM_MODEL 'prescribed'!)",
       cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_at_max_l", 0.0, "0D maximum left atrial elastance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_at_min_l", 0.0, "0D baseline left atrial elastance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_at_max_r", 0.0, "0D maximum right atrial elastance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_at_min_r", 0.0, "0D baseline right atrial elastance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "E_at_max_l", {.description = "0D maximum left atrial elastance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "E_at_min_l", {.description = "0D baseline left atrial elastance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "E_at_max_r", {.description = "0D maximum right atrial elastance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "E_at_min_r", {.description = "0D baseline right atrial elastance", .default_value = 0.0}));
 
   Core::Utils::string_to_integral_parameter<Cardvasc0DVentricleModel>("VENTRICLE_MODEL", "3D", "",
       tuple<std::string>("3D", "0D", "prescribed"),
@@ -118,212 +129,220 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
   Core::Utils::int_parameter("Ventricle_prescr_E_curve_r", -1,
       "right ventricular elastance prescription curve (ONLY for VENTRICLE_MODEL 'prescribed'!)",
       cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_v_max_l", 0.0, "0D maximum left ventricular elastance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_v_min_l", 0.0, "0D baseline left ventricular elastance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_v_max_r", 0.0, "0D maximum right ventricular elastance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "E_v_min_r", 0.0, "0D baseline right ventricular elastance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "E_v_max_l", {.description = "0D maximum left ventricular elastance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("E_v_min_l",
+      {.description = "0D baseline left ventricular elastance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("E_v_max_r",
+      {.description = "0D maximum right ventricular elastance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("E_v_min_r",
+      {.description = "0D baseline right ventricular elastance", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "C_ar_sys", 0.0, "systemic arterial compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_ar_sys", 0.0, "systemic arterial resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "L_ar_sys", 0.0, "systemic arterial inertance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "Z_ar_sys", 0.0, "systemic arterial impedance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_ar_pul", 0.0, "pulmonary arterial compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_ar_pul", 0.0, "pulmonary arterial resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "L_ar_pul", 0.0, "pulmonary arterial inertance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "Z_ar_pul", 0.0, "pulmonary arterial impedance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "C_ar_sys", {.description = "systemic arterial compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_ar_sys", {.description = "systemic arterial resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "L_ar_sys", {.description = "systemic arterial inertance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "Z_ar_sys", {.description = "systemic arterial impedance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "C_ar_pul", {.description = "pulmonary arterial compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_ar_pul", {.description = "pulmonary arterial resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "L_ar_pul", {.description = "pulmonary arterial inertance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "Z_ar_pul", {.description = "pulmonary arterial impedance", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "C_ven_sys", 0.0, "systemic venous compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_ven_sys", 0.0, "systemic venous resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "L_ven_sys", 0.0, "systemic venous inertance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_ven_pul", 0.0, "pulmonary venous compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_ven_pul", 0.0, "pulmonary venous resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "L_ven_pul", 0.0, "pulmonary venous inertance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "C_ven_sys", {.description = "systemic venous compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_ven_sys", {.description = "systemic venous resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "L_ven_sys", {.description = "systemic venous inertance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "C_ven_pul", {.description = "pulmonary venous compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_ven_pul", {.description = "pulmonary venous resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "L_ven_pul", {.description = "pulmonary venous inertance", .default_value = 0.0}));
 
   // initial conditions
-  Core::Utils::double_parameter(
-      "q_vin_l_0", 0.0, "initial left ventricular in-flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_at_l_0", 0.0, "initial left atrial pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_vout_l_0", 0.0, "initial left ventricular out-flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_v_l_0", 0.0, "initial left ventricular pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_ar_sys_0", 0.0, "initial systemic arterial pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_ar_sys_0", 0.0, "initial systemic arterial flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_ven_sys_0", 0.0, "initial systemic venous pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_ven_sys_0", 0.0, "initial systemic venous flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_vin_r_0", 0.0, "initial right ventricular in-flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_at_r_0", 0.0, "initial right atrial pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_vout_r_0", 0.0, "initial right ventricular out-flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_v_r_0", 0.0, "initial right ventricular pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_ar_pul_0", 0.0, "initial pulmonary arterial pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_ar_pul_0", 0.0, "initial pulmonary arterial flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_ven_pul_0", 0.0, "initial pulmonary venous pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_ven_pul_0", 0.0, "initial pulmonary venous flux", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_vin_l_0", {.description = "initial left ventricular in-flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_at_l_0", {.description = "initial left atrial pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_vout_l_0", {.description = "initial left ventricular out-flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_v_l_0", {.description = "initial left ventricular pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_ar_sys_0", {.description = "initial systemic arterial pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_ar_sys_0", {.description = "initial systemic arterial flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_ven_sys_0", {.description = "initial systemic venous pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_ven_sys_0", {.description = "initial systemic venous flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_vin_r_0", {.description = "initial right ventricular in-flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_at_r_0", {.description = "initial right atrial pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_vout_r_0", {.description = "initial right ventricular out-flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_v_r_0", {.description = "initial right ventricular pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_ar_pul_0", {.description = "initial pulmonary arterial pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_ar_pul_0", {.description = "initial pulmonary arterial flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "p_ven_pul_0", {.description = "initial pulmonary venous pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_ven_pul_0", {.description = "initial pulmonary venous flux", .default_value = 0.0}));
 
   // unstressed volumes - only for postprocessing matters!
-  Core::Utils::double_parameter(
-      "V_at_l_u", 0.0, "unstressed volume of left 0D atrium", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "V_v_l_u", 0.0, "unstressed volume of left 0D ventricle", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_ar_sys_u", 0.0,
-      "unstressed volume of systemic arteries and capillaries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "V_ven_sys_u", 100.0e3, "unstressed volume of systemic veins", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "V_at_r_u", 0.0, "unstressed volume of right 0D atrium", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "V_v_r_u", 0.0, "unstressed volume of right 0D ventricle", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_ar_pul_u", 0.0,
-      "unstressed volume of pulmonary arteries and capillaries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "V_ven_pul_u", 120.0e3, "unstressed volume of pulmonary veins", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_at_l_u", {.description = "unstressed volume of left 0D atrium", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_v_l_u", {.description = "unstressed volume of left 0D ventricle", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_ar_sys_u", {.description = "unstressed volume of systemic arteries and capillaries",
+                        .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_ven_sys_u",
+      {.description = "unstressed volume of systemic veins", .default_value = 100.0e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_at_r_u", {.description = "unstressed volume of right 0D atrium", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_v_r_u", {.description = "unstressed volume of right 0D ventricle", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_ar_pul_u", {.description = "unstressed volume of pulmonary arteries and capillaries",
+                        .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_ven_pul_u",
+      {.description = "unstressed volume of pulmonary veins", .default_value = 120.0e3}));
 
 
 
   // parameters for extended sys pul circulation including periphery
-  Core::Utils::double_parameter(
-      "C_arspl_sys", 0.0, "systemic arterial splanchnic compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_arspl_sys", 0.0, "systemic arterial splanchnic resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_arespl_sys", 0.0, "systemic arterial extra-splanchnic compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_arespl_sys", 0.0, "systemic arterial extra-splanchnic resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_armsc_sys", 0.0, "systemic arterial muscular compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_armsc_sys", 0.0, "systemic arterial muscular resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_arcer_sys", 0.0, "systemic arterial cerebral compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_arcer_sys", 0.0, "systemic arterial cerebral resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_arcor_sys", 0.0, "systemic arterial coronary compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_arcor_sys", 0.0, "systemic arterial coronary resistance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arspl_sys",
+      {.description = "systemic arterial splanchnic compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arspl_sys",
+      {.description = "systemic arterial splanchnic resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arespl_sys",
+      {.description = "systemic arterial extra-splanchnic compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arespl_sys",
+      {.description = "systemic arterial extra-splanchnic resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_armsc_sys",
+      {.description = "systemic arterial muscular compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_armsc_sys",
+      {.description = "systemic arterial muscular resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arcer_sys",
+      {.description = "systemic arterial cerebral compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arcer_sys",
+      {.description = "systemic arterial cerebral resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arcor_sys",
+      {.description = "systemic arterial coronary compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arcor_sys",
+      {.description = "systemic arterial coronary resistance", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "C_venspl_sys", 0.0, "systemic venous splanchnic compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_venspl_sys", 0.0, "systemic venous splanchnic resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_venespl_sys", 0.0, "systemic venous extra-splanchnic compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_venespl_sys", 0.0, "systemic venous extra-splanchnic resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_venmsc_sys", 0.0, "systemic venous muscular compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_venmsc_sys", 0.0, "systemic venous muscular resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_vencer_sys", 0.0, "systemic venous cerebral compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_vencer_sys", 0.0, "systemic venous cerebral resistance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "C_vencor_sys", 0.0, "systemic venous coronary compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_vencor_sys", 0.0, "systemic venous coronary resistance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_venspl_sys",
+      {.description = "systemic venous splanchnic compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_venspl_sys",
+      {.description = "systemic venous splanchnic resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_venespl_sys",
+      {.description = "systemic venous extra-splanchnic compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_venespl_sys",
+      {.description = "systemic venous extra-splanchnic resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_venmsc_sys",
+      {.description = "systemic venous muscular compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_venmsc_sys",
+      {.description = "systemic venous muscular resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_vencer_sys",
+      {.description = "systemic venous cerebral compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_vencer_sys",
+      {.description = "systemic venous cerebral resistance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_vencor_sys",
+      {.description = "systemic venous coronary compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_vencor_sys",
+      {.description = "systemic venous coronary resistance", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "C_cap_pul", 0.0, "pulmonary capillary compliance", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "R_cap_pul", 0.0, "pulmonary capillary resistance", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "C_cap_pul", {.description = "pulmonary capillary compliance", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "R_cap_pul", {.description = "pulmonary capillary resistance", .default_value = 0.0}));
 
   // initial conditions for extended sys pul circulation including periphery
-  Core::Utils::double_parameter(
-      "p_arperi_sys_0", 0.0, "initial systemic peripheral arterial pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_arspl_sys_0", 0.0, "initial systemic arterial splanchnic flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("q_arespl_sys_0", 0.0,
-      "initial systemic arterial extra-splanchnic flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_armsc_sys_0", 0.0, "initial systemic arterial muscular flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_arcer_sys_0", 0.0, "initial systemic arterial cerebral flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_arcor_sys_0", 0.0, "initial systemic arterial coronary flux", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_arperi_sys_0",
+      {.description = "initial systemic peripheral arterial pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arspl_sys_0",
+      {.description = "initial systemic arterial splanchnic flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arespl_sys_0",
+      {.description = "initial systemic arterial extra-splanchnic flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_armsc_sys_0",
+      {.description = "initial systemic arterial muscular flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arcer_sys_0",
+      {.description = "initial systemic arterial cerebral flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arcor_sys_0",
+      {.description = "initial systemic arterial coronary flux", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "p_venspl_sys_0", 0.0, "initial systemic venous splanchnic pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_venspl_sys_0", 0.0, "initial systemic venous splanchnic flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("p_venespl_sys_0", 0.0,
-      "initial systemic venous extra-splanchnic pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("q_venespl_sys_0", 0.0,
-      "initial systemic venous extra-splanchnic flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_venmsc_sys_0", 0.0, "initial systemic venous muscular pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_venmsc_sys_0", 0.0, "initial systemic venous muscular flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_vencer_sys_0", 0.0, "initial systemic venous cerebral pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_vencer_sys_0", 0.0, "initial systemic venous cerebral flux", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "p_vencor_sys_0", 0.0, "initial systemic venous coronary pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_vencor_sys_0", 0.0, "initial systemic venous coronary flux", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_venspl_sys_0",
+      {.description = "initial systemic venous splanchnic pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_venspl_sys_0",
+      {.description = "initial systemic venous splanchnic flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_venespl_sys_0",
+      {.description = "initial systemic venous extra-splanchnic pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_venespl_sys_0",
+      {.description = "initial systemic venous extra-splanchnic flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_venmsc_sys_0",
+      {.description = "initial systemic venous muscular pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_venmsc_sys_0",
+      {.description = "initial systemic venous muscular flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_vencer_sys_0",
+      {.description = "initial systemic venous cerebral pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_vencer_sys_0",
+      {.description = "initial systemic venous cerebral flux", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_vencor_sys_0",
+      {.description = "initial systemic venous coronary pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_vencor_sys_0",
+      {.description = "initial systemic venous coronary flux", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "p_cap_pul_0", 0.0, "initial pulmonary capillary pressure", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "q_cap_pul_0", 0.0, "initial pulmonary capillary flux", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_cap_pul_0",
+      {.description = "initial pulmonary capillary pressure", .default_value = 0.0}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "q_cap_pul_0", {.description = "initial pulmonary capillary flux", .default_value = 0.0}));
 
 
   // unstressed volumes
   // default values according to Ursino et al. Am J Physiol Heart Circ Physiol (2000), in mm^3
-  Core::Utils::double_parameter("V_arspl_sys_u", 274.4e3,
-      "unstressed volume of systemic splanchnic arteries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_arespl_sys_u", 134.64e3,
-      "unstressed volume of systemic extra-splanchnic arteries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_armsc_sys_u", 105.8e3,
-      "unstressed volume of systemic muscular arteries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_arcer_sys_u", 72.13e3,
-      "unstressed volume of systemic cerebral arteries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_arcor_sys_u", 24.0e3,
-      "unstressed volume of systemic coronary arteries", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_venspl_sys_u", 1121.0e3,
-      "unstressed volume of systemic splanchnic veins", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_venespl_sys_u", 550.0e3,
-      "unstressed volume of systemic extra-splanchnic veins", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_venmsc_sys_u", 432.14e3,
-      "unstressed volume of systemic muscular veins", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_vencer_sys_u", 294.64e3,
-      "unstressed volume of systemic cerebral veins", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter("V_vencor_sys_u", 98.21e3,
-      "unstressed volume of systemic coronary veins", cardvasc0dsyspulcirc);
-  Core::Utils::double_parameter(
-      "V_cap_pul_u", 123.0e3, "unstressed volume of pulmonary capillaries", cardvasc0dsyspulcirc);
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_arspl_sys_u", {.description = "unstressed volume of systemic splanchnic arteries",
+                           .default_value = 274.4e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_arespl_sys_u", {.description = "unstressed volume of systemic extra-splanchnic arteries",
+                            .default_value = 134.64e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_armsc_sys_u", {.description = "unstressed volume of systemic muscular arteries",
+                           .default_value = 105.8e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_arcer_sys_u", {.description = "unstressed volume of systemic cerebral arteries",
+                           .default_value = 72.13e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_arcor_sys_u",
+      {.description = "unstressed volume of systemic coronary arteries", .default_value = 24.0e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_venspl_sys_u", {.description = "unstressed volume of systemic splanchnic veins",
+                            .default_value = 1121.0e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
+      "V_venespl_sys_u", {.description = "unstressed volume of systemic extra-splanchnic veins",
+                             .default_value = 550.0e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_venmsc_sys_u",
+      {.description = "unstressed volume of systemic muscular veins", .default_value = 432.14e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_vencer_sys_u",
+      {.description = "unstressed volume of systemic cerebral veins", .default_value = 294.64e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_vencor_sys_u",
+      {.description = "unstressed volume of systemic coronary veins", .default_value = 98.21e3}));
+  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_cap_pul_u",
+      {.description = "unstressed volume of pulmonary capillaries", .default_value = 123.0e3}));
 
   cardvasc0dsyspulcirc.move_into_collection(list);
 
@@ -338,181 +357,221 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
       cardvascrespir0d);
 
 
-  Core::Utils::double_parameter("L_alv", 0.0, "alveolar inertance", cardvascrespir0d);
-  Core::Utils::double_parameter("R_alv", 0.0, "alveolar resistance", cardvascrespir0d);
-  Core::Utils::double_parameter("E_alv", 0.0, "alveolar elastance", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("L_alv", {.description = "alveolar inertance", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("R_alv", {.description = "alveolar resistance", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("E_alv", {.description = "alveolar elastance", .default_value = 0.0}));
 
-  Core::Utils::double_parameter("V_lung_tidal", 0.4e6,
-      "tidal volume (the total volume of inspired air, in a single breath)", cardvascrespir0d);
-  Core::Utils::double_parameter("V_lung_dead", 0.15e6, "dead space volume", cardvascrespir0d);
-  Core::Utils::double_parameter("V_lung_u", 0.0,
-      "unstressed lung volume (volume of the lung when it is fully collapsed outside the body)",
-      cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>("V_lung_tidal",
+      {.description = "tidal volume (the total volume of inspired air, in a single breath)",
+          .default_value = 0.4e6}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_lung_dead", {.description = "dead space volume", .default_value = 0.15e6}));
+  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("V_lung_u", {.description = "unstressed lung volume (volume of the lung "
+                                                    "when it is fully collapsed outside the body)",
+                                        .default_value = 0.0}));
 
   Core::Utils::int_parameter("U_t_curve", -1,
       "time-varying, prescribed pleural pressure curve driven by diaphragm", cardvascrespir0d);
-  Core::Utils::double_parameter("U_m", 0.0, "in-breath pressure", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("U_m", {.description = "in-breath pressure", .default_value = 0.0}));
 
-  Core::Utils::double_parameter("fCO2_ext", 0.03, "atmospheric CO2 gas fraction", cardvascrespir0d);
-  Core::Utils::double_parameter("fO2_ext", 0.21, "atmospheric O2 gas fraction", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "fCO2_ext", {.description = "atmospheric CO2 gas fraction", .default_value = 0.03}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "fO2_ext", {.description = "atmospheric O2 gas fraction", .default_value = 0.21}));
 
-  Core::Utils::double_parameter("kappa_CO2", 0.0,
-      "diffusion coefficient for CO2 across the hemato-alveolar membrane, in molar value / (time * "
-      "pressure)",
-      cardvascrespir0d);
-  Core::Utils::double_parameter("kappa_O2", 0.0,
-      "diffusion coefficient for O2 across the hemato-alveolar membrane, in molar value / (time * "
-      "pressure)",
-      cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "kappa_CO2", {.description = "diffusion coefficient for CO2 across the hemato-alveolar "
+                                   "membrane, in molar value / (time * pressure)",
+                       .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "kappa_O2", {.description = "diffusion coefficient for O2 across the hemato-alveolar "
+                                  "membrane, in molar value / (time * pressure)",
+                      .default_value = 0.0}));
 
   // should be 22.4 liters per mol !
   // however we specify it as an input parameter since its decimal power depends on the system of
   // units your whole model is specified in! i.e. if you have kg - mm - s - mmol, it's 22.4e3 mm^3 /
   // mmol
-  Core::Utils::double_parameter(
-      "V_m_gas", 22.4e3, "molar volume of an ideal gas", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_m_gas", {.description = "molar volume of an ideal gas", .default_value = 22.4e3}));
 
   // should be 47.1 mmHg = 6.279485 kPa !
   // however we specify it as an input parameter since its decimal power depends on the system of
   // units your whole model is specified in! i.e. if you have kg - mm - s - mmol, it's 6.279485 kPa
-  Core::Utils::double_parameter("p_vap_water_37", 6.279485,
-      "vapor pressure of water at 37  degrees celsius", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "p_vap_water_37", {.description = "vapor pressure of water at 37  degrees celsius",
+                            .default_value = 6.279485}));
 
-  Core::Utils::double_parameter("alpha_CO2", 0.0,
-      "CO2 solubility constant, in molar value / (volume * pressure)", cardvascrespir0d);
-  Core::Utils::double_parameter("alpha_O2", 0.0,
-      "O2 solubility constant, in molar value / (volume * pressure)", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "alpha_CO2", {.description = "CO2 solubility constant, in molar value / (volume * pressure)",
+                       .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "alpha_O2", {.description = "O2 solubility constant, in molar value / (volume * pressure)",
+                      .default_value = 0.0}));
 
-  Core::Utils::double_parameter("c_Hb", 0.0,
-      "hemoglobin concentration of the blood, in molar value / volume", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "c_Hb", {.description = "hemoglobin concentration of the blood, in molar value / volume",
+                  .default_value = 0.0}));
 
 
-  Core::Utils::double_parameter(
-      "M_CO2_arspl", 0.0, "splanchnic metabolic rate of CO2 production", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_O2_arspl", 0.0, "splanchnic metabolic rate of O2 consumption", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_CO2_arespl", 0.0, "extra-splanchnic metabolic rate of CO2 production", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_O2_arespl", 0.0, "extra-splanchnic metabolic rate of O2 consumption", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_CO2_armsc", 0.0, "muscular metabolic rate of CO2 production", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_O2_armsc", 0.0, "muscular metabolic rate of O2 consumption", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_CO2_arcer", 0.0, "cerebral metabolic rate of CO2 production", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_O2_arcer", 0.0, "cerebral metabolic rate of O2 consumption", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_CO2_arcor", 0.0, "coronary metabolic rate of CO2 production", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "M_O2_arcor", 0.0, "coronary metabolic rate of O2 consumption", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arspl",
+      {.description = "splanchnic metabolic rate of CO2 production", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arspl",
+      {.description = "splanchnic metabolic rate of O2 consumption", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arespl",
+      {.description = "extra-splanchnic metabolic rate of CO2 production", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arespl",
+      {.description = "extra-splanchnic metabolic rate of O2 consumption", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_armsc",
+      {.description = "muscular metabolic rate of CO2 production", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_armsc",
+      {.description = "muscular metabolic rate of O2 consumption", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arcer",
+      {.description = "cerebral metabolic rate of CO2 production", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arcer",
+      {.description = "cerebral metabolic rate of O2 consumption", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arcor",
+      {.description = "coronary metabolic rate of CO2 production", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arcor",
+      {.description = "coronary metabolic rate of O2 consumption", .default_value = 0.0}));
 
-  Core::Utils::double_parameter("V_tissspl", 1.0, "splanchnic tissue volume", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "V_tissespl", 1.0, "extra-splanchnic tissue volume", cardvascrespir0d);
-  Core::Utils::double_parameter("V_tissmsc", 1.0, "muscular tissue volume", cardvascrespir0d);
-  Core::Utils::double_parameter("V_tisscer", 1.0, "cerebral tissue volume", cardvascrespir0d);
-  Core::Utils::double_parameter("V_tisscor", 1.0, "coronary tissue volume", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_tissspl", {.description = "splanchnic tissue volume", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_tissespl", {.description = "extra-splanchnic tissue volume", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_tissmsc", {.description = "muscular tissue volume", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_tisscer", {.description = "cerebral tissue volume", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_tisscor", {.description = "coronary tissue volume", .default_value = 1.0}));
 
 
   // initial conditions for respiratory model
-  Core::Utils::double_parameter("V_alv_0", -1.0, "initial alveolar volume", cardvascrespir0d);
-  Core::Utils::double_parameter("q_alv_0", 0.0, "initial alveolar flux", cardvascrespir0d);
-  Core::Utils::double_parameter("p_alv_0", -1.0, "initial alveolar pressure", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "V_alv_0", {.description = "initial alveolar volume", .default_value = -1.0}));
+  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("q_alv_0", {.description = "initial alveolar flux", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "p_alv_0", {.description = "initial alveolar pressure", .default_value = -1.0}));
 
-  Core::Utils::double_parameter(
-      "fCO2_alv_0", 0.05263, "initial alveolar CO2 fraction", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "fO2_alv_0", 0.1368, "initial alveolar O2 fraction", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "fCO2_alv_0", {.description = "initial alveolar CO2 fraction", .default_value = 0.05263}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "fO2_alv_0", {.description = "initial alveolar O2 fraction", .default_value = 0.1368}));
 
-  Core::Utils::double_parameter(
-      "q_arspl_sys_in_0", 0.0, "initial arterial splanchnic in-flux", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "q_arsspl_sys_in_0", 0.0, "initial arterial extra-splanchnic in-flux", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "q_armsc_sys_in_0", 0.0, "initial arterial muscular in-flux", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "q_arcer_sys_in_0", 0.0, "initial arterial cerebral in-flux", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "q_arcor_sys_in_0", 0.0, "initial arterial coronary in-flux", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arspl_sys_in_0",
+      {.description = "initial arterial splanchnic in-flux", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arsspl_sys_in_0",
+      {.description = "initial arterial extra-splanchnic in-flux", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("q_armsc_sys_in_0",
+      {.description = "initial arterial muscular in-flux", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arcer_sys_in_0",
+      {.description = "initial arterial cerebral in-flux", .default_value = 0.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arcor_sys_in_0",
+      {.description = "initial arterial coronary in-flux", .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "ppCO2_at_r_0", 1.0, "initial right atrial CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_at_r_0", 1.0, "initial right atrial O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_v_r_0", 1.0, "initial right ventricular CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_v_r_0", 1.0, "initial right ventricular O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_ar_pul_0", 1.0, "initial pulmonary arterial CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_ar_pul_0", 1.0, "initial pulmonary arterial O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_cap_pul_0", 1.0, "initial pulmonary capillary CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_cap_pul_0", 1.0, "initial pulmonary capillary O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_ven_pul_0", 1.0, "initial pulmonary venous CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_ven_pul_0", 1.0, "initial pulmonary venous O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_at_l_0", 1.0, "initial left atrial CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_at_l_0", 1.0, "initial left atrial O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_v_l_0", 1.0, "initial left ventricular CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_v_l_0", 1.0, "initial left ventricular O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_ar_sys_0", 1.0, "initial systemic arterial CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_ar_sys_0", 1.0, "initial systemic arterial O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_arspl_sys_0", 1.0,
-      "initial systemic arterial splanchnic CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_arspl_sys_0", 1.0,
-      "initial systemic arterial splanchnic O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_arespl_sys_0", 1.0,
-      "initial systemic arterial extra-splanchnic CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_arespl_sys_0", 1.0,
-      "initial systemic arterial extra-splanchnic O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_armsc_sys_0", 1.0,
-      "initial systemic arterial muscular CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_armsc_sys_0", 1.0,
-      "initial systemic arterial muscular O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_arcer_sys_0", 1.0,
-      "initial systemic arterial cerebral CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_arcer_sys_0", 1.0,
-      "initial systemic arterial cerebral O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_arcor_sys_0", 1.0,
-      "initial systemic arterial coronary CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_arcor_sys_0", 1.0,
-      "initial systemic arterial coronary O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_venspl_sys_0", 1.0,
-      "initial systemic venous splanchnic CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_venspl_sys_0", 1.0,
-      "initial systemic venous splanchnic O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_venespl_sys_0", 1.0,
-      "initial systemic venous extra-splanchnic CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_venespl_sys_0", 1.0,
-      "initial systemic venous extra-splanchnic O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_venmsc_sys_0", 1.0,
-      "initial systemic venous muscular CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_venmsc_sys_0", 1.0,
-      "initial systemic venous muscular O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_vencer_sys_0", 1.0,
-      "initial systemic venous cerebral CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_vencer_sys_0", 1.0,
-      "initial systemic venous cerebral O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppCO2_vencor_sys_0", 1.0,
-      "initial systemic venous coronary CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter("ppO2_vencor_sys_0", 1.0,
-      "initial systemic venous coronary O2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppCO2_ven_sys_0", 1.0, "initial systemic venous CO2 partial pressure", cardvascrespir0d);
-  Core::Utils::double_parameter(
-      "ppO2_ven_sys_0", 1.0, "initial systemic venous O2 partial pressure", cardvascrespir0d);
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_at_r_0",
+      {.description = "initial right atrial CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_at_r_0",
+      {.description = "initial right atrial O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_v_r_0",
+      {.description = "initial right ventricular CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_v_r_0",
+      {.description = "initial right ventricular O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ar_pul_0",
+      {.description = "initial pulmonary arterial CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ar_pul_0",
+      {.description = "initial pulmonary arterial O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_cap_pul_0",
+      {.description = "initial pulmonary capillary CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_cap_pul_0",
+      {.description = "initial pulmonary capillary O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ven_pul_0",
+      {.description = "initial pulmonary venous CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ven_pul_0",
+      {.description = "initial pulmonary venous O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_at_l_0",
+      {.description = "initial left atrial CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_at_l_0",
+      {.description = "initial left atrial O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_v_l_0",
+      {.description = "initial left ventricular CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_v_l_0",
+      {.description = "initial left ventricular O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ar_sys_0",
+      {.description = "initial systemic arterial CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ar_sys_0",
+      {.description = "initial systemic arterial O2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arspl_sys_0",
+      {.description = "initial systemic arterial splanchnic CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_arspl_sys_0",
+      {.description = "initial systemic arterial splanchnic O2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arespl_sys_0",
+      {.description = "initial systemic arterial extra-splanchnic CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_arespl_sys_0",
+      {.description = "initial systemic arterial extra-splanchnic O2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_armsc_sys_0",
+      {.description = "initial systemic arterial muscular CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_armsc_sys_0", {.description = "initial systemic arterial muscular O2 partial pressure",
+                              .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arcer_sys_0",
+      {.description = "initial systemic arterial cerebral CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_arcer_sys_0", {.description = "initial systemic arterial cerebral O2 partial pressure",
+                              .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arcor_sys_0",
+      {.description = "initial systemic arterial coronary CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_arcor_sys_0", {.description = "initial systemic arterial coronary O2 partial pressure",
+                              .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_venspl_sys_0",
+      {.description = "initial systemic venous splanchnic CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_venspl_sys_0", {.description = "initial systemic venous splanchnic O2 partial pressure",
+                               .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_venespl_sys_0",
+      {.description = "initial systemic venous extra-splanchnic CO2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_venespl_sys_0",
+      {.description = "initial systemic venous extra-splanchnic O2 partial pressure",
+          .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppCO2_venmsc_sys_0", {.description = "initial systemic venous muscular CO2 partial pressure",
+                                .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_venmsc_sys_0", {.description = "initial systemic venous muscular O2 partial pressure",
+                               .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppCO2_vencer_sys_0", {.description = "initial systemic venous cerebral CO2 partial pressure",
+                                .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_vencer_sys_0", {.description = "initial systemic venous cerebral O2 partial pressure",
+                               .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppCO2_vencor_sys_0", {.description = "initial systemic venous coronary CO2 partial pressure",
+                                .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>(
+      "ppO2_vencor_sys_0", {.description = "initial systemic venous coronary O2 partial pressure",
+                               .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ven_sys_0",
+      {.description = "initial systemic venous CO2 partial pressure", .default_value = 1.0}));
+  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ven_sys_0",
+      {.description = "initial systemic venous O2 partial pressure", .default_value = 1.0}));
 
   cardvascrespir0d.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_constraint_framework.cpp
+++ b/src/inpar/4C_inpar_constraint_framework.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::CONSTRAINTS::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs embeddedmeshcoupling{"EMBEDDED MESH COUPLING"};
   {

--- a/src/inpar/4C_inpar_constraint_framework.cpp
+++ b/src/inpar/4C_inpar_constraint_framework.cpp
@@ -47,9 +47,10 @@ void Inpar::CONSTRAINTS::set_valid_parameters(std::map<std::string, Core::IO::In
             EmbeddedMeshConstraintEnforcement::none, EmbeddedMeshConstraintEnforcement::penalty),
         embeddedmeshcoupling);
 
-    Core::Utils::double_parameter("CONSTRAINT_ENFORCEMENT_PENALTYPARAM", 0.0,
-        "Penalty parameter for the constraint enforcement in embedded mesh coupling",
-        embeddedmeshcoupling);
+    embeddedmeshcoupling.specs.emplace_back(parameter<double>("CONSTRAINT_ENFORCEMENT_PENALTYPARAM",
+        {.description =
+                "Penalty parameter for the constraint enforcement in embedded mesh coupling",
+            .default_value = 0.0}));
 
     embeddedmeshcoupling.move_into_collection(list);
   }

--- a/src/inpar/4C_inpar_contact.cpp
+++ b/src/inpar/4C_inpar_contact.cpp
@@ -71,22 +71,26 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
           system_none),
       scontact);
 
-  Core::Utils::double_parameter("PENALTYPARAM", 0.0,
-      "Penalty parameter for penalty / Uzawa augmented solution strategy", scontact);
-  Core::Utils::double_parameter("PENALTYPARAMTAN", 0.0,
-      "Tangential penalty parameter for penalty / Uzawa augmented solution strategy", scontact);
+  scontact.specs.emplace_back(parameter<double>("PENALTYPARAM",
+      {.description = "Penalty parameter for penalty / Uzawa augmented solution strategy",
+          .default_value = 0.0}));
+  scontact.specs.emplace_back(parameter<double>("PENALTYPARAMTAN",
+      {.description =
+              "Tangential penalty parameter for penalty / Uzawa augmented solution strategy",
+          .default_value = 0.0}));
   Core::Utils::int_parameter(
       "UZAWAMAXSTEPS", 10, "Maximum no. of Uzawa steps for Uzawa solution strategy", scontact);
-  Core::Utils::double_parameter("UZAWACONSTRTOL", 1.0e-8,
-      "Tolerance of constraint norm for Uzawa solution strategy", scontact);
+  scontact.specs.emplace_back(parameter<double>(
+      "UZAWACONSTRTOL", {.description = "Tolerance of constraint norm for Uzawa solution strategy",
+                            .default_value = 1.0e-8}));
 
   scontact.specs.emplace_back(parameter<bool>("SEMI_SMOOTH_NEWTON",
       {.description = "If chosen semi-smooth Newton concept is applied", .default_value = true}));
 
-  Core::Utils::double_parameter(
-      "SEMI_SMOOTH_CN", 1.0, "Weighting factor cn for semi-smooth PDASS", scontact);
-  Core::Utils::double_parameter(
-      "SEMI_SMOOTH_CT", 1.0, "Weighting factor ct for semi-smooth PDASS", scontact);
+  scontact.specs.emplace_back(parameter<double>("SEMI_SMOOTH_CN",
+      {.description = "Weighting factor cn for semi-smooth PDASS", .default_value = 1.0}));
+  scontact.specs.emplace_back(parameter<double>("SEMI_SMOOTH_CT",
+      {.description = "Weighting factor ct for semi-smooth PDASS", .default_value = 1.0}));
 
   scontact.specs.emplace_back(parameter<bool>("CONTACTFORCE_ENDTIME",
       {.description = "If chosen, the contact force is not evaluated at the generalized midpoint, "
@@ -99,8 +103,9 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
   scontact.specs.emplace_back(parameter<bool>("INITCONTACTBYGAP",
       {.description = "Initialize init contact by weighted gap vector", .default_value = false}));
 
-  Core::Utils::double_parameter("INITCONTACTGAPVALUE", 0.0,
-      "Value for initialization of init contact set with gap vector", scontact);
+  scontact.specs.emplace_back(parameter<double>("INITCONTACTGAPVALUE",
+      {.description = "Value for initialization of init contact set with gap vector",
+          .default_value = 0.0}));
 
   // solver convergence test parameters for contact/meshtying in saddlepoint formulation
   Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFCONTCONSTR",
@@ -113,12 +118,14 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), scontact);
 
-  Core::Utils::double_parameter("TOLCONTCONSTR", 1.0E-6,
-      "tolerance in the contact constraint norm for the newton iteration (saddlepoint formulation "
-      "only)",
-      scontact);
-  Core::Utils::double_parameter("TOLLAGR", 1.0E-6,
-      "tolerance in the LM norm for the newton iteration (saddlepoint formulation only)", scontact);
+  scontact.specs.emplace_back(parameter<double>(
+      "TOLCONTCONSTR", {.description = "tolerance in the contact constraint norm for the newton "
+                                       "iteration (saddlepoint formulation only)",
+                           .default_value = 1.0E-6}));
+  scontact.specs.emplace_back(parameter<double>("TOLLAGR",
+      {.description =
+              "tolerance in the LM norm for the newton iteration (saddlepoint formulation only)",
+          .default_value = 1.0E-6}));
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::ConstraintDirection>(
       "CONSTRAINT_DIRECTIONS", "ntt",
@@ -140,12 +147,14 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
               "the surface that is defined to be a self contact surface is non-smooth!",
           .default_value = false}));
 
-  Core::Utils::double_parameter("HYBRID_ANGLE_MIN", -1.0,
-      "Non-smooth contact: angle between cpp normal and element normal: begin transition (Mortar)",
-      scontact);
-  Core::Utils::double_parameter("HYBRID_ANGLE_MAX", -1.0,
-      "Non-smooth contact: angle between cpp normal and element normal: end transition (NTS)",
-      scontact);
+  scontact.specs.emplace_back(parameter<double>(
+      "HYBRID_ANGLE_MIN", {.description = "Non-smooth contact: angle between cpp normal and "
+                                          "element normal: begin transition (Mortar)",
+                              .default_value = -1.0}));
+  scontact.specs.emplace_back(parameter<double>(
+      "HYBRID_ANGLE_MAX", {.description = "Non-smooth contact: angle between cpp normal and "
+                                          "element normal: end transition (NTS)",
+                              .default_value = -1.0}));
 
   scontact.specs.emplace_back(parameter<bool>("CPP_NORMALS",
       {.description = "If chosen the nodal normal field is created as averaged CPP normal field.",
@@ -156,10 +165,12 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
                             .default_value = false}));
 
   // --------------------------------------------------------------------------
-  Core::Utils::double_parameter(
-      "NITSCHE_THETA", 0.0, "+1: symmetric, 0: non-symmetric, -1: skew-symmetric", scontact);
-  Core::Utils::double_parameter("NITSCHE_THETA_2", 1.0,
-      "+1: Chouly-type, 0: Burman penalty-free (only with theta=-1)", scontact);
+  scontact.specs.emplace_back(parameter<double>(
+      "NITSCHE_THETA", {.description = "+1: symmetric, 0: non-symmetric, -1: skew-symmetric",
+                           .default_value = 0.0}));
+  scontact.specs.emplace_back(parameter<double>("NITSCHE_THETA_2",
+      {.description = "+1: Chouly-type, 0: Burman penalty-free (only with theta=-1)",
+          .default_value = 1.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING",
       "harmonic", "how to weight consistency terms in Nitsche contact formulation",
@@ -173,8 +184,8 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
 
   scontact.specs.emplace_back(parameter<bool>("REGULARIZED_NORMAL_CONTACT",
       {.description = "add a regularized normal contact formulation", .default_value = false}));
-  Core::Utils::double_parameter(
-      "REGULARIZATION_THICKNESS", -1., "maximum contact penetration", scontact);
+  scontact.specs.emplace_back(parameter<double>("REGULARIZATION_THICKNESS",
+      {.description = "maximum contact penetration", .default_value = -1.}));
   Core::Utils::double_parameter("REGULARIZATION_STIFFNESS", -1.,
       "initial contact stiffness (i.e. initial \"penalty parameter\")", scontact);
 

--- a/src/inpar/4C_inpar_contact.cpp
+++ b/src/inpar/4C_inpar_contact.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for structural meshtying and contact */
   Core::Utils::SectionSpecs scontact{"CONTACT DYNAMIC"};
@@ -24,8 +25,9 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::int_parameter(
       "LINEAR_SOLVER", -1, "number of linear solver used for meshtying and contact", scontact);
 
-  Core::Utils::bool_parameter("RESTART_WITH_CONTACT", false,
-      "Must be chosen if a non-contact simulation is to be restarted with contact", scontact);
+  scontact.specs.emplace_back(parameter<bool>("RESTART_WITH_CONTACT",
+      {.description = "Must be chosen if a non-contact simulation is to be restarted with contact",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::AdhesionType>("ADHESION", "None",
       "Type of adhesion law", tuple<std::string>("None", "none", "bounded", "b"),
@@ -39,14 +41,16 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
           friction_none, friction_stick, friction_tresca, friction_coulomb),
       scontact);
 
-  Core::Utils::bool_parameter("FRLESS_FIRST", false,
-      "If chosen the first time step of a newly in contact slave node is regarded as frictionless",
-      scontact);
+  scontact.specs.emplace_back(parameter<bool>(
+      "FRLESS_FIRST", {.description = "If chosen the first time step of a newly in contact slave "
+                                      "node is regarded as frictionless",
+                          .default_value = false}));
 
-  Core::Utils::bool_parameter("GP_SLIP_INCR", false,
-      "If chosen the slip increment is computed gp-wise which results to a non-objective quantity, "
-      "but this would be consistent to wear and tsi calculations.",
-      scontact);
+  scontact.specs.emplace_back(parameter<bool>("GP_SLIP_INCR",
+      {.description =
+              "If chosen the slip increment is computed gp-wise which results to a non-objective "
+              "quantity, but this would be consistent to wear and tsi calculations.",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::SolvingStrategy>("STRATEGY",
       "LagrangianMultipliers", "Type of employed solving strategy",
@@ -76,24 +80,24 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::double_parameter("UZAWACONSTRTOL", 1.0e-8,
       "Tolerance of constraint norm for Uzawa solution strategy", scontact);
 
-  Core::Utils::bool_parameter(
-      "SEMI_SMOOTH_NEWTON", true, "If chosen semi-smooth Newton concept is applied", scontact);
+  scontact.specs.emplace_back(parameter<bool>("SEMI_SMOOTH_NEWTON",
+      {.description = "If chosen semi-smooth Newton concept is applied", .default_value = true}));
 
   Core::Utils::double_parameter(
       "SEMI_SMOOTH_CN", 1.0, "Weighting factor cn for semi-smooth PDASS", scontact);
   Core::Utils::double_parameter(
       "SEMI_SMOOTH_CT", 1.0, "Weighting factor ct for semi-smooth PDASS", scontact);
 
-  Core::Utils::bool_parameter("CONTACTFORCE_ENDTIME", false,
-      "If chosen, the contact force is not evaluated at the generalized midpoint, but at the end "
-      "of the time step",
-      scontact);
+  scontact.specs.emplace_back(parameter<bool>("CONTACTFORCE_ENDTIME",
+      {.description = "If chosen, the contact force is not evaluated at the generalized midpoint, "
+                      "but at the end of the time step",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "VELOCITY_UPDATE", false, "If chosen, velocity update method is applied", scontact);
+  scontact.specs.emplace_back(parameter<bool>("VELOCITY_UPDATE",
+      {.description = "If chosen, velocity update method is applied", .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "INITCONTACTBYGAP", false, "Initialize init contact by weighted gap vector", scontact);
+  scontact.specs.emplace_back(parameter<bool>("INITCONTACTBYGAP",
+      {.description = "Initialize init contact by weighted gap vector", .default_value = false}));
 
   Core::Utils::double_parameter("INITCONTACTGAPVALUE", 0.0,
       "Value for initialization of init contact set with gap vector", scontact);
@@ -122,18 +126,19 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       tuple<std::string>("ntt", "xyz"),
       tuple<Inpar::CONTACT::ConstraintDirection>(constr_ntt, constr_xyz), scontact);
 
-  Core::Utils::bool_parameter("NONSMOOTH_GEOMETRIES", false,
-      "If chosen the contact algorithm combines mortar and nts formulations. This is needed if "
-      "contact between entities of different geometric dimension (such as contact between surfaces "
-      "and lines, or lines and nodes) can occur",
-      scontact);
+  scontact.specs.emplace_back(parameter<bool>("NONSMOOTH_GEOMETRIES",
+      {.description = "If chosen the contact algorithm combines mortar and nts formulations. This "
+                      "is needed if contact between entities of different geometric dimension "
+                      "(such as contact between surfaces and lines, or lines and nodes) can occur",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("NONSMOOTH_CONTACT_SURFACE", false,
-      "This flag is used to alter the criterion for the evaluation of the so-called qualified "
-      "vectors in the case of a self contact scenario. This is needed as the standard criterion is "
-      "only valid for smooth surfaces and thus has to be altered, if the surface that is defined "
-      "to be a self contact surface is non-smooth!",
-      scontact);
+  scontact.specs.emplace_back(parameter<bool>("NONSMOOTH_CONTACT_SURFACE",
+      {.description =
+              "This flag is used to alter the criterion for the evaluation of the so-called "
+              "qualified vectors in the case of a self contact scenario. This is needed as the "
+              "standard criterion is only valid for smooth surfaces and thus has to be altered, if "
+              "the surface that is defined to be a self contact surface is non-smooth!",
+          .default_value = false}));
 
   Core::Utils::double_parameter("HYBRID_ANGLE_MIN", -1.0,
       "Non-smooth contact: angle between cpp normal and element normal: begin transition (Mortar)",
@@ -142,11 +147,13 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       "Non-smooth contact: angle between cpp normal and element normal: end transition (NTS)",
       scontact);
 
-  Core::Utils::bool_parameter("CPP_NORMALS", false,
-      "If chosen the nodal normal field is created as averaged CPP normal field.", scontact);
+  scontact.specs.emplace_back(parameter<bool>("CPP_NORMALS",
+      {.description = "If chosen the nodal normal field is created as averaged CPP normal field.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "TIMING_DETAILS", false, "Enable and print detailed contact timings to screen.", scontact);
+  scontact.specs.emplace_back(parameter<bool>(
+      "TIMING_DETAILS", {.description = "Enable and print detailed contact timings to screen.",
+                            .default_value = false}));
 
   // --------------------------------------------------------------------------
   Core::Utils::double_parameter(
@@ -160,11 +167,12 @@ void Inpar::CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputS
       tuple<Inpar::CONTACT::NitscheWeighting>(NitWgt_slave, NitWgt_master, NitWgt_harmonic),
       scontact);
 
-  Core::Utils::bool_parameter("NITSCHE_PENALTY_ADAPTIVE", true,
-      "adapt penalty parameter after each converged time step", scontact);
+  scontact.specs.emplace_back(parameter<bool>("NITSCHE_PENALTY_ADAPTIVE",
+      {.description = "adapt penalty parameter after each converged time step",
+          .default_value = true}));
 
-  Core::Utils::bool_parameter("REGULARIZED_NORMAL_CONTACT", false,
-      "add a regularized normal contact formulation", scontact);
+  scontact.specs.emplace_back(parameter<bool>("REGULARIZED_NORMAL_CONTACT",
+      {.description = "add a regularized normal contact formulation", .default_value = false}));
   Core::Utils::double_parameter(
       "REGULARIZATION_THICKNESS", -1., "maximum contact penetration", scontact);
   Core::Utils::double_parameter("REGULARIZATION_STIFFNESS", -1.,

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -23,18 +23,21 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ehldyn{"ELASTO HYDRO DYNAMIC"};
 
   // Output type
-  Core::Utils::double_parameter(
-      "RESTARTEVERYTIME", 0, "write restart possibility every RESTARTEVERY steps", ehldyn);
+  ehldyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
+      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0}));
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", ehldyn);
   // Time loop control
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", ehldyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", ehldyn);
-  Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", ehldyn);
+  ehldyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  ehldyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
   ehldyn.specs.emplace_back(parameter<bool>(
       "DIFFTIMESTEPSIZE", {.description = "use different step size for lubrication and solid",
                               .default_value = false}));
-  Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", ehldyn);
+  ehldyn.specs.emplace_back(parameter<double>(
+      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ehldyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ehldyn);
   Core::Utils::int_parameter("ITEMIN", 1, "minimal number of iterations over fields", ehldyn);
@@ -67,11 +70,12 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ehldynmono{ehldyn, "MONOLITHIC"};
 
   // convergence tolerance of EHL residual
-  Core::Utils::double_parameter(
-      "CONVTOL", 1e-6, "tolerance for convergence check of EHL", ehldynmono);
+  ehldynmono.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "tolerance for convergence check of EHL", .default_value = 1e-6}));
   // Iterationparameters
-  Core::Utils::double_parameter("TOLINC", 1.0e-6,
-      "tolerance for convergence check of EHL-increment in monolithic EHL", ehldynmono);
+  ehldynmono.specs.emplace_back(parameter<double>("TOLINC",
+      {.description = "tolerance for convergence check of EHL-increment in monolithic EHL",
+          .default_value = 1.0e-6}));
 
   Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
@@ -96,9 +100,10 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       tuple<std::string>("L1", "L1_Scaled", "L2", "Rms", "Inf"),
       tuple<VectorNorm>(norm_l1, norm_l1_scaled, norm_l2, norm_rms, norm_inf), ehldynmono);
 
-  Core::Utils::double_parameter("PTCDT", 0.1,
-      "pseudo time step for pseudo-transient continuation (PTC) stabilised Newton procedure",
-      ehldynmono);
+  ehldynmono.specs.emplace_back(
+      parameter<double>("PTCDT", {.description = "pseudo time step for pseudo-transient "
+                                                 "continuation (PTC) stabilised Newton procedure",
+                                     .default_value = 0.1}));
 
   // number of linear solver used for monolithic EHL
   Core::Utils::int_parameter(
@@ -109,10 +114,10 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      ehldynmono);
+  ehldynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   ehldynmono.specs.emplace_back(parameter<bool>("INFNORMSCALING",
       {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}));
@@ -125,15 +130,17 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ehldynpart{ehldyn, "PARTITIONED"};
 
   // Solver parameter for relaxation of iterative staggered partitioned EHL
-  Core::Utils::double_parameter(
-      "MAXOMEGA", 10.0, "largest omega allowed for Aitken relaxation", ehldynpart);
-  Core::Utils::double_parameter(
-      "MINOMEGA", 0.1, "smallest omega allowed for Aitken relaxation", ehldynpart);
-  Core::Utils::double_parameter("STARTOMEGA", 1.0, "fixed relaxation parameter", ehldynpart);
+  ehldynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
+      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
+  ehldynpart.specs.emplace_back(parameter<double>("MINOMEGA",
+      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
+  ehldynpart.specs.emplace_back(parameter<double>(
+      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
 
   // convergence tolerance of outer iteration loop
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "tolerance for convergence check of outer iteration within partitioned EHL", ehldynpart);
+  ehldynpart.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description = "tolerance for convergence check of outer iteration within partitioned EHL",
+          .default_value = 1e-6}));
 
   ehldynpart.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -32,7 +32,7 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   ehldyn.specs.emplace_back(parameter<double>(
       "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
   ehldyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
   ehldyn.specs.emplace_back(parameter<bool>(
       "DIFFTIMESTEPSIZE", {.description = "use different step size for lubrication and solid",
                               .default_value = false}));

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs ehldyn{"ELASTO HYDRO DYNAMIC"};
 
@@ -30,8 +31,9 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", ehldyn);
   Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", ehldyn);
   Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", ehldyn);
-  Core::Utils::bool_parameter(
-      "DIFFTIMESTEPSIZE", false, "use different step size for lubrication and solid", ehldyn);
+  ehldyn.specs.emplace_back(parameter<bool>(
+      "DIFFTIMESTEPSIZE", {.description = "use different step size for lubrication and solid",
+                              .default_value = false}));
   Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", ehldyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ehldyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ehldyn);
@@ -48,12 +50,14 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       tuple<SolutionSchemeOverFields>(ehl_IterStagg, ehl_Monolithic), ehldyn);
 
   // set unprojectable nodes to zero pressure via Dirichlet condition
-  Core::Utils::bool_parameter("UNPROJ_ZERO_DBC", false,
-      "set unprojectable nodes to zero pressure via Dirichlet condition", ehldyn);
+  ehldyn.specs.emplace_back(parameter<bool>("UNPROJ_ZERO_DBC",
+      {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
+          .default_value = false}));
 
   // use dry contact model
-  Core::Utils::bool_parameter("DRY_CONTACT_MODEL", false,
-      "set unprojectable nodes to zero pressure via Dirichlet condition", ehldyn);
+  ehldyn.specs.emplace_back(parameter<bool>("DRY_CONTACT_MODEL",
+      {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
+          .default_value = false}));
 
 
   ehldyn.move_into_collection(list);
@@ -101,15 +105,17 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "LINEAR_SOLVER", -1, "number of linear solver used for monolithic EHL problems", ehldynmono);
 
   // convergence criteria adaptivity of monolithic EHL solver
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution", ehldynmono);
+  ehldynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
       ehldynmono);
 
-  Core::Utils::bool_parameter(
-      "INFNORMSCALING", true, "Scale blocks of matrix with row infnorm?", ehldynmono);
+  ehldynmono.specs.emplace_back(parameter<bool>("INFNORMSCALING",
+      {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}));
 
   ehldynmono.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -24,7 +24,7 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   // Output type
   ehldyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0}));
+      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0.0}));
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", ehldyn);
   // Time loop control
@@ -37,7 +37,7 @@ void Inpar::EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "DIFFTIMESTEPSIZE", {.description = "use different step size for lubrication and solid",
                               .default_value = false}));
   ehldyn.specs.emplace_back(parameter<double>(
-      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
+      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0.0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ehldyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ehldyn);
   Core::Utils::int_parameter("ITEMIN", 1, "minimal number of iterations over fields", ehldyn);

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -24,18 +24,22 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
 
   Core::Utils::int_parameter("MOVBOUNDARYITEMAX", 10,
       "Maximum number of outer iterations in electrode shape change computations", elchcontrol);
-  Core::Utils::double_parameter("MOVBOUNDARYCONVTOL", 1e-6,
-      "Convergence check tolerance for outer loop in electrode shape change computations",
-      elchcontrol);
-  Core::Utils::double_parameter("TEMPERATURE", 298.0, "Constant temperature (Kelvin)", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<double>("MOVBOUNDARYCONVTOL",
+      {.description =
+              "Convergence check tolerance for outer loop in electrode shape change computations",
+          .default_value = 1e-6}));
+  elchcontrol.specs.emplace_back(parameter<double>(
+      "TEMPERATURE", {.description = "Constant temperature (Kelvin)", .default_value = 298.0}));
   Core::Utils::int_parameter("TEMPERATURE_FROM_FUNCT", -1,
       "Homogeneous temperature within electrochemistry field that can be time dependent according "
       "to function definition",
       elchcontrol);
-  Core::Utils::double_parameter("FARADAY_CONSTANT", 9.64853399e4,
-      "Faraday constant (in unit system as chosen in input file)", elchcontrol);
-  Core::Utils::double_parameter("GAS_CONSTANT", 8.314472,
-      "(universal) gas constant (in unit system as chosen in input file)", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<double>("FARADAY_CONSTANT",
+      {.description = "Faraday constant (in unit system as chosen in input file)",
+          .default_value = 9.64853399e4}));
+  elchcontrol.specs.emplace_back(parameter<double>("GAS_CONSTANT",
+      {.description = "(universal) gas constant (in unit system as chosen in input file)",
+          .default_value = 8.314472}));
   // parameter for possible types of ELCH algorithms for deforming meshes
   Core::Utils::string_to_integral_parameter<Inpar::ElCh::ElchMovingBoundary>("MOVINGBOUNDARY", "No",
       "ELCH algorithm for deforming meshes",
@@ -43,10 +47,12 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<Inpar::ElCh::ElchMovingBoundary>(
           elch_mov_bndry_no, elch_mov_bndry_pseudo_transient, elch_mov_bndry_fully_transient),
       elchcontrol);
-  Core::Utils::double_parameter(
-      "MOLARVOLUME", 0.0, "Molar volume for electrode shape change computations", elchcontrol);
-  Core::Utils::double_parameter("MOVBOUNDARYTHETA", 0.0,
-      "One-step-theta factor in electrode shape change computations", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<double>(
+      "MOLARVOLUME", {.description = "Molar volume for electrode shape change computations",
+                         .default_value = 0.0}));
+  elchcontrol.specs.emplace_back(parameter<double>("MOVBOUNDARYTHETA",
+      {.description = "One-step-theta factor in electrode shape change computations",
+          .default_value = 0.0}));
   elchcontrol.specs.emplace_back(parameter<bool>(
       "GALVANOSTATIC", {.description = "flag for galvanostatic mode", .default_value = false}));
   Core::Utils::string_to_integral_parameter<Inpar::ElCh::ApproxElectResist>(
@@ -60,15 +66,17 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "GSTATCONDID_CATHODE", 0, "condition id of electrode kinetics for cathode", elchcontrol);
   Core::Utils::int_parameter(
       "GSTATCONDID_ANODE", 1, "condition id of electrode kinetics for anode", elchcontrol);
-  Core::Utils::double_parameter(
-      "GSTATCONVTOL", 1.e-5, "Convergence check tolerance for galvanostatic mode", elchcontrol);
-  Core::Utils::double_parameter("GSTATCURTOL", 1.e-15, "Current Tolerance", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<double>(
+      "GSTATCONVTOL", {.description = "Convergence check tolerance for galvanostatic mode",
+                          .default_value = 1.e-5}));
+  elchcontrol.specs.emplace_back(parameter<double>(
+      "GSTATCURTOL", {.description = "Current Tolerance", .default_value = 1.e-15}));
   Core::Utils::int_parameter(
       "GSTATFUNCTNO", -1, "function number defining the imposed current curve", elchcontrol);
   Core::Utils::int_parameter(
       "GSTATITEMAX", 10, "maximum number of iterations for galvanostatic mode", elchcontrol);
-  Core::Utils::double_parameter(
-      "GSTAT_LENGTH_CURRENTPATH", 0.0, "average length of the current path", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<double>("GSTAT_LENGTH_CURRENTPATH",
+      {.description = "average length of the current path", .default_value = 0.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ElCh::EquPot>("EQUPOT", "Undefined",
       "type of closing equation for electric potential",
@@ -89,8 +97,8 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       {.description = "Coupling of lithium-ion flux density and electric current density at "
                       "Dirichlet and Neumann boundaries",
           .default_value = true}));
-  Core::Utils::double_parameter(
-      "CYCLING_TIMESTEP", -1., "modified time step size for CCCV cell cycling", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<double>("CYCLING_TIMESTEP",
+      {.description = "modified time step size for CCCV cell cycling", .default_value = -1.}));
   elchcontrol.specs.emplace_back(parameter<bool>("ELECTRODE_INFO_EVERY_STEP",
       {.description = "the cell voltage, SOC, and C-Rate will be written to the csv file every "
                       "step, even if RESULTSEVERY is not 1",
@@ -119,17 +127,17 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   ///         C
   //
   // default: concentrated solution theory according to Newman
-  Core::Utils::double_parameter("MAT_NEWMAN_CONST_A", 2.0,
-      "Constant A for the Newman model(term for the concentration overpotential)",
-      elchdiffcondcontrol);
-  Core::Utils::double_parameter("MAT_NEWMAN_CONST_B", -2.0,
-      "Constant B for the Newman model(term for the concentration overpotential)",
-      elchdiffcondcontrol);
-  Core::Utils::double_parameter("MAT_NEWMAN_CONST_C", -1.0,
-      "Constant C for the Newman model(term for the concentration overpotential)",
-      elchdiffcondcontrol);
-  Core::Utils::double_parameter(
-      "PERMITTIVITY_VACUUM", 8.8541878128e-12, "Vacuum permittivity", elchdiffcondcontrol);
+  elchdiffcondcontrol.specs.emplace_back(parameter<double>("MAT_NEWMAN_CONST_A",
+      {.description = "Constant A for the Newman model(term for the concentration overpotential)",
+          .default_value = 2.0}));
+  elchdiffcondcontrol.specs.emplace_back(parameter<double>("MAT_NEWMAN_CONST_B",
+      {.description = "Constant B for the Newman model(term for the concentration overpotential)",
+          .default_value = -2.0}));
+  elchdiffcondcontrol.specs.emplace_back(parameter<double>("MAT_NEWMAN_CONST_C",
+      {.description = "Constant C for the Newman model(term for the concentration overpotential)",
+          .default_value = -1.0}));
+  elchdiffcondcontrol.specs.emplace_back(parameter<double>("PERMITTIVITY_VACUUM",
+      {.description = "Vacuum permittivity", .default_value = 8.8541878128e-12}));
 
   elchdiffcondcontrol.move_into_collection(list);
 
@@ -153,7 +161,8 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       sclcontrol);
   Core::Utils::int_parameter("ADAPT_TIME_STEP", -1,
       "time step when time step size should be updated to 'ADAPTED_TIME_STEP_SIZE'.", sclcontrol);
-  Core::Utils::double_parameter("ADAPTED_TIME_STEP_SIZE", -1.0, "new time step size.", sclcontrol);
+  sclcontrol.specs.emplace_back(parameter<double>(
+      "ADAPTED_TIME_STEP_SIZE", {.description = "new time step size.", .default_value = -1.0}));
 
   Core::Utils::string_to_integral_parameter<ScaTra::InitialField>("INITIALFIELD", "zero_field",
       "Initial Field for scalar transport problem",

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs elchcontrol{"ELCH CONTROL"};
 
@@ -46,7 +47,8 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "MOLARVOLUME", 0.0, "Molar volume for electrode shape change computations", elchcontrol);
   Core::Utils::double_parameter("MOVBOUNDARYTHETA", 0.0,
       "One-step-theta factor in electrode shape change computations", elchcontrol);
-  Core::Utils::bool_parameter("GALVANOSTATIC", false, "flag for galvanostatic mode", elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<bool>(
+      "GALVANOSTATIC", {.description = "flag for galvanostatic mode", .default_value = false}));
   Core::Utils::string_to_integral_parameter<Inpar::ElCh::ApproxElectResist>(
       "GSTAT_APPROX_ELECT_RESIST", "relation_pot_cur", "relation of potential and current flow",
       tuple<std::string>("relation_pot_cur", "effective_length_with_initial_cond",
@@ -75,22 +77,24 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<Inpar::ElCh::EquPot>(equpot_undefined, equpot_enc, equpot_enc_pde, equpot_enc_pde_elim,
           equpot_poisson, equpot_laplace, equpot_divi),
       elchcontrol);
-  Core::Utils::bool_parameter(
-      "DIFFCOND_FORMULATION", false, "Activation of diffusion-conduction formulation", elchcontrol);
-  Core::Utils::bool_parameter("INITPOTCALC", false,
-      "Automatically calculate initial field for electric potential", elchcontrol);
-  Core::Utils::bool_parameter("ONLYPOTENTIAL", false,
-      "Coupling of general ion transport equation with Laplace equation", elchcontrol);
-  Core::Utils::bool_parameter("COUPLE_BOUNDARY_FLUXES", true,
-      "Coupling of lithium-ion flux density and electric current density at Dirichlet and Neumann "
-      "boundaries",
-      elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<bool>("DIFFCOND_FORMULATION",
+      {.description = "Activation of diffusion-conduction formulation", .default_value = false}));
+  elchcontrol.specs.emplace_back(parameter<bool>(
+      "INITPOTCALC", {.description = "Automatically calculate initial field for electric potential",
+                         .default_value = false}));
+  elchcontrol.specs.emplace_back(parameter<bool>("ONLYPOTENTIAL",
+      {.description = "Coupling of general ion transport equation with Laplace equation",
+          .default_value = false}));
+  elchcontrol.specs.emplace_back(parameter<bool>("COUPLE_BOUNDARY_FLUXES",
+      {.description = "Coupling of lithium-ion flux density and electric current density at "
+                      "Dirichlet and Neumann boundaries",
+          .default_value = true}));
   Core::Utils::double_parameter(
       "CYCLING_TIMESTEP", -1., "modified time step size for CCCV cell cycling", elchcontrol);
-  Core::Utils::bool_parameter("ELECTRODE_INFO_EVERY_STEP", false,
-      "the cell voltage, SOC, and C-Rate will be written to the csv file every step, even if "
-      "RESULTSEVERY is not 1",
-      elchcontrol);
+  elchcontrol.specs.emplace_back(parameter<bool>("ELECTRODE_INFO_EVERY_STEP",
+      {.description = "the cell voltage, SOC, and C-Rate will be written to the csv file every "
+                      "step, even if RESULTSEVERY is not 1",
+          .default_value = false}));
 
   elchcontrol.move_into_collection(list);
 
@@ -98,11 +102,12 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   // attention: this list is a sublist of elchcontrol
   Core::Utils::SectionSpecs elchdiffcondcontrol{elchcontrol, "DIFFCOND"};
 
-  Core::Utils::bool_parameter(
-      "CURRENT_SOLUTION_VAR", false, "Current as a solution variable", elchdiffcondcontrol);
-  Core::Utils::bool_parameter("MAT_DIFFCOND_DIFFBASED", true,
-      "Coupling terms of chemical diffusion for current equation are based on t and kappa",
-      elchdiffcondcontrol);
+  elchdiffcondcontrol.specs.emplace_back(parameter<bool>("CURRENT_SOLUTION_VAR",
+      {.description = "Current as a solution variable", .default_value = false}));
+  elchdiffcondcontrol.specs.emplace_back(parameter<bool>("MAT_DIFFCOND_DIFFBASED",
+      {.description =
+              "Coupling terms of chemical diffusion for current equation are based on t and kappa",
+          .default_value = true}));
 
   /// dilute solution theory (diffusion potential in current equation):
   ///    A          B
@@ -132,12 +137,13 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   // sublist for space-charge layers
   Core::Utils::SectionSpecs sclcontrol{elchcontrol, "SCL"};
 
-  Core::Utils::bool_parameter(
-      "ADD_MICRO_MACRO_COUPLING", false, "flag for micro macro coupling with scls", sclcontrol);
-  Core::Utils::bool_parameter("COUPLING_OUTPUT", false,
-      "write coupled node gids and node coordinates to csv file", sclcontrol);
-  Core::Utils::bool_parameter(
-      "INITPOTCALC", false, "calculate initial potential field?", sclcontrol);
+  sclcontrol.specs.emplace_back(parameter<bool>("ADD_MICRO_MACRO_COUPLING",
+      {.description = "flag for micro macro coupling with scls", .default_value = false}));
+  sclcontrol.specs.emplace_back(parameter<bool>(
+      "COUPLING_OUTPUT", {.description = "write coupled node gids and node coordinates to csv file",
+                             .default_value = false}));
+  sclcontrol.specs.emplace_back(parameter<bool>("INITPOTCALC",
+      {.description = "calculate initial potential field?", .default_value = false}));
   Core::Utils::int_parameter("SOLVER", -1, "solver for coupled SCL problem", sclcontrol);
   Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",
       "type of global system matrix in global system of equations",

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -22,10 +22,13 @@ void Inpar::EleMag::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs electromagneticdyn{"ELECTROMAGNETIC DYNAMIC"};
 
   // general settings for time-integration scheme
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "Time-step length dt", electromagneticdyn);
-  Core::Utils::double_parameter("TAU", 1, "Stabilization parameter", electromagneticdyn);
+  electromagneticdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time-step length dt", .default_value = 0.01}));
+  electromagneticdyn.specs.emplace_back(
+      parameter<double>("TAU", {.description = "Stabilization parameter", .default_value = 1}));
   Core::Utils::int_parameter("NUMSTEP", 100, "Number of time steps", electromagneticdyn);
-  Core::Utils::double_parameter("MAXTIME", 1.0, "Total simulation time", electromagneticdyn);
+  electromagneticdyn.specs.emplace_back(
+      parameter<double>("MAXTIME", {.description = "Total simulation time", .default_value = 1.0}));
 
   // additional parameters
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -25,7 +25,7 @@ void Inpar::EleMag::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   electromagneticdyn.specs.emplace_back(
       parameter<double>("TIMESTEP", {.description = "Time-step length dt", .default_value = 0.01}));
   electromagneticdyn.specs.emplace_back(
-      parameter<double>("TAU", {.description = "Stabilization parameter", .default_value = 1}));
+      parameter<double>("TAU", {.description = "Stabilization parameter", .default_value = 1.0}));
   Core::Utils::int_parameter("NUMSTEP", 100, "Number of time steps", electromagneticdyn);
   electromagneticdyn.specs.emplace_back(
       parameter<double>("MAXTIME", {.description = "Total simulation time", .default_value = 1.0}));

--- a/src/inpar/4C_inpar_elemag.cpp
+++ b/src/inpar/4C_inpar_elemag.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::EleMag::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs electromagneticdyn{"ELECTROMAGNETIC DYNAMIC"};
 
@@ -80,12 +81,12 @@ void Inpar::EleMag::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "zero_field", "Initial field for ele problem", name, label, electromagneticdyn);
 
     // Error calculation
-    Core::Utils::bool_parameter(
-        "CALCERR", false, "Calc the error wrt ERRORFUNCNO?", electromagneticdyn);
+    electromagneticdyn.specs.emplace_back(parameter<bool>(
+        "CALCERR", {.description = "Calc the error wrt ERRORFUNCNO?", .default_value = false}));
 
     // Post process solution?
-    Core::Utils::bool_parameter(
-        "POSTPROCESS", false, "Postprocess solution? (very slow)", electromagneticdyn);
+    electromagneticdyn.specs.emplace_back(parameter<bool>("POSTPROCESS",
+        {.description = "Postprocess solution? (very slow)", .default_value = false}));
   }
 
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fbi.cpp
+++ b/src/inpar/4C_inpar_fbi.cpp
@@ -16,6 +16,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs fbi{"FLUID BEAM INTERACTION"};
 
@@ -90,33 +91,37 @@ void Inpar::FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       beam_to_fluid_meshtying, "RUNTIME VTK OUTPUT"};
 
   // Whether to write visualization output at all for beam to fluid meshtying.
-  Core::Utils::bool_parameter("WRITE_OUTPUT", false,
-      "Enable / disable beam-to-fluid mesh tying output.", beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
+      "WRITE_OUTPUT", {.description = "Enable / disable beam-to-fluid mesh tying output.",
+                          .default_value = false}));
 
-  Core::Utils::bool_parameter("NODAL_FORCES", false,
-      "Enable / disable output of the resulting nodal forces due to beam to Fluid interaction.",
-      beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
+      "NODAL_FORCES", {.description = "Enable / disable output of the resulting nodal forces due "
+                                      "to beam to Fluid interaction.",
+                          .default_value = false}));
 
-  Core::Utils::bool_parameter("SEGMENTATION", false,
-      "Enable / disable output of segmentation points.", beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>("SEGMENTATION",
+      {.description = "Enable / disable output of segmentation points.", .default_value = false}));
 
-  Core::Utils::bool_parameter("INTEGRATION_POINTS", false,
-      "Enable / disable output of used integration points. If the meshtying method has 'forces' at "
-      "the integration point, they will also be output.",
-      beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>("INTEGRATION_POINTS",
+      {.description = "Enable / disable output of used integration points. If the meshtying method "
+                      "has 'forces' at the integration point, they will also be output.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("CONSTRAINT_VIOLATION", false,
-      "Enable / disable output of the constraint violation into a output_name.penalty csv file.",
-      beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
+      "CONSTRAINT_VIOLATION", {.description = "Enable / disable output of the constraint violation "
+                                              "into a output_name.penalty csv file.",
+                                  .default_value = false}));
 
-  Core::Utils::bool_parameter("MORTAR_LAMBDA_DISCRET", false,
-      "Enable / disable output of the discrete Lagrange multipliers at the node of the Lagrange "
-      "multiplier shape functions.",
-      beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>("MORTAR_LAMBDA_DISCRET",
+      {.description = "Enable / disable output of the discrete Lagrange multipliers at the node of "
+                      "the Lagrange multiplier shape functions.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("MORTAR_LAMBDA_CONTINUOUS", false,
-      "Enable / disable output of the continuous Lagrange multipliers function along the beam.",
-      beam_to_fluid_meshtying_output);
+  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
+      "MORTAR_LAMBDA_CONTINUOUS", {.description = "Enable / disable output of the continuous "
+                                                  "Lagrange multipliers function along the beam.",
+                                      .default_value = false}));
 
   Core::Utils::int_parameter("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS", 5,
       "Number of segments for continuous mortar output", beam_to_fluid_meshtying_output);

--- a/src/inpar/4C_inpar_fbi.cpp
+++ b/src/inpar/4C_inpar_fbi.cpp
@@ -60,13 +60,14 @@ void Inpar::FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           BeamToFluidConstraintEnforcement::none, BeamToFluidConstraintEnforcement::penalty),
       beam_to_fluid_meshtying);
 
-  Core::Utils::double_parameter("PENALTY_PARAMETER", 0.0,
-      "Penalty parameter for beam-to-Fluid volume meshtying", beam_to_fluid_meshtying);
+  beam_to_fluid_meshtying.specs.emplace_back(parameter<double>(
+      "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-Fluid volume meshtying",
+                               .default_value = 0.0}));
 
-  Core::Utils::double_parameter("SEARCH_RADIUS", 1000,
-      "Absolute Search radius for beam-to-fluid volume meshtying. Choose carefully to not blow up "
-      "memory demand but to still find all interaction pairs!",
-      beam_to_fluid_meshtying);
+  beam_to_fluid_meshtying.specs.emplace_back(parameter<double>("SEARCH_RADIUS",
+      {.description = "Absolute Search radius for beam-to-fluid volume meshtying. Choose carefully "
+                      "to not blow up memory demand but to still find all interaction pairs!",
+          .default_value = 1000}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FBI::BeamToFluidMeshtingMortarShapefunctions>(
       "MORTAR_SHAPE_FUNCTION", "none", "Shape function for the mortar Lagrange-multipliers",

--- a/src/inpar/4C_inpar_fbi.cpp
+++ b/src/inpar/4C_inpar_fbi.cpp
@@ -67,7 +67,7 @@ void Inpar::FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   beam_to_fluid_meshtying.specs.emplace_back(parameter<double>("SEARCH_RADIUS",
       {.description = "Absolute Search radius for beam-to-fluid volume meshtying. Choose carefully "
                       "to not blow up memory demand but to still find all interaction pairs!",
-          .default_value = 1000}));
+          .default_value = 1000.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FBI::BeamToFluidMeshtingMortarShapefunctions>(
       "MORTAR_SHAPE_FUNCTION", "none", "Shape function for the mortar Lagrange-multipliers",

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -91,8 +91,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   std::vector<std::string> predictor_valid_input = {"steady_state", "zero_acceleration",
       "constant_acceleration", "constant_increment", "explicit_second_order_midpoint", "TangVel"};
-  Core::Utils::string_parameter("PREDICTOR", "steady_state",
-      "Predictor for first guess in nonlinear iteration", fdyn, predictor_valid_input);
+  fdyn.specs.emplace_back(selection<std::string>("PREDICTOR", predictor_valid_input,
+      {.description = "Predictor for first guess in nonlinear iteration",
+          .default_value = "steady_state"}));
 
 
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::ItNorm>("CONVCHECK", "L_2_norm",
@@ -142,8 +143,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
                       .default_value = false}));
 
   std::vector<std::string> convform_valid_input = {"convective", "conservative"};
-  Core::Utils::string_parameter(
-      "CONVFORM", "convective", "form of convective term", fdyn, convform_valid_input);
+  fdyn.specs.emplace_back(selection<std::string>("CONVFORM", convform_valid_input,
+      {.description = "form of convective term", .default_value = "convective"}));
 
   fdyn.specs.emplace_back(parameter<bool>("NONLINEARBC",
       {.description = "Flag to activate check for potential nonlinear boundary conditions",
@@ -474,15 +475,16 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // this parameter selects the location where tau is evaluated
 
   std::vector<std::string> evaluation_tau_valid_input = {"element_center", "integration_point"};
-  Core::Utils::string_parameter("EVALUATION_TAU", "element_center",
-      "Location where tau is evaluated", fdyn_stab, evaluation_tau_valid_input);
+  fdyn_stab.specs.emplace_back(selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
+      {.description = "Location where tau is evaluated", .default_value = "element_center"}));
 
   // this parameter selects the location where the material law is evaluated
   // (does not fit here very well, but parameter transfer is easier)
 
   std::vector<std::string> evaluation_mat_valid_input = {"element_center", "integration_point"};
-  Core::Utils::string_parameter("EVALUATION_MAT", "element_center",
-      "Location where material law is evaluated", fdyn_stab, evaluation_mat_valid_input);
+  fdyn_stab.specs.emplace_back(selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
+      {.description = "Location where material law is evaluated",
+          .default_value = "element_center"}));
 
   // these parameters active additional terms in loma continuity equation
   // which might be identified as SUPG-/cross- and Reynolds-stress term
@@ -746,14 +748,17 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   // this parameter selects the location where tau is evaluated
   evaluation_tau_valid_input = {"element_center", "integration_point"};
-  Core::Utils::string_parameter("EVALUATION_TAU", "element_center",
-      "Location where tau is evaluated", fdyn_porostab, evaluation_tau_valid_input);
+  fdyn_porostab.specs.emplace_back(
+      selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
+          {.description = "Location where tau is evaluated", .default_value = "element_center"}));
 
   // this parameter selects the location where the material law is evaluated
   // (does not fit here very well, but parameter transfer is easier)
   evaluation_mat_valid_input = {"element_center", "integration_point"};
-  Core::Utils::string_parameter("EVALUATION_MAT", "element_center",
-      "Location where material law is evaluated", fdyn_porostab, evaluation_mat_valid_input);
+  fdyn_porostab.specs.emplace_back(
+      selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
+          {.description = "Location where material law is evaluated",
+              .default_value = "element_center"}));
 
 
   // these parameters active additional terms in loma continuity equation
@@ -791,8 +796,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "kind of turbulence model! Perform a classical Large Eddy Simulation adding addititional "
       "turbulent viscosity. This may be based on various physical models.)";
 
-  Core::Utils::string_parameter("TURBULENCE_APPROACH", "DNS_OR_RESVMM_LES",
-      turbulence_approach_doc_string, fdyn_turbu, turbulence_approach_valid_input);
+  fdyn_turbu.specs.emplace_back(
+      selection<std::string>("TURBULENCE_APPROACH", turbulence_approach_valid_input,
+          {.description = turbulence_approach_doc_string, .default_value = "DNS_OR_RESVMM_LES"}));
 
   std::vector<std::string> physical_model_valid_input = {"no_model", "Smagorinsky",
       "Smagorinsky_with_van_Driest_damping", "Dynamic_Smagorinsky", "Multifractal_Subgrid_Scales",
@@ -808,8 +814,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "averaging in the xz plane, hence this implementation will only work for a channel flow. "
       "Multifractal Subgrid-Scale Modeling based on the work of burton. Vremans constant model. "
       "Dynamic Vreman model according to You and Moin (2007)";
-  Core::Utils::string_parameter("PHYSICAL_MODEL", "no_model", physical_model_doc_string, fdyn_turbu,
-      physical_model_valid_input);
+  fdyn_turbu.specs.emplace_back(selection<std::string>("PHYSICAL_MODEL", physical_model_valid_input,
+      {.description = physical_model_doc_string, .default_value = "no_model"}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::FineSubgridVisc>("FSSUGRVISC", "No",
       "fine-scale subgrid viscosity",
@@ -902,8 +908,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
         "blood_fda_flow: For this flow, statistical data is evaluated on various planes.\n"
         "backward_facing_step2: For this flow, statistical data is evaluated on various planes.\n";
 
-    Core::Utils::string_parameter(
-        "CANONICAL_FLOW", "no", canonical_flow_doc, fdyn_turbu, canonical_flow_valid_input);
+    fdyn_turbu.specs.emplace_back(selection<std::string>("CANONICAL_FLOW",
+        canonical_flow_valid_input, {.description = canonical_flow_doc, .default_value = "no"}));
   }
 
   std::vector<std::string> homdir_valid_input = {
@@ -919,8 +925,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "xz: Wall normal direction is y, average in x and z direction\n"
       "yz: Wall normal direction is x, average in y and z direction\n"
       "xyz: Averaging in all directions\n";
-  Core::Utils::string_parameter(
-      "HOMDIR", "not_specified", homdir_doc, fdyn_turbu, homdir_valid_input);
+  fdyn_turbu.specs.emplace_back(selection<std::string>(
+      "HOMDIR", homdir_valid_input, {.description = homdir_doc, .default_value = "not_specified"}));
 
   //---------------------------------------
   // further problem-specific parameters
@@ -963,8 +969,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "no: Do not force the scalar field\n"
       "isotropic: Force scalar field isotropically such as the fluid field.\n"
       "mean_scalar_gradient: Force scalar field by imposed mean-scalar gradient.\n";
-  Core::Utils::string_parameter(
-      "SCALAR_FORCING", "no", scalar_forcing_doc, fdyn_turbu, scalar_forcing_valid_input);
+  fdyn_turbu.specs.emplace_back(selection<std::string>("SCALAR_FORCING", scalar_forcing_valid_input,
+      {.description = scalar_forcing_doc, .default_value = "no"}));
 
   fdyn_turbu.specs.emplace_back(parameter<double>("MEAN_SCALAR_GRADIENT",
       {.description = "Value of imposed mean-scalar gradient to force scalar field.",
@@ -1039,8 +1045,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "constant: Use the constant wall shear stress given in the input file for the whole "
       "simulation.\n"
       "between_steps: Calculate wall shear stress in between time steps.\n";
-  Core::Utils::string_parameter(
-      "Tauw_Type", "constant", tauw_type_doc, fdyn_wallmodel, tauw_type_valid_input);
+  fdyn_wallmodel.specs.emplace_back(selection<std::string>("Tauw_Type", tauw_type_valid_input,
+      {.description = tauw_type_doc, .default_value = "constant"}));
 
   std::vector<std::string> tauw_calc_type_valid_input = {
       "residual", "gradient", "gradient_to_residual"};
@@ -1048,8 +1054,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "residual: Residual (force) divided by area.\n"
       "gradient: Gradient via shape functions and nodal values.\n"
       "gradient_to_residual: First gradient, then residual.\n";
-  Core::Utils::string_parameter(
-      "Tauw_Calc_Type", "residual", tauw_calc_type_doc, fdyn_wallmodel, tauw_calc_type_valid_input);
+  fdyn_wallmodel.specs.emplace_back(
+      selection<std::string>("Tauw_Calc_Type", tauw_calc_type_valid_input,
+          {.description = tauw_calc_type_doc, .default_value = "residual"}));
 
 
   Core::Utils::int_parameter(
@@ -1060,8 +1067,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   std::string projection_doc =
       "Flag to switch projection of the enriched dofs after updating tauw, alternatively with or "
       "without continuity constraint.";
-  Core::Utils::string_parameter(
-      "Projection", "No", projection_doc, fdyn_wallmodel, projection_valid_input);
+  fdyn_wallmodel.specs.emplace_back(selection<std::string>("Projection", projection_valid_input,
+      {.description = projection_doc, .default_value = "No"}));
 
   fdyn_wallmodel.specs.emplace_back(parameter<double>(
       "C_Tauw", {.description = "Constant wall shear stress for Spalding's law, if applicable",
@@ -1081,8 +1088,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "none: No ramp function, does not converge!\n"
       "ramp_function: Enrichment is multiplied with linear ramp function resulting in zero "
       "enrichment at the interface.\n";
-  Core::Utils::string_parameter(
-      "Blending_Type", "none", blending_type_doc, fdyn_wallmodel, blending_type_valid_input);
+  fdyn_wallmodel.specs.emplace_back(selection<std::string>("Blending_Type",
+      blending_type_valid_input, {.description = blending_type_doc, .default_value = "none"}));
 
 
   Core::Utils::int_parameter(
@@ -1116,8 +1123,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "no_scale_sep: no scale separation.\n"
       "box_filter: classical box filter.\n"
       "algebraic_multigrid_operator: scale separation by algebraic multigrid operator.\n";
-  Core::Utils::string_parameter("SCALE_SEPARATION", "no_scale_sep", scale_separation_doc,
-      fdyn_turbmfs, scale_separation_valid_input);
+  fdyn_turbmfs.specs.emplace_back(
+      selection<std::string>("SCALE_SEPARATION", scale_separation_valid_input,
+          {.description = scale_separation_doc, .default_value = "no_scale_sep"}));
 
 
   Core::Utils::int_parameter("ML_SOLVER", -1,
@@ -1141,8 +1149,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "streamlength: streamlength taken from stabilization.\n"
       "gradient_based: gradient based length taken from stabilization.\n"
       "metric_tensor: metric tensor taken from stabilization.\n";
-  Core::Utils::string_parameter(
-      "REF_LENGTH", "cube_edge", ref_length_doc, fdyn_turbmfs, ref_length_valid_input);
+  fdyn_turbmfs.specs.emplace_back(selection<std::string>("REF_LENGTH", ref_length_valid_input,
+      {.description = ref_length_doc, .default_value = "cube_edge"}));
 
   std::vector<std::string> ref_velocity_valid_input = {"strainrate", "resolved", "fine_scale"};
   std::string ref_velocity_doc =
@@ -1150,8 +1158,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "strainrate: norm of strain rate.\n"
       "resolved: resolved velocity.\n"
       "fine_scale: fine-scale velocity.\n";
-  Core::Utils::string_parameter(
-      "REF_VELOCITY", "strainrate", ref_velocity_doc, fdyn_turbmfs, ref_velocity_valid_input);
+  fdyn_turbmfs.specs.emplace_back(selection<std::string>("REF_VELOCITY", ref_velocity_valid_input,
+      {.description = ref_velocity_doc, .default_value = "strainrate"}));
 
 
   fdyn_turbmfs.specs.emplace_back(parameter<double>("C_NU",
@@ -1167,8 +1175,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Location where B is evaluated\n"
       "element_center: evaluate B at element center.\n"
       "integration_point: evaluate B at integration point.\n";
-  Core::Utils::string_parameter(
-      "EVALUATION_B", "element_center", evaluation_b_doc, fdyn_turbmfs, evaluation_b_valid_input);
+  fdyn_turbmfs.specs.emplace_back(selection<std::string>("EVALUATION_B", evaluation_b_valid_input,
+      {.description = evaluation_b_doc, .default_value = "element_center"}));
 
 
   fdyn_turbmfs.specs.emplace_back(parameter<double>(
@@ -1180,8 +1188,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "form of convective term\n"
       "convective: Use the convective form.\n"
       "conservative: Use the conservative form.\n";
-  Core::Utils::string_parameter(
-      "CONVFORM", "convective", convform_doc, fdyn_turbmfs, convform_valid_input);
+  fdyn_turbmfs.specs.emplace_back(selection<std::string>("CONVFORM", convform_valid_input,
+      {.description = convform_doc, .default_value = "convective"}));
 
   fdyn_turbmfs.specs.emplace_back(parameter<double>("CSGS_PHI",
       {.description = "Modelparameter of multifractal subgrid-scales for scalar transport.",
@@ -1257,8 +1265,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "flow.\n"
       "scatra_channel_flow_of_height_2: For this flow, all statistical data could be averaged in "
       "\nthe homogeneous planes --- it is essentially a statistically one dimensional flow.\n";
-  Core::Utils::string_parameter(
-      "CANONICAL_INFLOW", "no", canonical_inflow_doc, fdyn_turbinf, canonical_inflow_valid_input);
+  fdyn_turbinf.specs.emplace_back(selection<std::string>("CANONICAL_INFLOW",
+      canonical_inflow_valid_input, {.description = canonical_inflow_doc, .default_value = "no"}));
 
 
   fdyn_turbinf.specs.emplace_back(parameter<double>("INFLOW_CHA_SIDE",
@@ -1277,8 +1285,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "xy: Wall normal direction is z, average in x and y direction.\n"
       "xz: Wall normal direction is y, average in x and z direction (standard case).\n"
       "yz: Wall normal direction is x, average in y and z direction.\n";
-  Core::Utils::string_parameter(
-      "INFLOW_HOMDIR", "not_specified", inflow_homdir_doc, fdyn_turbinf, inflow_homdir_valid_input);
+  fdyn_turbinf.specs.emplace_back(selection<std::string>("INFLOW_HOMDIR", inflow_homdir_valid_input,
+      {.description = inflow_homdir_doc, .default_value = "not_specified"}));
 
   Core::Utils::int_parameter("INFLOW_SAMPLING_START", 10000000,
       "Time step after when sampling shall be started", fdyn_turbinf);
@@ -1335,8 +1343,9 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", lomacontrol);
 
   std::vector<std::string> constthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
-  Core::Utils::string_parameter("CONSTHERMPRESS", "Yes",
-      "treatment of thermodynamic pressure in time", lomacontrol, constthermpress_valid_input);
+  lomacontrol.specs.emplace_back(
+      selection<std::string>("CONSTHERMPRESS", constthermpress_valid_input,
+          {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
 
   lomacontrol.specs.emplace_back(parameter<bool>(
       "SGS_MATERIAL_UPDATE", {.description = "update material by adding subgrid-scale scalar field",

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -211,15 +211,15 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter("BODYFORCEFUNCNO", -1,
       "Function for calculation of the body force for the weakly compressible problem", fdyn);
 
-  Core::Utils::double_parameter("STAB_DEN_REF", 0.0,
-      "Reference stabilization parameter for the density for the HDG weakly compressible "
-      "formulation",
-      fdyn);
+  fdyn.specs.emplace_back(parameter<double>(
+      "STAB_DEN_REF", {.description = "Reference stabilization parameter for the density for the "
+                                      "HDG weakly compressible formulation",
+                          .default_value = 0.0}));
 
-  Core::Utils::double_parameter("STAB_MOM_REF", 0.0,
-      "Reference stabilization parameter for the momentum for the HDG weakly compressible "
-      "formulation",
-      fdyn);
+  fdyn.specs.emplace_back(parameter<double>(
+      "STAB_MOM_REF", {.description = "Reference stabilization parameter for the momentum for the "
+                                      "HDG weakly compressible formulation",
+                          .default_value = 0.0}));
 
   Core::Utils::int_parameter("VARVISCFUNCNO", -1,
       "Function for calculation of a variable viscosity for the weakly compressible problem", fdyn);
@@ -229,7 +229,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
                                     "considered element average pressure",
                         .default_value = false}));
 
-  Core::Utils::double_parameter("REFMACH", 1.0, "Reference Mach number", fdyn);
+  fdyn.specs.emplace_back(
+      parameter<double>("REFMACH", {.description = "Reference Mach number", .default_value = 1.0}));
 
   fdyn.specs.emplace_back(parameter<bool>("BLOCKMATRIX",
       {.description =
@@ -240,10 +241,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      fdyn);
+  fdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   fdyn.specs.emplace_back(parameter<bool>("INFNORMSCALING",
       {.description = "Scale blocks of matrix with row infnorm?", .default_value = false}));
@@ -268,15 +269,21 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter("ITEMAX", 10, "max. number of nonlin. iterations", fdyn);
   Core::Utils::int_parameter("INITSTATITEMAX", 5,
       "max number of nonlinear iterations for initial stationary solution", fdyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", fdyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", fdyn);
-  Core::Utils::double_parameter("ALPHA_M", 1.0, "Time integration factor", fdyn);
-  Core::Utils::double_parameter("ALPHA_F", 1.0, "Time integration factor", fdyn);
-  Core::Utils::double_parameter("GAMMA", 1.0, "Time integration factor", fdyn);
-  Core::Utils::double_parameter("THETA", 0.66, "Time integration factor", fdyn);
+  fdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
+  fdyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
+  fdyn.specs.emplace_back(parameter<double>(
+      "ALPHA_M", {.description = "Time integration factor", .default_value = 1.0}));
+  fdyn.specs.emplace_back(parameter<double>(
+      "ALPHA_F", {.description = "Time integration factor", .default_value = 1.0}));
+  fdyn.specs.emplace_back(
+      parameter<double>("GAMMA", {.description = "Time integration factor", .default_value = 1.0}));
+  fdyn.specs.emplace_back(parameter<double>(
+      "THETA", {.description = "Time integration factor", .default_value = 0.66}));
 
-  Core::Utils::double_parameter(
-      "START_THETA", 1.0, "Time integration factor for starting scheme", fdyn);
+  fdyn.specs.emplace_back(parameter<double>("START_THETA",
+      {.description = "Time integration factor for starting scheme", .default_value = 1.0}));
 
   fdyn.specs.emplace_back(parameter<bool>("STRONG_REDD_3D_COUPLING_TYPE",
       {.description = "Flag to (de)activate potential Strong 3D redD coupling",
@@ -305,17 +312,21 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs fdyn_nln{fdyn, "NONLINEAR SOLVER TOLERANCES"};
 
-  Core::Utils::double_parameter(
-      "TOL_VEL_RES", 1e-6, "Tolerance for convergence check of velocity residual", fdyn_nln);
+  fdyn_nln.specs.emplace_back(parameter<double>(
+      "TOL_VEL_RES", {.description = "Tolerance for convergence check of velocity residual",
+                         .default_value = 1e-6}));
 
-  Core::Utils::double_parameter(
-      "TOL_VEL_INC", 1e-6, "Tolerance for convergence check of velocity increment", fdyn_nln);
+  fdyn_nln.specs.emplace_back(parameter<double>(
+      "TOL_VEL_INC", {.description = "Tolerance for convergence check of velocity increment",
+                         .default_value = 1e-6}));
 
-  Core::Utils::double_parameter(
-      "TOL_PRES_RES", 1e-6, "Tolerance for convergence check of pressure residual", fdyn_nln);
+  fdyn_nln.specs.emplace_back(parameter<double>(
+      "TOL_PRES_RES", {.description = "Tolerance for convergence check of pressure residual",
+                          .default_value = 1e-6}));
 
-  Core::Utils::double_parameter(
-      "TOL_PRES_INC", 1e-6, "Tolerance for convergence check of pressure increment", fdyn_nln);
+  fdyn_nln.specs.emplace_back(parameter<double>(
+      "TOL_PRES_INC", {.description = "Tolerance for convergence check of pressure increment",
+                          .default_value = 1e-6}));
 
   fdyn_nln.move_into_collection(list);
 
@@ -626,9 +637,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   fdyn_porostab.specs.emplace_back(parameter<bool>("STAB_BIOT",
       {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}));
-  Core::Utils::double_parameter("STAB_BIOT_SCALING", 1.0,
-      "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
-      fdyn_porostab);
+  fdyn_porostab.specs.emplace_back(parameter<double>("STAB_BIOT_SCALING",
+      {.description =
+              "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
+          .default_value = 1.0}));
 
   // this parameter defines various stabilized methods
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::StabType>("STABTYPE", "residual_based",
@@ -916,10 +928,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // CHANNEL FLOW
   //--------------
 
-  Core::Utils::double_parameter("CHAN_AMPL_INIT_DIST", 0.1,
-      "Max. amplitude of the random disturbance in percent of the initial value in mean flow "
-      "direction.",
-      fdyn_turbu);
+  fdyn_turbu.specs.emplace_back(parameter<double>(
+      "CHAN_AMPL_INIT_DIST", {.description = "Max. amplitude of the random disturbance in percent "
+                                             "of the initial value in mean flow direction.",
+                                 .default_value = 0.1}));
 
   Core::Utils::string_to_integral_parameter<ForcingType>("FORCING_TYPE",
       "linear_compensation_from_intermediate_spectrum", "forcing strategy",
@@ -938,12 +950,13 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "turbulence only.",
       fdyn_turbu);
 
-  Core::Utils::double_parameter("THRESHOLD_WAVENUMBER", 0.0,
-      "Forcing is only applied to wave numbers lower or equal than the given threshold wave "
-      "number.",
-      fdyn_turbu);
+  fdyn_turbu.specs.emplace_back(parameter<double>(
+      "THRESHOLD_WAVENUMBER", {.description = "Forcing is only applied to wave numbers lower or "
+                                              "equal than the given threshold wave number.",
+                                  .default_value = 0.0}));
 
-  Core::Utils::double_parameter("POWER_INPUT", 0.0, "power of forcing", fdyn_turbu);
+  fdyn_turbu.specs.emplace_back(
+      parameter<double>("POWER_INPUT", {.description = "power of forcing", .default_value = 0.0}));
 
   std::vector<std::string> scalar_forcing_valid_input = {"no", "isotropic", "mean_scalar_gradient"};
   std::string scalar_forcing_doc =
@@ -953,8 +966,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::string_parameter(
       "SCALAR_FORCING", "no", scalar_forcing_doc, fdyn_turbu, scalar_forcing_valid_input);
 
-  Core::Utils::double_parameter("MEAN_SCALAR_GRADIENT", 0.0,
-      "Value of imposed mean-scalar gradient to force scalar field.", fdyn_turbu);
+  fdyn_turbu.specs.emplace_back(parameter<double>("MEAN_SCALAR_GRADIENT",
+      {.description = "Value of imposed mean-scalar gradient to force scalar field.",
+          .default_value = 0.0}));
 
   // filtering with xfem
   //--------------
@@ -969,14 +983,15 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // sublist with additional input parameters for Smagorinsky model
   Core::Utils::SectionSpecs fdyn_turbsgv{fdyn, "SUBGRID VISCOSITY"};
 
-  Core::Utils::double_parameter("C_SMAGORINSKY", 0.0,
-      "Constant for the Smagorinsky model. Something between 0.1 to 0.24. Vreman constant if the "
-      "constant vreman model is applied (something between 0.07 and 0.01).",
-      fdyn_turbsgv);
-  Core::Utils::double_parameter("C_YOSHIZAWA", -1.0,
-      "Constant for the compressible Smagorinsky model: isotropic part of subgrid-stress tensor. "
-      "About 0.09 or 0.0066. Ci will not be squared!",
-      fdyn_turbsgv);
+  fdyn_turbsgv.specs.emplace_back(parameter<double>("C_SMAGORINSKY",
+      {.description =
+              "Constant for the Smagorinsky model. Something between 0.1 to 0.24. Vreman constant "
+              "if the constant vreman model is applied (something between 0.07 and 0.01).",
+          .default_value = 0.0}));
+  fdyn_turbsgv.specs.emplace_back(parameter<double>("C_YOSHIZAWA",
+      {.description = "Constant for the compressible Smagorinsky model: isotropic part of "
+                      "subgrid-stress tensor. About 0.09 or 0.0066. Ci will not be squared!",
+          .default_value = -1.0}));
   fdyn_turbsgv.specs.emplace_back(parameter<bool>("C_SMAGORINSKY_AVERAGED",
       {.description = "Flag to (de)activate averaged Smagorinksy constant",
           .default_value = false}));
@@ -993,14 +1008,16 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   //           if C_INCLUDE_CI==true and C_YOSHIZAWA<0.0 then C_YOSHIZAWA is determined dynamically
   //        else all values are taken from input
 
-  Core::Utils::double_parameter("CHANNEL_L_TAU", 0.0,
-      "Used for normalisation of the wall normal distance in the Van \nDriest Damping function. "
-      "May be taken from the output of \nthe apply_mesh_stretching.pl preprocessing script.",
-      fdyn_turbsgv);
+  fdyn_turbsgv.specs.emplace_back(parameter<double>("CHANNEL_L_TAU",
+      {.description = "Used for normalisation of the wall normal distance in the Van \nDriest "
+                      "Damping function. May be taken from the output of \nthe "
+                      "apply_mesh_stretching.pl preprocessing script.",
+          .default_value = 0.0}));
 
-  Core::Utils::double_parameter("C_TURBPRANDTL", 1.0,
-      "(Constant) turbulent Prandtl number for the Smagorinsky model in scalar transport.",
-      fdyn_turbsgv);
+  fdyn_turbsgv.specs.emplace_back(parameter<double>("C_TURBPRANDTL",
+      {.description =
+              "(Constant) turbulent Prandtl number for the Smagorinsky model in scalar transport.",
+          .default_value = 1.0}));
 
   Core::Utils::string_to_integral_parameter<VremanFiMethod>("FILTER_WIDTH", "CubeRootVol",
       "The Vreman model requires a filter width.",
@@ -1046,14 +1063,17 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::string_parameter(
       "Projection", "No", projection_doc, fdyn_wallmodel, projection_valid_input);
 
-  Core::Utils::double_parameter("C_Tauw", 1.0,
-      "Constant wall shear stress for Spalding's law, if applicable", fdyn_wallmodel);
+  fdyn_wallmodel.specs.emplace_back(parameter<double>(
+      "C_Tauw", {.description = "Constant wall shear stress for Spalding's law, if applicable",
+                    .default_value = 1.0}));
 
-  Core::Utils::double_parameter("Min_Tauw", 2.0e-9,
-      "Minimum wall shear stress preventing system to become singular", fdyn_wallmodel);
+  fdyn_wallmodel.specs.emplace_back(parameter<double>(
+      "Min_Tauw", {.description = "Minimum wall shear stress preventing system to become singular",
+                      .default_value = 2.0e-9}));
 
-  Core::Utils::double_parameter(
-      "Inc_Tauw", 1.0, "Increment of Tauw of full step, between 0.0 and 1.0", fdyn_wallmodel);
+  fdyn_wallmodel.specs.emplace_back(parameter<double>(
+      "Inc_Tauw", {.description = "Increment of Tauw of full step, between 0.0 and 1.0",
+                      .default_value = 1.0}));
 
   std::vector<std::string> blending_type_valid_input = {"none", "ramp_function"};
   std::string blending_type_doc =
@@ -1086,8 +1106,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // sublist with additional input parameters for multifractal subgrid-scales
   Core::Utils::SectionSpecs fdyn_turbmfs{fdyn, "MULTIFRACTAL SUBGRID SCALES"};
 
-  Core::Utils::double_parameter(
-      "CSGS", 0.0, "Modelparameter of multifractal subgrid-scales.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<double>("CSGS",
+      {.description = "Modelparameter of multifractal subgrid-scales.", .default_value = 0.0}));
 
   std::vector<std::string> scale_separation_valid_input = {
       "no_scale_sep", "box_filter", "algebraic_multigrid_operator"};
@@ -1109,7 +1129,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "CALC_N", {.description = "Flag to (de)activate calculation of N from the Reynolds number.",
                     .default_value = false}));
 
-  Core::Utils::double_parameter("N", 1.0, "Set grid to viscous scale ratio.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<double>(
+      "N", {.description = "Set grid to viscous scale ratio.", .default_value = 1.0}));
 
   std::vector<std::string> ref_length_valid_input = {
       "cube_edge", "sphere_diameter", "streamlength", "gradient_based", "metric_tensor"};
@@ -1133,9 +1154,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "REF_VELOCITY", "strainrate", ref_velocity_doc, fdyn_turbmfs, ref_velocity_valid_input);
 
 
-  Core::Utils::double_parameter("C_NU", 1.0,
-      "Proportionality constant between Re and ratio viscous scale to element length.",
-      fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<double>("C_NU",
+      {.description =
+              "Proportionality constant between Re and ratio viscous scale to element length.",
+          .default_value = 1.0}));
 
   fdyn_turbmfs.specs.emplace_back(parameter<bool>("NEAR_WALL_LIMIT",
       {.description = "Flag to (de)activate near-wall limit.", .default_value = false}));
@@ -1149,8 +1171,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "EVALUATION_B", "element_center", evaluation_b_doc, fdyn_turbmfs, evaluation_b_valid_input);
 
 
-  Core::Utils::double_parameter(
-      "BETA", 0.0, "Cross- and Reynolds-stress terms only on right-hand-side.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<double>(
+      "BETA", {.description = "Cross- and Reynolds-stress terms only on right-hand-side.",
+                  .default_value = 0.0}));
 
   convform_valid_input = {"convective", "conservative"};
   std::string convform_doc =
@@ -1160,8 +1183,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::string_parameter(
       "CONVFORM", "convective", convform_doc, fdyn_turbmfs, convform_valid_input);
 
-  Core::Utils::double_parameter("CSGS_PHI", 0.0,
-      "Modelparameter of multifractal subgrid-scales for scalar transport.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<double>("CSGS_PHI",
+      {.description = "Modelparameter of multifractal subgrid-scales for scalar transport.",
+          .default_value = 0.0}));
 
   fdyn_turbmfs.specs.emplace_back(parameter<bool>("ADAPT_CSGS_PHI",
       {.description = "Flag to (de)activate adaption of CsgsD to CsgsB.", .default_value = false}));
@@ -1174,10 +1198,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       {.description = "Flag to (de)activate the consistency term for residual-based stabilization.",
           .default_value = false}));
 
-  Core::Utils::double_parameter("C_DIFF", 1.0,
-      "Proportionality constant between Re*Pr and ratio dissipative scale to element length. "
-      "Usually equal cnu.",
-      fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<double>(
+      "C_DIFF", {.description = "Proportionality constant between Re*Pr and ratio dissipative "
+                                "scale to element length. Usually equal cnu.",
+                    .default_value = 1.0}));
 
   fdyn_turbmfs.specs.emplace_back(parameter<bool>("SET_FINE_SCALE_VEL",
       {.description = "Flag to set fine-scale velocity for parallel nightly tests.",
@@ -1208,10 +1232,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter(
       "INFLOWFUNC", -1, "Function number for initial flow field in inflow section", fdyn_turbinf);
 
-  Core::Utils::double_parameter("INFLOW_INIT_DIST", 0.1,
-      "Max. amplitude of the random disturbance in percent of the initial value in mean flow "
-      "direction.",
-      fdyn_turbinf);
+  fdyn_turbinf.specs.emplace_back(parameter<double>(
+      "INFLOW_INIT_DIST", {.description = "Max. amplitude of the random disturbance in percent of "
+                                          "the initial value in mean flow direction.",
+                              .default_value = 0.1}));
 
   Core::Utils::int_parameter("NUMINFLOWSTEP", 1,
       "Total number of time steps for development of turbulent flow", fdyn_turbinf);
@@ -1237,8 +1261,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "CANONICAL_INFLOW", "no", canonical_inflow_doc, fdyn_turbinf, canonical_inflow_valid_input);
 
 
-  Core::Utils::double_parameter("INFLOW_CHA_SIDE", 0.0,
-      "Most right side of inflow channel. Necessary to define sampling domain.", fdyn_turbinf);
+  fdyn_turbinf.specs.emplace_back(parameter<double>("INFLOW_CHA_SIDE",
+      {.description = "Most right side of inflow channel. Necessary to define sampling domain.",
+          .default_value = 0.0}));
 
   std::vector<std::string> inflow_homdir_valid_input = {
       "not_specified", "x", "y", "z", "xy", "xz", "yz"};
@@ -1273,14 +1298,14 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       tuple<AdaptiveTimeStepEstimator>(const_dt, cfl_number, only_print_cfl_number),
       fdyn_timintada);
 
-  Core::Utils::double_parameter(
-      "CFL_NUMBER", -1.0, "CFL number for adaptive time step", fdyn_timintada);
+  fdyn_timintada.specs.emplace_back(parameter<double>(
+      "CFL_NUMBER", {.description = "CFL number for adaptive time step", .default_value = -1.0}));
   Core::Utils::int_parameter("FREEZE_ADAPTIVE_DT_AT", 1000000,
       "keep time step constant after this step, otherwise turbulence statistics sampling is not "
       "consistent",
       fdyn_timintada);
-  Core::Utils::double_parameter(
-      "ADAPTIVE_DT_INC", 0.8, "Increment of whole step for adaptive dt via CFL", fdyn_timintada);
+  fdyn_timintada.specs.emplace_back(parameter<double>("ADAPTIVE_DT_INC",
+      {.description = "Increment of whole step for adaptive dt via CFL", .default_value = 0.8}));
 
   fdyn_timintada.move_into_collection(list);
 }
@@ -1297,12 +1322,15 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
   lomacontrol.specs.emplace_back(
       parameter<bool>("MONOLITHIC", {.description = "monolithic solver", .default_value = false}));
   Core::Utils::int_parameter("NUMSTEP", 24, "Total number of time steps", lomacontrol);
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", lomacontrol);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", lomacontrol);
+  lomacontrol.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
+  lomacontrol.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("ITEMAX", 10, "Maximum number of outer iterations", lomacontrol);
   Core::Utils::int_parameter("ITEMAX_BEFORE_SAMPLING", 1,
       "Maximum number of outer iterations before sampling (for turbulent flows only)", lomacontrol);
-  Core::Utils::double_parameter("CONVTOL", 1e-6, "Tolerance for convergence check", lomacontrol);
+  lomacontrol.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-6}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", lomacontrol);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", lomacontrol);
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -20,6 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs fdyn{"FLUID DYNAMIC"};
 
@@ -98,8 +99,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Norm for convergence check (relative increments and absolute residuals)",
       tuple<std::string>("L_2_norm"), tuple<Inpar::FLUID::ItNorm>(fncc_L2), fdyn);
 
-  Core::Utils::bool_parameter("INCONSISTENT_RESIDUAL", false,
-      "do not evaluate residual after solution has converged (->faster)", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("INCONSISTENT_RESIDUAL",
+      {.description = "do not evaluate residual after solution has converged (->faster)",
+          .default_value = false}));
 
   {
     // a standard Teuchos::tuple can have at maximum 10 entries! We have to circumvent this here.
@@ -135,15 +137,17 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter(
       "OSEENFIELDFUNCNO", -1, "function number of Oseen advective field", fdyn);
 
-  Core::Utils::bool_parameter(
-      "LIFTDRAG", false, "Calculate lift and drag forces along specified boundary", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>(
+      "LIFTDRAG", {.description = "Calculate lift and drag forces along specified boundary",
+                      .default_value = false}));
 
   std::vector<std::string> convform_valid_input = {"convective", "conservative"};
   Core::Utils::string_parameter(
       "CONVFORM", "convective", "form of convective term", fdyn, convform_valid_input);
 
-  Core::Utils::bool_parameter("NONLINEARBC", false,
-      "Flag to activate check for potential nonlinear boundary conditions", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("NONLINEARBC",
+      {.description = "Flag to activate check for potential nonlinear boundary conditions",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::MeshTying>("MESHTYING", "no",
       "Flag to (de)activate mesh tying algorithm",
@@ -156,7 +160,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "scheme for determination of gridvelocity from displacements",
       tuple<std::string>("BE", "BDF2", "OST"), tuple<Inpar::FLUID::Gridvel>(BE, BDF2, OST), fdyn);
 
-  Core::Utils::bool_parameter("ALLDOFCOUPLED", true, "all dof (incl. pressure) are coupled", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("ALLDOFCOUPLED",
+      {.description = "all dof (incl. pressure) are coupled", .default_value = true}));
 
   {
     Teuchos::Tuple<std::string, 16> name;
@@ -219,34 +224,41 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter("VARVISCFUNCNO", -1,
       "Function for calculation of a variable viscosity for the weakly compressible problem", fdyn);
 
-  Core::Utils::bool_parameter("PRESSAVGBC", false,
-      "Flag to (de)activate imposition of boundary condition for the considered element average "
-      "pressure",
-      fdyn);
+  fdyn.specs.emplace_back(parameter<bool>(
+      "PRESSAVGBC", {.description = "Flag to (de)activate imposition of boundary condition for the "
+                                    "considered element average pressure",
+                        .default_value = false}));
 
   Core::Utils::double_parameter("REFMACH", 1.0, "Reference Mach number", fdyn);
 
-  Core::Utils::bool_parameter("BLOCKMATRIX", false,
-      "Indicates if system matrix should be assembled into a sparse block matrix type.", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("BLOCKMATRIX",
+      {.description =
+              "Indicates if system matrix should be assembled into a sparse block matrix type.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
       fdyn);
 
-  Core::Utils::bool_parameter(
-      "INFNORMSCALING", false, "Scale blocks of matrix with row infnorm?", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("INFNORMSCALING",
+      {.description = "Scale blocks of matrix with row infnorm?", .default_value = false}));
 
-  Core::Utils::bool_parameter("GMSH_OUTPUT", false, "write output to gmsh files", fdyn);
-  Core::Utils::bool_parameter(
-      "COMPUTE_DIVU", false, "Compute divergence of velocity field at the element center", fdyn);
-  Core::Utils::bool_parameter("COMPUTE_EKIN", false,
-      "Compute kinetic energy at the end of each time step and write it to file.", fdyn);
-  Core::Utils::bool_parameter("NEW_OST", false,
-      "Solve the Navier-Stokes equation with the new One Step Theta algorithm",
-      fdyn);  // TODO: To be removed.
+  fdyn.specs.emplace_back(parameter<bool>(
+      "GMSH_OUTPUT", {.description = "write output to gmsh files", .default_value = false}));
+  fdyn.specs.emplace_back(parameter<bool>(
+      "COMPUTE_DIVU", {.description = "Compute divergence of velocity field at the element center",
+                          .default_value = false}));
+  fdyn.specs.emplace_back(parameter<bool>("COMPUTE_EKIN",
+      {.description = "Compute kinetic energy at the end of each time step and write it to file.",
+          .default_value = false}));
+  fdyn.specs.emplace_back(parameter<bool>("NEW_OST",
+      {.description = "Solve the Navier-Stokes equation with the new One Step Theta algorithm",
+          .default_value = false}));  // TODO: To be removed.
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", fdyn);
   Core::Utils::int_parameter("RESTARTEVERY", 20, "Increment for writing restart", fdyn);
   Core::Utils::int_parameter("NUMSTEP", 1, "Total number of Timesteps", fdyn);
@@ -266,8 +278,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::double_parameter(
       "START_THETA", 1.0, "Time integration factor for starting scheme", fdyn);
 
-  Core::Utils::bool_parameter("STRONG_REDD_3D_COUPLING_TYPE", false,
-      "Flag to (de)activate potential Strong 3D redD coupling", fdyn);
+  fdyn.specs.emplace_back(parameter<bool>("STRONG_REDD_3D_COUPLING_TYPE",
+      {.description = "Flag to (de)activate potential Strong 3D redD coupling",
+          .default_value = false}));
 
   Core::Utils::int_parameter(
       "VELGRAD_PROJ_SOLVER", -1, "Number of linear solver used for L2 projection", fdyn);
@@ -282,10 +295,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           ),
       fdyn);
 
-  Core::Utils::bool_parameter("OFF_PROC_ASSEMBLY", false,
-      "Do not evaluate ghosted elements but communicate them --> faster if element call is "
-      "expensive",
-      fdyn);
+  fdyn.specs.emplace_back(parameter<bool>(
+      "OFF_PROC_ASSEMBLY", {.description = "Do not evaluate ghosted elements but communicate them "
+                                           "--> faster if element call is expensive",
+                               .default_value = false}));
 
   fdyn.move_into_collection(list);
 
@@ -323,14 +336,15 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           stabtype_nostab, stabtype_residualbased, stabtype_edgebased, stabtype_pressureprojection),
       fdyn_stab);
 
-  Core::Utils::bool_parameter("INCONSISTENT", false,
-      "residual based without second derivatives (i.e. only consistent for tau->0, but faster)",
-      fdyn_stab);
+  fdyn_stab.specs.emplace_back(parameter<bool>(
+      "INCONSISTENT", {.description = "residual based without second derivatives (i.e. only "
+                                      "consistent for tau->0, but faster)",
+                          .default_value = false}));
 
-  Core::Utils::bool_parameter("Reconstruct_Sec_Der", false,
-      "residual computed with a reconstruction of the second derivatives via projection or "
-      "superconvergent patch recovery",
-      fdyn_stab);
+  fdyn_stab.specs.emplace_back(parameter<bool>("Reconstruct_Sec_Der",
+      {.description = "residual computed with a reconstruction of the second derivatives via "
+                      "projection or superconvergent patch recovery",
+          .default_value = false}));
 
   // the following parameters are necessary only if a residual based stabilized method is applied
   Core::Utils::string_to_integral_parameter<SubscalesTD>("TDS", "quasistatic",
@@ -346,9 +360,12 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       tuple<Transient>(inertia_stab_drop, inertia_stab_keep, inertia_stab_keep_complete),
       fdyn_stab);
 
-  Core::Utils::bool_parameter("PSPG", true, "Flag to (de)activate PSPG stabilization.", fdyn_stab);
-  Core::Utils::bool_parameter("SUPG", true, "Flag to (de)activate SUPG stabilization.", fdyn_stab);
-  Core::Utils::bool_parameter("GRAD_DIV", true, "Flag to (de)activate grad-div term.", fdyn_stab);
+  fdyn_stab.specs.emplace_back(parameter<bool>(
+      "PSPG", {.description = "Flag to (de)activate PSPG stabilization.", .default_value = true}));
+  fdyn_stab.specs.emplace_back(parameter<bool>(
+      "SUPG", {.description = "Flag to (de)activate SUPG stabilization.", .default_value = true}));
+  fdyn_stab.specs.emplace_back(parameter<bool>(
+      "GRAD_DIV", {.description = "Flag to (de)activate grad-div term.", .default_value = true}));
 
   Core::Utils::string_to_integral_parameter<VStab>("VSTAB", "no_vstab",
       "Flag to (de)activate viscous term in residual-based stabilization. Options: "
@@ -458,8 +475,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   // these parameters active additional terms in loma continuity equation
   // which might be identified as SUPG-/cross- and Reynolds-stress term
-  Core::Utils::bool_parameter("LOMA_CONTI_SUPG", false,
-      "Flag to (de)activate SUPG stabilization in loma continuity equation.", fdyn_stab);
+  fdyn_stab.specs.emplace_back(parameter<bool>("LOMA_CONTI_SUPG",
+      {.description = "Flag to (de)activate SUPG stabilization in loma continuity equation.",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
       "Flag to (de)activate cross-stress term loma continuity equation-> residual-based VMM.",
@@ -551,9 +569,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   //! special least-squares condition for pseudo 2D examples where pressure level is determined via
   //! Krylov-projection
-  Core::Utils::bool_parameter("PRES_KRYLOV_2Dz", false,
-      "residual based without second derivatives (i.e. only consistent for tau->0, but faster)",
-      fdyn_edge_based_stab);
+  fdyn_edge_based_stab.specs.emplace_back(parameter<bool>(
+      "PRES_KRYLOV_2Dz", {.description = "residual based without second derivatives (i.e. only "
+                                         "consistent for tau->0, but faster)",
+                             .default_value = false}));
 
   //! this parameter selects the definition of Edge-based stabilization parameter
   Core::Utils::string_to_integral_parameter<EosTauType>("EOS_DEFINITION_TAU",
@@ -605,8 +624,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs fdyn_porostab{fdyn, "POROUS-FLOW STABILIZATION"};
 
-  Core::Utils::bool_parameter(
-      "STAB_BIOT", false, "Flag to (de)activate BIOT stabilization.", fdyn_porostab);
+  fdyn_porostab.specs.emplace_back(parameter<bool>("STAB_BIOT",
+      {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}));
   Core::Utils::double_parameter("STAB_BIOT_SCALING", 1.0,
       "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
       fdyn_porostab);
@@ -623,14 +642,15 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       tuple<Inpar::FLUID::StabType>(stabtype_nostab, stabtype_residualbased, stabtype_edgebased),
       fdyn_porostab);
 
-  Core::Utils::bool_parameter("INCONSISTENT", false,
-      "residual based without second derivatives (i.e. only consistent for tau->0, but faster)",
-      fdyn_porostab);
+  fdyn_porostab.specs.emplace_back(parameter<bool>(
+      "INCONSISTENT", {.description = "residual based without second derivatives (i.e. only "
+                                      "consistent for tau->0, but faster)",
+                          .default_value = false}));
 
-  Core::Utils::bool_parameter("Reconstruct_Sec_Der", false,
-      "residual computed with a reconstruction of the second derivatives via projection or "
-      "superconvergent patch recovery",
-      fdyn_porostab);
+  fdyn_porostab.specs.emplace_back(parameter<bool>("Reconstruct_Sec_Der",
+      {.description = "residual computed with a reconstruction of the second derivatives via "
+                      "projection or superconvergent patch recovery",
+          .default_value = false}));
 
   // the following parameters are necessary only if a residual based stabilized method is applied
   Core::Utils::string_to_integral_parameter<SubscalesTD>("TDS", "quasistatic",
@@ -644,12 +664,12 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       tuple<Transient>(inertia_stab_drop, inertia_stab_keep, inertia_stab_keep_complete),
       fdyn_porostab);
 
-  Core::Utils::bool_parameter(
-      "PSPG", true, "Flag to (de)activate PSPG stabilization.", fdyn_porostab);
-  Core::Utils::bool_parameter(
-      "SUPG", true, "Flag to (de)activate SUPG stabilization.", fdyn_porostab);
-  Core::Utils::bool_parameter(
-      "GRAD_DIV", true, "Flag to (de)activate grad-div term.", fdyn_porostab);
+  fdyn_porostab.specs.emplace_back(parameter<bool>(
+      "PSPG", {.description = "Flag to (de)activate PSPG stabilization.", .default_value = true}));
+  fdyn_porostab.specs.emplace_back(parameter<bool>(
+      "SUPG", {.description = "Flag to (de)activate SUPG stabilization.", .default_value = true}));
+  fdyn_porostab.specs.emplace_back(parameter<bool>(
+      "GRAD_DIV", {.description = "Flag to (de)activate grad-div term.", .default_value = true}));
 
   Core::Utils::string_to_integral_parameter<VStab>("VSTAB", "no_vstab",
       "Flag to (de)activate viscous term in residual-based stabilization.",
@@ -726,8 +746,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   // these parameters active additional terms in loma continuity equation
   // which might be identified as SUPG-/cross- and Reynolds-stress term
-  Core::Utils::bool_parameter("LOMA_CONTI_SUPG", false,
-      "Flag to (de)activate SUPG stabilization in loma continuity equation.", fdyn_porostab);
+  fdyn_porostab.specs.emplace_back(parameter<bool>("LOMA_CONTI_SUPG",
+      {.description = "Flag to (de)activate SUPG stabilization in loma continuity equation.",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<CrossStress>("LOMA_CONTI_CROSS_STRESS", "no_cross",
       "Flag to (de)activate cross-stress term loma continuity equation-> residual-based VMM.",
@@ -794,13 +815,15 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "SAMPLING_STOP", 1, "Time step when sampling shall be stopped", fdyn_turbu);
   Core::Utils::int_parameter("DUMPING_PERIOD", 1,
       "Period of time steps after which statistical data shall be dumped", fdyn_turbu);
-  Core::Utils::bool_parameter("SUBGRID_DISSIPATION", false,
-      "Flag to (de)activate estimation of subgrid-scale dissipation (only for seclected flows).",
-      fdyn_turbu);
-  Core::Utils::bool_parameter(
-      "OUTMEAN", false, "Flag to (de)activate averaged paraview output", fdyn_turbu);
-  Core::Utils::bool_parameter("TURBMODEL_LS", true,
-      "Flag to (de)activate turbulence model in level-set equation", fdyn_turbu);
+  fdyn_turbu.specs.emplace_back(parameter<bool>(
+      "SUBGRID_DISSIPATION", {.description = "Flag to (de)activate estimation of subgrid-scale "
+                                             "dissipation (only for seclected flows).",
+                                 .default_value = false}));
+  fdyn_turbu.specs.emplace_back(parameter<bool>("OUTMEAN",
+      {.description = "Flag to (de)activate averaged paraview output", .default_value = false}));
+  fdyn_turbu.specs.emplace_back(parameter<bool>(
+      "TURBMODEL_LS", {.description = "Flag to (de)activate turbulence model in level-set equation",
+                          .default_value = true}));
 
   //----------------------------------------------------------------------
   // turbulent flow problem and general characteristics
@@ -936,8 +959,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // filtering with xfem
   //--------------
 
-  Core::Utils::bool_parameter("EXCLUDE_XFEM", false,
-      "Flag to (de)activate XFEM dofs in calculation of fine-scale velocity.", fdyn_turbu);
+  fdyn_turbu.specs.emplace_back(parameter<bool>("EXCLUDE_XFEM",
+      {.description = "Flag to (de)activate XFEM dofs in calculation of fine-scale velocity.",
+          .default_value = false}));
 
   fdyn_turbu.move_into_collection(list);
 
@@ -953,10 +977,11 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Constant for the compressible Smagorinsky model: isotropic part of subgrid-stress tensor. "
       "About 0.09 or 0.0066. Ci will not be squared!",
       fdyn_turbsgv);
-  Core::Utils::bool_parameter("C_SMAGORINSKY_AVERAGED", false,
-      "Flag to (de)activate averaged Smagorinksy constant", fdyn_turbsgv);
-  Core::Utils::bool_parameter(
-      "C_INCLUDE_CI", false, "Flag to (de)inclusion of Yoshizawa model", fdyn_turbsgv);
+  fdyn_turbsgv.specs.emplace_back(parameter<bool>("C_SMAGORINSKY_AVERAGED",
+      {.description = "Flag to (de)activate averaged Smagorinksy constant",
+          .default_value = false}));
+  fdyn_turbsgv.specs.emplace_back(parameter<bool>("C_INCLUDE_CI",
+      {.description = "Flag to (de)inclusion of Yoshizawa model", .default_value = false}));
   // remark: following Moin et al. 1991, the extension of the dynamic Smagorinsky model to
   // compressibel flow
   //        also contains a model for the isotropic part of the subgrid-stress tensor according to
@@ -988,7 +1013,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // sublist with additional input parameters for Smagorinsky model
   Core::Utils::SectionSpecs fdyn_wallmodel{fdyn, "WALL MODEL"};
 
-  Core::Utils::bool_parameter("X_WALL", false, "Flag to switch on the xwall model", fdyn_wallmodel);
+  fdyn_wallmodel.specs.emplace_back(parameter<bool>(
+      "X_WALL", {.description = "Flag to switch on the xwall model", .default_value = false}));
 
 
   std::vector<std::string> tauw_type_valid_input = {"constant", "between_steps"};
@@ -1046,9 +1072,10 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::int_parameter(
       "GP_Wall_Parallel", 3, "Gauss points in wall parallel direction", fdyn_wallmodel);
 
-  Core::Utils::bool_parameter("Treat_Tauw_on_Dirichlet_Inflow", false,
-      "Flag to treat residual on Dirichlet inflow nodes for calculation of wall shear stress",
-      fdyn_wallmodel);
+  fdyn_wallmodel.specs.emplace_back(parameter<bool>("Treat_Tauw_on_Dirichlet_Inflow",
+      {.description = "Flag to treat residual on Dirichlet inflow nodes for calculation of wall "
+                      "shear stress",
+          .default_value = false}));
 
   Core::Utils::int_parameter(
       "PROJECTION_SOLVER", -1, "Set solver number for l2-projection.", fdyn_wallmodel);
@@ -1078,8 +1105,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "aggregation.",
       fdyn_turbmfs);
 
-  Core::Utils::bool_parameter("CALC_N", false,
-      "Flag to (de)activate calculation of N from the Reynolds number.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>(
+      "CALC_N", {.description = "Flag to (de)activate calculation of N from the Reynolds number.",
+                    .default_value = false}));
 
   Core::Utils::double_parameter("N", 1.0, "Set grid to viscous scale ratio.", fdyn_turbmfs);
 
@@ -1109,8 +1137,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Proportionality constant between Re and ratio viscous scale to element length.",
       fdyn_turbmfs);
 
-  Core::Utils::bool_parameter(
-      "NEAR_WALL_LIMIT", false, "Flag to (de)activate near-wall limit.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>("NEAR_WALL_LIMIT",
+      {.description = "Flag to (de)activate near-wall limit.", .default_value = false}));
 
   std::vector<std::string> evaluation_b_valid_input = {"element_center", "integration_point"};
   std::string evaluation_b_doc =
@@ -1135,35 +1163,40 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   Core::Utils::double_parameter("CSGS_PHI", 0.0,
       "Modelparameter of multifractal subgrid-scales for scalar transport.", fdyn_turbmfs);
 
-  Core::Utils::bool_parameter(
-      "ADAPT_CSGS_PHI", false, "Flag to (de)activate adaption of CsgsD to CsgsB.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>("ADAPT_CSGS_PHI",
+      {.description = "Flag to (de)activate adaption of CsgsD to CsgsB.", .default_value = false}));
 
-  Core::Utils::bool_parameter("NEAR_WALL_LIMIT_CSGS_PHI", false,
-      "Flag to (de)activate near-wall limit for scalar field.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>("NEAR_WALL_LIMIT_CSGS_PHI",
+      {.description = "Flag to (de)activate near-wall limit for scalar field.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("CONSISTENT_FLUID_RESIDUAL", false,
-      "Flag to (de)activate the consistency term for residual-based stabilization.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>("CONSISTENT_FLUID_RESIDUAL",
+      {.description = "Flag to (de)activate the consistency term for residual-based stabilization.",
+          .default_value = false}));
 
   Core::Utils::double_parameter("C_DIFF", 1.0,
       "Proportionality constant between Re*Pr and ratio dissipative scale to element length. "
       "Usually equal cnu.",
       fdyn_turbmfs);
 
-  Core::Utils::bool_parameter("SET_FINE_SCALE_VEL", false,
-      "Flag to set fine-scale velocity for parallel nightly tests.", fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>("SET_FINE_SCALE_VEL",
+      {.description = "Flag to set fine-scale velocity for parallel nightly tests.",
+          .default_value = false}));
 
   // activate cross- and Reynolds-stress terms in loma continuity equation
-  Core::Utils::bool_parameter("LOMA_CONTI", false,
-      "Flag to (de)activate cross- and Reynolds-stress terms in loma continuity equation.",
-      fdyn_turbmfs);
+  fdyn_turbmfs.specs.emplace_back(parameter<bool>("LOMA_CONTI",
+      {.description =
+              "Flag to (de)activate cross- and Reynolds-stress terms in loma continuity equation.",
+          .default_value = false}));
 
   fdyn_turbmfs.move_into_collection(list);
 
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs fdyn_turbinf{fdyn, "TURBULENT INFLOW"};
 
-  Core::Utils::bool_parameter("TURBULENTINFLOW", false,
-      "Flag to (de)activate potential separate turbulent inflow section", fdyn_turbinf);
+  fdyn_turbinf.specs.emplace_back(parameter<bool>("TURBULENTINFLOW",
+      {.description = "Flag to (de)activate potential separate turbulent inflow section",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<InitialField>("INITIALINFLOWFIELD", "zero_field",
       "Initial field for inflow section",
@@ -1257,10 +1290,12 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs lomacontrol{"LOMA CONTROL"};
 
-  Core::Utils::bool_parameter("MONOLITHIC", false, "monolithic solver", lomacontrol);
+  lomacontrol.specs.emplace_back(
+      parameter<bool>("MONOLITHIC", {.description = "monolithic solver", .default_value = false}));
   Core::Utils::int_parameter("NUMSTEP", 24, "Total number of time steps", lomacontrol);
   Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", lomacontrol);
   Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", lomacontrol);
@@ -1275,8 +1310,9 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
   Core::Utils::string_parameter("CONSTHERMPRESS", "Yes",
       "treatment of thermodynamic pressure in time", lomacontrol, constthermpress_valid_input);
 
-  Core::Utils::bool_parameter("SGS_MATERIAL_UPDATE", false,
-      "update material by adding subgrid-scale scalar field", lomacontrol);
+  lomacontrol.specs.emplace_back(parameter<bool>(
+      "SGS_MATERIAL_UPDATE", {.description = "update material by adding subgrid-scale scalar field",
+                                 .default_value = false}));
 
   // number of linear solver used for LOMA solver
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -108,12 +108,16 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::int_parameter("FDCheck_row", 0, "print row value during fd_check", fpsidyn);
   Core::Utils::int_parameter("FDCheck_column", 0, "print column value during fd_check", fpsidyn);
 
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", fpsidyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", fpsidyn);
-  Core::Utils::double_parameter("CONVTOL", 1e-6, "Tolerance for iteration over fields", fpsidyn);
-  Core::Utils::double_parameter("ALPHABJ", 1.0,
-      "Beavers-Joseph-Coefficient for Slip-Boundary-Condition at Fluid-Porous-Interface (0.1-4)",
-      fpsidyn);
+  fpsidyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
+  fpsidyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
+  fpsidyn.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "Tolerance for iteration over fields", .default_value = 1e-6}));
+  fpsidyn.specs.emplace_back(parameter<double>(
+      "ALPHABJ", {.description = "Beavers-Joseph-Coefficient for Slip-Boundary-Condition at "
+                                 "Fluid-Porous-Interface (0.1-4)",
+                     .default_value = 1.0}));
 
   fpsidyn.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -51,19 +51,19 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       {.description = "Second order coupling at the interface.", .default_value = false}));
 
   // Iterationparameters
-  Core::Utils::string_parameter("RESTOL", "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8",
-      "Tolerances for single fields in the residual norm for the Newton iteration. \n"
-      "For NORM_RESF != Abs_sys_split only the first value is used for all fields. \n"
-      "Order of fields: porofluidvelocity, porofluidpressure, porostructure, fluidvelocity, "
-      "fluidpressure, ale",
-      fpsidyn);
+  fpsidyn.specs.emplace_back(parameter<std::string>("RESTOL",
+      {.description = "Tolerances for single fields in the residual norm for the Newton iteration. "
+                      "\nFor NORM_RESF != Abs_sys_split only the first value is used for all "
+                      "fields. \nOrder of fields: porofluidvelocity, porofluidpressure, "
+                      "porostructure, fluidvelocity, fluidpressure, ale",
+          .default_value = "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8"}));
 
-  Core::Utils::string_parameter("INCTOL", "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8",
-      "Tolerance in the increment norm for the Newton iteration. \n"
-      "For NORM_INC != \\*_split only the first value is used for all fields. \n"
-      "Order of fields: porofluidvelocity, porofluidpressure, porostructure, fluidvelocity, "
-      "fluidpressure, ale",
-      fpsidyn);
+  fpsidyn.specs.emplace_back(parameter<std::string>(
+      "INCTOL", {.description = "Tolerance in the increment norm for the Newton iteration. \nFor "
+                                "NORM_INC != \\*_split only the first value is used for all "
+                                "fields. \nOrder of fields: porofluidvelocity, porofluidpressure, "
+                                "porostructure, fluidvelocity, fluidpressure, ale",
+                    .default_value = "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8"}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FPSI::ConvergenceNorm>("NORM_INC", "Abs",
       "Type of norm for primary variables convergence check.  \n"

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs fpsidyn{"FPSI DYNAMIC"};
 
@@ -31,24 +32,23 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::string_to_integral_parameter<FpsiCouplingType>("COUPALGO", "fpsi_monolithic_plain",
       "Iteration Scheme over the fields", name, label, fpsidyn);
 
-  Core::Utils::bool_parameter("SHAPEDERIVATIVES", false,
-      "Include linearization with respect to mesh movement in Navier Stokes equation.\n"
-      "Supported in monolithic FPSI for now.",
-      fpsidyn);
+  fpsidyn.specs.emplace_back(parameter<bool>("SHAPEDERIVATIVES",
+      {.description = "Include linearization with respect to mesh movement in Navier Stokes "
+                      "equation.\nSupported in monolithic FPSI for now.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("USESHAPEDERIVATIVES", false,
-      "Add linearization with respect to mesh movement in Navier Stokes equation to stiffness "
-      "matrix.\n"
-      "Supported in monolithic FPSI for now.",
-      fpsidyn);
+  fpsidyn.specs.emplace_back(parameter<bool>("USESHAPEDERIVATIVES",
+      {.description = "Add linearization with respect to mesh movement in Navier Stokes equation "
+                      "to stiffness matrix.\nSupported in monolithic FPSI for now.",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FPSI::PartitionedCouplingMethod>("PARTITIONED",
       "RobinNeumann", "Coupling strategies for partitioned FPSI solvers.",
       tuple<std::string>("RobinNeumann", "monolithic", "nocoupling"),
       tuple<Inpar::FPSI::PartitionedCouplingMethod>(RobinNeumann, monolithic, nocoupling), fpsidyn);
 
-  Core::Utils::bool_parameter(
-      "SECONDORDER", false, "Second order coupling at the interface.", fpsidyn);
+  fpsidyn.specs.emplace_back(parameter<bool>("SECONDORDER",
+      {.description = "Second order coupling at the interface.", .default_value = false}));
 
   // Iterationparameters
   Core::Utils::string_parameter("RESTOL", "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8",
@@ -87,12 +87,13 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "binary operator to combine primary variables and residual force values",
       tuple<std::string>("And", "Or"), tuple<Inpar::FPSI::BinaryOp>(bop_and, bop_or), fpsidyn);
 
-  Core::Utils::bool_parameter("LineSearch", false,
-      "adapt increment in case of non-monotonic residual convergence or residual oscillations",
-      fpsidyn);
+  fpsidyn.specs.emplace_back(
+      parameter<bool>("LineSearch", {.description = "adapt increment in case of non-monotonic "
+                                                    "residual convergence or residual oscillations",
+                                        .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "FDCheck", false, "perform FPSIFDCheck() finite difference check", fpsidyn);
+  fpsidyn.specs.emplace_back(parameter<bool>("FDCheck",
+      {.description = "perform FPSIFDCheck() finite difference check", .default_value = false}));
 
   // number of linear solver used for poroelasticity
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -21,9 +21,11 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
 
   Core::Utils::SectionSpecs fs3idyn{"FS3I DYNAMIC"};
 
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", fs3idyn);
+  fs3idyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
   Core::Utils::int_parameter("NUMSTEP", 20, "Total number of time steps", fs3idyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", fs3idyn);
+  fs3idyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", fs3idyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", fs3idyn);
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::SolverType>("SCATRA_SOLVERTYPE",
@@ -104,8 +106,9 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<SolutionSchemeOverFields>(fs3i_SequStagg, fs3i_IterStagg), fs3idynpart);
 
   // convergence tolerance of outer iteration loop
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "tolerance for convergence check of outer iteration within partitioned FS3I", fs3idynpart);
+  fs3idynpart.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description = "tolerance for convergence check of outer iteration within partitioned FS3I",
+          .default_value = 1e-6}));
 
   Core::Utils::int_parameter("ITEMAX", 10, "Maximum number of outer iterations", fs3idynpart);
 

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -36,8 +36,8 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   fs3idyn.specs.emplace_back(parameter<bool>(
       "INF_PERM", {.description = "Flag for infinite permeability", .default_value = true}));
   std::vector<std::string> consthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
-  Core::Utils::string_parameter("CONSTHERMPRESS", "Yes",
-      "treatment of thermodynamic pressure in time", fs3idyn, consthermpress_valid_input);
+  fs3idyn.specs.emplace_back(selection<std::string>("CONSTHERMPRESS", consthermpress_valid_input,
+      {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
 
   // number of linear solver used for fs3i problems
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs fs3idyn{"FS3I DYNAMIC"};
 
@@ -30,7 +31,8 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<Inpar::ScaTra::SolverType>(
           Inpar::ScaTra::solvertype_linear_incremental, Inpar::ScaTra::solvertype_nonlinear),
       fs3idyn);
-  Core::Utils::bool_parameter("INF_PERM", true, "Flag for infinite permeability", fs3idyn);
+  fs3idyn.specs.emplace_back(parameter<bool>(
+      "INF_PERM", {.description = "Flag for infinite permeability", .default_value = true}));
   std::vector<std::string> consthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
   Core::Utils::string_parameter("CONSTHERMPRESS", "Yes",
       "treatment of thermodynamic pressure in time", fs3idyn, consthermpress_valid_input);
@@ -83,9 +85,10 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       fs3idyn);
 
   // Restart from FSI instead of FS3I
-  Core::Utils::bool_parameter("RESTART_FROM_PART_FSI", false,
-      "restart from partitioned fsi problem (e.g. from prestress calculations) instead of fs3i",
-      fs3idyn);
+  fs3idyn.specs.emplace_back(parameter<bool>(
+      "RESTART_FROM_PART_FSI", {.description = "restart from partitioned fsi problem (e.g. from "
+                                               "prestress calculations) instead of fs3i",
+                                   .default_value = false}));
 
   fs3idyn.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -86,7 +86,8 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       {.description = "is matching grid (fluid-ale) and is full fluid-ale (without euler part)",
           .default_value = true}));
 
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", fsidyn);
+  fsidyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("NUMSTEP", 200, "Total number of Timesteps", fsidyn);
 
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", fsidyn);
@@ -108,7 +109,8 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::FSI::ALEprojection_rot_z, Inpar::FSI::ALEprojection_rot_zsphere),
       fsidyn);
 
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", fsidyn);
+  fsidyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
 
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", fsidyn);
 
@@ -151,13 +153,13 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::FSI::divcont_halve_step, Inpar::FSI::divcont_revert_dt),
       fsiadapt);
 
-  Core::Utils::double_parameter(
-      "DTMAX", 0.1, "Limit maximally permitted time step size (>0)", fsiadapt);
-  Core::Utils::double_parameter(
-      "DTMIN", 1.0e-4, "Limit minimally allowed time step size (>0)", fsiadapt);
+  fsiadapt.specs.emplace_back(parameter<double>("DTMAX",
+      {.description = "Limit maximally permitted time step size (>0)", .default_value = 0.1}));
+  fsiadapt.specs.emplace_back(parameter<double>("DTMIN",
+      {.description = "Limit minimally allowed time step size (>0)", .default_value = 1.0e-4}));
 
-  Core::Utils::double_parameter(
-      "LOCERRTOLFLUID", 1.0e-3, "Tolerance for the norm of local velocity error", fsiadapt);
+  fsiadapt.specs.emplace_back(parameter<double>("LOCERRTOLFLUID",
+      {.description = "Tolerance for the norm of local velocity error", .default_value = 1.0e-3}));
 
 
   Core::Utils::int_parameter("NUMINCREASESTEPS", 0,
@@ -165,19 +167,19 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "actually increasing it. Set 0 to deactivate this feature.",
       fsiadapt);
 
-  Core::Utils::double_parameter("SAFETYFACTOR", 0.9,
-      "This is a safety factor to scale theoretical optimal step size, \n"
-      "should be lower than 1 and must be larger than 0",
-      fsiadapt);
+  fsiadapt.specs.emplace_back(parameter<double>(
+      "SAFETYFACTOR", {.description = "This is a safety factor to scale theoretical optimal step "
+                                      "size, \nshould be lower than 1 and must be larger than 0",
+                          .default_value = 0.9}));
 
-  Core::Utils::double_parameter("SIZERATIOMAX", 2.0,
-      "Limit maximally permitted change of\n"
-      "time step size compared to previous size (>0).",
-      fsiadapt);
-  Core::Utils::double_parameter("SIZERATIOMIN", 0.5,
-      "Limit minimally permitted change of\n"
-      "time step size compared to previous size (>0).",
-      fsiadapt);
+  fsiadapt.specs.emplace_back(parameter<double>("SIZERATIOMAX",
+      {.description =
+              "Limit maximally permitted change of\ntime step size compared to previous size (>0).",
+          .default_value = 2.0}));
+  fsiadapt.specs.emplace_back(parameter<double>("SIZERATIOMIN",
+      {.description =
+              "Limit minimally permitted change of\ntime step size compared to previous size (>0).",
+          .default_value = 0.5}));
 
   fsiadapt.specs.emplace_back(parameter<bool>("TIMEADAPTON",
       {.description = "Activate or deactivate time step size adaptivity", .default_value = false}));
@@ -204,9 +206,9 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "to the nonlinear convergence test using a absolute residual norm.",
       fsimono);
 
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "Nonlinear tolerance for lung/constraint/fluid-fluid FSI",
-      fsimono);  // ToDo remove
+  fsimono.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "Nonlinear tolerance for lung/constraint/fluid-fluid FSI",
+                     .default_value = 1e-6}));  // ToDo remove
 
   fsimono.specs.emplace_back(parameter<bool>("ENERGYFILE",
       {.description = "Write artificial interface energy due to temporal discretization to file",
@@ -325,41 +327,57 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   // tolerances for convergence check of nonlinear solver in monolithic FSI
   // structure displacements
-  Core::Utils::double_parameter("TOL_DIS_RES_L2", 1e-6,
-      "Absolute tolerance for structure displacement residual in L2-norm", fsimono);
-  Core::Utils::double_parameter("TOL_DIS_RES_INF", 1e-6,
-      "Absolute tolerance for structure displacement residual in Inf-norm", fsimono);
-  Core::Utils::double_parameter("TOL_DIS_INC_L2", 1e-6,
-      "Absolute tolerance for structure displacement increment in L2-norm", fsimono);
-  Core::Utils::double_parameter("TOL_DIS_INC_INF", 1e-6,
-      "Absolute tolerance for structure displacement increment in Inf-norm", fsimono);
+  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_RES_L2",
+      {.description = "Absolute tolerance for structure displacement residual in L2-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_RES_INF",
+      {.description = "Absolute tolerance for structure displacement residual in Inf-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_INC_L2",
+      {.description = "Absolute tolerance for structure displacement increment in L2-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_INC_INF",
+      {.description = "Absolute tolerance for structure displacement increment in Inf-norm",
+          .default_value = 1e-6}));
   // interface tolerances
-  Core::Utils::double_parameter(
-      "TOL_FSI_RES_L2", 1e-6, "Absolute tolerance for interface residual in L2-norm", fsimono);
-  Core::Utils::double_parameter(
-      "TOL_FSI_RES_INF", 1e-6, "Absolute tolerance for interface residual in Inf-norm", fsimono);
-  Core::Utils::double_parameter(
-      "TOL_FSI_INC_L2", 1e-6, "Absolute tolerance for interface increment in L2-norm", fsimono);
-  Core::Utils::double_parameter(
-      "TOL_FSI_INC_INF", 1e-6, "Absolute tolerance for interface increment in Inf-norm", fsimono);
+  fsimono.specs.emplace_back(parameter<double>(
+      "TOL_FSI_RES_L2", {.description = "Absolute tolerance for interface residual in L2-norm",
+                            .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>(
+      "TOL_FSI_RES_INF", {.description = "Absolute tolerance for interface residual in Inf-norm",
+                             .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>(
+      "TOL_FSI_INC_L2", {.description = "Absolute tolerance for interface increment in L2-norm",
+                            .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>(
+      "TOL_FSI_INC_INF", {.description = "Absolute tolerance for interface increment in Inf-norm",
+                             .default_value = 1e-6}));
   // fluid pressure
-  Core::Utils::double_parameter(
-      "TOL_PRE_RES_L2", 1e-6, "Absolute tolerance for fluid pressure residual in L2-norm", fsimono);
-  Core::Utils::double_parameter("TOL_PRE_RES_INF", 1e-6,
-      "Absolute tolerance for fluid pressure residual in Inf-norm", fsimono);
-  Core::Utils::double_parameter("TOL_PRE_INC_L2", 1e-6,
-      "Absolute tolerance for fluid pressure increment in L2-norm", fsimono);
-  Core::Utils::double_parameter("TOL_PRE_INC_INF", 1e-6,
-      "Absolute tolerance for fluid pressure increment in Inf-norm", fsimono);
+  fsimono.specs.emplace_back(parameter<double>(
+      "TOL_PRE_RES_L2", {.description = "Absolute tolerance for fluid pressure residual in L2-norm",
+                            .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_PRE_RES_INF",
+      {.description = "Absolute tolerance for fluid pressure residual in Inf-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_PRE_INC_L2",
+      {.description = "Absolute tolerance for fluid pressure increment in L2-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_PRE_INC_INF",
+      {.description = "Absolute tolerance for fluid pressure increment in Inf-norm",
+          .default_value = 1e-6}));
   // fluid velocities
-  Core::Utils::double_parameter(
-      "TOL_VEL_RES_L2", 1e-6, "Absolute tolerance for fluid velocity residual in L2-norm", fsimono);
-  Core::Utils::double_parameter("TOL_VEL_RES_INF", 1e-6,
-      "Absolute tolerance for fluid velocity residual in Inf-norm", fsimono);
-  Core::Utils::double_parameter("TOL_VEL_INC_L2", 1e-6,
-      "Absolute tolerance for fluid velocity increment in L2-norm", fsimono);
-  Core::Utils::double_parameter("TOL_VEL_INC_INF", 1e-6,
-      "Absolute tolerance for fluid velocity increment in Inf-norm", fsimono);
+  fsimono.specs.emplace_back(parameter<double>(
+      "TOL_VEL_RES_L2", {.description = "Absolute tolerance for fluid velocity residual in L2-norm",
+                            .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_VEL_RES_INF",
+      {.description = "Absolute tolerance for fluid velocity residual in Inf-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_VEL_INC_L2",
+      {.description = "Absolute tolerance for fluid velocity increment in L2-norm",
+          .default_value = 1e-6}));
+  fsimono.specs.emplace_back(parameter<double>("TOL_VEL_INC_INF",
+      {.description = "Absolute tolerance for fluid velocity increment in Inf-norm",
+          .default_value = 1e-6}));
 
   fsimono.move_into_collection(list);
 
@@ -375,8 +393,9 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "to the nonlinear convergence test using a absolute residual norm.",
       fsipart);
 
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "Tolerance for iteration over fields in case of partitioned scheme", fsipart);
+  fsipart.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description = "Tolerance for iteration over fields in case of partitioned scheme",
+          .default_value = 1e-6}));
 
   std::vector<std::string> coupmethod_valid_input = {"mortar", "conforming", "immersed"};
   Core::Utils::string_parameter("COUPMETHOD", "conforming",
@@ -394,11 +413,13 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   Core::Utils::int_parameter("ITEMAX", 100, "Maximum number of iterations over fields", fsipart);
 
-  Core::Utils::double_parameter("MAXOMEGA", 0.0,
-      "largest omega allowed for Aitken relaxation (0.0 means no constraint)", fsipart);
+  fsipart.specs.emplace_back(parameter<double>("MAXOMEGA",
+      {.description = "largest omega allowed for Aitken relaxation (0.0 means no constraint)",
+          .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "MINOMEGA", -1.0, "smallest omega allowed for Aitken relaxation (default is -1.0)", fsipart);
+  fsipart.specs.emplace_back(parameter<double>(
+      "MINOMEGA", {.description = "smallest omega allowed for Aitken relaxation (default is -1.0)",
+                      .default_value = -1.0}));
 
 
   Core::Utils::string_to_integral_parameter<Inpar::FSI::PartitionedCouplingMethod>("PARTITIONED",
@@ -415,8 +436,9 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "PREDICTOR", "d(n)", "Predictor for interface displacements", fsipart, predictor_valid_input);
 
 
-  Core::Utils::double_parameter(
-      "RELAX", 1.0, "fixed relaxation parameter for partitioned FSI solvers", fsipart);
+  fsipart.specs.emplace_back(parameter<double>(
+      "RELAX", {.description = "fixed relaxation parameter for partitioned FSI solvers",
+                   .default_value = 1.0}));
 
   fsipart.move_into_collection(list);
 
@@ -427,7 +449,8 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "preconditioner to use", tuple<std::string>("Simple", "Simplec"),
       tuple<Inpar::FSI::PrecConstr>(Inpar::FSI::Simple, Inpar::FSI::Simplec), constrfsi);
   Core::Utils::int_parameter("SIMPLEITER", 2, "Number of iterations for simple pc", constrfsi);
-  Core::Utils::double_parameter("ALPHA", 0.8, "alpha parameter for simple pc", constrfsi);
+  constrfsi.specs.emplace_back(parameter<double>(
+      "ALPHA", {.description = "alpha parameter for simple pc", .default_value = 0.8}));
 
   constrfsi.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs fsidyn{"FSI DYNAMIC"};
 
@@ -73,27 +74,31 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   std::string debugoutput_doc =
       "Output of unconverged interface values during FSI iteration. There will be a new control "
       "file for each time step. This might be helpful to understand the coupling iteration.";
-  Core::Utils::bool_parameter("DEBUGOUTPUT", false, debugoutput_doc, fsidyn);
+  fsidyn.specs.emplace_back(
+      parameter<bool>("DEBUGOUTPUT", {.description = debugoutput_doc, .default_value = false}));
+  fsidyn.specs.emplace_back(parameter<bool>("MATCHGRID_FLUIDALE",
+      {.description = "is matching grid (fluid-ale)", .default_value = true}));
 
-  Core::Utils::bool_parameter("MATCHGRID_FLUIDALE", true, "is matching grid (fluid-ale)", fsidyn);
+  fsidyn.specs.emplace_back(parameter<bool>("MATCHGRID_STRUCTALE",
+      {.description = "is matching grid (structure-ale)", .default_value = true}));
 
-  Core::Utils::bool_parameter(
-      "MATCHGRID_STRUCTALE", true, "is matching grid (structure-ale)", fsidyn);
-
-  Core::Utils::bool_parameter("MATCHALL", true,
-      "is matching grid (fluid-ale) and is full fluid-ale (without euler part)", fsidyn);
+  fsidyn.specs.emplace_back(parameter<bool>("MATCHALL",
+      {.description = "is matching grid (fluid-ale) and is full fluid-ale (without euler part)",
+          .default_value = true}));
 
   Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", fsidyn);
   Core::Utils::int_parameter("NUMSTEP", 200, "Total number of Timesteps", fsidyn);
 
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", fsidyn);
 
-  Core::Utils::bool_parameter("RESTART_FROM_PART_FSI", false,
-      "restart from partitioned fsi (e.g. from prestress calculations) instead of monolithic fsi",
-      fsidyn);
+  fsidyn.specs.emplace_back(parameter<bool>(
+      "RESTART_FROM_PART_FSI", {.description = "restart from partitioned fsi (e.g. from prestress "
+                                               "calculations) instead of monolithic fsi",
+                                   .default_value = false}));
 
-  Core::Utils::bool_parameter("SECONDORDER", false,
-      "Second order displacement-velocity conversion at the interface.", fsidyn);
+  fsidyn.specs.emplace_back(parameter<bool>("SECONDORDER",
+      {.description = "Second order displacement-velocity conversion at the interface.",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FSI::SlideALEProj>("SLIDEALEPROJ", "None",
       "Projection method to use for sliding FSI.",
@@ -174,8 +179,8 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "time step size compared to previous size (>0).",
       fsiadapt);
 
-  Core::Utils::bool_parameter(
-      "TIMEADAPTON", false, "Activate or deactivate time step size adaptivity", fsiadapt);
+  fsiadapt.specs.emplace_back(parameter<bool>("TIMEADAPTON",
+      {.description = "Activate or deactivate time step size adaptivity", .default_value = false}));
 
   fsiadapt.move_into_collection(list);
 
@@ -203,13 +208,15 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "Nonlinear tolerance for lung/constraint/fluid-fluid FSI",
       fsimono);  // ToDo remove
 
-  Core::Utils::bool_parameter("ENERGYFILE", false,
-      "Write artificial interface energy due to temporal discretization to file", fsimono);
+  fsimono.specs.emplace_back(parameter<bool>("ENERGYFILE",
+      {.description = "Write artificial interface energy due to temporal discretization to file",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "FSIAMGANALYZE", false, "run analysis on fsiamg multigrid scheme", fsimono);
+  fsimono.specs.emplace_back(parameter<bool>("FSIAMGANALYZE",
+      {.description = "run analysis on fsiamg multigrid scheme", .default_value = false}));
 
-  Core::Utils::bool_parameter("INFNORMSCALING", true, "Scale Blocks with row infnorm?", fsimono);
+  fsimono.specs.emplace_back(parameter<bool>(
+      "INFNORMSCALING", {.description = "Scale Blocks with row infnorm?", .default_value = true}));
 
   Core::Utils::int_parameter(
       "ITEMAX", 100, "Maximum allowed number of nonlinear iterations", fsimono);
@@ -253,14 +260,17 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "Number of iterations in one time step reusing the preconditioner before rebuilding it",
       fsimono);
 
-  Core::Utils::bool_parameter("REBUILDPRECEVERYSTEP", true,
-      "Enforce rebuilding the preconditioner at the beginning of every time step", fsimono);
+  fsimono.specs.emplace_back(parameter<bool>("REBUILDPRECEVERYSTEP",
+      {.description = "Enforce rebuilding the preconditioner at the beginning of every time step",
+          .default_value = true}));
 
-  Core::Utils::bool_parameter("SHAPEDERIVATIVES", false,
-      "Include linearization with respect to mesh movement in Navier Stokes equation.", fsimono);
+  fsimono.specs.emplace_back(parameter<bool>("SHAPEDERIVATIVES",
+      {.description =
+              "Include linearization with respect to mesh movement in Navier Stokes equation.",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "SYMMETRICPRECOND", false, "Symmetric block GS preconditioner or ordinary GS", fsimono);
+  fsimono.specs.emplace_back(parameter<bool>("SYMMETRICPRECOND",
+      {.description = "Symmetric block GS preconditioner or ordinary GS", .default_value = false}));
 
   // monolithic preconditioner parameter
 
@@ -378,8 +388,9 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::FSI::CoupVarPart::vel),
       fsipart);
 
-  Core::Utils::bool_parameter("DIVPROJECTION", false,
-      "Project velocity into divergence-free subspace for partitioned fsi", fsipart);
+  fsipart.specs.emplace_back(parameter<bool>("DIVPROJECTION",
+      {.description = "Project velocity into divergence-free subspace for partitioned fsi",
+          .default_value = false}));
 
   Core::Utils::int_parameter("ITEMAX", 100, "Maximum number of iterations over fields", fsipart);
 

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -138,12 +138,12 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::FSI::timada_fld_adamsbashforth2),
       fsiadapt);
 
-  Core::Utils::string_parameter("AVERAGINGDT", "0.3 0.7",
-      "Averaging of time step sizes in case of increasing time step size.\n"
-      "Parameters are ordered from most recent weight to the most historic one.\n"
-      "Number of parameters determines the number of previous time steps that are involved\n"
-      "in the averaging procedure.",
-      fsiadapt);
+  fsiadapt.specs.emplace_back(parameter<std::string>("AVERAGINGDT",
+      {.description = "Averaging of time step sizes in case of increasing time step "
+                      "size.\nParameters are ordered from most recent weight to the most historic "
+                      "one.\nNumber of parameters determines the number of previous time steps "
+                      "that are involved\nin the averaging procedure.",
+          .default_value = "0.3 0.7"}));
 
 
   Core::Utils::string_to_integral_parameter<Inpar::FSI::DivContAct>("DIVERCONT", "stop",
@@ -276,54 +276,55 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   // monolithic preconditioner parameter
 
-  Core::Utils::string_parameter("ALEPCOMEGA", "1.0 1.0 1.0 1.0",
-      "Relaxation factor for Richardson iteration on ale block in MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
-  Core::Utils::string_parameter("ALEPCITER", "1 1 1 1",
-      "Number of Richardson iterations on ale block in MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
-  Core::Utils::string_parameter("FLUIDPCOMEGA", "1.0 1.0 1.0 1.0",
-      "Relaxation factor for Richardson iteration on fluid block in MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
-  Core::Utils::string_parameter("FLUIDPCITER", "1 1 1 1",
-      "Number of Richardson iterations on fluid block in MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
-  Core::Utils::string_parameter("STRUCTPCOMEGA", "1.0 1.0 1.0 1.0",
-      "Relaxation factor for Richardson iteration on structural block in MFSI block "
-      "preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
-  Core::Utils::string_parameter("STRUCTPCITER", "1 1 1 1",
-      "Number of Richardson iterations on structural block in MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
+  fsimono.specs.emplace_back(parameter<std::string>("ALEPCOMEGA",
+      {.description = "Relaxation factor for Richardson iteration on ale block in MFSI block "
+                      "preconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1.0 1.0 1.0 1.0"}));
+  fsimono.specs.emplace_back(parameter<std::string>("ALEPCITER",
+      {.description = "Number of Richardson iterations on ale block in MFSI block "
+                      "preconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1 1 1 1"}));
+  fsimono.specs.emplace_back(parameter<std::string>("FLUIDPCOMEGA",
+      {.description = "Relaxation factor for Richardson iteration on fluid block in MFSI block "
+                      "preconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1.0 1.0 1.0 1.0"}));
+  fsimono.specs.emplace_back(parameter<std::string>("FLUIDPCITER",
+      {.description = "Number of Richardson iterations on fluid block in MFSI block "
+                      "preconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1 1 1 1"}));
+  fsimono.specs.emplace_back(parameter<std::string>("STRUCTPCOMEGA",
+      {.description = "Relaxation factor for Richardson iteration on structural block in MFSI "
+                      "block \npreconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1.0 1.0 1.0 1.0"}));
+  fsimono.specs.emplace_back(parameter<std::string>("STRUCTPCITER",
+      {.description = "Number of Richardson iterations on structural block in MFSI block "
+                      "preconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1 1 1 1"}));
 
-  Core::Utils::string_parameter("PCOMEGA", "1.0 1.0 1.0",
-      "Relaxation factor for Richardson iteration on whole MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
-  Core::Utils::string_parameter("PCITER", "1 1 1",
-      "Number of Richardson iterations on whole MFSI block preconditioner\n"
-      "FSIAMG: each number belongs to a level\n"
-      "PreconditiondKrylov: only first number is used for finest level",
-      fsimono);
+  fsimono.specs.emplace_back(parameter<std::string>("PCOMEGA",
+      {.description = "Relaxation factor for Richardson iteration on whole MFSI block "
+                      "preconditioner\nFSIAMG: each number belongs to a "
+                      "level\nPreconditiondKrylov: only first number is used for finest level",
+          .default_value = "1.0 1.0 1.0"}));
+  fsimono.specs.emplace_back(parameter<std::string>("PCITER",
+      {.description = "Number of Richardson iterations on whole MFSI block preconditioner\nFSIAMG: "
+                      "each number belongs to a level\nPreconditiondKrylov: only first number is "
+                      "used for finest level",
+          .default_value = "1 1 1"}));
 
-  Core::Utils::string_parameter(
-      "BLOCKSMOOTHER", "BGS BGS BGS", "Type of block smoother, can be BGS or Schur", fsimono);
+  fsimono.specs.emplace_back(parameter<std::string>(
+      "BLOCKSMOOTHER", {.description = "Type of block smoother, can be BGS or Schur",
+                           .default_value = "BGS BGS BGS"}));
 
-  Core::Utils::string_parameter(
-      "SCHUROMEGA", "0.001 0.01 0.1", "Damping factor for Schur complement construction", fsimono);
+  fsimono.specs.emplace_back(parameter<std::string>(
+      "SCHUROMEGA", {.description = "Damping factor for Schur complement construction",
+                        .default_value = "0.001 0.01 0.1"}));
 
   // tolerances for convergence check of nonlinear solver in monolithic FSI
   // structure displacements
@@ -398,8 +399,9 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           .default_value = 1e-6}));
 
   std::vector<std::string> coupmethod_valid_input = {"mortar", "conforming", "immersed"};
-  Core::Utils::string_parameter("COUPMETHOD", "conforming",
-      "Coupling Method mortar or conforming nodes at interface", fsipart, coupmethod_valid_input);
+  fsipart.specs.emplace_back(selection<std::string>("COUPMETHOD", coupmethod_valid_input,
+      {.description = "Coupling Method mortar or conforming nodes at interface",
+          .default_value = "conforming"}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FSI::CoupVarPart>("COUPVARIABLE", "Displacement",
       "Coupling variable at the interface", tuple<std::string>("Displacement", "Force", "Velocity"),
@@ -432,8 +434,8 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   std::vector<std::string> predictor_valid_input = {
       "d(n)", "d(n)+dt*(1.5*v(n)-0.5*v(n-1))", "d(n)+dt*v(n)", "d(n)+dt*v(n)+0.5*dt^2*a(n)"};
-  Core::Utils::string_parameter(
-      "PREDICTOR", "d(n)", "Predictor for interface displacements", fsipart, predictor_valid_input);
+  fsipart.specs.emplace_back(selection<std::string>("PREDICTOR", predictor_valid_input,
+      {.description = "Predictor for interface displacements", .default_value = "d(n)"}));
 
 
   fsipart.specs.emplace_back(parameter<double>(

--- a/src/inpar/4C_inpar_geometric_search.cpp
+++ b/src/inpar/4C_inpar_geometric_search.cpp
@@ -13,6 +13,7 @@ FOUR_C_NAMESPACE_OPEN
 
 void Inpar::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
+  using namespace Core::IO::InputSpecBuilders;
   Core::Utils::SectionSpecs boundingvolumestrategy{"BOUNDINGVOLUME STRATEGY"};
 
   Core::Utils::double_parameter("BEAM_RADIUS_EXTENSION_FACTOR", 2.0,
@@ -25,8 +26,9 @@ void Inpar::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO
       "radius in all directions (+ and -).",
       boundingvolumestrategy);
 
-  Core::Utils::bool_parameter("WRITE_GEOMETRIC_SEARCH_VISUALIZATION", false,
-      "If visualization output for the geometric search should be written", boundingvolumestrategy);
+  boundingvolumestrategy.specs.emplace_back(parameter<bool>("WRITE_GEOMETRIC_SEARCH_VISUALIZATION",
+      {.description = "If visualization output for the geometric search should be written",
+          .default_value = false}));
 
   boundingvolumestrategy.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_geometric_search.cpp
+++ b/src/inpar/4C_inpar_geometric_search.cpp
@@ -16,15 +16,16 @@ void Inpar::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO
   using namespace Core::IO::InputSpecBuilders;
   Core::Utils::SectionSpecs boundingvolumestrategy{"BOUNDINGVOLUME STRATEGY"};
 
-  Core::Utils::double_parameter("BEAM_RADIUS_EXTENSION_FACTOR", 2.0,
-      "Beams radius is multiplied with the factor and then the bounding volume only depending on "
-      "the beam centerline is extended in all directions (+ and -) by that value.",
-      boundingvolumestrategy);
+  boundingvolumestrategy.specs.emplace_back(parameter<double>("BEAM_RADIUS_EXTENSION_FACTOR",
+      {.description = "Beams radius is multiplied with the factor and then the bounding volume "
+                      "only depending on the beam centerline is extended in all directions (+ and "
+                      "-) by that value.",
+          .default_value = 2.0}));
 
-  Core::Utils::double_parameter("SPHERE_RADIUS_EXTENSION_FACTOR", 2.0,
-      "Bounding volume of the sphere is the sphere center extended by this factor times the sphere "
-      "radius in all directions (+ and -).",
-      boundingvolumestrategy);
+  boundingvolumestrategy.specs.emplace_back(parameter<double>("SPHERE_RADIUS_EXTENSION_FACTOR",
+      {.description = "Bounding volume of the sphere is the sphere center extended by this factor "
+                      "times the sphere radius in all directions (+ and -).",
+          .default_value = 2.0}));
 
   boundingvolumestrategy.specs.emplace_back(parameter<bool>("WRITE_GEOMETRIC_SEARCH_VISUALIZATION",
       {.description = "If visualization output for the geometric search should be written",

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -150,8 +150,10 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
           FourC::Core::IO::verbose, FourC::Core::IO::debug, FourC::Core::IO::debug),
       io);
 
-  Core::Utils::double_parameter("RESTARTWALLTIMEINTERVAL", -1.0,
-      "Enforce restart after this walltime interval (in seconds), smaller zero to disable", io);
+  io.specs.emplace_back(parameter<double>("RESTARTWALLTIMEINTERVAL",
+      {.description =
+              "Enforce restart after this walltime interval (in seconds), smaller zero to disable",
+          .default_value = -1.0}));
   Core::Utils::int_parameter("RESTARTEVERY", -1, "write restart every RESTARTEVERY steps", io);
 
   io.move_into_collection(list);

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -17,26 +17,33 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs io{"IO"};
 
-  Core::Utils::bool_parameter("OUTPUT_GMSH", false, "", io);
-  Core::Utils::bool_parameter("OUTPUT_ROT", false, "", io);
-  Core::Utils::bool_parameter("OUTPUT_SPRING", false, "", io);
-  Core::Utils::bool_parameter("OUTPUT_BIN", true, "Do you want to have binary output?", io);
+  io.specs.emplace_back(
+      parameter<bool>("OUTPUT_GMSH", {.description = "", .default_value = false}));
+  io.specs.emplace_back(parameter<bool>("OUTPUT_ROT", {.description = "", .default_value = false}));
+  io.specs.emplace_back(
+      parameter<bool>("OUTPUT_SPRING", {.description = "", .default_value = false}));
+  io.specs.emplace_back(parameter<bool>(
+      "OUTPUT_BIN", {.description = "Do you want to have binary output?", .default_value = true}));
 
   // Output every iteration (for debugging purposes)
-  Core::Utils::bool_parameter("OUTPUT_EVERY_ITER", false,
-      "Do you desire structural displ. output every Newton iteration", io);
+  io.specs.emplace_back(parameter<bool>("OUTPUT_EVERY_ITER",
+      {.description = "Do you desire structural displ. output every Newton iteration",
+          .default_value = false}));
   Core::Utils::int_parameter(
       "OEI_FILE_COUNTER", 0, "Add an output name affix by introducing a additional number", io);
 
-  Core::Utils::bool_parameter(
-      "ELEMENT_MAT_ID", false, "Output of the material id of each element", io);
+  io.specs.emplace_back(parameter<bool>("ELEMENT_MAT_ID",
+      {.description = "Output of the material id of each element", .default_value = false}));
 
   // Structural output
-  Core::Utils::bool_parameter("STRUCT_ELE", true, "Output of element properties", io);
-  Core::Utils::bool_parameter("STRUCT_DISP", true, "Output of displacements", io);
+  io.specs.emplace_back(parameter<bool>(
+      "STRUCT_ELE", {.description = "Output of element properties", .default_value = true}));
+  io.specs.emplace_back(parameter<bool>(
+      "STRUCT_DISP", {.description = "Output of displacements", .default_value = true}));
   Core::Utils::string_to_integral_parameter<Inpar::Solid::StressType>("STRUCT_STRESS", "No",
       "Output of stress",
       tuple<std::string>("No", "no", "NO", "Yes", "yes", "YES", "Cauchy", "cauchy", "2PK", "2pk"),
@@ -79,8 +86,10 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
           Inpar::Solid::optquantity_none, Inpar::Solid::optquantity_none,
           Inpar::Solid::optquantity_membranethickness),
       io);
-  Core::Utils::bool_parameter("STRUCT_SURFACTANT", false, "", io);
-  Core::Utils::bool_parameter("STRUCT_JACOBIAN_MATLAB", false, "", io);
+  io.specs.emplace_back(
+      parameter<bool>("STRUCT_SURFACTANT", {.description = "", .default_value = false}));
+  io.specs.emplace_back(
+      parameter<bool>("STRUCT_JACOBIAN_MATLAB", {.description = "", .default_value = false}));
   Core::Utils::string_to_integral_parameter<Inpar::Solid::ConditionNumber>(
       "STRUCT_CONDITION_NUMBER", "none",
       "Compute the condition number of the structural system matrix and write it to a text file.",
@@ -89,11 +98,16 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
           Inpar::Solid::ConditionNumber::max_min_ev_ratio, Inpar::Solid::ConditionNumber::one_norm,
           Inpar::Solid::ConditionNumber::inf_norm, Inpar::Solid::ConditionNumber::none),
       io);
-  Core::Utils::bool_parameter("FLUID_STRESS", false, "", io);
-  Core::Utils::bool_parameter("FLUID_WALL_SHEAR_STRESS", false, "", io);
-  Core::Utils::bool_parameter("FLUID_ELEDATA_EVERY_STEP", false, "", io);
-  Core::Utils::bool_parameter("FLUID_NODEDATA_FIRST_STEP", false, "", io);
-  Core::Utils::bool_parameter("THERM_TEMPERATURE", false, "", io);
+  io.specs.emplace_back(
+      parameter<bool>("FLUID_STRESS", {.description = "", .default_value = false}));
+  io.specs.emplace_back(
+      parameter<bool>("FLUID_WALL_SHEAR_STRESS", {.description = "", .default_value = false}));
+  io.specs.emplace_back(
+      parameter<bool>("FLUID_ELEDATA_EVERY_STEP", {.description = "", .default_value = false}));
+  io.specs.emplace_back(
+      parameter<bool>("FLUID_NODEDATA_FIRST_STEP", {.description = "", .default_value = false}));
+  io.specs.emplace_back(
+      parameter<bool>("THERM_TEMPERATURE", {.description = "", .default_value = false}));
   Core::Utils::string_to_integral_parameter<Thermo::HeatFluxType>("THERM_HEATFLUX", "None", "",
       tuple<std::string>("None", "No", "NO", "no", "Current", "Initial"),
       tuple<Thermo::HeatFluxType>(Thermo::heatflux_none, Thermo::heatflux_none,
@@ -111,18 +125,20 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
       "FILESTEPS", 1000, "Amount of timesteps written to a single result file", io);
   Core::Utils::int_parameter("STDOUTEVERY", 1, "Print to screen every n step", io);
 
-  Core::Utils::bool_parameter("WRITE_TO_SCREEN", true, "Write screen output", io);
-  Core::Utils::bool_parameter("WRITE_TO_FILE", false, "Write the output into a file", io);
+  io.specs.emplace_back(parameter<bool>(
+      "WRITE_TO_SCREEN", {.description = "Write screen output", .default_value = true}));
+  io.specs.emplace_back(parameter<bool>(
+      "WRITE_TO_FILE", {.description = "Write the output into a file", .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "WRITE_INITIAL_STATE", true, "Do you want to write output for initial state ?", io);
-  Core::Utils::bool_parameter("WRITE_FINAL_STATE", false,
-      "Enforce to write output/restart data at the final state regardless of the other "
-      "output/restart intervals",
-      io);
+  io.specs.emplace_back(parameter<bool>("WRITE_INITIAL_STATE",
+      {.description = "Do you want to write output for initial state ?", .default_value = true}));
+  io.specs.emplace_back(parameter<bool>(
+      "WRITE_FINAL_STATE", {.description = "Enforce to write output/restart data at the final "
+                                           "state regardless of the other output/restart intervals",
+                               .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "PREFIX_GROUP_ID", false, "Put a <GroupID>: in front of every line", io);
+  io.specs.emplace_back(parameter<bool>("PREFIX_GROUP_ID",
+      {.description = "Put a <GroupID>: in front of every line", .default_value = false}));
   Core::Utils::int_parameter(
       "LIMIT_OUTP_TO_PROC", -1, "Only the specified procs will write output", io);
   Core::Utils::string_to_integral_parameter<FourC::Core::IO::Verbositylevel>("VERBOSITY", "verbose",
@@ -144,8 +160,8 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
   Core::Utils::SectionSpecs io_every_iter{io, "EVERY ITERATION"};
 
   // Output every iteration (for debugging purposes)
-  Core::Utils::bool_parameter(
-      "OUTPUT_EVERY_ITER", false, "Do you wish output every Newton iteration?", io_every_iter);
+  io_every_iter.specs.emplace_back(parameter<bool>("OUTPUT_EVERY_ITER",
+      {.description = "Do you wish output every Newton iteration?", .default_value = false}));
 
   Core::Utils::int_parameter("RUN_NUMBER", -1,
       "Create a new folder for different runs of the same simulation. "
@@ -158,11 +174,10 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
       "be written.",
       io_every_iter);
 
-  Core::Utils::bool_parameter("WRITE_OWNER_EACH_NEWTON_ITER", false,
-      "If yes, the ownership "
-      "of elements and nodes are written each Newton step, instead of only once"
-      "per time/load step.",
-      io_every_iter);
+  io_every_iter.specs.emplace_back(parameter<bool>("WRITE_OWNER_EACH_NEWTON_ITER",
+      {.description = "If yes, the ownership of elements and nodes are written each Newton step, "
+                      "instead of only once per time/load step.",
+          .default_value = false}));
 
   io_every_iter.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -22,8 +22,10 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::SectionSpecs levelsetcontrol{"LEVEL-SET CONTROL"};
 
   Core::Utils::int_parameter("NUMSTEP", 24, "Total number of time steps", levelsetcontrol);
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", levelsetcontrol);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", levelsetcontrol);
+  levelsetcontrol.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
+  levelsetcontrol.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", levelsetcontrol);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", levelsetcontrol);
 
@@ -64,18 +66,20 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
   ls_reinit.specs.emplace_back(parameter<bool>("REINITBAND",
       {.description = "reinitialization only within a band around the interface, or entire domain?",
           .default_value = false}));
-  Core::Utils::double_parameter("REINITBANDWIDTH", 1.0,
-      "level-set value defining band width for reinitialization", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<double>(
+      "REINITBANDWIDTH", {.description = "level-set value defining band width for reinitialization",
+                             .default_value = 1.0}));
 
   // parameters for reinitialization equation
   Core::Utils::int_parameter(
       "NUMSTEPSREINIT", 1, "(maximal) number of pseudo-time steps", ls_reinit);
-  Core::Utils::double_parameter("TIMESTEPREINIT", 1.0,
-      "pseudo-time step length (usually a * characteristic element length of discretization with "
-      "a>0)",
-      ls_reinit);
-  Core::Utils::double_parameter(
-      "THETAREINIT", 1.0, "theta for time discretization of reinitialization equation", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<double>(
+      "TIMESTEPREINIT", {.description = "pseudo-time step length (usually a * characteristic "
+                                        "element length of discretization with a>0)",
+                            .default_value = 1.0}));
+  ls_reinit.specs.emplace_back(parameter<double>(
+      "THETAREINIT", {.description = "theta for time discretization of reinitialization equation",
+                         .default_value = 1.0}));
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::StabType>("STABTYPEREINIT", "SUPG",
       "Type of stabilization (if any). No stabilization is only reasonable for low-Peclet-number.",
       tuple<std::string>("no_stabilization", "SUPG", "GLS", "USFEM"),
@@ -131,8 +135,9 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
       tuple<Inpar::ScaTra::CharEleLengthReinit>(
           Inpar::ScaTra::root_of_volume_reinit, Inpar::ScaTra::streamlength_reinit),
       ls_reinit);
-  Core::Utils::double_parameter("INTERFACE_THICKNESS", 1.0,
-      "factor for interface thickness (multiplied by element length)", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<double>("INTERFACE_THICKNESS",
+      {.description = "factor for interface thickness (multiplied by element length)",
+          .default_value = 1.0}));
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::VelReinit>("VELREINIT",
       "integration_point_based",
       "evaluate velocity at integration point or compute node-based velocity",
@@ -149,15 +154,16 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
       "CORRECTOR_STEP", {.description = "correction of interface position via volume constraint "
                                         "according to Sussman & Fatemi",
                             .default_value = true}));
-  Core::Utils::double_parameter("CONVTOL_REINIT", -1.0,
-      "tolerance for convergence check according to Sussman et al. 1994 (turned off negative)",
-      ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<double>(
+      "CONVTOL_REINIT", {.description = "tolerance for convergence check according to Sussman et "
+                                        "al. 1994 (turned off negative)",
+                            .default_value = -1.0}));
 
   ls_reinit.specs.emplace_back(parameter<bool>("REINITVOLCORRECTION",
       {.description = "volume correction after reinitialization", .default_value = false}));
 
-  Core::Utils::double_parameter(
-      "PENALTY_PARA", -1.0, "penalty parameter for elliptic reinitialization", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<double>("PENALTY_PARA",
+      {.description = "penalty parameter for elliptic reinitialization", .default_value = -1.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::LSDim>("DIMENSION", "3D",
       "number of space dimensions for handling of quasi-2D problems with 3D elements",
@@ -169,8 +175,8 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
   ls_reinit.specs.emplace_back(parameter<bool>(
       "PROJECTION", {.description = "use L2-projection for grad phi and related quantities",
                         .default_value = true}));
-  Core::Utils::double_parameter(
-      "PROJECTION_DIFF", 0.0, "use diffusive term for L2-projection", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<double>("PROJECTION_DIFF",
+      {.description = "use diffusive term for L2-projection", .default_value = 0.0}));
   ls_reinit.specs.emplace_back(parameter<bool>("LUMPING",
       {.description = "use lumped mass matrix for L2-projection", .default_value = false}));
 

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs levelsetcontrol{"LEVEL-SET CONTROL"};
 
@@ -32,10 +33,10 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::ScaTra::calcerror_no_ls, Inpar::ScaTra::calcerror_initial_field),
       levelsetcontrol);
 
-  Core::Utils::bool_parameter("EXTRACT_INTERFACE_VEL", false,
-      "replace computed velocity at nodes of given distance of interface by approximated interface "
-      "velocity",
-      levelsetcontrol);
+  levelsetcontrol.specs.emplace_back(parameter<bool>("EXTRACT_INTERFACE_VEL",
+      {.description = "replace computed velocity at nodes of given distance of interface by "
+                      "approximated interface velocity",
+          .default_value = false}));
   Core::Utils::int_parameter("NUM_CONVEL_LAYERS", -1,
       "number of layers around the interface which keep their computed convective velocity",
       levelsetcontrol);
@@ -54,13 +55,15 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::ScaTra::reinitaction_ellipticeq),
       ls_reinit);
 
-  Core::Utils::bool_parameter("REINIT_INITIAL", false,
-      "Has level set field to be reinitialized before first time step?", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<bool>("REINIT_INITIAL",
+      {.description = "Has level set field to be reinitialized before first time step?",
+          .default_value = false}));
   Core::Utils::int_parameter("REINITINTERVAL", 1, "reinitialization interval", ls_reinit);
 
   // parameters for signed distance reinitialization
-  Core::Utils::bool_parameter("REINITBAND", false,
-      "reinitialization only within a band around the interface, or entire domain?", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<bool>("REINITBAND",
+      {.description = "reinitialization only within a band around the interface, or entire domain?",
+          .default_value = false}));
   Core::Utils::double_parameter("REINITBANDWIDTH", 1.0,
       "level-set value defining band width for reinitialization", ls_reinit);
 
@@ -142,15 +145,16 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
       tuple<std::string>("newton", "fixed_point"),
       tuple<Inpar::ScaTra::LinReinit>(Inpar::ScaTra::newton, Inpar::ScaTra::fixed_point),
       ls_reinit);
-  Core::Utils::bool_parameter("CORRECTOR_STEP", true,
-      "correction of interface position via volume constraint according to Sussman & Fatemi",
-      ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<bool>(
+      "CORRECTOR_STEP", {.description = "correction of interface position via volume constraint "
+                                        "according to Sussman & Fatemi",
+                            .default_value = true}));
   Core::Utils::double_parameter("CONVTOL_REINIT", -1.0,
       "tolerance for convergence check according to Sussman et al. 1994 (turned off negative)",
       ls_reinit);
 
-  Core::Utils::bool_parameter(
-      "REINITVOLCORRECTION", false, "volume correction after reinitialization", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<bool>("REINITVOLCORRECTION",
+      {.description = "volume correction after reinitialization", .default_value = false}));
 
   Core::Utils::double_parameter(
       "PENALTY_PARA", -1.0, "penalty parameter for elliptic reinitialization", ls_reinit);
@@ -162,12 +166,13 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::ScaTra::ls_2Dy, Inpar::ScaTra::ls_2Dz),
       ls_reinit);
 
-  Core::Utils::bool_parameter(
-      "PROJECTION", true, "use L2-projection for grad phi and related quantities", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<bool>(
+      "PROJECTION", {.description = "use L2-projection for grad phi and related quantities",
+                        .default_value = true}));
   Core::Utils::double_parameter(
       "PROJECTION_DIFF", 0.0, "use diffusive term for L2-projection", ls_reinit);
-  Core::Utils::bool_parameter(
-      "LUMPING", false, "use lumped mass matrix for L2-projection", ls_reinit);
+  ls_reinit.specs.emplace_back(parameter<bool>("LUMPING",
+      {.description = "use lumped mass matrix for L2-projection", .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::DiffFunc>("DIFF_FUNC", "hyperbolic",
       "function for diffusivity",

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -46,8 +46,9 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<Inpar::Mortar::BinaryTreeUpdateType>(binarytree_bottom_up, binarytree_top_down),
       mortar);
 
-  Core::Utils::double_parameter(
-      "SEARCH_PARAM", 0.3, "Radius / Bounding volume inflation for contact search", mortar);
+  mortar.specs.emplace_back(parameter<double>(
+      "SEARCH_PARAM", {.description = "Radius / Bounding volume inflation for contact search",
+                          .default_value = 0.3}));
 
   mortar.specs.emplace_back(parameter<bool>("SEARCH_USE_AUX_POS",
       {.description = "If chosen auxiliary position is used for computing dops",
@@ -137,18 +138,19 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           ExtendGhosting::roundrobin, ExtendGhosting::binning),
       parallelRedist);
 
-  Core::Utils::double_parameter("IMBALANCE_TOL", 1.1,
-      "Max. relative imbalance of subdomain size after redistribution", parallelRedist);
+  parallelRedist.specs.emplace_back(parameter<double>("IMBALANCE_TOL",
+      {.description = "Max. relative imbalance of subdomain size after redistribution",
+          .default_value = 1.1}));
 
-  Core::Utils::double_parameter("MAX_BALANCE_EVAL_TIME", 2.0,
-      "Max-to-min ratio of contact evaluation time per processor to trigger parallel "
-      "redistribution",
-      parallelRedist);
+  parallelRedist.specs.emplace_back(parameter<double>(
+      "MAX_BALANCE_EVAL_TIME", {.description = "Max-to-min ratio of contact evaluation time per "
+                                               "processor to trigger parallel redistribution",
+                                   .default_value = 2.0}));
 
-  Core::Utils::double_parameter("MAX_BALANCE_SLAVE_ELES", 0.5,
-      "Max-to-min ratio of mortar slave elements per processor to trigger parallel "
-      "redistribution",
-      parallelRedist);
+  parallelRedist.specs.emplace_back(parameter<double>(
+      "MAX_BALANCE_SLAVE_ELES", {.description = "Max-to-min ratio of mortar slave elements per "
+                                                "processor to trigger parallel redistribution",
+                                    .default_value = 0.5}));
 
   Core::Utils::int_parameter("MIN_ELEPROC", 0,
       "Minimum no. of elements per processor for parallel redistribution", parallelRedist);

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for mortar coupling */
   Core::Utils::SectionSpecs mortar{"MORTAR COUPLING"};
@@ -48,8 +49,9 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::double_parameter(
       "SEARCH_PARAM", 0.3, "Radius / Bounding volume inflation for contact search", mortar);
 
-  Core::Utils::bool_parameter("SEARCH_USE_AUX_POS", true,
-      "If chosen auxiliary position is used for computing dops", mortar);
+  mortar.specs.emplace_back(parameter<bool>("SEARCH_USE_AUX_POS",
+      {.description = "If chosen auxiliary position is used for computing dops",
+          .default_value = true}));
 
   Core::Utils::string_to_integral_parameter<Inpar::Mortar::LagMultQuad>("LM_QUAD", "undefined",
       "Type of LM interpolation for quadratic FE",
@@ -59,8 +61,9 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           lagmult_pwlin, lagmult_pwlin, lagmult_lin, lagmult_lin, lagmult_const),
       mortar);
 
-  Core::Utils::bool_parameter("CROSSPOINTS", false,
-      "If chosen, multipliers are removed from crosspoints / edge nodes", mortar);
+  mortar.specs.emplace_back(parameter<bool>("CROSSPOINTS",
+      {.description = "If chosen, multipliers are removed from crosspoints / edge nodes",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::Mortar::ConsistentDualType>("LM_DUAL_CONSISTENT",
       "boundary",
@@ -104,14 +107,16 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           triangulation_center, triangulation_center),
       mortar);
 
-  Core::Utils::bool_parameter("RESTART_WITH_MESHTYING", false,
-      "Must be chosen if a non-meshtying simulation is to be restarted with meshtying", mortar);
+  mortar.specs.emplace_back(parameter<bool>("RESTART_WITH_MESHTYING",
+      {.description =
+              "Must be chosen if a non-meshtying simulation is to be restarted with meshtying",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("OUTPUT_INTERFACES", false,
-      "Write output for each mortar interface separately.\nThis is an additional feature, purely "
-      "to enhance visualization. Currently, this is limited to solid meshtying and contact w/o "
-      "friction.",
-      mortar);
+  mortar.specs.emplace_back(parameter<bool>("OUTPUT_INTERFACES",
+      {.description = "Write output for each mortar interface separately.\nThis is an additional "
+                      "feature, purely to enhance visualization. Currently, this is limited to "
+                      "solid meshtying and contact w/o friction.",
+          .default_value = false}));
 
   mortar.move_into_collection(list);
 
@@ -119,10 +124,11 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   // parameters for parallel redistribution of mortar interfaces
   Core::Utils::SectionSpecs parallelRedist{mortar, "PARALLEL REDISTRIBUTION"};
 
-  Core::Utils::bool_parameter("EXPLOIT_PROXIMITY", true,
-      "Exploit information on geometric proximity to split slave interface into close and "
-      "non-close parts and redistribute them independently. [Contact only]",
-      parallelRedist);
+  parallelRedist.specs.emplace_back(parameter<bool>("EXPLOIT_PROXIMITY",
+      {.description =
+              "Exploit information on geometric proximity to split slave interface into close and "
+              "non-close parts and redistribute them independently. [Contact only]",
+          .default_value = true}));
 
   Core::Utils::string_to_integral_parameter<ExtendGhosting>("GHOSTING_STRATEGY", "redundant_master",
       "Type of interface ghosting and ghosting extension algorithm",
@@ -153,9 +159,10 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           ParallelRedist::redist_dynamic),
       parallelRedist);
 
-  Core::Utils::bool_parameter("PRINT_DISTRIBUTION", true,
-      "Print details of the parallel distribution, i.e. number of nodes/elements for each rank.",
-      parallelRedist);
+  parallelRedist.specs.emplace_back(parameter<bool>(
+      "PRINT_DISTRIBUTION", {.description = "Print details of the parallel distribution, i.e. "
+                                            "number of nodes/elements for each rank.",
+                                .default_value = true}));
 
   parallelRedist.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_mpc_rve.cpp
+++ b/src/inpar/4C_inpar_mpc_rve.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 // set the mpc specific parameters
 void Inpar::RveMpc::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
+  using namespace Core::IO::InputSpecBuilders;
   Core::Utils::SectionSpecs mpc{"MULTI POINT CONSTRAINTS"};
 
   Core::Utils::string_to_integral_parameter<Inpar::RveMpc::RveReferenceDeformationDefinition>(
@@ -29,7 +30,8 @@ void Inpar::RveMpc::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       Teuchos::tuple<std::string>("penalty_method", "lagrange_multiplier_method"),
       Teuchos::tuple<Inpar::RveMpc::EnforcementStrategy>(penalty, lagrangeMultiplier), mpc);
 
-  Core::Utils::double_parameter("PENALTY_PARAM", 1e5, "Value of the penalty parameter", mpc);
+  mpc.specs.emplace_back(parameter<double>(
+      "PENALTY_PARAM", {.description = "Value of the penalty parameter", .default_value = 1e5}));
 
   mpc.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -59,8 +59,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 1.0}));
 
   // gravity acceleration control
-  Core::Utils::string_parameter(
-      "GRAVITY_ACCELERATION", "0.0 0.0 0.0", "acceleration due to gravity", particledyn);
+  particledyn.specs.emplace_back(parameter<std::string>("GRAVITY_ACCELERATION",
+      {.description = "acceleration due to gravity", .default_value = "0.0 0.0 0.0"}));
   Core::Utils::int_parameter(
       "GRAVITY_RAMP_FUNCT", -1, "number of function governing gravity ramp", particledyn);
 
@@ -74,16 +74,18 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       {.description = "transfer particles to new bins every time step", .default_value = false}));
 
   // considered particle phases with dynamic load balance weighting factor
-  Core::Utils::string_parameter("PHASE_TO_DYNLOADBALFAC", "none",
-      "considered particle phases with dynamic load balance weighting factor", particledyn);
+  particledyn.specs.emplace_back(parameter<std::string>("PHASE_TO_DYNLOADBALFAC",
+      {.description = "considered particle phases with dynamic load balance weighting factor",
+          .default_value = "none"}));
 
   // relate particle phase to material id
-  Core::Utils::string_parameter(
-      "PHASE_TO_MATERIAL_ID", "none", "relate particle phase to material id", particledyn);
+  particledyn.specs.emplace_back(parameter<std::string>("PHASE_TO_MATERIAL_ID",
+      {.description = "relate particle phase to material id", .default_value = "none"}));
 
   // amplitude of noise added to initial position for each spatial direction
-  Core::Utils::string_parameter("INITIAL_POSITION_AMPLITUDE", "0.0 0.0 0.0",
-      "amplitude of noise added to initial position for each spatial direction", particledyn);
+  particledyn.specs.emplace_back(parameter<std::string>("INITIAL_POSITION_AMPLITUDE",
+      {.description = "amplitude of noise added to initial position for each spatial direction",
+          .default_value = "0.0 0.0 0.0"}));
 
   // type of particle wall source
   Core::Utils::string_to_integral_parameter<ParticleWallSource>("PARTICLE_WALL_SOURCE",
@@ -119,41 +121,49 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::SectionSpecs particledynconditions{particledyn, "INITIAL AND BOUNDARY CONDITIONS"};
 
   // initial temperature field of particle phase given by function
-  Core::Utils::string_parameter("INITIAL_TEMP_FIELD", "none",
-      "Refer to the function ID describing the initial temperature field of particle phase",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(parameter<std::string>("INITIAL_TEMP_FIELD",
+      {.description =
+              "Refer to the function ID describing the initial temperature field of particle phase",
+          .default_value = "none"}));
 
   // initial velocity field of particle phase given by function
-  Core::Utils::string_parameter("INITIAL_VELOCITY_FIELD", "none",
-      "Refer to the function ID describing the initial velocity field of particle phase",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(parameter<std::string>("INITIAL_VELOCITY_FIELD",
+      {.description =
+              "Refer to the function ID describing the initial velocity field of particle phase",
+          .default_value = "none"}));
 
   // initial angular velocity field of particle phase given by function
-  Core::Utils::string_parameter("INITIAL_ANGULAR_VELOCITY_FIELD", "none",
-      "Refer to the function ID describing the initial angular velocity field of rigid body "
-      "phase/DEM particle",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(parameter<std::string>("INITIAL_ANGULAR_VELOCITY_FIELD",
+      {.description = "Refer to the function ID describing the initial angular velocity field of "
+                      "rigid body  phase/DEM particle",
+          .default_value = "none"}));
+
 
   // initial acceleration field of particle phase given by function
-  Core::Utils::string_parameter("INITIAL_ACCELERATION_FIELD", "none",
-      "Refer to the function ID describing the initial acceleration field of particle phase",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(parameter<std::string>(
+      "INITIAL_ACCELERATION_FIELD", {.description = "Refer to the function ID describing the "
+                                                    "initial acceleration field of particle phase",
+                                        .default_value = "none"}));
 
   // initial angular acceleration field of particle phase given by function
-  Core::Utils::string_parameter("INITIAL_ANGULAR_ACCELERATION_FIELD", "none",
-      "Refer to the function ID describing the initial angular acceleration field of rigid body "
-      "phase/DEM particle",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(
+      parameter<std::string>("INITIAL_ANGULAR_ACCELERATION_FIELD",
+          {.description = "Refer to the function ID describing the initial angular acceleration "
+                          "field of rigid body  phase/DEM particle",
+              .default_value = "none"}));
+
 
   // dirichlet boundary condition of particle phase given by function
-  Core::Utils::string_parameter("DIRICHLET_BOUNDARY_CONDITION", "none",
-      "Refer to the function ID describing the dirichlet boundary condition of particle phase",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(parameter<std::string>("DIRICHLET_BOUNDARY_CONDITION",
+      {.description = "Refer to the function ID describing the dirichlet boundary condition of "
+                      "particle phase",
+          .default_value = "none"}));
 
   // temperature boundary condition of particle phase given by function
-  Core::Utils::string_parameter("TEMPERATURE_BOUNDARY_CONDITION", "none",
-      "Refer to the function ID describing the temperature boundary condition of particle phase",
-      particledynconditions);
+  particledynconditions.specs.emplace_back(parameter<std::string>("TEMPERATURE_BOUNDARY_CONDITION",
+      {.description = "Refer to the function ID describing the temperature boundary condition of "
+                      "particle phase",
+          .default_value = "none"}));
 
   particledynconditions.move_into_collection(list);
 
@@ -275,8 +285,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::int_parameter(
       "HEATSOURCE_FUNCT", -1, "number of function governing heat source", particledynsph);
 
-  Core::Utils::string_parameter(
-      "HEATSOURCE_DIRECTION", "0.0 0.0 0.0", "direction of surface heat source", particledynsph);
+  particledynsph.specs.emplace_back(parameter<std::string>("HEATSOURCE_DIRECTION",
+      {.description = "direction of surface heat source", .default_value = "0.0 0.0 0.0"}));
 
   // evaporation induced heat loss
   particledynsph.specs.emplace_back(parameter<bool>("VAPOR_HEATLOSS",
@@ -391,10 +401,11 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::int_parameter("DIRICHLET_FUNCT", -1,
       "number of function governing velocity condition on dirichlet open boundary", particledynsph);
 
-  Core::Utils::string_parameter("DIRICHLET_OUTWARD_NORMAL", "0.0 0.0 0.0",
-      "direction of outward normal on dirichlet open boundary", particledynsph);
-  Core::Utils::string_parameter("DIRICHLET_PLANE_POINT", "0.0 0.0 0.0",
-      "point on dirichlet open boundary plane", particledynsph);
+  particledynsph.specs.emplace_back(parameter<std::string>("DIRICHLET_OUTWARD_NORMAL",
+      {.description = "direction of outward normal on dirichlet open boundary",
+          .default_value = "0.0 0.0 0.0"}));
+  particledynsph.specs.emplace_back(parameter<std::string>("DIRICHLET_PLANE_POINT",
+      {.description = "point on dirichlet open boundary plane", .default_value = "0.0 0.0 0.0"}));
 
   // type of neumann open boundary
   Core::Utils::string_to_integral_parameter<NeumannOpenBoundaryType>("NEUMANNBOUNDARYTYPE",
@@ -407,10 +418,11 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::int_parameter("NEUMANN_FUNCT", -1,
       "number of function governing pressure condition on neumann open boundary", particledynsph);
 
-  Core::Utils::string_parameter("NEUMANN_OUTWARD_NORMAL", "0.0 0.0 0.0",
-      "direction of outward normal on neumann open boundary", particledynsph);
-  Core::Utils::string_parameter(
-      "NEUMANN_PLANE_POINT", "0.0 0.0 0.0", "point on neumann open boundary plane", particledynsph);
+  particledynsph.specs.emplace_back(parameter<std::string>("NEUMANN_OUTWARD_NORMAL",
+      {.description = "direction of outward normal on neumann open boundary",
+          .default_value = "0.0 0.0 0.0"}));
+  particledynsph.specs.emplace_back(parameter<std::string>("NEUMANN_PLANE_POINT",
+      {.description = "point on neumann open boundary plane", .default_value = "0.0 0.0 0.0"}));
 
   // type of phase change
   Core::Utils::string_to_integral_parameter<PhaseChangeType>("PHASECHANGETYPE", "NoPhaseChange",
@@ -424,8 +436,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       particledynsph);
 
   // definition of phase change
-  Core::Utils::string_parameter(
-      "PHASECHANGEDEFINITION", "none", "phase change definition", particledynsph);
+  particledynsph.specs.emplace_back(parameter<std::string>("PHASECHANGEDEFINITION",
+      {.description = "phase change definition", .default_value = "none"}));
 
   // type of rigid particle contact
   Core::Utils::string_to_integral_parameter<RigidParticleContactType>("RIGIDPARTICLECONTACTTYPE",

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -52,9 +52,11 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       {.description = "write ghosted particles (debug feature)", .default_value = false}));
 
   // time loop control
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "time step size", particledyn);
+  particledyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.01}));
   Core::Utils::int_parameter("NUMSTEP", 100, "maximum number of steps", particledyn);
-  Core::Utils::double_parameter("MAXTIME", 1.0, "maximum time", particledyn);
+  particledyn.specs.emplace_back(
+      parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 1.0}));
 
   // gravity acceleration control
   Core::Utils::string_parameter(
@@ -63,8 +65,9 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "GRAVITY_RAMP_FUNCT", -1, "number of function governing gravity ramp", particledyn);
 
   // viscous damping factor
-  Core::Utils::double_parameter("VISCOUS_DAMPING", -1.0,
-      "apply viscous damping force to determine static equilibrium solutions", particledyn);
+  particledyn.specs.emplace_back(parameter<double>("VISCOUS_DAMPING",
+      {.description = "apply viscous damping force to determine static equilibrium solutions",
+          .default_value = -1.0}));
 
   // transfer particles to new bins every time step
   particledyn.specs.emplace_back(parameter<bool>("TRANSFER_EVERY",
@@ -104,8 +107,9 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   particledyn.specs.emplace_back(parameter<bool>(
       "RIGID_BODY_MOTION", {.description = "consider rigid body motion", .default_value = false}));
 
-  Core::Utils::double_parameter("RIGID_BODY_PHASECHANGE_RADIUS", -1.0,
-      "search radius for neighboring rigid bodies in case of phase change", particledyn);
+  particledyn.specs.emplace_back(parameter<double>("RIGID_BODY_PHASECHANGE_RADIUS",
+      {.description = "search radius for neighboring rigid bodies in case of phase change",
+          .default_value = -1.0}));
 
   particledyn.move_into_collection(list);
 
@@ -176,8 +180,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::PARTICLE::Kernel1D, Inpar::PARTICLE::Kernel2D, Inpar::PARTICLE::Kernel3D),
       particledynsph);
 
-  Core::Utils::double_parameter(
-      "INITIALPARTICLESPACING", 0.0, "initial spacing of particles", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("INITIALPARTICLESPACING",
+      {.description = "initial spacing of particles", .default_value = 0.0}));
 
   // type of smoothed particle hydrodynamics equation of state
   Core::Utils::string_to_integral_parameter<EquationOfStateType>("EQUATIONOFSTATE", "GenTait",
@@ -277,24 +281,25 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   // evaporation induced heat loss
   particledynsph.specs.emplace_back(parameter<bool>("VAPOR_HEATLOSS",
       {.description = "evaluate evaporation induced heat loss", .default_value = false}));
-  Core::Utils::double_parameter(
-      "VAPOR_HEATLOSS_LATENTHEAT", 0.0, "latent heat in heat loss formula", particledynsph);
-  Core::Utils::double_parameter("VAPOR_HEATLOSS_ENTHALPY_REFTEMP", 0.0,
-      "enthalpy reference temperature in heat loss formula", particledynsph);
-  Core::Utils::double_parameter(
-      "VAPOR_HEATLOSS_PFAC", 0.0, "pressure factor in heat loss formula", particledynsph);
-  Core::Utils::double_parameter(
-      "VAPOR_HEATLOSS_TFAC", 0.0, "temperature factor in heat loss formula", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_LATENTHEAT",
+      {.description = "latent heat in heat loss formula", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_ENTHALPY_REFTEMP",
+      {.description = "enthalpy reference temperature in heat loss formula",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_PFAC",
+      {.description = "pressure factor in heat loss formula", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_TFAC",
+      {.description = "temperature factor in heat loss formula", .default_value = 0.0}));
 
   // evaporation induced recoil pressure
   particledynsph.specs.emplace_back(parameter<bool>("VAPOR_RECOIL",
       {.description = "evaluate evaporation induced recoil pressure", .default_value = false}));
-  Core::Utils::double_parameter("VAPOR_RECOIL_BOILINGTEMPERATURE", 0.0,
-      "boiling temperature in recoil pressure formula", particledynsph);
-  Core::Utils::double_parameter(
-      "VAPOR_RECOIL_PFAC", 0.0, "pressure factor in recoil pressure formula", particledynsph);
-  Core::Utils::double_parameter(
-      "VAPOR_RECOIL_TFAC", 0.0, "temperature factor in recoil pressure formula", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_RECOIL_BOILINGTEMPERATURE",
+      {.description = "boiling temperature in recoil pressure formula", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_RECOIL_PFAC",
+      {.description = "pressure factor in recoil pressure formula", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("VAPOR_RECOIL_TFAC",
+      {.description = "temperature factor in recoil pressure formula", .default_value = 0.0}));
 
   // type of surface tension formulation
   Core::Utils::string_to_integral_parameter<SurfaceTensionFormulation>("SURFACETENSIONFORMULATION",
@@ -307,62 +312,73 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::int_parameter("SURFACETENSION_RAMP_FUNCT", -1,
       "number of function governing surface tension ramp", particledynsph);
 
-  Core::Utils::double_parameter("SURFACETENSIONCOEFFICIENT", -1.0,
-      "constant part of surface tension coefficient", particledynsph);
-  Core::Utils::double_parameter("SURFACETENSIONMINIMUM", 0.0,
-      "minimum surface tension coefficient in case of temperature dependence", particledynsph);
-  Core::Utils::double_parameter("SURFACETENSIONTEMPFAC", 0.0,
-      "factor of dependence of surface tension coefficient on temperature", particledynsph);
-  Core::Utils::double_parameter("SURFACETENSIONREFTEMP", 0.0,
-      "reference temperature for surface tension coefficient", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONCOEFFICIENT",
+      {.description = "constant part of surface tension coefficient", .default_value = -1.0}));
+  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONMINIMUM",
+      {.description = "minimum surface tension coefficient in case of temperature dependence",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONTEMPFAC",
+      {.description = "factor of dependence of surface tension coefficient on temperature",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONREFTEMP",
+      {.description = "reference temperature for surface tension coefficient",
+          .default_value = 0.0}));
 
   // wetting
-  Core::Utils::double_parameter("STATICCONTACTANGLE", 0.0,
-      "static contact angle in degree with wetting effects", particledynsph);
-  Core::Utils::double_parameter("TRIPLEPOINTNORMAL_CORR_CF_LOW", 0.0,
-      "triple point normal correction wall color field low", particledynsph);
-  Core::Utils::double_parameter("TRIPLEPOINTNORMAL_CORR_CF_UP", 0.0,
-      "triple point normal correction wall color field up", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>(
+      "STATICCONTACTANGLE", {.description = "static contact angle in degree with wetting effects",
+                                .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRIPLEPOINTNORMAL_CORR_CF_LOW",
+      {.description = "triple point normal correction wall color field low",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRIPLEPOINTNORMAL_CORR_CF_UP",
+      {.description = "triple point normal correction wall color field up", .default_value = 0.0}));
 
   // interface viscosity
   particledynsph.specs.emplace_back(parameter<bool>("INTERFACE_VISCOSITY",
       {.description = "evaluate interface viscosity", .default_value = false}));
-  Core::Utils::double_parameter("INTERFACE_VISCOSITY_LIQUIDGAS", 0.0,
-      "artificial viscosity on liquid-gas interface", particledynsph);
-  Core::Utils::double_parameter("INTERFACE_VISCOSITY_SOLIDLIQUID", 0.0,
-      "artificial viscosity on solid-liquid interface", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("INTERFACE_VISCOSITY_LIQUIDGAS",
+      {.description = "artificial viscosity on liquid-gas interface", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("INTERFACE_VISCOSITY_SOLIDLIQUID",
+      {.description = "artificial viscosity on solid-liquid interface", .default_value = 0.0}));
 
   // barrier force
   particledynsph.specs.emplace_back(parameter<bool>(
       "BARRIER_FORCE", {.description = "evaluate barrier force", .default_value = false}));
-  Core::Utils::double_parameter(
-      "BARRIER_FORCE_DISTANCE", 0.0, "barrier force distance", particledynsph);
-  Core::Utils::double_parameter(
-      "BARRIER_FORCE_TEMPSCALE", 0.0, "barrier force temperature scaling", particledynsph);
-  Core::Utils::double_parameter(
-      "BARRIER_FORCE_STIFF_HEAVY", -1.0, "barrier force stiffness of heavy phase", particledynsph);
-  Core::Utils::double_parameter("BARRIER_FORCE_DAMP_HEAVY", 0.0,
-      "barrier force damping parameter of heavy phase", particledynsph);
-  Core::Utils::double_parameter(
-      "BARRIER_FORCE_STIFF_GAS", -1.0, "barrier force stiffness of gas phase", particledynsph);
-  Core::Utils::double_parameter("BARRIER_FORCE_DAMP_GAS", 0.0,
-      "barrier force damping parameter of gas phase", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>(
+      "BARRIER_FORCE_DISTANCE", {.description = "barrier force distance", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_TEMPSCALE",
+      {.description = "barrier force temperature scaling", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_STIFF_HEAVY",
+      {.description = "barrier force stiffness of heavy phase", .default_value = -1.0}));
+  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_DAMP_HEAVY",
+      {.description = "barrier force damping parameter of heavy phase", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_STIFF_GAS",
+      {.description = "barrier force stiffness of gas phase", .default_value = -1.0}));
+  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_DAMP_GAS",
+      {.description = "barrier force damping parameter of gas phase", .default_value = 0.0}));
 
   // linear transition in surface tension evaluation
-  Core::Utils::double_parameter(
-      "TRANS_REF_TEMPERATURE", 0.0, "transition reference temperature", particledynsph);
-  Core::Utils::double_parameter("TRANS_DT_SURFACETENSION", 0.0,
-      "transition temperature difference for surface tension evaluation", particledynsph);
-  Core::Utils::double_parameter("TRANS_DT_MARANGONI", 0.0,
-      "transition temperature difference for marangoni evaluation", particledynsph);
-  Core::Utils::double_parameter("TRANS_DT_CURVATURE", 0.0,
-      "transition temperature difference for curvature evaluation", particledynsph);
-  Core::Utils::double_parameter("TRANS_DT_WETTING", 0.0,
-      "transition temperature difference for wetting evaluation", particledynsph);
-  Core::Utils::double_parameter("TRANS_DT_INTVISC", 0.0,
-      "transition temperature difference for interface viscosity evaluation", particledynsph);
-  Core::Utils::double_parameter("TRANS_DT_BARRIER", 0.0,
-      "transition temperature difference for barrier force evaluation", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_REF_TEMPERATURE",
+      {.description = "transition reference temperature", .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_SURFACETENSION",
+      {.description = "transition temperature difference for surface tension evaluation",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_MARANGONI",
+      {.description = "transition temperature difference for marangoni evaluation",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_CURVATURE",
+      {.description = "transition temperature difference for curvature evaluation",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_WETTING",
+      {.description = "transition temperature difference for wetting evaluation",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_INTVISC",
+      {.description = "transition temperature difference for interface viscosity evaluation",
+          .default_value = 0.0}));
+  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_BARRIER",
+      {.description = "transition temperature difference for barrier force evaluation",
+          .default_value = 0.0}));
 
   // type of dirichlet open boundary
   Core::Utils::string_to_integral_parameter<DirichletOpenBoundaryType>("DIRICHLETBOUNDARYTYPE",
@@ -419,10 +435,10 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::PARTICLE::NoRigidParticleContact, Inpar::PARTICLE::ElasticRigidParticleContact),
       particledynsph);
 
-  Core::Utils::double_parameter(
-      "RIGIDPARTICLECONTACTSTIFF", -1.0, "rigid particle contact stiffness", particledynsph);
-  Core::Utils::double_parameter(
-      "RIGIDPARTICLECONTACTDAMP", 0.0, "rigid particle contact damping parameter", particledynsph);
+  particledynsph.specs.emplace_back(parameter<double>("RIGIDPARTICLECONTACTSTIFF",
+      {.description = "rigid particle contact stiffness", .default_value = -1.0}));
+  particledynsph.specs.emplace_back(parameter<double>("RIGIDPARTICLECONTACTDAMP",
+      {.description = "rigid particle contact damping parameter", .default_value = 0.0}));
 
   particledynsph.move_into_collection(list);
 
@@ -484,12 +500,12 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::PARTICLE::LogNormalSurfaceEnergyDistribution),
       particledyndem);
 
-  Core::Utils::double_parameter(
-      "MIN_RADIUS", 0.0, "minimum allowed particle radius", particledyndem);
-  Core::Utils::double_parameter(
-      "MAX_RADIUS", 0.0, "maximum allowed particle radius", particledyndem);
-  Core::Utils::double_parameter(
-      "MAX_VELOCITY", -1.0, "maximum expected particle velocity", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>(
+      "MIN_RADIUS", {.description = "minimum allowed particle radius", .default_value = 0.0}));
+  particledyndem.specs.emplace_back(parameter<double>(
+      "MAX_RADIUS", {.description = "maximum allowed particle radius", .default_value = 0.0}));
+  particledyndem.specs.emplace_back(parameter<double>("MAX_VELOCITY",
+      {.description = "maximum expected particle velocity", .default_value = -1.0}));
 
   // type of initial particle radius assignment
   Core::Utils::string_to_integral_parameter<InitialRadiusAssignment>("INITIAL_RADIUS",
@@ -501,38 +517,41 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::PARTICLE::LogNormalRadiusDistribution),
       particledyndem);
 
-  Core::Utils::double_parameter("RADIUSDISTRIBUTION_SIGMA", -1.0,
-      "sigma of random particle radius distribution", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("RADIUSDISTRIBUTION_SIGMA",
+      {.description = "sigma of random particle radius distribution", .default_value = -1.0}));
 
-  Core::Utils::double_parameter(
-      "REL_PENETRATION", -1.0, "maximum allowed relative penetration", particledyndem);
-  Core::Utils::double_parameter("NORMAL_STIFF", -1.0, "normal contact stiffness", particledyndem);
-  Core::Utils::double_parameter(
-      "NORMAL_DAMP", -1.0, "normal contact damping parameter", particledyndem);
-  Core::Utils::double_parameter(
-      "COEFF_RESTITUTION", -1.0, "coefficient of restitution", particledyndem);
-  Core::Utils::double_parameter("DAMP_REG_FAC", -1.0,
-      "linearly regularized damping normal force in the interval "
-      "$|g| < (\\text{DAMP_REG_FAC} \\cdot r_{\\min})$",
-      particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("REL_PENETRATION",
+      {.description = "maximum allowed relative penetration", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>(
+      "NORMAL_STIFF", {.description = "normal contact stiffness", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>(
+      "NORMAL_DAMP", {.description = "normal contact damping parameter", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>(
+      "COEFF_RESTITUTION", {.description = "coefficient of restitution", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>(
+      "DAMP_REG_FAC", {.description = "linearly regularized damping normal force in the interval "
+                                      "$|g| < (\\text{DAMP_REG_FAC} \\cdot r_{\\min})$",
+                          .default_value = -1.0}));
   particledyndem.specs.emplace_back(parameter<bool>("TENSION_CUTOFF",
       {.description = "evaluate tension cutoff of normal contact force", .default_value = true}));
 
-  Core::Utils::double_parameter("POISSON_RATIO", -1.0, "poisson ratio", particledyndem);
-  Core::Utils::double_parameter("YOUNG_MODULUS", -1.0, "young's modulus", particledyndem);
+  particledyndem.specs.emplace_back(
+      parameter<double>("POISSON_RATIO", {.description = "poisson ratio", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>(
+      "YOUNG_MODULUS", {.description = "young's modulus", .default_value = -1.0}));
 
-  Core::Utils::double_parameter(
-      "FRICT_COEFF_TANG", -1.0, "friction coefficient for tangential contact", particledyndem);
-  Core::Utils::double_parameter(
-      "FRICT_COEFF_ROLL", -1.0, "friction coefficient for rolling contact", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("FRICT_COEFF_TANG",
+      {.description = "friction coefficient for tangential contact", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>("FRICT_COEFF_ROLL",
+      {.description = "friction coefficient for rolling contact", .default_value = -1.0}));
 
-  Core::Utils::double_parameter(
-      "ADHESION_DISTANCE", -1.0, "adhesion distance between interacting surfaces", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_DISTANCE",
+      {.description = "adhesion distance between interacting surfaces", .default_value = -1.0}));
 
-  Core::Utils::double_parameter(
-      "ADHESION_MAX_CONTACT_PRESSURE", 0.0, "adhesion maximum contact pressure", particledyndem);
-  Core::Utils::double_parameter(
-      "ADHESION_MAX_CONTACT_FORCE", 0.0, "adhesion maximum contact force", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_MAX_CONTACT_PRESSURE",
+      {.description = "adhesion maximum contact pressure", .default_value = 0.0}));
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_MAX_CONTACT_FORCE",
+      {.description = "adhesion maximum contact force", .default_value = 0.0}));
   particledyndem.specs.emplace_back(parameter<bool>("ADHESION_USE_MAX_CONTACT_FORCE",
       {.description = "use maximum contact force instead of maximum contact pressure",
           .default_value = false}));
@@ -540,17 +559,21 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   particledyndem.specs.emplace_back(parameter<bool>("ADHESION_VDW_CURVE_SHIFT",
       {.description = "shifts van-der-Waals-curve to g = 0", .default_value = false}));
 
-  Core::Utils::double_parameter(
-      "ADHESION_HAMAKER", -1.0, "hamaker constant of van-der-Waals interaction", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_HAMAKER",
+      {.description = "hamaker constant of van-der-Waals interaction", .default_value = -1.0}));
 
-  Core::Utils::double_parameter("ADHESION_SURFACE_ENERGY", -1.0,
-      "adhesion surface energy for the calculation of the pull-out force", particledyndem);
-  Core::Utils::double_parameter("ADHESION_SURFACE_ENERGY_DISTRIBUTION_VAR", -1.0,
-      "variance of adhesion surface energy distribution", particledyndem);
-  Core::Utils::double_parameter("ADHESION_SURFACE_ENERGY_DISTRIBUTION_CUTOFF_FACTOR", -1.0,
-      "adhesion surface energy distribution limited by multiple of variance", particledyndem);
-  Core::Utils::double_parameter("ADHESION_SURFACE_ENERGY_FACTOR", 1.0,
-      "factor to calculate minimum adhesion surface energy", particledyndem);
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_SURFACE_ENERGY",
+      {.description = "adhesion surface energy for the calculation of the pull-out force",
+          .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_SURFACE_ENERGY_DISTRIBUTION_VAR",
+      {.description = "variance of adhesion surface energy distribution", .default_value = -1.0}));
+  particledyndem.specs.emplace_back(
+      parameter<double>("ADHESION_SURFACE_ENERGY_DISTRIBUTION_CUTOFF_FACTOR",
+          {.description = "adhesion surface energy distribution limited by multiple of variance",
+              .default_value = -1.0}));
+  particledyndem.specs.emplace_back(parameter<double>("ADHESION_SURFACE_ENERGY_FACTOR",
+      {.description = "factor to calculate minimum adhesion surface energy",
+          .default_value = 1.0}));
 
   particledyndem.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -19,6 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /*-------------------------------------------------------------------------*
    | general control parameters for particle simulations                     |
@@ -47,8 +48,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", particledyn);
 
   // write ghosted particles
-  Core::Utils::bool_parameter(
-      "WRITE_GHOSTED_PARTICLES", false, "write ghosted particles (debug feature)", particledyn);
+  particledyn.specs.emplace_back(parameter<bool>("WRITE_GHOSTED_PARTICLES",
+      {.description = "write ghosted particles (debug feature)", .default_value = false}));
 
   // time loop control
   Core::Utils::double_parameter("TIMESTEP", 0.01, "time step size", particledyn);
@@ -66,8 +67,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "apply viscous damping force to determine static equilibrium solutions", particledyn);
 
   // transfer particles to new bins every time step
-  Core::Utils::bool_parameter(
-      "TRANSFER_EVERY", false, "transfer particles to new bins every time step", particledyn);
+  particledyn.specs.emplace_back(parameter<bool>("TRANSFER_EVERY",
+      {.description = "transfer particles to new bins every time step", .default_value = false}));
 
   // considered particle phases with dynamic load balance weighting factor
   Core::Utils::string_parameter("PHASE_TO_DYNLOADBALFAC", "none",
@@ -94,14 +95,14 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "material id for particle wall from bounding box source", particledyn);
 
   // flags defining considered states of particle wall
-  Core::Utils::bool_parameter(
-      "PARTICLE_WALL_MOVING", false, "consider a moving particle wall", particledyn);
-  Core::Utils::bool_parameter(
-      "PARTICLE_WALL_LOADED", false, "consider loading on particle wall", particledyn);
+  particledyn.specs.emplace_back(parameter<bool>("PARTICLE_WALL_MOVING",
+      {.description = "consider a moving particle wall", .default_value = false}));
+  particledyn.specs.emplace_back(parameter<bool>("PARTICLE_WALL_LOADED",
+      {.description = "consider loading on particle wall", .default_value = false}));
 
   // consider rigid body motion
-  Core::Utils::bool_parameter(
-      "RIGID_BODY_MOTION", false, "consider rigid body motion", particledyn);
+  particledyn.specs.emplace_back(parameter<bool>(
+      "RIGID_BODY_MOTION", {.description = "consider rigid body motion", .default_value = false}));
 
   Core::Utils::double_parameter("RIGID_BODY_PHASECHANGE_RADIUS", -1.0,
       "search radius for neighboring rigid bodies in case of phase change", particledyn);
@@ -158,8 +159,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::SectionSpecs particledynsph{particledyn, "SPH"};
 
   // write particle-wall interaction output
-  Core::Utils::bool_parameter("WRITE_PARTICLE_WALL_INTERACTION", false,
-      "write particle-wall interaction output", particledynsph);
+  particledynsph.specs.emplace_back(parameter<bool>("WRITE_PARTICLE_WALL_INTERACTION",
+      {.description = "write particle-wall interaction output", .default_value = false}));
 
   // type of smoothed particle hydrodynamics kernel
   Core::Utils::string_to_integral_parameter<KernelType>("KERNEL", "CubicSpline",
@@ -256,8 +257,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           Inpar::PARTICLE::NoTemperatureEvaluation, Inpar::PARTICLE::TemperatureIntegration),
       particledynsph);
 
-  Core::Utils::bool_parameter(
-      "TEMPERATUREGRADIENT", false, "evaluate temperature gradient", particledynsph);
+  particledynsph.specs.emplace_back(parameter<bool>("TEMPERATUREGRADIENT",
+      {.description = "evaluate temperature gradient", .default_value = false}));
 
   // type of heat source
   Core::Utils::string_to_integral_parameter<HeatSourceType>("HEATSOURCETYPE", "NoHeatSource",
@@ -274,8 +275,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "HEATSOURCE_DIRECTION", "0.0 0.0 0.0", "direction of surface heat source", particledynsph);
 
   // evaporation induced heat loss
-  Core::Utils::bool_parameter(
-      "VAPOR_HEATLOSS", false, "evaluate evaporation induced heat loss", particledynsph);
+  particledynsph.specs.emplace_back(parameter<bool>("VAPOR_HEATLOSS",
+      {.description = "evaluate evaporation induced heat loss", .default_value = false}));
   Core::Utils::double_parameter(
       "VAPOR_HEATLOSS_LATENTHEAT", 0.0, "latent heat in heat loss formula", particledynsph);
   Core::Utils::double_parameter("VAPOR_HEATLOSS_ENTHALPY_REFTEMP", 0.0,
@@ -286,8 +287,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "VAPOR_HEATLOSS_TFAC", 0.0, "temperature factor in heat loss formula", particledynsph);
 
   // evaporation induced recoil pressure
-  Core::Utils::bool_parameter(
-      "VAPOR_RECOIL", false, "evaluate evaporation induced recoil pressure", particledynsph);
+  particledynsph.specs.emplace_back(parameter<bool>("VAPOR_RECOIL",
+      {.description = "evaluate evaporation induced recoil pressure", .default_value = false}));
   Core::Utils::double_parameter("VAPOR_RECOIL_BOILINGTEMPERATURE", 0.0,
       "boiling temperature in recoil pressure formula", particledynsph);
   Core::Utils::double_parameter(
@@ -324,15 +325,16 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "triple point normal correction wall color field up", particledynsph);
 
   // interface viscosity
-  Core::Utils::bool_parameter(
-      "INTERFACE_VISCOSITY", false, "evaluate interface viscosity", particledynsph);
+  particledynsph.specs.emplace_back(parameter<bool>("INTERFACE_VISCOSITY",
+      {.description = "evaluate interface viscosity", .default_value = false}));
   Core::Utils::double_parameter("INTERFACE_VISCOSITY_LIQUIDGAS", 0.0,
       "artificial viscosity on liquid-gas interface", particledynsph);
   Core::Utils::double_parameter("INTERFACE_VISCOSITY_SOLIDLIQUID", 0.0,
       "artificial viscosity on solid-liquid interface", particledynsph);
 
   // barrier force
-  Core::Utils::bool_parameter("BARRIER_FORCE", false, "evaluate barrier force", particledynsph);
+  particledynsph.specs.emplace_back(parameter<bool>(
+      "BARRIER_FORCE", {.description = "evaluate barrier force", .default_value = false}));
   Core::Utils::double_parameter(
       "BARRIER_FORCE_DISTANCE", 0.0, "barrier force distance", particledynsph);
   Core::Utils::double_parameter(
@@ -430,12 +432,12 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   Core::Utils::SectionSpecs particledyndem{particledyn, "DEM"};
 
   // write particle energy output
-  Core::Utils::bool_parameter(
-      "WRITE_PARTICLE_ENERGY", false, "write particle energy output", particledyndem);
+  particledyndem.specs.emplace_back(parameter<bool>("WRITE_PARTICLE_ENERGY",
+      {.description = "write particle energy output", .default_value = false}));
 
   // write particle-wall interaction output
-  Core::Utils::bool_parameter("WRITE_PARTICLE_WALL_INTERACTION", false,
-      "write particle-wall interaction output", particledyndem);
+  particledyndem.specs.emplace_back(parameter<bool>("WRITE_PARTICLE_WALL_INTERACTION",
+      {.description = "write particle-wall interaction output", .default_value = false}));
 
   // type of normal contact law
   Core::Utils::string_to_integral_parameter<NormalContact>("NORMALCONTACTLAW", "NormalLinearSpring",
@@ -513,8 +515,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "linearly regularized damping normal force in the interval "
       "$|g| < (\\text{DAMP_REG_FAC} \\cdot r_{\\min})$",
       particledyndem);
-  Core::Utils::bool_parameter(
-      "TENSION_CUTOFF", true, "evaluate tension cutoff of normal contact force", particledyndem);
+  particledyndem.specs.emplace_back(parameter<bool>("TENSION_CUTOFF",
+      {.description = "evaluate tension cutoff of normal contact force", .default_value = true}));
 
   Core::Utils::double_parameter("POISSON_RATIO", -1.0, "poisson ratio", particledyndem);
   Core::Utils::double_parameter("YOUNG_MODULUS", -1.0, "young's modulus", particledyndem);
@@ -531,11 +533,12 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
       "ADHESION_MAX_CONTACT_PRESSURE", 0.0, "adhesion maximum contact pressure", particledyndem);
   Core::Utils::double_parameter(
       "ADHESION_MAX_CONTACT_FORCE", 0.0, "adhesion maximum contact force", particledyndem);
-  Core::Utils::bool_parameter("ADHESION_USE_MAX_CONTACT_FORCE", false,
-      "use maximum contact force instead of maximum contact pressure", particledyndem);
+  particledyndem.specs.emplace_back(parameter<bool>("ADHESION_USE_MAX_CONTACT_FORCE",
+      {.description = "use maximum contact force instead of maximum contact pressure",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "ADHESION_VDW_CURVE_SHIFT", false, "shifts van-der-Waals-curve to g = 0", particledyndem);
+  particledyndem.specs.emplace_back(parameter<bool>("ADHESION_VDW_CURVE_SHIFT",
+      {.description = "shifts van-der-Waals-curve to g = 0", .default_value = false}));
 
   Core::Utils::double_parameter(
       "ADHESION_HAMAKER", -1.0, "hamaker constant of van-der-Waals interaction", particledyndem);

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -24,9 +24,11 @@ void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   // time loop control
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", pasidyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", pasidyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.01, "Time increment dt", pasidyn);
+  pasidyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
   Core::Utils::int_parameter("NUMSTEP", 100, "Total number of Timesteps", pasidyn);
-  Core::Utils::double_parameter("MAXTIME", 1.0, "Total simulation time", pasidyn);
+  pasidyn.specs.emplace_back(
+      parameter<double>("MAXTIME", {.description = "Total simulation time", .default_value = 1.0}));
 
   // type of partitioned coupling
   Core::Utils::string_to_integral_parameter<PartitionedCouplingType>("COUPLING",
@@ -42,29 +44,35 @@ void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::int_parameter(
       "ITEMAX", 10, "maximum number of partitioned iterations over fields", pasidyn);
 
-  Core::Utils::double_parameter("CONVTOLSCALEDDISP", -1.0,
-      "tolerance of dof and dt scaled interface displacement increments in partitioned iterations",
-      pasidyn);
+  pasidyn.specs.emplace_back(parameter<double>(
+      "CONVTOLSCALEDDISP", {.description = "tolerance of dof and dt scaled interface displacement "
+                                           "increments in partitioned iterations",
+                               .default_value = -1.0}));
 
-  Core::Utils::double_parameter("CONVTOLRELATIVEDISP", -1.0,
-      "tolerance of relative interface displacement increments in partitioned iterations", pasidyn);
+  pasidyn.specs.emplace_back(parameter<double>("CONVTOLRELATIVEDISP",
+      {.description =
+              "tolerance of relative interface displacement increments in partitioned iterations",
+          .default_value = -1.0}));
 
-  Core::Utils::double_parameter("CONVTOLSCALEDFORCE", -1.0,
-      "tolerance of dof and dt scaled interface force increments in partitioned iterations",
-      pasidyn);
+  pasidyn.specs.emplace_back(parameter<double>("CONVTOLSCALEDFORCE",
+      {.description =
+              "tolerance of dof and dt scaled interface force increments in partitioned iterations",
+          .default_value = -1.0}));
 
-  Core::Utils::double_parameter("CONVTOLRELATIVEFORCE", -1.0,
-      "tolerance of relative interface force increments in partitioned iterations", pasidyn);
+  pasidyn.specs.emplace_back(parameter<double>("CONVTOLRELATIVEFORCE",
+      {.description = "tolerance of relative interface force increments in partitioned iterations",
+          .default_value = -1.0}));
 
   pasidyn.specs.emplace_back(parameter<bool>("IGNORE_CONV_CHECK",
       {.description = "ignore convergence check and proceed simulation", .default_value = false}));
 
   // parameters for relaxation
-  Core::Utils::double_parameter("STARTOMEGA", 1.0, "fixed relaxation parameter", pasidyn);
-  Core::Utils::double_parameter(
-      "MAXOMEGA", 10.0, "largest omega allowed for Aitken relaxation", pasidyn);
-  Core::Utils::double_parameter(
-      "MINOMEGA", 0.1, "smallest omega allowed for Aitken relaxation", pasidyn);
+  pasidyn.specs.emplace_back(parameter<double>(
+      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
+  pasidyn.specs.emplace_back(parameter<double>("MAXOMEGA",
+      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
+  pasidyn.specs.emplace_back(parameter<double>("MINOMEGA",
+      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
 
   pasidyn.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs pasidyn{"PASI DYNAMIC"};
 
@@ -55,8 +56,8 @@ void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::double_parameter("CONVTOLRELATIVEFORCE", -1.0,
       "tolerance of relative interface force increments in partitioned iterations", pasidyn);
 
-  Core::Utils::bool_parameter(
-      "IGNORE_CONV_CHECK", false, "ignore convergence check and proceed simulation", pasidyn);
+  pasidyn.specs.emplace_back(parameter<bool>("IGNORE_CONV_CHECK",
+      {.description = "ignore convergence check and proceed simulation", .default_value = false}));
 
   // parameters for relaxation
   Core::Utils::double_parameter("STARTOMEGA", 1.0, "fixed relaxation parameter", pasidyn);

--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::Plasticity::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /*----------------------------------------------------------------------*/
   /* parameters for semi-smooth Newton plasticity algorithm */

--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -24,10 +24,10 @@ void Inpar::Plasticity::set_valid_parameters(std::map<std::string, Core::IO::Inp
   /* parameters for semi-smooth Newton plasticity algorithm */
   Core::Utils::SectionSpecs iplast{"SEMI-SMOOTH PLASTICITY"};
 
-  Core::Utils::double_parameter(
-      "SEMI_SMOOTH_CPL", 1.0, "Weighting factor cpl for semi-smooth PDASS", iplast);
-  Core::Utils::double_parameter(
-      "STABILIZATION_S", 1.0, "Stabilization factor s for semi-smooth PDASS", iplast);
+  iplast.specs.emplace_back(parameter<double>("SEMI_SMOOTH_CPL",
+      {.description = "Weighting factor cpl for semi-smooth PDASS", .default_value = 1.0}));
+  iplast.specs.emplace_back(parameter<double>("STABILIZATION_S",
+      {.description = "Stabilization factor s for semi-smooth PDASS", .default_value = 1.0}));
 
   // solver convergence test parameters for semi-smooth plasticity formulation
   Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFPLASTCONSTR",
@@ -42,10 +42,12 @@ void Inpar::Plasticity::set_valid_parameters(std::map<std::string, Core::IO::Inp
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), iplast);
 
-  Core::Utils::double_parameter("TOLPLASTCONSTR", 1.0E-8,
-      "tolerance in the plastic constraint norm for the newton iteration", iplast);
-  Core::Utils::double_parameter("TOLDELTALP", 1.0E-8,
-      "tolerance in the plastic flow (Delta Lp) norm for the Newton iteration", iplast);
+  iplast.specs.emplace_back(parameter<double>("TOLPLASTCONSTR",
+      {.description = "tolerance in the plastic constraint norm for the newton iteration",
+          .default_value = 1.0E-8}));
+  iplast.specs.emplace_back(parameter<double>("TOLDELTALP",
+      {.description = "tolerance in the plastic flow (Delta Lp) norm for the Newton iteration",
+          .default_value = 1.0E-8}));
 
   Core::Utils::string_to_integral_parameter<Inpar::Solid::BinaryOp>("NORMCOMBI_EASRES", "And",
       "binary operator to combine EAS-residual and residual force values",
@@ -57,10 +59,12 @@ void Inpar::Plasticity::set_valid_parameters(std::map<std::string, Core::IO::Inp
       tuple<std::string>("And", "Or"),
       tuple<Inpar::Solid::BinaryOp>(Inpar::Solid::bop_and, Inpar::Solid::bop_or), iplast);
 
-  Core::Utils::double_parameter(
-      "TOLEASRES", 1.0E-8, "tolerance in the EAS residual norm for the newton iteration", iplast);
-  Core::Utils::double_parameter(
-      "TOLEASINCR", 1.0E-8, "tolerance in the EAS increment norm for the Newton iteration", iplast);
+  iplast.specs.emplace_back(parameter<double>(
+      "TOLEASRES", {.description = "tolerance in the EAS residual norm for the newton iteration",
+                       .default_value = 1.0E-8}));
+  iplast.specs.emplace_back(parameter<double>(
+      "TOLEASINCR", {.description = "tolerance in the EAS increment norm for the Newton iteration",
+                        .default_value = 1.0E-8}));
 
   Core::Utils::string_to_integral_parameter<Inpar::TSI::DissipationMode>("DISSIPATION_MODE",
       "pl_multiplier", "method to calculate the plastic dissipation",

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs poroelastdyn{"POROELASTICITY DYNAMIC"};
 
@@ -112,19 +113,23 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
       tuple<Inpar::PoroElast::VectorNorm>(norm_l1, norm_l1_scaled, norm_l2, norm_rms, norm_inf),
       poroelastdyn);
 
-  Core::Utils::bool_parameter(
-      "SECONDORDER", true, "Second order coupling at the interface.", poroelastdyn);
+  poroelastdyn.specs.emplace_back(parameter<bool>("SECONDORDER",
+      {.description = "Second order coupling at the interface.", .default_value = true}));
 
-  Core::Utils::bool_parameter("CONTIPARTINT", false,
-      "Partial integration of porosity gradient in continuity equation", poroelastdyn);
+  poroelastdyn.specs.emplace_back(parameter<bool>("CONTIPARTINT",
+      {.description = "Partial integration of porosity gradient in continuity equation",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("CONTACT_NO_PENETRATION", false,
-      "No-Penetration Condition on active contact surface in case of poro contact problem!",
-      poroelastdyn);
+  poroelastdyn.specs.emplace_back(parameter<bool>("CONTACT_NO_PENETRATION",
+      {.description =
+              "No-Penetration Condition on active contact surface in case of poro contact problem!",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", poroelastdyn);
+  poroelastdyn.specs.emplace_back(
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
-  Core::Utils::bool_parameter("CONVECTIVE_TERM", false, "convective term ", poroelastdyn);
+  poroelastdyn.specs.emplace_back(parameter<bool>(
+      "CONVECTIVE_TERM", {.description = "convective term ", .default_value = false}));
 
   // number of linear solver used for poroelasticity
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -53,36 +53,49 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
 
   // Time loop control
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", poroelastdyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", poroelastdyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.05, "time step size dt", poroelastdyn);
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  poroelastdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
   Core::Utils::int_parameter(
       "ITEMAX", 10, "maximum number of iterations over fields", poroelastdyn);
   Core::Utils::int_parameter("ITEMIN", 1, "minimal number of iterations over fields", poroelastdyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", poroelastdyn);
 
   // Iterationparameters
-  Core::Utils::double_parameter("TOLRES_GLOBAL", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter("TOLINC_GLOBAL", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter(
-      "TOLRES_DISP", 1e-8, "tolerance in the residual norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter("TOLINC_DISP", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter(
-      "TOLRES_PORO", 1e-8, "tolerance in the residual norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter("TOLINC_PORO", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter(
-      "TOLRES_VEL", 1e-8, "tolerance in the residual norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter(
-      "TOLINC_VEL", 1e-8, "tolerance in the increment norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter(
-      "TOLRES_PRES", 1e-8, "tolerance in the residual norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter("TOLINC_PRES", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroelastdyn);
-  Core::Utils::double_parameter("TOLRES_NCOUP", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poroelastdyn);
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLRES_DISP", {.description = "tolerance in the residual norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLINC_DISP", {.description = "tolerance in the increment norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLRES_PORO", {.description = "tolerance in the residual norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLINC_PORO", {.description = "tolerance in the increment norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLRES_VEL", {.description = "tolerance in the residual norm for the Newton iteration",
+                        .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLINC_VEL", {.description = "tolerance in the increment norm for the Newton iteration",
+                        .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLRES_PRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLINC_PRES", {.description = "tolerance in the increment norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroelastdyn.specs.emplace_back(parameter<double>(
+      "TOLRES_NCOUP", {.description = "tolerance in the residual norm for the Newton iteration",
+                          .default_value = 1e-8}));
 
   Core::Utils::string_to_integral_parameter<Inpar::PoroElast::ConvNorm>("NORM_INC",
       "AbsSingleFields", "type of norm for primary variables convergence check",

--- a/src/inpar/4C_inpar_porofluidmultiphase.cpp
+++ b/src/inpar/4C_inpar_porofluidmultiphase.cpp
@@ -20,16 +20,18 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
 
   Core::Utils::SectionSpecs porofluidmultiphasedyn{"POROFLUIDMULTIPHASE DYNAMIC"};
 
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("NUMSTEP", 20, "Total number of time steps", porofluidmultiphasedyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
   Core::Utils::int_parameter(
       "RESULTSEVERY", 1, "Increment for writing solution", porofluidmultiphasedyn);
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "Increment for writing restart", porofluidmultiphasedyn);
 
-  Core::Utils::double_parameter(
-      "THETA", 0.5, "One-step-theta time integration factor", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
+      "THETA", {.description = "One-step-theta time integration factor", .default_value = 0.5}));
 
   Core::Utils::string_to_integral_parameter<TimeIntegrationScheme>("TIMEINTEGR", "One_Step_Theta",
       "Time Integration Scheme", tuple<std::string>("One_Step_Theta"),
@@ -49,19 +51,20 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
 
   Core::Utils::int_parameter(
       "ITEMAX", 10, "max. number of nonlin. iterations", porofluidmultiphasedyn);
-  Core::Utils::double_parameter("ABSTOLRES", 1e-14,
-      "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
-      porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("ABSTOLRES",
+      {.description =
+              "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
+          .default_value = 1e-14}));
 
   // convergence criteria adaptivity
   porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   // parameters for finite difference check
   Core::Utils::string_to_integral_parameter<FdCheck>("FDCHECK", "none",
@@ -69,12 +72,12 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       tuple<std::string>("none",
           "global"),  // perform finite difference check on time integrator level
       tuple<FdCheck>(fdcheck_none, fdcheck_global), porofluidmultiphasedyn);
-  Core::Utils::double_parameter("FDCHECKEPS", 1.e-6,
-      "dof perturbation magnitude for finite difference check (1.e-6 seems to work very well, "
-      "whereas smaller values don't)",
-      porofluidmultiphasedyn);
-  Core::Utils::double_parameter("FDCHECKTOL", 1.e-6,
-      "relative tolerance for finite difference check", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
+      "FDCHECKEPS", {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
+                                    "seems to work very well, whereas smaller values don't)",
+                        .default_value = 1.e-6}));
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("FDCHECKTOL",
+      {.description = "relative tolerance for finite difference check", .default_value = 1.e-6}));
   porofluidmultiphasedyn.specs.emplace_back(parameter<bool>(
       "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
                          .default_value = true}));
@@ -93,9 +96,10 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
   // Biot stabilization
   porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("STAB_BIOT",
       {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}));
-  Core::Utils::double_parameter("STAB_BIOT_SCALING", 1.0,
-      "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
-      porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("STAB_BIOT_SCALING",
+      {.description =
+              "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
+          .default_value = 1.0}));
 
   Core::Utils::string_to_integral_parameter<VectorNorm>("VECTORNORM_RESF", "L2",
       "type of norm to be applied to residuals",
@@ -114,10 +118,12 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasedyn);
 
   // Iterationparameters
-  Core::Utils::double_parameter("TOLRES", 1e-6,
-      "tolerance in the residual norm for the Newton iteration", porofluidmultiphasedyn);
-  Core::Utils::double_parameter("TOLINC", 1e-6,
-      "tolerance in the increment norm for the Newton iteration", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
+      "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                    .default_value = 1e-6}));
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
+      "TOLINC", {.description = "tolerance in the increment norm for the Newton iteration",
+                    .default_value = 1e-6}));
 
   Core::Utils::string_to_integral_parameter<InitialField>("INITIALFIELD", "zero_field",
       "Initial Field for transport problem",
@@ -153,8 +159,8 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
   porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
       {.description = "Coupling with 1D blood vessels.", .default_value = false}));
 
-  Core::Utils::double_parameter("STARTING_DBC_TIME_END", -1.0,
-      "End time for the starting Dirichlet BC.", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("STARTING_DBC_TIME_END",
+      {.description = "End time for the starting Dirichlet BC.", .default_value = -1.0}));
 
   Core::Utils::string_parameter("STARTING_DBC_ONOFF", "0",
       "Switching the starting Dirichlet BC on or off.", porofluidmultiphasedyn);
@@ -174,8 +180,8 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasemshtdyn);
 
   // penalty parameter
-  Core::Utils::double_parameter(
-      "PENALTY", 1000.0, "Penalty parameter for line-based coupling", porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<double>("PENALTY",
+      {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}));
 
   Core::Utils::string_to_integral_parameter<
       Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>("ARTERY_COUPLING_METHOD",
@@ -257,10 +263,11 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
           .default_value = false}));
 
   // components whose size is smaller than this fraction of the total network size are also deleted
-  Core::Utils::double_parameter("DELETE_SMALL_FREE_HANGING_COMPS", -1.0,
-      "Small connected components whose size is smaller than this fraction of the overall network "
-      "size are additionally deleted (a valid choice of this parameter should lie between 0 and 1)",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<double>("DELETE_SMALL_FREE_HANGING_COMPS",
+      {.description = "Small connected components whose size is smaller than this fraction of the "
+                      "overall network size are additionally deleted (a valid choice of this "
+                      "parameter should lie between 0 and 1)",
+          .default_value = -1.0}));
 
   porofluidmultiphasemshtdyn.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_porofluidmultiphase.cpp
+++ b/src/inpar/4C_inpar_porofluidmultiphase.cpp
@@ -152,8 +152,8 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasedyn);
 
   // functions used for domain integrals
-  Core::Utils::string_parameter(
-      "DOMAININT_FUNCT", "-1.0", "functions used for domain integrals", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<std::string>("DOMAININT_FUNCT",
+      {.description = "functions used for domain integrals", .default_value = "-1.0"}));
 
   // coupling with 1D artery network active
   porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
@@ -162,11 +162,11 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
   porofluidmultiphasedyn.specs.emplace_back(parameter<double>("STARTING_DBC_TIME_END",
       {.description = "End time for the starting Dirichlet BC.", .default_value = -1.0}));
 
-  Core::Utils::string_parameter("STARTING_DBC_ONOFF", "0",
-      "Switching the starting Dirichlet BC on or off.", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<std::string>("STARTING_DBC_ONOFF",
+      {.description = "Switching the starting Dirichlet BC on or off.", .default_value = "0"}));
 
-  Core::Utils::string_parameter("STARTING_DBC_FUNCT", "0",
-      "Function prescribing the starting Dirichlet BC.", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<std::string>("STARTING_DBC_FUNCT",
+      {.description = "Function prescribing the starting Dirichlet BC.", .default_value = "0"}));
 
   porofluidmultiphasedyn.move_into_collection(list);
 
@@ -199,28 +199,28 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasemshtdyn);
 
   // coupled artery dofs for mesh tying
-  Core::Utils::string_parameter(
-      "COUPLEDDOFS_ART", "-1.0", "coupled artery dofs for mesh tying", porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_ART",
+      {.description = "coupled artery dofs for mesh tying", .default_value = "-1.0"}));
 
   // coupled porofluid dofs for mesh tying
-  Core::Utils::string_parameter("COUPLEDDOFS_PORO", "-1.0", "coupled porofluid dofs for mesh tying",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_PORO",
+      {.description = "coupled porofluid dofs for mesh tying", .default_value = "-1.0"}));
 
   // functions for coupling (artery part)
-  Core::Utils::string_parameter(
-      "REACFUNCT_ART", "-1", "functions for coupling (artery part)", porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("REACFUNCT_ART",
+      {.description = "functions for coupling (artery part)", .default_value = "-1"}));
 
   // scale for coupling (artery part)
-  Core::Utils::string_parameter(
-      "SCALEREAC_ART", "0", "scale for coupling (artery part)", porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>(
+      "SCALEREAC_ART", {.description = "scale for coupling (artery part)", .default_value = "0"}));
 
   // functions for coupling (porofluid part)
-  Core::Utils::string_parameter("REACFUNCT_CONT", "-1", "functions for coupling (porofluid part)",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("REACFUNCT_CONT",
+      {.description = "functions for coupling (porofluid part)", .default_value = "-1"}));
 
   // scale for coupling (porofluid part)
-  Core::Utils::string_parameter(
-      "SCALEREAC_CONT", "0", "scale for coupling (porofluid part)", porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("SCALEREAC_CONT",
+      {.description = "scale for coupling (porofluid part)", .default_value = "0"}));
 
   // Flag if artery elements are evaluated in reference or current configuration
   porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("EVALUATE_IN_REF_CONFIG",

--- a/src/inpar/4C_inpar_porofluidmultiphase.cpp
+++ b/src/inpar/4C_inpar_porofluidmultiphase.cpp
@@ -16,6 +16,7 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
     std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs porofluidmultiphasedyn{"POROFLUIDMULTIPHASE DYNAMIC"};
 
@@ -53,9 +54,10 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasedyn);
 
   // convergence criteria adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-      porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
@@ -73,20 +75,24 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasedyn);
   Core::Utils::double_parameter("FDCHECKTOL", 1.e-6,
       "relative tolerance for finite difference check", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("SKIPINITDER", true,
-      "Flag to skip computation of initial time derivative", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_SATANDPRESS", true,
-      "Flag if output of saturations and pressures should be calculated", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_SOLIDPRESS", true,
-      "Flag if output of solid pressure should be calculated", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_POROSITY", true,
-      "Flag if output of porosity should be calculated", porofluidmultiphasedyn);
-  Core::Utils::bool_parameter("OUTPUT_PHASE_VELOCITIES", true,
-      "Flag if output of phase velocities should be calculated", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>(
+      "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
+                         .default_value = true}));
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("OUTPUT_SATANDPRESS",
+      {.description = "Flag if output of saturations and pressures should be calculated",
+          .default_value = true}));
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>(
+      "OUTPUT_SOLIDPRESS", {.description = "Flag if output of solid pressure should be calculated",
+                               .default_value = true}));
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("OUTPUT_POROSITY",
+      {.description = "Flag if output of porosity should be calculated", .default_value = true}));
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("OUTPUT_PHASE_VELOCITIES",
+      {.description = "Flag if output of phase velocities should be calculated",
+          .default_value = true}));
 
   // Biot stabilization
-  Core::Utils::bool_parameter(
-      "STAB_BIOT", false, "Flag to (de)activate BIOT stabilization.", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("STAB_BIOT",
+      {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}));
   Core::Utils::double_parameter("STAB_BIOT_SCALING", 1.0,
       "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
       porofluidmultiphasedyn);
@@ -144,8 +150,8 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       "DOMAININT_FUNCT", "-1.0", "functions used for domain integrals", porofluidmultiphasedyn);
 
   // coupling with 1D artery network active
-  Core::Utils::bool_parameter(
-      "ARTERY_COUPLING", false, "Coupling with 1D blood vessels.", porofluidmultiphasedyn);
+  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
+      {.description = "Coupling with 1D blood vessels.", .default_value = false}));
 
   Core::Utils::double_parameter("STARTING_DBC_TIME_END", -1.0,
       "End time for the starting Dirichlet BC.", porofluidmultiphasedyn);
@@ -211,16 +217,16 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       "SCALEREAC_CONT", "0", "scale for coupling (porofluid part)", porofluidmultiphasemshtdyn);
 
   // Flag if artery elements are evaluated in reference or current configuration
-  Core::Utils::bool_parameter("EVALUATE_IN_REF_CONFIG", true,
-      "Flag if artery elements are evaluated in reference or current configuration",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("EVALUATE_IN_REF_CONFIG",
+      {.description = "Flag if artery elements are evaluated in reference or current configuration",
+          .default_value = true}));
 
   // Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of embedded artery
   // elements
-  Core::Utils::bool_parameter("LATERAL_SURFACE_COUPLING", false,
-      "Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of embedded artery "
-      "elements",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("LATERAL_SURFACE_COUPLING",
+      {.description = "Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of "
+                      "embedded artery elements",
+          .default_value = false}));
 
   // Number of integration patches per 1D element in axial direction for lateral surface coupling
   Core::Utils::int_parameter("NUMPATCH_AXI", 1,
@@ -235,18 +241,20 @@ void Inpar::POROFLUIDMULTIPHASE::set_valid_parameters(
       porofluidmultiphasemshtdyn);
 
   // Flag if blood vessel volume fraction should be output
-  Core::Utils::bool_parameter("OUTPUT_BLOODVESSELVOLFRAC", false,
-      "Flag if output of blood vessel volume fraction should be calculated",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("OUTPUT_BLOODVESSELVOLFRAC",
+      {.description = "Flag if output of blood vessel volume fraction should be calculated",
+          .default_value = false}));
 
   // Flag if summary of coupling-pairs should be printed
-  Core::Utils::bool_parameter("PRINT_OUT_SUMMARY_PAIRS", false,
-      "Flag if summary of coupling-pairs should be printed", porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("PRINT_OUT_SUMMARY_PAIRS",
+      {.description = "Flag if summary of coupling-pairs should be printed",
+          .default_value = false}));
 
   // Flag if free-hanging elements (after blood vessel collapse) should be deleted
-  Core::Utils::bool_parameter("DELETE_FREE_HANGING_ELES", false,
-      "Flag if free-hanging elements (after blood vessel collapse) should be deleted",
-      porofluidmultiphasemshtdyn);
+  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("DELETE_FREE_HANGING_ELES",
+      {.description =
+              "Flag if free-hanging elements (after blood vessel collapse) should be deleted",
+          .default_value = false}));
 
   // components whose size is smaller than this fraction of the total network size are also deleted
   Core::Utils::double_parameter("DELETE_SMALL_FREE_HANGING_COMPS", -1.0,

--- a/src/inpar/4C_inpar_poromultiphase.cpp
+++ b/src/inpar/4C_inpar_poromultiphase.cpp
@@ -28,8 +28,10 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", poromultiphasedyn);
   // Time loop control
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", poromultiphasedyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", poromultiphasedyn);
-  Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", poromultiphasedyn);
+  poromultiphasedyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  poromultiphasedyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
   Core::Utils::int_parameter(
       "RESULTSEVERY", 1, "increment for writing solution", poromultiphasedyn);
   Core::Utils::int_parameter(
@@ -59,10 +61,12 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
   Core::Utils::SectionSpecs poromultiphasedynmono{poromultiphasedyn, "MONOLITHIC"};
 
   // convergence tolerances for monolithic coupling
-  Core::Utils::double_parameter("TOLRES_GLOBAL", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poromultiphasedynmono);
-  Core::Utils::double_parameter("TOLINC_GLOBAL", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poromultiphasedynmono);
+  poromultiphasedynmono.specs.emplace_back(parameter<double>(
+      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poromultiphasedynmono.specs.emplace_back(parameter<double>(
+      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
+                           .default_value = 1e-8}));
 
   // number of linear solver used for poroelasticity
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,
@@ -110,10 +114,10 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.001,
-      "The linear solver shall be this much better "
-      "than the current nonlinear residual in the nonlinear convergence limit",
-      poromultiphasedynmono);
+  poromultiphasedynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.001}));
 
   poromultiphasedynmono.move_into_collection(list);
 
@@ -122,8 +126,9 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
   Core::Utils::SectionSpecs poromultiphasedynpart{poromultiphasedyn, "PARTITIONED"};
 
   // convergence tolerance of outer iteration loop
-  Core::Utils::double_parameter(
-      "CONVTOL", 1e-6, "tolerance for convergence check of outer iteration", poromultiphasedynpart);
+  poromultiphasedynpart.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
+                     .default_value = 1e-6}));
 
   // flag for relaxation of partitioned scheme
   Core::Utils::string_to_integral_parameter<RelaxationMethods>("RELAXATION", "none",
@@ -132,12 +137,12 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
       poromultiphasedynpart);
 
   // parameters for relaxation of partitioned coupling
-  Core::Utils::double_parameter(
-      "STARTOMEGA", 1.0, "fixed relaxation parameter", poromultiphasedynpart);
-  Core::Utils::double_parameter(
-      "MINOMEGA", 0.1, "smallest omega allowed for Aitken relaxation", poromultiphasedynpart);
-  Core::Utils::double_parameter(
-      "MAXOMEGA", 10.0, "largest omega allowed for Aitken relaxation", poromultiphasedynpart);
+  poromultiphasedynpart.specs.emplace_back(parameter<double>(
+      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
+  poromultiphasedynpart.specs.emplace_back(parameter<double>("MINOMEGA",
+      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
+  poromultiphasedynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
+      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
 
   poromultiphasedynpart.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_poromultiphase.cpp
+++ b/src/inpar/4C_inpar_poromultiphase.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   // ----------------------------------------------------------------------
   // (1) general control parameters
@@ -36,8 +37,8 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
 
   // here the computation of the structure can be skipped, this is helpful if only fluid-scatra
   // coupling should be calculated
-  Core::Utils::bool_parameter(
-      "SOLVE_STRUCTURE", true, "Flag to skip computation of structural field", poromultiphasedyn);
+  poromultiphasedyn.specs.emplace_back(parameter<bool>("SOLVE_STRUCTURE",
+      {.description = "Flag to skip computation of structural field", .default_value = true}));
 
 
   // Coupling strategy for solvers
@@ -48,8 +49,8 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
       poromultiphasedyn);
 
   // coupling with 1D artery network active
-  Core::Utils::bool_parameter(
-      "ARTERY_COUPLING", false, "Coupling with 1D blood vessels.", poromultiphasedyn);
+  poromultiphasedyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
+      {.description = "Coupling with 1D blood vessels.", .default_value = false}));
 
   poromultiphasedyn.move_into_collection(list);
 
@@ -105,9 +106,10 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
       poromultiphasedynmono);
 
   // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-      poromultiphasedynmono);
+  poromultiphasedynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.001,
       "The linear solver shall be this much better "
       "than the current nonlinear residual in the nonlinear convergence limit",

--- a/src/inpar/4C_inpar_poromultiphase.cpp
+++ b/src/inpar/4C_inpar_poromultiphase.cpp
@@ -31,7 +31,7 @@ void Inpar::POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO:
   poromultiphasedyn.specs.emplace_back(parameter<double>(
       "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
   poromultiphasedyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
   Core::Utils::int_parameter(
       "RESULTSEVERY", 1, "increment for writing solution", poromultiphasedyn);
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_poromultiphase_scatra.cpp
+++ b/src/inpar/4C_inpar_poromultiphase_scatra.cpp
@@ -19,6 +19,7 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
     std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   // ----------------------------------------------------------------------
   // (1) general control parameters
@@ -50,8 +51,8 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
       poromultiphasescatradyn);
 
   // coupling with 1D artery network active
-  Core::Utils::bool_parameter(
-      "ARTERY_COUPLING", false, "Coupling with 1D blood vessels.", poromultiphasescatradyn);
+  poromultiphasescatradyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
+      {.description = "Coupling with 1D blood vessels.", .default_value = false}));
 
   // no convergence of coupling scheme
   Core::Utils::string_to_integral_parameter<DivContAct>("DIVERCONT", "stop",
@@ -82,9 +83,10 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
       poromultiphasescatradynmono);
 
   // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-      poromultiphasescatradynmono);
+  poromultiphasescatradynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.001,
       "The linear solver shall be this much better "
       "than the current nonlinear residual in the nonlinear convergence limit",

--- a/src/inpar/4C_inpar_poromultiphase_scatra.cpp
+++ b/src/inpar/4C_inpar_poromultiphase_scatra.cpp
@@ -31,9 +31,10 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
   // Time loop control
   Core::Utils::int_parameter(
       "NUMSTEP", 200, "maximum number of Timesteps", poromultiphasescatradyn);
-  Core::Utils::double_parameter(
-      "MAXTIME", 1000.0, "total simulation time", poromultiphasescatradyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.05, "time step size dt", poromultiphasescatradyn);
+  poromultiphasescatradyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  poromultiphasescatradyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
   Core::Utils::int_parameter(
       "RESULTSEVERY", 1, "increment for writing solution", poromultiphasescatradyn);
   Core::Utils::int_parameter(
@@ -87,16 +88,18 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.001,
-      "The linear solver shall be this much better "
-      "than the current nonlinear residual in the nonlinear convergence limit",
-      poromultiphasescatradynmono);
+  poromultiphasescatradynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.001}));
 
   // Iterationparameters
-  Core::Utils::double_parameter("TOLRES_GLOBAL", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poromultiphasescatradynmono);
-  Core::Utils::double_parameter("TOLINC_GLOBAL", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poromultiphasescatradynmono);
+  poromultiphasescatradynmono.specs.emplace_back(parameter<double>(
+      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poromultiphasescatradynmono.specs.emplace_back(parameter<double>(
+      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
+                           .default_value = 1e-8}));
 
   // number of linear solver used for poroelasticity
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,
@@ -131,8 +134,9 @@ void Inpar::PoroMultiPhaseScaTra::set_valid_parameters(
   Core::Utils::SectionSpecs poromultiphasescatradynpart{poromultiphasescatradyn, "PARTITIONED"};
 
   // convergence tolerance of outer iteration loop
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "tolerance for convergence check of outer iteration", poromultiphasescatradynpart);
+  poromultiphasescatradynpart.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
+                     .default_value = 1e-6}));
 
   poromultiphasescatradynpart.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -27,8 +27,10 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", poroscatradyn);
   // Time loop control
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", poroscatradyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", poroscatradyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.05, "time step size dt", poroscatradyn);
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  poroscatradyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", poroscatradyn);
   Core::Utils::int_parameter(
       "ITEMAX", 10, "maximum number of iterations over fields", poroscatradyn);
@@ -36,26 +38,36 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
       "ITEMIN", 1, "minimal number of iterations over fields", poroscatradyn);
 
   // Iterationparameters
-  Core::Utils::double_parameter("TOLRES_GLOBAL", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLINC_GLOBAL", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLRES_DISP", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLINC_DISP", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter(
-      "TOLRES_VEL", 1e-8, "tolerance in the residual norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLINC_VEL", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLRES_PRES", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLINC_PRES", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLRES_SCALAR", 1e-8,
-      "tolerance in the residual norm for the Newton iteration", poroscatradyn);
-  Core::Utils::double_parameter("TOLINC_SCALAR", 1e-8,
-      "tolerance in the increment norm for the Newton iteration", poroscatradyn);
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLRES_DISP", {.description = "tolerance in the residual norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLINC_DISP", {.description = "tolerance in the increment norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLRES_VEL", {.description = "tolerance in the residual norm for the Newton iteration",
+                        .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLINC_VEL", {.description = "tolerance in the increment norm for the Newton iteration",
+                        .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLRES_PRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLINC_PRES", {.description = "tolerance in the increment norm for the Newton iteration",
+                         .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLRES_SCALAR", {.description = "tolerance in the residual norm for the Newton iteration",
+                           .default_value = 1e-8}));
+  poroscatradyn.specs.emplace_back(parameter<double>(
+      "TOLINC_SCALAR", {.description = "tolerance in the increment norm for the Newton iteration",
+                           .default_value = 1e-8}));
 
   Core::Utils::string_to_integral_parameter<Inpar::PoroElast::ConvNorm>("NORM_INC",
       "AbsSingleFields", "type of norm for primary variables convergence check",

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs poroscatradyn{"POROSCATRA CONTROL"};
 
@@ -104,7 +105,8 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
           Monolithic, Part_ScatraToPoro, Part_PoroToScatra, Part_TwoWay),
       poroscatradyn);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", poroscatradyn);
+  poroscatradyn.specs.emplace_back(
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
   poroscatradyn.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_problemtype.cpp
+++ b/src/inpar/4C_inpar_problemtype.cpp
@@ -18,6 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::PROBLEMTYPE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs type{"PROBLEM TYPE"};

--- a/src/inpar/4C_inpar_rebalance.cpp
+++ b/src/inpar/4C_inpar_rebalance.cpp
@@ -15,6 +15,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::Rebalance::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs meshpartitioning{"MESH PARTITIONING"};
 

--- a/src/inpar/4C_inpar_rebalance.cpp
+++ b/src/inpar/4C_inpar_rebalance.cpp
@@ -29,10 +29,10 @@ void Inpar::Rebalance::set_valid_parameters(std::map<std::string, Core::IO::Inpu
           Core::Rebalance::RebalanceType::monolithic),
       meshpartitioning);
 
-  Core::Utils::double_parameter("IMBALANCE_TOL", 1.1,
-      "Tolerance for relative imbalance of subdomain sizes for graph partitioning of unstructured "
-      "meshes read from input files.",
-      meshpartitioning);
+  meshpartitioning.specs.emplace_back(parameter<double>("IMBALANCE_TOL",
+      {.description = "Tolerance for relative imbalance of subdomain sizes for graph partitioning "
+                      "of unstructured meshes read from input files.",
+          .default_value = 1.1}));
 
   Core::Utils::int_parameter("MIN_ELE_PER_PROC", 0,
       "This parameter defines the minimum number of elements to be assigned to any MPI rank during "

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -19,6 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs s2icoupling{"SCALAR TRANSPORT DYNAMIC/S2I COUPLING"};
 
@@ -41,9 +42,10 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       s2icoupling);
 
   // flag for evaluation of interface linearizations and residuals on slave side only
-  Core::Utils::bool_parameter("SLAVEONLY", false,
-      "flag for evaluation of interface linearizations and residuals on slave side only",
-      s2icoupling);
+  s2icoupling.specs.emplace_back(parameter<bool>("SLAVEONLY",
+      {.description =
+              "flag for evaluation of interface linearizations and residuals on slave side only",
+          .default_value = false}));
 
   // node-to-segment projection tolerance
   Core::Utils::double_parameter(
@@ -84,13 +86,14 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "growth",
       s2icoupling);
 
-  Core::Utils::bool_parameter("MESHTYING_CONDITIONS_INDEPENDENT_SETUP", false,
-      "mesh tying for different conditions should be setup independently", s2icoupling);
+  s2icoupling.specs.emplace_back(parameter<bool>("MESHTYING_CONDITIONS_INDEPENDENT_SETUP",
+      {.description = "mesh tying for different conditions should be setup independently",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("OUTPUT_INTERFACE_FLUX", false,
-      "evaluate integral of coupling flux on slave side for each s2i condition and write it to csv "
-      "file",
-      s2icoupling);
+  s2icoupling.specs.emplace_back(parameter<bool>(
+      "OUTPUT_INTERFACE_FLUX", {.description = "evaluate integral of coupling flux on slave side "
+                                               "for each s2i condition and write it to csv file",
+                                   .default_value = false}));
 
   s2icoupling.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -48,8 +48,8 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           .default_value = false}));
 
   // node-to-segment projection tolerance
-  Core::Utils::double_parameter(
-      "NTSPROJTOL", 0.0, "node-to-segment projection tolerance", s2icoupling);
+  s2icoupling.specs.emplace_back(parameter<double>(
+      "NTSPROJTOL", {.description = "node-to-segment projection tolerance", .default_value = 0.0}));
 
   // flag for evaluation of scatra-scatra interface coupling involving interface layer growth
   Core::Utils::string_to_integral_parameter<GrowthEvaluation>("INTLAYERGROWTH_EVALUATION", "none",
@@ -61,10 +61,10 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   // local Newton-Raphson convergence tolerance for scatra-scatra interface coupling involving
   // interface layer growth
-  Core::Utils::double_parameter("INTLAYERGROWTH_CONVTOL", 1.e-12,
-      "local Newton-Raphson convergence tolerance for scatra-scatra interface coupling involving "
-      "interface layer growth",
-      s2icoupling);
+  s2icoupling.specs.emplace_back(parameter<double>("INTLAYERGROWTH_CONVTOL",
+      {.description = "local Newton-Raphson convergence tolerance for scatra-scatra interface "
+                      "coupling involving interface layer growth",
+          .default_value = 1.e-12}));
 
   // maximum number of local Newton-Raphson iterations for scatra-scatra interface coupling
   // involving interface layer growth
@@ -81,10 +81,10 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       s2icoupling);
 
   // modified time step size for scatra-scatra interface coupling involving interface layer growth
-  Core::Utils::double_parameter("INTLAYERGROWTH_TIMESTEP", -1.,
-      "modified time step size for scatra-scatra interface coupling involving interface layer "
-      "growth",
-      s2icoupling);
+  s2icoupling.specs.emplace_back(parameter<double>("INTLAYERGROWTH_TIMESTEP",
+      {.description = "modified time step size for scatra-scatra interface coupling involving "
+                      "interface layer growth",
+          .default_value = -1.}));
 
   s2icoupling.specs.emplace_back(parameter<bool>("MESHTYING_CONDITIONS_INDEPENDENT_SETUP",
       {.description = "mesh tying for different conditions should be setup independently",

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -48,16 +48,19 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           timeint_stationary, timeint_one_step_theta, timeint_bdf2, timeint_gen_alpha),
       scatradyn);
 
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", scatradyn);
+  scatradyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("NUMSTEP", 20, "Total number of time steps", scatradyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", scatradyn);
-  Core::Utils::double_parameter("THETA", 0.5, "One-step-theta time integration factor", scatradyn);
-  Core::Utils::double_parameter(
-      "ALPHA_M", 0.5, "Generalized-alpha time integration factor", scatradyn);
-  Core::Utils::double_parameter(
-      "ALPHA_F", 0.5, "Generalized-alpha time integration factor", scatradyn);
-  Core::Utils::double_parameter(
-      "GAMMA", 0.5, "Generalized-alpha time integration factor", scatradyn);
+  scatradyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
+  scatradyn.specs.emplace_back(parameter<double>(
+      "THETA", {.description = "One-step-theta time integration factor", .default_value = 0.5}));
+  scatradyn.specs.emplace_back(parameter<double>("ALPHA_M",
+      {.description = "Generalized-alpha time integration factor", .default_value = 0.5}));
+  scatradyn.specs.emplace_back(parameter<double>("ALPHA_F",
+      {.description = "Generalized-alpha time integration factor", .default_value = 0.5}));
+  scatradyn.specs.emplace_back(parameter<double>(
+      "GAMMA", {.description = "Generalized-alpha time integration factor", .default_value = 0.5}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", scatradyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", scatradyn);
   Core::Utils::int_parameter("MATID", -1, "Material ID for automatic mesh generation", scatradyn);
@@ -254,12 +257,12 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<Inpar::ScaTra::FdCheck>(
           fdcheck_none, fdcheck_global, fdcheck_global_extended, fdcheck_local),
       scatradyn);
-  Core::Utils::double_parameter("FDCHECKEPS", 1.e-6,
-      "dof perturbation magnitude for finite difference check (1.e-6 seems to work very well, "
-      "whereas smaller values don't)",
-      scatradyn);
-  Core::Utils::double_parameter(
-      "FDCHECKTOL", 1.e-6, "relative tolerance for finite difference check", scatradyn);
+  scatradyn.specs.emplace_back(parameter<double>(
+      "FDCHECKEPS", {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
+                                    "seems to work very well, whereas smaller values don't)",
+                        .default_value = 1.e-6}));
+  scatradyn.specs.emplace_back(parameter<double>("FDCHECKTOL",
+      {.description = "relative tolerance for finite difference check", .default_value = 1.e-6}));
 
   // parameter for optional computation of domain and boundary integrals, i.e., of surface areas and
   // volumes associated with specified nodesets
@@ -274,10 +277,12 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   // moment only used for HDG and cardiac monodomain problems)
   scatradyn.specs.emplace_back(parameter<bool>(
       "PADAPTIVITY", {.description = "Flag to (de)activate p-adativity", .default_value = false}));
-  Core::Utils::double_parameter("PADAPTERRORTOL", 1e-6,
-      "The error tolerance to calculate the variation of the elemental degree", scatradyn);
-  Core::Utils::double_parameter("PADAPTERRORBASE", 1.66,
-      "The error tolerance base to calculate the variation of the elemental degree", scatradyn);
+  scatradyn.specs.emplace_back(parameter<double>("PADAPTERRORTOL",
+      {.description = "The error tolerance to calculate the variation of the elemental degree",
+          .default_value = 1e-6}));
+  scatradyn.specs.emplace_back(parameter<double>("PADAPTERRORBASE",
+      {.description = "The error tolerance base to calculate the variation of the elemental degree",
+          .default_value = 1.66}));
   Core::Utils::int_parameter(
       "PADAPTDEGREEMAX", 4, "The max. degree of the shape functions", scatradyn);
   scatradyn.specs.emplace_back(parameter<bool>("SEMIIMPLICIT",
@@ -310,31 +315,33 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs scatra_nonlin{scatradyn, "NONLINEAR"};
 
   Core::Utils::int_parameter("ITEMAX", 10, "max. number of nonlin. iterations", scatra_nonlin);
-  Core::Utils::double_parameter("CONVTOL", 1e-6, "Tolerance for convergence check", scatra_nonlin);
+  scatra_nonlin.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-6}));
   Core::Utils::int_parameter("ITEMAX_OUTER", 10,
       "Maximum number of outer iterations in partitioned coupling schemes (natural convection, "
       "multi-scale simulations etc.)",
       scatra_nonlin);
-  Core::Utils::double_parameter("CONVTOL_OUTER", 1e-6,
-      "Convergence check tolerance for outer loop in partitioned coupling schemes (natural "
-      "convection, multi-scale simulations etc.)",
-      scatra_nonlin);
+  scatra_nonlin.specs.emplace_back(parameter<double>("CONVTOL_OUTER",
+      {.description = "Convergence check tolerance for outer loop in partitioned coupling schemes "
+                      "(natural convection, multi-scale simulations etc.)",
+          .default_value = 1e-6}));
   scatra_nonlin.specs.emplace_back(parameter<bool>("EXPLPREDICT",
       {.description = "do an explicit predictor step before starting nonlinear iteration",
           .default_value = false}));
-  Core::Utils::double_parameter("ABSTOLRES", 1e-14,
-      "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
-      scatra_nonlin);
+  scatra_nonlin.specs.emplace_back(parameter<double>("ABSTOLRES",
+      {.description =
+              "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
+          .default_value = 1e-14}));
 
   // convergence criteria adaptivity
   scatra_nonlin.specs.emplace_back(parameter<bool>("ADAPTCONV",
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      scatra_nonlin);
+  scatra_nonlin.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   scatra_nonlin.move_into_collection(list);
 
@@ -417,8 +424,8 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       scatradyn_stab);
 
   // this parameter defines the numerical value, if stabilization with numerical values is used
-  Core::Utils::double_parameter(
-      "TAU_VALUE", 0.0, "Numerical value for tau for stabilization", scatradyn_stab);
+  scatradyn_stab.specs.emplace_back(parameter<double>("TAU_VALUE",
+      {.description = "Numerical value for tau for stabilization", .default_value = 0.0}));
 
   scatradyn_stab.move_into_collection(list);
 
@@ -442,8 +449,8 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       scatradyn_art);
 
   // penalty parameter
-  Core::Utils::double_parameter(
-      "PENALTY", 1000.0, "Penalty parameter for line-based coupling", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<double>("PENALTY",
+      {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}));
 
   // coupled artery dofs for mesh tying
   Core::Utils::string_parameter(

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -146,9 +146,10 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       {.description = "perform approximate boundary flux calculation involving matrix lumping",
           .default_value = true}));
 
-  Core::Utils::string_parameter("WRITEFLUX_IDS", "-1",
-      "Write diffusive/total flux vector fields for these scalar fields only (starting with 1)",
-      scatradyn);
+  scatradyn.specs.emplace_back(parameter<std::string>(
+      "WRITEFLUX_IDS", {.description = "Write diffusive/total flux vector fields for these scalar "
+                                       "fields only (starting with 1)",
+                           .default_value = "-1"}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::OutputScalarType>("OUTPUTSCALARS",
       "none", "Output of total and mean values for transported scalars",
@@ -453,28 +454,28 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}));
 
   // coupled artery dofs for mesh tying
-  Core::Utils::string_parameter(
-      "COUPLEDDOFS_ARTSCATRA", "-1.0", "coupled artery dofs for mesh tying", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_ARTSCATRA",
+      {.description = "coupled artery dofs for mesh tying", .default_value = "-1.0"}));
 
   // coupled porofluid dofs for mesh tying
-  Core::Utils::string_parameter(
-      "COUPLEDDOFS_SCATRA", "-1.0", "coupled porofluid dofs for mesh tying", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_SCATRA",
+      {.description = "coupled porofluid dofs for mesh tying", .default_value = "-1.0"}));
 
   // functions for coupling (arteryscatra part)
-  Core::Utils::string_parameter(
-      "REACFUNCT_ART", "-1", "functions for coupling (arteryscatra part)", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<std::string>("REACFUNCT_ART",
+      {.description = "functions for coupling (arteryscatra part)", .default_value = "-1"}));
 
   // scale for coupling (arteryscatra part)
-  Core::Utils::string_parameter(
-      "SCALEREAC_ART", "0", "scale for coupling (arteryscatra part)", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<std::string>("SCALEREAC_ART",
+      {.description = "scale for coupling (arteryscatra part)", .default_value = "0"}));
 
   // functions for coupling (scatra part)
-  Core::Utils::string_parameter(
-      "REACFUNCT_CONT", "-1", "functions for coupling (scatra part)", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<std::string>("REACFUNCT_CONT",
+      {.description = "functions for coupling (scatra part)", .default_value = "-1"}));
 
   // scale for coupling (scatra part)
-  Core::Utils::string_parameter(
-      "SCALEREAC_CONT", "0", "scale for coupling (scatra part)", scatradyn_art);
+  scatradyn_art.specs.emplace_back(parameter<std::string>(
+      "SCALEREAC_CONT", {.description = "scale for coupling (scatra part)", .default_value = "0"}));
 
   scatradyn_art.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -25,6 +25,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs scatradyn{"SCALAR TRANSPORT DYNAMIC"};
 
@@ -108,7 +109,8 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::int_parameter(
       "INITFUNCNO", -1, "function number for scalar transport initial field", scatradyn);
 
-  Core::Utils::bool_parameter("SPHERICALCOORDS", false, "use of spherical coordinates", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>(
+      "SPHERICALCOORDS", {.description = "use of spherical coordinates", .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::CalcError>("CALCERROR", "No",
       "compute error compared to analytical solution",
@@ -127,8 +129,9 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<std::string>("No", "total", "diffusive"),
       tuple<Inpar::ScaTra::FluxType>(flux_none, flux_total, flux_diffusive), scatradyn);
 
-  Core::Utils::bool_parameter("CALCFLUX_DOMAIN_LUMPED", true,
-      "perform approximate domain flux calculation involving matrix lumping", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("CALCFLUX_DOMAIN_LUMPED",
+      {.description = "perform approximate domain flux calculation involving matrix lumping",
+          .default_value = true}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FluxType>("CALCFLUX_BOUNDARY", "No",
       "output of convective/diffusive/total flux vectors on boundary",
@@ -136,8 +139,9 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<Inpar::ScaTra::FluxType>(flux_none, flux_total, flux_diffusive, flux_convective),
       scatradyn);
 
-  Core::Utils::bool_parameter("CALCFLUX_BOUNDARY_LUMPED", true,
-      "perform approximate boundary flux calculation involving matrix lumping", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("CALCFLUX_BOUNDARY_LUMPED",
+      {.description = "perform approximate boundary flux calculation involving matrix lumping",
+          .default_value = true}));
 
   Core::Utils::string_parameter("WRITEFLUX_IDS", "-1",
       "Write diffusive/total flux vector fields for these scalar fields only (starting with 1)",
@@ -149,28 +153,32 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       tuple<Inpar::ScaTra::OutputScalarType>(outputscalars_none, outputscalars_entiredomain,
           outputscalars_condition, outputscalars_entiredomain_condition),
       scatradyn);
-  Core::Utils::bool_parameter(
-      "OUTPUTSCALARSMEANGRAD", false, "Output of mean gradient of scalars", scatradyn);
-  Core::Utils::bool_parameter(
-      "OUTINTEGRREAC", false, "Output of integral reaction values", scatradyn);
-  Core::Utils::bool_parameter(
-      "OUTPUT_GMSH", false, "Do you want to write Gmsh postprocessing files?", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("OUTPUTSCALARSMEANGRAD",
+      {.description = "Output of mean gradient of scalars", .default_value = false}));
+  scatradyn.specs.emplace_back(parameter<bool>("OUTINTEGRREAC",
+      {.description = "Output of integral reaction values", .default_value = false}));
+  scatradyn.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
+      {.description = "Do you want to write Gmsh postprocessing files?", .default_value = false}));
 
-  Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", false,
-      "Do you want to write the state solution to Matlab file?", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("MATLAB_STATE_OUTPUT",
+      {.description = "Do you want to write the state solution to Matlab file?",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::ConvForm>("CONVFORM", "convective",
       "form of convective term", tuple<std::string>("convective", "conservative"),
       tuple<Inpar::ScaTra::ConvForm>(convform_convective, convform_conservative), scatradyn);
 
-  Core::Utils::bool_parameter(
-      "NEUMANNINFLOW", false, "Flag to (de)activate potential Neumann inflow term(s)", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>(
+      "NEUMANNINFLOW", {.description = "Flag to (de)activate potential Neumann inflow term(s)",
+                           .default_value = false}));
 
-  Core::Utils::bool_parameter("CONV_HEAT_TRANS", false,
-      "Flag to (de)activate potential convective heat transfer boundary conditions", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("CONV_HEAT_TRANS",
+      {.description = "Flag to (de)activate potential convective heat transfer boundary conditions",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "SKIPINITDER", false, "Flag to skip computation of initial time derivative", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>(
+      "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
+                         .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FSSUGRDIFF>("FSSUGRDIFF", "No",
       "fine-scale subgrid diffusivity",
@@ -180,8 +188,9 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       scatradyn);
 
   // flag for output of performance statistics associated with nonlinear solver into *.csv file
-  Core::Utils::bool_parameter("ELECTROMAGNETICDIFFUSION", false,
-      "flag to activate electromagnetic diffusion problems", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("ELECTROMAGNETICDIFFUSION",
+      {.description = "flag to activate electromagnetic diffusion problems",
+          .default_value = false}));
 
   // Current density source function for EMD problems
   Core::Utils::int_parameter("EMDSOURCE", -1, "Current density source", scatradyn);
@@ -229,8 +238,8 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       scatradyn);
 
   // flag for natural convection effects
-  Core::Utils::bool_parameter(
-      "NATURAL_CONVECTION", false, "Include natural convection effects", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("NATURAL_CONVECTION",
+      {.description = "Include natural convection effects", .default_value = false}));
 
   // parameters for finite difference check
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::FdCheck>("FDCHECK", "none",
@@ -263,33 +272,37 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   // parameter for using p-adpativity and semi-implicit evaluation of the reaction term (at the
   // moment only used for HDG and cardiac monodomain problems)
-  Core::Utils::bool_parameter("PADAPTIVITY", false, "Flag to (de)activate p-adativity", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>(
+      "PADAPTIVITY", {.description = "Flag to (de)activate p-adativity", .default_value = false}));
   Core::Utils::double_parameter("PADAPTERRORTOL", 1e-6,
       "The error tolerance to calculate the variation of the elemental degree", scatradyn);
   Core::Utils::double_parameter("PADAPTERRORBASE", 1.66,
       "The error tolerance base to calculate the variation of the elemental degree", scatradyn);
   Core::Utils::int_parameter(
       "PADAPTDEGREEMAX", 4, "The max. degree of the shape functions", scatradyn);
-  Core::Utils::bool_parameter("SEMIIMPLICIT", false,
-      "Flag to (de)activate semi-implicit calculation of the reaction term", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("SEMIIMPLICIT",
+      {.description = "Flag to (de)activate semi-implicit calculation of the reaction term",
+          .default_value = false}));
 
   // flag for output of performance statistics associated with linear solver into *.csv file
-  Core::Utils::bool_parameter("OUTPUTLINSOLVERSTATS", false,
-      "flag for output of performance statistics associated with linear solver into csv file",
-      scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>(
+      "OUTPUTLINSOLVERSTATS", {.description = "flag for output of performance statistics "
+                                              "associated with linear solver into csv file",
+                                  .default_value = false}));
 
   // flag for output of performance statistics associated with nonlinear solver into *.csv file
-  Core::Utils::bool_parameter("OUTPUTNONLINSOLVERSTATS", false,
-      "flag for output of performance statistics associated with nonlinear solver into csv file",
-      scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>(
+      "OUTPUTNONLINSOLVERSTATS", {.description = "flag for output of performance statistics "
+                                                 "associated with nonlinear solver into csv file",
+                                     .default_value = false}));
 
   // flag for point-based null space calculation
-  Core::Utils::bool_parameter(
-      "NULLSPACE_POINTBASED", false, "flag for point-based null space calculation", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("NULLSPACE_POINTBASED",
+      {.description = "flag for point-based null space calculation", .default_value = false}));
 
   // flag for adaptive time stepping
-  Core::Utils::bool_parameter(
-      "ADAPTIVE_TIMESTEPPING", false, "flag for adaptive time stepping", scatradyn);
+  scatradyn.specs.emplace_back(parameter<bool>("ADAPTIVE_TIMESTEPPING",
+      {.description = "flag for adaptive time stepping", .default_value = false}));
 
   scatradyn.move_into_collection(list);
 
@@ -306,16 +319,18 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       "Convergence check tolerance for outer loop in partitioned coupling schemes (natural "
       "convection, multi-scale simulations etc.)",
       scatra_nonlin);
-  Core::Utils::bool_parameter("EXPLPREDICT", false,
-      "do an explicit predictor step before starting nonlinear iteration", scatra_nonlin);
+  scatra_nonlin.specs.emplace_back(parameter<bool>("EXPLPREDICT",
+      {.description = "do an explicit predictor step before starting nonlinear iteration",
+          .default_value = false}));
   Core::Utils::double_parameter("ABSTOLRES", 1e-14,
       "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
       scatra_nonlin);
 
   // convergence criteria adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-      scatra_nonlin);
+  scatra_nonlin.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
@@ -335,14 +350,15 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
       scatradyn_stab);
 
   // this parameter governs whether subgrid-scale velocity is included
-  Core::Utils::bool_parameter(
-      "SUGRVEL", false, "potential incorporation of subgrid-scale velocity", scatradyn_stab);
+  scatradyn_stab.specs.emplace_back(parameter<bool>(
+      "SUGRVEL", {.description = "potential incorporation of subgrid-scale velocity",
+                     .default_value = false}));
 
   // this parameter governs whether all-scale subgrid diffusivity is included
-  Core::Utils::bool_parameter("ASSUGRDIFF", false,
-      "potential incorporation of all-scale subgrid diffusivity (a.k.a. discontinuity-capturing) "
-      "term",
-      scatradyn_stab);
+  scatradyn_stab.specs.emplace_back(parameter<bool>(
+      "ASSUGRDIFF", {.description = "potential incorporation of all-scale subgrid diffusivity "
+                                    "(a.k.a. discontinuity-capturing) term",
+                        .default_value = false}));
 
   // this parameter selects the tau definition applied
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::TauType>("DEFINITION_TAU",
@@ -459,8 +475,8 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs scatradyn_external_force{scatradyn, "EXTERNAL FORCE"};
 
   // Flag for external force
-  Core::Utils::bool_parameter(
-      "EXTERNAL_FORCE", false, "Flag to activate external force", scatradyn_external_force);
+  scatradyn_external_force.specs.emplace_back(parameter<bool>("EXTERNAL_FORCE",
+      {.description = "Flag to activate external force", .default_value = false}));
 
   // Function ID for external force
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_searchtree.cpp
+++ b/src/inpar/4C_inpar_searchtree.cpp
@@ -16,6 +16,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::Geo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs search_tree{"SEARCH TREE"};
 

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -70,8 +70,8 @@ namespace Inpar::SOLVER
           "The amount of fill allowed for an internal \"ilu\" preconditioner.", list);
 
       std::vector<std::string> ifpack_combine_valid_input = {"Add", "Insert", "Zero"};
-      Core::Utils::string_parameter("IFPACKCOMBINE", "Add",
-          "Combine mode for Ifpack Additive Schwarz", list, ifpack_combine_valid_input);
+      list.specs.emplace_back(selection<std::string>("IFPACKCOMBINE", ifpack_combine_valid_input,
+          {.description = "Combine mode for Ifpack Additive Schwarz", .default_value = "Add"}));
     }
 
     // Iterative solver options
@@ -128,14 +128,15 @@ namespace Inpar::SOLVER
     }
 
     // user-given name of solver block (just for beauty)
-    Core::Utils::string_parameter("NAME", "No_name", "User specified name for solver block", list);
+    list.specs.emplace_back(parameter<std::string>("NAME",
+        {.description = "User specified name for solver block", .default_value = "No_name"}));
 
     // Parameters for AMGnxn Preconditioner
     {
-      Core::Utils::string_parameter("AMGNXN_TYPE", "AMG(BGS)",
-          "Name of the pre-built preconditioner to be used. If set to\"XML\" the preconditioner "
-          "is defined using a xml file",
-          list);
+      list.specs.emplace_back(parameter<std::string>(
+          "AMGNXN_TYPE", {.description = "Name of the pre-built preconditioner to be used. If set "
+                                         "to\"XML\" the preconditioner is defined using a xml file",
+                             .default_value = "AMG(BGS)"}));
       list.specs.emplace_back(
           Core::IO::InputSpecBuilders::parameter<Core::IO::Noneable<std::filesystem::path>>(
               "AMGNXN_XML_FILE",

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -18,6 +18,7 @@ namespace Inpar::SOLVER
 {
   void set_valid_solver_parameters(Core::IO::InputSpec& spec)
   {
+    using namespace Core::IO::InputSpecBuilders;
     Core::Utils::SectionSpecs list{"dummy"};
     // Solver options
     {
@@ -80,8 +81,10 @@ namespace Inpar::SOLVER
           "perform",
           list);
 
-      Core::Utils::double_parameter("AZTOL", 1e-8,
-          "The level the residual norms must reach to decide about successful convergence", list);
+      list.specs.emplace_back(parameter<double>("AZTOL",
+          {.description =
+                  "The level the residual norms must reach to decide about successful convergence",
+              .default_value = 1e-8}));
 
       Core::Utils::string_to_integral_parameter<Belos::ScaleType>("AZCONV", "AZ_r0",
           "The implicit residual norm scaling type to use for terminating the iterative solver.",

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -249,8 +249,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     Core::Utils::int_parameter("Maximum Iteration for Increase", 0,
         "Maximum index of the nonlinear iteration for which we allow a relative increase",
         polynomial);
-    polynomial.specs.emplace_back(
-        parameter<double>("Allowed Relative Increase", {.description = "", .default_value = 100}));
+    polynomial.specs.emplace_back(parameter<double>(
+        "Allowed Relative Increase", {.description = "", .default_value = 100.0}));
   }
   polynomial.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /*----------------------------------------------------------------------*
    * parameters for NOX - non-linear solution
@@ -63,11 +64,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     Core::Utils::double_parameter("Forcing Term Maximum Tolerance", 0.01, "", newton);
     Core::Utils::double_parameter("Forcing Term Alpha", 1.5, "used only by \"Type 2\"", newton);
     Core::Utils::double_parameter("Forcing Term Gamma", 0.9, "used only by \"Type 2\"", newton);
-    Core::Utils::bool_parameter("Rescue Bad Newton Solve", true,
-        "If set to true, we will use "
-        "the computed direction even if the linear solve does not achieve the tolerance "
-        "specified by the forcing term",
-        newton);
+    newton.specs.emplace_back(parameter<bool>("Rescue Bad Newton Solve",
+        {.description = "If set to true, we will use the computed direction even if the linear "
+                        "solve does not achieve the tolerance specified by the forcing term",
+            .default_value = true}));
   }
   newton.move_into_collection(list);
 
@@ -166,10 +166,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "A multiplier between zero and one that reduces the step size between line search "
         "iterations",
         backtrack);
-    Core::Utils::bool_parameter("Allow Exceptions", false,
-        "Set to true, if exceptions during the force evaluation and backtracking routine should be "
-        "allowed.",
-        backtrack);
+    backtrack.specs.emplace_back(parameter<bool>("Allow Exceptions",
+        {.description = "Set to true, if exceptions during the force evaluation and backtracking "
+                        "routine should be allowed.",
+            .default_value = false}));
   }
   backtrack.move_into_collection(list);
 
@@ -218,15 +218,15 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     Core::Utils::double_parameter(
         "Alpha Factor", 1.0e-4, "Parameter choice for sufficient decrease condition", polynomial);
-    Core::Utils::bool_parameter("Force Interpolation", false,
-        "Set to true if at least one interpolation step should be used. The default is false which "
-        "means that the line search will stop if the default step length satisfies the convergence "
-        "criteria",
-        polynomial);
-    Core::Utils::bool_parameter("Use Counters", true,
-        "Set to true if we should use counters and then output the result to the parameter list as "
-        "described in Output Parameters",
-        polynomial);
+    polynomial.specs.emplace_back(parameter<bool>("Force Interpolation",
+        {.description = "Set to true if at least one interpolation step should be used. The "
+                        "default is false which means that the line search will stop if the "
+                        "default step length satisfies the convergence criteria",
+            .default_value = false}));
+    polynomial.specs.emplace_back(parameter<bool>("Use Counters",
+        {.description = "Set to true if we should use counters and then output the result to the "
+                        "parameter list as described in Output Parameters",
+            .default_value = true}));
     Core::Utils::int_parameter("Maximum Iteration for Increase", 0,
         "Maximum index of the nonlinear iteration for which we allow a relative increase",
         polynomial);
@@ -269,14 +269,14 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "Choice to use for the sufficient decrease condition", morethuente,
         sufficient_decrease_condition_valid_input);
 
-    Core::Utils::bool_parameter("Optimize Slope Calculation", false,
-        "Boolean value. If set to true the value of $s^T J^T F$ is estimated using a "
-        "directional derivative in a call to ::NOX::LineSearch::Common::computeSlopeWithOutJac. "
-        "If false the slope computation is computed with the "
-        "::NOX::LineSearch::Common::computeSlope method. "
-        "Setting this to true eliminates having to compute the Jacobian at each inner iteration of "
-        "the More'-Thuente line search",
-        morethuente);
+    morethuente.specs.emplace_back(parameter<bool>("Optimize Slope Calculation",
+        {.description = "Boolean value. If set to true the value of $s^T J^T F$ is estimated using "
+                        "a directional derivative in a call to "
+                        "::NOX::LineSearch::Common::computeSlopeWithOutJac. If false the slope "
+                        "computation is computed with the ::NOX::LineSearch::Common::computeSlope "
+                        "method. Setting this to true eliminates having to compute the Jacobian at "
+                        "each inner iteration of the More'-Thuente line search",
+            .default_value = false}));
   }
   morethuente.move_into_collection(list);
 
@@ -309,16 +309,26 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs printing{snox, "Printing"};
 
   {
-    Core::Utils::bool_parameter("Error", false, "", printing);
-    Core::Utils::bool_parameter("Warning", true, "", printing);
-    Core::Utils::bool_parameter("Outer Iteration", true, "", printing);
-    Core::Utils::bool_parameter("Inner Iteration", true, "", printing);
-    Core::Utils::bool_parameter("Parameters", false, "", printing);
-    Core::Utils::bool_parameter("Details", false, "", printing);
-    Core::Utils::bool_parameter("Outer Iteration StatusTest", true, "", printing);
-    Core::Utils::bool_parameter("Linear Solver Details", false, "", printing);
-    Core::Utils::bool_parameter("Test Details", false, "", printing);
-    Core::Utils::bool_parameter("Debug", false, "", printing);
+    printing.specs.emplace_back(
+        parameter<bool>("Error", {.description = "", .default_value = false}));
+    printing.specs.emplace_back(
+        parameter<bool>("Warning", {.description = "", .default_value = true}));
+    printing.specs.emplace_back(
+        parameter<bool>("Outer Iteration", {.description = "", .default_value = true}));
+    printing.specs.emplace_back(
+        parameter<bool>("Inner Iteration", {.description = "", .default_value = true}));
+    printing.specs.emplace_back(
+        parameter<bool>("Parameters", {.description = "", .default_value = false}));
+    printing.specs.emplace_back(
+        parameter<bool>("Details", {.description = "", .default_value = false}));
+    printing.specs.emplace_back(
+        parameter<bool>("Outer Iteration StatusTest", {.description = "", .default_value = true}));
+    printing.specs.emplace_back(
+        parameter<bool>("Linear Solver Details", {.description = "", .default_value = false}));
+    printing.specs.emplace_back(
+        parameter<bool>("Test Details", {.description = "", .default_value = false}));
+    printing.specs.emplace_back(
+        parameter<bool>("Debug", {.description = "", .default_value = false}));
   }
   printing.move_into_collection(list);
 
@@ -356,20 +366,22 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   {
     // convergence criteria adaptivity
-    Core::Utils::bool_parameter("Adaptive Control", false,
-        "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-        linearSolver);
+    linearSolver.specs.emplace_back(parameter<bool>("Adaptive Control",
+        {.description =
+                "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+            .default_value = false}));
     Core::Utils::double_parameter("Adaptive Control Objective", 0.1,
         "The linear solver shall be this much better than the current nonlinear residual in the "
         "nonlinear convergence limit",
         linearSolver);
-    Core::Utils::bool_parameter(
-        "Zero Initial Guess", true, "Zero out the delta X vector if requested.", linearSolver);
-    Core::Utils::bool_parameter("Computing Scaling Manually", false,
-        "Allows the manually scaling of your linear system (not supported at the moment).",
-        linearSolver);
-    Core::Utils::bool_parameter(
-        "Output Solver Details", true, "Switch the linear solver output on and off.", linearSolver);
+    linearSolver.specs.emplace_back(parameter<bool>("Zero Initial Guess",
+        {.description = "Zero out the delta X vector if requested.", .default_value = true}));
+    linearSolver.specs.emplace_back(parameter<bool>("Computing Scaling Manually",
+        {.description =
+                "Allows the manually scaling of your linear system (not supported at the moment).",
+            .default_value = false}));
+    linearSolver.specs.emplace_back(parameter<bool>("Output Solver Details",
+        {.description = "Switch the linear solver output on and off.", .default_value = true}));
   }
   linearSolver.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -29,8 +29,9 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "Pseudo Transient", "Trust Region Based", "Inexact Trust Region Based", "Tensor Based",
         "Single Step"};
 
-    Core::Utils::string_parameter("Nonlinear Solver", "Line Search Based",
-        "Choose a nonlinear solver method.", snox, nonlinear_solver_valid_input);
+    snox.specs.emplace_back(selection<std::string>("Nonlinear Solver", nonlinear_solver_valid_input,
+        {.description = "Choose a nonlinear solver method.",
+            .default_value = "Line Search Based"}));
   }
   snox.move_into_collection(list);
 
@@ -40,13 +41,15 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     std::vector<std::string> newton_method_valid_input = {
         "Newton", "Steepest Descent", "NonlinearCG", "Broyden", "User Defined"};
-    Core::Utils::string_parameter("Method", "Newton",
-        "Choose a direction method for the nonlinear solver.", direction,
-        newton_method_valid_input);
+    direction.specs.emplace_back(selection<std::string>("Method", newton_method_valid_input,
+        {.description = "Choose a direction method for the nonlinear solver.",
+            .default_value = "Newton"}));
 
     std::vector<std::string> user_defined_method_valid_input = {"Newton", "Modified Newton"};
-    Core::Utils::string_parameter("User Defined Method", "Modified Newton",
-        "Choose a user-defined direction method.", direction, user_defined_method_valid_input);
+    direction.specs.emplace_back(
+        selection<std::string>("User Defined Method", user_defined_method_valid_input,
+            {.description = "Choose a user-defined direction method.",
+                .default_value = "Modified Newton"}));
   }
   direction.move_into_collection(list);
 
@@ -55,8 +58,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   {
     std::vector<std::string> forcing_term_valid_input = {"Constant", "Type 1", "Type 2"};
-    Core::Utils::string_parameter(
-        "Forcing Term Method", "Constant", "", newton, forcing_term_valid_input);
+    newton.specs.emplace_back(selection<std::string>("Forcing Term Method",
+        forcing_term_valid_input, {.description = "", .default_value = "Constant"}));
 
     newton.specs.emplace_back(parameter<double>("Forcing Term Initial Tolerance",
         {.description = "initial linear solver tolerance", .default_value = 0.1}));
@@ -79,8 +82,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     std::vector<std::string> scaling_type_valid_input = {
         "2-Norm", "Quadratic Model Min", "F 2-Norm", "None"};
-    Core::Utils::string_parameter(
-        "Scaling Type", "None", "", steepestdescent, scaling_type_valid_input);
+    steepestdescent.specs.emplace_back(selection<std::string>(
+        "Scaling Type", scaling_type_valid_input, {.description = "", .default_value = "None"}));
   }
   steepestdescent.move_into_collection(list);
 
@@ -109,21 +112,24 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     std::vector<std::string> time_step_control_valid_input = {"SER",
         "Switched Evolution Relaxation", "TTE", "Temporal Truncation Error", "MRR",
         "Model Reduction Ratio"};
-    Core::Utils::string_parameter(
-        "Time Step Control", "SER", "", ptc, time_step_control_valid_input);
+    ptc.specs.emplace_back(selection<std::string>("Time Step Control",
+        time_step_control_valid_input, {.description = "", .default_value = "SER"}));
 
     std::vector<std::string> tsc_norm_type_valid_input = {"Two Norm", "One Norm", "Max Norm"};
-    Core::Utils::string_parameter("Norm Type for TSC", "Max Norm",
-        "Norm Type for the time step control", ptc, tsc_norm_type_valid_input);
+    ptc.specs.emplace_back(selection<std::string>("Norm Type for TSC", tsc_norm_type_valid_input,
+        {.description = "Norm Type for the time step control", .default_value = "Max Norm"}));
 
     std::vector<std::string> scaling_op_valid_input = {
         "Identity", "CFL Diagonal", "Lumped Mass", "Element based"};
-    Core::Utils::string_parameter("Scaling Type", "Identity",
-        "Type of the scaling matrix for the PTC method.", ptc, scaling_op_valid_input);
+    ptc.specs.emplace_back(selection<std::string>("Scaling Type", scaling_op_valid_input,
+        {.description = "Type of the scaling matrix for the PTC method.",
+            .default_value = "Identity"}));
 
     std::vector<std::string> build_scale_op_valid_input = {"every iter", "every timestep"};
-    Core::Utils::string_parameter("Build scaling operator", "every timestep",
-        "Build scaling operator in every iteration or timestep", ptc, build_scale_op_valid_input);
+    ptc.specs.emplace_back(
+        selection<std::string>("Build scaling operator", build_scale_op_valid_input,
+            {.description = "Build scaling operator in every iteration or timestep",
+                .default_value = "every timestep"}));
   }
   ptc.move_into_collection(list);
 
@@ -133,7 +139,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     std::vector<std::string> method_valid_input = {
         "Full Step", "Backtrack", "Polynomial", "More'-Thuente", "User Defined"};
-    Core::Utils::string_parameter("Method", "Full Step", "", linesearch, method_valid_input);
+    linesearch.specs.emplace_back(selection<std::string>(
+        "Method", method_valid_input, {.description = "", .default_value = "Full Step"}));
 
 
     Teuchos::Array<std::string> checktypes =
@@ -196,9 +203,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                             .default_value = 1.0e-12}));
 
     std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
-    Core::Utils::string_parameter("Recovery Step Type", "Constant",
-        "Determines the step size to take when the line search fails", polynomial,
-        recovery_step_type_valid_input);
+    polynomial.specs.emplace_back(
+        selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
+            {.description = "Determines the step size to take when the line search fails",
+                .default_value = "Constant"}));
 
     Core::Utils::double_parameter("Recovery Step", 1.0,
         "The value of the step to take when the line search fails. Only used if the \"Recovery "
@@ -206,8 +214,9 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         polynomial);
 
     std::vector<std::string> interpolation_type_valid_input = {"Quadratic", "Quadratic3", "Cubic"};
-    Core::Utils::string_parameter("Interpolation Type", "Cubic",
-        "Type of interpolation that should be used", polynomial, interpolation_type_valid_input);
+    polynomial.specs.emplace_back(selection<std::string>("Interpolation Type",
+        interpolation_type_valid_input,
+        {.description = "Type of interpolation that should be used", .default_value = "Cubic"}));
 
     polynomial.specs.emplace_back(parameter<double>("Min Bounds Factor",
         {.description = "Choice for $\\gamma_{\\min}$, i.e., the factor that limits the minimum "
@@ -220,9 +229,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     std::vector<std::string> sufficient_decrease_condition_valid_input = {
         "Armijo-Goldstein", "Ared/Pred", "None"};
-    Core::Utils::string_parameter("Sufficient Decrease Condition", "Armijo-Goldstein",
-        "Choice to use for the sufficient decrease condition", polynomial,
-        sufficient_decrease_condition_valid_input);
+    polynomial.specs.emplace_back(selection<std::string>("Sufficient Decrease Condition",
+        sufficient_decrease_condition_valid_input,
+        {.description = "Choice to use for the sufficient decrease condition",
+            .default_value = "Armijo-Goldstein"}));
 
     polynomial.specs.emplace_back(parameter<double>(
         "Alpha Factor", {.description = "Parameter choice for sufficient decrease condition",
@@ -266,9 +276,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "Default Step", {.description = "starting step length", .default_value = 1.0}));
 
     std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
-    Core::Utils::string_parameter("Recovery Step Type", "Constant",
-        "Determines the step size to take when the line search fails", morethuente,
-        recovery_step_type_valid_input);
+    morethuente.specs.emplace_back(
+        selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
+            {.description = "Determines the step size to take when the line search fails",
+                .default_value = "Constant"}));
 
     Core::Utils::double_parameter("Recovery Step", 1.0,
         "The value of the step to take when the line search fails. Only used if the \"Recovery "
@@ -277,9 +288,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     std::vector<std::string> sufficient_decrease_condition_valid_input = {
         "Armijo-Goldstein", "Ared/Pred", "None"};
-    Core::Utils::string_parameter("Sufficient Decrease Condition", "Armijo-Goldstein",
-        "Choice to use for the sufficient decrease condition", morethuente,
-        sufficient_decrease_condition_valid_input);
+    morethuente.specs.emplace_back(selection<std::string>("Sufficient Decrease Condition",
+        sufficient_decrease_condition_valid_input,
+        {.description = "Choice to use for the sufficient decrease condition",
+            .default_value = "Armijo-Goldstein"}));
 
     morethuente.specs.emplace_back(parameter<bool>("Optimize Slope Calculation",
         {.description = "Boolean value. If set to true the value of $s^T J^T F$ is estimated using "
@@ -371,8 +383,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         solverOptions);
 
     std::vector<std::string> status_test_check_type_valid_input = {"Complete", "Minimal", "None"};
-    Core::Utils::string_parameter("Status Test Check Type", "Complete", "", solverOptions,
-        status_test_check_type_valid_input);
+    solverOptions.specs.emplace_back(selection<std::string>("Status Test Check Type",
+        status_test_check_type_valid_input, {.description = "", .default_value = "Complete"}));
   }
   solverOptions.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -58,10 +58,12 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     Core::Utils::string_parameter(
         "Forcing Term Method", "Constant", "", newton, forcing_term_valid_input);
 
-    Core::Utils::double_parameter(
-        "Forcing Term Initial Tolerance", 0.1, "initial linear solver tolerance", newton);
-    Core::Utils::double_parameter("Forcing Term Minimum Tolerance", 1.0e-6, "", newton);
-    Core::Utils::double_parameter("Forcing Term Maximum Tolerance", 0.01, "", newton);
+    newton.specs.emplace_back(parameter<double>("Forcing Term Initial Tolerance",
+        {.description = "initial linear solver tolerance", .default_value = 0.1}));
+    newton.specs.emplace_back(parameter<double>(
+        "Forcing Term Minimum Tolerance", {.description = "", .default_value = 1.0e-6}));
+    newton.specs.emplace_back(parameter<double>(
+        "Forcing Term Maximum Tolerance", {.description = "", .default_value = 0.01}));
     Core::Utils::double_parameter("Forcing Term Alpha", 1.5, "used only by \"Type 2\"", newton);
     Core::Utils::double_parameter("Forcing Term Gamma", 0.9, "used only by \"Type 2\"", newton);
     newton.specs.emplace_back(parameter<bool>("Rescue Bad Newton Solve",
@@ -86,20 +88,23 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs ptc{snox, "Pseudo Transient"};
 
   {
-    Core::Utils::double_parameter("deltaInit", -1.0,
-        "Initial time step size. If its negative, the initial time step is calculated "
-        "automatically.",
-        ptc);
+    ptc.specs.emplace_back(parameter<double>(
+        "deltaInit", {.description = "Initial time step size. If its negative, the initial time "
+                                     "step is calculated automatically.",
+                         .default_value = -1.0}));
     Core::Utils::double_parameter("deltaMax", std::numeric_limits<double>::max(),
         "Maximum time step size. "
         "If the new step size is greater than this value, the transient terms will be eliminated "
         "from the Newton iteration resulting in a full Newton solve.",
         ptc);
-    Core::Utils::double_parameter("deltaMin", 1.0e-5, "Minimum step size.", ptc);
+    ptc.specs.emplace_back(parameter<double>(
+        "deltaMin", {.description = "Minimum step size.", .default_value = 1.0e-5}));
     Core::Utils::int_parameter(
         "Max Number of PTC Iterations", std::numeric_limits<int>::max(), "", ptc);
-    Core::Utils::double_parameter("SER_alpha", 1.0, "Exponent of SET.", ptc);
-    Core::Utils::double_parameter("ScalingFactor", 1.0, "Scaling Factor for ptc matrix.", ptc);
+    ptc.specs.emplace_back(
+        parameter<double>("SER_alpha", {.description = "Exponent of SET.", .default_value = 1.0}));
+    ptc.specs.emplace_back(parameter<double>(
+        "ScalingFactor", {.description = "Scaling Factor for ptc matrix.", .default_value = 1.0}));
 
     std::vector<std::string> time_step_control_valid_input = {"SER",
         "Switched Evolution Relaxation", "TTE", "Temporal Truncation Error", "MRR",
@@ -146,7 +151,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs fullstep{linesearch, "Full Step"};
 
   {
-    Core::Utils::double_parameter("Full Step", 1.0, "length of a full step", fullstep);
+    fullstep.specs.emplace_back(parameter<double>(
+        "Full Step", {.description = "length of a full step", .default_value = 1.0}));
   }
   fullstep.move_into_collection(list);
 
@@ -154,18 +160,19 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs backtrack{linesearch, "Backtrack"};
 
   {
-    Core::Utils::double_parameter("Default Step", 1.0, "starting step length", backtrack);
-    Core::Utils::double_parameter(
-        "Minimum Step", 1.0e-12, "minimum acceptable step length", backtrack);
+    backtrack.specs.emplace_back(parameter<double>(
+        "Default Step", {.description = "starting step length", .default_value = 1.0}));
+    backtrack.specs.emplace_back(parameter<double>("Minimum Step",
+        {.description = "minimum acceptable step length", .default_value = 1.0e-12}));
     Core::Utils::double_parameter("Recovery Step", 1.0,
         "step to take when the line search fails (defaults to value for \"Default Step\")",
         backtrack);
     Core::Utils::int_parameter(
         "Max Iters", 50, "maximum number of iterations (i.e., RHS computations)", backtrack);
-    Core::Utils::double_parameter("Reduction Factor", 0.5,
-        "A multiplier between zero and one that reduces the step size between line search "
-        "iterations",
-        backtrack);
+    backtrack.specs.emplace_back(parameter<double>(
+        "Reduction Factor", {.description = "A multiplier between zero and one that reduces the "
+                                            "step size between line search iterations",
+                                .default_value = 0.5}));
     backtrack.specs.emplace_back(parameter<bool>("Allow Exceptions",
         {.description = "Set to true, if exceptions during the force evaluation and backtracking "
                         "routine should be allowed.",
@@ -177,15 +184,16 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs polynomial{linesearch, "Polynomial"};
 
   {
-    Core::Utils::double_parameter("Default Step", 1.0, "Starting step length", polynomial);
+    polynomial.specs.emplace_back(parameter<double>(
+        "Default Step", {.description = "Starting step length", .default_value = 1.0}));
     Core::Utils::int_parameter("Max Iters", 100,
         "Maximum number of line search iterations. "
         "The search fails if the number of iterations exceeds this value",
         polynomial);
-    Core::Utils::double_parameter("Minimum Step", 1.0e-12,
-        "Minimum acceptable step length. The search fails if the computed $\\lambda_k$ "
-        "is less than this value",
-        polynomial);
+    polynomial.specs.emplace_back(parameter<double>(
+        "Minimum Step", {.description = "Minimum acceptable step length. The search fails if the "
+                                        "computed $\\lambda_k$ is less than this value",
+                            .default_value = 1.0e-12}));
 
     std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
     Core::Utils::string_parameter("Recovery Step Type", "Constant",
@@ -201,14 +209,14 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     Core::Utils::string_parameter("Interpolation Type", "Cubic",
         "Type of interpolation that should be used", polynomial, interpolation_type_valid_input);
 
-    Core::Utils::double_parameter("Min Bounds Factor", 0.1,
-        "Choice for $\\gamma_{\\min}$, i.e., the factor that limits the minimum size "
-        "of the new step based on the previous step",
-        polynomial);
-    Core::Utils::double_parameter("Max Bounds Factor", 0.5,
-        "Choice for $\\gamma_{\\max}$, i.e., the factor that limits the maximum size "
-        "of the new step based on the previous step",
-        polynomial);
+    polynomial.specs.emplace_back(parameter<double>("Min Bounds Factor",
+        {.description = "Choice for $\\gamma_{\\min}$, i.e., the factor that limits the minimum "
+                        "size of the new step based on the previous step",
+            .default_value = 0.1}));
+    polynomial.specs.emplace_back(parameter<double>("Max Bounds Factor",
+        {.description = "Choice for $\\gamma_{\\max}$, i.e., the factor that limits the maximum "
+                        "size of the new step based on the previous step",
+            .default_value = 0.5}));
 
     std::vector<std::string> sufficient_decrease_condition_valid_input = {
         "Armijo-Goldstein", "Ared/Pred", "None"};
@@ -216,8 +224,9 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "Choice to use for the sufficient decrease condition", polynomial,
         sufficient_decrease_condition_valid_input);
 
-    Core::Utils::double_parameter(
-        "Alpha Factor", 1.0e-4, "Parameter choice for sufficient decrease condition", polynomial);
+    polynomial.specs.emplace_back(parameter<double>(
+        "Alpha Factor", {.description = "Parameter choice for sufficient decrease condition",
+                            .default_value = 1.0e-4}));
     polynomial.specs.emplace_back(parameter<bool>("Force Interpolation",
         {.description = "Set to true if at least one interpolation step should be used. The "
                         "default is false which means that the line search will stop if the "
@@ -230,7 +239,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     Core::Utils::int_parameter("Maximum Iteration for Increase", 0,
         "Maximum index of the nonlinear iteration for which we allow a relative increase",
         polynomial);
-    Core::Utils::double_parameter("Allowed Relative Increase", 100, "", polynomial);
+    polynomial.specs.emplace_back(
+        parameter<double>("Allowed Relative Increase", {.description = "", .default_value = 100}));
   }
   polynomial.move_into_collection(list);
 
@@ -238,20 +248,22 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs morethuente{linesearch, "More'-Thuente"};
 
   {
-    Core::Utils::double_parameter("Sufficient Decrease", 1.0e-4,
-        "The ftol in the sufficient decrease condition", morethuente);
-    Core::Utils::double_parameter(
-        "Curvature Condition", 0.9999, "The gtol in the curvature condition", morethuente);
-    Core::Utils::double_parameter("Interval Width", 1.0e-15,
-        "The maximum width of the interval containing the minimum of the modified function",
-        morethuente);
-    Core::Utils::double_parameter(
-        "Maximum Step", 1.0e6, "maximum allowable step length", morethuente);
-    Core::Utils::double_parameter(
-        "Minimum Step", 1.0e-12, "minimum allowable step length", morethuente);
+    morethuente.specs.emplace_back(parameter<double>("Sufficient Decrease",
+        {.description = "The ftol in the sufficient decrease condition", .default_value = 1.0e-4}));
+    morethuente.specs.emplace_back(parameter<double>("Curvature Condition",
+        {.description = "The gtol in the curvature condition", .default_value = 0.9999}));
+    morethuente.specs.emplace_back(parameter<double>("Interval Width",
+        {.description =
+                "The maximum width of the interval containing the minimum of the modified function",
+            .default_value = 1.0e-15}));
+    morethuente.specs.emplace_back(parameter<double>(
+        "Maximum Step", {.description = "maximum allowable step length", .default_value = 1.0e6}));
+    morethuente.specs.emplace_back(parameter<double>("Minimum Step",
+        {.description = "minimum allowable step length", .default_value = 1.0e-12}));
     Core::Utils::int_parameter("Max Iters", 20,
         "maximum number of right-hand-side and corresponding Jacobian evaluations", morethuente);
-    Core::Utils::double_parameter("Default Step", 1.0, "starting step length", morethuente);
+    morethuente.specs.emplace_back(parameter<double>(
+        "Default Step", {.description = "starting step length", .default_value = 1.0}));
 
     std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
     Core::Utils::string_parameter("Recovery Step Type", "Constant",
@@ -284,24 +296,27 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   Core::Utils::SectionSpecs trustregion{snox, "Trust Region"};
 
   {
-    Core::Utils::double_parameter("Minimum Trust Region Radius", 1.0e-6,
-        "Minimum allowable trust region radius", trustregion);
-    Core::Utils::double_parameter("Maximum Trust Region Radius", 1.0e+9,
-        "Maximum allowable trust region radius", trustregion);
-    Core::Utils::double_parameter("Minimum Improvement Ratio", 1.0e-4,
-        "Minimum improvement ratio to accept the step", trustregion);
+    trustregion.specs.emplace_back(parameter<double>("Minimum Trust Region Radius",
+        {.description = "Minimum allowable trust region radius", .default_value = 1.0e-6}));
+    trustregion.specs.emplace_back(parameter<double>("Maximum Trust Region Radius",
+        {.description = "Maximum allowable trust region radius", .default_value = 1.0e+9}));
+    trustregion.specs.emplace_back(parameter<double>("Minimum Improvement Ratio",
+        {.description = "Minimum improvement ratio to accept the step", .default_value = 1.0e-4}));
     Core::Utils::double_parameter("Contraction Trigger Ratio", 0.1,
         "If the improvement ratio is less than this value, then the trust region is contracted by "
         "the amount specified by the \"Contraction Factor\". Must be larger than \"Minimum "
         "Improvement Ratio\"",
         trustregion);
-    Core::Utils::double_parameter("Contraction Factor", 0.25, "", trustregion);
+    trustregion.specs.emplace_back(
+        parameter<double>("Contraction Factor", {.description = "", .default_value = 0.25}));
     Core::Utils::double_parameter("Expansion Trigger Ratio", 0.75,
         "If the improvement ratio is greater than this value, then the trust region is contracted "
         "by the amount specified by the \"Expansion Factor\"",
         trustregion);
-    Core::Utils::double_parameter("Expansion Factor", 4.0, "", trustregion);
-    Core::Utils::double_parameter("Recovery Step", 1.0, "", trustregion);
+    trustregion.specs.emplace_back(
+        parameter<double>("Expansion Factor", {.description = "", .default_value = 4.0}));
+    trustregion.specs.emplace_back(
+        parameter<double>("Recovery Step", {.description = "", .default_value = 1.0}));
   }
   trustregion.move_into_collection(list);
 
@@ -370,10 +385,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         {.description =
                 "Switch on adaptive control of linear solver tolerance for nonlinear solution",
             .default_value = false}));
-    Core::Utils::double_parameter("Adaptive Control Objective", 0.1,
-        "The linear solver shall be this much better than the current nonlinear residual in the "
-        "nonlinear convergence limit",
-        linearSolver);
+    linearSolver.specs.emplace_back(parameter<double>("Adaptive Control Objective",
+        {.description = "The linear solver shall be this much better than the current nonlinear "
+                        "residual in the nonlinear convergence limit",
+            .default_value = 0.1}));
     linearSolver.specs.emplace_back(parameter<bool>("Zero Initial Guess",
         {.description = "Zero out the delta X vector if requested.", .default_value = true}));
     linearSolver.specs.emplace_back(parameter<bool>("Computing Scaling Manually",

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -45,8 +45,9 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       {.description = "read scatra result from restart files (use option 'restartfromfile' during "
                       "execution of 4C)",
           .default_value = false}));
-  Core::Utils::string_parameter(
-      "SCATRA_FILENAME", "nil", "Control-file name for reading scatra results in SSI", ssidyn);
+  ssidyn.specs.emplace_back(parameter<std::string>(
+      "SCATRA_FILENAME", {.description = "Control-file name for reading scatra results in SSI",
+                             .default_value = "nil"}));
 
   // Type of coupling strategy between the two fields
   Core::Utils::string_to_integral_parameter<FieldCoupling>("FIELDCOUPLING", "volume_matching",

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -20,6 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs ssidyn{"SSI CONTROL"};
 
@@ -32,15 +33,15 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", ssidyn);
   Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", ssidyn);
   Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", ssidyn);
-  Core::Utils::bool_parameter(
-      "DIFFTIMESTEPSIZE", false, "use different step size for scatra and solid", ssidyn);
+  ssidyn.specs.emplace_back(parameter<bool>("DIFFTIMESTEPSIZE",
+      {.description = "use different step size for scatra and solid", .default_value = false}));
   Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", ssidyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ssidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ssidyn);
-  Core::Utils::bool_parameter("SCATRA_FROM_RESTART_FILE", false,
-      "read scatra result from restart files (use option 'restartfromfile' during execution of "
-      "4C)",
-      ssidyn);
+  ssidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",
+      {.description = "read scatra result from restart files (use option 'restartfromfile' during "
+                      "execution of 4C)",
+          .default_value = false}));
   Core::Utils::string_parameter(
       "SCATRA_FILENAME", "nil", "Control-file name for reading scatra results in SSI", ssidyn);
 
@@ -84,17 +85,20 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       ssidyn);
 
   // Restart from Structure problem instead of SSI
-  Core::Utils::bool_parameter("RESTART_FROM_STRUCTURE", false,
-      "restart from structure problem (e.g. from prestress calculations) instead of ssi", ssidyn);
+  ssidyn.specs.emplace_back(parameter<bool>("RESTART_FROM_STRUCTURE",
+      {.description =
+              "restart from structure problem (e.g. from prestress calculations) instead of ssi",
+          .default_value = false}));
 
   // Adaptive time stepping
-  Core::Utils::bool_parameter(
-      "ADAPTIVE_TIMESTEPPING", false, "flag for adaptive time stepping", ssidyn);
+  ssidyn.specs.emplace_back(parameter<bool>("ADAPTIVE_TIMESTEPPING",
+      {.description = "flag for adaptive time stepping", .default_value = false}));
 
   // do redistribution by binning of solid mechanics discretization (scatra dis is cloned from solid
   // dis for volume_matching and volumeboundary_matching)
-  Core::Utils::bool_parameter("REDISTRIBUTE_SOLID", false,
-      "redistribution by binning of solid mechanics discretization", ssidyn);
+  ssidyn.specs.emplace_back(parameter<bool>("REDISTRIBUTE_SOLID",
+      {.description = "redistribution by binning of solid mechanics discretization",
+          .default_value = false}));
 
   ssidyn.move_into_collection(list);
 
@@ -177,10 +181,10 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Core::LinAlg::EquilibrationMethod::symmetry),
       ssidynmono);
 
-  Core::Utils::bool_parameter("PRINT_MAT_RHS_MAP_MATLAB", false,
-      "print system matrix, rhs vector, and full map to matlab readable file after solution of "
-      "time step",
-      ssidynmono);
+  ssidynmono.specs.emplace_back(parameter<bool>("PRINT_MAT_RHS_MAP_MATLAB",
+      {.description = "print system matrix, rhs vector, and full map to matlab readable file after "
+                      "solution of time step",
+          .default_value = false}));
 
   Core::Utils::double_parameter("RELAX_LIN_SOLVER_TOLERANCE", 1.0,
       "relax the tolerance of the linear solver in case it is an iterative solver by scaling the "
@@ -199,11 +203,12 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   Core::Utils::SectionSpecs ssidynmanifold{ssidyn, "MANIFOLD"};
 
-  Core::Utils::bool_parameter(
-      "ADD_MANIFOLD", false, "activate additional manifold?", ssidynmanifold);
+  ssidynmanifold.specs.emplace_back(parameter<bool>(
+      "ADD_MANIFOLD", {.description = "activate additional manifold?", .default_value = false}));
 
-  Core::Utils::bool_parameter("MESHTYING_MANIFOLD", false,
-      "activate meshtying between all manifold fields in case they intersect?", ssidynmanifold);
+  ssidynmanifold.specs.emplace_back(parameter<bool>("MESHTYING_MANIFOLD",
+      {.description = "activate meshtying between all manifold fields in case they intersect?",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<Inpar::ScaTra::InitialField>("INITIALFIELD",
       "zero_field", "Initial field for scalar transport on manifold",
@@ -218,10 +223,10 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::int_parameter(
       "LINEAR_SOLVER", -1, "linear solver for scalar transport on manifold", ssidynmanifold);
 
-  Core::Utils::bool_parameter("OUTPUT_INFLOW", false,
-      "write output of inflow of scatra manifold - scatra coupling into scatra manifold to csv "
-      "file",
-      ssidynmanifold);
+  ssidynmanifold.specs.emplace_back(parameter<bool>(
+      "OUTPUT_INFLOW", {.description = "write output of inflow of scatra manifold - scatra "
+                                       "coupling into scatra manifold to csv file",
+                           .default_value = false}));
 
   ssidynmanifold.move_into_collection(list);
 
@@ -229,8 +234,9 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   /* parameters for SSI with elch */
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs ssidynelch{ssidyn, "ELCH"};
-  Core::Utils::bool_parameter("INITPOTCALC", false,
-      "Automatically calculate initial field for electric potential", ssidynelch);
+  ssidynelch.specs.emplace_back(parameter<bool>(
+      "INITPOTCALC", {.description = "Automatically calculate initial field for electric potential",
+                         .default_value = false}));
 
   ssidynelch.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -26,7 +26,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   // Output type
   ssidyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0}));
+      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0.0}));
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", ssidyn);
   // Time loop control
@@ -34,11 +34,11 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   ssidyn.specs.emplace_back(parameter<double>(
       "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
   ssidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
   ssidyn.specs.emplace_back(parameter<bool>("DIFFTIMESTEPSIZE",
       {.description = "use different step size for scatra and solid", .default_value = false}));
   ssidyn.specs.emplace_back(parameter<double>(
-      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
+      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0.0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ssidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ssidyn);
   ssidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -25,17 +25,20 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ssidyn{"SSI CONTROL"};
 
   // Output type
-  Core::Utils::double_parameter(
-      "RESTARTEVERYTIME", 0, "write restart possibility every RESTARTEVERY steps", ssidyn);
+  ssidyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
+      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0}));
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", ssidyn);
   // Time loop control
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", ssidyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", ssidyn);
-  Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", ssidyn);
+  ssidyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  ssidyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
   ssidyn.specs.emplace_back(parameter<bool>("DIFFTIMESTEPSIZE",
       {.description = "use different step size for scatra and solid", .default_value = false}));
-  Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", ssidyn);
+  ssidyn.specs.emplace_back(parameter<double>(
+      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", ssidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", ssidyn);
   ssidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",
@@ -108,15 +111,17 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ssidynpart{ssidyn, "PARTITIONED"};
 
   // Solver parameter for relaxation of iterative staggered partitioned SSI
-  Core::Utils::double_parameter(
-      "MAXOMEGA", 10.0, "largest omega allowed for Aitken relaxation", ssidynpart);
-  Core::Utils::double_parameter(
-      "MINOMEGA", 0.1, "smallest omega allowed for Aitken relaxation", ssidynpart);
-  Core::Utils::double_parameter("STARTOMEGA", 1.0, "fixed relaxation parameter", ssidynpart);
+  ssidynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
+      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
+  ssidynpart.specs.emplace_back(parameter<double>("MINOMEGA",
+      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
+  ssidynpart.specs.emplace_back(parameter<double>(
+      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
 
   // convergence tolerance of outer iteration loop
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "tolerance for convergence check of outer iteration within partitioned SSI", ssidynpart);
+  ssidynpart.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description = "tolerance for convergence check of outer iteration within partitioned SSI",
+          .default_value = 1e-6}));
 
   ssidynpart.move_into_collection(list);
 
@@ -126,12 +131,14 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs ssidynmono{ssidyn, "MONOLITHIC"};
 
   // convergence tolerances of Newton-Raphson iteration loop
-  Core::Utils::double_parameter("ABSTOLRES", 1.e-14,
-      "absolute tolerance for deciding if global residual of nonlinear problem is already zero",
-      ssidynmono);
-  Core::Utils::double_parameter("CONVTOL", 1.e-6,
-      "tolerance for convergence check of Newton-Raphson iteration within monolithic SSI",
-      ssidynmono);
+  ssidynmono.specs.emplace_back(parameter<double>(
+      "ABSTOLRES", {.description = "absolute tolerance for deciding if global residual of "
+                                   "nonlinear problem is already zero",
+                       .default_value = 1.e-14}));
+  ssidynmono.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description =
+              "tolerance for convergence check of Newton-Raphson iteration within monolithic SSI",
+          .default_value = 1.e-6}));
 
   // ID of linear solver for global system of equations
   Core::Utils::int_parameter(
@@ -186,10 +193,10 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
                       "solution of time step",
           .default_value = false}));
 
-  Core::Utils::double_parameter("RELAX_LIN_SOLVER_TOLERANCE", 1.0,
-      "relax the tolerance of the linear solver in case it is an iterative solver by scaling the "
-      "convergence tolerance with factor RELAX_LIN_SOLVER_TOLERANCE",
-      ssidynmono);
+  ssidynmono.specs.emplace_back(parameter<double>("RELAX_LIN_SOLVER_TOLERANCE",
+      {.description = "relax the tolerance of the linear solver in case it is an iterative solver "
+                      "by scaling the convergence tolerance with factor RELAX_LIN_SOLVER_TOLERANCE",
+          .default_value = 1.0}));
 
   Core::Utils::int_parameter("RELAX_LIN_SOLVER_STEP", -1,
       "relax the tolerance of the linear solver within the first RELAX_LIN_SOLVER_STEP steps",

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -32,7 +32,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   sstidyn.specs.emplace_back(parameter<double>(
       "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
   sstidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
   sstidyn.specs.emplace_back(parameter<double>(
       "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", sstidyn);
@@ -41,8 +41,9 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       {.description = "read scatra result from restart files (use option 'restartfromfile' during "
                       "execution of 4C)",
           .default_value = false}));
-  Core::Utils::string_parameter(
-      "SCATRA_FILENAME", "nil", "Control-file name for reading scatra results in SSTI", sstidyn);
+  sstidyn.specs.emplace_back(parameter<std::string>(
+      "SCATRA_FILENAME", {.description = "Control-file name for reading scatra results in SSTI",
+                             .default_value = "nil"}));
   Core::Utils::string_to_integral_parameter<SolutionScheme>("COUPALGO", "ssti_Monolithic",
       "Coupling strategies for SSTI solvers", tuple<std::string>("ssti_Monolithic"),
       tuple<Inpar::SSTI::SolutionScheme>(SolutionScheme::monolithic), sstidyn);

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -24,14 +24,17 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
 
   Core::Utils::SectionSpecs sstidyn{"SSTI CONTROL"};
 
-  Core::Utils::double_parameter(
-      "RESTARTEVERYTIME", 0, "write restart possibility every RESTARTEVERY steps", sstidyn);
+  sstidyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
+      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0}));
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", sstidyn);
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", sstidyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", sstidyn);
-  Core::Utils::double_parameter("TIMESTEP", -1, "time step size dt", sstidyn);
-  Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", sstidyn);
+  sstidyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  sstidyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1}));
+  sstidyn.specs.emplace_back(parameter<double>(
+      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", sstidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", sstidyn);
   sstidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",
@@ -56,12 +59,14 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   /* parameters for monolithic SSTI                                       */
   /*----------------------------------------------------------------------*/
   Core::Utils::SectionSpecs sstidynmono{sstidyn, "MONOLITHIC"};
-  Core::Utils::double_parameter("ABSTOLRES", 1.0e-14,
-      "absolute tolerance for deciding if global residual of nonlinear problem is already zero",
-      sstidynmono);
-  Core::Utils::double_parameter("CONVTOL", 1.0e-6,
-      "tolerance for convergence check of Newton-Raphson iteration within monolithic SSI",
-      sstidynmono);
+  sstidynmono.specs.emplace_back(parameter<double>(
+      "ABSTOLRES", {.description = "absolute tolerance for deciding if global residual of "
+                                   "nonlinear problem is already zero",
+                       .default_value = 1.0e-14}));
+  sstidynmono.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description =
+              "tolerance for convergence check of Newton-Raphson iteration within monolithic SSI",
+          .default_value = 1.0e-6}));
   Core::Utils::int_parameter(
       "LINEAR_SOLVER", -1, "ID of linear solver for global system of equations", sstidynmono);
   Core::Utils::string_to_integral_parameter<Core::LinAlg::MatrixType>("MATRIXTYPE", "undefined",

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -20,6 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs sstidyn{"SSTI CONTROL"};
 
@@ -33,10 +34,10 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::double_parameter("RESULTSEVERYTIME", 0, "increment for writing solution", sstidyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", sstidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", sstidyn);
-  Core::Utils::bool_parameter("SCATRA_FROM_RESTART_FILE", false,
-      "read scatra result from restart files (use option 'restartfromfile' during execution of "
-      "4C)",
-      sstidyn);
+  sstidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",
+      {.description = "read scatra result from restart files (use option 'restartfromfile' during "
+                      "execution of 4C)",
+          .default_value = false}));
   Core::Utils::string_parameter(
       "SCATRA_FILENAME", "nil", "Control-file name for reading scatra results in SSTI", sstidyn);
   Core::Utils::string_to_integral_parameter<SolutionScheme>("COUPALGO", "ssti_Monolithic",
@@ -46,8 +47,8 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "scalar transport time integration type is needed to instantiate correct scalar transport "
       "time integration scheme for ssi problems",
       tuple<std::string>("Elch"), tuple<ScaTraTimIntType>(ScaTraTimIntType::elch), sstidyn);
-  Core::Utils::bool_parameter(
-      "ADAPTIVE_TIMESTEPPING", false, "flag for adaptive time stepping", sstidyn);
+  sstidyn.specs.emplace_back(parameter<bool>("ADAPTIVE_TIMESTEPPING",
+      {.description = "flag for adaptive time stepping", .default_value = false}));
 
   sstidyn.move_into_collection(list);
 
@@ -110,9 +111,10 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           Core::LinAlg::EquilibrationMethod::rowsandcolumns_maindiag,
           Core::LinAlg::EquilibrationMethod::symmetry),
       sstidynmono);
-  Core::Utils::bool_parameter("EQUILIBRATION_INIT_SCATRA", false,
-      "use equilibration method of ScaTra to equilibrate initial calculation of potential",
-      sstidynmono);
+  sstidynmono.specs.emplace_back(parameter<bool>("EQUILIBRATION_INIT_SCATRA",
+      {.description =
+              "use equilibration method of ScaTra to equilibrate initial calculation of potential",
+          .default_value = false}));
 
   sstidynmono.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -25,7 +25,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs sstidyn{"SSTI CONTROL"};
 
   sstidyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0}));
+      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0.0}));
   Core::Utils::int_parameter(
       "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", sstidyn);
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", sstidyn);
@@ -34,7 +34,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   sstidyn.specs.emplace_back(
       parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
   sstidyn.specs.emplace_back(parameter<double>(
-      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0}));
+      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0.0}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", sstidyn);
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", sstidyn);
   sstidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -20,6 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs stidyn{"STI DYNAMIC"};
 
@@ -62,8 +63,10 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "THERMO_LINEAR_SOLVER", -1, "ID of linear solver for temperature field", stidyn);
 
   // flag for double condensation of linear equations associated with temperature field
-  Core::Utils::bool_parameter("THERMO_CONDENSATION", false,
-      "flag for double condensation of linear equations associated with temperature field", stidyn);
+  stidyn.specs.emplace_back(parameter<bool>("THERMO_CONDENSATION",
+      {.description =
+              "flag for double condensation of linear equations associated with temperature field",
+          .default_value = false}));
 
   stidyn.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -93,11 +93,13 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs stidyn_partitioned{stidyn, "PARTITIONED"};
 
   // relaxation parameter
-  Core::Utils::double_parameter("OMEGA", 1., "relaxation parameter", stidyn_partitioned);
+  stidyn_partitioned.specs.emplace_back(
+      parameter<double>("OMEGA", {.description = "relaxation parameter", .default_value = 1.}));
 
   // maximum value of Aitken relaxation parameter
-  Core::Utils::double_parameter("OMEGAMAX", 0.,
-      "maximum value of Aitken relaxation parameter (0.0 = no constraint)", stidyn_partitioned);
+  stidyn_partitioned.specs.emplace_back(parameter<double>("OMEGAMAX",
+      {.description = "maximum value of Aitken relaxation parameter (0.0 = no constraint)",
+          .default_value = 0.}));
 
   stidyn_partitioned.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -22,6 +22,7 @@ namespace Inpar
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
     {
       using Teuchos::tuple;
+      using namespace Core::IO::InputSpecBuilders;
 
       Core::Utils::SectionSpecs sdyn{"STRUCTURAL DYNAMIC"};
 
@@ -29,8 +30,8 @@ namespace Inpar
           "global type of the used integration strategy", tuple<std::string>("Old", "Standard"),
           tuple<Solid::IntegrationStrategy>(int_old, int_standard), sdyn);
 
-      Core::Utils::bool_parameter(
-          "TIME_ADAPTIVITY", false, "Enable adaptive time integration", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>("TIME_ADAPTIVITY",
+          {.description = "Enable adaptive time integration", .default_value = false}));
 
       Core::Utils::string_to_integral_parameter<Solid::DynamicType>("DYNAMICTYPE", "GenAlpha",
           "type of the specific dynamic time integration scheme",
@@ -67,8 +68,9 @@ namespace Inpar
           "RESEVERYERGY", 0, "write system energies every requested step", sdyn);
       Core::Utils::int_parameter(
           "RESTARTEVERY", 1, "write restart possibility every RESTARTEVERY steps", sdyn);
-      Core::Utils::bool_parameter("CALC_ACC_ON_RESTART", false,
-          "Compute the initial state for a restart dynamics analysis", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>("CALC_ACC_ON_RESTART",
+          {.description = "Compute the initial state for a restart dynamics analysis",
+              .default_value = false}));
       Core::Utils::int_parameter("OUTPUT_STEP_OFFSET", 0,
           "An offset added to the current step to shift the steps to be written.", sdyn);
 
@@ -184,15 +186,17 @@ namespace Inpar
           "way of evaluating the constitutive matrix", sdyn, material_tangent_valid_input);
 
 
-      Core::Utils::bool_parameter(
-          "LOADLIN", false, "Use linearization of external follower load in Newton", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>(
+          "LOADLIN", {.description = "Use linearization of external follower load in Newton",
+                         .default_value = false}));
 
       Core::Utils::string_to_integral_parameter<Solid::MassLin>("MASSLIN", "none",
           "Application of nonlinear inertia terms",
           tuple<std::string>("none", "standard", "rotations"),
           tuple<Solid::MassLin>(ml_none, ml_standard, ml_rotations), sdyn);
 
-      Core::Utils::bool_parameter("NEGLECTINERTIA", false, "Neglect inertia", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>(
+          "NEGLECTINERTIA", {.description = "Neglect inertia", .default_value = false}));
 
       // Since predictor "none" would be misleading, the usage of no predictor is called vague.
       Core::Utils::string_to_integral_parameter<Solid::PredEnum>("PREDICT", "ConstDis",
@@ -218,18 +222,22 @@ namespace Inpar
           tuple<Solid::ConSolveAlgo>(consolve_uzawa, consolve_simple, consolve_direct), sdyn);
 
       // convergence criteria adaptivity
-      Core::Utils::bool_parameter("ADAPTCONV", false,
-          "Switch on adaptive control of linear solver tolerance for nonlinear solution", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}));
       Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
           "The linear solver shall be this much better than the current nonlinear residual in the "
           "nonlinear convergence limit",
           sdyn);
 
-      Core::Utils::bool_parameter(
-          "LUMPMASS", false, "Lump the mass matrix for explicit time integration", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>(
+          "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
+                          .default_value = false}));
 
-      Core::Utils::bool_parameter("MODIFIEDEXPLEULER", true,
-          "Use the modified explicit Euler time integration scheme", sdyn);
+      sdyn.specs.emplace_back(parameter<bool>("MODIFIEDEXPLEULER",
+          {.description = "Use the modified explicit Euler time integration scheme",
+              .default_value = true}));
 
       // linear solver id used for structural problems
       Core::Utils::int_parameter(
@@ -328,8 +336,9 @@ namespace Inpar
           tuple<Inpar::Solid::DynamicType>(dyna_expleuler, dyna_centrdiff, dyna_ab2, dyna_ab4),
           jep);
 
-      Core::Utils::bool_parameter(
-          "LUMPMASS", false, "Lump the mass matrix for explicit time integration", jep);
+      jep.specs.emplace_back(parameter<bool>(
+          "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
+                          .default_value = false}));
 
       Core::Utils::string_to_integral_parameter<Inpar::Solid::DampKind>("DAMPING", "None",
           "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M + K_DAMP x K, "
@@ -369,9 +378,10 @@ namespace Inpar
       /*----------------------------------------------------------------------*/
       /* parameters for error evaluation */
       Core::Utils::SectionSpecs errorevaluator{sdyn, "ERROR EVALUATION"};
-      Core::Utils::bool_parameter("EVALUATE_ERROR_ANALYTICAL_REFERENCE", false,
-          "Calculate error with respect to analytical solution defined by a function",
-          errorevaluator);
+      errorevaluator.specs.emplace_back(parameter<bool>("EVALUATE_ERROR_ANALYTICAL_REFERENCE",
+          {.description =
+                  "Calculate error with respect to analytical solution defined by a function",
+              .default_value = false}));
       Core::Utils::int_parameter("ANALYTICAL_DISPLACEMENT_FUNCTION", -1,
           "function ID of the analytical solution", errorevaluator);
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -53,11 +53,12 @@ namespace Inpar
               Inpar::Solid::PreStress::material_iterative),
           sdyn);
 
-      Core::Utils::double_parameter(
-          "PRESTRESSTIME", 0.0, "time to switch from pre to post stressing", sdyn);
+      sdyn.specs.emplace_back(parameter<double>("PRESTRESSTIME",
+          {.description = "time to switch from pre to post stressing", .default_value = 0.0}));
 
-      Core::Utils::double_parameter(
-          "PRESTRESSTOLDISP", 1e-9, "tolerance in the displacement norm during prestressing", sdyn);
+      sdyn.specs.emplace_back(parameter<double>("PRESTRESSTOLDISP",
+          {.description = "tolerance in the displacement norm during prestressing",
+              .default_value = 1e-9}));
       Core::Utils::int_parameter(
           "PRESTRESSMINLOADSTEPS", 0, "Minimum number of load steps during prestressing", sdyn);
 
@@ -75,10 +76,13 @@ namespace Inpar
           "An offset added to the current step to shift the steps to be written.", sdyn);
 
       // Time loop control
-      Core::Utils::double_parameter("TIMESTEP", 0.05, "time step size", sdyn);
+      sdyn.specs.emplace_back(
+          parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.05}));
       Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of steps", sdyn);
-      Core::Utils::double_parameter("TIMEINIT", 0.0, "initial time", sdyn);
-      Core::Utils::double_parameter("MAXTIME", 5.0, "maximum time", sdyn);
+      sdyn.specs.emplace_back(
+          parameter<double>("TIMEINIT", {.description = "initial time", .default_value = 0.0}));
+      sdyn.specs.emplace_back(
+          parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 5.0}));
 
       // Damping
       Core::Utils::string_to_integral_parameter<Solid::DampKind>("DAMPING", "None",
@@ -86,30 +90,36 @@ namespace Inpar
           "(2) Material based and calculated in elements",
           tuple<std::string>("None", "Rayleigh", "Material"),
           tuple<Solid::DampKind>(damp_none, damp_rayleigh, damp_material), sdyn);
-      Core::Utils::double_parameter("M_DAMP", -1.0, "", sdyn);
-      Core::Utils::double_parameter("K_DAMP", -1.0, "", sdyn);
+      sdyn.specs.emplace_back(
+          parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}));
+      sdyn.specs.emplace_back(
+          parameter<double>("K_DAMP", {.description = "", .default_value = -1.0}));
 
-      Core::Utils::double_parameter(
-          "TOLDISP", 1.0E-10, "tolerance in the displacement norm for the newton iteration", sdyn);
+      sdyn.specs.emplace_back(parameter<double>(
+          "TOLDISP", {.description = "tolerance in the displacement norm for the newton iteration",
+                         .default_value = 1.0E-10}));
       Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_DISP", "Abs",
           "type of norm for displacement convergence check",
           tuple<std::string>("Abs", "Rel", "Mix"),
           tuple<Solid::ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), sdyn);
 
-      Core::Utils::double_parameter(
-          "TOLRES", 1.0E-08, "tolerance in the residual norm for the newton iteration", sdyn);
+      sdyn.specs.emplace_back(parameter<double>(
+          "TOLRES", {.description = "tolerance in the residual norm for the newton iteration",
+                        .default_value = 1.0E-08}));
       Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_RESF", "Abs",
           "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
           tuple<Solid::ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), sdyn);
 
-      Core::Utils::double_parameter(
-          "TOLPRE", 1.0E-08, "tolerance in pressure norm for the newton iteration", sdyn);
+      sdyn.specs.emplace_back(parameter<double>(
+          "TOLPRE", {.description = "tolerance in pressure norm for the newton iteration",
+                        .default_value = 1.0E-08}));
       Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_PRES", "Abs",
           "type of norm for pressure convergence check", tuple<std::string>("Abs"),
           tuple<Solid::ConvNorm>(convnorm_abs), sdyn);
 
-      Core::Utils::double_parameter("TOLINCO", 1.0E-08,
-          "tolerance in the incompressible residual norm for the newton iteration", sdyn);
+      sdyn.specs.emplace_back(parameter<double>("TOLINCO",
+          {.description = "tolerance in the incompressible residual norm for the newton iteration",
+              .default_value = 1.0E-08}));
       Core::Utils::string_to_integral_parameter<Solid::ConvNorm>("NORM_INCO", "Abs",
           "type of norm for incompressible residual convergence check", tuple<std::string>("Abs"),
           tuple<Solid::ConvNorm>(convnorm_abs), sdyn);
@@ -133,15 +143,18 @@ namespace Inpar
 
       Core::Utils::int_parameter("STC_LAYER", 1, "number of STC layers for multilayer case", sdyn);
 
-      Core::Utils::double_parameter("PTCDT", 0.1,
-          "pseudo time step for pseudo transient continuation (PTC) stabilized Newton procedure",
-          sdyn);
+      sdyn.specs.emplace_back(parameter<double>(
+          "PTCDT", {.description = "pseudo time step for pseudo transient continuation (PTC) "
+                                   "stabilized Newton procedure",
+                       .default_value = 0.1}));
 
-      Core::Utils::double_parameter("TOLCONSTR", 1.0E-08,
-          "tolerance in the constr error norm for the newton iteration", sdyn);
+      sdyn.specs.emplace_back(parameter<double>("TOLCONSTR",
+          {.description = "tolerance in the constr error norm for the newton iteration",
+              .default_value = 1.0E-08}));
 
-      Core::Utils::double_parameter("TOLCONSTRINCR", 1.0E-08,
-          "tolerance in the constr lm incr norm for the newton iteration", sdyn);
+      sdyn.specs.emplace_back(parameter<double>("TOLCONSTRINCR",
+          {.description = "tolerance in the constr lm incr norm for the newton iteration",
+              .default_value = 1.0E-08}));
 
       Core::Utils::int_parameter("MAXITER", 50,
           "maximum number of iterations allowed for Newton-Raphson iteration before failure", sdyn);
@@ -176,10 +189,12 @@ namespace Inpar
           sdyn);
 
       Core::Utils::int_parameter("LSMAXITER", 30, "maximum number of line search steps", sdyn);
-      Core::Utils::double_parameter(
-          "ALPHA_LS", 0.5, "step reduction factor alpha in (Newton) line search scheme", sdyn);
-      Core::Utils::double_parameter(
-          "SIGMA_LS", 1.e-4, "sufficient descent factor in (Newton) line search scheme", sdyn);
+      sdyn.specs.emplace_back(parameter<double>(
+          "ALPHA_LS", {.description = "step reduction factor alpha in (Newton) line search scheme",
+                          .default_value = 0.5}));
+      sdyn.specs.emplace_back(parameter<double>(
+          "SIGMA_LS", {.description = "sufficient descent factor in (Newton) line search scheme",
+                          .default_value = 1.e-4}));
 
       std::vector<std::string> material_tangent_valid_input = {"analytical", "finitedifferences"};
       Core::Utils::string_parameter("MATERIALTANGENT", "analytical",
@@ -209,10 +224,12 @@ namespace Inpar
           sdyn);
 
       // Uzawa iteration for constraint systems
-      Core::Utils::double_parameter("UZAWAPARAM", 1.0,
-          "Parameter for Uzawa algorithm dealing with lagrange multipliers", sdyn);
-      Core::Utils::double_parameter(
-          "UZAWATOL", 1.0E-8, "Tolerance for iterative solve with Uzawa algorithm", sdyn);
+      sdyn.specs.emplace_back(parameter<double>("UZAWAPARAM",
+          {.description = "Parameter for Uzawa algorithm dealing with lagrange multipliers",
+              .default_value = 1.0}));
+      sdyn.specs.emplace_back(parameter<double>(
+          "UZAWATOL", {.description = "Tolerance for iterative solve with Uzawa algorithm",
+                          .default_value = 1.0E-8}));
       Core::Utils::int_parameter("UZAWAMAXITER", 50,
           "maximum number of iterations allowed for uzawa algorithm before failure going to next "
           "newton step",
@@ -226,10 +243,10 @@ namespace Inpar
           {.description =
                   "Switch on adaptive control of linear solver tolerance for nonlinear solution",
               .default_value = false}));
-      Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-          "The linear solver shall be this much better than the current nonlinear residual in the "
-          "nonlinear convergence limit",
-          sdyn);
+      sdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}));
 
       sdyn.specs.emplace_back(parameter<bool>(
           "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
@@ -279,32 +296,34 @@ namespace Inpar
               Inpar::Solid::timada_kind_centraldiff),
           tap);
 
-      Core::Utils::double_parameter("OUTSYSPERIOD", 0.0,
-          "Write system vectors (displacements, velocities, etc) every given period of time", tap);
-      Core::Utils::double_parameter(
-          "OUTSTRPERIOD", 0.0, "Write stress/strain every given period of time", tap);
-      Core::Utils::double_parameter(
-          "OUTENEPERIOD", 0.0, "Write energy every given period of time", tap);
-      Core::Utils::double_parameter(
-          "OUTRESTPERIOD", 0.0, "Write restart data every given period of time", tap);
+      tap.specs.emplace_back(parameter<double>(
+          "OUTSYSPERIOD", {.description = "Write system vectors (displacements, velocities, etc) "
+                                          "every given period of time",
+                              .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("OUTSTRPERIOD",
+          {.description = "Write stress/strain every given period of time", .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("OUTENEPERIOD",
+          {.description = "Write energy every given period of time", .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("OUTRESTPERIOD",
+          {.description = "Write restart data every given period of time", .default_value = 0.0}));
       Core::Utils::int_parameter("OUTSIZEEVERY", 0, "Write step size every given time step", tap);
 
-      Core::Utils::double_parameter(
-          "STEPSIZEMAX", 0.0, "Limit maximally permitted time step size (>0)", tap);
-      Core::Utils::double_parameter(
-          "STEPSIZEMIN", 0.0, "Limit minimally allowed time step size (>0)", tap);
-      Core::Utils::double_parameter("SIZERATIOMAX", 0.0,
-          "Limit maximally permitted change of time step size compared to previous size, important "
-          "for multi-step schemes (>0)",
-          tap);
-      Core::Utils::double_parameter("SIZERATIOMIN", 0.0,
-          "Limit minimally permitted change of time step size compared to previous size, important "
-          "for multi-step schemes (>0)",
-          tap);
-      Core::Utils::double_parameter("SIZERATIOSCALE", 0.9,
-          "This is a safety factor to scale theoretical optimal step size, should be lower than 1 "
-          "and must be larger than 0",
-          tap);
+      tap.specs.emplace_back(parameter<double>("STEPSIZEMAX",
+          {.description = "Limit maximally permitted time step size (>0)", .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("STEPSIZEMIN",
+          {.description = "Limit minimally allowed time step size (>0)", .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("SIZERATIOMAX",
+          {.description = "Limit maximally permitted change of time step size compared to previous "
+                          "size, important for multi-step schemes (>0)",
+              .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("SIZERATIOMIN",
+          {.description = "Limit minimally permitted change of time step size compared to previous "
+                          "size, important for multi-step schemes (>0)",
+              .default_value = 0.0}));
+      tap.specs.emplace_back(parameter<double>("SIZERATIOSCALE",
+          {.description = "This is a safety factor to scale theoretical optimal step size, should "
+                          "be lower than 1 and must be larger than 0",
+              .default_value = 0.9}));
 
       Core::Utils::string_to_integral_parameter<Inpar::Solid::VectorNorm>("LOCERRNORM", "Vague",
           "Vector norm to treat error vector with",
@@ -313,7 +332,8 @@ namespace Inpar
               Inpar::Solid::norm_l2, Inpar::Solid::norm_rms, Inpar::Solid::norm_inf),
           tap);
 
-      Core::Utils::double_parameter("LOCERRTOL", 0.0, "Target local error tolerance (>0)", tap);
+      tap.specs.emplace_back(parameter<double>(
+          "LOCERRTOL", {.description = "Target local error tolerance (>0)", .default_value = 0.0}));
       Core::Utils::int_parameter(
           "ADAPTSTEPMAX", 0, "Limit maximally allowed step size reduction attempts (>0)", tap);
       tap.move_into_collection(list);
@@ -346,8 +366,10 @@ namespace Inpar
           tuple<std::string>("None", "Rayleigh", "Material"),
           tuple<Inpar::Solid::DampKind>(damp_none, damp_rayleigh, damp_material), jep);
 
-      Core::Utils::double_parameter("M_DAMP", -1.0, "", jep);
-      Core::Utils::double_parameter("K_DAMP", -1.0, "", jep);
+      jep.specs.emplace_back(
+          parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}));
+      jep.specs.emplace_back(
+          parameter<double>("K_DAMP", {.description = "", .default_value = -1.0}));
 
       jep.move_into_collection(list);
 
@@ -358,12 +380,18 @@ namespace Inpar
       Core::Utils::string_to_integral_parameter<Solid::MidAverageEnum>("GENAVG", "TrLike",
           "mid-average type of internal forces", tuple<std::string>("Vague", "ImrLike", "TrLike"),
           tuple<Solid::MidAverageEnum>(midavg_vague, midavg_imrlike, midavg_trlike), genalpha);
-      Core::Utils::double_parameter("BETA", -1.0, "Generalised-alpha factor in (0,1/2]", genalpha);
-      Core::Utils::double_parameter("GAMMA", -1.0, "Generalised-alpha factor in (0,1]", genalpha);
-      Core::Utils::double_parameter("ALPHA_M", -1.0, "Generalised-alpha factor in [0,1)", genalpha);
-      Core::Utils::double_parameter("ALPHA_F", -1.0, "Generalised-alpha factor in [0,1)", genalpha);
-      Core::Utils::double_parameter("RHO_INF", 1.0,
-          "Spectral radius for generalised-alpha time integration, valid range is [0,1]", genalpha);
+      genalpha.specs.emplace_back(parameter<double>(
+          "BETA", {.description = "Generalised-alpha factor in (0,1/2]", .default_value = -1.0}));
+      genalpha.specs.emplace_back(parameter<double>(
+          "GAMMA", {.description = "Generalised-alpha factor in (0,1]", .default_value = -1.0}));
+      genalpha.specs.emplace_back(parameter<double>(
+          "ALPHA_M", {.description = "Generalised-alpha factor in [0,1)", .default_value = -1.0}));
+      genalpha.specs.emplace_back(parameter<double>(
+          "ALPHA_F", {.description = "Generalised-alpha factor in [0,1)", .default_value = -1.0}));
+      genalpha.specs.emplace_back(parameter<double>("RHO_INF",
+          {.description =
+                  "Spectral radius for generalised-alpha time integration, valid range is [0,1]",
+              .default_value = 1.0}));
 
       genalpha.move_into_collection(list);
 
@@ -371,7 +399,8 @@ namespace Inpar
       /* parameters for one-step-theta structural integrator */
       Core::Utils::SectionSpecs onesteptheta{sdyn, "ONESTEPTHETA"};
 
-      Core::Utils::double_parameter("THETA", 0.5, "One-step-theta factor in (0,1]", onesteptheta);
+      onesteptheta.specs.emplace_back(parameter<double>(
+          "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5}));
 
       onesteptheta.move_into_collection(list);
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -197,8 +197,10 @@ namespace Inpar
                           .default_value = 1.e-4}));
 
       std::vector<std::string> material_tangent_valid_input = {"analytical", "finitedifferences"};
-      Core::Utils::string_parameter("MATERIALTANGENT", "analytical",
-          "way of evaluating the constitutive matrix", sdyn, material_tangent_valid_input);
+      sdyn.specs.emplace_back(
+          selection<std::string>("MATERIALTANGENT", material_tangent_valid_input,
+              {.description = "way of evaluating the constitutive matrix",
+                  .default_value = "analytical"}));
 
 
       sdyn.specs.emplace_back(parameter<bool>(

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs tsidyn{"TSI DYNAMIC"};
 
@@ -29,7 +30,8 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           IterStaggAitkenIrons, IterStaggFixedRel, Monolithic),
       tsidyn);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", tsidyn);
+  tsidyn.specs.emplace_back(
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
   // output type
   Core::Utils::int_parameter(
@@ -91,26 +93,29 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "LINEAR_SOLVER", -1, "number of linear solver used for monolithic TSI problems", tsidynmono);
 
   // convergence criteria adaptivity of monolithic TSI solver
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution", tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
       tsidynmono);
 
-  Core::Utils::bool_parameter(
-      "INFNORMSCALING", true, "Scale blocks of matrix with row infnorm?", tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<bool>("INFNORMSCALING",
+      {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}));
 
   // merge TSI block matrix to enable use of direct solver in monolithic TSI
   // default: "No", i.e. use block matrix
-  Core::Utils::bool_parameter(
-      "MERGE_TSI_BLOCK_MATRIX", false, "Merge TSI block matrix", tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<bool>(
+      "MERGE_TSI_BLOCK_MATRIX", {.description = "Merge TSI block matrix", .default_value = false}));
 
   // in case of monolithic TSI nodal values (displacements, temperatures and
   // reaction forces) at fix points of the body can be calculated
   // default: "No", i.e. nothing is calculated
-  Core::Utils::bool_parameter("CALC_NECKING_TSI_VALUES", false,
-      "Calculate nodal values for evaluation and validation of necking", tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<bool>("CALC_NECKING_TSI_VALUES",
+      {.description = "Calculate nodal values for evaluation and validation of necking",
+          .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<LineSearch>("TSI_LINE_SEARCH", "none",
       "line-search strategy", tuple<std::string>("none", "structure", "thermo", "and", "or"),
@@ -164,8 +169,9 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           Inpar::CONTACT::NitWgt_physical),
       tsic);
 
-  Core::Utils::bool_parameter("NITSCHE_PENALTY_ADAPTIVE_TSI", true,
-      "adapt penalty parameter after each converged time step", tsic);
+  tsic.specs.emplace_back(parameter<bool>("NITSCHE_PENALTY_ADAPTIVE_TSI",
+      {.description = "adapt penalty parameter after each converged time step",
+          .default_value = true}));
 
   Core::Utils::double_parameter(
       "PENALTYPARAM_THERMO", 0.0, "Penalty parameter for Nitsche solution strategy", tsic);

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -39,8 +39,10 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   // time loop control
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of Timesteps", tsidyn);
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "total simulation time", tsidyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.05, "time step size dt", tsidyn);
+  tsidyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
+  tsidyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
   Core::Utils::int_parameter("ITEMAX", 10, "maximum number of iterations over fields", tsidyn);
   Core::Utils::int_parameter("ITEMIN", 1, "minimal number of iterations over fields", tsidyn);
   Core::Utils::int_parameter("RESULTSEVERY", 1, "increment for writing solution", tsidyn);
@@ -57,11 +59,12 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs tsidynmono{tsidyn, "MONOLITHIC"};
 
   // convergence tolerance of tsi residual
-  Core::Utils::double_parameter(
-      "CONVTOL", 1e-6, "tolerance for convergence check of TSI", tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "tolerance for convergence check of TSI", .default_value = 1e-6}));
   // Iterationparameters
-  Core::Utils::double_parameter("TOLINC", 1.0e-6,
-      "tolerance for convergence check of TSI-increment in monolithic TSI", tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<double>("TOLINC",
+      {.description = "tolerance for convergence check of TSI-increment in monolithic TSI",
+          .default_value = 1.0e-6}));
 
   Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
@@ -84,9 +87,10 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "Nonlinear solution technique", tuple<std::string>("fullnewton", "ptc"),
       tuple<NlnSolTech>(soltech_newtonfull, soltech_ptc), tsidynmono);
 
-  Core::Utils::double_parameter("PTCDT", 0.1,
-      "pseudo time step for pseudo-transient continuation (PTC) stabilised Newton procedure",
-      tsidynmono);
+  tsidynmono.specs.emplace_back(
+      parameter<double>("PTCDT", {.description = "pseudo time step for pseudo-transient "
+                                                 "continuation (PTC) stabilised Newton procedure",
+                                     .default_value = 0.1}));
 
   // number of linear solver used for monolithic TSI
   Core::Utils::int_parameter(
@@ -97,10 +101,10 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      tsidynmono);
+  tsidynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   tsidynmono.specs.emplace_back(parameter<bool>("INFNORMSCALING",
       {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}));
@@ -133,13 +137,16 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       "COUPVARIABLE", "Displacement", "Coupling variable", tsidynpart, couplvariable_valid_input);
 
   // Solver parameter for relaxation of iterative staggered partitioned TSI
-  Core::Utils::double_parameter("MAXOMEGA", 0.0,
-      "largest omega allowed for Aitken relaxation (0.0 means no constraint)", tsidynpart);
-  Core::Utils::double_parameter("FIXEDOMEGA", 1.0, "fixed relaxation parameter", tsidynpart);
+  tsidynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
+      {.description = "largest omega allowed for Aitken relaxation (0.0 means no constraint)",
+          .default_value = 0.0}));
+  tsidynpart.specs.emplace_back(parameter<double>(
+      "FIXEDOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
 
   // convergence tolerance of outer iteration loop
-  Core::Utils::double_parameter("CONVTOL", 1e-6,
-      "tolerance for convergence check of outer iteraiton within partitioned TSI", tsidynpart);
+  tsidynpart.specs.emplace_back(parameter<double>("CONVTOL",
+      {.description = "tolerance for convergence check of outer iteraiton within partitioned TSI",
+          .default_value = 1e-6}));
 
   tsidynpart.move_into_collection(list);
 
@@ -147,18 +154,23 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   /* parameters for tsi contact */
   Core::Utils::SectionSpecs tsic{"TSI CONTACT"};
 
-  Core::Utils::double_parameter(
-      "HEATTRANSSLAVE", 0.0, "Heat transfer parameter for slave side in thermal contact", tsic);
-  Core::Utils::double_parameter(
-      "HEATTRANSMASTER", 0.0, "Heat transfer parameter for master side in thermal contact", tsic);
-  Core::Utils::double_parameter("TEMP_DAMAGE", 1.0e12,
-      "damage temperature at contact interface: friction coefficient zero there", tsic);
-  Core::Utils::double_parameter("TEMP_REF", 0.0,
-      "reference temperature at contact interface: friction coefficient equals the given value",
-      tsic);
+  tsic.specs.emplace_back(parameter<double>(
+      "HEATTRANSSLAVE", {.description = "Heat transfer parameter for slave side in thermal contact",
+                            .default_value = 0.0}));
+  tsic.specs.emplace_back(parameter<double>("HEATTRANSMASTER",
+      {.description = "Heat transfer parameter for master side in thermal contact",
+          .default_value = 0.0}));
+  tsic.specs.emplace_back(parameter<double>("TEMP_DAMAGE",
+      {.description = "damage temperature at contact interface: friction coefficient zero there",
+          .default_value = 1.0e12}));
+  tsic.specs.emplace_back(
+      parameter<double>("TEMP_REF", {.description = "reference temperature at contact interface: "
+                                                    "friction coefficient equals the given value",
+                                        .default_value = 0.0}));
 
-  Core::Utils::double_parameter(
-      "NITSCHE_THETA_TSI", 0.0, "+1: symmetric, 0: non-symmetric, -1: skew-symmetric", tsic);
+  tsic.specs.emplace_back(parameter<double>(
+      "NITSCHE_THETA_TSI", {.description = "+1: symmetric, 0: non-symmetric, -1: skew-symmetric",
+                               .default_value = 0.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::NitscheWeighting>(
       "NITSCHE_WEIGHTING_TSI", "harmonic",
@@ -173,8 +185,8 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
       {.description = "adapt penalty parameter after each converged time step",
           .default_value = true}));
 
-  Core::Utils::double_parameter(
-      "PENALTYPARAM_THERMO", 0.0, "Penalty parameter for Nitsche solution strategy", tsic);
+  tsic.specs.emplace_back(parameter<double>("PENALTYPARAM_THERMO",
+      {.description = "Penalty parameter for Nitsche solution strategy", .default_value = 0.0}));
 
   Core::Utils::string_to_integral_parameter<Inpar::CONTACT::NitscheThermoMethod>(
       "NITSCHE_METHOD_TSI", "nitsche",

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -133,8 +133,9 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs tsidynpart{tsidyn, "PARTITIONED"};
 
   std::vector<std::string> couplvariable_valid_input = {"Displacement", "Temperature"};
-  Core::Utils::string_parameter(
-      "COUPVARIABLE", "Displacement", "Coupling variable", tsidynpart, couplvariable_valid_input);
+  tsidynpart.specs.emplace_back(selection<std::string>("COUPVARIABLE", couplvariable_valid_input,
+      {.description = "Coupling variable", .default_value = "Displacement"}));
+
 
   // Solver parameter for relaxation of iterative staggered partitioned TSI
   tsidynpart.specs.emplace_back(parameter<double>("MAXOMEGA",

--- a/src/inpar/4C_inpar_validparameters.cpp
+++ b/src/inpar/4C_inpar_validparameters.cpp
@@ -128,9 +128,10 @@ std::map<std::string, Core::IO::InputSpec> Input::valid_parameters()
 
   Core::Utils::SectionSpecs nurbs_param{"NURBS"};
 
-  Core::Utils::bool_parameter("DO_LS_DBC_PROJECTION", false,
-      "Determines if a projection is needed for least square Dirichlet boundary conditions.",
-      nurbs_param);
+  nurbs_param.specs.emplace_back(parameter<bool>(
+      "DO_LS_DBC_PROJECTION", {.description = "Determines if a projection is needed for least "
+                                              "square Dirichlet boundary conditions.",
+                                  .default_value = false}));
 
   Core::Utils::int_parameter("SOLVER_LS_DBC_PROJECTION", -1,
       "Number of linear solver for the projection of least squares Dirichlet boundary conditions "

--- a/src/inpar/4C_inpar_volmortar.cpp
+++ b/src/inpar/4C_inpar_volmortar.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::VolMortar::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for volmortar */
   Core::Utils::SectionSpecs volmortar{"VOLMORTAR COUPLING"};
@@ -64,11 +65,13 @@ void Inpar::VolMortar::set_valid_parameters(std::map<std::string, Core::IO::Inpu
           Coupling::VolMortar::dualquad_quad_mod),
       volmortar);
 
-  Core::Utils::bool_parameter(
-      "MESH_INIT", false, "If chosen, mesh initialization procedure is performed", volmortar);
+  volmortar.specs.emplace_back(parameter<bool>(
+      "MESH_INIT", {.description = "If chosen, mesh initialization procedure is performed",
+                       .default_value = false}));
 
-  Core::Utils::bool_parameter("KEEP_EXTENDEDGHOSTING", true,
-      "If chosen, extended ghosting is kept for simulation", volmortar);
+  volmortar.specs.emplace_back(parameter<bool>("KEEP_EXTENDEDGHOSTING",
+      {.description = "If chosen, extended ghosting is kept for simulation",
+          .default_value = true}));
 
   volmortar.move_into_collection(list);
 }

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -35,12 +35,15 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           wear_shape_standard),
       wear);
 
-  Core::Utils::double_parameter("WEARCOEFF", 0.0, "Wear coefficient for slave surface", wear);
-  Core::Utils::double_parameter(
-      "WEARCOEFF_MASTER", 0.0, "Wear coefficient for master surface", wear);
-  Core::Utils::double_parameter(
-      "WEAR_TIMERATIO", 1.0, "Time step ratio between wear and spatial time scale", wear);
-  Core::Utils::double_parameter("SSSLIP", 1.0, "Fixed slip for steady state wear", wear);
+  wear.specs.emplace_back(parameter<double>(
+      "WEARCOEFF", {.description = "Wear coefficient for slave surface", .default_value = 0.0}));
+  wear.specs.emplace_back(parameter<double>("WEARCOEFF_MASTER",
+      {.description = "Wear coefficient for master surface", .default_value = 0.0}));
+  wear.specs.emplace_back(parameter<double>(
+      "WEAR_TIMERATIO", {.description = "Time step ratio between wear and spatial time scale",
+                            .default_value = 1.0}));
+  wear.specs.emplace_back(parameter<double>(
+      "SSSLIP", {.description = "Fixed slip for steady state wear", .default_value = 1.0}));
 
   wear.specs.emplace_back(parameter<bool>(
       "SSWEAR", {.description = "flag for steady state wear", .default_value = false}));

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -16,6 +16,7 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for wear */
   Core::Utils::SectionSpecs wear{"WEAR"};
@@ -24,7 +25,8 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<std::string>("None", "none", "Archard", "archard"),
       tuple<WearLaw>(wear_none, wear_none, wear_archard, wear_archard), wear);
 
-  Core::Utils::bool_parameter("MATCHINGGRID", true, "is matching grid", wear);
+  wear.specs.emplace_back(
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
   Core::Utils::string_to_integral_parameter<WearShape>("WEAR_SHAPEFCN", "std",
       "Type of employed set of shape functions for wear",
@@ -40,7 +42,8 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "WEAR_TIMERATIO", 1.0, "Time step ratio between wear and spatial time scale", wear);
   Core::Utils::double_parameter("SSSLIP", 1.0, "Fixed slip for steady state wear", wear);
 
-  Core::Utils::bool_parameter("SSWEAR", false, "flag for steady state wear", wear);
+  wear.specs.emplace_back(parameter<bool>(
+      "SSWEAR", {.description = "flag for steady state wear", .default_value = false}));
 
   Core::Utils::string_to_integral_parameter<WearSide>("WEAR_SIDE", "slave",
       "Definition of wear side",

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -94,8 +94,8 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       {.description = "switch on/off for relaxing Ale in monolithic fluid-fluid-fsi",
           .default_value = true}));
 
-  Core::Utils::double_parameter(
-      "XFLUIDFLUID_SEARCHRADIUS", 1.0, "Radius of the search tree", xfluid_general);
+  xfluid_general.specs.emplace_back(parameter<double>("XFLUIDFLUID_SEARCHRADIUS",
+      {.description = "Radius of the search tree", .default_value = 1.0}));
 
   // xfluidfluid-fsi-monolithic approach
   Core::Utils::string_to_integral_parameter<MonolithicXffsiApproach>("MONOLITHIC_XFFSI_APPROACH",
@@ -206,10 +206,12 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       xfluid_stab);
 
   // viscous and convective Nitsche/MSH stabilization parameter
-  Core::Utils::double_parameter(
-      "NIT_STAB_FAC", 35.0, " ( stabilization parameter for Nitsche's penalty term", xfluid_stab);
-  Core::Utils::double_parameter("NIT_STAB_FAC_TANG", 35.0,
-      " ( stabilization parameter for Nitsche's penalty tangential term", xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<double>(
+      "NIT_STAB_FAC", {.description = " ( stabilization parameter for Nitsche's penalty term",
+                          .default_value = 35.0}));
+  xfluid_stab.specs.emplace_back(parameter<double>("NIT_STAB_FAC_TANG",
+      {.description = " ( stabilization parameter for Nitsche's penalty tangential term",
+          .default_value = 35.0}));
 
   Core::Utils::string_to_integral_parameter<ViscStabTraceEstimate>("VISC_STAB_TRACE_ESTIMATE",
       "CT_div_by_hk", "how to estimate the scaling from the trace inequality in Nitsche's method",
@@ -323,19 +325,23 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           .default_value = false}));
 
 
-  Core::Utils::double_parameter("GHOST_PENALTY_FAC", 0.1,
-      "define stabilization parameter ghost penalty interface stabilization", xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<double>("GHOST_PENALTY_FAC",
+      {.description = "define stabilization parameter ghost penalty interface stabilization",
+          .default_value = 0.1}));
 
-  Core::Utils::double_parameter("GHOST_PENALTY_TRANSIENT_FAC", 0.001,
-      "define stabilization parameter ghost penalty transient interface stabilization",
-      xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<double>("GHOST_PENALTY_TRANSIENT_FAC",
+      {.description =
+              "define stabilization parameter ghost penalty transient interface stabilization",
+          .default_value = 0.001}));
 
-  Core::Utils::double_parameter("GHOST_PENALTY_2nd_FAC", 0.05,
-      "define stabilization parameter ghost penalty 2nd order viscous interface stabilization",
-      xfluid_stab);
-  Core::Utils::double_parameter("GHOST_PENALTY_PRESSURE_2nd_FAC", 0.05,
-      "define stabilization parameter ghost penalty 2nd order pressure interface stabilization",
-      xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<double>(
+      "GHOST_PENALTY_2nd_FAC", {.description = "define stabilization parameter ghost penalty 2nd "
+                                               "order viscous interface stabilization",
+                                   .default_value = 0.05}));
+  xfluid_stab.specs.emplace_back(parameter<double>("GHOST_PENALTY_PRESSURE_2nd_FAC",
+      {.description = "define stabilization parameter ghost penalty 2nd order pressure interface "
+                      "stabilization",
+          .default_value = 0.05}));
 
 
   xfluid_stab.specs.emplace_back(parameter<bool>("XFF_EOS_PRES_EMB_LAYER",
@@ -366,25 +372,30 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   xfsi_monolithic.specs.emplace_back(parameter<bool>("ND_NEWTON_DAMPING",
       {.description = "Activate Newton damping based on residual and increment",
           .default_value = false}));
-  Core::Utils::double_parameter("ND_MAX_DISP_ITERINC", -1.0,
-      "Maximal displacement increment to apply full newton --> otherwise damp newton",
-      xfsi_monolithic);
-  Core::Utils::double_parameter("ND_MAX_VEL_ITERINC", -1.0,
-      "Maximal fluid velocity increment to apply full newton --> otherwise damp newton",
-      xfsi_monolithic);
-  Core::Utils::double_parameter("ND_MAX_PRES_ITERINC", -1.0,
-      "Maximal fluid pressure increment to apply full newton --> otherwise damp newton",
-      xfsi_monolithic);
-  Core::Utils::double_parameter("ND_MAX_PVEL_ITERINC", -1.0,
-      "Maximal porofluid velocity increment to apply full newton --> otherwise damp newton",
-      xfsi_monolithic);
-  Core::Utils::double_parameter("ND_MAX_PPRES_ITERINC", -1.0,
-      "Maximal porofluid pressure increment to apply full newton --> otherwise damp newton",
-      xfsi_monolithic);
-  Core::Utils::double_parameter("CUT_EVALUATE_MINTOL", 0.0,
-      "Minimal value of the maximal structural displacement for which the CUT is evaluate in this "
-      "iteration!",
-      xfsi_monolithic);
+  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_DISP_ITERINC",
+      {.description =
+              "Maximal displacement increment to apply full newton --> otherwise damp newton",
+          .default_value = -1.0}));
+  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_VEL_ITERINC",
+      {.description =
+              "Maximal fluid velocity increment to apply full newton --> otherwise damp newton",
+          .default_value = -1.0}));
+  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_PRES_ITERINC",
+      {.description =
+              "Maximal fluid pressure increment to apply full newton --> otherwise damp newton",
+          .default_value = -1.0}));
+  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_PVEL_ITERINC",
+      {.description =
+              "Maximal porofluid velocity increment to apply full newton --> otherwise damp newton",
+          .default_value = -1.0}));
+  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_PPRES_ITERINC",
+      {.description =
+              "Maximal porofluid pressure increment to apply full newton --> otherwise damp newton",
+          .default_value = -1.0}));
+  xfsi_monolithic.specs.emplace_back(parameter<double>(
+      "CUT_EVALUATE_MINTOL", {.description = "Minimal value of the maximal structural displacement "
+                                             "for which the CUT is evaluate in this iteration!",
+                                 .default_value = 0.0}));
   Core::Utils::int_parameter("CUT_EVALUATE_MINITER", 0,
       "Minimal number of nonlinear iterations, before the CUT is potentially not evaluated",
       xfsi_monolithic);
@@ -392,10 +403,12 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "EXTRAPOLATE_TO_ZERO", {.description = "the extrapolation of the fluid stress in the contact "
                                              "zone is relaxed to zero after a certain distance",
                                  .default_value = false}));
-  Core::Utils::double_parameter("POROCONTACTFPSI_HFRACTION", 1.0,
-      "factor of element size, when transition between FPSI and PSCI is started!", xfsi_monolithic);
-  Core::Utils::double_parameter("POROCONTACTFPSI_FULLPCFRACTION", 0.0,
-      "ration of gap/(POROCONTACTFPSI_HFRACTION*h) when full PSCI is started!", xfsi_monolithic);
+  xfsi_monolithic.specs.emplace_back(parameter<double>("POROCONTACTFPSI_HFRACTION",
+      {.description = "factor of element size, when transition between FPSI and PSCI is started!",
+          .default_value = 1.0}));
+  xfsi_monolithic.specs.emplace_back(parameter<double>("POROCONTACTFPSI_FULLPCFRACTION",
+      {.description = "ration of gap/(POROCONTACTFPSI_HFRACTION*h) when full PSCI is started!",
+          .default_value = 0.0}));
   xfsi_monolithic.specs.emplace_back(parameter<bool>(
       "USE_PORO_PRESSURE", {.description = "the extrapolation of the fluid stress in the contact "
                                            "zone is relaxed to zero after a certtain distance",

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -667,7 +667,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
 
   xfem_surf_fpi_mono.add_component(parameter<int>("COUPLINGID"));
   xfem_surf_fpi_mono.add_component(
-      parameter<double>("BJ_COEFF", {.description = "", .default_value = 0}));
+      parameter<double>("BJ_COEFF", {.description = "", .default_value = 0.}));
   xfem_surf_fpi_mono.add_component(selection<std::string>(
       "Variant", {"BJ", "BJS"}, {.description = "variant", .default_value = "BJ"}));
   xfem_surf_fpi_mono.add_component(selection<std::string>(

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -19,26 +19,34 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs xfem_general{"XFEM GENERAL"};
 
   // OUTPUT options
-  Core::Utils::bool_parameter("GMSH_DEBUG_OUT", false,
-      "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_DEBUG_OUT_SCREEN", false,
-      "Do you want to be informed, if Gmsh output is written?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_SOL_OUT", false,
-      "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_TIMINT_OUT", false,
-      "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_EOS_OUT", false,
-      "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_DISCRET_OUT", false,
-      "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter("GMSH_CUT_OUT", false,
-      "Do you want to write extended Gmsh output for each timestep?", xfem_general);
-  Core::Utils::bool_parameter(
-      "PRINT_OUTPUT", false, "Is the output of the cut process desired?", xfem_general);
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_DEBUG_OUT",
+      {.description = "Do you want to write extended Gmsh output for each timestep?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_DEBUG_OUT_SCREEN",
+      {.description = "Do you want to be informed, if Gmsh output is written?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_SOL_OUT",
+      {.description = "Do you want to write extended Gmsh output for each timestep?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_TIMINT_OUT",
+      {.description = "Do you want to write extended Gmsh output for each timestep?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_EOS_OUT",
+      {.description = "Do you want to write extended Gmsh output for each timestep?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_DISCRET_OUT",
+      {.description = "Do you want to write extended Gmsh output for each timestep?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("GMSH_CUT_OUT",
+      {.description = "Do you want to write extended Gmsh output for each timestep?",
+          .default_value = false}));
+  xfem_general.specs.emplace_back(parameter<bool>("PRINT_OUTPUT",
+      {.description = "Is the output of the cut process desired?", .default_value = false}));
 
   Core::Utils::int_parameter(
       "MAX_NUM_DOFSETS", 3, "Maximum number of volumecells in the XFEM element", xfem_general);
@@ -75,14 +83,16 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::SectionSpecs xfluid_general{xfluid_dyn, "GENERAL"};
 
   // Do we use more than one fluid discretization?
-  Core::Utils::bool_parameter("XFLUIDFLUID", false, "Use an embedded fluid patch.", xfluid_general);
+  xfluid_general.specs.emplace_back(parameter<bool>(
+      "XFLUIDFLUID", {.description = "Use an embedded fluid patch.", .default_value = false}));
 
   // How many monolithic steps we keep the fluidfluid-boundary fixed
   Core::Utils::int_parameter(
       "RELAXING_ALE_EVERY", 1, "Relaxing Ale after how many monolithic steps", xfluid_general);
 
-  Core::Utils::bool_parameter("RELAXING_ALE", true,
-      "switch on/off for relaxing Ale in monolithic fluid-fluid-fsi", xfluid_general);
+  xfluid_general.specs.emplace_back(parameter<bool>("RELAXING_ALE",
+      {.description = "switch on/off for relaxing Ale in monolithic fluid-fluid-fsi",
+          .default_value = true}));
 
   Core::Utils::double_parameter(
       "XFLUIDFLUID_SEARCHRADIUS", 1.0, "Radius of the search tree", xfluid_general);
@@ -138,7 +148,8 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_Proj_AND_GHOST_by_Proj_or_Copy_or_GP),
       xfluid_general);
 
-  Core::Utils::bool_parameter("ALE_XFluid", false, "XFluid is Ale Fluid?", xfluid_general);
+  xfluid_general.specs.emplace_back(parameter<bool>(
+      "ALE_XFluid", {.description = "XFluid is Ale Fluid?", .default_value = false}));
 
   // for new OST-implementation: which interface terms to be evaluated for previous time step
   Core::Utils::string_to_integral_parameter<InterfaceTermsPreviousState>(
@@ -153,11 +164,13 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           ),
       xfluid_general);
 
-  Core::Utils::bool_parameter("XFLUID_TIMEINT_CHECK_INTERFACETIPS", true,
-      "Xfluid TimeIntegration Special Check if node has changed the side!", xfluid_general);
+  xfluid_general.specs.emplace_back(parameter<bool>("XFLUID_TIMEINT_CHECK_INTERFACETIPS",
+      {.description = "Xfluid TimeIntegration Special Check if node has changed the side!",
+          .default_value = true}));
 
-  Core::Utils::bool_parameter("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE", true,
-      "Xfluid TimeIntegration Special Check if node is sliding on surface!", xfluid_general);
+  xfluid_general.specs.emplace_back(parameter<bool>("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE",
+      {.description = "Xfluid TimeIntegration Special Check if node is sliding on surface!",
+          .default_value = true}));
 
   xfluid_general.move_into_collection(list);
 
@@ -292,18 +305,22 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           ),
       xfluid_stab);
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_STAB", false,
-      "switch on/off ghost penalty interface stabilization", xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<bool>(
+      "GHOST_PENALTY_STAB", {.description = "switch on/off ghost penalty interface stabilization",
+                                .default_value = false}));
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_TRANSIENT_STAB", false,
-      "switch on/off ghost penalty transient interface stabilization", xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_TRANSIENT_STAB",
+      {.description = "switch on/off ghost penalty transient interface stabilization",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_2nd_STAB", false,
-      "switch on/off ghost penalty interface stabilization for 2nd order derivatives", xfluid_stab);
-  Core::Utils::bool_parameter("GHOST_PENALTY_2nd_STAB_NORMAL", false,
-      "switch between ghost penalty interface stabilization for 2nd order derivatives in normal or "
-      "all spatial directions",
-      xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_2nd_STAB",
+      {.description =
+              "switch on/off ghost penalty interface stabilization for 2nd order derivatives",
+          .default_value = false}));
+  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_2nd_STAB_NORMAL",
+      {.description = "switch between ghost penalty interface stabilization for 2nd order "
+                      "derivatives in normal or all spatial directions",
+          .default_value = false}));
 
 
   Core::Utils::double_parameter("GHOST_PENALTY_FAC", 0.1,
@@ -321,20 +338,21 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       xfluid_stab);
 
 
-  Core::Utils::bool_parameter("XFF_EOS_PRES_EMB_LAYER", false,
-      "switch on/off edge-based pressure stabilization on interface-contributing elements of the "
-      "embedded fluid",
-      xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<bool>("XFF_EOS_PRES_EMB_LAYER",
+      {.description = "switch on/off edge-based pressure stabilization on interface-contributing "
+                      "elements of the embedded fluid",
+          .default_value = false}));
 
-  Core::Utils::bool_parameter("IS_PSEUDO_2D", false,
-      "modify viscous interface stabilization due to the vanishing polynomial in third dimension "
-      "when using strong Dirichlet conditions to block polynomials in one spatial dimension",
-      xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<bool>(
+      "IS_PSEUDO_2D", {.description = "modify viscous interface stabilization due to the vanishing "
+                                      "polynomial in third dimension when using strong Dirichlet "
+                                      "conditions to block polynomials in one spatial dimension",
+                          .default_value = false}));
 
-  Core::Utils::bool_parameter("GHOST_PENALTY_ADD_INNER_FACES", false,
-      "Apply ghost penalty stabilization also for inner faces if this is possible due to the "
-      "dofsets",
-      xfluid_stab);
+  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_ADD_INNER_FACES",
+      {.description = "Apply ghost penalty stabilization also for inner faces if this is possible "
+                      "due to the dofsets",
+          .default_value = false}));
 
   xfluid_stab.move_into_collection(list);
 
@@ -345,8 +363,9 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "ITEMIN", 1, "How many iterations are performed minimal", xfsi_monolithic);
   Core::Utils::int_parameter(
       "ITEMAX_OUTER", 5, "How many outer iterations are performed maximal", xfsi_monolithic);
-  Core::Utils::bool_parameter("ND_NEWTON_DAMPING", false,
-      "Activate Newton damping based on residual and increment", xfsi_monolithic);
+  xfsi_monolithic.specs.emplace_back(parameter<bool>("ND_NEWTON_DAMPING",
+      {.description = "Activate Newton damping based on residual and increment",
+          .default_value = false}));
   Core::Utils::double_parameter("ND_MAX_DISP_ITERINC", -1.0,
       "Maximal displacement increment to apply full newton --> otherwise damp newton",
       xfsi_monolithic);
@@ -369,18 +388,18 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::int_parameter("CUT_EVALUATE_MINITER", 0,
       "Minimal number of nonlinear iterations, before the CUT is potentially not evaluated",
       xfsi_monolithic);
-  Core::Utils::bool_parameter("EXTRAPOLATE_TO_ZERO", false,
-      "the extrapolation of the fluid stress in the contact zone is relaxed to zero after a "
-      "certain distance",
-      xfsi_monolithic);
+  xfsi_monolithic.specs.emplace_back(parameter<bool>(
+      "EXTRAPOLATE_TO_ZERO", {.description = "the extrapolation of the fluid stress in the contact "
+                                             "zone is relaxed to zero after a certain distance",
+                                 .default_value = false}));
   Core::Utils::double_parameter("POROCONTACTFPSI_HFRACTION", 1.0,
       "factor of element size, when transition between FPSI and PSCI is started!", xfsi_monolithic);
   Core::Utils::double_parameter("POROCONTACTFPSI_FULLPCFRACTION", 0.0,
       "ration of gap/(POROCONTACTFPSI_HFRACTION*h) when full PSCI is started!", xfsi_monolithic);
-  Core::Utils::bool_parameter("USE_PORO_PRESSURE", true,
-      "the extrapolation of the fluid stress in the contact zone is relaxed to zero after a "
-      "certtain distance",
-      xfsi_monolithic);
+  xfsi_monolithic.specs.emplace_back(parameter<bool>(
+      "USE_PORO_PRESSURE", {.description = "the extrapolation of the fluid stress in the contact "
+                                           "zone is relaxed to zero after a certtain distance",
+                               .default_value = true}));
 
   xfsi_monolithic.move_into_collection(list);
 }

--- a/src/lubrication/src/4C_lubrication_input.cpp
+++ b/src/lubrication/src/4C_lubrication_input.cpp
@@ -14,6 +14,7 @@ FOUR_C_NAMESPACE_OPEN
 void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs lubricationdyn("LUBRICATION DYNAMIC");
 
@@ -48,14 +49,15 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   Core::Utils::int_parameter(
       "HFUNCNO", -1, "function number for lubrication height field", lubricationdyn);
 
-  Core::Utils::bool_parameter(
-      "OUTMEAN", false, "Output of mean values for scalars and density", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>("OUTMEAN",
+      {.description = "Output of mean values for scalars and density", .default_value = false}));
 
-  Core::Utils::bool_parameter(
-      "OUTPUT_GMSH", false, "Do you want to write Gmsh postprocessing files?", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
+      {.description = "Do you want to write Gmsh postprocessing files?", .default_value = false}));
 
-  Core::Utils::bool_parameter("MATLAB_STATE_OUTPUT", false,
-      "Do you want to write the state solution to Matlab file?", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>("MATLAB_STATE_OUTPUT",
+      {.description = "Do you want to write the state solution to Matlab file?",
+          .default_value = false}));
 
   /// linear solver id used for lubrication problems
   Core::Utils::int_parameter("LINEAR_SOLVER", -1,
@@ -69,9 +71,10 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "CONVTOL", 1e-13, "Tolerance for convergence check", lubricationdyn);
 
   // convergence criteria adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-      lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
@@ -106,17 +109,19 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "ROUGHNESS_STD_DEVIATION", 0., "standard deviation of surface roughness", lubricationdyn);
 
   /// use modified reynolds equ.
-  Core::Utils::bool_parameter("MODIFIED_REYNOLDS_EQU", false,
-      "the lubrication problem will use the modified reynolds equ. in order to consider surface"
-      " roughness",
-      lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>("MODIFIED_REYNOLDS_EQU",
+      {.description = "the lubrication problem will use the modified reynolds equ. in order to "
+                      "consider surface roughness",
+          .default_value = false}));
 
   /// Flag for considering the Squeeze term in Reynolds Equation
-  Core::Utils::bool_parameter("ADD_SQUEEZE_TERM", false,
-      "the squeeze term will also be considered in the Reynolds Equation", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>("ADD_SQUEEZE_TERM",
+      {.description = "the squeeze term will also be considered in the Reynolds Equation",
+          .default_value = false}));
 
   /// Flag for considering the pure Reynolds Equation
-  Core::Utils::bool_parameter("PURE_LUB", false, "the problem is pure lubrication", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<bool>(
+      "PURE_LUB", {.description = "the problem is pure lubrication", .default_value = false}));
 
   lubricationdyn.move_into_collection(list);
 }

--- a/src/lubrication/src/4C_lubrication_input.cpp
+++ b/src/lubrication/src/4C_lubrication_input.cpp
@@ -18,9 +18,11 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
 
   Core::Utils::SectionSpecs lubricationdyn("LUBRICATION DYNAMIC");
 
-  Core::Utils::double_parameter("MAXTIME", 1000.0, "Total simulation time", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>(
+      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
   Core::Utils::int_parameter("NUMSTEP", 20, "Total number of time steps", lubricationdyn);
-  Core::Utils::double_parameter("TIMESTEP", 0.1, "Time increment dt", lubricationdyn);
+  lubricationdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
   Core::Utils::int_parameter("RESULTSEVERY", 1, "Increment for writing solution", lubricationdyn);
   Core::Utils::int_parameter("RESTARTEVERY", 1, "Increment for writing restart", lubricationdyn);
 
@@ -64,21 +66,22 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       "number of linear solver used for the Lubrication problem", lubricationdyn);
 
   Core::Utils::int_parameter("ITEMAX", 10, "max. number of nonlin. iterations", lubricationdyn);
-  Core::Utils::double_parameter("ABSTOLRES", 1e-14,
-      "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
-      lubricationdyn);
-  Core::Utils::double_parameter(
-      "CONVTOL", 1e-13, "Tolerance for convergence check", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>("ABSTOLRES",
+      {.description =
+              "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
+          .default_value = 1e-14}));
+  lubricationdyn.specs.emplace_back(parameter<double>(
+      "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-13}));
 
   // convergence criteria adaptivity
   lubricationdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_PRE", "Abs",
       "type of norm for temperature convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
@@ -93,20 +96,22 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
       tuple<VectorNorm>(norm_l1, norm_l2, norm_rms, norm_inf), lubricationdyn);
 
   /// Iterationparameters
-  Core::Utils::double_parameter("TOLPRE", 1.0E-06,
-      "tolerance in the temperature norm of the Newton iteration", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>(
+      "TOLPRE", {.description = "tolerance in the temperature norm of the Newton iteration",
+                    .default_value = 1.0E-06}));
 
-  Core::Utils::double_parameter(
-      "TOLRES", 1.0E-06, "tolerance in the residual norm for the Newton iteration", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>(
+      "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                    .default_value = 1.0E-06}));
 
-  Core::Utils::double_parameter(
-      "PENALTY_CAVITATION", 0., "penalty parameter for regularized cavitation", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>("PENALTY_CAVITATION",
+      {.description = "penalty parameter for regularized cavitation", .default_value = 0.}));
 
-  Core::Utils::double_parameter(
-      "GAP_OFFSET", 0., "Additional offset to the fluid gap", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>(
+      "GAP_OFFSET", {.description = "Additional offset to the fluid gap", .default_value = 0.}));
 
-  Core::Utils::double_parameter(
-      "ROUGHNESS_STD_DEVIATION", 0., "standard deviation of surface roughness", lubricationdyn);
+  lubricationdyn.specs.emplace_back(parameter<double>("ROUGHNESS_STD_DEVIATION",
+      {.description = "standard deviation of surface roughness", .default_value = 0.}));
 
   /// use modified reynolds equ.
   lubricationdyn.specs.emplace_back(parameter<bool>("MODIFIED_REYNOLDS_EQU",

--- a/src/mat/4C_mat_fluidporo_multiphase_singlereaction.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase_singlereaction.cpp
@@ -36,7 +36,6 @@ Mat::PAR::FluidPoroSingleReaction::FluidPoroSingleReaction(
       porosityname_("porosity"),
       volfracnames_(numvolfrac_),
       volfracpressurenames_(numvolfrac_)
-
 {
 }
 

--- a/src/mat/4C_mat_list_reactions.cpp
+++ b/src/mat/4C_mat_list_reactions.cpp
@@ -26,8 +26,6 @@ Mat::PAR::MatListReactions::MatListReactions(const Core::Mat::PAR::Parameter::Da
 {
   // check if sizes fit
   if (numreac_ != (int)reacids_.size())
-
-
     FOUR_C_THROW("number of materials %d does not fit to size of material vector %d", nummat_,
         reacids_.size());
 

--- a/src/mat/4C_mat_scatra_multiscale_gp.cpp
+++ b/src/mat/4C_mat_scatra_multiscale_gp.cpp
@@ -68,7 +68,6 @@ Mat::ScatraMultiScaleGP::ScatraMultiScaleGP(
       ddet_fdtn_(0.0),
       ddet_fdtnp_(0.0),
       is_ale_(is_ale)
-
 {
 }
 

--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
@@ -29,8 +29,7 @@ Mat::Elastic::PAR::CoupTransverselyIsotropic::CoupTransverselyIsotropic(
       angle_(matdata.parameters.get<double>("ANGLE")),
       fiber_gid_(matdata.parameters.get<int>("FIBER")),
       init_(matdata.parameters.get<int>("INIT"))
-{
-  /* empty */
+{ /* empty */
 }
 
 void Mat::Elastic::PAR::CoupTransverselyIsotropic::print() const
@@ -47,8 +46,7 @@ void Mat::Elastic::PAR::CoupTransverselyIsotropic::print() const
 
 Mat::Elastic::CoupTransverselyIsotropic::CoupTransverselyIsotropic(my_params* params)
     : params_(params)
-{
-  /* empty */
+{ /* empty */
 }
 
 void Mat::Elastic::CoupTransverselyIsotropic::setup(

--- a/src/mat/elast/4C_mat_elast_visco_generalizedgenmax.cpp
+++ b/src/mat/elast/4C_mat_elast_visco_generalizedgenmax.cpp
@@ -19,7 +19,6 @@ Mat::Elastic::PAR::GeneralizedGenMax::GeneralizedGenMax(
       numbranch_(matdata.parameters.get<int>("NUMBRANCH")),
       matids_(matdata.parameters.get<std::vector<int>>("MATIDS")),
       solve_(matdata.parameters.get<std::string>("SOLVE"))
-
 {
 }
 

--- a/src/mortar/4C_mortar_interface.cpp
+++ b/src/mortar/4C_mortar_interface.cpp
@@ -85,8 +85,7 @@ Mortar::InterfaceDataContainer::InterfaceDataContainer()
       porotype_(Inpar::Mortar::other),
       ehl_(false),
       isinit_(false)
-{
-  /* empty */
+{ /* empty */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/mortar/4C_mortar_matrix_transform.cpp
+++ b/src/mortar/4C_mortar_matrix_transform.cpp
@@ -25,8 +25,7 @@ Mortar::MatrixRowColTransformer::MatrixRowColTransformer(const unsigned num_tran
       slave_col_(num_transformer),
       master_row_(num_transformer),
       master_col_(num_transformer)
-{
-  /* empty */
+{ /* empty */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -47,7 +47,6 @@ ScaTra::TimIntHDG::TimIntHDG(const std::shared_ptr<Core::FE::Discretization>& ac
       padapterrorbase_(params->get<double>("PADAPTERRORBASE")),
       padaptdegreemax_(params->get<int>("PADAPTDEGREEMAX")),
       elementdegree_(nullptr)
-
 {
 }
 

--- a/src/so3/4C_so3_poro_evaluate.cpp
+++ b/src/so3/4C_so3_poro_evaluate.cpp
@@ -495,8 +495,9 @@ void Discret::Elements::So3Poro<So3Ele, distype>::nonlinear_stiffness_poroelast(
     Core::LinAlg::Matrix<numdof_, 1>* force,              // element internal force vector
     // Core::LinAlg::Matrix<numgptpar_, numstr_>* elestress, // stresses at GP
     // Core::LinAlg::Matrix<numgptpar_, numstr_>* elestrain, // strains at GP
-    Teuchos::ParameterList& params  // algorithmic parameters e.g. time
-    //   const Inpar::Solid::StressType       iostress     // stress output option
+    Teuchos::ParameterList&
+        params  // algorithmic parameters e.g. time
+                //   const Inpar::Solid::StressType       iostress     // stress output option
 )
 {
   get_materials();

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -267,8 +267,7 @@ void NOX::Nln::LinearSystem::set_linear_problem_for_solve(Epetra_LinearProblem& 
  *----------------------------------------------------------------------*/
 void NOX::Nln::LinearSystem::complete_solution_after_solve(
     const Epetra_LinearProblem& linProblem, Core::LinAlg::Vector<double>& lhs) const
-{
-  /* nothing to do in the default case */
+{ /* nothing to do in the default case */
 }
 
 /*----------------------------------------------------------------------*

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
@@ -43,8 +43,7 @@ NOX::Nln::Problem::Problem(const Teuchos::RCP<NOX::Nln::GlobalData>& noxNlnGloba
       xVector_(nullptr),
       jac_(nullptr),
       precMat_(Teuchos::null)
-{
-  /* intentionally left blank */
+{ /* intentionally left blank */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
@@ -79,7 +79,7 @@ void SSI::ScatraStructureOffDiagCoupling::evaluate_off_diag_block_scatra_structu
   // create strategy for assembly of scatra-structure matrix block
   Core::FE::AssembleStrategy strategyscatrastructure(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
-      // scalar transport discretization
+          // scalar transport discretization
       1,  // column assembly based on number of dofset associated with structural dofs on scalar
       // transport discretization
       scatrastructureblock,  // scatra-structure matrix block
@@ -117,7 +117,7 @@ void SSI::ScatraManifoldStructureOffDiagCoupling::
   // create strategy for assembly of scatra-structure matrix block
   Core::FE::AssembleStrategy strategyscatrastructure(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
-      // scalar transport discretization
+          // scalar transport discretization
       1,  // column assembly based on number of dofset associated with structural dofs on scalar
       // transport discretization
       scatramanifoldstructureblock,  // scatra-structure matrix block
@@ -209,7 +209,7 @@ void SSI::ScatraStructureOffDiagCoupling::evaluate_off_diag_block_structure_scat
   // create strategy for assembly of structure-scatra matrix block
   Core::FE::AssembleStrategy strategystructurescatra(
       0,  // row assembly based on number of dofset associated with structure dofs on structural
-      // discretization
+          // discretization
       1,  // column assembly based on number of dofset associated with scalar transport dofs on
       // structural discretization
       structurescatradomain,  // structure-scatra matrix block
@@ -378,7 +378,7 @@ void SSI::ScatraStructureOffDiagCoupling::
   // create strategy for assembly of auxiliary system matrix
   Core::FE::AssembleStrategy strategyscatras2istructure(
       0,  // row assembly based on number of dofset associated with scalar transport dofs on
-      // scalar transport discretization
+          // scalar transport discretization
       1,  // column assembly based on number of dofset associated with structural dofs on
       // structural discretization
       scatra_slave_flux_structure_slave_dofs_on_scatra_slave_matrix,

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -710,8 +710,7 @@ void Solid::Integrator::post_time_loop()
  *----------------------------------------------------------------------------*/
 Solid::Integrator::MidTimeEnergy::MidTimeEnergy(const Integrator& integrator)
     : integrator_(integrator), avg_type_(Inpar::Solid::midavg_vague)
-{
-  /* empty */
+{ /* empty */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/4C_structure_new_timint_basedataio.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataio.cpp
@@ -279,8 +279,7 @@ void Solid::TimeInt::BaseDataIO::set_last_written_results(const int step)
 NOX::Nln::Solver::PrePostOp::TimeInt::WriteOutputEveryIteration::WriteOutputEveryIteration(
     Core::IO::EveryIterationWriter& every_iter_writer)
     : every_iter_writer_(every_iter_writer)
-{
-  /* empty */
+{ /* empty */
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/thermo/src/implicit/4C_thermo_timint.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.cpp
@@ -656,7 +656,6 @@ void Thermo::TimInt::output_heatflux_tempgrad(bool& datawritten)
 std::shared_ptr<Core::Utils::ResultTest> Thermo::TimInt::create_field_test()
 {
   return std::make_shared<Thermo::ResultTest>(*this);
-
 }  // CreateFieldTest()
 
 

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -42,20 +42,24 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
   Core::Utils::int_parameter("INITFUNCNO", -1, "function number for thermal initial field", tdyn);
 
   // Time loop control
-  Core::Utils::double_parameter("TIMESTEP", 0.05, "time step size", tdyn);
+  tdyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.05}));
   Core::Utils::int_parameter("NUMSTEP", 200, "maximum number of steps", tdyn);
-  Core::Utils::double_parameter("MAXTIME", 5.0, "maximum time", tdyn);
+  tdyn.specs.emplace_back(
+      parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 5.0}));
 
   // Iterationparameters
-  Core::Utils::double_parameter(
-      "TOLTEMP", 1.0E-10, "tolerance in the temperature norm of the Newton iteration", tdyn);
+  tdyn.specs.emplace_back(parameter<double>(
+      "TOLTEMP", {.description = "tolerance in the temperature norm of the Newton iteration",
+                     .default_value = 1.0E-10}));
 
   Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_TEMP", "Abs",
       "type of norm for temperature convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
       tuple<ConvNorm>(convnorm_abs, convnorm_rel, convnorm_mix), tdyn);
 
-  Core::Utils::double_parameter(
-      "TOLRES", 1.0E-08, "tolerance in the residual norm for the Newton iteration", tdyn);
+  tdyn.specs.emplace_back(parameter<double>(
+      "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                    .default_value = 1.0E-08}));
 
   Core::Utils::string_to_integral_parameter<ConvNorm>("NORM_RESF", "Abs",
       "type of norm for residual convergence check", tuple<std::string>("Abs", "Rel", "Mix"),
@@ -99,10 +103,10 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
       {.description =
               "Switch on adaptive control of linear solver tolerance for nonlinear solution",
           .default_value = false}));
-  Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
-      "The linear solver shall be this much better than the current nonlinear residual in the "
-      "nonlinear convergence limit",
-      tdyn);
+  tdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
+      {.description = "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+          .default_value = 0.1}));
 
   tdyn.specs.emplace_back(parameter<bool>(
       "LUMPCAPA", {.description = "Lump the capacity matrix for explicit time integration",
@@ -135,10 +139,14 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
       tuple<MidAverageEnum>(midavg_vague, midavg_imrlike, midavg_trlike), tgenalpha);
 
   // default values correspond to midpoint-rule
-  Core::Utils::double_parameter("GAMMA", 0.5, "Generalised-alpha factor in (0,1]", tgenalpha);
-  Core::Utils::double_parameter("ALPHA_M", 0.5, "Generalised-alpha factor in [0.5,1)", tgenalpha);
-  Core::Utils::double_parameter("ALPHA_F", 0.5, "Generalised-alpha factor in [0.5,1)", tgenalpha);
-  Core::Utils::double_parameter("RHO_INF", -1.0, "Generalised-alpha factor in [0,1]", tgenalpha);
+  tgenalpha.specs.emplace_back(parameter<double>(
+      "GAMMA", {.description = "Generalised-alpha factor in (0,1]", .default_value = 0.5}));
+  tgenalpha.specs.emplace_back(parameter<double>(
+      "ALPHA_M", {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}));
+  tgenalpha.specs.emplace_back(parameter<double>(
+      "ALPHA_F", {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}));
+  tgenalpha.specs.emplace_back(parameter<double>(
+      "RHO_INF", {.description = "Generalised-alpha factor in [0,1]", .default_value = -1.0}));
 
   tgenalpha.move_into_collection(list);
 
@@ -146,7 +154,8 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
   /* parameters for one-step-theta thermal integrator */
   Core::Utils::SectionSpecs tonesteptheta{tdyn, "ONESTEPTHETA"};
 
-  Core::Utils::double_parameter("THETA", 0.5, "One-step-theta factor in (0,1]", tonesteptheta);
+  tonesteptheta.specs.emplace_back(parameter<double>(
+      "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5}));
 
   tonesteptheta.move_into_collection(list);
 

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -17,6 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using Teuchos::tuple;
+  using namespace Core::IO::InputSpecBuilders;
 
   Core::Utils::SectionSpecs tdyn{"THERMAL DYNAMIC"};
 
@@ -94,15 +95,18 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
       tuple<PredEnum>(pred_vague, pred_consttemp, pred_consttemprate, pred_tangtemp), tdyn);
 
   // convergence criteria solver adaptivity
-  Core::Utils::bool_parameter("ADAPTCONV", false,
-      "Switch on adaptive control of linear solver tolerance for nonlinear solution", tdyn);
+  tdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
+      {.description =
+              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+          .default_value = false}));
   Core::Utils::double_parameter("ADAPTCONV_BETTER", 0.1,
       "The linear solver shall be this much better than the current nonlinear residual in the "
       "nonlinear convergence limit",
       tdyn);
 
-  Core::Utils::bool_parameter(
-      "LUMPCAPA", false, "Lump the capacity matrix for explicit time integration", tdyn);
+  tdyn.specs.emplace_back(parameter<bool>(
+      "LUMPCAPA", {.description = "Lump the capacity matrix for explicit time integration",
+                      .default_value = false}));
 
   // number of linear solver used for thermal problems
   Core::Utils::int_parameter(
@@ -151,29 +155,32 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
     Core::Utils::SectionSpecs sublist_vtk_output{tdyn, "RUNTIME VTK OUTPUT"};
 
     // whether to write output for thermo
-    Core::Utils::bool_parameter("OUTPUT_THERMO", false, "write thermo output", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "OUTPUT_THERMO", {.description = "write thermo output", .default_value = false}));
 
     // whether to write temperature state
-    Core::Utils::bool_parameter(
-        "TEMPERATURE", false, "write temperature output", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "TEMPERATURE", {.description = "write temperature output", .default_value = false}));
 
     // whether to write heatflux state
-    Core::Utils::bool_parameter("HEATFLUX", false, "write heatflux output", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "HEATFLUX", {.description = "write heatflux output", .default_value = false}));
 
     // whether to write temperature gradient state
-    Core::Utils::bool_parameter(
-        "TEMPGRAD", false, "write temperature gradient output", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "TEMPGRAD", {.description = "write temperature gradient output", .default_value = false}));
 
     // whether to write element owner
-    Core::Utils::bool_parameter("ELEMENT_OWNER", false, "write element owner", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}));
 
     // whether to write element GIDs
-    Core::Utils::bool_parameter(
-        "ELEMENT_GID", false, "write 4C internal element GIDs", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "ELEMENT_GID", {.description = "write 4C internal element GIDs", .default_value = false}));
 
     // whether to write node GIDs
-    Core::Utils::bool_parameter(
-        "NODE_GID", false, "write 4C internal node GIDs", sublist_vtk_output);
+    sublist_vtk_output.specs.emplace_back(parameter<bool>(
+        "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}));
 
     sublist_vtk_output.move_into_collection(list);
   }
@@ -183,10 +190,12 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
     Core::Utils::SectionSpecs sublist_csv_output{tdyn, "RUNTIME CSV OUTPUT"};
 
     // whether to write csv output for thermo
-    Core::Utils::bool_parameter("OUTPUT_THERMO", false, "write thermo output", sublist_csv_output);
+    sublist_csv_output.specs.emplace_back(parameter<bool>(
+        "OUTPUT_THERMO", {.description = "write thermo output", .default_value = false}));
 
     // whether to write energy state
-    Core::Utils::bool_parameter("ENERGY", false, "write energy output", sublist_csv_output);
+    sublist_csv_output.specs.emplace_back(
+        parameter<bool>("ENERGY", {.description = "write energy output", .default_value = false}));
 
     sublist_csv_output.move_into_collection(list);
   }

--- a/src/truss3/4C_truss3.cpp
+++ b/src/truss3/4C_truss3.cpp
@@ -119,7 +119,6 @@ Discret::Elements::Truss3::Truss3(const Discret::Elements::Truss3& old)
       kintype_(old.kintype_),
       material_(old.material_),
       x_(old.x_)
-
 {
 }
 /*----------------------------------------------------------------------*


### PR DESCRIPTION
Removes the calls of input helper functions `Core::Utils::bool_parameter`, `Core::Utils::double_parameter`, `Core::Utils::string_parameter`. `int_parameter` and `string_to_integral_parameter` should follow soon. See #463