### PR TITLE
Fix MPI_COMM nullptr initialization

### DIFF
--- a/src/cut/4C_cut_levelsetintersection.cpp
+++ b/src/cut/4C_cut_levelsetintersection.cpp
@@ -9,12 +9,13 @@
 
 #include "4C_cut_side.hpp"
 
+#include <mpi.h>
 #include <Teuchos_TimeMonitor.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
 Cut::LevelSetIntersection::LevelSetIntersection(int myrank, bool create_side)
-    : ParentIntersection(myrank), side_(nullptr), comm_(nullptr)
+    : ParentIntersection(myrank), side_(nullptr), comm_(MPI_COMM_NULL)
 {
   if (create_side) add_cut_side(1);
 }


### PR DESCRIPTION
I missed a nullptr for the MPI_COMM. Follow-up to PR #433