### PR TITLE
Deprecate old InputSpecBuilders::selection function

### DIFF
--- a/src/ale/4C_ale_input.cpp
+++ b/src/ale/4C_ale_input.cpp
@@ -100,7 +100,7 @@ void ALE::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition
 
   const auto make_ale_update = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
-    cond.add_component(selection<std::string>("COUPLING",
+    cond.add_component(deprecated_selection<std::string>("COUPLING",
         {"lagrange", "heightfunction", "sphereHeightFunction", "meantangentialvelocity",
             "meantangentialvelocityscaled"},
         {.description = "", .default_value = "lagrange"}));

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -1924,7 +1924,8 @@ void CONTACT::STRATEGY::Factory::set_parameters_for_contact_condition(
       if (s2ikinetics_cond->parameters().get<int>("ConditionID") == conditiongroupid)
       {
         // only the slave-side stores the parameters
-        if (s2ikinetics_cond->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+        if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+            Inpar::S2I::side_slave)
         {
           // fill the parameters from the s2i condition
           ScaTra::MeshtyingStrategyS2I::

--- a/src/contact/4C_contact_utils.cpp
+++ b/src/contact/4C_contact_utils.cpp
@@ -456,17 +456,16 @@ void CONTACT::Utils::DbcHandler::detect_dbc_slave_nodes_and_elements(
 
       const Core::Conditions::Condition* sl_cond = ccond_grp[i];
 
-      const int dbc_handling_id = sl_cond->parameters().get<int>("DbcHandling");
-      const auto dbc_handling = static_cast<Inpar::Mortar::DBCHandling>(dbc_handling_id);
-
+      const auto dbc_handling =
+          sl_cond->parameters().get<Inpar::Mortar::DBCHandling>("DbcHandling");
       switch (dbc_handling)
       {
-        case Inpar::Mortar::DBCHandling::remove_dbc_nodes_from_slave_side:
+        case Inpar::Mortar::DBCHandling::RemoveDBCSlaveNodes:
         {
           sl_conds.push_back(sl_cond);
           break;
         }
-        case Inpar::Mortar::DBCHandling::do_nothing:
+        case Inpar::Mortar::DBCHandling::DoNothing:
         {
           break;
         }

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -974,11 +974,7 @@ namespace Core::IO
     [[nodiscard]] auto from_parameter(const std::string& name);
 
     /**
-     * A parameter whose value is a selection from a list of choices. For example:
-     *
-     * @code
-     * selection<int>("my_selection", {{"a", 1}, {"b", 2}, {"c", 3}});
-     * @endcode
+     * A parameter whose value is a selection from a list of choices.
      *
      * The choices are given as a map from string to stored type T. This function is for
      * convenience, as you do not need to convert parsed string values to another type yourself. A
@@ -996,7 +992,7 @@ namespace Core::IO
      */
     template <typename T>
       requires(std::is_enum_v<T>)
-    [[nodiscard]] InputSpec selection(std::string name,
+    [[nodiscard]] InputSpec deprecated_selection(std::string name,
         std::map<std::string, RemoveOptional<T>> choices, ParameterDataIn<T> data = {});
 
 
@@ -1013,7 +1009,7 @@ namespace Core::IO
      * @relatedalso InputSpec
      */
     template <std::same_as<std::string> T>
-    [[nodiscard]] InputSpec selection(
+    [[nodiscard]] InputSpec deprecated_selection(
         std::string name, std::vector<std::string> choices, ParameterDataIn<T> data = {});
 
     /**
@@ -1769,7 +1765,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
   for (auto&& [choice_name, choice_spec] : choices.choices)
   {
     specs.emplace_back(all_of({
-        selection<std::string>(selector.name, {choice_name},
+        deprecated_selection<std::string>(selector.name, {choice_name},
             {.description = "Selects which other parameters are allowed in this group."}),
         std::move(choice_spec),
     }));
@@ -1850,7 +1846,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::Internal::selection_internal(
 
 template <typename T>
   requires(std::is_enum_v<T>)
-Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
+Core::IO::InputSpec Core::IO::InputSpecBuilders::deprecated_selection(
     std::string name, std::map<std::string, RemoveOptional<T>> choices, ParameterDataIn<T> data)
 {
   return Internal::selection_internal(name, choices, data);
@@ -1858,7 +1854,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
 
 
 template <std::same_as<std::string> T>
-Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
+Core::IO::InputSpec Core::IO::InputSpecBuilders::deprecated_selection(
     std::string name, std::vector<std::string> choices, ParameterDataIn<T> data)
 {
   std::map<std::string, std::string> choices_with_strings;

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -989,10 +989,13 @@ namespace Core::IO
      * @note If you want to store the choices as strings and not map them to another type, use the
      * other selection() function.
      *
+     * @deprecated If you want to select from a set of enum constants use the parameter() function
+     * with the enum type.
+     *
      * @relatedalso InputSpec
      */
     template <typename T>
-      requires(!std::same_as<T, std::string>)
+      requires(std::is_enum_v<T>)
     [[nodiscard]] InputSpec selection(std::string name,
         std::map<std::string, RemoveOptional<T>> choices, ParameterDataIn<T> data = {});
 
@@ -1003,6 +1006,9 @@ namespace Core::IO
      *
      * @note Although this function only works with strings, you still need to provide a type for
      * the first template parameter for consistency with the other functions.
+     *
+     * @deprecated If you want to select from a set of strings, create an enum with the name
+     * of the strings and use the parameter() function with the enum type.
      *
      * @relatedalso InputSpec
      */
@@ -1843,7 +1849,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::Internal::selection_internal(
 
 
 template <typename T>
-  requires(!std::same_as<T, std::string>)
+  requires(std::is_enum_v<T>)
 Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
     std::string name, std::map<std::string, RemoveOptional<T>> choices, ParameterDataIn<T> data)
 {

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -80,7 +80,7 @@ namespace
     };
 
     auto spec = all_of({
-        selection<EnumClass>("enum",
+        deprecated_selection<EnumClass>("enum",
             {
                 {"A", EnumClass::A},
                 {"B", EnumClass::B},

--- a/src/core/utils/src/functions/4C_utils_function_manager.cpp
+++ b/src/core/utils/src/functions/4C_utils_function_manager.cpp
@@ -94,17 +94,18 @@ void Core::Utils::add_valid_builtin_functions(Core::Utils::FunctionManager& func
           parameter<std::string>("NAME"),
           one_of({
               all_of({
-                  selection<std::string>("TYPE", {"expression"}),
+                  deprecated_selection<std::string>("TYPE", {"expression"}),
                   parameter<std::string>("DESCRIPTION"),
               }),
               all_of({
-                  selection<std::string>("TYPE", {"linearinterpolation", "fourierinterpolation"}),
+                  deprecated_selection<std::string>(
+                      "TYPE", {"linearinterpolation", "fourierinterpolation"}),
                   time_info,
                   parameter<std::vector<double>>(
                       "VALUES", {.size = from_parameter<int>("NUMPOINTS")}),
               }),
               all_of({
-                  selection<std::string>("TYPE", {"multifunction"}),
+                  deprecated_selection<std::string>("TYPE", {"multifunction"}),
                   time_info,
                   parameter<std::vector<std::string>>(
                       "DESCRIPTION", {.size = [](const IO::InputParameterContainer& container)

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.cpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.cpp
@@ -54,8 +54,9 @@ namespace Core::Utils
     }
     else
     {
-      section_specs.specs.emplace_back(Core::IO::InputSpecBuilders::selection<std::string>(
-          paramName, validParams, {.description = docString, .default_value = value}));
+      section_specs.specs.emplace_back(
+          Core::IO::InputSpecBuilders::deprecated_selection<std::string>(
+              paramName, validParams, {.description = docString, .default_value = value}));
     }
   }
 

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
@@ -112,11 +112,12 @@ namespace Core
       auto default_it = std::find(strings.begin(), strings.end(), defaultValue);
       FOUR_C_ASSERT(default_it != strings.end(), "Default value not found in choices.");
 
-      section_specs.specs.emplace_back(Core::IO::InputSpecBuilders::selection<T>(paramName, choices,
-          {
-              .description = docString,
-              .default_value = integrals[std::distance(strings.begin(), default_it)],
-          }));
+      section_specs.specs.emplace_back(
+          Core::IO::InputSpecBuilders::deprecated_selection<T>(paramName, choices,
+              {
+                  .description = docString,
+                  .default_value = integrals[std::distance(strings.begin(), default_it)],
+              }));
     }
 
   }  // namespace Utils

--- a/src/fluid/4C_fluid_functions.cpp
+++ b/src/fluid/4C_fluid_functions.cpp
@@ -337,13 +337,13 @@ void FLD::add_valid_fluid_functions(Core::Utils::FunctionManager& function_manag
   using namespace Core::IO::InputSpecBuilders;
   auto spec = one_of({
       all_of({
-          selection<std::string>("FLUID_FUNCTION", {"BELTRAMI"}),
+          deprecated_selection<std::string>("FLUID_FUNCTION", {"BELTRAMI"}),
           parameter<double>("c1"),
       }),
-      selection<std::string>("FLUID_FUNCTION",
+      deprecated_selection<std::string>("FLUID_FUNCTION",
           {"CHANNELWEAKLYCOMPRESSIBLE", "CORRECTIONTERMCHANNELWEAKLYCOMPRESSIBLE"}),
       all_of({
-          selection<std::string>("FLUID_FUNCTION",
+          deprecated_selection<std::string>("FLUID_FUNCTION",
               {"WEAKLYCOMPRESSIBLE_POISEUILLE", "WEAKLYCOMPRESSIBLE_POISEUILLE_FORCE"}),
           parameter<int>("MAT"),
           parameter<double>("L"),
@@ -351,33 +351,33 @@ void FLD::add_valid_fluid_functions(Core::Utils::FunctionManager& function_manag
           parameter<double>("U"),
       }),
       all_of({
-          selection<std::string>("FLUID_FUNCTION",
+          deprecated_selection<std::string>("FLUID_FUNCTION",
               {"WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW", "WEAKLYCOMPRESSIBLE_MANUFACTUREDFLOW_FORCE",
                   "WEAKLYCOMPRESSIBLE_ETIENNE_CFD", "WEAKLYCOMPRESSIBLE_ETIENNE_CFD_FORCE",
                   "WEAKLYCOMPRESSIBLE_ETIENNE_CFD_VISCOSITY"}),
           parameter<int>("MAT"),
       }),
       all_of({
-          selection<std::string>("FLUID_FUNCTION",
+          deprecated_selection<std::string>("FLUID_FUNCTION",
               {"WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID", "WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_FORCE",
                   "WEAKLYCOMPRESSIBLE_ETIENNE_FSI_FLUID_VISCOSITY"}),
           parameter<int>("MAT_FLUID"),
           parameter<int>("MAT_STRUCT"),
       }),
       all_of({
-          selection<std::string>(
+          deprecated_selection<std::string>(
               "FLUID_FUNCTION", {"BELTRAMI-UP", "BELTRAMI-GRADU", "KIMMOIN-UP", "KIMMOIN-GRADU"}),
           parameter<int>("MAT"),
           parameter<int>("ISSTAT"),
       }),
       all_of({
-          selection<std::string>("FLUID_FUNCTION", {"BELTRAMI-RHS", "KIMMOIN-RHS"}),
+          deprecated_selection<std::string>("FLUID_FUNCTION", {"BELTRAMI-RHS", "KIMMOIN-RHS"}),
           parameter<int>("MAT"),
           parameter<int>("ISSTAT"),
           parameter<int>("ISSTOKES"),
       }),
       all_of({
-          selection<std::string>("FLUID_FUNCTION", {"KIMMOIN-STRESS"}),
+          deprecated_selection<std::string>("FLUID_FUNCTION", {"KIMMOIN-STRESS"}),
           parameter<int>("MAT"),
           parameter<int>("ISSTAT"),
           parameter<double>("AMPLITUDE"),

--- a/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.cpp
@@ -12,6 +12,7 @@
 #include "4C_fem_general_node.hpp"
 #include "4C_fem_geometric_search_matchingoctree.hpp"
 #include "4C_global_data.hpp"
+#include "4C_inpar_fluid.hpp"
 #include "4C_io_input_parameter_container.hpp"
 #include "4C_utils_function_of_time.hpp"
 
@@ -320,7 +321,8 @@ void FLD::TransferTurbulentInflowCondition::get_data(
 {
   id = cond->parameters().get<int>("ID");
 
-  direction = cond->parameters().get<int>("DIRECTION");
+  direction =
+      static_cast<int>(cond->parameters().get<Inpar::FLUID::TurbInflowDirection>("DIRECTION"));
 
   const auto mytoggle = cond->parameters().get<std::string>("toggle");
   if (mytoggle == "master")

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
@@ -194,9 +194,9 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
   using namespace Core::IO::InputSpecBuilders;
 
   auto spec = one_of({
-      selection<std::string>("XFLUID_FUNCTION", {"FORWARDFACINGSTEP"}),
+      deprecated_selection<std::string>("XFLUID_FUNCTION", {"FORWARDFACINGSTEP"}),
       all_of({
-          selection<std::string>("XFLUID_FUNCTION", {"MOVINGLEVELSETCYLINDER"}),
+          deprecated_selection<std::string>("XFLUID_FUNCTION", {"MOVINGLEVELSETCYLINDER"}),
           parameter<std::vector<double>>("ORIGIN", {.size = 3}),
           parameter<double>("RADIUS"),
           parameter<std::vector<double>>("DIRECTION", {.size = 3}),
@@ -204,7 +204,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           parameter<double>("MAXSPEED"),
       }),
       all_of({
-          selection<std::string>(
+          deprecated_selection<std::string>(
               "XFLUID_FUNCTION", {"MOVINGLEVELSETTORUS", "MOVINGLEVELSETTORUSVELOCITY"}),
           parameter<std::vector<double>>("ORIGIN", {.size = 3}),
           parameter<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
@@ -218,7 +218,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           parameter<double>("ROTATION_RAMPTIME"),
       }),
       all_of({
-          selection<std::string>("XFLUID_FUNCTION", {"MOVINGLEVELSETTORUSSLIPLENGTH"}),
+          deprecated_selection<std::string>("XFLUID_FUNCTION", {"MOVINGLEVELSETTORUSSLIPLENGTH"}),
           parameter<std::vector<double>>("ORIGIN", {.size = 3}),
           parameter<std::vector<double>>("ORIENTVEC_TORUS", {.size = 3}),
           parameter<double>("RADIUS"),
@@ -232,7 +232,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           parameter<int>("SLIP_FUNCT"),
       }),
       all_of({
-          selection<std::string>("XFLUID_FUNCTION", {"TAYLORCOUETTEFLOW"}),
+          deprecated_selection<std::string>("XFLUID_FUNCTION", {"TAYLORCOUETTEFLOW"}),
           parameter<double>("RADIUS_I"),
           parameter<double>("RADIUS_O"),
           parameter<double>("VEL_THETA_I"),
@@ -244,7 +244,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
           parameter<double>("VISCOSITY"),
       }),
       all_of({
-          selection<std::string>("XFLUID_FUNCTION",
+          deprecated_selection<std::string>("XFLUID_FUNCTION",
               {"URQUIZABOXFLOW", "URQUIZABOXFLOW_TRACTION", "URQUIZABOXFLOW_FORCE"}),
           parameter<double>("LENGTHX"),
           parameter<double>("LENGTHY"),

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
@@ -42,7 +42,7 @@ void Discret::Utils::add_valid_combust_functions(Core::Utils::FunctionManager& f
   using namespace Core::IO::InputSpecBuilders;
 
   auto spec = one_of({
-      selection<std::string>("COMBUSTION_FUNCTION",
+      deprecated_selection<std::string>("COMBUSTION_FUNCTION",
           {
               "ZALESAKSDISK",
               "COLLAPSINGWATERCOLUMN",

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -529,7 +529,7 @@ std::shared_ptr<std::vector<std::shared_ptr<Mat::MaterialDefinition>>> Global::v
     m->add_component(parameter<double>("LAMBDAOPT",
         {.description = "optimal active fiber stretch related to active nominal stress maximum"}));
 
-    m->add_component(selection<Inpar::Mat::ActivationType>("ACTEVALTYPE",
+    m->add_component(deprecated_selection<Inpar::Mat::ActivationType>("ACTEVALTYPE",
         {{"function", Inpar::Mat::ActivationType::function_of_space_time},
             {"map", Inpar::Mat::ActivationType::map}},
         {.description = "type of activation evaluation"}));

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -205,7 +205,7 @@ void Inpar::BeamInteraction::set_valid_conditions(
       Core::Conditions::geometry_type_line);
 
   beam_filament_condition.add_component(parameter<int>("ID", {.description = "filament id"}));
-  beam_filament_condition.add_component(selection<std::string>("TYPE",
+  beam_filament_condition.add_component(deprecated_selection<std::string>("TYPE",
       {"Arbitrary", "arbitrary", "Actin", "actin", "Collagen", "collagen"},
       {.description = "", .default_value = "Arbitrary"}));
 

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -112,10 +112,10 @@ void Inpar::ArteryNetwork::set_valid_conditions(
   Core::Conditions::ConditionDefinition art_in_bc("DESIGN NODE 1D ARTERY PRESCRIBED CONDITIONS",
       "ArtPrescribedCond", "Artery prescribed boundary condition",
       Core::Conditions::ArtPrescribedCond, true, Core::Conditions::geometry_type_point);
-  art_in_bc.add_component(selection<std::string>("boundarycond",
+  art_in_bc.add_component(deprecated_selection<std::string>("boundarycond",
       {"flow", "pressure", "velocity", "area", "characteristicWave"},
       {.description = "boundarycond", .default_value = "flow"}));
-  art_in_bc.add_component(selection<std::string>(
+  art_in_bc.add_component(deprecated_selection<std::string>(
       "type", {"forced", "absorbing"}, {.description = "type", .default_value = "forced"}));
 
   art_in_bc.add_component(
@@ -146,8 +146,8 @@ void Inpar::ArteryNetwork::set_valid_conditions(
       "Artery terminal in_outlet condition", Core::Conditions::ArtInOutletCond, true,
       Core::Conditions::geometry_type_point);
 
-  art_in_outlet_bc.add_component(selection<std::string>("terminaltype", {"inlet", "outlet"},
-      {.description = "terminaltype", .default_value = "inlet"}));
+  art_in_outlet_bc.add_component(deprecated_selection<std::string>("terminaltype",
+      {"inlet", "outlet"}, {.description = "terminaltype", .default_value = "inlet"}));
 
   condlist.push_back(art_in_outlet_bc);
 
@@ -183,7 +183,7 @@ void Inpar::ArteryNetwork::set_valid_conditions(
       Core::Conditions::ArtPorofluidCouplingCondNodeToPoint, true,
       Core::Conditions::geometry_type_point);
 
-  artcoup_ntp.add_component(selection<std::string>("COUPLING_TYPE", {"ARTERY", "AIRWAY"},
+  artcoup_ntp.add_component(deprecated_selection<std::string>("COUPLING_TYPE", {"ARTERY", "AIRWAY"},
       {.description = "coupling type", .default_value = "ARTERY"}));
   artcoup_ntp.add_component(parameter<int>("NUMDOF"));
   artcoup_ntp.add_component(parameter<std::vector<int>>(
@@ -203,8 +203,8 @@ void Inpar::ArteryNetwork::set_valid_conditions(
       Core::Conditions::ArtScatraCouplingCondNodeToPoint, true,
       Core::Conditions::geometry_type_point);
 
-  artscatracoup_ntp.add_component(selection<std::string>("COUPLING_TYPE", {"ARTERY", "AIRWAY"},
-      {.description = "coupling type", .default_value = "ARTERY"}));
+  artscatracoup_ntp.add_component(deprecated_selection<std::string>("COUPLING_TYPE",
+      {"ARTERY", "AIRWAY"}, {.description = "coupling type", .default_value = "ARTERY"}));
   artscatracoup_ntp.add_component(parameter<int>("NUMDOF"));
   artscatracoup_ntp.add_component(parameter<std::vector<int>>(
       "COUPLEDDOF_REDUCED", {.description = "coupling dofs of reduced airways or arteries",
@@ -336,10 +336,10 @@ void Inpar::ReducedLung::set_valid_conditions(
       Core::Conditions::geometry_type_point);
 
   art_red_to_3d_bc.add_component(parameter<int>("ConditionID"));
-  art_red_to_3d_bc.add_component(selection<std::string>("CouplingType", {"forced", "absorbing"},
-      {.description = "coupling type", .default_value = "forced"}));
-  art_red_to_3d_bc.add_component(selection<std::string>("ReturnedVariable", {"pressure", "flow"},
-      {.description = "returned variable", .default_value = "pressure"}));
+  art_red_to_3d_bc.add_component(deprecated_selection<std::string>("CouplingType",
+      {"forced", "absorbing"}, {.description = "coupling type", .default_value = "forced"}));
+  art_red_to_3d_bc.add_component(deprecated_selection<std::string>("ReturnedVariable",
+      {"pressure", "flow"}, {.description = "returned variable", .default_value = "pressure"}));
   art_red_to_3d_bc.add_component(parameter<double>("Tolerance"));
   art_red_to_3d_bc.add_component(parameter<int>("MaximumIterations"));
 
@@ -353,8 +353,8 @@ void Inpar::ReducedLung::set_valid_conditions(
       Core::Conditions::geometry_type_surface);
 
   art_3d_to_red_bc.add_component(parameter<int>("ConditionID"));
-  art_3d_to_red_bc.add_component(selection<std::string>("ReturnedVariable", {"pressure", "flow"},
-      {.description = "returned variable", .default_value = "flow"}));
+  art_3d_to_red_bc.add_component(deprecated_selection<std::string>("ReturnedVariable",
+      {"pressure", "flow"}, {.description = "returned variable", .default_value = "flow"}));
   art_3d_to_red_bc.add_component(parameter<double>("Tolerance"));
   art_3d_to_red_bc.add_component(parameter<int>("MaximumIterations"));
 
@@ -393,7 +393,7 @@ void Inpar::ReducedLung::set_valid_conditions(
       "Reduced d airway prescribed boundary condition", Core::Conditions::RedAirwayPrescribedCond,
       true, Core::Conditions::geometry_type_point);
 
-  raw_in_bc.add_component(selection<std::string>("boundarycond",
+  raw_in_bc.add_component(deprecated_selection<std::string>("boundarycond",
       {"flow", "pressure", "switchFlowPressure", "VolumeDependentPleuralPressure"},
       {.description = "boundary condition type", .default_value = "flow"}));
 
@@ -434,7 +434,7 @@ void Inpar::ReducedLung::set_valid_conditions(
       Core::Conditions::RedAirwayVolDependentPleuralPressureCond, true,
       Core::Conditions::geometry_type_line);
 
-  raw_volPpl_bc.add_component(selection<std::string>("TYPE",
+  raw_volPpl_bc.add_component(deprecated_selection<std::string>("TYPE",
       {"Linear_Polynomial", "Linear_Exponential", "Linear_Ogden", "Nonlinear_Polynomial",
           "Nonlinear_Exponential", "Nonlinear_Ogden"},
       {.description = "type", .default_value = "Linear_Exponential"}));
@@ -476,7 +476,7 @@ void Inpar::ReducedLung::set_valid_conditions(
 
   impedancebc.add_component(parameter<int>("ConditionID"));
   impedancebc.add_component(
-      selection<std::string>("TYPE", {"windkessel", "resistive", "pressure_by_funct"},
+      deprecated_selection<std::string>("TYPE", {"windkessel", "resistive", "pressure_by_funct"},
           {.description = "type", .default_value = "windkessel"}));
   impedancebc.add_component(parameter<double>("R1"));
   impedancebc.add_component(parameter<double>("R2"));

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -654,7 +654,7 @@ void Inpar::Cardiovascular0D::set_valid_conditions(
       Core::Conditions::geometry_type_surface);
 
   cardiovascular0dsyspulcirculationcond.add_component(parameter<int>("id"));
-  cardiovascular0dsyspulcirculationcond.add_component(selection<std::string>("TYPE",
+  cardiovascular0dsyspulcirculationcond.add_component(deprecated_selection<std::string>("TYPE",
       {"ventricle_left", "ventricle_right", "atrium_left", "atrium_right", "dummy"},
       {.description = ""}));
 
@@ -672,9 +672,10 @@ void Inpar::Cardiovascular0D::set_valid_conditions(
       Core::Conditions::geometry_type_surface);
 
   cardiovascularrespiratory0dsyspulperiphcirculationcond.add_component(parameter<int>("id"));
-  cardiovascularrespiratory0dsyspulperiphcirculationcond.add_component(selection<std::string>(
-      "TYPE", {"ventricle_left", "ventricle_right", "atrium_left", "atrium_right", "dummy"},
-      {.description = ""}));
+  cardiovascularrespiratory0dsyspulperiphcirculationcond.add_component(
+      deprecated_selection<std::string>("TYPE",
+          {"ventricle_left", "ventricle_right", "atrium_left", "atrium_right", "dummy"},
+          {.description = ""}));
 
   condlist.push_back(cardiovascularrespiratory0dsyspulperiphcirculationcond);
 

--- a/src/inpar/4C_inpar_ehl.cpp
+++ b/src/inpar/4C_inpar_ehl.cpp
@@ -162,9 +162,9 @@ void Inpar::EHL::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
   const auto make_ehl_cond = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("InterfaceID"));
-    cond.add_component(
-        selection<std::string>("Side", {"Master", "Slave"}, {.description = "interface side"}));
-    cond.add_component(selection<std::string>("Initialization", {"Inactive", "Active"},
+    cond.add_component(deprecated_selection<std::string>(
+        "Side", {"Master", "Slave"}, {.description = "interface side"}));
+    cond.add_component(deprecated_selection<std::string>("Initialization", {"Inactive", "Active"},
         {.description = "initialization", .default_value = "Active"}));
     cond.add_component(
         parameter<double>("FrCoeffOrBound", {.description = "", .default_value = 0.0}));

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -256,7 +256,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   {
     auto reaction_model_choices = one_of({
         all_of({
-            selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
+            deprecated_selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer", Inpar::ElCh::ElectrodeKinetics::butler_volmer},
                     {"Butler-Volmer-Yang1997",
@@ -270,7 +270,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<Inpar::ElCh::ElectrodeKinetics>(
+            deprecated_selection<Inpar::ElCh::ElectrodeKinetics>(
                 "KINETIC_MODEL", {{"Tafel", Inpar::ElCh::ElectrodeKinetics::tafel}}),
             parameter<double>("ALPHA"),
             parameter<double>("I0"),
@@ -279,7 +279,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<Inpar::ElCh::ElectrodeKinetics>(
+            deprecated_selection<Inpar::ElCh::ElectrodeKinetics>(
                 "KINETIC_MODEL", {{"linear", Inpar::ElCh::ElectrodeKinetics::linear}}),
             parameter<double>("ALPHA"),
             parameter<double>("I0"),
@@ -288,7 +288,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
+            deprecated_selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
                 {{"Butler-Volmer-Newman", Inpar::ElCh::ElectrodeKinetics::butler_volmer_newman}}),
             parameter<double>("K_A"),
             parameter<double>("K_C"),
@@ -296,7 +296,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
+            deprecated_selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
                 {{"Butler-Volmer-Bard", Inpar::ElCh::ElectrodeKinetics::butler_volmer_bard}}),
             parameter<double>("E0"),
             parameter<double>("K0"),
@@ -306,7 +306,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<Inpar::ElCh::ElectrodeKinetics>(
+            deprecated_selection<Inpar::ElCh::ElectrodeKinetics>(
                 "KINETIC_MODEL", {{"Nernst", Inpar::ElCh::ElectrodeKinetics::nernst}}),
             parameter<double>("E0"),
             parameter<double>("C0"),
@@ -381,7 +381,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
         parameter<std::vector<int>>("STOICH", {.size = from_parameter<int>("NUMSCAL")}),
         parameter<int>("E-"),
         parameter<int>("ZERO_CUR"),
-        selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
+        deprecated_selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
             {
                 {"Butler-Volmer", Inpar::ElCh::ElectrodeKinetics::butler_volmer},
             }),

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -256,7 +256,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   {
     auto reaction_model_choices = one_of({
         all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer", Inpar::ElCh::ElectrodeKinetics::butler_volmer},
                     {"Butler-Volmer-Yang1997",
@@ -270,7 +270,8 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<int>("KINETIC_MODEL", {{"Tafel", Inpar::ElCh::ElectrodeKinetics::tafel}}),
+            selection<Inpar::ElCh::ElectrodeKinetics>(
+                "KINETIC_MODEL", {{"Tafel", Inpar::ElCh::ElectrodeKinetics::tafel}}),
             parameter<double>("ALPHA"),
             parameter<double>("I0"),
             parameter<double>("GAMMA"),
@@ -278,7 +279,8 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<int>("KINETIC_MODEL", {{"linear", Inpar::ElCh::ElectrodeKinetics::linear}}),
+            selection<Inpar::ElCh::ElectrodeKinetics>(
+                "KINETIC_MODEL", {{"linear", Inpar::ElCh::ElectrodeKinetics::linear}}),
             parameter<double>("ALPHA"),
             parameter<double>("I0"),
             parameter<double>("GAMMA"),
@@ -286,7 +288,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
                 {{"Butler-Volmer-Newman", Inpar::ElCh::ElectrodeKinetics::butler_volmer_newman}}),
             parameter<double>("K_A"),
             parameter<double>("K_C"),
@@ -294,7 +296,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
                 {{"Butler-Volmer-Bard", Inpar::ElCh::ElectrodeKinetics::butler_volmer_bard}}),
             parameter<double>("E0"),
             parameter<double>("K0"),
@@ -304,7 +306,8 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
             parameter<double>("DL_SPEC_CAP"),
         }),
         all_of({
-            selection<int>("KINETIC_MODEL", {{"Nernst", Inpar::ElCh::ElectrodeKinetics::nernst}}),
+            selection<Inpar::ElCh::ElectrodeKinetics>(
+                "KINETIC_MODEL", {{"Nernst", Inpar::ElCh::ElectrodeKinetics::nernst}}),
             parameter<double>("E0"),
             parameter<double>("C0"),
             parameter<double>("DL_SPEC_CAP"),
@@ -378,7 +381,7 @@ void Inpar::ElCh::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
         parameter<std::vector<int>>("STOICH", {.size = from_parameter<int>("NUMSCAL")}),
         parameter<int>("E-"),
         parameter<int>("ZERO_CUR"),
-        selection<int>("KINETIC_MODEL",
+        selection<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL",
             {
                 {"Butler-Volmer", Inpar::ElCh::ElectrodeKinetics::butler_volmer},
             }),

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -1374,8 +1374,8 @@ void Inpar::FLUID::set_valid_conditions(
   tbc_turb_inflow.add_component(parameter<int>("ID", {.description = ""}));
   tbc_turb_inflow.add_component(
       selection<std::string>("toggle", {"master", "slave"}, {.description = "toggle"}));
-  tbc_turb_inflow.add_component(selection<int>("DIRECTION", {{"x", 0}, {"y", 1}, {"z", 2}},
-      {.description = "transfer direction", .default_value = 0}));
+  tbc_turb_inflow.add_component(parameter<TurbInflowDirection>(
+      "DIRECTION", {.description = "transfer direction", .default_value = TurbInflowDirection::x}));
   tbc_turb_inflow.add_component(
       parameter<std::optional<int>>("curve", {.description = "curve id"}));
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -91,7 +91,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
   std::vector<std::string> predictor_valid_input = {"steady_state", "zero_acceleration",
       "constant_acceleration", "constant_increment", "explicit_second_order_midpoint", "TangVel"};
-  fdyn.specs.emplace_back(selection<std::string>("PREDICTOR", predictor_valid_input,
+  fdyn.specs.emplace_back(deprecated_selection<std::string>("PREDICTOR", predictor_valid_input,
       {.description = "Predictor for first guess in nonlinear iteration",
           .default_value = "steady_state"}));
 
@@ -143,7 +143,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
                       .default_value = false}));
 
   std::vector<std::string> convform_valid_input = {"convective", "conservative"};
-  fdyn.specs.emplace_back(selection<std::string>("CONVFORM", convform_valid_input,
+  fdyn.specs.emplace_back(deprecated_selection<std::string>("CONVFORM", convform_valid_input,
       {.description = "form of convective term", .default_value = "convective"}));
 
   fdyn.specs.emplace_back(parameter<bool>("NONLINEARBC",
@@ -475,16 +475,18 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // this parameter selects the location where tau is evaluated
 
   std::vector<std::string> evaluation_tau_valid_input = {"element_center", "integration_point"};
-  fdyn_stab.specs.emplace_back(selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
-      {.description = "Location where tau is evaluated", .default_value = "element_center"}));
+  fdyn_stab.specs.emplace_back(
+      deprecated_selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
+          {.description = "Location where tau is evaluated", .default_value = "element_center"}));
 
   // this parameter selects the location where the material law is evaluated
   // (does not fit here very well, but parameter transfer is easier)
 
   std::vector<std::string> evaluation_mat_valid_input = {"element_center", "integration_point"};
-  fdyn_stab.specs.emplace_back(selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
-      {.description = "Location where material law is evaluated",
-          .default_value = "element_center"}));
+  fdyn_stab.specs.emplace_back(
+      deprecated_selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
+          {.description = "Location where material law is evaluated",
+              .default_value = "element_center"}));
 
   // these parameters active additional terms in loma continuity equation
   // which might be identified as SUPG-/cross- and Reynolds-stress term
@@ -749,14 +751,14 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   // this parameter selects the location where tau is evaluated
   evaluation_tau_valid_input = {"element_center", "integration_point"};
   fdyn_porostab.specs.emplace_back(
-      selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
+      deprecated_selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
           {.description = "Location where tau is evaluated", .default_value = "element_center"}));
 
   // this parameter selects the location where the material law is evaluated
   // (does not fit here very well, but parameter transfer is easier)
   evaluation_mat_valid_input = {"element_center", "integration_point"};
   fdyn_porostab.specs.emplace_back(
-      selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
+      deprecated_selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
           {.description = "Location where material law is evaluated",
               .default_value = "element_center"}));
 
@@ -797,7 +799,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "turbulent viscosity. This may be based on various physical models.)";
 
   fdyn_turbu.specs.emplace_back(
-      selection<std::string>("TURBULENCE_APPROACH", turbulence_approach_valid_input,
+      deprecated_selection<std::string>("TURBULENCE_APPROACH", turbulence_approach_valid_input,
           {.description = turbulence_approach_doc_string, .default_value = "DNS_OR_RESVMM_LES"}));
 
   std::vector<std::string> physical_model_valid_input = {"no_model", "Smagorinsky",
@@ -814,8 +816,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "averaging in the xz plane, hence this implementation will only work for a channel flow. "
       "Multifractal Subgrid-Scale Modeling based on the work of burton. Vremans constant model. "
       "Dynamic Vreman model according to You and Moin (2007)";
-  fdyn_turbu.specs.emplace_back(selection<std::string>("PHYSICAL_MODEL", physical_model_valid_input,
-      {.description = physical_model_doc_string, .default_value = "no_model"}));
+  fdyn_turbu.specs.emplace_back(
+      deprecated_selection<std::string>("PHYSICAL_MODEL", physical_model_valid_input,
+          {.description = physical_model_doc_string, .default_value = "no_model"}));
 
   Core::Utils::string_to_integral_parameter<Inpar::FLUID::FineSubgridVisc>("FSSUGRVISC", "No",
       "fine-scale subgrid viscosity",
@@ -908,7 +911,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
         "blood_fda_flow: For this flow, statistical data is evaluated on various planes.\n"
         "backward_facing_step2: For this flow, statistical data is evaluated on various planes.\n";
 
-    fdyn_turbu.specs.emplace_back(selection<std::string>("CANONICAL_FLOW",
+    fdyn_turbu.specs.emplace_back(deprecated_selection<std::string>("CANONICAL_FLOW",
         canonical_flow_valid_input, {.description = canonical_flow_doc, .default_value = "no"}));
   }
 
@@ -925,7 +928,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "xz: Wall normal direction is y, average in x and z direction\n"
       "yz: Wall normal direction is x, average in y and z direction\n"
       "xyz: Averaging in all directions\n";
-  fdyn_turbu.specs.emplace_back(selection<std::string>(
+  fdyn_turbu.specs.emplace_back(deprecated_selection<std::string>(
       "HOMDIR", homdir_valid_input, {.description = homdir_doc, .default_value = "not_specified"}));
 
   //---------------------------------------
@@ -969,8 +972,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "no: Do not force the scalar field\n"
       "isotropic: Force scalar field isotropically such as the fluid field.\n"
       "mean_scalar_gradient: Force scalar field by imposed mean-scalar gradient.\n";
-  fdyn_turbu.specs.emplace_back(selection<std::string>("SCALAR_FORCING", scalar_forcing_valid_input,
-      {.description = scalar_forcing_doc, .default_value = "no"}));
+  fdyn_turbu.specs.emplace_back(deprecated_selection<std::string>("SCALAR_FORCING",
+      scalar_forcing_valid_input, {.description = scalar_forcing_doc, .default_value = "no"}));
 
   fdyn_turbu.specs.emplace_back(parameter<double>("MEAN_SCALAR_GRADIENT",
       {.description = "Value of imposed mean-scalar gradient to force scalar field.",
@@ -1045,8 +1048,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "constant: Use the constant wall shear stress given in the input file for the whole "
       "simulation.\n"
       "between_steps: Calculate wall shear stress in between time steps.\n";
-  fdyn_wallmodel.specs.emplace_back(selection<std::string>("Tauw_Type", tauw_type_valid_input,
-      {.description = tauw_type_doc, .default_value = "constant"}));
+  fdyn_wallmodel.specs.emplace_back(deprecated_selection<std::string>("Tauw_Type",
+      tauw_type_valid_input, {.description = tauw_type_doc, .default_value = "constant"}));
 
   std::vector<std::string> tauw_calc_type_valid_input = {
       "residual", "gradient", "gradient_to_residual"};
@@ -1055,7 +1058,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "gradient: Gradient via shape functions and nodal values.\n"
       "gradient_to_residual: First gradient, then residual.\n";
   fdyn_wallmodel.specs.emplace_back(
-      selection<std::string>("Tauw_Calc_Type", tauw_calc_type_valid_input,
+      deprecated_selection<std::string>("Tauw_Calc_Type", tauw_calc_type_valid_input,
           {.description = tauw_calc_type_doc, .default_value = "residual"}));
 
 
@@ -1067,8 +1070,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   std::string projection_doc =
       "Flag to switch projection of the enriched dofs after updating tauw, alternatively with or "
       "without continuity constraint.";
-  fdyn_wallmodel.specs.emplace_back(selection<std::string>("Projection", projection_valid_input,
-      {.description = projection_doc, .default_value = "No"}));
+  fdyn_wallmodel.specs.emplace_back(deprecated_selection<std::string>("Projection",
+      projection_valid_input, {.description = projection_doc, .default_value = "No"}));
 
   fdyn_wallmodel.specs.emplace_back(parameter<double>(
       "C_Tauw", {.description = "Constant wall shear stress for Spalding's law, if applicable",
@@ -1088,7 +1091,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "none: No ramp function, does not converge!\n"
       "ramp_function: Enrichment is multiplied with linear ramp function resulting in zero "
       "enrichment at the interface.\n";
-  fdyn_wallmodel.specs.emplace_back(selection<std::string>("Blending_Type",
+  fdyn_wallmodel.specs.emplace_back(deprecated_selection<std::string>("Blending_Type",
       blending_type_valid_input, {.description = blending_type_doc, .default_value = "none"}));
 
 
@@ -1124,7 +1127,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "box_filter: classical box filter.\n"
       "algebraic_multigrid_operator: scale separation by algebraic multigrid operator.\n";
   fdyn_turbmfs.specs.emplace_back(
-      selection<std::string>("SCALE_SEPARATION", scale_separation_valid_input,
+      deprecated_selection<std::string>("SCALE_SEPARATION", scale_separation_valid_input,
           {.description = scale_separation_doc, .default_value = "no_scale_sep"}));
 
 
@@ -1149,8 +1152,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "streamlength: streamlength taken from stabilization.\n"
       "gradient_based: gradient based length taken from stabilization.\n"
       "metric_tensor: metric tensor taken from stabilization.\n";
-  fdyn_turbmfs.specs.emplace_back(selection<std::string>("REF_LENGTH", ref_length_valid_input,
-      {.description = ref_length_doc, .default_value = "cube_edge"}));
+  fdyn_turbmfs.specs.emplace_back(deprecated_selection<std::string>("REF_LENGTH",
+      ref_length_valid_input, {.description = ref_length_doc, .default_value = "cube_edge"}));
 
   std::vector<std::string> ref_velocity_valid_input = {"strainrate", "resolved", "fine_scale"};
   std::string ref_velocity_doc =
@@ -1158,8 +1161,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "strainrate: norm of strain rate.\n"
       "resolved: resolved velocity.\n"
       "fine_scale: fine-scale velocity.\n";
-  fdyn_turbmfs.specs.emplace_back(selection<std::string>("REF_VELOCITY", ref_velocity_valid_input,
-      {.description = ref_velocity_doc, .default_value = "strainrate"}));
+  fdyn_turbmfs.specs.emplace_back(deprecated_selection<std::string>("REF_VELOCITY",
+      ref_velocity_valid_input, {.description = ref_velocity_doc, .default_value = "strainrate"}));
 
 
   fdyn_turbmfs.specs.emplace_back(parameter<double>("C_NU",
@@ -1175,8 +1178,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "Location where B is evaluated\n"
       "element_center: evaluate B at element center.\n"
       "integration_point: evaluate B at integration point.\n";
-  fdyn_turbmfs.specs.emplace_back(selection<std::string>("EVALUATION_B", evaluation_b_valid_input,
-      {.description = evaluation_b_doc, .default_value = "element_center"}));
+  fdyn_turbmfs.specs.emplace_back(
+      deprecated_selection<std::string>("EVALUATION_B", evaluation_b_valid_input,
+          {.description = evaluation_b_doc, .default_value = "element_center"}));
 
 
   fdyn_turbmfs.specs.emplace_back(parameter<double>(
@@ -1188,8 +1192,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "form of convective term\n"
       "convective: Use the convective form.\n"
       "conservative: Use the conservative form.\n";
-  fdyn_turbmfs.specs.emplace_back(selection<std::string>("CONVFORM", convform_valid_input,
-      {.description = convform_doc, .default_value = "convective"}));
+  fdyn_turbmfs.specs.emplace_back(deprecated_selection<std::string>("CONVFORM",
+      convform_valid_input, {.description = convform_doc, .default_value = "convective"}));
 
   fdyn_turbmfs.specs.emplace_back(parameter<double>("CSGS_PHI",
       {.description = "Modelparameter of multifractal subgrid-scales for scalar transport.",
@@ -1265,7 +1269,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "flow.\n"
       "scatra_channel_flow_of_height_2: For this flow, all statistical data could be averaged in "
       "\nthe homogeneous planes --- it is essentially a statistically one dimensional flow.\n";
-  fdyn_turbinf.specs.emplace_back(selection<std::string>("CANONICAL_INFLOW",
+  fdyn_turbinf.specs.emplace_back(deprecated_selection<std::string>("CANONICAL_INFLOW",
       canonical_inflow_valid_input, {.description = canonical_inflow_doc, .default_value = "no"}));
 
 
@@ -1285,8 +1289,9 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
       "xy: Wall normal direction is z, average in x and y direction.\n"
       "xz: Wall normal direction is y, average in x and z direction (standard case).\n"
       "yz: Wall normal direction is x, average in y and z direction.\n";
-  fdyn_turbinf.specs.emplace_back(selection<std::string>("INFLOW_HOMDIR", inflow_homdir_valid_input,
-      {.description = inflow_homdir_doc, .default_value = "not_specified"}));
+  fdyn_turbinf.specs.emplace_back(
+      deprecated_selection<std::string>("INFLOW_HOMDIR", inflow_homdir_valid_input,
+          {.description = inflow_homdir_doc, .default_value = "not_specified"}));
 
   Core::Utils::int_parameter("INFLOW_SAMPLING_START", 10000000,
       "Time step after when sampling shall be started", fdyn_turbinf);
@@ -1344,7 +1349,7 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
 
   std::vector<std::string> constthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
   lomacontrol.specs.emplace_back(
-      selection<std::string>("CONSTHERMPRESS", constthermpress_valid_input,
+      deprecated_selection<std::string>("CONSTHERMPRESS", constthermpress_valid_input,
           {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
 
   lomacontrol.specs.emplace_back(parameter<bool>(
@@ -1373,7 +1378,7 @@ void Inpar::FLUID::set_valid_conditions(
 
   tbc_turb_inflow.add_component(parameter<int>("ID", {.description = ""}));
   tbc_turb_inflow.add_component(
-      selection<std::string>("toggle", {"master", "slave"}, {.description = "toggle"}));
+      deprecated_selection<std::string>("toggle", {"master", "slave"}, {.description = "toggle"}));
   tbc_turb_inflow.add_component(parameter<TurbInflowDirection>(
       "DIRECTION", {.description = "transfer direction", .default_value = TurbInflowDirection::x}));
   tbc_turb_inflow.add_component(
@@ -1401,7 +1406,7 @@ void Inpar::FLUID::set_valid_conditions(
 
   // flow-dependent pressure conditions can be imposed either based on
   // (out)flow rate or (out)flow volume (e.g., for air-cushion condition)
-  surfflowdeppressure.add_component(selection<std::string>("TYPE_OF_FLOW_DEPENDENCE",
+  surfflowdeppressure.add_component(deprecated_selection<std::string>("TYPE_OF_FLOW_DEPENDENCE",
       {"flow_rate", "flow_volume", "fixed_pressure"}, {.description = "type of flow dependence"}));
   surfflowdeppressure.add_component(parameter<double>("ConstCoeff",
       {.description = "constant coefficient for (linear) flow-rate-based condition"}));
@@ -1513,15 +1518,16 @@ void Inpar::FLUID::set_valid_conditions(
 
     // the penalty parameter could be computed dynamically (using Spaldings
     // law of the wall) or using a fixed value (1)
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "PENTYPE", {"constant", "Spalding"}, {.description = "how penalty parameter is computed"}));
 
     // scaling factor for penalty parameter tauB
     cond.add_component(parameter<double>("hB_divided_by"));
 
     // if Spaldings law is used, this defines the way how the traction at y is computed from utau
-    cond.add_component(selection<std::string>("utau_computation", {"at_wall", "viscous_tangent"},
-        {.description = "how traction at y is computed from utau"}));
+    cond.add_component(
+        deprecated_selection<std::string>("utau_computation", {"at_wall", "viscous_tangent"},
+            {.description = "how traction at y is computed from utau"}));
 
     // we append it to the list of all conditions
     condlist.push_back(cond);
@@ -1589,17 +1595,17 @@ void Inpar::FLUID::set_valid_conditions(
   volumetric_surface_flow_cond.add_component(parameter<int>("ConditionID"));
 
   volumetric_surface_flow_cond.add_component(
-      selection<std::string>("ConditionType", {"POLYNOMIAL", "WOMERSLEY"},
+      deprecated_selection<std::string>("ConditionType", {"POLYNOMIAL", "WOMERSLEY"},
           {.description = "condition type", .default_value = "POLYNOMIAL"}));
 
   volumetric_surface_flow_cond.add_component(
-      selection<std::string>("prebiased", {"NOTPREBIASED", "PREBIASED", "FORCED"},
+      deprecated_selection<std::string>("prebiased", {"NOTPREBIASED", "PREBIASED", "FORCED"},
           {.description = "prebiased", .default_value = "NOTPREBIASED"}));
 
-  volumetric_surface_flow_cond.add_component(selection<std::string>(
+  volumetric_surface_flow_cond.add_component(deprecated_selection<std::string>(
       "FlowType", {"InFlow", "OutFlow"}, {.description = "flow type", .default_value = "InFlow"}));
   volumetric_surface_flow_cond.add_component(
-      selection<std::string>("CorrectionFlag", {"WithOutCorrection", "WithCorrection"},
+      deprecated_selection<std::string>("CorrectionFlag", {"WithOutCorrection", "WithCorrection"},
           {.description = "correction flag", .default_value = "WithOutCorrection"}));
 
   volumetric_surface_flow_cond.add_component(parameter<double>("Period"));
@@ -1609,13 +1615,13 @@ void Inpar::FLUID::set_valid_conditions(
   volumetric_surface_flow_cond.add_component(parameter<int>("Funct"));
 
   volumetric_surface_flow_cond.add_component(
-      selection<std::string>("NORMAL", {"SelfEvaluateNormal", "UsePrescribedNormal"},
+      deprecated_selection<std::string>("NORMAL", {"SelfEvaluateNormal", "UsePrescribedNormal"},
           {.description = "normal", .default_value = "SelfEvaluateNormal"}));
   volumetric_surface_flow_cond.add_component(parameter<double>("n1"));
   volumetric_surface_flow_cond.add_component(parameter<double>("n2"));
   volumetric_surface_flow_cond.add_component(parameter<double>("n3"));
 
-  volumetric_surface_flow_cond.add_component(selection<std::string>("CenterOfMass",
+  volumetric_surface_flow_cond.add_component(deprecated_selection<std::string>("CenterOfMass",
       {"SelfEvaluateCenterOfMass", "UsePrescribedCenterOfMass"},
       {.description = "center of mass", .default_value = "SelfEvaluateCenterOfMass"}));
   volumetric_surface_flow_cond.add_component(parameter<double>("c1"));
@@ -1647,17 +1653,17 @@ void Inpar::FLUID::set_valid_conditions(
 
   total_traction_correction_cond.add_component(parameter<int>("ConditionID"));
   total_traction_correction_cond.add_component(
-      selection<std::string>("ConditionType", {"POLYNOMIAL", "WOMERSLEY"},
+      deprecated_selection<std::string>("ConditionType", {"POLYNOMIAL", "WOMERSLEY"},
           {.description = "condition type", .default_value = "POLYNOMIAL"}));
 
   total_traction_correction_cond.add_component(
-      selection<std::string>("prebiased", {"NOTPREBIASED", "PREBIASED", "FORCED"},
+      deprecated_selection<std::string>("prebiased", {"NOTPREBIASED", "PREBIASED", "FORCED"},
           {.description = "prebiased", .default_value = "NOTPREBIASED"}));
 
-  total_traction_correction_cond.add_component(selection<std::string>(
+  total_traction_correction_cond.add_component(deprecated_selection<std::string>(
       "FlowType", {"InFlow", "OutFlow"}, {.description = "flow type", .default_value = "InFlow"}));
   total_traction_correction_cond.add_component(
-      selection<std::string>("CorrectionFlag", {"WithOutCorrection", "WithCorrection"},
+      deprecated_selection<std::string>("CorrectionFlag", {"WithOutCorrection", "WithCorrection"},
           {.description = "correction flag", .default_value = "WithOutCorrection"}));
 
   total_traction_correction_cond.add_component(parameter<double>("Period"));
@@ -1667,13 +1673,13 @@ void Inpar::FLUID::set_valid_conditions(
   total_traction_correction_cond.add_component(parameter<int>("Funct"));
 
   total_traction_correction_cond.add_component(
-      selection<std::string>("NORMAL", {"SelfEvaluateNormal", "UsePrescribedNormal"},
+      deprecated_selection<std::string>("NORMAL", {"SelfEvaluateNormal", "UsePrescribedNormal"},
           {.description = "normal", .default_value = "SelfEvaluateNormal"}));
   total_traction_correction_cond.add_component(parameter<double>("n1"));
   total_traction_correction_cond.add_component(parameter<double>("n2"));
   total_traction_correction_cond.add_component(parameter<double>("n3"));
 
-  total_traction_correction_cond.add_component(selection<std::string>("CenterOfMass",
+  total_traction_correction_cond.add_component(deprecated_selection<std::string>("CenterOfMass",
       {"SelfEvaluateCenterOfMass", "UsePrescribedCenterOfMass"},
       {.description = "center of mass", .default_value = "SelfEvaluateCenterOfMass"}));
   total_traction_correction_cond.add_component(parameter<double>("c1"));

--- a/src/inpar/4C_inpar_fluid.hpp
+++ b/src/inpar/4C_inpar_fluid.hpp
@@ -327,6 +327,14 @@ namespace Inpar
       dynamic_vreman
     };
 
+    //! Direction of inflow for turbulence
+    enum class TurbInflowDirection
+    {
+      x,
+      y,
+      z,
+    };
+
     /// Define forcing for scalar field
     enum ScalarForcing
     {

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -36,8 +36,9 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   fs3idyn.specs.emplace_back(parameter<bool>(
       "INF_PERM", {.description = "Flag for infinite permeability", .default_value = true}));
   std::vector<std::string> consthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
-  fs3idyn.specs.emplace_back(selection<std::string>("CONSTHERMPRESS", consthermpress_valid_input,
-      {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
+  fs3idyn.specs.emplace_back(
+      deprecated_selection<std::string>("CONSTHERMPRESS", consthermpress_valid_input,
+          {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
 
   // number of linear solver used for fs3i problems
   Core::Utils::int_parameter(

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -399,7 +399,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           .default_value = 1e-6}));
 
   std::vector<std::string> coupmethod_valid_input = {"mortar", "conforming", "immersed"};
-  fsipart.specs.emplace_back(selection<std::string>("COUPMETHOD", coupmethod_valid_input,
+  fsipart.specs.emplace_back(deprecated_selection<std::string>("COUPMETHOD", coupmethod_valid_input,
       {.description = "Coupling Method mortar or conforming nodes at interface",
           .default_value = "conforming"}));
 
@@ -434,7 +434,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
   std::vector<std::string> predictor_valid_input = {
       "d(n)", "d(n)+dt*(1.5*v(n)-0.5*v(n-1))", "d(n)+dt*v(n)", "d(n)+dt*v(n)+0.5*dt^2*a(n)"};
-  fsipart.specs.emplace_back(selection<std::string>("PREDICTOR", predictor_valid_input,
+  fsipart.specs.emplace_back(deprecated_selection<std::string>("PREDICTOR", predictor_valid_input,
       {.description = "Predictor for interface displacements", .default_value = "d(n)"}));
 
 
@@ -496,7 +496,7 @@ void Inpar::FSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       Core::Conditions::geometry_type_surface);
 
   surfsac.add_component(parameter<int>("coupling_id"));
-  surfsac.add_component(selection<std::string>(
+  surfsac.add_component(deprecated_selection<std::string>(
       "field", {"structure", "ale"}, {.description = "field", .default_value = "structure"}));
 
   condlist.push_back(surfsac);
@@ -510,7 +510,7 @@ void Inpar::FSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       Core::Conditions::geometry_type_volume);
 
   volsfv.add_component(parameter<int>("coupling_id"));
-  volsfv.add_component(selection<std::string>(
+  volsfv.add_component(deprecated_selection<std::string>(
       "field", {"structure", "ale"}, {.description = "field", .default_value = "structure"}));
 
   condlist.push_back(volsfv);

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -202,12 +202,8 @@ void Inpar::Mortar::set_valid_conditions(
         {.description = "application", .default_value = "Solidcontact"}));
 
     // optional DBC handling
-    cond.add_component(selection<int>("DbcHandling",
-        {{"DoNothing", static_cast<int>(DBCHandling::do_nothing)},
-            {"RemoveDBCSlaveNodes",
-                static_cast<int>(DBCHandling::remove_dbc_nodes_from_slave_side)}},
-        {.description = "DbcHandling",
-            .default_value = static_cast<int>(DBCHandling::do_nothing)}));
+    cond.add_component(parameter<DBCHandling>(
+        "DbcHandling", {.description = "DbcHandling", .default_value = DBCHandling::DoNothing}));
     cond.add_component(parameter<double>(
         "TwoHalfPass", {.description = "optional two half pass approach", .default_value = 0.0}));
     cond.add_component(parameter<double>("RefConfCheckNonSmoothSelfContactSurface",

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -187,9 +187,9 @@ void Inpar::Mortar::set_valid_conditions(
   const auto make_contact = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("InterfaceID"));
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "Side", {"Master", "Slave", "Selfcontact"}, {.description = "interface side"}));
-    cond.add_component(selection<std::string>("Initialization", {"Inactive", "Active"},
+    cond.add_component(deprecated_selection<std::string>("Initialization", {"Inactive", "Active"},
         {.description = "initialization", .default_value = "Inactive"}));
 
     cond.add_component(parameter<double>(
@@ -197,7 +197,7 @@ void Inpar::Mortar::set_valid_conditions(
     cond.add_component(parameter<double>(
         "AdhesionBound", {.description = "adhesion bound", .default_value = 0.0}));
 
-    cond.add_component(selection<std::string>("Application",
+    cond.add_component(deprecated_selection<std::string>("Application",
         {"Solidcontact", "Beamtosolidcontact", "Beamtosolidmeshtying"},
         {.description = "application", .default_value = "Solidcontact"}));
 
@@ -232,9 +232,9 @@ void Inpar::Mortar::set_valid_conditions(
     const auto make_mortar = [&condlist](Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("InterfaceID"));
-      cond.add_component(
-          selection<std::string>("Side", {"Master", "Slave"}, {.description = "interface side"}));
-      cond.add_component(selection<std::string>("Initialization", {"Inactive", "Active"},
+      cond.add_component(deprecated_selection<std::string>(
+          "Side", {"Master", "Slave"}, {.description = "interface side"}));
+      cond.add_component(deprecated_selection<std::string>("Initialization", {"Inactive", "Active"},
           {.description = "initialization", .default_value = "Inactive"}));
 
       condlist.push_back(cond);
@@ -298,9 +298,9 @@ void Inpar::Mortar::set_valid_conditions(
     const auto make_mortar_multi = [&condlist](Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("InterfaceID"));
-      cond.add_component(
-          selection<std::string>("Side", {"Master", "Slave"}, {.description = "interface side"}));
-      cond.add_component(selection<std::string>("Initialization", {"Inactive", "Active"},
+      cond.add_component(deprecated_selection<std::string>(
+          "Side", {"Master", "Slave"}, {.description = "interface side"}));
+      cond.add_component(deprecated_selection<std::string>("Initialization", {"Inactive", "Active"},
           {.description = "initialization", .default_value = "Inactive"}));
 
       condlist.push_back(cond);

--- a/src/inpar/4C_inpar_mortar.hpp
+++ b/src/inpar/4C_inpar_mortar.hpp
@@ -141,8 +141,8 @@ namespace Inpar
     /// Enum to encode handling of Dirichlet boundary conditions at contact interfaces
     enum class DBCHandling : int
     {
-      do_nothing,
-      remove_dbc_nodes_from_slave_side  // ToDo (mayr.mt) Remove? Do not change DBCs at runtime!
+      DoNothing,
+      RemoveDBCSlaveNodes  // ToDo (mayr.mt) Remove? Do not change DBCs at runtime!
     };
 
     /// set the mortar parameters

--- a/src/inpar/4C_inpar_mpc_rve.cpp
+++ b/src/inpar/4C_inpar_mpc_rve.cpp
@@ -49,7 +49,7 @@ void Inpar::RveMpc::set_valid_conditions(
       Core::Conditions::LineRvePeriodic, false, Core::Conditions::geometry_type_line);
 
   rve_lineperiodic_condition.add_component(
-      selection<std::string>("EDGE", {"x+", "x-", "y+", "y-", "undefined"},
+      deprecated_selection<std::string>("EDGE", {"x+", "x-", "y+", "y-", "undefined"},
           {.description = "edge line id", .default_value = "undefined"}));
 
   condlist.push_back(rve_lineperiodic_condition);
@@ -61,7 +61,7 @@ void Inpar::RveMpc::set_valid_conditions(
       Core::Conditions::SurfaceRvePeriodic, false, Core::Conditions::geometry_type_surface);
 
   rve_surfperiodic_condition.add_component(
-      selection<std::string>("SURF", {"x+", "x-", "y+", "y-", "z+", "z-", "undefined"},
+      deprecated_selection<std::string>("SURF", {"x+", "x-", "y+", "y-", "z+", "z-", "undefined"},
           {.description = "surface id", .default_value = "undefined"}));
 
   condlist.push_back(rve_surfperiodic_condition);
@@ -73,9 +73,9 @@ void Inpar::RveMpc::set_valid_conditions(
       "condition -  only required if RVE_REFERENCE_POINTS = automatic",
       Core::Conditions::PointRvePeriodicReference, false, Core::Conditions::geometry_type_point);
 
-  rve_cornerpoint_condition.add_component(
-      selection<std::string>("POSITION", {"N1L", "N1B", "N2", "N4", "N1", "N3", "undefined"},
-          {.description = "position of reference node", .default_value = "undefined"}));
+  rve_cornerpoint_condition.add_component(deprecated_selection<std::string>("POSITION",
+      {"N1L", "N1B", "N2", "N4", "N1", "N3", "undefined"},
+      {.description = "position of reference node", .default_value = "undefined"}));
 
   condlist.push_back(rve_cornerpoint_condition);
 
@@ -88,7 +88,7 @@ void Inpar::RveMpc::set_valid_conditions(
       Core::Conditions::PointLinearCoupledEquation, false, Core::Conditions::geometry_type_point);
 
   linear_ce.add_component(parameter<int>("EQUATION", {.description = "EQUATION"}));
-  linear_ce.add_component(selection<std::string>("ADD", {"dispx", "dispy", "undefined"},
+  linear_ce.add_component(deprecated_selection<std::string>("ADD", {"dispx", "dispy", "undefined"},
       {.description = "degrees of freedom", .default_value = "undefined"}));
   linear_ce.add_component(parameter<double>("COEFFICIENT"));
 

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -122,7 +122,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
     const auto make_s2imeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("ConditionID"));
-      cond.add_component(selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
+      cond.add_component(deprecated_selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
           {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
               {"Master", Inpar::S2I::side_master}},
           {.description = "interface side"}));
@@ -164,7 +164,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       {
         // constant and linear permeability
         auto constlinperm = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"ConstantPermeability", Inpar::S2I::kinetics_constperm},
                     {"LinearPermeability", Inpar::S2I::kinetics_linearperm},
@@ -179,7 +179,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer", Inpar::S2I::kinetics_butlervolmer},
                     {"Butler-Volmer_Linearized", Inpar::S2I::kinetics_butlervolmerlinearized},
@@ -201,7 +201,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_peltier = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer-Peltier", Inpar::S2I::kinetics_butlervolmerpeltier},
                 }),
@@ -221,7 +221,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_capacitance = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Capacitance",
                         Inpar::S2I::kinetics_butlervolmerreducedcapacitance},
@@ -242,7 +242,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_resistance = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer_Resistance", Inpar::S2I::kinetics_butlervolmerresistance},
                 }),
@@ -263,7 +263,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_with_resistance = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Resistance",
                         Inpar::S2I::kinetics_butlervolmerreducedresistance},
@@ -286,7 +286,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_thermo = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_ThermoResistance",
                         Inpar::S2I::kinetics_butlervolmerreducedthermoresistance},
@@ -308,7 +308,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto constant_interface_resistance = all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"ConstantInterfaceResistance",
                         Inpar::S2I::kinetics_constantinterfaceresistance},
@@ -324,7 +324,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         // no interface flux
-        auto noflux = selection<KineticModels>(
+        auto noflux = deprecated_selection<KineticModels>(
             "KINETIC_MODEL", {
                                  {"NoInterfaceFlux", Inpar::S2I::kinetics_nointerfaceflux},
                              });
@@ -336,10 +336,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
     }
 
     auto interface_side_options = one_of({
-        selection<InterfaceSides>(
+        deprecated_selection<InterfaceSides>(
             "INTERFACE_SIDE", {{"Master", side_master}, {"Undefined", side_undefined}}),
         all_of({
-            selection<InterfaceSides>("INTERFACE_SIDE", {{"Slave", side_slave}}),
+            deprecated_selection<InterfaceSides>("INTERFACE_SIDE", {{"Slave", side_slave}}),
             one_of(kinetic_model_choices),
         }),
     });
@@ -390,7 +390,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         parameter<double>("MOLMASS"),
         parameter<double>("DENSITY"),
         parameter<double>("CONDUCTIVITY"),
-        selection<RegularizationType>("REGTYPE",
+        deprecated_selection<RegularizationType>("REGTYPE",
             {
                 {"none", Inpar::S2I::regularization_none},
                 {"polynomial", Inpar::S2I::regularization_polynomial},
@@ -405,7 +405,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
                                     Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("ConditionID"));
-      cond.add_component(selection<GrowthKineticModels>(
+      cond.add_component(deprecated_selection<GrowthKineticModels>(
           "KINETIC_MODEL", {{"Butler-Volmer", growth_kinetics_butlervolmer}}));
       cond.add_component(butler_volmer);
 
@@ -423,7 +423,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         "S2ISCLCoupling", "Scatra-scatra surface with SCL micro-macro coupling between",
         Core::Conditions::S2ISCLCoupling, true, Core::Conditions::geometry_type_surface);
 
-    s2isclcond.add_component(selection<InterfaceSides>("INTERFACE_SIDE",
+    s2isclcond.add_component(deprecated_selection<InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface side"}));

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -122,7 +122,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
     const auto make_s2imeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("ConditionID"));
-      cond.add_component(selection<int>("INTERFACE_SIDE",
+      cond.add_component(selection<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE",
           {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
               {"Master", Inpar::S2I::side_master}},
           {.description = "interface side"}));
@@ -164,7 +164,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       {
         // constant and linear permeability
         auto constlinperm = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"ConstantPermeability", Inpar::S2I::kinetics_constperm},
                     {"LinearPermeability", Inpar::S2I::kinetics_linearperm},
@@ -179,7 +179,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer", Inpar::S2I::kinetics_butlervolmer},
                     {"Butler-Volmer_Linearized", Inpar::S2I::kinetics_butlervolmerlinearized},
@@ -201,7 +201,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_peltier = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer-Peltier", Inpar::S2I::kinetics_butlervolmerpeltier},
                 }),
@@ -221,7 +221,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_capacitance = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Capacitance",
                         Inpar::S2I::kinetics_butlervolmerreducedcapacitance},
@@ -242,7 +242,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_resistance = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-Volmer_Resistance", Inpar::S2I::kinetics_butlervolmerresistance},
                 }),
@@ -263,7 +263,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_with_resistance = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_Resistance",
                         Inpar::S2I::kinetics_butlervolmerreducedresistance},
@@ -286,7 +286,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto butler_volmer_reduced_thermo = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"Butler-VolmerReduced_ThermoResistance",
                         Inpar::S2I::kinetics_butlervolmerreducedthermoresistance},
@@ -308,7 +308,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         auto constant_interface_resistance = all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {
                     {"ConstantInterfaceResistance",
                         Inpar::S2I::kinetics_constantinterfaceresistance},
@@ -324,7 +324,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
       {
         // no interface flux
-        auto noflux = selection<int>(
+        auto noflux = selection<KineticModels>(
             "KINETIC_MODEL", {
                                  {"NoInterfaceFlux", Inpar::S2I::kinetics_nointerfaceflux},
                              });
@@ -336,9 +336,10 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
     }
 
     auto interface_side_options = one_of({
-        selection<int>("INTERFACE_SIDE", {{"Master", side_master}, {"Undefined", side_undefined}}),
+        selection<InterfaceSides>(
+            "INTERFACE_SIDE", {{"Master", side_master}, {"Undefined", side_undefined}}),
         all_of({
-            selection<int>("INTERFACE_SIDE", {{"Slave", side_slave}}),
+            selection<InterfaceSides>("INTERFACE_SIDE", {{"Slave", side_slave}}),
             one_of(kinetic_model_choices),
         }),
     });
@@ -389,7 +390,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         parameter<double>("MOLMASS"),
         parameter<double>("DENSITY"),
         parameter<double>("CONDUCTIVITY"),
-        selection<int>("REGTYPE",
+        selection<RegularizationType>("REGTYPE",
             {
                 {"none", Inpar::S2I::regularization_none},
                 {"polynomial", Inpar::S2I::regularization_polynomial},
@@ -404,8 +405,8 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
                                     Core::Conditions::ConditionDefinition& cond)
     {
       cond.add_component(parameter<int>("ConditionID"));
-      cond.add_component(
-          selection<int>("KINETIC_MODEL", {{"Butler-Volmer", growth_kinetics_butlervolmer}}));
+      cond.add_component(selection<GrowthKineticModels>(
+          "KINETIC_MODEL", {{"Butler-Volmer", growth_kinetics_butlervolmer}}));
       cond.add_component(butler_volmer);
 
       condlist.emplace_back(cond);
@@ -422,7 +423,7 @@ void Inpar::S2I::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
         "S2ISCLCoupling", "Scatra-scatra surface with SCL micro-macro coupling between",
         Core::Conditions::S2ISCLCoupling, true, Core::Conditions::geometry_type_surface);
 
-    s2isclcond.add_component(selection<int>("INTERFACE_SIDE",
+    s2isclcond.add_component(selection<InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface side"}));

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -647,7 +647,7 @@ void Inpar::ScaTra::set_valid_conditions(
     // --> Tempn (old temperature T_n)
     // or if the exact solution is needed
     // --> Tempnp (current temperature solution T_n+1) with linearisation
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "temperature_state", {"Tempnp", "Tempn"}, {.description = "temperature state"}));
     cond.add_component(parameter<double>("coeff", {.description = "heat transfer coefficient h"}));
     cond.add_component(

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -70,8 +70,9 @@ namespace Inpar::SOLVER
           "The amount of fill allowed for an internal \"ilu\" preconditioner.", list);
 
       std::vector<std::string> ifpack_combine_valid_input = {"Add", "Insert", "Zero"};
-      list.specs.emplace_back(selection<std::string>("IFPACKCOMBINE", ifpack_combine_valid_input,
-          {.description = "Combine mode for Ifpack Additive Schwarz", .default_value = "Add"}));
+      list.specs.emplace_back(
+          deprecated_selection<std::string>("IFPACKCOMBINE", ifpack_combine_valid_input,
+              {.description = "Combine mode for Ifpack Additive Schwarz", .default_value = "Add"}));
     }
 
     // Iterative solver options

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -29,9 +29,10 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         "Pseudo Transient", "Trust Region Based", "Inexact Trust Region Based", "Tensor Based",
         "Single Step"};
 
-    snox.specs.emplace_back(selection<std::string>("Nonlinear Solver", nonlinear_solver_valid_input,
-        {.description = "Choose a nonlinear solver method.",
-            .default_value = "Line Search Based"}));
+    snox.specs.emplace_back(
+        deprecated_selection<std::string>("Nonlinear Solver", nonlinear_solver_valid_input,
+            {.description = "Choose a nonlinear solver method.",
+                .default_value = "Line Search Based"}));
   }
   snox.move_into_collection(list);
 
@@ -41,13 +42,14 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     std::vector<std::string> newton_method_valid_input = {
         "Newton", "Steepest Descent", "NonlinearCG", "Broyden", "User Defined"};
-    direction.specs.emplace_back(selection<std::string>("Method", newton_method_valid_input,
-        {.description = "Choose a direction method for the nonlinear solver.",
-            .default_value = "Newton"}));
+    direction.specs.emplace_back(
+        deprecated_selection<std::string>("Method", newton_method_valid_input,
+            {.description = "Choose a direction method for the nonlinear solver.",
+                .default_value = "Newton"}));
 
     std::vector<std::string> user_defined_method_valid_input = {"Newton", "Modified Newton"};
     direction.specs.emplace_back(
-        selection<std::string>("User Defined Method", user_defined_method_valid_input,
+        deprecated_selection<std::string>("User Defined Method", user_defined_method_valid_input,
             {.description = "Choose a user-defined direction method.",
                 .default_value = "Modified Newton"}));
   }
@@ -58,7 +60,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
   {
     std::vector<std::string> forcing_term_valid_input = {"Constant", "Type 1", "Type 2"};
-    newton.specs.emplace_back(selection<std::string>("Forcing Term Method",
+    newton.specs.emplace_back(deprecated_selection<std::string>("Forcing Term Method",
         forcing_term_valid_input, {.description = "", .default_value = "Constant"}));
 
     newton.specs.emplace_back(parameter<double>("Forcing Term Initial Tolerance",
@@ -82,7 +84,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     std::vector<std::string> scaling_type_valid_input = {
         "2-Norm", "Quadratic Model Min", "F 2-Norm", "None"};
-    steepestdescent.specs.emplace_back(selection<std::string>(
+    steepestdescent.specs.emplace_back(deprecated_selection<std::string>(
         "Scaling Type", scaling_type_valid_input, {.description = "", .default_value = "None"}));
   }
   steepestdescent.move_into_collection(list);
@@ -112,22 +114,23 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
     std::vector<std::string> time_step_control_valid_input = {"SER",
         "Switched Evolution Relaxation", "TTE", "Temporal Truncation Error", "MRR",
         "Model Reduction Ratio"};
-    ptc.specs.emplace_back(selection<std::string>("Time Step Control",
+    ptc.specs.emplace_back(deprecated_selection<std::string>("Time Step Control",
         time_step_control_valid_input, {.description = "", .default_value = "SER"}));
 
     std::vector<std::string> tsc_norm_type_valid_input = {"Two Norm", "One Norm", "Max Norm"};
-    ptc.specs.emplace_back(selection<std::string>("Norm Type for TSC", tsc_norm_type_valid_input,
-        {.description = "Norm Type for the time step control", .default_value = "Max Norm"}));
+    ptc.specs.emplace_back(
+        deprecated_selection<std::string>("Norm Type for TSC", tsc_norm_type_valid_input,
+            {.description = "Norm Type for the time step control", .default_value = "Max Norm"}));
 
     std::vector<std::string> scaling_op_valid_input = {
         "Identity", "CFL Diagonal", "Lumped Mass", "Element based"};
-    ptc.specs.emplace_back(selection<std::string>("Scaling Type", scaling_op_valid_input,
+    ptc.specs.emplace_back(deprecated_selection<std::string>("Scaling Type", scaling_op_valid_input,
         {.description = "Type of the scaling matrix for the PTC method.",
             .default_value = "Identity"}));
 
     std::vector<std::string> build_scale_op_valid_input = {"every iter", "every timestep"};
     ptc.specs.emplace_back(
-        selection<std::string>("Build scaling operator", build_scale_op_valid_input,
+        deprecated_selection<std::string>("Build scaling operator", build_scale_op_valid_input,
             {.description = "Build scaling operator in every iteration or timestep",
                 .default_value = "every timestep"}));
   }
@@ -139,7 +142,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   {
     std::vector<std::string> method_valid_input = {
         "Full Step", "Backtrack", "Polynomial", "More'-Thuente", "User Defined"};
-    linesearch.specs.emplace_back(selection<std::string>(
+    linesearch.specs.emplace_back(deprecated_selection<std::string>(
         "Method", method_valid_input, {.description = "", .default_value = "Full Step"}));
 
 
@@ -204,7 +207,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
     polynomial.specs.emplace_back(
-        selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
+        deprecated_selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
             {.description = "Determines the step size to take when the line search fails",
                 .default_value = "Constant"}));
 
@@ -214,7 +217,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         polynomial);
 
     std::vector<std::string> interpolation_type_valid_input = {"Quadratic", "Quadratic3", "Cubic"};
-    polynomial.specs.emplace_back(selection<std::string>("Interpolation Type",
+    polynomial.specs.emplace_back(deprecated_selection<std::string>("Interpolation Type",
         interpolation_type_valid_input,
         {.description = "Type of interpolation that should be used", .default_value = "Cubic"}));
 
@@ -229,7 +232,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     std::vector<std::string> sufficient_decrease_condition_valid_input = {
         "Armijo-Goldstein", "Ared/Pred", "None"};
-    polynomial.specs.emplace_back(selection<std::string>("Sufficient Decrease Condition",
+    polynomial.specs.emplace_back(deprecated_selection<std::string>("Sufficient Decrease Condition",
         sufficient_decrease_condition_valid_input,
         {.description = "Choice to use for the sufficient decrease condition",
             .default_value = "Armijo-Goldstein"}));
@@ -277,7 +280,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
     morethuente.specs.emplace_back(
-        selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
+        deprecated_selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
             {.description = "Determines the step size to take when the line search fails",
                 .default_value = "Constant"}));
 
@@ -288,8 +291,8 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
     std::vector<std::string> sufficient_decrease_condition_valid_input = {
         "Armijo-Goldstein", "Ared/Pred", "None"};
-    morethuente.specs.emplace_back(selection<std::string>("Sufficient Decrease Condition",
-        sufficient_decrease_condition_valid_input,
+    morethuente.specs.emplace_back(deprecated_selection<std::string>(
+        "Sufficient Decrease Condition", sufficient_decrease_condition_valid_input,
         {.description = "Choice to use for the sufficient decrease condition",
             .default_value = "Armijo-Goldstein"}));
 
@@ -381,7 +384,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
         solverOptions);
 
     std::vector<std::string> status_test_check_type_valid_input = {"Complete", "Minimal", "None"};
-    solverOptions.specs.emplace_back(selection<std::string>("Status Test Check Type",
+    solverOptions.specs.emplace_back(deprecated_selection<std::string>("Status Test Check Type",
         status_test_check_type_valid_input, {.description = "", .default_value = "Complete"}));
   }
   solverOptions.move_into_collection(list);

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -353,7 +353,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
   const auto make_ssiinterfacemeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+    cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface_side"}));
@@ -373,7 +373,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       true, Core::Conditions::geometry_type_surface);
 
   ssisurfacemanifold.add_component(parameter<int>("ConditionID"));
-  ssisurfacemanifold.add_component(selection<Inpar::ScaTra::ImplType>("ImplType",
+  ssisurfacemanifold.add_component(deprecated_selection<Inpar::ScaTra::ImplType>("ImplType",
       {{"Undefined", Inpar::ScaTra::impltype_undefined}, {"Standard", Inpar::ScaTra::impltype_std},
           {"ElchElectrode", Inpar::ScaTra::impltype_elch_electrode},
           {"ElchDiffCond", Inpar::ScaTra::impltype_elch_diffcond}},
@@ -390,7 +390,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       Core::Conditions::geometry_type_surface);
 
   surfmanifoldinitfields.add_component(
-      selection<std::string>("FIELD", {"ScaTra"}, {.description = "init field"}));
+      deprecated_selection<std::string>("FIELD", {"ScaTra"}, {.description = "init field"}));
   surfmanifoldinitfields.add_component(parameter<int>("FUNCT"));
 
   condlist.emplace_back(surfmanifoldinitfields);
@@ -410,7 +410,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
     surfmanifoldkinetics.add_component(one_of({
         all_of({
-            selection<Inpar::S2I::KineticModels>(
+            deprecated_selection<Inpar::S2I::KineticModels>(
                 "KINETIC_MODEL", {{"ConstantInterfaceResistance",
                                      Inpar::S2I::kinetics_constantinterfaceresistance}}),
             parameter<std::vector<int>>("ONOFF", {.size = 2}),
@@ -418,7 +418,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
             parameter<int>("E-"),
         }),
         all_of({
-            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
+            deprecated_selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {{"Butler-VolmerReduced", Inpar::S2I::kinetics_butlervolmerreduced}}),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -428,7 +428,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
             parameter<double>("ALPHA_A"),
             parameter<double>("ALPHA_C"),
         }),
-        selection<S2I::KineticModels>(
+        deprecated_selection<S2I::KineticModels>(
             "KINETIC_MODEL", {{"NoInterfaceFlux", Inpar::S2I::kinetics_nointerfaceflux}}),
     }));
   }
@@ -484,7 +484,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
   const auto make_ssiinterfacecontact = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+    cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface_side"}));

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -353,7 +353,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
   const auto make_ssiinterfacemeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(selection<int>("INTERFACE_SIDE",
+    cond.add_component(selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface_side"}));
@@ -373,7 +373,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
       true, Core::Conditions::geometry_type_surface);
 
   ssisurfacemanifold.add_component(parameter<int>("ConditionID"));
-  ssisurfacemanifold.add_component(selection<int>("ImplType",
+  ssisurfacemanifold.add_component(selection<Inpar::ScaTra::ImplType>("ImplType",
       {{"Undefined", Inpar::ScaTra::impltype_undefined}, {"Standard", Inpar::ScaTra::impltype_std},
           {"ElchElectrode", Inpar::ScaTra::impltype_elch_electrode},
           {"ElchDiffCond", Inpar::ScaTra::impltype_elch_diffcond}},
@@ -410,14 +410,15 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
 
     surfmanifoldkinetics.add_component(one_of({
         all_of({
-            selection<int>("KINETIC_MODEL", {{"ConstantInterfaceResistance",
-                                                Inpar::S2I::kinetics_constantinterfaceresistance}}),
+            selection<Inpar::S2I::KineticModels>(
+                "KINETIC_MODEL", {{"ConstantInterfaceResistance",
+                                     Inpar::S2I::kinetics_constantinterfaceresistance}}),
             parameter<std::vector<int>>("ONOFF", {.size = 2}),
             parameter<double>("RESISTANCE"),
             parameter<int>("E-"),
         }),
         all_of({
-            selection<int>("KINETIC_MODEL",
+            selection<Inpar::S2I::KineticModels>("KINETIC_MODEL",
                 {{"Butler-VolmerReduced", Inpar::S2I::kinetics_butlervolmerreduced}}),
             parameter<int>("NUMSCAL"),
             parameter<std::vector<int>>(
@@ -427,7 +428,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
             parameter<double>("ALPHA_A"),
             parameter<double>("ALPHA_C"),
         }),
-        selection<int>(
+        selection<S2I::KineticModels>(
             "KINETIC_MODEL", {{"NoInterfaceFlux", Inpar::S2I::kinetics_nointerfaceflux}}),
     }));
   }
@@ -483,7 +484,7 @@ void Inpar::SSI::set_valid_conditions(std::vector<Core::Conditions::ConditionDef
   const auto make_ssiinterfacecontact = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(selection<int>("INTERFACE_SIDE",
+    cond.add_component(selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface_side"}));

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -161,7 +161,7 @@ void Inpar::SSTI::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   const auto make_sstiinterfacemeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(selection<S2I::InterfaceSides>("INTERFACE_SIDE",
+    cond.add_component(deprecated_selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface side"}));

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -161,7 +161,7 @@ void Inpar::SSTI::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   const auto make_sstiinterfacemeshtying = [&condlist](Core::Conditions::ConditionDefinition& cond)
   {
     cond.add_component(parameter<int>("ConditionID"));
-    cond.add_component(selection<int>("INTERFACE_SIDE",
+    cond.add_component(selection<S2I::InterfaceSides>("INTERFACE_SIDE",
         {{"Undefined", Inpar::S2I::side_undefined}, {"Slave", Inpar::S2I::side_slave},
             {"Master", Inpar::S2I::side_master}},
         {.description = "interface side"}));

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -198,7 +198,7 @@ namespace Inpar
 
       std::vector<std::string> material_tangent_valid_input = {"analytical", "finitedifferences"};
       sdyn.specs.emplace_back(
-          selection<std::string>("MATERIALTANGENT", material_tangent_valid_input,
+          deprecated_selection<std::string>("MATERIALTANGENT", material_tangent_valid_input,
               {.description = "way of evaluating the constitutive matrix",
                   .default_value = "analytical"}));
 
@@ -461,7 +461,7 @@ namespace Inpar
         cond.add_component(parameter<std::vector<int>>(
             "FUNCTNONLINSTIFF", {.description = "", .size = from_parameter<int>("NUMDOF")}));
         cond.add_component(
-            selection<CONSTRAINTS::SpringDashpot::RobinSpringDashpotType>("DIRECTION",
+            deprecated_selection<CONSTRAINTS::SpringDashpot::RobinSpringDashpotType>("DIRECTION",
                 {{"xyz", CONSTRAINTS::SpringDashpot::RobinSpringDashpotType::xyz},
                     {"refsurfnormal",
                         CONSTRAINTS::SpringDashpot::RobinSpringDashpotType::refsurfnormal},

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -133,8 +133,9 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   Core::Utils::SectionSpecs tsidynpart{tsidyn, "PARTITIONED"};
 
   std::vector<std::string> couplvariable_valid_input = {"Displacement", "Temperature"};
-  tsidynpart.specs.emplace_back(selection<std::string>("COUPVARIABLE", couplvariable_valid_input,
-      {.description = "Coupling variable", .default_value = "Displacement"}));
+  tsidynpart.specs.emplace_back(
+      deprecated_selection<std::string>("COUPVARIABLE", couplvariable_valid_input,
+          {.description = "Coupling variable", .default_value = "Displacement"}));
 
 
   // Solver parameter for relaxation of iterative staggered partitioned TSI

--- a/src/inpar/4C_inpar_validconditions.cpp
+++ b/src/inpar/4C_inpar_validconditions.cpp
@@ -161,7 +161,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
         "VAL", {.description = "values", .size = from_parameter<int>("NUMDOF")}));
     cond.add_component(parameter<std::vector<std::optional<int>>>(
         "FUNCT", {.description = "function ids", .size = from_parameter<int>("NUMDOF")}));
-    cond.add_component(selection<std::string>("TYPE",
+    cond.add_component(deprecated_selection<std::string>("TYPE",
         {"Live", "Dead", "pseudo_orthopressure", "orthopressure", "PressureGrad"},
         {.description = "type", .default_value = "Live"}));
 
@@ -284,7 +284,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
         "FUNCT", {.description = "", .size = from_parameter<int>("NUMDOF")}));
 
     // optional
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "TAG", {"none", "monitor_reaction"}, {.description = "", .default_value = "none"}));
 
     condlist.emplace_back(cond);
@@ -362,7 +362,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   const auto make_init_field_condition = [&condlist](auto& cond)
   {
-    cond.add_component(selection<std::string>("FIELD",
+    cond.add_component(deprecated_selection<std::string>("FIELD",
         {"Undefined", "Velocity", "Pressure", "Temperature", "ScaTra", "Porosity", "PoroMultiFluid",
             "Artery"},
         {.description = "init field"}));
@@ -407,8 +407,8 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   const auto make_thermo_init_field_condition = [&condlist](auto& cond)
   {
-    cond.add_component(
-        selection<std::string>("FIELD", {"Undefined", "ScaTra"}, {.description = "init field"}));
+    cond.add_component(deprecated_selection<std::string>(
+        "FIELD", {"Undefined", "ScaTra"}, {.description = "init field"}));
     cond.add_component(parameter<int>("FUNCT"));
 
     condlist.emplace_back(cond);
@@ -520,9 +520,9 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   const auto make_periodic_condition = [&condlist](auto& cond)
   {
     cond.add_component(parameter<int>("ID", {.description = "periodic boundary condition id"}));
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "MASTER_OR_SLAVE", {"Master", "Slave"}, {.description = "master-slave toggle"}));
-    cond.add_component(selection<std::string>("PLANE", {"xy", "yz", "xz", "xyz"},
+    cond.add_component(deprecated_selection<std::string>("PLANE", {"xy", "yz", "xz", "xyz"},
         {.description = "degrees of freedom for the pbc plane"}));
     cond.add_component(
         parameter<int>("LAYER", {.description = "layer of periodic boundary condition"}));
@@ -549,17 +549,18 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   const auto make_weak_dirichlet_condition = [&condlist](auto& cond)
   {
     // weak DBCs can be imposed adjoint consistent or adjoint inconsistent
-    cond.add_component(selection<std::string>("GAMMATYPE",
+    cond.add_component(deprecated_selection<std::string>("GAMMATYPE",
         {"adjoint-consistent", "diffusive-optimal"}, {.description = "Choice of gamma parameter"}));
 
     // weak DBCs can be imposed in all directions or only in normal direction
     // (SCATRA: not checked, only in all_directions so far)
-    cond.add_component(selection<std::string>("DIR", {"all_directions", "only_in_normal_direction"},
-        {.description = "Directions to apply weak dbc"}));
+    cond.add_component(
+        deprecated_selection<std::string>("DIR", {"all_directions", "only_in_normal_direction"},
+            {.description = "Directions to apply weak dbc"}));
 
     // FLUID: penalty parameter either computed dynamically (using Spaldings law of
     // the wall) or by a fixed value; SCATRA: not checked, only constant value so far
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "PENTYPE", {"constant", "Spalding"}, {.description = "Definition of penalty parameter"}));
 
     // scaling factor for penalty parameter tauB or
@@ -572,7 +573,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
     // suppressed, since the flux is a kink function and including this one
     // might result in even worse convergence behaviour
     // (SCATRA: not checked)
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "LINEARISATION", {"lin_all", "no_lin_conv_inflow"}, {.description = "Linearisation"}));
 
     // we provide a vector of 3 values for velocities
@@ -612,8 +613,8 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   volumeconstraint.add_component(
       parameter<std::optional<int>>("curve", {.description = "id of the curve"}));
   volumeconstraint.add_component(parameter<double>("activeTime"));
-  volumeconstraint.add_component(selection<std::string>("projection", {"none", "xy", "yz", "xz"},
-      {.description = "projection", .default_value = "none"}));
+  volumeconstraint.add_component(deprecated_selection<std::string>("projection",
+      {"none", "xy", "yz", "xz"}, {.description = "projection", .default_value = "none"}));
 
 
   condlist.push_back(volumeconstraint);
@@ -632,8 +633,8 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   volumeconstraintpen.add_component(parameter<double>("activeTime"));
   volumeconstraintpen.add_component(parameter<double>("penalty"));
   volumeconstraintpen.add_component(parameter<double>("rho"));
-  volumeconstraintpen.add_component(selection<std::string>("projection", {"none", "xy", "yz", "xz"},
-      {.description = "projection", .default_value = "none"}));
+  volumeconstraintpen.add_component(deprecated_selection<std::string>("projection",
+      {"none", "xy", "yz", "xz"}, {.description = "projection", .default_value = "none"}));
 
   condlist.push_back(volumeconstraintpen);
 
@@ -671,8 +672,8 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
       Core::Conditions::geometry_type_surface);
 
   areamonitor.add_component(parameter<int>("ConditionID"));
-  areamonitor.add_component(selection<std::string>("projection", {"none", "xy", "yz", "xz"},
-      {.description = "projection", .default_value = "none"}));
+  areamonitor.add_component(deprecated_selection<std::string>("projection",
+      {"none", "xy", "yz", "xz"}, {.description = "projection", .default_value = "none"}));
 
   condlist.push_back(areamonitor);
 
@@ -713,7 +714,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   nodeonplaneconst3D.add_component(parameter<double>("activeTime"));
   nodeonplaneconst3D.add_component(parameter<std::vector<int>>(
       "planeNodes", {.description = "ids of the nodes spanning the plane", .size = 3}));
-  nodeonplaneconst3D.add_component(selection<std::string>("control", {"rel", "abs"},
+  nodeonplaneconst3D.add_component(deprecated_selection<std::string>("control", {"rel", "abs"},
       {.description = "relative or absolute control", .default_value = "rel"}));
 
   condlist.push_back(nodeonplaneconst3D);
@@ -733,9 +734,9 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   nodemasterconst3D.add_component(parameter<int>("masterNode"));
   nodemasterconst3D.add_component(
       parameter<std::vector<double>>("direction", {.description = "direction", .size = 3}));
-  nodemasterconst3D.add_component(selection<std::string>(
+  nodemasterconst3D.add_component(deprecated_selection<std::string>(
       "value", {"disp", "x"}, {.description = "value", .default_value = "disp"}));
-  nodemasterconst3D.add_component(selection<std::string>("control", {"rel", "abs"},
+  nodemasterconst3D.add_component(deprecated_selection<std::string>("control", {"rel", "abs"},
       {.description = "relative or absolute control", .default_value = "rel"}));
 
   condlist.push_back(nodemasterconst3D);
@@ -757,9 +758,9 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   nodemasterconst3Dpen.add_component(parameter<int>("masterNode"));
   nodemasterconst3Dpen.add_component(
       parameter<std::vector<int>>("direction", {.description = "direction", .size = 3}));
-  nodemasterconst3Dpen.add_component(selection<std::string>(
+  nodemasterconst3Dpen.add_component(deprecated_selection<std::string>(
       "value", {"disp", "x"}, {.description = "value", .default_value = "disp"}));
-  nodemasterconst3Dpen.add_component(selection<std::string>("control", {"rel", "abs"},
+  nodemasterconst3Dpen.add_component(deprecated_selection<std::string>("control", {"rel", "abs"},
       {.description = "relative or absolute control", .default_value = "rel"}));
 
   condlist.push_back(nodemasterconst3Dpen);
@@ -775,7 +776,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   nodeonlineconst2D.add_component(parameter<int>("constrNode1"));
   nodeonlineconst2D.add_component(parameter<int>("constrNode2"));
   nodeonlineconst2D.add_component(parameter<int>("constrNode3"));
-  nodeonlineconst2D.add_component(selection<std::string>("control", {"dist", "angle"},
+  nodeonlineconst2D.add_component(deprecated_selection<std::string>("control", {"dist", "angle"},
       {.description = "distance or angle control", .default_value = "dist"}));
   nodeonlineconst2D.add_component(parameter<double>("activeTime"));
 
@@ -814,13 +815,13 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
 
   const auto make_rigidbody_mode_condition = [&condlist](auto& cond)
   {
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "DIS", {"fluid", "scatra", "solid"}, {.description = "discretization"}));
     cond.add_component(parameter<int>("NUMMODES"));
     cond.add_component(parameter<std::vector<int>>(
         "ONOFF", {.description = "", .size = from_parameter<int>("NUMMODES")}));
-    cond.add_component(selection<std::string>("WEIGHTVECDEF", {"integration", "pointvalues"},
-        {.description = "weight vector definition"}));
+    cond.add_component(deprecated_selection<std::string>("WEIGHTVECDEF",
+        {"integration", "pointvalues"}, {.description = "weight vector definition"}));
 
     condlist.emplace_back(cond);
   };

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -428,7 +428,8 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       parameter<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<std::optional<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
-      selection<std::string>("TAG", {"none", "monitor_reaction"}, {.default_value = "none"}),
+      deprecated_selection<std::string>(
+          "TAG", {"none", "monitor_reaction"}, {.default_value = "none"}),
   });
 
   auto neumanncomponents = all_of({
@@ -436,7 +437,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       parameter<std::vector<int>>("ONOFF", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<double>>("VAL", {.size = from_parameter<int>("NUMDOF")}),
       parameter<std::vector<std::optional<int>>>("FUNCT", {.size = from_parameter<int>("NUMDOF")}),
-      selection<std::string>("TYPE",
+      deprecated_selection<std::string>("TYPE",
           {"Live", "Dead", "pseudo_orthopressure", "orthopressure", "PressureGrad"},
           {.default_value = "Live"}),
   });
@@ -472,7 +473,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_Displacement, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_displacement.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_displacement.add_component(selection<std::string>("EVALTYPE",
+  xfem_surf_displacement.add_component(deprecated_selection<std::string>("EVALTYPE",
       {"zero", "funct", "implementation"}, {.description = "", .default_value = "funct"}));
 
   xfem_surf_displacement.add_component(dirichletbundcomponents);
@@ -485,7 +486,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   auto levelsetfield_components = all_of({
       parameter<int>("COUPLINGID"),
       parameter<int>("LEVELSETFIELDNO"),
-      selection<std::string>("BOOLEANTYPE",
+      deprecated_selection<std::string>("BOOLEANTYPE",
           {"none", "cut", "union", "difference", "sym_difference"},
           {.description = "define which boolean operator is used for combining this level-set "
                           "field with the previous one with smaller coupling id"}),
@@ -540,7 +541,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
 
   xfem_levelset_navier_slip.add_component(levelsetfield_components);
 
-  xfem_levelset_navier_slip.add_component(selection<ProjToSurface>("SURFACE_PROJECTION",
+  xfem_levelset_navier_slip.add_component(deprecated_selection<ProjToSurface>("SURFACE_PROJECTION",
       {{"proj_normal", Inpar::XFEM::Proj_normal}, {"proj_smoothed", Inpar::XFEM::Proj_smoothed},
           {"proj_normal_smoothed_comb", Inpar::XFEM::Proj_normal_smoothed_comb},
           {"proj_normal_phi", Inpar::XFEM::Proj_normal_phi}},
@@ -606,7 +607,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_FluidFluid, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_fluidfluid.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_fluidfluid.add_component(selection<AveragingStrategy>("COUPSTRATEGY",
+  xfem_surf_fluidfluid.add_component(deprecated_selection<AveragingStrategy>("COUPSTRATEGY",
       {{"xfluid", Inpar::XFEM::Xfluid_Sided}, {"embedded", Inpar::XFEM::Embedded_Sided},
           {"mean", Inpar::XFEM::Mean}},
       {.description = "coupling strategy"}));
@@ -623,7 +624,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   xfem_surf_fsi_part.add_component(parameter<int>("COUPLINGID"));
 
   // COUPSTRATEGY IS FLUID SIDED
-  xfem_surf_fsi_part.add_component(selection<InterfaceLaw>("INTLAW",
+  xfem_surf_fsi_part.add_component(deprecated_selection<InterfaceLaw>("INTLAW",
       {{"noslip", Inpar::XFEM::noslip}, {"noslip_splitpen", Inpar::XFEM::noslip_splitpen},
           {"slip", Inpar::XFEM::slip}, {"navslip", Inpar::XFEM::navierslip}},
       {.description = "", .default_value = Inpar::XFEM::noslip}));
@@ -642,11 +643,11 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_FSIMono, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_fsi_mono.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_fsi_mono.add_component(selection<AveragingStrategy>("COUPSTRATEGY",
+  xfem_surf_fsi_mono.add_component(deprecated_selection<AveragingStrategy>("COUPSTRATEGY",
       {{"xfluid", Inpar::XFEM::Xfluid_Sided}, {"solid", Inpar::XFEM::Embedded_Sided},
           {"mean", Inpar::XFEM::Mean}, {"harmonic", Inpar::XFEM::Harmonic}},
       {.description = "", .default_value = Inpar::XFEM::Xfluid_Sided}));
-  xfem_surf_fsi_mono.add_component(selection<InterfaceLaw>("INTLAW",
+  xfem_surf_fsi_mono.add_component(deprecated_selection<InterfaceLaw>("INTLAW",
       {{"noslip", Inpar::XFEM::noslip}, {"noslip_splitpen", Inpar::XFEM::noslip_splitpen},
           {"slip", Inpar::XFEM::slip}, {"navslip", Inpar::XFEM::navierslip},
           {"navslip_contact", Inpar::XFEM::navierslip_contact}},
@@ -668,9 +669,9 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   xfem_surf_fpi_mono.add_component(parameter<int>("COUPLINGID"));
   xfem_surf_fpi_mono.add_component(
       parameter<double>("BJ_COEFF", {.description = "", .default_value = 0.}));
-  xfem_surf_fpi_mono.add_component(selection<std::string>(
+  xfem_surf_fpi_mono.add_component(deprecated_selection<std::string>(
       "Variant", {"BJ", "BJS"}, {.description = "variant", .default_value = "BJ"}));
-  xfem_surf_fpi_mono.add_component(selection<std::string>(
+  xfem_surf_fpi_mono.add_component(deprecated_selection<std::string>(
       "Method", {"NIT", "SUB"}, {.description = "method", .default_value = "NIT"}));
   xfem_surf_fpi_mono.add_component(
       parameter<bool>("Contact", {.description = "contact", .default_value = false}));
@@ -686,7 +687,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_Weak_Dirichlet, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_wdbc.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_wdbc.add_component(selection<std::string>("EVALTYPE",
+  xfem_surf_wdbc.add_component(deprecated_selection<std::string>("EVALTYPE",
       {"zero", "funct_interpolated", "funct_gausspoint", "displacement_1storder_wo_initfunct",
           "displacement_2ndorder_wo_initfunct", "displacement_1storder_with_initfunct",
           "displacement_2ndorder_with_initfunct"},
@@ -727,7 +728,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_Navier_Slip, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_navier_slip.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_navier_slip.add_component(selection<std::string>("EVALTYPE",
+  xfem_surf_navier_slip.add_component(deprecated_selection<std::string>("EVALTYPE",
       {"zero", "funct_interpolated", "funct_gausspoint", "displacement_1storder_wo_initfunct",
           "displacement_2ndorder_wo_initfunct", "displacement_1storder_with_initfunct",
           "displacement_2ndorder_with_initfunct"},
@@ -756,7 +757,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       parameter<std::optional<int>>("ROBIN_ID", {.description = "robin id"}));
 
   // Likely, not necessary. But needed for the current structure.
-  xfem_navier_slip_robin_dirch_surf.add_component(selection<std::string>("EVALTYPE",
+  xfem_navier_slip_robin_dirch_surf.add_component(deprecated_selection<std::string>("EVALTYPE",
       {"zero", "funct_interpolated", "funct_gausspoint", "displacement_1storder_wo_initfunct",
           "displacement_2ndorder_wo_initfunct", "displacement_1storder_with_initfunct",
           "displacement_2ndorder_with_initfunct"},

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -540,7 +540,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
 
   xfem_levelset_navier_slip.add_component(levelsetfield_components);
 
-  xfem_levelset_navier_slip.add_component(selection<int>("SURFACE_PROJECTION",
+  xfem_levelset_navier_slip.add_component(selection<ProjToSurface>("SURFACE_PROJECTION",
       {{"proj_normal", Inpar::XFEM::Proj_normal}, {"proj_smoothed", Inpar::XFEM::Proj_smoothed},
           {"proj_normal_smoothed_comb", Inpar::XFEM::Proj_normal_smoothed_comb},
           {"proj_normal_phi", Inpar::XFEM::Proj_normal_phi}},
@@ -606,7 +606,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_FluidFluid, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_fluidfluid.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_fluidfluid.add_component(selection<int>("COUPSTRATEGY",
+  xfem_surf_fluidfluid.add_component(selection<AveragingStrategy>("COUPSTRATEGY",
       {{"xfluid", Inpar::XFEM::Xfluid_Sided}, {"embedded", Inpar::XFEM::Embedded_Sided},
           {"mean", Inpar::XFEM::Mean}},
       {.description = "coupling strategy"}));
@@ -623,7 +623,7 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
   xfem_surf_fsi_part.add_component(parameter<int>("COUPLINGID"));
 
   // COUPSTRATEGY IS FLUID SIDED
-  xfem_surf_fsi_part.add_component(selection<int>("INTLAW",
+  xfem_surf_fsi_part.add_component(selection<InterfaceLaw>("INTLAW",
       {{"noslip", Inpar::XFEM::noslip}, {"noslip_splitpen", Inpar::XFEM::noslip_splitpen},
           {"slip", Inpar::XFEM::slip}, {"navslip", Inpar::XFEM::navierslip}},
       {.description = "", .default_value = Inpar::XFEM::noslip}));
@@ -642,11 +642,11 @@ void Inpar::XFEM::set_valid_conditions(std::vector<Core::Conditions::ConditionDe
       Core::Conditions::XFEM_Surf_FSIMono, true, Core::Conditions::geometry_type_surface);
 
   xfem_surf_fsi_mono.add_component(parameter<int>("COUPLINGID"));
-  xfem_surf_fsi_mono.add_component(selection<int>("COUPSTRATEGY",
+  xfem_surf_fsi_mono.add_component(selection<AveragingStrategy>("COUPSTRATEGY",
       {{"xfluid", Inpar::XFEM::Xfluid_Sided}, {"solid", Inpar::XFEM::Embedded_Sided},
           {"mean", Inpar::XFEM::Mean}, {"harmonic", Inpar::XFEM::Harmonic}},
       {.description = "", .default_value = Inpar::XFEM::Xfluid_Sided}));
-  xfem_surf_fsi_mono.add_component(selection<int>("INTLAW",
+  xfem_surf_fsi_mono.add_component(selection<InterfaceLaw>("INTLAW",
       {{"noslip", Inpar::XFEM::noslip}, {"noslip_splitpen", Inpar::XFEM::noslip_splitpen},
           {"slip", Inpar::XFEM::slip}, {"navslip", Inpar::XFEM::navierslip},
           {"navslip_contact", Inpar::XFEM::navierslip_contact}},

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_function.cpp
@@ -199,7 +199,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
 
   auto spec = one_of({
       all_of({
-          selection<std::string>("POROMULTIPHASESCATRA_FUNCTION",
+          deprecated_selection<std::string>("POROMULTIPHASESCATRA_FUNCTION",
               {"TUMOR_GROWTH_LAW_HEAVISIDE", "TUMOR_GROWTH_LAW_HEAVISIDE_OXY",
                   "TUMOR_GROWTH_LAW_HEAVISIDE_NECRO"}),
           parameter<int>("NUMPARAMS"),
@@ -213,7 +213,8 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
               }),
       }),
       all_of({
-          selection<std::string>("POROMULTIPHASESCATRA_FUNCTION", {"NECROSIS_LAW_HEAVISIDE"}),
+          deprecated_selection<std::string>(
+              "POROMULTIPHASESCATRA_FUNCTION", {"NECROSIS_LAW_HEAVISIDE"}),
           parameter<int>("NUMPARAMS"),
           group("PARAMS",
               {
@@ -225,7 +226,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
               }),
       }),
       all_of({
-          selection<std::string>(
+          deprecated_selection<std::string>(
               "POROMULTIPHASESCATRA_FUNCTION", {"OXYGEN_CONSUMPTION_LAW_HEAVISIDE"}),
           parameter<int>("NUMPARAMS"),
           group("PARAMS",
@@ -238,7 +239,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
               }),
       }),
       all_of({
-          selection<std::string>(
+          deprecated_selection<std::string>(
               "POROMULTIPHASESCATRA_FUNCTION", {"OXYGEN_TRANSVASCULAR_EXCHANGE_LAW_CONT"}),
           parameter<int>("NUMPARAMS"),
           group("PARAMS",
@@ -255,7 +256,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
               }),
       }),
       all_of({
-          selection<std::string>(
+          deprecated_selection<std::string>(
               "POROMULTIPHASESCATRA_FUNCTION", {"OXYGEN_TRANSVASCULAR_EXCHANGE_LAW_DISC"}),
           parameter<int>("NUMPARAMS"),
           group("PARAMS",
@@ -273,7 +274,8 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
               }),
       }),
       all_of({
-          selection<std::string>("POROMULTIPHASESCATRA_FUNCTION", {"LUNG_OXYGEN_EXCHANGE_LAW"}),
+          deprecated_selection<std::string>(
+              "POROMULTIPHASESCATRA_FUNCTION", {"LUNG_OXYGEN_EXCHANGE_LAW"}),
           parameter<int>("NUMPARAMS"),
           group("PARAMS",
               {
@@ -290,7 +292,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
               }),
       }),
       all_of({
-          selection<std::string>(
+          deprecated_selection<std::string>(
               "POROMULTIPHASESCATRA_FUNCTION", {"LUNG_CARBONDIOXIDE_EXCHANGE_LAW"}),
           parameter<int>("NUMPARAMS"),
           group("PARAMS",

--- a/src/red_airways/4C_red_airways_acinus.cpp
+++ b/src/red_airways/4C_red_airways_acinus.cpp
@@ -67,7 +67,7 @@ void Discret::Elements::RedAcinusType::setup_element_definition(
   defs["LINE2"] = all_of({
       parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
-      selection<std::string>("TYPE",
+      deprecated_selection<std::string>("TYPE",
           {"NeoHookean", "Exponential", "DoubleExponential", "VolumetricOgden"},
           {.description = "Visco-elastic model of this acinus"}),
       parameter<double>("AcinusVolume"),

--- a/src/red_airways/4C_red_airways_airway.cpp
+++ b/src/red_airways/4C_red_airways_airway.cpp
@@ -69,7 +69,7 @@ void Discret::Elements::RedAirwayType::setup_element_definition(
       parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("ElemSolvingType"),
-      selection<std::string>("TYPE",
+      deprecated_selection<std::string>("TYPE",
           {"Resistive", "InductoResistive", "CompliantResistive", "RLC", "ViscoElasticRLC",
               "ConvectiveViscoElasticRLC"},
           {.description = "Reduced-dimensional model of this airway"}),

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -891,9 +891,9 @@ void ScaTra::ScaTraTimIntElch::read_restart_problem_specific(
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
     // only slave side has relevant information
-    if (s2ikinetics_cond->parameters().get<int>("INTERFACE_SIDE") ==
+    if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
             static_cast<int>(Inpar::S2I::side_slave) and
-        s2ikinetics_cond->parameters().get<int>("KINETIC_MODEL") ==
+        s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
             static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
     {
       reader.read_vector(phidtnp_, "phidtnp");
@@ -1627,9 +1627,9 @@ void ScaTra::ScaTraTimIntElch::write_restart() const
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
     // only slave side has relevant information
-    if (s2ikinetics_cond->parameters().get<int>("INTERFACE_SIDE") ==
+    if (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
             static_cast<int>(Inpar::S2I::side_slave) and
-        s2ikinetics_cond->parameters().get<int>("KINETIC_MODEL") ==
+        s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
             static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
     {
       output_->write_vector("phidtnp", phidtnp_);
@@ -1826,7 +1826,8 @@ void ScaTra::ScaTraTimIntElch::init_nernst_bc()
   for (unsigned icond = 0; icond < Elchcond.size(); ++icond)
   {
     // check if Nernst-BC is defined on electrode kinetics condition
-    if (Elchcond[icond]->parameters().get<int>("KINETIC_MODEL") == Inpar::ElCh::nernst)
+    if (Elchcond[icond]->parameters().get<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL") ==
+        Inpar::ElCh::nernst)
     {
       // safety check
       if (!Elchcond[icond]->geometry_description())

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -604,7 +604,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
       // is this node owned by this proc?
       if (!Core::Communication::is_node_gid_on_this_proc(*discret_, coupling_node_gid)) continue;
 
-      switch (coupling_condition->parameters().get<int>("INTERFACE_SIDE"))
+      switch (coupling_condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
       {
         case Inpar::S2I::side_slave:
           my_macro_slave_node_gids.emplace_back(coupling_node_gid);

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -3386,7 +3386,8 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
 
           // compute matrix and vector contributions according to kinetic model for current
           // macro-micro coupling condition
-          const int kinetic_model = condition->parameters().get<int>("KINETIC_MODEL");
+          const int kinetic_model =
+              condition->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL");
 
           switch (kinetic_model)
           {
@@ -3507,12 +3508,12 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
               const double eta = phinp_macro_[2] - phinp_macro_[1] - epd;
 
               // Butler-Volmer exchange mass flux density
-              const double j0 = condition->parameters().get<int>("KINETIC_MODEL") ==
-                                        Inpar::S2I::kinetics_butlervolmerreduced
-                                    ? kr
-                                    : kr * std::pow(conc_el, alphaa) *
-                                          std::pow(cmax - conc_ed, alphaa) *
-                                          std::pow(conc_ed, alphac);
+              const double j0 =
+                  condition->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
+                          Inpar::S2I::kinetics_butlervolmerreduced
+                      ? kr
+                      : kr * std::pow(conc_el, alphaa) * std::pow(cmax - conc_ed, alphaa) *
+                            std::pow(conc_ed, alphac);
 
               // exponential Butler-Volmer terms
               const double expterm1 = std::exp(alphaa * frt * eta);

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
@@ -202,7 +202,8 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
 
     // compute matrix and vector contributions according to kinetic model for current point coupling
     // condition
-    const int kinetic_model = cond_slave->parameters().get<int>("KINETIC_MODEL");
+    const int kinetic_model =
+        cond_slave->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL");
     switch (kinetic_model)
     {
       case Inpar::S2I::kinetics_butlervolmer:
@@ -278,8 +279,8 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
         const double eta = ed_pot - el_pot - epd;
 
         // Butler-Volmer exchange mass flux density
-        const double j0 = cond_slave->parameters().get<int>("KINETIC_MODEL") ==
-                                  Inpar::S2I::kinetics_butlervolmerreduced
+        const double j0 = cond_slave->parameters().get<Inpar::S2I::KineticModels>(
+                              "KINETIC_MODEL") == Inpar::S2I::kinetics_butlervolmerreduced
                               ? kr
                               : kr * std::pow(el_conc, alphaa) * std::pow(cmax - ed_conc, alphaa) *
                                     std::pow(ed_conc, alphac);
@@ -386,7 +387,7 @@ void ScaTra::MeshtyingStrategyS2IElch::update() const
     {
       // extract current condition
       // extract kinetic model from current condition
-      switch (condition->parameters().get<int>("KINETIC_MODEL"))
+      switch (condition->parameters().get<Inpar::S2I::GrowthKineticModels>("KINETIC_MODEL"))
       {
         case Inpar::S2I::growth_kinetics_butlervolmer:
         {
@@ -1222,7 +1223,7 @@ void ScaTra::MeshtyingStrategyS2IElchSCL::setup_meshtying()
     if (s2imeshtying_condition->parameters().get<int>("S2I_KINETICS_ID") != -1)
       FOUR_C_THROW("No kinetics condition is allowed for the coupled space-charge layer problem.");
 
-    switch (s2imeshtying_condition->parameters().get<int>("INTERFACE_SIDE"))
+    switch (s2imeshtying_condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
     {
       case Inpar::S2I::side_slave:
       {

--- a/src/scatra/4C_scatra_utils.cpp
+++ b/src/scatra/4C_scatra_utils.cpp
@@ -86,7 +86,7 @@ void ScaTra::ScaTraUtils::check_consistency_with_s2_i_kinetics_condition(
     const int s2ikinetics_id = conditionToBeTested->parameters().get<int>("S2I_KINETICS_ID");
 
     // check the interface side
-    switch (conditionToBeTested->parameters().get<int>("INTERFACE_SIDE"))
+    switch (conditionToBeTested->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
     {
       case Inpar::S2I::side_slave:
       {
@@ -114,7 +114,7 @@ void ScaTra::ScaTraUtils::check_consistency_with_s2_i_kinetics_condition(
       if (s2ikinetics_id != s2ikinetics_cond_id) continue;
 
       // check the interface side
-      switch (s2ikinetics_cond->parameters().get<int>("INTERFACE_SIDE"))
+      switch (s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE"))
       {
         case Inpar::S2I::side_slave:
         {

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.cpp
@@ -107,7 +107,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_elch_b
   if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'ElchBoundaryKinetics'");
 
   // access parameters of the condition
-  const auto kinetics = cond->parameters().get<int>("KINETIC_MODEL");
+  const auto kinetics = cond->parameters().get<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL");
   auto pot0 = cond->parameters().get<double>("POT");
   const auto curvenum = cond->parameters().get<std::optional<int>>("FUNCT");
   const auto nume = cond->parameters().get<int>("E-");
@@ -227,7 +227,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>::calc_nernst
       params.get<std::shared_ptr<Core::Conditions::Condition>>("condition");
   if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'ElchBoundaryKinetics'");
 
-  const auto kinetics = cond->parameters().get<int>("KINETIC_MODEL");
+  const auto kinetics = cond->parameters().get<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL");
 
   // Nernst-BC
   if (kinetics == Inpar::ElCh::nernst)

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch.cpp
@@ -353,7 +353,7 @@ void Discret::Elements::ScaTraEleCalcElch<distype, probdim>::calc_elch_boundary_
   if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'ElchBoundaryKineticsPoint'!");
 
   // access parameters of the condition
-  const int kinetics = cond->parameters().get<int>("KINETIC_MODEL");
+  const int kinetics = cond->parameters().get<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL");
   double pot0 = cond->parameters().get<double>("POT");
   const auto functnum = cond->parameters().get<std::optional<int>>("FUNCT");
   const int nume = cond->parameters().get<int>("E-");

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond.cpp
@@ -264,7 +264,7 @@ void Discret::Elements::ScaTraEleCalcElchDiffCond<distype, probdim>::calc_elch_d
   if (cond == nullptr) FOUR_C_THROW("Cannot access condition 'ElchDomainKinetics'");
 
   // access parameters of the condition
-  const int kinetics = cond->parameters().get<int>("KINETIC_MODEL");
+  const int kinetics = cond->parameters().get<Inpar::ElCh::ElectrodeKinetics>("KINETIC_MODEL");
   double pot0 = cond->parameters().get<double>("POT");
   const auto curvenum = cond->parameters().get<std::optional<int>>("FUNCT");
   const int nume = cond->parameters().get<int>("E-");

--- a/src/scatra_ele/4C_scatra_ele_parameter_boundary.cpp
+++ b/src/scatra_ele/4C_scatra_ele_parameter_boundary.cpp
@@ -288,8 +288,7 @@ void Discret::Elements::ScaTraEleParameterBoundary::set_regularization(
   regularizationparameter_ = parameters.get<double>("REGPAR", -1.0);
   if (regularizationparameter_ < 0.0)
     FOUR_C_THROW("Regularization parameter for lithium stripping must not be negative!");
-  regularizationtype_ = static_cast<Inpar::S2I::RegularizationType>(
-      parameters.get<int>("REGTYPE", std::numeric_limits<int>::infinity()));
+  regularizationtype_ = parameters.get<Inpar::S2I::RegularizationType>("REGTYPE");
 }
 
 /*----------------------------------------------------------------------*

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -33,7 +33,7 @@ namespace
 
   Core::IO::InputSpec get_kinem_type_input_spec()
   {
-    return selection<Inpar::Solid::KinemType>("KINEM",
+    return deprecated_selection<Inpar::Solid::KinemType>("KINEM",
         {
             {kinem_type_string(Inpar::Solid::KinemType::linear), Inpar::Solid::KinemType::linear},
             {kinem_type_string(Inpar::Solid::KinemType::nonlinearTotLag),
@@ -51,7 +51,7 @@ namespace
             Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
         parameter<int>("MAT"),
         get_kinem_type_input_spec(),
-        selection<Discret::Elements::PrestressTechnology>("PRESTRESS_TECH",
+        deprecated_selection<Discret::Elements::PrestressTechnology>("PRESTRESS_TECH",
             {
                 {Discret::Elements::prestress_technology_string(
                      Discret::Elements::PrestressTechnology::mulf),
@@ -83,7 +83,7 @@ void Discret::Elements::SolidType::setup_element_definition(
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       get_default_input_spec<Core::FE::CellType::hex8>(),
-      selection<ElementTechnology>("TECH",
+      deprecated_selection<ElementTechnology>("TECH",
           {
               {element_technology_string(ElementTechnology::none), ElementTechnology::none},
               {element_technology_string(ElementTechnology::fbar), ElementTechnology::fbar},
@@ -117,7 +117,7 @@ void Discret::Elements::SolidType::setup_element_definition(
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::wedge6)] = all_of({
       get_default_input_spec<Core::FE::CellType::wedge6>(),
-      selection<ElementTechnology>("TECH",
+      deprecated_selection<ElementTechnology>("TECH",
           {
               {element_technology_string(ElementTechnology::none), ElementTechnology::none},
               {element_technology_string(ElementTechnology::shell_ans),
@@ -130,7 +130,7 @@ void Discret::Elements::SolidType::setup_element_definition(
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::pyramid5)] = all_of({
       get_default_input_spec<Core::FE::CellType::pyramid5>(),
-      selection<ElementTechnology>("TECH",
+      deprecated_selection<ElementTechnology>("TECH",
           {
               {element_technology_string(ElementTechnology::none), ElementTechnology::none},
               {element_technology_string(ElementTechnology::fbar), ElementTechnology::fbar},

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -41,7 +41,7 @@ namespace Discret::Elements::SolidPoroPressureBasedInternal
           parameter<std::vector<int>>(
               Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
           parameter<int>("MAT"),
-          selection<Inpar::Solid::KinemType>("KINEM",
+          deprecated_selection<Inpar::Solid::KinemType>("KINEM",
               {
                   {kinem_type_string(Inpar::Solid::KinemType::linear),
                       Inpar::Solid::KinemType::linear},
@@ -50,7 +50,8 @@ namespace Discret::Elements::SolidPoroPressureBasedInternal
               },
               {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                               "kinematics (large displacements)"}),
-          selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
+          deprecated_selection<Inpar::ScaTra::ImplType>("TYPE",
+              Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
       });

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -43,7 +43,7 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
           parameter<std::vector<int>>(
               Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
           parameter<int>("MAT"),
-          selection<Inpar::Solid::KinemType>("KINEM",
+          deprecated_selection<Inpar::Solid::KinemType>("KINEM",
               {
                   {kinem_type_string(Inpar::Solid::KinemType::linear),
                       Inpar::Solid::KinemType::linear},
@@ -55,7 +55,8 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
           parameter<std::optional<std::vector<double>>>("POROANISODIR1", {.size = 3}),
           parameter<std::optional<std::vector<double>>>("POROANISODIR2", {.size = 3}),
           parameter<std::optional<std::vector<double>>>("POROANISODIR3", {.size = 3}),
-          selection<Inpar::ScaTra::ImplType>("TYPE", Discret::Elements::get_impltype_inpar_map(),
+          deprecated_selection<Inpar::ScaTra::ImplType>("TYPE",
+              Discret::Elements::get_impltype_inpar_map(),
               {.description = "Scalar transport implementation type",
                   .default_value = Inpar::ScaTra::ImplType::impltype_undefined}),
       });

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -33,7 +33,7 @@ namespace
         parameter<std::vector<int>>(
             Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
         parameter<int>("MAT"),
-        selection<Inpar::Solid::KinemType>("KINEM",
+        deprecated_selection<Inpar::Solid::KinemType>("KINEM",
             {
                 {kinem_type_string(Inpar::Solid::KinemType::linear),
                     Inpar::Solid::KinemType::linear},
@@ -43,7 +43,7 @@ namespace
             {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                             "kinematics (large displacements)"}),
         parameter<std::string>("TYPE"),
-        selection<Discret::Elements::PrestressTechnology>("PRESTRESS_TECH",
+        deprecated_selection<Discret::Elements::PrestressTechnology>("PRESTRESS_TECH",
             {
                 {Discret::Elements::prestress_technology_string(
                      Discret::Elements::PrestressTechnology::mulf),
@@ -79,7 +79,7 @@ void Discret::Elements::SolidScatraType::setup_element_definition(
 
   defsgeneral[Core::FE::cell_type_to_string(Core::FE::CellType::hex8)] = all_of({
       get_default_input_spec<Core::FE::CellType::hex8>(),
-      selection<ElementTechnology>("TECH",
+      deprecated_selection<ElementTechnology>("TECH",
           {
               {element_technology_string(ElementTechnology::none), ElementTechnology::none},
               {element_technology_string(ElementTechnology::fbar), ElementTechnology::fbar},

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -870,8 +870,9 @@ bool SSI::SSIBase::check_s2_i_kinetics_condition_for_pseudo_contact(
   structdis->get_condition("SSIInterfaceContact", ssi_contact_conditions);
   for (auto* s2ikinetics_cond : s2ikinetics_conditions)
   {
-    if ((s2ikinetics_cond->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave) and
-        (s2ikinetics_cond->parameters().get<int>("KINETIC_MODEL") !=
+    if ((s2ikinetics_cond->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+            Inpar::S2I::side_slave) and
+        (s2ikinetics_cond->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
             Inpar::S2I::kinetics_nointerfaceflux) and
         s2ikinetics_cond->parameters().get<bool>("IS_PSEUDO_CONTACT"))
     {

--- a/src/ssi/4C_ssi_clonestrategy.cpp
+++ b/src/ssi/4C_ssi_clonestrategy.cpp
@@ -132,7 +132,7 @@ void SSI::ScatraStructureCloneStrategyManifold::set_element_data(
     auto cond_eles = condition->geometry();
     if (cond_eles.find(oldele->id()) != cond_eles.end())
     {
-      impltype = static_cast<Inpar::ScaTra::ImplType>(condition->parameters().get<int>("ImplType"));
+      impltype = condition->parameters().get<Inpar::ScaTra::ImplType>("ImplType");
       continue;
     }
   }

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -696,7 +696,9 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::pre_evaluate(
   eleparams.set<Core::Conditions::ConditionType>(
       "condition type", Core::Conditions::ConditionType::S2IKinetics);
 
-  switch (scatra_manifold_coupling.condition_kinetics()->parameters().get<int>("KINETIC_MODEL"))
+  switch (
+      scatra_manifold_coupling.condition_kinetics()->parameters().get<Inpar::S2I::KineticModels>(
+          "KINETIC_MODEL"))
   {
     case Inpar::S2I::kinetics_constantinterfaceresistance:
     {

--- a/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
@@ -390,7 +390,7 @@ void SSI::ScatraStructureOffDiagCoupling::
   for (auto kinetics_slave_cond :
       meshtying_strategy_s2i_->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<int>("KINETIC_MODEL") ==
+    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") ==
         static_cast<int>(Inpar::S2I::kinetics_butlervolmerreducedcapacitance))
     {
       // collect condition specific data and store to scatra boundary parameter class
@@ -625,7 +625,7 @@ void SSI::ScatraStructureOffDiagCoupling::
   for (auto kinetics_slave_cond :
       meshtying_strategy_s2i_->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<int>("KINETIC_MODEL") !=
+    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
         static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class

--- a/src/ssi/4C_ssi_utils.cpp
+++ b/src/ssi/4C_ssi_utils.cpp
@@ -1341,7 +1341,8 @@ void SSI::Utils::SSIMeshTying::find_slave_slave_transformation_nodes(Core::FE::D
   std::vector<int> original_slave_gids;
   for (auto* meshtying_condition : meshtying_conditions)
   {
-    if (meshtying_condition->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+    if (meshtying_condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+        Inpar::S2I::side_slave)
     {
       Core::Communication::add_owned_node_gid_from_list(
           dis, *meshtying_condition->get_nodes(), original_slave_gids);

--- a/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
@@ -319,7 +319,7 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_thermo_structure_interface_s
   for (auto kinetics_slave_cond :
       meshtying_strategy_thermo_->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<int>("KINETIC_MODEL") !=
+    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
         static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class

--- a/src/sti/4C_sti_algorithm.cpp
+++ b/src/sti/4C_sti_algorithm.cpp
@@ -120,7 +120,8 @@ STI::Algorithm::Algorithm(MPI_Comm comm, const Teuchos::ParameterList& stidyn,
         for (auto& condition : conditions)
         {
           // consider conditions for slave side only
-          if (condition->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+          if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+              Inpar::S2I::side_slave)
           {
             // extract ID of current condition
             const int condid = condition->parameters().get<int>("ConditionID");
@@ -331,7 +332,8 @@ void STI::Algorithm::transfer_scatra_to_thermo(
         for (auto& condition : conditions)
         {
           // consider conditions for slave side only
-          if (condition->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+          if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+              Inpar::S2I::side_slave)
           {
             // extract ID of current condition
             const int condid = condition->parameters().get<int>("ConditionID");
@@ -379,7 +381,8 @@ void STI::Algorithm::transfer_thermo_to_scatra(
     for (auto& condition : conditions)
     {
       // consider conditions for slave side only
-      if (condition->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+      if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+          Inpar::S2I::side_slave)
       {
         // extract ID of current condition
         const int condid = condition->parameters().get<int>("ConditionID");

--- a/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
+++ b/src/sti/4C_sti_monolithic_evaluate_OffDiag.cpp
@@ -310,7 +310,7 @@ void STI::ScatraThermoOffDiagCouplingMatchingNodes::evaluate_scatra_thermo_inter
   for (const auto& kinetics_slave_cond :
       meshtying_strategy_scatra()->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<int>("KINETIC_MODEL") !=
+    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
         static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class
@@ -492,7 +492,7 @@ void STI::ScatraThermoOffDiagCouplingMatchingNodes::evaluate_off_diag_block_ther
   for (const auto& kinetics_slave_cond :
       meshtying_strategy_thermo()->kinetics_conditions_meshtying_slave_side())
   {
-    if (kinetics_slave_cond.second->parameters().get<int>("KINETIC_MODEL") !=
+    if (kinetics_slave_cond.second->parameters().get<Inpar::S2I::KineticModels>("KINETIC_MODEL") !=
         static_cast<int>(Inpar::S2I::kinetics_nointerfaceflux))
     {
       // collect condition specific data and store to scatra boundary parameter class
@@ -664,7 +664,8 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   for (const auto& condition : conditions)
   {
     // consider conditions for slave side only
-    if (condition->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+    if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+        Inpar::S2I::side_slave)
     {
       // add condition to parameter list
       condparams.set<Core::Conditions::Condition*>("condition", condition);
@@ -811,7 +812,8 @@ void STI::ScatraThermoOffDiagCouplingMortarStandard::
   for (const auto& condition : conditions)
   {
     // consider conditions for slave side only
-    if (condition->parameters().get<int>("INTERFACE_SIDE") == Inpar::S2I::side_slave)
+    if (condition->parameters().get<Inpar::S2I::InterfaceSides>("INTERFACE_SIDE") ==
+        Inpar::S2I::side_slave)
     {
       // add condition to parameter list
       condparams.set<Core::Conditions::Condition*>("condition", condition);

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -232,7 +232,7 @@ void Thermo::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinit
     // --> Tempn (old temperature T_n)
     // or if the exact solution is needed
     // --> Tempnp (current temperature solution T_n+1) with linearisation
-    cond.add_component(selection<std::string>(
+    cond.add_component(deprecated_selection<std::string>(
         "temperature_state", {"Tempnp", "Tempn"}, {.description = "temperature state"}));
     cond.add_component(parameter<double>("coeff", {.description = "heat transfer coefficient h"}));
     cond.add_component(

--- a/src/xfem/4C_xfem_coupling_base.cpp
+++ b/src/xfem/4C_xfem_coupling_base.cpp
@@ -377,8 +377,9 @@ void XFEM::CouplingBase::set_averaging_strategy()
     {
       // ask the first cutter element
       const int lid = 0;
-      const int val = cutterele_conds_[lid].second->parameters().get<int>("COUPSTRATEGY");
-      averaging_strategy_ = static_cast<Inpar::XFEM::AveragingStrategy>(val);
+      averaging_strategy_ =
+          cutterele_conds_[lid].second->parameters().get<Inpar::XFEM::AveragingStrategy>(
+              "COUPSTRATEGY");
       // check unhandled cased
       if (averaging_strategy_ == Inpar::XFEM::Mean || averaging_strategy_ == Inpar::XFEM::Harmonic)
         FOUR_C_THROW(
@@ -396,8 +397,9 @@ void XFEM::CouplingBase::set_averaging_strategy()
     {
       // ask the first cutter element
       const int lid = 0;
-      const int val = cutterele_conds_[lid].second->parameters().get<int>("COUPSTRATEGY");
-      averaging_strategy_ = static_cast<Inpar::XFEM::AveragingStrategy>(val);
+      averaging_strategy_ =
+          cutterele_conds_[lid].second->parameters().get<Inpar::XFEM::AveragingStrategy>(
+              "COUPSTRATEGY");
       break;
     }
     case Inpar::XFEM::CouplingCond_LEVELSET_TWOPHASE:

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -427,8 +427,8 @@ bool XFEM::LevelSetCoupling::set_level_set_field(const double time)
   if (cond_type == Inpar::XFEM::CouplingCond_LEVELSET_NAVIER_SLIP)
   {
     // Do we need smoothed gradients? I.e. what type is it?
-    const int val = cutterele_conds_[lid].second->parameters().get<int>("SURFACE_PROJECTION");
-    projtosurf_ = static_cast<Inpar::XFEM::ProjToSurface>(val);
+    projtosurf_ = cutterele_conds_[lid].second->parameters().get<Inpar::XFEM::ProjToSurface>(
+        "SURFACE_PROJECTION");
 
     if (projtosurf_ != Inpar::XFEM::Proj_normal)  // and projtosurf_!=Inpar::XFEM::Proj_normal_phi
     {

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1823,7 +1823,7 @@ void XFEM::MeshCouplingFSI::set_condition_specific_parameters()
       FOUR_C_THROW("ID already existing! For sliplength_map_.");
 
     Inpar::XFEM::InterfaceLaw interfacelaw =
-        static_cast<Inpar::XFEM::InterfaceLaw>(cond->parameters().get<int>("INTLAW"));
+        cond->parameters().get<Inpar::XFEM::InterfaceLaw>("INTLAW");
     if (i != conditions_XFSI.begin())
     {
       if (interfacelaw_ != interfacelaw)


### PR DESCRIPTION
Now that we have magic_enum, there is no good reason to used the old `selection` function where you have to manually specify the mapping between input and stored value. 

- First commit changes the function to only allow fors strings and enums. The few cases that used `int` were never a good idea and exist for historical reasons when fist converting old input mechanism to `InputSpec`.
- Second commit renames the function to indicate that we do not want to use it.