### PR TITLE
Assume yaml filename for --to-yaml if not given

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -635,6 +635,10 @@ namespace Core::IO
   {
     if (Core::Communication::my_mpi_rank(pimpl_->comm_) == 0)
     {
+      // the top_level_file must exist
+      if (!std::filesystem::is_regular_file(top_level_file))
+        FOUR_C_THROW("Input file '%s' does not exist.", top_level_file.c_str());
+
       // Start by "including" the top-level file.
       std::list<std::filesystem::path> included_files{top_level_file};
 


### PR DESCRIPTION
## Description and Context

As of now, for the tool `4C --to-yaml` it is necessary to define the the dat file input AND the yaml output. Since I presume that one often might want to simply replace the .dat suffix by .yaml for the output filename, it shouldn't be necessary to define the output explicitly. 
This is what the PR mainly does. Overwriting an existing yaml file is prevented.

In addition, when the given input file (also for 4C simulations in general) does not exist, an error message will be thrown. As of now, if a yaml file name is given as input - and the respective file does not exist - the message was `Error message:   The input file '<whatever_your_inputfile_is>.yaml' must contain a map as root node`, which I don't find intuitive.

## Related Issues and Pull Requests

See discussion #490 .