### PR TITLE
Extend LNM presets for Ubuntu 24.04

### DIFF
--- a/presets/lnm/workstation/CMakePresets.json
+++ b/presets/lnm/workstation/CMakePresets.json
@@ -15,9 +15,9 @@
         "FOUR_C_TRILINOS_ROOT": "/lnm/lib/packages/trilinos/16-1-0_v2/release-shared",
         "BUILD_SHARED_LIBS": "ON",
         "CMAKE_BUILD_TYPE": "RELEASE",
-        "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
+        "CMAKE_CXX_COMPILER": "g++",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
-        "CMAKE_C_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/gcc",
+        "CMAKE_C_COMPILER": "gcc",
         "CMAKE_C_COMPILER_LAUNCHER": "ccache"
       }
     },
@@ -61,6 +61,50 @@
         "FOUR_C_WITH_ARBORX": "OFF",
         "FOUR_C_WITH_MIRCO": "ON",
         "CMAKE_BUILD_TYPE": "DEBUG"
+      }
+    },
+    {
+      "name": "lnm_workstation_ubuntu_20_04",
+      "displayName": "Release build for an LNM workstation on Ubuntu 20.04",
+      "inherits": [
+        "lnm_workstation"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
+        "CMAKE_C_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/gcc"
+      }
+    },
+    {
+      "name": "lnm_workstation_relwithdebinfo_ubuntu_20_04",
+      "displayName": "Release build with debug information for an LNM workstation on Ubuntu 20.04",
+      "inherits": [
+        "lnm_workstation_relwithdebinfo"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
+        "CMAKE_C_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/gcc"
+      }
+    },
+    {
+      "name": "lnm_workstation_debug_ubuntu_20_04",
+      "displayName": "Debug build for an LNM workstation on Ubuntu 20.04",
+      "inherits": [
+        "lnm_workstation_debug"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
+        "CMAKE_C_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/gcc"
+      }
+    },
+    {
+      "name": "lnm_workstation_coverage_ubuntu_20_04",
+      "displayName": "Coverage report for an LNM workstation on Ubuntu 20.04",
+      "inherits": [
+        "lnm_workstation_coverage"
+      ],
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
+        "CMAKE_C_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/gcc"
       }
     }
   ]


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Based on the new Ubuntu 24.04 install we need to use the built-in gcc and g++ compiler. This PR extends the presets so we have the new setup as standard and a backup for the old Ubuntu 20.04 installs available.

Once all workstations are switched we can remove the presets for 20.04

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
