### PR TITLE
Rework new selection to work with magic_enum

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -481,6 +481,13 @@ namespace
           }
           break;
         }
+        case MatchEntry::Type::selection:
+        {
+          if (entry.state == MatchEntry::State::matched)
+          {
+            matched_node_ids.push_back(entry.matched_node);
+          }
+        }
         default:
           break;
       }


### PR DESCRIPTION
Just as we don't like to use untyped strings, we also do not want to use them for the `selection`. This PR changes the new selection from #469 to work with enums.

FYI @bwirthl 