### PR TITLE
Update pre-commit to version 4.1.0

### DIFF
--- a/utilities/requirements.txt
+++ b/utilities/requirements.txt
@@ -1,3 +1,3 @@
 # for pre-commit:
 -e utilities/four_c_utils
-pre-commit==3.5.0
+pre-commit==4.1.0


### PR DESCRIPTION
I ran into a weird go error when first committing after upgrading to Ubuntu 24.04 (probably this one `https://github.com/pre-commit/pre-commit/pull/3130`). Updating pre-commit fixes this.