### PR TITLE
Fix bug in cmake testing functions for omp threads

### DIFF
--- a/cmake/functions/four_c_testing_functions.cmake
+++ b/cmake/functions/four_c_testing_functions.cmake
@@ -311,7 +311,7 @@ function(four_c_test)
   if(${_parsed_OMP_THREADS})
     set(name_of_test ${name_of_test}-OMP${_parsed_OMP_THREADS})
     set(test_command
-        "export OMP_NUM_THREADS=${_parsed_OMP_THREADS}; ${test_command}; unset OMP_NUM_THREADS"
+        "export OMP_NUM_THREADS=${_parsed_OMP_THREADS} && ${test_command} && unset OMP_NUM_THREADS"
         )
     math(EXPR total_procs "${_parsed_NP}*${_parsed_OMP_THREADS}")
   endif()
@@ -370,7 +370,7 @@ function(four_c_test)
     if(${_parsed_OMP_THREADS})
       set(name_of_test ${name_of_test}-OMP${_parsed_OMP_THREADS})
       set(test_command
-          "export OMP_NUM_THREADS=${_parsed_OMP_THREADS}; ${test_command}; unset OMP_NUM_THREADS"
+          "export OMP_NUM_THREADS=${_parsed_OMP_THREADS} && ${test_command} && unset OMP_NUM_THREADS"
           )
       math(EXPR total_procs "${_parsed_NP}*${_parsed_OMP_THREADS}")
     endif()

--- a/src/contact/4C_contact_strategy_factory.cpp
+++ b/src/contact/4C_contact_strategy_factory.cpp
@@ -703,13 +703,14 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
           CONTACT::CONSTITUTIVELAW::ConstitutiveLawType::colaw_mirco)
       {
         mircolaw = true;
-        resolution = coconstlaw.get<int>("Resolution");
-        randomtopologyflag = coconstlaw.get<bool>("RandomTopologyFlag");
-        randomseedflag = coconstlaw.get<bool>("RandomSeedFlag");
-        randomgeneratorseed = coconstlaw.get<int>("RandomGeneratorSeed");
-        hurstexponentfunction = coconstlaw.get<int>("HurstExponentFunct");
+        const auto& mirco_data = coconstlaw.group("CoConstLaw_mirco");
+        resolution = mirco_data.get<int>("Resolution");
+        randomtopologyflag = mirco_data.get<bool>("RandomTopologyFlag");
+        randomseedflag = mirco_data.get<bool>("RandomSeedFlag");
+        randomgeneratorseed = mirco_data.get<int>("RandomGeneratorSeed");
+        hurstexponentfunction = mirco_data.get<int>("HurstExponentFunct");
         initialtopologystddeviationfunction =
-            coconstlaw.get<int>("InitialTopologyStdDeviationFunct");
+            mirco_data.get<int>("InitialTopologyStdDeviationFunct");
       }
     }
 


### PR DESCRIPTION
## Description and Context
the test command with omp threads used a semicolon to separate the different commands, e.g. test-command; unset OMP_VARIABLE. This led the test pass since the last command always evaluated to true.

Unfortunately, this hid a bug in the micro tests. #535 

## Related Issues and Pull Requests
Closes #535 
