### PR TITLE
Reduce compile time by moving magic_enum to separate header

### DIFF
--- a/apps/global_full/4C_global_full_cal_control.cpp
+++ b/apps/global_full/4C_global_full_cal_control.cpp
@@ -35,6 +35,7 @@
 #include "4C_structure_dyn_nln_drt.hpp"
 #include "4C_thermo_dyn.hpp"
 #include "4C_tsi_dyn.hpp"
+#include "4C_utils_enum.hpp"
 
 /*----------------------------------------------------------------------*
  |  routine to control execution phase                   m.gee 6/01     |

--- a/apps/post_monitor/4C_post_monitor.cpp
+++ b/apps/post_monitor/4C_post_monitor.cpp
@@ -15,6 +15,7 @@
 #include "4C_io_legacy_table.hpp"
 #include "4C_post_common.hpp"
 #include "4C_thermo_ele_action.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 #include <Teuchos_CommandLineProcessor.hpp>

--- a/apps/post_processor/4C_post_processor.cpp
+++ b/apps/post_processor/4C_post_processor.cpp
@@ -11,6 +11,7 @@
 #include "4C_post_processor_single_field_writers.hpp"
 #include "4C_post_writer_base.hpp"
 #include "4C_scatra_ele.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_singleton_owner.hpp"
 

--- a/src/adapter/4C_adapter_coupling_poro_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_poro_mortar.cpp
@@ -334,7 +334,7 @@ void Adapter::CouplingPoroMortar::create_strategy(
   // to other time integration strategies
 
   if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(stru, "DYNAMICTYPE") ==
-      Inpar::Solid::dyna_statics)
+      Inpar::Solid::DynamicType::Statics)
   {
     theta = 1.0;
   }

--- a/src/adapter/4C_adapter_str_structure.cpp
+++ b/src/adapter/4C_adapter_str_structure.cpp
@@ -59,12 +59,12 @@ void Adapter::StructureBaseAlgorithm::create_structure(const Teuchos::ParameterL
   // major switch to different time integrators
   switch (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE"))
   {
-    case Inpar::Solid::dyna_statics:
-    case Inpar::Solid::dyna_genalpha:
-    case Inpar::Solid::dyna_onesteptheta:
-    case Inpar::Solid::dyna_expleuler:
-    case Inpar::Solid::dyna_centrdiff:
-    case Inpar::Solid::dyna_ab2:
+    case Inpar::Solid::DynamicType::Statics:
+    case Inpar::Solid::DynamicType::GenAlpha:
+    case Inpar::Solid::DynamicType::OneStepTheta:
+    case Inpar::Solid::DynamicType::ExplEuler:
+    case Inpar::Solid::DynamicType::CentrDiff:
+    case Inpar::Solid::DynamicType::AdamsBashforth2:
       create_tim_int(prbdyn, sdyn, actdis);  // <-- here is the show
       break;
     default:
@@ -153,7 +153,7 @@ void Adapter::StructureBaseAlgorithm::create_tim_int(const Teuchos::ParameterLis
       if (par->type() == Core::Materials::m_struct_multiscale)
       {
         if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE") !=
-            Inpar::Solid::dyna_genalpha)
+            Inpar::Solid::DynamicType::GenAlpha)
           FOUR_C_THROW("In multi-scale simulations, you have to use DYNAMICTYPE=GenAlpha");
         else if (Teuchos::getIntegralValue<Inpar::Solid::MidAverageEnum>(
                      sdyn.sublist("GENALPHA"), "GENAVG") != Inpar::Solid::midavg_trlike)

--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -87,14 +87,14 @@ void Adapter::StructureBaseAlgorithmNew::setup()
   // major switch to different time integrators
   switch (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(*sdyn_, "DYNAMICTYPE"))
   {
-    case Inpar::Solid::dyna_statics:
-    case Inpar::Solid::dyna_genalpha:
-    case Inpar::Solid::dyna_genalpha_liegroup:
-    case Inpar::Solid::dyna_onesteptheta:
-    case Inpar::Solid::dyna_expleuler:
-    case Inpar::Solid::dyna_centrdiff:
-    case Inpar::Solid::dyna_ab2:
-    case Inpar::Solid::dyna_ab4:
+    case Inpar::Solid::DynamicType::Statics:
+    case Inpar::Solid::DynamicType::GenAlpha:
+    case Inpar::Solid::DynamicType::GenAlphaLieGroup:
+    case Inpar::Solid::DynamicType::OneStepTheta:
+    case Inpar::Solid::DynamicType::ExplEuler:
+    case Inpar::Solid::DynamicType::CentrDiff:
+    case Inpar::Solid::DynamicType::AdamsBashforth2:
+    case Inpar::Solid::DynamicType::AdamsBashforth4:
       setup_tim_int();  // <-- here is the show
       break;
     default:
@@ -244,7 +244,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
       if (mat->type() == Core::Materials::m_struct_multiscale)
       {
         if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(*sdyn_, "DYNAMICTYPE") !=
-            Inpar::Solid::dyna_genalpha)
+            Inpar::Solid::DynamicType::GenAlpha)
           FOUR_C_THROW("In multi-scale simulations, you have to use DYNAMICTYPE=GenAlpha");
         else if (Teuchos::getIntegralValue<Inpar::Solid::MidAverageEnum>(
                      sdyn_->sublist("GENALPHA"), "GENAVG") != Inpar::Solid::midavg_trlike)

--- a/src/ale/4C_ale.cpp
+++ b/src/ale/4C_ale.cpp
@@ -27,6 +27,7 @@
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>

--- a/src/ale/4C_ale_ale3_surface_evaluate.cpp
+++ b/src/ale/4C_ale_ale3_surface_evaluate.cpp
@@ -12,6 +12,7 @@
 #include "4C_fem_general_utils_boundary_integration.hpp"
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_fem_geometry_position_array.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/art_net/4C_art_net_artery.cpp
+++ b/src/art_net/4C_art_net_artery.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_shared_ptr_from_ref.hpp"
 
@@ -158,6 +159,30 @@ void Discret::Elements::Artery::unpack(Core::Communication::UnpackBuffer& buffer
 std::vector<std::shared_ptr<Core::Elements::Element>> Discret::Elements::Artery::lines()
 {
   return {Core::Utils::shared_ptr_from_ref(*this)};
+}
+
+int Discret::Elements::Artery::num_dof_per_node(const Core::Nodes::Node& node) const
+{
+  switch (impltype_)
+  {
+    case Inpar::ArtDyn::impltype_lin_exp:
+    {
+      return 2;
+      break;
+    }
+    case Inpar::ArtDyn::impltype_pressure_based:
+    {
+      return 1;
+      break;
+    }
+    default:
+    {
+      FOUR_C_THROW("Defined problem type {} does not exist!!", impltype_);
+      break;
+    }
+  }
+
+  return 0;
 }
 
 

--- a/src/art_net/4C_art_net_artery.hpp
+++ b/src/art_net/4C_art_net_artery.hpp
@@ -180,29 +180,7 @@ namespace Discret
       number of degrees of freedom per node along the way for each of it's nodes
       separately.
       */
-      int num_dof_per_node(const Core::Nodes::Node& node) const override
-      {
-        switch (impltype_)
-        {
-          case Inpar::ArtDyn::impltype_lin_exp:
-          {
-            return 2;
-            break;
-          }
-          case Inpar::ArtDyn::impltype_pressure_based:
-          {
-            return 1;
-            break;
-          }
-          default:
-          {
-            FOUR_C_THROW("Defined problem type {} does not exist!!", impltype_);
-            break;
-          }
-        }
-
-        return 0;
-      }
+      int num_dof_per_node(const Core::Nodes::Node& node) const override;
 
       /*!
       \brief Get number of degrees of freedom per element

--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
@@ -16,6 +16,7 @@
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_cnst_1d_art.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 #include "4C_utils_singleton_owner.hpp"

--- a/src/art_net/4C_art_net_artery_ele_calc_pres_based.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_pres_based.cpp
@@ -13,11 +13,11 @@
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_cnst_1d_art.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 #include <fstream>
-#include <iomanip>
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/art_net/4C_art_net_artery_ele_factory.cpp
+++ b/src/art_net/4C_art_net_artery_ele_factory.cpp
@@ -10,6 +10,7 @@
 #include "4C_art_net_artery_ele_calc_lin_exp.hpp"
 #include "4C_art_net_artery_ele_calc_pres_based.hpp"
 #include "4C_art_net_artery_ele_interface.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/art_net/4C_art_net_artery_evaluate.cpp
+++ b/src/art_net/4C_art_net_artery_evaluate.cpp
@@ -13,6 +13,7 @@
 #include "4C_inpar_bio.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mat_cnst_1d_art.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>

--- a/src/art_net/4C_art_net_artery_input.cpp
+++ b/src/art_net/4C_art_net_artery_input.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_art_net_artery.hpp"
 #include "4C_mat_cnst_1d_art.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/art_net/4C_art_net_impl_stationary.cpp
+++ b/src/art_net/4C_art_net_impl_stationary.cpp
@@ -24,6 +24,7 @@
 #include "4C_mat_cnst_1d_art.hpp"
 #include "4C_scatra_resulttest.hpp"
 #include "4C_scatra_timint_implicit.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>

--- a/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
@@ -128,7 +128,7 @@ int Discret::Elements::Beam3eb::evaluate(Teuchos::ParameterList& params,
       const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
 
       if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE") !=
-          Inpar::Solid::dyna_statics)
+          Inpar::Solid::DynamicType::Statics)
       {
         vel = discretization.get_state("velocity");
         if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");
@@ -250,7 +250,7 @@ int Discret::Elements::Beam3eb::evaluate_neumann(Teuchos::ParameterList& params,
   // (UNCOMMENT IF NEEDED)
   const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
   if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE") !=
-      Inpar::Solid::dyna_statics)
+      Inpar::Solid::DynamicType::Statics)
   {
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel = discretization.get_state("velocity");
     if (vel == nullptr) FOUR_C_THROW("Cannot get state vectors 'velocity'");

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
@@ -47,7 +47,7 @@ void Solid::ModelEvaluator::BrownianDyn::setup()
 
   // safety check, brownian dynamics simulation only for one step theta and
   // theta = 1.0 (see Cyron 2012)
-  if (tim_int().get_data_sdyn_ptr()->get_dynamic_type() != Inpar::Solid::dyna_onesteptheta)
+  if (tim_int().get_data_sdyn_ptr()->get_dynamic_type() != Inpar::Solid::DynamicType::OneStepTheta)
     FOUR_C_THROW("Brownian dynamics simulation only consistent for one step theta schema.");
 
   discret_ptr_ = discret_ptr();

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -26,6 +26,7 @@
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_truss3.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"

--- a/src/contact/4C_contact_abstract_strategy.cpp
+++ b/src/contact/4C_contact_abstract_strategy.cpp
@@ -2697,7 +2697,7 @@ void CONTACT::AbstractStrategy::evaluate(CONTACT::ParamsInterface& cparams,
     // -------------------------------------------------------------------
     default:
     {
-      FOUR_C_THROW("Unsupported action type: {} | {}", act, action_type_to_string(act).c_str());
+      FOUR_C_THROW("Unsupported action type: {}", action_type_to_string(act));
       break;
     }
   }

--- a/src/contact/4C_contact_integrator_factory.cpp
+++ b/src/contact/4C_contact_integrator_factory.cpp
@@ -87,8 +87,8 @@ std::shared_ptr<CONTACT::Integrator> CONTACT::INTEGRATOR::Factory::build_integra
     }
     default:
     {
-      FOUR_C_THROW("Unsupported solving strategy! (stype = {} | {})",
-          CONTACT::solving_strategy_to_string(sol_type).c_str(), sol_type);
+      FOUR_C_THROW("Unsupported solving strategy! (stype = {})",
+          CONTACT::solving_strategy_to_string(sol_type));
       exit(EXIT_FAILURE);
     }
   }  // end switch

--- a/src/contact/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_tsi.cpp
@@ -1006,13 +1006,13 @@ void CONTACT::LagrangeStrategyTsi::set_alphaf_thermo(const Teuchos::ParameterLis
   auto dyn_type = Teuchos::getIntegralValue<Thermo::DynamicType>(tdyn, "DYNAMICTYPE");
   switch (dyn_type)
   {
-    case Thermo::dyna_genalpha:
+    case Thermo::DynamicType::GenAlpha:
       tsi_alpha_ = tdyn.sublist("GENALPHA").get<double>("ALPHA_F");
       break;
-    case Thermo::dyna_onesteptheta:
+    case Thermo::DynamicType::OneStepTheta:
       tsi_alpha_ = tdyn.sublist("ONESTEPTHETA").get<double>("THETA");
       break;
-    case Thermo::dyna_statics:
+    case Thermo::DynamicType::Statics:
       tsi_alpha_ = 1.;
       break;
     default:

--- a/src/contact/4C_contact_nitsche_strategy_fsi.cpp
+++ b/src/contact/4C_contact_nitsche_strategy_fsi.cpp
@@ -12,6 +12,7 @@
 #include "4C_contact_nitsche_integrator_fsi.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_mortar_projector.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/contact/4C_contact_noxinterface.cpp
+++ b/src/contact/4C_contact_noxinterface.cpp
@@ -11,6 +11,7 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_solver_nonlin_nox_aux.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <NOX_Epetra_Vector.H>
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>

--- a/src/contact/4C_contact_utils.cpp
+++ b/src/contact/4C_contact_utils.cpp
@@ -15,6 +15,7 @@
 #include "4C_inpar_mortar.hpp"
 #include "4C_io_every_iteration_writer.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.cpp
@@ -14,6 +14,7 @@
 #include "4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp"
 #include "4C_contact_constitutivelaw_power_contactconstitutivelaw.hpp"
 #include "4C_global_data.hpp"
+#include "4C_utils_enum.hpp"
 
 #ifdef FOUR_C_WITH_MIRCO
 #include "4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp"

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_integration.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_integration.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_fem_general_utils_integration.hpp"
 
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <cmath>

--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -15,6 +15,7 @@
 #include "4C_io_legacy_table.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <algorithm>

--- a/src/core/io/src/legacy/4C_io_legacy_table.cpp
+++ b/src/core/io/src/legacy/4C_io_legacy_table.cpp
@@ -8,6 +8,7 @@
 #include "4C_io_legacy_table.hpp"
 
 #include "4C_io_legacy_types.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <cctype>

--- a/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_conditions.cpp
+++ b/src/core/legacy_enum_definitions/4C_legacy_enum_definitions_conditions.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_legacy_enum_definitions_conditions.hpp"
 
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <Epetra_Import.h>

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -12,6 +12,7 @@
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linear_solver_method_direct.hpp"
 #include "4C_linear_solver_method_iterative.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 #include <BelosTypes.hpp>  // for Belos verbosity codes

--- a/src/core/utils/src/exceptions/4C_utils_exceptions.hpp
+++ b/src/core/utils/src/exceptions/4C_utils_exceptions.hpp
@@ -10,24 +10,10 @@
 
 #include "4C_config.hpp"
 
-#include <magic_enum/magic_enum.hpp>
-
+#include <exception>
 #include <format>
 #include <memory>
-#include <stdexcept>
 #include <string>
-#include <type_traits>
-
-// Specialize formatting for any enum type.
-template <typename T>
-  requires std::is_enum_v<T>
-struct std::formatter<T> : std::formatter<std::string_view>
-{
-  auto format(T e, std::format_context& ctx) const
-  {
-    return std::formatter<std::string_view>::format(magic_enum::enum_name(e), ctx);
-  }
-};
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
+++ b/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_utils_symbolic_expression.hpp"
 
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <Sacado.hpp>

--- a/src/core/utils/src/stl_extension/4C_utils_enum.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_enum.hpp
@@ -1,0 +1,19 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_UTILS_ENUM_HPP
+#define FOUR_C_UTILS_ENUM_HPP
+
+#include "4C_config.hpp"
+
+// 1) Include <format> before the magic_enum header to enable std::format support.
+#include <format>
+
+// 2) Include magic_enum header.
+#include <magic_enum/magic_enum_format.hpp>
+
+#endif

--- a/src/core/utils/src/stl_extension/4C_utils_enum.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_enum.hpp
@@ -15,5 +15,14 @@
 
 // 2) Include magic_enum header.
 #include <magic_enum/magic_enum_format.hpp>
+#include <magic_enum/magic_enum_iostream.hpp>
+
+FOUR_C_NAMESPACE_OPEN
+
+// Import the stream insertion and extraction operators for enums.
+using magic_enum::iostream_operators::operator<<;
+using magic_enum::iostream_operators::operator>>;
+
+FOUR_C_NAMESPACE_CLOSE
 
 #endif

--- a/src/cut/4C_cut_direct_divergence_refplane.cpp
+++ b/src/cut/4C_cut_direct_divergence_refplane.cpp
@@ -12,6 +12,7 @@
 #include "4C_cut_output.hpp"
 #include "4C_cut_side.hpp"
 #include "4C_cut_volumecell.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/cut/4C_cut_edge.cpp
+++ b/src/cut/4C_cut_edge.cpp
@@ -12,6 +12,7 @@
 #include "4C_cut_point_impl.hpp"
 #include "4C_cut_position.hpp"
 #include "4C_global_data.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <stack>
 #include <string>
@@ -869,7 +870,6 @@ bool Cut::ConcreteEdge<prob_dim, edge_type, dim_edge, num_nodes_edge>::compute_c
       }
       default:
         FOUR_C_THROW("Unsupported intersection status! ( status = {} )", istatus);
-        exit(EXIT_FAILURE);
     }
     return (static_cast<bool>(retstatus));
   }
@@ -905,8 +905,7 @@ std::shared_ptr<Cut::Edge> Cut::EdgeFactory::create_edge(
     }
     default:
     {
-      FOUR_C_THROW("Unsupported edge type! ( {} | {} )", edgetype,
-          Core::FE::cell_type_to_string(edgetype).c_str());
+      FOUR_C_THROW("Unsupported edge type! ({})", Core::FE::cell_type_to_string(edgetype));
       break;
     }
   }

--- a/src/cut/4C_cut_element.cpp
+++ b/src/cut/4C_cut_element.cpp
@@ -1336,8 +1336,7 @@ std::shared_ptr<Cut::Element> Cut::ElementFactory::create_element(Core::FE::Cell
       break;
     default:
     {
-      FOUR_C_THROW("Unsupported element type! ( {} | {} )", elementtype,
-          Core::FE::cell_type_to_string(elementtype).c_str());
+      FOUR_C_THROW("Unsupported element type! ( {} )", Core::FE::cell_type_to_string(elementtype));
       break;
     }
   }

--- a/src/cut/4C_cut_elementhandle.cpp
+++ b/src/cut/4C_cut_elementhandle.cpp
@@ -16,6 +16,7 @@
 #include "4C_cut_quadrature_compression.hpp"
 #include "4C_cut_tolerance.hpp"
 #include "4C_cut_volumecell.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 

--- a/src/cut/4C_cut_integrationcellcreator.cpp
+++ b/src/cut/4C_cut_integrationcellcreator.cpp
@@ -14,6 +14,7 @@
 #include "4C_cut_pointgraph_simple.hpp"
 #include "4C_cut_position.hpp"
 #include "4C_cut_side.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/cut/4C_cut_intersection.hpp
+++ b/src/cut/4C_cut_intersection.hpp
@@ -1202,8 +1202,8 @@ namespace Cut
         FOUR_C_THROW(
             "This compute_distance routine is only meaningful for "
             "QUAD4 side elements! But you passed in a side element "
-            "of type {} | {}.",
-            sidetype, Core::FE::cell_type_to_string(sidetype).c_str());
+            "of type {}.",
+            Core::FE::cell_type_to_string(sidetype));
 
       TEUCHOS_FUNC_TIME_MONITOR("compute_distance");
 

--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -290,8 +290,7 @@ namespace Cut::Kernel
         break;
       }
       default:
-        FOUR_C_THROW("unsupported element type: {} | {}", element_type,
-            Core::FE::cell_type_to_string(element_type).c_str());
+        FOUR_C_THROW("unsupported element type: {}", Core::FE::cell_type_to_string(element_type));
         break;
     }
   }
@@ -431,8 +430,7 @@ namespace Cut::Kernel
         break;
       }
       default:
-        FOUR_C_THROW("unsupported element type: {} | {}", element_type,
-            Core::FE::cell_type_to_string(element_type).c_str());
+        FOUR_C_THROW("unsupported element type: {}", Core::FE::cell_type_to_string(element_type));
         break;
     }  // switch ( elementType )
     return false;
@@ -524,8 +522,7 @@ namespace Cut::Kernel
         break;
       }
       default:
-        FOUR_C_THROW("unsupported element type: {} | {}", element_type,
-            Core::FE::cell_type_to_string(element_type).c_str());
+        FOUR_C_THROW("unsupported element type: {}", Core::FE::cell_type_to_string(element_type));
         break;
     }  // switch ( elementType )
     return false;

--- a/src/cut/4C_cut_levelsetside.cpp
+++ b/src/cut/4C_cut_levelsetside.cpp
@@ -270,8 +270,8 @@ bool Cut::LevelSetSide<probdim>::find_ambiguous_cut_lines(
       break;
     }  // case Core::FE::CellType::quad4:
     default:
-      FOUR_C_THROW("Unsupported side shape! (shape = {} | {} )", side.shape(),
-          Core::FE::cell_type_to_string(side.shape()).c_str());
+      FOUR_C_THROW(
+          "Unsupported side shape! (shape = {} )", Core::FE::cell_type_to_string(side.shape()));
       break;
   }
   return false;

--- a/src/cut/4C_cut_pointpool.cpp
+++ b/src/cut/4C_cut_pointpool.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_cut_output.hpp"
 #include "4C_global_data.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/cut/4C_cut_side.cpp
+++ b/src/cut/4C_cut_side.cpp
@@ -1876,8 +1876,8 @@ Cut::Side* Cut::SideFactory::create_side(Core::FE::CellType sidetype, int sid,
       break;
     default:
     {
-      FOUR_C_THROW("Unsupported side type! ( {} | {} )", sidetype,
-          Core::FE::cell_type_to_string(sidetype).c_str());
+      FOUR_C_THROW(
+          "Unsupported side type! ( {} )", Core::FE::cell_type_to_string(sidetype).c_str());
       break;
     }
   }

--- a/src/cut/4C_cut_side.hpp
+++ b/src/cut/4C_cut_side.hpp
@@ -696,8 +696,7 @@ namespace Cut
           return shards::getCellTopologyData<shards::Line<2>>();
           break;
         default:
-          FOUR_C_THROW("Unknown sidetype! ({} | {})\n", sidetype,
-              Core::FE::cell_type_to_string(sidetype).c_str());
+          FOUR_C_THROW("Unknown sidetype! ({})\n", Core::FE::cell_type_to_string(sidetype));
           break;
       }
       exit(EXIT_FAILURE);

--- a/src/ehl/4C_ehl_input.hpp
+++ b/src/ehl/4C_ehl_input.hpp
@@ -68,21 +68,6 @@ namespace EHL
     soltech_newtonfull  //!< full Newton-Raphson iteration
   };
 
-  //! Map solution technique enum to std::string
-  static inline std::string nln_sol_tech_string(const enum NlnSolTech name  //!< enum to convert
-  )
-  {
-    switch (name)
-    {
-      case soltech_newtonfull:
-        return "fullnewton";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for solution technique {}", name);
-        return "";
-    }
-  }
-
   //! type of vector norm used for error/residual vectors
   enum VectorNorm
   {

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -438,12 +438,12 @@ void EHL::Monolithic::setup_system_matrix()
   double alphaf = -1.;
   switch (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn_, "DYNAMICTYPE"))
   {
-    case Inpar::Solid::dyna_genalpha:
+    case Inpar::Solid::DynamicType::GenAlpha:
     {
       alphaf = sdyn_.sublist("GENALPHA").get<double>("ALPHA_F");
       break;
     }
-    case Inpar::Solid::dyna_statics:
+    case Inpar::Solid::DynamicType::Statics:
     {
       alphaf = 0.;
       break;

--- a/src/elch/4C_elch_dyn.cpp
+++ b/src/elch/4C_elch_dyn.cpp
@@ -18,6 +18,7 @@
 #include "4C_scatra_ele.hpp"
 #include "4C_scatra_timint_elch.hpp"
 #include "4C_scatra_utils_clonestrategy.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/fluid/4C_fluid_timint_poro.cpp
+++ b/src/fluid/4C_fluid_timint_poro.cpp
@@ -13,6 +13,7 @@
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_poroelast_utils.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
@@ -25,6 +25,7 @@
 #include "4C_mat_modpowerlaw.hpp"
 #include "4C_mat_newtonianfluid.hpp"
 #include "4C_mat_sutherland.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/fluid_ele/4C_fluid_ele_boundary_evaluate.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_evaluate.cpp
@@ -11,6 +11,7 @@
 #include "4C_fluid_ele_boundary_calc.hpp"
 #include "4C_fluid_ele_boundary_factory.hpp"
 #include "4C_fluid_ele_boundary_parent_calc.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
@@ -23,6 +23,7 @@
 #include "4C_mat_modpowerlaw.hpp"
 #include "4C_mat_newtonianfluid.hpp"
 #include "4C_mat_sutherland.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 

--- a/src/fluid_ele/4C_fluid_ele_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc.cpp
@@ -32,6 +32,7 @@
 #include "4C_mat_modpowerlaw.hpp"
 #include "4C_mat_newtonianfluid.hpp"
 #include "4C_mat_sutherland.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 

--- a/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_fluidporo.hpp"
 #include "4C_mat_list.hpp"
 #include "4C_mat_newtonianfluid.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem_coupling.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem_coupling.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_bele_bele3.hpp"
 #include "4C_fluid_ele_calc_xfem_coupling_impl.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/fluid_ele/4C_fluid_ele_evaluate.cpp
+++ b/src/fluid_ele/4C_fluid_ele_evaluate.cpp
@@ -18,6 +18,7 @@
 #include "4C_fluid_ele_parameter_xfem.hpp"
 #include "4C_fluid_ele_tds.hpp"
 #include "4C_fluid_ele_xwall.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/fluid_ele/4C_fluid_ele_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.cpp
@@ -14,6 +14,7 @@
 #include "4C_fluid_ele_interface.hpp"
 #include "4C_inpar_fluid.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
@@ -13,6 +13,7 @@
 #include "4C_fluid_ele_interface.hpp"
 #include "4C_io_input_parameter_container.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/fluid_ele/4C_fluid_ele_intfaces_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_intfaces_calc.cpp
@@ -14,6 +14,7 @@
 #include "4C_fluid_ele_parameter_std.hpp"
 #include "4C_fluid_ele_parameter_timint.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 

--- a/src/fs3i/4C_fs3i.cpp
+++ b/src/fs3i/4C_fs3i.cpp
@@ -175,7 +175,7 @@ void FS3I::FS3IBase::check_f_s3_i_inputs()
   if (fluidtimealgo == Inpar::FLUID::timeint_one_step_theta)
   {
     if (scatratimealgo != Inpar::ScaTra::timeint_one_step_theta or
-        structtimealgo != Inpar::Solid::dyna_onesteptheta)
+        structtimealgo != Inpar::Solid::DynamicType::OneStepTheta)
       FOUR_C_THROW(
           "Partitioned FS3I computations should feature consistent time-integration schemes for "
           "the subproblems; in this case, a one-step-theta scheme is intended to be used for the "
@@ -192,7 +192,7 @@ void FS3I::FS3IBase::check_f_s3_i_inputs()
   else if (fluidtimealgo == Inpar::FLUID::timeint_afgenalpha)
   {
     if (scatratimealgo != Inpar::ScaTra::timeint_gen_alpha or
-        structtimealgo != Inpar::Solid::dyna_genalpha)
+        structtimealgo != Inpar::Solid::DynamicType::GenAlpha)
       FOUR_C_THROW(
           "Partitioned FS3I computations should feature consistent time-integration schemes for "
           "the subproblems; in this case, a (alpha_f-based) generalized-alpha scheme is intended "
@@ -232,7 +232,7 @@ void FS3I::FS3IBase::check_f_s3_i_inputs()
       Global::Problem::instance()->structural_dynamic_params(), "PRESTRESS");
   // is structure calculated dynamic when not prestressing?
   if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(structdynparams, "DYNAMICTYPE") ==
-          Inpar::Solid::dyna_statics and
+          Inpar::Solid::DynamicType::Statics and
       pstype != Inpar::Solid::PreStress::mulf)
     FOUR_C_THROW(
         "Since we need a velocity field in the structure domain for the scalar field you need do "

--- a/src/fs3i/4C_fs3i_dyn.cpp
+++ b/src/fs3i/4C_fs3i_dyn.cpp
@@ -15,6 +15,7 @@
 #include "4C_fs3i_partitioned_1wc.hpp"
 #include "4C_fs3i_partitioned_2wc.hpp"
 #include "4C_global_data.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -254,7 +254,7 @@ void FS3I::PartFPS3I::init()
   if (fluidtimealgo == Inpar::FLUID::timeint_one_step_theta)
   {
     if (scatratimealgo != Inpar::ScaTra::timeint_one_step_theta or
-        structtimealgo != Inpar::Solid::dyna_onesteptheta)
+        structtimealgo != Inpar::Solid::DynamicType::OneStepTheta)
       FOUR_C_THROW(
           "Partitioned FS3I computations should feature consistent time-integration schemes for "
           "the subproblems; in this case, a one-step-theta scheme is intended to be used for the "
@@ -270,7 +270,7 @@ void FS3I::PartFPS3I::init()
   else if (fluidtimealgo == Inpar::FLUID::timeint_afgenalpha)
   {
     if (scatratimealgo != Inpar::ScaTra::timeint_gen_alpha or
-        structtimealgo != Inpar::Solid::dyna_genalpha)
+        structtimealgo != Inpar::Solid::DynamicType::GenAlpha)
       FOUR_C_THROW(
           "Partitioned FS3I computations should feature consistent time-integration schemes for "
           "the subproblems; in this case, a (alpha_f-based) generalized-alpha scheme is intended "

--- a/src/inpar/4C_inpar_poroelast.hpp
+++ b/src/inpar/4C_inpar_poroelast.hpp
@@ -86,33 +86,6 @@ namespace Inpar
       //   initfield_field_by_condition
     };
 
-    //! map enum term to std::string
-    static inline std::string vector_norm_string(const enum VectorNorm norm  //!< input enum term
-    )
-    {
-      switch (norm)
-      {
-        case Inpar::PoroElast::norm_l1:
-          return "L1";
-          break;
-        case Inpar::PoroElast::norm_l1_scaled:
-          return "L1_scaled";
-          break;
-        case Inpar::PoroElast::norm_l2:
-          return "L2";
-          break;
-        case Inpar::PoroElast::norm_rms:
-          return "Rms";
-          break;
-        case Inpar::PoroElast::norm_inf:
-          return "Inf";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-          return "";
-      }
-    }
-
     //@}
 
 

--- a/src/inpar/4C_inpar_porofluidmultiphase.hpp
+++ b/src/inpar/4C_inpar_porofluidmultiphase.hpp
@@ -87,33 +87,6 @@ namespace Inpar
       gradreco_l2
     };
 
-    //! map enum term to std::string
-    static inline std::string vector_norm_string(const enum VectorNorm norm  //!< input enum term
-    )
-    {
-      switch (norm)
-      {
-        case Inpar::POROFLUIDMULTIPHASE::norm_l1:
-          return "L1";
-          break;
-        case Inpar::POROFLUIDMULTIPHASE::norm_l1_scaled:
-          return "L1_scaled";
-          break;
-        case Inpar::POROFLUIDMULTIPHASE::norm_l2:
-          return "L2";
-          break;
-        case Inpar::POROFLUIDMULTIPHASE::norm_rms:
-          return "Rms";
-          break;
-        case Inpar::POROFLUIDMULTIPHASE::norm_inf:
-          return "Inf";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-          return "";
-      }
-    }
-
     /// set the lubrication parameters
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
 

--- a/src/inpar/4C_inpar_poromultiphase.hpp
+++ b/src/inpar/4C_inpar_poromultiphase.hpp
@@ -61,34 +61,6 @@ namespace Inpar
       relaxation_aitken
     };
 
-    //! map enum term to std::string
-    static inline std::string vector_norm_string(const enum VectorNorm norm  //!< input enum term
-    )
-    {
-      switch (norm)
-      {
-        case Inpar::POROMULTIPHASE::norm_l1:
-          return "L1";
-          break;
-        case Inpar::POROMULTIPHASE::norm_l1_scaled:
-          return "L1_scaled";
-          break;
-        case Inpar::POROMULTIPHASE::norm_l2:
-          return "L2";
-          break;
-        case Inpar::POROMULTIPHASE::norm_rms:
-          return "Rms";
-          break;
-        case Inpar::POROMULTIPHASE::norm_inf:
-          return "Inf";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-          return "";
-      }
-    }
-
-
     /// set the POROMULTIPHASE parameters
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
 

--- a/src/inpar/4C_inpar_poromultiphase_scatra.hpp
+++ b/src/inpar/4C_inpar_poromultiphase_scatra.hpp
@@ -63,33 +63,6 @@ namespace Inpar
       divcont_continue  ///< continue nevertheless
     };
 
-    //! map enum term to std::string
-    static inline std::string vector_norm_string(const enum VectorNorm norm  //!< input enum term
-    )
-    {
-      switch (norm)
-      {
-        case Inpar::PoroMultiPhaseScaTra::norm_l1:
-          return "L1";
-          break;
-        case Inpar::PoroMultiPhaseScaTra::norm_l1_scaled:
-          return "L1_scaled";
-          break;
-        case Inpar::PoroMultiPhaseScaTra::norm_l2:
-          return "L2";
-          break;
-        case Inpar::PoroMultiPhaseScaTra::norm_rms:
-          return "Rms";
-          break;
-        case Inpar::PoroMultiPhaseScaTra::norm_inf:
-          return "Inf";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-          return "";
-      }
-    }
-
     /// set the poromultiphasescatra parameters
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
 

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -14,6 +14,7 @@
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_sparseoperator.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_parameter_list.hpp"
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -37,8 +37,9 @@ namespace Inpar
           "type of the specific dynamic time integration scheme",
           tuple<std::string>("Statics", "GenAlpha", "GenAlphaLieGroup", "OneStepTheta",
               "ExplicitEuler", "CentrDiff", "AdamsBashforth2", "AdamsBashforth4"),
-          tuple<Solid::DynamicType>(dyna_statics, dyna_genalpha, dyna_genalpha_liegroup,
-              dyna_onesteptheta, dyna_expleuler, dyna_centrdiff, dyna_ab2, dyna_ab4),
+          tuple<Solid::DynamicType>(DynamicType::Statics, DynamicType::GenAlpha,
+              DynamicType::GenAlphaLieGroup, DynamicType::OneStepTheta, DynamicType::ExplEuler,
+              DynamicType::CentrDiff, DynamicType::AdamsBashforth2, DynamicType::AdamsBashforth4),
           sdyn);
 
       Core::Utils::string_to_integral_parameter<Inpar::Solid::PreStress>("PRESTRESS", "none",
@@ -371,7 +372,8 @@ namespace Inpar
       Core::Utils::string_to_integral_parameter<Inpar::Solid::DynamicType>("DYNAMICTYPE",
           "CentrDiff", "type of the specific auxiliary dynamic time integration scheme",
           tuple<std::string>("ExplicitEuler", "CentrDiff", "AdamsBashforth2", "AdamsBashforth4"),
-          tuple<Inpar::Solid::DynamicType>(dyna_expleuler, dyna_centrdiff, dyna_ab2, dyna_ab4),
+          tuple<Inpar::Solid::DynamicType>(DynamicType::ExplEuler, DynamicType::CentrDiff,
+              DynamicType::AdamsBashforth2, DynamicType::AdamsBashforth4),
           jep);
 
       jep.specs.emplace_back(parameter<bool>(

--- a/src/inpar/4C_inpar_structure.hpp
+++ b/src/inpar/4C_inpar_structure.hpp
@@ -196,54 +196,18 @@ namespace Inpar
     };
 
     /// Type of time integrator including statics
-    enum DynamicType : int
+    enum class DynamicType : int
     {
-      dyna_statics,            ///< static analysis
-      dyna_genalpha,           ///< generalised-alpha time integrator (implicit)
-      dyna_genalpha_liegroup,  ///< generalised-alpha time integrator for Lie groups (e.g. SO3 group
-                               ///< of rotation matrices) (implicit)
-      dyna_onesteptheta,       ///< one-step-theta time integrator (implicit)
-      dyna_expleuler,          ///< forward Euler (explicit)
-      dyna_centrdiff,          ///< central differences (explicit)
-      dyna_ab2,                ///< Adams-Bashforth 2nd order (explicit)
-      dyna_ab4                 ///< Adams-Bashforth 4th order (explicit)
+      Statics,           ///< static analysis
+      GenAlpha,          ///< generalised-alpha time integrator (implicit)
+      GenAlphaLieGroup,  ///< generalised-alpha time integrator for Lie groups (e.g. SO3 group
+                         ///< of rotation matrices) (implicit)
+      OneStepTheta,      ///< one-step-theta time integrator (implicit)
+      ExplEuler,         ///< forward Euler (explicit)
+      CentrDiff,         ///< central differences (explicit)
+      AdamsBashforth2,   ///< Adams-Bashforth 2nd order (explicit)
+      AdamsBashforth4    ///< Adams-Bashforth 4th order (explicit)
     };
-
-    /// Map time integrator to std::string
-    static inline std::string dynamic_type_string(const enum DynamicType name  ///< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case dyna_statics:
-          return "Statics";
-          break;
-        case dyna_genalpha:
-          return "GenAlpha";
-          break;
-        case dyna_genalpha_liegroup:
-          return "GenAlphaLieGroup";
-          break;
-        case dyna_onesteptheta:
-          return "OneStepTheta";
-          break;
-        case dyna_expleuler:
-          return "ExplEuler";
-          break;
-        case dyna_centrdiff:
-          return "CentrDiff";
-          break;
-        case dyna_ab2:
-          return "AdamsBashforth2";
-          break;
-        case dyna_ab4:
-          return "AdamsBashforth4";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string for time integrator {}", name);
-          return "";
-      }
-    }
 
     /// Type of (global) damping
     enum DampKind
@@ -273,26 +237,6 @@ namespace Inpar
                          ///<  (TR means trapezoidal rule.)
     };
 
-    /// Map mid-averaging to std::string
-    static inline std::string mid_average_string(
-        const enum MidAverageEnum name  ///< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case midavg_vague:
-          return "Vague";
-          break;
-        case midavg_imrlike:
-          return "IMR-like";
-        case midavg_trlike:
-          return "TR-like";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string for time integrator {}", name);
-          return "";
-      }
-    }
 
     /// Type of predictor
     enum PredEnum : int
@@ -378,51 +322,6 @@ namespace Inpar
       soltech_singlestep            ///< single step for explicit dynamics
     };
 
-    /// Map solution technique enum to std::string
-    static inline std::string nonlin_sol_tech_string(
-        const enum NonlinSolTech name  ///< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case soltech_vague:
-          return "vague";
-          break;
-        case soltech_newtonfull:
-          return "fullnewton";
-          break;
-        case soltech_newtonls:
-          return "lsnewton";
-          break;
-        case soltech_newtonmod:
-          return "modnewton";
-          break;
-        case soltech_newtonuzawalin:
-          return "newtonlinuzawa";
-          break;
-        case soltech_newtonuzawanonlin:
-          return "augmentedlagrange";
-          break;
-        case soltech_noxnewtonlinesearch:
-          return "NoxNewtonLineSearch";
-          break;
-        case soltech_noxgeneral:
-          return "noxgeneral";
-          break;
-        case soltech_nox_nln:
-          return "nox_nln";
-          break;
-        case soltech_ptc:
-          return "ptc";
-          break;
-        case soltech_singlestep:
-          return "singlestep";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string for solution technique {}", name);
-          return "";
-      }
-    }
 
     /// Handling of non-converged nonlinear solver
     enum DivContAct

--- a/src/inpar/4C_inpar_structure.hpp
+++ b/src/inpar/4C_inpar_structure.hpp
@@ -12,6 +12,7 @@
 #include "4C_config.hpp"
 
 #include "4C_io_input_spec.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <map>
@@ -667,32 +668,6 @@ namespace Inpar
       byfunct                ///< evaluate error from function
     };
 
-    /// map enum term to std::string
-    static inline std::string vector_norm_string(const enum VectorNorm norm  ///< input enum term
-    )
-    {
-      switch (norm)
-      {
-        case Inpar::Solid::norm_vague:
-          return "Vague";
-          break;
-        case Inpar::Solid::norm_l1:
-          return "L1";
-          break;
-        case Inpar::Solid::norm_l2:
-          return "L2";
-          break;
-        case Inpar::Solid::norm_rms:
-          return "Rms";
-          break;
-        case Inpar::Solid::norm_inf:
-          return "Inf";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-          return "";
-      }
-    }
 
     /// kinematic description
     enum class KinemType

--- a/src/inpar/4C_inpar_tsi.hpp
+++ b/src/inpar/4C_inpar_tsi.hpp
@@ -74,24 +74,6 @@ namespace Inpar
       LS_and,        //!< line-search based on structural and thermal residual
     };
 
-    //! Map solution technique enum to std::string
-    static inline std::string nln_sol_tech_string(const enum NlnSolTech name  //!< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case soltech_newtonfull:
-          return "fullnewton";
-          break;
-        case soltech_ptc:
-          return "ptc";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string for solution technique {}", name);
-          return "";
-      }
-    }
-
     //@}
 
     //! @name General

--- a/src/inpar/4C_inpar_tsi.hpp
+++ b/src/inpar/4C_inpar_tsi.hpp
@@ -108,36 +108,6 @@ namespace Inpar
       norm_inf         //!< Maximum/infinity norm
     };
 
-    //! map enum term to std::string
-    static inline std::string vector_norm_string(const enum VectorNorm norm  //!< input enum term
-    )
-    {
-      switch (norm)
-      {
-        case Inpar::TSI::norm_vague:
-          return "Vague";
-          break;
-        case Inpar::TSI::norm_l1:
-          return "L1";
-          break;
-        case Inpar::TSI::norm_l1_scaled:
-          return "L1_scaled";
-          break;
-        case Inpar::TSI::norm_l2:
-          return "L2";
-          break;
-        case Inpar::TSI::norm_rms:
-          return "Rms";
-          break;
-        case Inpar::TSI::norm_inf:
-          return "Inf";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-          return "";
-      }
-    }
-
     //! Method used to calculate plastic dissipation
     enum DissipationMode
     {

--- a/src/levelset/4C_levelset_intersection_utils.cpp
+++ b/src/levelset/4C_levelset_intersection_utils.cpp
@@ -20,6 +20,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/loma/4C_loma_dyn.cpp
+++ b/src/loma/4C_loma_dyn.cpp
@@ -15,6 +15,7 @@
 #include "4C_scatra_ele.hpp"
 #include "4C_scatra_timint_implicit.hpp"
 #include "4C_scatra_utils_clonestrategy.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/lubrication/src/4C_lubrication_ele_calc.cpp
+++ b/src/lubrication/src/4C_lubrication_ele_calc.cpp
@@ -18,6 +18,7 @@
 #include "4C_lubrication_ele_parameter.hpp"
 #include "4C_lubrication_input.hpp"
 #include "4C_mat_lubrication_mat.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_singleton_owner.hpp"
 

--- a/src/lubrication/src/4C_lubrication_ele_evaluate.cpp
+++ b/src/lubrication/src/4C_lubrication_ele_evaluate.cpp
@@ -11,6 +11,7 @@
 #include "4C_lubrication_ele_factory.hpp"
 #include "4C_lubrication_ele_interface.hpp"
 #include "4C_lubrication_ele_parameter.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/lubrication/src/4C_lubrication_input.hpp
+++ b/src/lubrication/src/4C_lubrication_input.hpp
@@ -61,33 +61,6 @@ namespace Lubrication
     norm_inf         //!< Maximum/infinity norm
   };
 
-  //! map enum term to std::string
-  static inline std::string vector_norm_string(const enum VectorNorm norm  //!< input enum term
-  )
-  {
-    switch (norm)
-    {
-      case Lubrication::norm_vague:
-        return "Vague";
-        break;
-      case Lubrication::norm_l1:
-        return "L1";
-        break;
-      case Lubrication::norm_l2:
-        return "L2";
-        break;
-      case Lubrication::norm_rms:
-        return "Rms";
-        break;
-      case Lubrication::norm_inf:
-        return "Inf";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-        return "";
-    }
-  }
-
   /// set the lubrication parameters
   void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
 

--- a/src/mat/4C_mat_aaaneohooke.cpp
+++ b/src/mat/4C_mat_aaaneohooke.cpp
@@ -14,6 +14,7 @@
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_beam3r_plasticity.cpp
+++ b/src/mat/4C_mat_beam3r_plasticity.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_beam_elasthyper_parameter.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_fad.hpp"
 
 #include <cmath>

--- a/src/mat/4C_mat_beam_elasthyper.cpp
+++ b/src/mat/4C_mat_beam_elasthyper.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_beam_elasthyper_parameter.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Sacado.hpp>
 

--- a/src/mat/4C_mat_carreauyasuda.cpp
+++ b/src/mat/4C_mat_carreauyasuda.cpp
@@ -10,8 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
-
-#include <vector>
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_cnst_1d_art.cpp
+++ b/src/mat/4C_mat_cnst_1d_art.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -21,6 +21,7 @@
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_constraintmixture_history.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_of_time.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>

--- a/src/mat/4C_mat_crosslinkermat.cpp
+++ b/src/mat/4C_mat_crosslinkermat.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_crystal_plasticity.cpp
+++ b/src/mat/4C_mat_crystal_plasticity.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_fixedsizematrix_solver.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_ENull.hpp>
 

--- a/src/mat/4C_mat_damage.cpp
+++ b/src/mat/4C_mat_damage.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_local_newton.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_elasthyper.cpp
+++ b/src/mat/4C_mat_elasthyper.cpp
@@ -13,6 +13,7 @@
 #include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <iostream>
 

--- a/src/mat/4C_mat_elchmat.cpp
+++ b/src/mat/4C_mat_elchmat.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_elchphase.cpp
+++ b/src/mat/4C_mat_elchphase.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_elchsinglemat.cpp
+++ b/src/mat/4C_mat_elchsinglemat.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_of_time.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_electrode.cpp
+++ b/src/mat/4C_mat_electrode.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_io_control.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_of_scalar.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_fluid_linear_density_viscosity.cpp
+++ b/src/mat/4C_mat_fluid_linear_density_viscosity.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_fluid_murnaghantait.cpp
+++ b/src/mat/4C_mat_fluid_murnaghantait.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_fluid_weakly_compressible.cpp
+++ b/src/mat/4C_mat_fluid_weakly_compressible.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_fluidporo.cpp
+++ b/src/mat/4C_mat_fluidporo.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_fluidporo_multiphase.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_fluidporo_singlephase.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_porofluidmultiphase_ele_calc_utils.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_SerialDenseSolver.hpp>
 

--- a/src/mat/4C_mat_fluidporo_multiphase_reactions.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase_reactions.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_fluidporo_multiphase_singlereaction.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_fluidporo_multiphase_singlereaction.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase_singlereaction.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <vector>

--- a/src/mat/4C_mat_fluidporo_relpermeability_law.cpp
+++ b/src/mat/4C_mat_fluidporo_relpermeability_law.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*

--- a/src/mat/4C_mat_fluidporo_singlephase.cpp
+++ b/src/mat/4C_mat_fluidporo_singlephase.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_fluidporo_singlephaseDof.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_poro_density_law.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_fluidporo_singlephaseDof.cpp
+++ b/src/mat/4C_mat_fluidporo_singlephaseDof.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_fluidporo_singlephaselaw.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_fluidporo_singlephaselaw.cpp
+++ b/src/mat/4C_mat_fluidporo_singlephaselaw.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_fluidporo_viscosity_law.cpp
+++ b/src/mat/4C_mat_fluidporo_viscosity_law.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*

--- a/src/mat/4C_mat_fourier.cpp
+++ b/src/mat/4C_mat_fourier.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -18,6 +18,7 @@
 #include "4C_mat_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_SerialDenseSolver.hpp>
 

--- a/src/mat/4C_mat_herschelbulkley.cpp
+++ b/src/mat/4C_mat_herschelbulkley.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -22,6 +22,7 @@
 #include "4C_mat_multiplicative_split_defgrad_elasthyper.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_vplast_law.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function_of_time.hpp"
 

--- a/src/mat/4C_mat_ion.cpp
+++ b/src/mat/4C_mat_ion.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_iterative_prestress.cpp
+++ b/src/mat/4C_mat_iterative_prestress.cpp
@@ -21,6 +21,7 @@
 #include "4C_mat_service.hpp"
 #include "4C_mat_so3_material.hpp"
 #include "4C_mixture_rule.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <Teuchos_ENull.hpp>

--- a/src/mat/4C_mat_lin_elast_1D.cpp
+++ b/src/mat/4C_mat_lin_elast_1D.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_library.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_list.cpp
+++ b/src/mat/4C_mat_list.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_list_chemoreac.cpp
+++ b/src/mat/4C_mat_list_chemoreac.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_list_chemotaxis.cpp
+++ b/src/mat/4C_mat_list_chemotaxis.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_list_reactions.cpp
+++ b/src/mat/4C_mat_list_reactions.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_scatra_reaction.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_lubrication_law.cpp
+++ b/src/mat/4C_mat_lubrication_law.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_lubrication_mat.cpp
+++ b/src/mat/4C_mat_lubrication_mat.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_lubrication_law.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_material_factory.cpp
+++ b/src/mat/4C_mat_material_factory.cpp
@@ -166,6 +166,7 @@
 #include "4C_mixture_rule_growthremodel.hpp"
 #include "4C_mixture_rule_map.hpp"
 #include "4C_mixture_rule_simple.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_maxwell_0d_acinus.cpp
+++ b/src/mat/4C_mat_maxwell_0d_acinus.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_maxwell_0d_acinus_DoubleExponential.cpp
+++ b/src/mat/4C_mat_maxwell_0d_acinus_DoubleExponential.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
 #include "4C_red_airways_elementbase.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_maxwell_0d_acinus_Exponential.cpp
+++ b/src/mat/4C_mat_maxwell_0d_acinus_Exponential.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
 #include "4C_red_airways_elementbase.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_maxwell_0d_acinus_NeoHookean.cpp
+++ b/src/mat/4C_mat_maxwell_0d_acinus_NeoHookean.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
 #include "4C_red_airways_elementbase.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_maxwell_0d_acinus_Ogden.cpp
+++ b/src/mat/4C_mat_maxwell_0d_acinus_Ogden.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
 #include "4C_red_airways_elementbase.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_membrane_active_strain.cpp
+++ b/src/mat/4C_mat_membrane_active_strain.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_utils_densematrix_inverse.hpp"
 #include "4C_mat_membrane_elasthyper.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_micromaterial.cpp
+++ b/src/mat/4C_mat_micromaterial.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_micromaterial_evaluate.cpp
+++ b/src/mat/4C_mat_micromaterial_evaluate.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_micromaterialgp_static.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_stru_multi_microstatic.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_mixture.cpp
+++ b/src/mat/4C_mat_mixture.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <memory>
 

--- a/src/mat/4C_mat_modpowerlaw.cpp
+++ b/src/mat/4C_mat_modpowerlaw.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
@@ -21,6 +21,7 @@
 #include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_structure_new_enum_lists.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 

--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_muscle_utils.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <variant>

--- a/src/mat/4C_mat_muscle_giantesio.cpp
+++ b/src/mat/4C_mat_muscle_giantesio.cpp
@@ -16,6 +16,7 @@
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_muscle_utils.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_local_newton.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_muscle_weickenmeier.cpp
+++ b/src/mat/4C_mat_muscle_weickenmeier.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_muscle_utils.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_myocard.cpp
+++ b/src/mat/4C_mat_myocard.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_myocard_san_garny.hpp"
 #include "4C_mat_myocard_tentusscher.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_ENull.hpp>
 

--- a/src/mat/4C_mat_myocard_fitzhugh_nagumo.cpp
+++ b/src/mat/4C_mat_myocard_fitzhugh_nagumo.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_myocard_inada.cpp
+++ b/src/mat/4C_mat_myocard_inada.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_myocard_minimal.cpp
+++ b/src/mat/4C_mat_myocard_minimal.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_myocard_san_garny.cpp
+++ b/src/mat/4C_mat_myocard_san_garny.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_myocard_tentusscher.cpp
+++ b/src/mat/4C_mat_myocard_tentusscher.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_newman.cpp
+++ b/src/mat/4C_mat_newman.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_of_time.hpp"
 
 #include <vector>

--- a/src/mat/4C_mat_newman_multiscale.cpp
+++ b/src/mat/4C_mat_newman_multiscale.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_newtonianfluid.cpp
+++ b/src/mat/4C_mat_newtonianfluid.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_par_aniso.cpp
+++ b/src/mat/4C_mat_par_aniso.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_par_bundle.cpp
+++ b/src/mat/4C_mat_par_bundle.cpp
@@ -11,6 +11,7 @@
 #include "4C_mat_elast_summand.hpp"
 #include "4C_mat_material_factory.hpp"
 #include "4C_material_base.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_particle_base.cpp
+++ b/src/mat/4C_mat_particle_base.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_particle_dem.cpp
+++ b/src/mat/4C_mat_particle_dem.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_particle_sph_boundary.cpp
+++ b/src/mat/4C_mat_particle_sph_boundary.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_particle_sph_fluid.cpp
+++ b/src/mat/4C_mat_particle_sph_fluid.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_particle_thermo.cpp
+++ b/src/mat/4C_mat_particle_thermo.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_particle_wall_dem.cpp
+++ b/src/mat/4C_mat_particle_wall_dem.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_plastic_VarConstUpdate.cpp
+++ b/src/mat/4C_mat_plastic_VarConstUpdate.cpp
@@ -16,6 +16,7 @@
 #include "4C_linalg_utils_densematrix_inverse.hpp"
 #include "4C_mat_elast_summand.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_SerialDenseSolver.hpp>
 

--- a/src/mat/4C_mat_plasticdruckerprager.cpp
+++ b/src/mat/4C_mat_plasticdruckerprager.cpp
@@ -19,6 +19,7 @@
 #include "4C_mat_stvenantkirchhoff.hpp"
 #include "4C_material_base.hpp"
 #include "4C_material_parameter_base.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_local_newton.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -15,6 +15,7 @@
 #include "4C_linalg_utils_densematrix_exp_log.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_SerialDenseSolver.hpp>
 

--- a/src/mat/4C_mat_plasticgtn.cpp
+++ b/src/mat/4C_mat_plasticgtn.cpp
@@ -24,6 +24,7 @@
 #include "4C_mat_stvenantkirchhoff.hpp"
 #include "4C_material_base.hpp"
 #include "4C_material_parameter_base.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_local_newton.hpp"
 

--- a/src/mat/4C_mat_plasticlinelast.cpp
+++ b/src/mat/4C_mat_plasticlinelast.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_tsi_defines.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_plasticnlnlogneohooke.cpp
+++ b/src/mat/4C_mat_plasticnlnlogneohooke.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_local_newton.hpp"
 

--- a/src/mat/4C_mat_poro_density_law.cpp
+++ b/src/mat/4C_mat_poro_density_law.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_poro_law.cpp
+++ b/src/mat/4C_mat_poro_law.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_poro_density_law.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_robinson.cpp
+++ b/src/mat/4C_mat_robinson.cpp
@@ -15,6 +15,7 @@
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_tsi_defines.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_scalardepinterp.cpp
+++ b/src/mat/4C_mat_scalardepinterp.cpp
@@ -11,6 +11,7 @@
 #include "4C_comm_utils_factory.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_scatra.cpp
+++ b/src/mat/4C_mat_scatra.cpp
@@ -11,6 +11,7 @@
 #include "4C_comm_utils.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_scatra_chemotaxis.cpp
+++ b/src/mat/4C_mat_scatra_chemotaxis.cpp
@@ -11,6 +11,7 @@
 #include "4C_comm_utils.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_scatra_multiporo.cpp
+++ b/src/mat/4C_mat_scatra_multiporo.cpp
@@ -11,6 +11,7 @@
 #include "4C_comm_utils.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_scatra_multiscale.cpp
+++ b/src/mat/4C_mat_scatra_multiscale.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_scatra_poro_ecm.cpp
+++ b/src/mat/4C_mat_scatra_poro_ecm.cpp
@@ -11,6 +11,7 @@
 #include "4C_comm_utils.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_scatra_reaction.cpp
+++ b/src/mat/4C_mat_scatra_reaction.cpp
@@ -12,6 +12,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_scatra_reaction_coupling.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <vector>

--- a/src/mat/4C_mat_scatra_reaction_coupling.cpp
+++ b/src/mat/4C_mat_scatra_reaction_coupling.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mat/4C_mat_scl.cpp
+++ b/src/mat/4C_mat_scl.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_of_scalar.hpp"
 
 #include <vector>

--- a/src/mat/4C_mat_service.cpp
+++ b/src/mat/4C_mat_service.cpp
@@ -25,6 +25,7 @@
 #include "4C_mixture_rule_growthremodel.hpp"
 #include "4C_mixture_rule_map.hpp"
 #include "4C_mixture_rule_simple.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Sacado.hpp>
 

--- a/src/mat/4C_mat_shell_kl.cpp
+++ b/src/mat/4C_mat_shell_kl.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <vector>

--- a/src/mat/4C_mat_soret.cpp
+++ b/src/mat/4C_mat_soret.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_spring.cpp
+++ b/src/mat/4C_mat_spring.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_structporo.cpp
+++ b/src/mat/4C_mat_structporo.cpp
@@ -13,6 +13,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_poro_law.hpp"
 #include "4C_mat_so3_material.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_structporo_reaction.cpp
+++ b/src/mat/4C_mat_structporo_reaction.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_structporo_reaction_ecm.cpp
+++ b/src/mat/4C_mat_structporo_reaction_ecm.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_poro_law.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_stvenantkirchhoff.cpp
+++ b/src/mat/4C_mat_stvenantkirchhoff.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_superelastic_sma.cpp
+++ b/src/mat/4C_mat_superelastic_sma.cpp
@@ -15,6 +15,7 @@
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_sutherland.cpp
+++ b/src/mat/4C_mat_sutherland.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_thermoplastichyperelast.cpp
+++ b/src/mat/4C_mat_thermoplastichyperelast.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_thermoplasticlinelast.cpp
+++ b/src/mat/4C_mat_thermoplasticlinelast.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_tsi_defines.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_thermostvenantkirchhoff.cpp
+++ b/src/mat/4C_mat_thermostvenantkirchhoff.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_stvenantkirchhoff.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/4C_mat_viscoanisotropic.cpp
+++ b/src/mat/4C_mat_viscoanisotropic.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_viscoelasthyper.cpp
+++ b/src/mat/4C_mat_viscoelasthyper.cpp
@@ -16,6 +16,7 @@
 #include "4C_mat_elast_visco_generalizedgenmax.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
@@ -857,7 +858,7 @@ void Mat::ViscoElastHyper::evaluate_visco_gen_max(Core::LinAlg::Matrix<6, 1>* st
     // 09/14)
     const auto dyntype = Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(
         Global::Problem::instance()->structural_dynamic_params(), "DYNAMICTYPE");
-    if (dyntype == Inpar::Solid::DynamicType::dyna_onesteptheta)
+    if (dyntype == Inpar::Solid::DynamicType::OneStepTheta)
       theta = Global::Problem::instance()
                   ->structural_dynamic_params()
                   .sublist("ONESTEPTHETA")
@@ -1065,7 +1066,7 @@ void Mat::ViscoElastHyper::evaluate_visco_generalized_gen_max(Core::LinAlg::Matr
       // 09/14)
       const auto dyntype = Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(
           Global::Problem::instance()->structural_dynamic_params(), "DYNAMICTYPE");
-      if (dyntype == Inpar::Solid::DynamicType::dyna_onesteptheta)
+      if (dyntype == Inpar::Solid::DynamicType::OneStepTheta)
         theta = Global::Problem::instance()
                     ->structural_dynamic_params()
                     .sublist("ONESTEPTHETA")

--- a/src/mat/4C_mat_visconeohooke.cpp
+++ b/src/mat/4C_mat_visconeohooke.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/mat/4C_mat_viscoplastic_no_yield_surface.cpp
+++ b/src/mat/4C_mat_viscoplastic_no_yield_surface.cpp
@@ -12,6 +12,7 @@
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_fad.hpp"
 
 #include <vector>

--- a/src/mat/elast/4C_mat_elast_summand.cpp
+++ b/src/mat/elast/4C_mat_elast_summand.cpp
@@ -52,6 +52,7 @@
 #include "4C_mat_elast_volpow.hpp"
 #include "4C_mat_elast_volsussmanbathe.hpp"
 #include "4C_mat_par_bundle.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mat/vplast/4C_mat_vplast_law.cpp
+++ b/src/mat/vplast/4C_mat_vplast_law.cpp
@@ -10,6 +10,7 @@
 #include "4C_global_data.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_vplast_reform_johnsoncook.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <utility>
 

--- a/src/mortar/4C_mortar_projector.cpp
+++ b/src/mortar/4C_mortar_projector.cpp
@@ -16,6 +16,7 @@
 #include "4C_mortar_defines.hpp"
 #include "4C_mortar_element.hpp"
 #include "4C_mortar_node.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mortar/4C_mortar_shape_utils.hpp
+++ b/src/mortar/4C_mortar_shape_utils.hpp
@@ -18,6 +18,7 @@
 #include "4C_linalg_utils_densematrix_inverse.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mortar_element.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/mortar/4C_mortar_strategy_base.cpp
+++ b/src/mortar/4C_mortar_strategy_base.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mortar_defines.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
@@ -33,7 +34,7 @@ Mortar::StrategyDataContainer::StrategyDataContainer()
       parredist_(false),
       maxdof_(0),
       systype_(CONTACT::SystemType::none),
-      dyntype_(Inpar::Solid::dyna_statics),
+      dyntype_(Inpar::Solid::DynamicType::Statics),
       dynparam_n_(0.0)
 {
 }
@@ -77,18 +78,16 @@ void Mortar::StrategyBase::set_time_integration_info(
   data().set_dyn_type(dyntype);
   switch (dyntype)
   {
-    case Inpar::Solid::dyna_statics:
+    case Inpar::Solid::DynamicType::Statics:
       data().set_dyn_parameter_n(0.0);
       break;
-    case Inpar::Solid::dyna_genalpha:
-    case Inpar::Solid::dyna_genalpha_liegroup:
-    case Inpar::Solid::dyna_onesteptheta:
+    case Inpar::Solid::DynamicType::GenAlpha:
+    case Inpar::Solid::DynamicType::GenAlphaLieGroup:
+    case Inpar::Solid::DynamicType::OneStepTheta:
       data().set_dyn_parameter_n(time_fac);
       break;
     default:
-      FOUR_C_THROW(
-          "Unsupported time integration detected! [\"{}\"]", dynamic_type_string(dyntype).c_str());
-      exit(EXIT_FAILURE);
+      FOUR_C_THROW("Unsupported time integration detected! [\"{}\"]", dyntype);
   }
 
   // Check if we only want to compute the contact force at the time endpoint

--- a/src/mortar/4C_mortar_strategy_base.hpp
+++ b/src/mortar/4C_mortar_strategy_base.hpp
@@ -28,7 +28,7 @@ namespace Inpar
 {
   namespace Solid
   {
-    enum DynamicType : int;
+    enum class DynamicType : int;
   }  // namespace Solid
 }  // namespace Inpar
 namespace Core::FE

--- a/src/poroelast/4C_poroelast_base.cpp
+++ b/src/poroelast/4C_poroelast_base.cpp
@@ -151,11 +151,11 @@ PoroElast::PoroBase::PoroBase(MPI_Comm comm, const Teuchos::ParameterList& timep
     auto fluidtimealgo =
         Teuchos::getIntegralValue<Inpar::FLUID::TimeIntegrationScheme>(fdyn, "TIMEINTEGR");
 
-    if (not((structtimealgo == Inpar::Solid::dyna_onesteptheta and
+    if (not((structtimealgo == Inpar::Solid::DynamicType::OneStepTheta and
                 fluidtimealgo == Inpar::FLUID::timeint_one_step_theta) or
-            (structtimealgo == Inpar::Solid::dyna_statics and
+            (structtimealgo == Inpar::Solid::DynamicType::Statics and
                 fluidtimealgo == Inpar::FLUID::timeint_stationary) or
-            (structtimealgo == Inpar::Solid::dyna_genalpha and
+            (structtimealgo == Inpar::Solid::DynamicType::GenAlpha and
                 (fluidtimealgo == Inpar::FLUID::timeint_afgenalpha or
                     fluidtimealgo == Inpar::FLUID::timeint_npgenalpha))))
     {
@@ -171,7 +171,7 @@ PoroElast::PoroBase::PoroBase(MPI_Comm comm, const Teuchos::ParameterList& timep
           "theory or use afgenalpha instead!");
     }
 
-    if (structtimealgo == Inpar::Solid::dyna_onesteptheta and
+    if (structtimealgo == Inpar::Solid::DynamicType::OneStepTheta and
         fluidtimealgo == Inpar::FLUID::timeint_one_step_theta)
     {
       double theta_struct = sdyn.sublist("ONESTEPTHETA").get<double>("THETA");
@@ -187,7 +187,7 @@ PoroElast::PoroBase::PoroBase(MPI_Comm comm, const Teuchos::ParameterList& timep
 
     auto damping = Teuchos::getIntegralValue<Inpar::Solid::DampKind>(sdyn, "DAMPING");
     if (damping != Inpar::Solid::DampKind::damp_material &&
-        structtimealgo != Inpar::Solid::dyna_statics)
+        structtimealgo != Inpar::Solid::DynamicType::Statics)
     {
       FOUR_C_THROW(
           "Material damping has to be used for dynamic porous media simulations! Set DAMPING to "

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -413,7 +413,7 @@ void PoroElast::Monolithic::setup_system()
     }
   }
 
-  if (no_penetration_ && not(strmethodname_ == Inpar::Solid::dyna_onesteptheta))
+  if (no_penetration_ && not(strmethodname_ == Inpar::Solid::DynamicType::OneStepTheta))
   {
     FOUR_C_THROW(
         "Porous contact with no penetration is only implemented for OneStepTheta. Please set "

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -846,8 +846,8 @@ void PoroElast::Monolithic::print_newton_iter_header_stream(std::ostringstream& 
 {
   oss << "------------------------------------------------------------" << std::endl;
   oss << "                   Newton-Raphson Scheme                    " << std::endl;
-  oss << "                NormRES " << vector_norm_string(vectornormfres_);
-  oss << "     NormINC " << vector_norm_string(vectornorminc_) << "                    "
+  oss << "                NormRES " << magic_enum::enum_name(vectornormfres_);
+  oss << "     NormINC " << magic_enum::enum_name(vectornorminc_) << "                    "
       << std::endl;
   oss << "------------------------------------------------------------" << std::endl;
 

--- a/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
+++ b/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
@@ -287,8 +287,8 @@ void PoroElast::MonolithicMeshtying::print_newton_iter_header_stream(std::ostrin
 {
   oss << "------------------------------------------------------------" << std::endl;
   oss << "                   Newton-Raphson Scheme                    " << std::endl;
-  oss << "                NormRES " << vector_norm_string(vectornormfres_);
-  oss << "     NormINC " << vector_norm_string(vectornorminc_) << "                    "
+  oss << "                NormRES " << magic_enum::enum_name(vectornormfres_);
+  oss << "     NormINC " << magic_enum::enum_name(vectornorminc_) << "                    "
       << std::endl;
   oss << "------------------------------------------------------------" << std::endl;
 

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
@@ -710,8 +710,8 @@ void PoroElastScaTra::PoroScatraMono::print_newton_iter_header(FILE* ofile)
 
   oss << "------------------------------------------------------------" << std::endl;
   oss << "                   Newton-Raphson Scheme                    " << std::endl;
-  oss << "                NormRES " << vector_norm_string(vectornormfres_);
-  oss << "     NormINC " << vector_norm_string(vectornorminc_) << "                    "
+  oss << "                NormRES " << magic_enum::enum_name(vectornormfres_);
+  oss << "     NormINC " << magic_enum::enum_name(vectornorminc_) << "                    "
       << std::endl;
   oss << "------------------------------------------------------------" << std::endl;
 

--- a/src/porofluidmultiphase/4C_porofluidmultiphase_timint_implicit.cpp
+++ b/src/porofluidmultiphase/4C_porofluidmultiphase_timint_implicit.cpp
@@ -1715,14 +1715,14 @@ inline void POROFLUIDMULTIPHASE::TimIntImpl::print_convergence_values_first_iter
   {
     std::cout << "|  " << std::setw(3) << itnum << "/" << std::setw(3) << itemax << "   | "
               << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
-              << std::setw(3) << vector_norm_string(vectornormfres_).c_str() << "]  | ";
+              << std::setw(3) << magic_enum::enum_name(vectornormfres_).c_str() << "]  | ";
 
     for (std::size_t i = 0; i < preresnorm.size(); ++i)
       std::cout << std::setw(10) << std::setprecision(3) << std::scientific << preresnorm[i]
                 << "   | ";
 
     std::cout << std::setw(10) << std::setprecision(3) << std::scientific << ittolinc_ << " ["
-              << std::setw(3) << vector_norm_string(vectornorminc_).c_str() << "]  |";
+              << std::setw(3) << magic_enum::enum_name(vectornorminc_).c_str() << "]  |";
 
     for (std::size_t i = 0; i < preresnorm.size(); ++i) std::cout << "      --      |";
     std::cout << " (    --   ,te=" << std::setw(10) << std::setprecision(3) << std::scientific
@@ -1749,12 +1749,12 @@ inline void POROFLUIDMULTIPHASE::TimIntImpl::print_convergence_values(
   {
     std::cout << "|  " << std::setw(3) << itnum << "/" << std::setw(3) << itemax << "   | "
               << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
-              << std::setw(3) << vector_norm_string(vectornormfres_).c_str() << "]  | ";
+              << std::setw(3) << magic_enum::enum_name(vectornormfres_).c_str() << "]  | ";
     for (std::size_t i = 0; i < preresnorm.size(); ++i)
       std::cout << std::setw(10) << std::setprecision(3) << std::scientific << preresnorm[i]
                 << "   | ";
     std::cout << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
-              << std::setw(3) << vector_norm_string(vectornorminc_).c_str() << "]  | ";
+              << std::setw(3) << magic_enum::enum_name(vectornorminc_).c_str() << "]  | ";
     for (std::size_t i = 0; i < preresnorm.size(); ++i)
       std::cout << std::setw(10) << std::setprecision(3) << std::scientific
                 << incprenorm[i] / prenorm[i] << "   | ";

--- a/src/porofluidmultiphase/4C_porofluidmultiphase_timint_implicit.cpp
+++ b/src/porofluidmultiphase/4C_porofluidmultiphase_timint_implicit.cpp
@@ -26,6 +26,7 @@
 #include "4C_porofluidmultiphase_meshtying_strategy_std.hpp"
 #include "4C_porofluidmultiphase_resulttest.hpp"
 #include "4C_porofluidmultiphase_utils.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
@@ -1715,14 +1716,14 @@ inline void POROFLUIDMULTIPHASE::TimIntImpl::print_convergence_values_first_iter
   {
     std::cout << "|  " << std::setw(3) << itnum << "/" << std::setw(3) << itemax << "   | "
               << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
-              << std::setw(3) << magic_enum::enum_name(vectornormfres_).c_str() << "]  | ";
+              << std::setw(3) << vectornormfres_ << "]  | ";
 
     for (std::size_t i = 0; i < preresnorm.size(); ++i)
       std::cout << std::setw(10) << std::setprecision(3) << std::scientific << preresnorm[i]
                 << "   | ";
 
     std::cout << std::setw(10) << std::setprecision(3) << std::scientific << ittolinc_ << " ["
-              << std::setw(3) << magic_enum::enum_name(vectornorminc_).c_str() << "]  |";
+              << std::setw(3) << vectornorminc_ << "]  |";
 
     for (std::size_t i = 0; i < preresnorm.size(); ++i) std::cout << "      --      |";
     std::cout << " (    --   ,te=" << std::setw(10) << std::setprecision(3) << std::scientific
@@ -1749,12 +1750,12 @@ inline void POROFLUIDMULTIPHASE::TimIntImpl::print_convergence_values(
   {
     std::cout << "|  " << std::setw(3) << itnum << "/" << std::setw(3) << itemax << "   | "
               << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
-              << std::setw(3) << magic_enum::enum_name(vectornormfres_).c_str() << "]  | ";
+              << std::setw(3) << vectornormfres_ << "]  | ";
     for (std::size_t i = 0; i < preresnorm.size(); ++i)
       std::cout << std::setw(10) << std::setprecision(3) << std::scientific << preresnorm[i]
                 << "   | ";
     std::cout << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
-              << std::setw(3) << magic_enum::enum_name(vectornorminc_).c_str() << "]  | ";
+              << std::setw(3) << vectornorminc_ << "]  | ";
     for (std::size_t i = 0; i < preresnorm.size(); ++i)
       std::cout << std::setw(10) << std::setprecision(3) << std::scientific
                 << incprenorm[i] / prenorm[i] << "   | ";

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele.cpp
@@ -13,6 +13,7 @@
 #include "4C_fluid_ele_nullspace.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_mat_fluidporo_multiphase.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_boundary_factory.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_boundary_factory.cpp
@@ -11,6 +11,7 @@
 #include "4C_global_data.hpp"
 #include "4C_porofluidmultiphase_ele_boundary_calc.hpp"
 #include "4C_porofluidmultiphase_ele_interface.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_calc.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_calc.cpp
@@ -18,6 +18,7 @@
 #include "4C_porofluidmultiphase_ele_parameter.hpp"
 #include "4C_porofluidmultiphase_ele_phasemanager.hpp"
 #include "4C_porofluidmultiphase_ele_variablemanager.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_evaluate.cpp
+++ b/src/porofluidmultiphase_ele/4C_porofluidmultiphase_ele_evaluate.cpp
@@ -11,6 +11,7 @@
 #include "4C_porofluidmultiphase_ele_factory.hpp"
 #include "4C_porofluidmultiphase_ele_interface.hpp"
 #include "4C_porofluidmultiphase_ele_parameter.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
+++ b/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
@@ -839,11 +839,11 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::newton_error_check()
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E  < %10.3E                                      "
           "|\n",
-          vector_norm_string(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E  < %10.3E                                      "
           "|\n",
-          vector_norm_string(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
       printf(
           "+--------------+--------------+--------------+--------------+--------------+"
           "-----------------+\n");
@@ -860,10 +860,10 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::newton_error_check()
           itmax_);
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E    %10.3E                                    |\n",
-          vector_norm_string(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E    %10.3E                                    |\n",
-          vector_norm_string(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
       printf(
           "+--------------+----------------+------------------+--------------------+---------------"
           "---+\n");

--- a/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
+++ b/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
@@ -837,13 +837,13 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::newton_error_check()
           "|  Quantity           [norm]:                 TOL                                       "
           "     |\n");
       printf(
-          "|  Max. rel. increment [%3s]:  %10.3E  < %10.3E                                      "
+          "|  Max. rel. increment [%s]:  %10.3E  < %10.3E                                      "
           "|\n",
-          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
-          "|  Maximum    residual [%3s]:  %10.3E  < %10.3E                                      "
+          "|  Maximum    residual [%s]:  %10.3E  < %10.3E                                      "
           "|\n",
-          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+--------------+--------------+--------------+--------------+"
           "-----------------+\n");
@@ -860,10 +860,10 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::newton_error_check()
           itmax_);
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E    %10.3E                                    |\n",
-          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E    %10.3E                                    |\n",
-          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+----------------+------------------+--------------------+---------------"
           "---+\n");

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_pair.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_pair.cpp
@@ -20,6 +20,7 @@
 #include "4C_porofluidmultiphase_ele_parameter.hpp"
 #include "4C_poromultiphase_scatra_artery_coupling_defines.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_fad.hpp"
 #include "4C_utils_function.hpp"
 

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
@@ -962,11 +962,11 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::newton_error_ch
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E  < %10.3E                                        "
           "       |\n",
-          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E  < %10.3E                                        "
           "       |\n",
-          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+-------------+-------------+--------------+------------+-----"
           "-------+-----------------+\n");
@@ -987,11 +987,11 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::newton_error_ch
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E    %10.3E                                        "
           "|\n",
-          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E    %10.3E                                        "
           "|\n",
-          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+-------------+-------------+--------------+------------+-----"
           "-------+-----------------+\n");

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
@@ -962,11 +962,11 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::newton_error_ch
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E  < %10.3E                                        "
           "       |\n",
-          vector_norm_string(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E  < %10.3E                                        "
           "       |\n",
-          vector_norm_string(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
       printf(
           "+--------------+-------------+-------------+--------------+------------+-----"
           "-------+-----------------+\n");
@@ -987,11 +987,11 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::newton_error_ch
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E    %10.3E                                        "
           "|\n",
-          vector_norm_string(vectornorminc_).c_str(), maxinc_, ittolinc_);
+          magic_enum::enum_name(vectornorminc_).c_str(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E    %10.3E                                        "
           "|\n",
-          vector_norm_string(vectornormfres_).c_str(), maxres_, ittolres_);
+          magic_enum::enum_name(vectornormfres_).c_str(), maxres_, ittolres_);
       printf(
           "+--------------+-------------+-------------+--------------+------------+-----"
           "-------+-----------------+\n");

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -14,6 +14,7 @@
 #include "4C_io_legacy_table_iter.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_post_common.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_xfem_discretization.hpp"
 
 #include <numeric>

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -18,6 +18,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
 #include "4C_red_airways_evaluation_data.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -18,6 +18,7 @@
 #include "4C_mat_par_bundle.hpp"
 #include "4C_red_airways_elem_params.hpp"
 #include "4C_red_airways_evaluation_data.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -22,6 +22,7 @@
 #include "4C_rebalance_print.hpp"
 #include "4C_red_airways_evaluation_data.hpp"
 #include "4C_red_airways_resulttest.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"
 

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -16,6 +16,7 @@
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_mat_newtonianfluid.hpp"
 #include "4C_red_airways_evaluation_data.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -27,6 +27,7 @@
 #include "4C_scatra_timint_meshtying_strategy_fluid_elch.hpp"
 #include "4C_scatra_timint_meshtying_strategy_s2i_elch.hpp"
 #include "4C_scatra_timint_meshtying_strategy_std_elch.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function_of_time.hpp"
 #include "4C_utils_parameter_list.hpp"
 

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -18,6 +18,7 @@
 #include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_hdg.hpp"
 #include "4C_scatra_resulttest_hdg.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -41,6 +41,7 @@
 #include "4C_scatra_turbulence_hit_scalar_forcing.hpp"
 #include "4C_scatra_utils.hpp"
 #include "4C_ssi_contact_strategy.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_parameter_list.hpp"
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -38,6 +38,7 @@
 #include "4C_scatra_ele_parameter_timint.hpp"
 #include "4C_scatra_timint_implicit.hpp"
 #include "4C_scatra_timint_meshtying_strategy_s2i_elch.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.cpp
@@ -19,6 +19,7 @@
 #include "4C_scatra_ele.hpp"
 #include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_boundary_factory.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_factory.cpp
@@ -21,6 +21,7 @@
 #include "4C_scatra_ele_boundary_calc_sti_electrode.hpp"
 #include "4C_scatra_ele_boundary_interface.hpp"
 #include "4C_scatra_ele_calc.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/scatra_ele/4C_scatra_ele_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc.cpp
@@ -24,6 +24,7 @@
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
 #include "4C_scatra_ele_parameter_turbulence.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <vector>

--- a/src/scatra_ele/4C_scatra_ele_calc_OD.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_OD.cpp
@@ -12,6 +12,7 @@
 #include "4C_scatra_ele_calc.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/scatra_ele/4C_scatra_ele_calc_artery.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_artery.cpp
@@ -11,6 +11,7 @@
 #include "4C_mat_scatra.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_calc_artery.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_artery.hpp
@@ -13,6 +13,7 @@
 #include "4C_fem_discretization.hpp"
 #include "4C_mat_cnst_1d_art.hpp"
 #include "4C_scatra_ele_calc.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/scatra_ele/4C_scatra_ele_calc_multiporo_reac.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_multiporo_reac.hpp
@@ -25,6 +25,7 @@
 #include "4C_porofluidmultiphase_ele_phasemanager.hpp"
 #include "4C_porofluidmultiphase_ele_variablemanager.hpp"
 #include "4C_scatra_ele_calc_poro_reac.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_evaluate.cpp
+++ b/src/scatra_ele/4C_scatra_ele_evaluate.cpp
@@ -18,6 +18,7 @@
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
 #include "4C_scatra_ele_parameter_turbulence.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/scatra_ele/4C_scatra_ele_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.cpp
@@ -23,6 +23,7 @@
 #include "4C_scatra_ele_factory.hpp"
 #include "4C_scatra_ele_hdg_boundary_calc.hpp"
 #include "4C_scatra_ele_interface.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 

--- a/src/scatra_ele/4C_scatra_ele_hdg_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg_boundary_calc.cpp
@@ -10,6 +10,7 @@
 #include "4C_fem_general_node.hpp"
 #include "4C_scatra_ele_action.hpp"
 #include "4C_scatra_ele_hdg.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_parameter_boundary.cpp
+++ b/src/scatra_ele/4C_scatra_ele_parameter_boundary.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_scatra_ele_parameter_boundary.hpp"
 
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_singleton_owner.hpp"
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
@@ -148,29 +148,6 @@ namespace NOX
         linear_system_undefined
       };
 
-      /// Map linear system type to std::string
-      inline std::string linear_system_type_to_string(const enum LinearSystemType type)
-      {
-        switch (type)
-        {
-          case linear_system_structure:
-            return "linear_system_structure";
-          case linear_system_structure_contact:
-            return "linear_system_structure_contact";
-          case linear_system_structure_cardiovascular0d:
-            return "linear_system_structure_cardiovascular0d";
-          case linear_system_structure_lag_pen_constraint:
-            return "linear_system_structure_lag_pen_constraint";
-          case linear_system_undefined:
-            return "linear_system_undefined";
-          case linear_system_scatra:
-            return "linear_system_scatra";
-          default:
-            return "unknown operator type";
-        }
-        exit(EXIT_FAILURE);
-      };
-
       //! List of types of epetra objects that can be used for the Jacobian and/or Preconditioner.
       enum OperatorType : int
       {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -693,8 +693,8 @@ const Core::LinAlg::SparseMatrix& NOX::Nln::LinearSystem::get_jacobian_block(
     }
     default:
     {
-      FOUR_C_THROW("Unsupported LinSystem::OperatorType: {} | {}", jacType_,
-          NOX::Nln::LinSystem::operator_type_to_string(jacType_).c_str());
+      FOUR_C_THROW("Unsupported LinSystem::OperatorType: {}",
+          NOX::Nln::LinSystem::operator_type_to_string(jacType_));
       exit(EXIT_FAILURE);
     }
   }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
@@ -15,6 +15,7 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_globaldata.hpp"
 #include "4C_structure_new_nox_nln_str_linearsystem.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <NOX_Epetra_Interface_Jacobian.H>
@@ -119,8 +120,8 @@ Teuchos::RCP<::NOX::Epetra::LinearSystem> NOX::Nln::LinSystem::Factory::build_li
     {
       FOUR_C_THROW(
           "ERROR - NOX::Nln::LinSystem::Factory::BuildLinearSystem - "
-          "No capable LinearSystem constructor was found (enum = {}|{})!",
-          NOX::Nln::LinSystem::linear_system_type_to_string(linsystype).c_str(), linsystype);
+          "No capable LinearSystem constructor was found (enum = {})!",
+          linsystype);
       break;
     }
   }  // end switch

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -850,7 +850,7 @@ void SSI::SSIBase::check_adaptive_time_stepping(
           structparams.sublist("TIMEADAPTIVITY"), "KIND") != Inpar::Solid::timada_kind_none)
     FOUR_C_THROW("Adaptive time stepping in SSI currently just from ScaTra");
   if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(structparams, "DYNAMICTYPE") ==
-      Inpar::Solid::dyna_ab2)
+      Inpar::Solid::DynamicType::AdamsBashforth2)
     FOUR_C_THROW("Currently, only one step methods are allowed for adaptive time stepping");
 }
 

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -486,7 +486,7 @@ void SSI::SsiMono::init(MPI_Comm comm, const Teuchos::ParameterList& globaltimep
     FOUR_C_THROW("Invalid type of velocity field for scalar-structure interaction!");
 
   if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(structparams, "DYNAMICTYPE") ==
-      Inpar::Solid::DynamicType::dyna_statics)
+      Inpar::Solid::DynamicType::Statics)
     FOUR_C_THROW(
         "Mass conservation is not fulfilled if 'Statics' time integration is chosen since the "
         "deformation velocities are incorrectly calculated.\n"

--- a/src/ssi/4C_ssi_partitioned_2wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_2wc.cpp
@@ -53,7 +53,7 @@ void SSI::SSIPart2WC::init(MPI_Comm comm, const Teuchos::ParameterList& globalti
   {
     auto structtimealgo =
         Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(structparams, "DYNAMICTYPE");
-    if (structtimealgo == Inpar::Solid::dyna_statics)
+    if (structtimealgo == Inpar::Solid::DynamicType::Statics)
     {
       FOUR_C_THROW(
           "If you use statics as the structural time integrator no velocities will be calculated "

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -130,7 +130,7 @@ void SSTI::SSTIAlgorithm::init(MPI_Comm comm, const Teuchos::ParameterList& ssti
             structparams.sublist("TIMEADAPTIVITY"), "KIND") != Inpar::Solid::timada_kind_none)
       FOUR_C_THROW("Adaptive time stepping in SSI currently just from ScaTra");
     if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(structparams, "DYNAMICTYPE") ==
-        Inpar::Solid::dyna_ab2)
+        Inpar::Solid::DynamicType::AdamsBashforth2)
       FOUR_C_THROW("Currently, only one step methods are allowed for adaptive time stepping");
   }
 

--- a/src/structure/4C_structure_dyn_nln_drt.cpp
+++ b/src/structure/4C_structure_dyn_nln_drt.cpp
@@ -40,14 +40,14 @@ void caldyn_drt()
   // major switch to different time integrators
   switch (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE"))
   {
-    case Inpar::Solid::dyna_statics:
-    case Inpar::Solid::dyna_genalpha:
-    case Inpar::Solid::dyna_genalpha_liegroup:
-    case Inpar::Solid::dyna_onesteptheta:
-    case Inpar::Solid::dyna_expleuler:
-    case Inpar::Solid::dyna_centrdiff:
-    case Inpar::Solid::dyna_ab2:
-    case Inpar::Solid::dyna_ab4:
+    case Inpar::Solid::DynamicType::Statics:
+    case Inpar::Solid::DynamicType::GenAlpha:
+    case Inpar::Solid::DynamicType::GenAlphaLieGroup:
+    case Inpar::Solid::DynamicType::OneStepTheta:
+    case Inpar::Solid::DynamicType::ExplEuler:
+    case Inpar::Solid::DynamicType::CentrDiff:
+    case Inpar::Solid::DynamicType::AdamsBashforth2:
+    case Inpar::Solid::DynamicType::AdamsBashforth4:
       dyn_nlnstructural_drt();
       break;
     default:

--- a/src/structure/4C_structure_timada.cpp
+++ b/src/structure/4C_structure_timada.cpp
@@ -470,7 +470,7 @@ void Solid::TimAda::print_constants(std::ostream& str) const
       << "   Max size ratio = " << sizeratiomax_ << std::endl
       << "   Min size ratio = " << sizeratiomin_ << std::endl
       << "   Size ratio scale = " << sizeratioscale_ << std::endl
-      << "   Error norm = " << Inpar::Solid::vector_norm_string(errnorm_) << std::endl
+      << "   Error norm = " << Inpar::Solid::magic_enum::enum_name(errnorm_) << std::endl
       << "   Error order = " << errorder_ << std::endl
       << "   Error tolerance = " << errtol_ << std::endl
       << "   Max adaptations = " << adaptstepmax_ << std::endl;

--- a/src/structure/4C_structure_timada.cpp
+++ b/src/structure/4C_structure_timada.cpp
@@ -470,7 +470,7 @@ void Solid::TimAda::print_constants(std::ostream& str) const
       << "   Max size ratio = " << sizeratiomax_ << std::endl
       << "   Min size ratio = " << sizeratiomin_ << std::endl
       << "   Size ratio scale = " << sizeratioscale_ << std::endl
-      << "   Error norm = " << Inpar::Solid::magic_enum::enum_name(errnorm_) << std::endl
+      << "   Error norm = " << errnorm_ << std::endl
       << "   Error order = " << errorder_ << std::endl
       << "   Error tolerance = " << errtol_ << std::endl
       << "   Max adaptations = " << adaptstepmax_ << std::endl;

--- a/src/structure/4C_structure_timada_joint.hpp
+++ b/src/structure/4C_structure_timada_joint.hpp
@@ -57,13 +57,13 @@ namespace Solid
     {
       switch (term)
       {
-        case Inpar::Solid::dyna_ab2:
+        case Inpar::Solid::DynamicType::AdamsBashforth2:
           return Inpar::Solid::timada_kind_ab2;
           break;
-        case Inpar::Solid::dyna_expleuler:
+        case Inpar::Solid::DynamicType::ExplEuler:
           return Inpar::Solid::timada_kind_expleuler;
           break;
-        case Inpar::Solid::dyna_centrdiff:
+        case Inpar::Solid::DynamicType::CentrDiff:
           return Inpar::Solid::timada_kind_centraldiff;
           break;
         default:

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -1265,7 +1265,7 @@ void Solid::TimInt::update_step_contact_vum()
       double beta = 0.0;
       double gamma = 0.0;
       if (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdynparams, "DYNAMICTYPE") ==
-          Inpar::Solid::dyna_genalpha)
+          Inpar::Solid::DynamicType::GenAlpha)
       {
         auto* genAlpha = dynamic_cast<Solid::TimIntGenAlpha*>(this);
         alpham = genAlpha->tim_int_param_alpham();
@@ -2565,7 +2565,7 @@ void Solid::TimInt::nonlinear_mass_sanity_check(
   {
     if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_rotations and
         Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(*sdynparams, "DYNAMICTYPE") !=
-            Inpar::Solid::dyna_genalpha)
+            Inpar::Solid::DynamicType::GenAlpha)
     {
       FOUR_C_THROW(
           "Nonlinear inertia forces for rotational DoFs only implemented "
@@ -2842,6 +2842,11 @@ void Solid::TimInt::set_force_interface(
 )
 {
   fifc_->update(1.0, *iforce, 0.0);
+}
+
+std::string Solid::TimInt::method_title() const
+{
+  return std::string(magic_enum::enum_name(method_name()));
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -542,7 +542,7 @@ namespace Solid
     virtual enum Inpar::Solid::DynamicType method_name() const = 0;
 
     //! Provide title
-    std::string method_title() const { return Inpar::Solid::dynamic_type_string(method_name()); }
+    std::string method_title() const;
 
     //! Return true, if time integrator is implicit
     virtual bool method_implicit() = 0;

--- a/src/structure/4C_structure_timint_ab2.hpp
+++ b/src/structure/4C_structure_timint_ab2.hpp
@@ -122,7 +122,10 @@ namespace Solid
     //@{
 
     //! Return time integrator name
-    enum Inpar::Solid::DynamicType method_name() const override { return Inpar::Solid::dyna_ab2; }
+    enum Inpar::Solid::DynamicType method_name() const override
+    {
+      return Inpar::Solid::DynamicType::AdamsBashforth2;
+    }
 
     //! Provide number of steps, e.g. a single-step method returns 1,
     //! a m-multistep method returns m

--- a/src/structure/4C_structure_timint_centrdiff.hpp
+++ b/src/structure/4C_structure_timint_centrdiff.hpp
@@ -133,7 +133,7 @@ namespace Solid
     //! Return time integrator name
     enum Inpar::Solid::DynamicType method_name() const override
     {
-      return Inpar::Solid::dyna_centrdiff;
+      return Inpar::Solid::DynamicType::CentrDiff;
     }
 
     //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure/4C_structure_timint_create.cpp
+++ b/src/structure/4C_structure_timint_create.cpp
@@ -79,7 +79,7 @@ std::shared_ptr<Solid::TimIntImpl> Solid::tim_int_impl_create(
   switch (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE"))
   {
     // Static analysis
-    case Inpar::Solid::dyna_statics:
+    case Inpar::Solid::DynamicType::Statics:
     {
       sti = std::make_shared<Solid::TimIntStatics>(
           timeparams, ioflags, sdyn, xparams, actdis, solver, contactsolver, output);
@@ -87,7 +87,7 @@ std::shared_ptr<Solid::TimIntImpl> Solid::tim_int_impl_create(
     }
 
     // Generalised-alpha time integration
-    case Inpar::Solid::dyna_genalpha:
+    case Inpar::Solid::DynamicType::GenAlpha:
     {
       sti = std::make_shared<Solid::TimIntGenAlpha>(
           timeparams, ioflags, sdyn, xparams, actdis, solver, contactsolver, output);
@@ -95,7 +95,7 @@ std::shared_ptr<Solid::TimIntImpl> Solid::tim_int_impl_create(
     }
 
     // One-step-theta (OST) time integration
-    case Inpar::Solid::dyna_onesteptheta:
+    case Inpar::Solid::DynamicType::OneStepTheta:
     {
       sti = std::make_shared<Solid::TimIntOneStepTheta>(
           timeparams, ioflags, sdyn, xparams, actdis, solver, contactsolver, output);
@@ -140,21 +140,21 @@ std::shared_ptr<Solid::TimIntExpl> Solid::tim_int_expl_create(
   switch (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE"))
   {
     // forward Euler time integration
-    case Inpar::Solid::dyna_expleuler:
+    case Inpar::Solid::DynamicType::ExplEuler:
     {
       sti = std::make_shared<Solid::TimIntExplEuler>(
           timeparams, ioflags, sdyn, xparams, actdis, solver, contactsolver, output);
       break;
     }
     // central differences time integration
-    case Inpar::Solid::dyna_centrdiff:
+    case Inpar::Solid::DynamicType::CentrDiff:
     {
       sti = std::make_shared<Solid::TimIntCentrDiff>(
           timeparams, ioflags, sdyn, xparams, actdis, solver, contactsolver, output);
       break;
     }
     // Adams-Bashforth 2nd order (AB2) time integration
-    case Inpar::Solid::dyna_ab2:
+    case Inpar::Solid::DynamicType::AdamsBashforth2:
     {
       sti = std::make_shared<Solid::TimIntAB2>(
           timeparams, ioflags, sdyn, xparams, actdis, solver, contactsolver, output);

--- a/src/structure/4C_structure_timint_expleuler.hpp
+++ b/src/structure/4C_structure_timint_expleuler.hpp
@@ -119,7 +119,7 @@ namespace Solid
     //! Return time integrator name
     enum Inpar::Solid::DynamicType method_name() const override
     {
-      return Inpar::Solid::dyna_expleuler;
+      return Inpar::Solid::DynamicType::ExplEuler;
     }
 
     //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure/4C_structure_timint_genalpha.cpp
+++ b/src/structure/4C_structure_timint_genalpha.cpp
@@ -17,6 +17,7 @@
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_structure_aux.hpp"
 #include "4C_structure_new_impl_genalpha.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -76,7 +77,7 @@ void Solid::TimIntGenAlpha::verify_coeff()
   if (midavg_ != Inpar::Solid::midavg_trlike)
     FOUR_C_THROW("mid-averaging of internal forces only implemented TR-like");
   else
-    std::cout << "   midavg = " << Inpar::Solid::mid_average_string(midavg_) << '\n';
+    std::cout << "   midavg = " << midavg_ << '\n';
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/structure/4C_structure_timint_genalpha.hpp
+++ b/src/structure/4C_structure_timint_genalpha.hpp
@@ -121,7 +121,7 @@ namespace Solid
     //! Return name
     enum Inpar::Solid::DynamicType method_name() const override
     {
-      return Inpar::Solid::dyna_genalpha;
+      return Inpar::Solid::DynamicType::GenAlpha;
     }
 
     //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -36,6 +36,7 @@
 #include "4C_solid_3D_ele.hpp"
 #include "4C_structure_aux.hpp"
 #include "4C_structure_timint.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
@@ -199,22 +200,21 @@ void Solid::TimIntImpl::setup()
   {
     if ((itertype_ != Inpar::Solid::soltech_newtonuzawalin) and
         (itertype_ != Inpar::Solid::soltech_newtonuzawanonlin))
-      FOUR_C_THROW("Chosen solution technique {} does not work constrained.",
-          Inpar::Solid::nonlin_sol_tech_string(itertype_).c_str());
+      FOUR_C_THROW("Chosen solution technique {} does not work constrained.", itertype_);
   }
   else if (cardvasc0dman_->have_cardiovascular0_d())
   {
     if (itertype_ != Inpar::Solid::soltech_newtonuzawalin)
       if (myrank_ == 0)
-        FOUR_C_THROW("Chosen solution technique {} does not work with Cardiovascular0D bc.",
-            Inpar::Solid::nonlin_sol_tech_string(itertype_).c_str());
+        FOUR_C_THROW(
+            "Chosen solution technique {} does not work with Cardiovascular0D bc.", itertype_);
   }
   else if ((itertype_ == Inpar::Solid::soltech_newtonuzawalin) or
            (itertype_ == Inpar::Solid::soltech_newtonuzawanonlin))
   {
     FOUR_C_THROW(
         "Chosen solution technique {} does only work constrained or with Cardiovascular0D bc.",
-        Inpar::Solid::nonlin_sol_tech_string(itertype_).c_str());
+        itertype_);
   }
 
   // setup tolerances and binary operators for convergence check of contact/meshtying problems
@@ -1414,8 +1414,7 @@ Inpar::Solid::ConvergenceStatus Solid::TimIntImpl::solve()
         break;
       // catch problems
       default:
-        FOUR_C_THROW("Solution technique \"{}\" is not implemented.",
-            Inpar::Solid::nonlin_sol_tech_string(itertype_).c_str());
+        FOUR_C_THROW("Solution technique \"{}\" is not implemented.", itertype_);
         break;
     }
   }

--- a/src/structure/4C_structure_timint_impl_nox.cpp
+++ b/src/structure/4C_structure_timint_impl_nox.cpp
@@ -118,7 +118,8 @@ Teuchos::RCP<::NOX::StatusTest::Combo> Solid::TimIntImpl::nox_create_status_test
   }
   else
   {
-    FOUR_C_THROW("Norm {} is not available", Inpar::Solid::vector_norm_string(iternorm_).c_str());
+    FOUR_C_THROW(
+        "Norm {} is not available", Inpar::Solid::magic_enum::enum_name(iternorm_).c_str());
   }
 
   // combined residual force and displacement test

--- a/src/structure/4C_structure_timint_impl_nox.cpp
+++ b/src/structure/4C_structure_timint_impl_nox.cpp
@@ -118,8 +118,7 @@ Teuchos::RCP<::NOX::StatusTest::Combo> Solid::TimIntImpl::nox_create_status_test
   }
   else
   {
-    FOUR_C_THROW(
-        "Norm {} is not available", Inpar::Solid::magic_enum::enum_name(iternorm_).c_str());
+    FOUR_C_THROW("Norm {} is not available", iternorm_);
   }
 
   // combined residual force and displacement test

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Epetra_CrsMatrix.h>
 #include <Epetra_LinearProblem.h>

--- a/src/structure/4C_structure_timint_ost.hpp
+++ b/src/structure/4C_structure_timint_ost.hpp
@@ -205,7 +205,7 @@ namespace Solid
     //! Return name
     enum Inpar::Solid::DynamicType method_name() const override
     {
-      return Inpar::Solid::dyna_onesteptheta;
+      return Inpar::Solid::DynamicType::OneStepTheta;
     }
 
     //! Provide number of steps, a single-step method returns 1

--- a/src/structure/4C_structure_timint_statics.cpp
+++ b/src/structure/4C_structure_timint_statics.cpp
@@ -54,7 +54,8 @@ void Solid::TimIntStatics::init(const Teuchos::ParameterList& timeparams,
       Teuchos::getIntegralValue<Inpar::Solid::PreStress>(
           Global::Problem::instance()->structural_dynamic_params(), "PRESTRESS");
 
-  if (pre_stress_type != Inpar::Solid::PreStress::none && dyntype != Inpar::Solid::dyna_statics)
+  if (pre_stress_type != Inpar::Solid::PreStress::none &&
+      dyntype != Inpar::Solid::DynamicType::Statics)
   {
     FOUR_C_THROW(
         "Paranoia Error: PRESTRESS is only allowed in combinations with DYNAMICTYPE Statics!!");

--- a/src/structure/4C_structure_timint_statics.hpp
+++ b/src/structure/4C_structure_timint_statics.hpp
@@ -110,7 +110,7 @@ namespace Solid
     //! Return name
     enum Inpar::Solid::DynamicType method_name() const override
     {
-      return Inpar::Solid::dyna_statics;
+      return Inpar::Solid::DynamicType::Statics;
     }
 
     //! Provide number of steps, a single-step method returns 1

--- a/src/structure_new/src/4C_structure_new_factory.cpp
+++ b/src/structure_new/src/4C_structure_new_factory.cpp
@@ -64,28 +64,28 @@ std::shared_ptr<Solid::Integrator> Solid::Factory::build_implicit_integrator(
   switch (dyntype)
   {
     // Static analysis
-    case Inpar::Solid::dyna_statics:
+    case Inpar::Solid::DynamicType::Statics:
     {
       impl_int_ptr = std::make_shared<Solid::IMPLICIT::Statics>();
       break;
     }
 
     // Generalised-alpha time integration
-    case Inpar::Solid::dyna_genalpha:
+    case Inpar::Solid::DynamicType::GenAlpha:
     {
       impl_int_ptr = std::make_shared<Solid::IMPLICIT::GenAlpha>();
       break;
     }
 
     // Generalised-alpha time integration for Lie groups (e.g. SO3 group of rotation matrices)
-    case Inpar::Solid::dyna_genalpha_liegroup:
+    case Inpar::Solid::DynamicType::GenAlphaLieGroup:
     {
       impl_int_ptr = std::make_shared<Solid::IMPLICIT::GenAlphaLieGroup>();
       break;
     }
 
     // One-step-theta (OST) time integration
-    case Inpar::Solid::dyna_onesteptheta:
+    case Inpar::Solid::DynamicType::OneStepTheta:
     {
       impl_int_ptr = std::make_shared<Solid::IMPLICIT::OneStepTheta>();
       break;
@@ -112,28 +112,28 @@ std::shared_ptr<Solid::Integrator> Solid::Factory::build_explicit_integrator(
   switch (datasdyn.get_dynamic_type())
   {
     // Forward Euler Scheme
-    case Inpar::Solid::dyna_expleuler:
+    case Inpar::Solid::DynamicType::ExplEuler:
     {
       expl_int_ptr = std::make_shared<Solid::EXPLICIT::ForwardEuler>();
       break;
     }
 
     // Central Difference Scheme
-    case Inpar::Solid::dyna_centrdiff:
+    case Inpar::Solid::DynamicType::CentrDiff:
     {
       expl_int_ptr = std::make_shared<Solid::EXPLICIT::CentrDiff>();
       break;
     }
 
     // Adams-Bashforth-2 Scheme
-    case Inpar::Solid::dyna_ab2:
+    case Inpar::Solid::DynamicType::AdamsBashforth2:
     {
       expl_int_ptr = std::make_shared<Solid::EXPLICIT::AdamsBashforth2>();
       break;
     }
 
     // Adams-Bashforth-4 Scheme
-    case Inpar::Solid::dyna_ab4:
+    case Inpar::Solid::DynamicType::AdamsBashforth4:
     {
       expl_int_ptr = std::make_shared<Solid::EXPLICIT::AdamsBashforthX<4>>();
       break;

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -800,7 +800,7 @@ bool Solid::Integrator::MidTimeEnergy::is_correctly_configured() const
 
   if (avg_type_ == Inpar::Solid::midavg_vague)
   {
-    if (integrator_.s_dyn().get_dynamic_type() != Inpar::Solid::dyna_statics) return false;
+    if (integrator_.s_dyn().get_dynamic_type() != Inpar::Solid::DynamicType::Statics) return false;
   }
   return true;
 }

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -947,4 +947,9 @@ bool Solid::TimeInt::Base::has_final_state_been_written() const
   return dataio_->get_last_written_results() == dataglobalstate_->get_step_n();
 }
 
+std::string Solid::TimeInt::Base::method_title() const
+{
+  return std::string(magic_enum::enum_name(method_name()));
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/structure_new/src/4C_structure_new_timint_base.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.hpp
@@ -668,7 +668,7 @@ namespace Solid
       virtual enum Inpar::Solid::DynamicType method_name() const = 0;
 
       //! Provide title
-      std::string method_title() const { return Inpar::Solid::dynamic_type_string(method_name()); }
+      std::string method_title() const;
 
       //! Return true, if time integrator is implicit
       virtual bool is_implicit() const = 0;

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -217,7 +217,7 @@ void Solid::TimeInt::BaseDataGlobalState::setup()
     }
   }
 
-  if (datasdyn_->get_dynamic_type() == Inpar::Solid::dyna_statics and
+  if (datasdyn_->get_dynamic_type() == Inpar::Solid::DynamicType::Statics and
       datasdyn_->get_mass_lin_type() != Inpar::Solid::MassLin::ml_none)
     FOUR_C_THROW(
         "Do not set parameter MASSLIN in static simulations as this leads to undesired"

--- a/src/structure_new/src/4C_structure_new_timint_basedatasdyn.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedatasdyn.cpp
@@ -37,7 +37,7 @@ Solid::TimeInt::BaseDataSDyn::BaseDataSDyn()
       modeltypes_(nullptr),
       eletechs_(nullptr),
       coupling_model_ptr_(nullptr),
-      dyntype_(Inpar::Solid::dyna_statics),
+      dyntype_(Inpar::Solid::DynamicType::Statics),
       stcscale_(Inpar::Solid::stc_inactive),
       stclayer_(-1),
       itermin_(-1),

--- a/src/structure_new/src/4C_structure_new_timint_factory.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_factory.cpp
@@ -67,9 +67,10 @@ std::shared_ptr<Solid::TimeInt::Base> Solid::TimeInt::Factory::build_implicit_st
   const bool is_prestress = Teuchos::getIntegralValue<Inpar::Solid::PreStress>(
                                 Global::Problem::instance()->structural_dynamic_params(),
                                 "PRESTRESS") != Inpar::Solid::PreStress::none;
-  if (is_prestress or dyntype == Inpar::Solid::dyna_statics or  // dynamic type
-      dyntype == Inpar::Solid::dyna_genalpha or dyntype == Inpar::Solid::dyna_genalpha_liegroup or
-      dyntype == Inpar::Solid::dyna_onesteptheta)
+  if (is_prestress or dyntype == Inpar::Solid::DynamicType::Statics or  // dynamic type
+      dyntype == Inpar::Solid::DynamicType::GenAlpha or
+      dyntype == Inpar::Solid::DynamicType::GenAlphaLieGroup or
+      dyntype == Inpar::Solid::DynamicType::OneStepTheta)
     ti_strategy = std::make_shared<Solid::TimeInt::Implicit>();
 
   return ti_strategy;
@@ -92,8 +93,10 @@ std::shared_ptr<Solid::TimeInt::Base> Solid::TimeInt::Factory::build_explicit_st
 
   const auto dyntype = Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE");
 
-  if (dyntype == Inpar::Solid::dyna_expleuler or dyntype == Inpar::Solid::dyna_centrdiff or
-      dyntype == Inpar::Solid::dyna_ab2 or dyntype == Inpar::Solid::dyna_ab4)
+  if (dyntype == Inpar::Solid::DynamicType::ExplEuler or
+      dyntype == Inpar::Solid::DynamicType::CentrDiff or
+      dyntype == Inpar::Solid::DynamicType::AdamsBashforth2 or
+      dyntype == Inpar::Solid::DynamicType::AdamsBashforth4)
     ti_strategy = std::make_shared<Solid::TimeInt::Explicit>();
 
   return ti_strategy;
@@ -110,14 +113,14 @@ std::shared_ptr<Solid::TimeInt::BaseDataSDyn> Solid::TimeInt::Factory::build_dat
 
   switch (dyntype)
   {
-    case Inpar::Solid::dyna_genalpha:
-    case Inpar::Solid::dyna_genalpha_liegroup:
+    case Inpar::Solid::DynamicType::GenAlpha:
+    case Inpar::Solid::DynamicType::GenAlphaLieGroup:
       sdyndata_ptr = std::make_shared<Solid::TimeInt::GenAlphaDataSDyn>();
       break;
-    case Inpar::Solid::dyna_onesteptheta:
+    case Inpar::Solid::DynamicType::OneStepTheta:
       sdyndata_ptr = std::make_shared<Solid::TimeInt::OneStepThetaDataSDyn>();
       break;
-    case Inpar::Solid::dyna_expleuler:
+    case Inpar::Solid::DynamicType::ExplEuler:
       sdyndata_ptr = std::make_shared<Solid::TimeInt::ExplEulerDataSDyn>();
       break;
     default:

--- a/src/structure_new/src/explicit/4C_structure_new_expl_ab2.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_ab2.hpp
@@ -64,7 +64,7 @@ namespace Solid
       //! Return time integrator name
       [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_ab2;
+        return Inpar::Solid::DynamicType::AdamsBashforth2;
       }
 
       //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure_new/src/explicit/4C_structure_new_expl_abx.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_abx.hpp
@@ -73,7 +73,7 @@ namespace Solid
       //! Return time integrator name
       [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_ab4;
+        return Inpar::Solid::DynamicType::AdamsBashforth4;
       }
 
       //! Provide number of steps, e.g. a single-step method returns 1,
@@ -129,7 +129,10 @@ namespace Solid
     struct AdamsBashforthHelper<2>
     {
       static constexpr std::array<double, 2> exc{{1.5, -0.5}};  // extrapolation coefficients
-      static enum Inpar::Solid::DynamicType method_name() { return Inpar::Solid::dyna_ab2; }
+      static enum Inpar::Solid::DynamicType method_name()
+      {
+        return Inpar::Solid::DynamicType::AdamsBashforth2;
+      }
     };
 
     template <>
@@ -137,7 +140,10 @@ namespace Solid
     {
       static constexpr std::array<double, 4> exc{
           {55.0 / 24.0, -59.0 / 24.0, 37.0 / 24.0, -9.0 / 24.0}};  // extrapolation coefficients
-      static enum Inpar::Solid::DynamicType method_name() { return Inpar::Solid::dyna_ab4; }
+      static enum Inpar::Solid::DynamicType method_name()
+      {
+        return Inpar::Solid::DynamicType::AdamsBashforth4;
+      }
     };
 
     //@}

--- a/src/structure_new/src/explicit/4C_structure_new_expl_centrdiff.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_centrdiff.hpp
@@ -64,7 +64,7 @@ namespace Solid
       //! Return time integrator name
       [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_centrdiff;
+        return Inpar::Solid::DynamicType::CentrDiff;
       }
 
       //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure_new/src/explicit/4C_structure_new_expl_forwardeuler.hpp
+++ b/src/structure_new/src/explicit/4C_structure_new_expl_forwardeuler.hpp
@@ -64,7 +64,7 @@ namespace Solid
       //! Return time integrator name
       [[nodiscard]] enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_expleuler;
+        return Inpar::Solid::DynamicType::ExplEuler;
       }
 
       //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
@@ -50,8 +50,8 @@ void Solid::TimeInt::Explicit::setup()
   if (nlnSolverType != Inpar::Solid::soltech_singlestep)
   {
     std::cout << "WARNING!!!Nonlinear solver for explicit dynamics is given (in the input file) as "
-              << Inpar::Solid::nonlin_sol_tech_string(nlnSolverType)
-              << ". This is not compatible. singlestep solver will be selected." << std::endl;
+              << nlnSolverType << ". This is not compatible. singlestep solver will be selected."
+              << std::endl;
     nlnSolverType = Inpar::Solid::soltech_singlestep;
   }
   nlnsolver_ptr_ = Solid::Nln::SOLVER::build_nln_solver(nlnSolverType);

--- a/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.cpp
@@ -97,7 +97,7 @@ void Solid::IMPLICIT::GenAlpha::setup()
     if (midavg != Inpar::Solid::midavg_trlike)
       FOUR_C_THROW("mid-averaging of internal forces only implemented TR-like");
     else
-      std::cout << "   midavg = " << Inpar::Solid::mid_average_string(midavg) << std::endl;
+      std::cout << "   midavg = " << midavg << std::endl;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_genalpha.hpp
@@ -155,7 +155,7 @@ namespace Solid
       //! Return name
       enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_genalpha;
+        return Inpar::Solid::DynamicType::GenAlpha;
       }
 
       //! Provide number of steps, e.g. a single-step method returns 1,

--- a/src/structure_new/src/implicit/4C_structure_new_impl_ost.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_ost.hpp
@@ -125,7 +125,7 @@ namespace Solid
       //! Return name
       enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_onesteptheta;
+        return Inpar::Solid::DynamicType::OneStepTheta;
       }
 
       //! Provide number of steps, a single-step method returns 1

--- a/src/structure_new/src/implicit/4C_structure_new_impl_statics.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_statics.hpp
@@ -103,7 +103,7 @@ namespace Solid
       //! Return name
       enum Inpar::Solid::DynamicType method_name() const override
       {
-        return Inpar::Solid::dyna_statics;
+        return Inpar::Solid::DynamicType::Statics;
       }
 
       //! Provide number of steps, a single-step method returns 1

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_factory.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_factory.cpp
@@ -12,6 +12,7 @@
 #include "4C_structure_new_nln_solver_ptc.hpp"
 #include "4C_structure_new_nln_solver_singlestep.hpp"
 #include "4C_structure_new_nln_solver_uzawa.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -48,8 +49,7 @@ std::shared_ptr<Solid::Nln::SOLVER::Generic> Solid::Nln::SOLVER::Factory::build_
       //      nlnSolver = Teuchos::rcp(new Solid::Nln::SOLVER::Uzawa());
       //      break;
     default:
-      FOUR_C_THROW("Solution technique \"{}\" is not implemented.",
-          Inpar::Solid::nonlin_sol_tech_string(nlnSolType).c_str());
+      FOUR_C_THROW("Solution technique \"{}\" is not implemented.", nlnSolType);
       break;
   }
 

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -449,9 +449,8 @@ double Solid::TimeInt::NoxInterface::get_model_value(const Epetra_Vector& x, con
     }
     default:
     {
-      FOUR_C_THROW("There is no objective model value for {} | {}.",
-          NOX::Nln::MeritFunction::merit_func_name_to_string(merit_func_type).c_str(),
-          merit_func_type);
+      FOUR_C_THROW("There is no objective model value for {}.",
+          NOX::Nln::MeritFunction::merit_func_name_to_string(merit_func_type).c_str());
       exit(EXIT_FAILURE);
     }
   }
@@ -473,8 +472,8 @@ double Solid::TimeInt::NoxInterface::get_linearized_model_terms(const ::NOX::Abs
       return 0.0;
     default:
     {
-      FOUR_C_THROW("There is no linearization for the objective model {} | {}.",
-          NOX::Nln::MeritFunction::merit_func_name_to_string(mf_type).c_str(), mf_type);
+      FOUR_C_THROW("There is no linearization for the objective model {}.",
+          NOX::Nln::MeritFunction::merit_func_name_to_string(mf_type));
       exit(EXIT_FAILURE);
     }
   }

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -73,7 +73,7 @@ enum ::NOX::Abstract::Vector::NormType Solid::Nln::convert2_nox_norm_type(
     case Inpar::Solid::norm_vague:
     default:
       FOUR_C_THROW("Unknown conversion for the given vector norm type: \" {} \"!",
-          Inpar::Solid::vector_norm_string(normtype).c_str());
+          Inpar::Solid::magic_enum::enum_name(normtype).c_str());
       break;
   }  // switch case normtype
 

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -72,8 +72,7 @@ enum ::NOX::Abstract::Vector::NormType Solid::Nln::convert2_nox_norm_type(
     case Inpar::Solid::norm_rms:
     case Inpar::Solid::norm_vague:
     default:
-      FOUR_C_THROW("Unknown conversion for the given vector norm type: \" {} \"!",
-          Inpar::Solid::magic_enum::enum_name(normtype).c_str());
+      FOUR_C_THROW("Unknown conversion for the given vector norm type: \" {} \"!", normtype);
       break;
   }  // switch case normtype
 

--- a/src/thermo/src/4C_thermo_adapter.cpp
+++ b/src/thermo/src/4C_thermo_adapter.cpp
@@ -13,6 +13,7 @@
 #include "4C_thermo_timint_genalpha.hpp"
 #include "4C_thermo_timint_ost.hpp"
 #include "4C_thermo_timint_statics.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>
@@ -63,19 +64,19 @@ Thermo::BaseAlgorithm::BaseAlgorithm(
 
   switch (timinttype)
   {
-    case Thermo::dyna_statics:
+    case Thermo::DynamicType::Statics:
     {
       thermo_ = std::make_shared<Thermo::TimIntStatics>(
           ioflags, parameters, xparams, actdis, solver, output);
       break;
     }
-    case Thermo::dyna_onesteptheta:
+    case Thermo::DynamicType::OneStepTheta:
     {
       thermo_ = std::make_shared<Thermo::TimIntOneStepTheta>(
           ioflags, parameters, xparams, actdis, solver, output);
       break;
     }
-    case Thermo::dyna_genalpha:
+    case Thermo::DynamicType::GenAlpha:
     {
       thermo_ = std::make_shared<Thermo::TimIntGenAlpha>(
           ioflags, parameters, xparams, actdis, solver, output);

--- a/src/thermo/src/element/4C_thermo_ele_action.hpp
+++ b/src/thermo/src/element/4C_thermo_ele_action.hpp
@@ -50,57 +50,6 @@ namespace Thermo
     calc_thermo_fextconvection_coupltang,
   };
 
-  /*!
-   * \brief translate to string for screen output
-   */
-  inline std::string action_to_string(const Action action)
-  {
-    switch (action)
-    {
-      case none:
-        return "none";
-      case calc_thermo_fint:
-        return "calc_thermo_fint";
-      case calc_thermo_fintcapa:
-        return "calc_thermo_fintcapa";
-      case calc_thermo_finttang:
-        return "calc_thermo_finttang";
-      case calc_thermo_heatflux:
-        return "calc_thermo_heatflux";
-      case postproc_thermo_heatflux:
-        return "postproc_thermo_heatflux";
-      case integrate_shape_functions:
-        return "integrate_shape_functions";
-      case calc_thermo_update_istep:
-        return "calc_thermo_update_istep";
-      case calc_thermo_reset_istep:
-        return "calc_thermo_reset_istep";
-      case calc_thermo_energy:
-        return "calc_thermo_energy";
-      case calc_thermo_coupltang:
-        return "calc_thermo_coupltang";
-      case calc_thermo_fintcond:
-        return "calc_thermo_fintcond";
-      default:
-        FOUR_C_THROW("no string for action {} defined!", action);
-    };
-  }
-
-  inline std::string boundary_action_to_string(const BoundaryAction baction)
-  {
-    switch (baction)
-    {
-      case boundary_none:
-        return "boundary_none";
-      case calc_thermo_fextconvection:
-        return "calc_thermo_fextconvection";
-      case calc_thermo_fextconvection_coupltang:
-        return "calc_thermo_fextconvection_coupltang";
-      default:
-        FOUR_C_THROW("no string for the boundary action {} defined!", baction);
-    };
-  }
-
 }  // namespace Thermo
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
@@ -17,6 +17,7 @@
 #include "4C_global_data.hpp"
 #include "4C_thermo_ele_action.hpp"
 #include "4C_thermo_input.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 #include "4C_utils_function_of_time.hpp"
 
@@ -286,17 +287,18 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
 
     // BUILD EFFECTIVE TANGENT AND RESIDUAL ACC TO TIME INTEGRATOR
     // check the time integrator
-    const auto timint = params.get<Thermo::DynamicType>("time integrator", Thermo::dyna_undefined);
+    const auto timint =
+        params.get<Thermo::DynamicType>("time integrator", Thermo::DynamicType::Undefined);
     switch (timint)
     {
-      case Thermo::dyna_statics:
+      case Thermo::DynamicType::Statics:
       {
         if (*tempstate == "Tempn")
           FOUR_C_THROW("Old temperature T_n is not allowed with static time integrator");
         // continue
         break;
       }
-      case Thermo::dyna_onesteptheta:
+      case Thermo::DynamicType::OneStepTheta:
       {
         // Note: efext is scaled with theta in thrtimint_ost.cpp. Because the
         // convective boundary condition is nonlinear and produces a term in the
@@ -306,14 +308,14 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
         etang.scale(theta);
         break;
       }
-      case Thermo::dyna_genalpha:
+      case Thermo::DynamicType::GenAlpha:
       {
         const double alphaf = params.get<double>("alphaf");
         // combined tangent and conductivity matrix to one global matrix
         etang.scale(alphaf);
         break;
       }
-      case Thermo::dyna_undefined:
+      case Thermo::DynamicType::Undefined:
       default:
       {
         FOUR_C_THROW("Don't know what to do...");
@@ -471,17 +473,17 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
         // BUILD EFFECTIVE TANGENT AND RESIDUAL ACC TO TIME INTEGRATOR
         // check the time integrator
         const auto timint =
-            params.get<Thermo::DynamicType>("time integrator", Thermo::dyna_undefined);
+            params.get<Thermo::DynamicType>("time integrator", Thermo::DynamicType::Undefined);
         switch (timint)
         {
-          case Thermo::dyna_statics:
+          case Thermo::DynamicType::Statics:
           {
             if (*tempstate == "Tempn")
               FOUR_C_THROW("Old temperature T_n is not allowed with static time integrator");
             // continue
             break;
           }
-          case Thermo::dyna_onesteptheta:
+          case Thermo::DynamicType::OneStepTheta:
           {
             // Note: efext is scaled with theta in thrtimint_ost.cpp. Because the
             // convective boundary condition is nonlinear and produces a term in the
@@ -491,7 +493,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
             etangcoupl.scale(theta);
             break;
           }
-          case Thermo::dyna_genalpha:
+          case Thermo::DynamicType::GenAlpha:
           {
             // Note: efext is scaled with theta in thrtimint_ost.cpp. Because the
             // convective boundary condition is nonlinear and produces a term in the
@@ -501,7 +503,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
             etangcoupl.scale(alphaf);
             break;
           }
-          case Thermo::dyna_undefined:
+          case Thermo::DynamicType::Undefined:
           default:
           {
             FOUR_C_THROW("Don't know what to do...");
@@ -514,8 +516,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
   }  // calc_thermo_fextconvection_coupltang
 
   else
-    FOUR_C_THROW("Unknown type of action for Temperature Implementation: {}",
-        Thermo::boundary_action_to_string(action).c_str());
+    FOUR_C_THROW("Unknown type of action for Temperature Implementation: {}", action);
 
   return 0;
 }  // evaluate()

--- a/src/thermo/src/implicit/4C_thermo_timint.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.cpp
@@ -16,6 +16,7 @@
 #include "4C_thermo_ele_action.hpp"
 #include "4C_thermo_resulttest.hpp"
 #include "4C_timestepping_mstep.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
@@ -801,7 +802,7 @@ void Thermo::TimInt::apply_force_tang_internal(
 
   // in case of genalpha extract midpoint temperature rate R_{n+alpha_m}
   // extract it after ClearState() is called.
-  if (method_name() == Thermo::dyna_genalpha)
+  if (method_name() == Thermo::DynamicType::GenAlpha)
   {
     std::shared_ptr<const Core::LinAlg::Vector<double>> ratem =
         p.get<std::shared_ptr<const Core::LinAlg::Vector<double>>>("mid-temprate");

--- a/src/thermo/src/implicit/4C_thermo_timint_genalpha.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_genalpha.cpp
@@ -8,6 +8,7 @@
 #include "4C_thermo_timint_genalpha.hpp"
 
 #include "4C_thermo_ele_action.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
@@ -101,7 +102,7 @@ Thermo::TimIntGenAlpha::TimIntGenAlpha(const Teuchos::ParameterList& ioparams,
               << "   alpha_f = " << alphaf_ << std::endl
               << "   alpha_m = " << alpham_ << std::endl
               << "   gamma = " << gamma_ << std::endl
-              << "   midavg = " << Thermo::mid_average_string(midavg_) << std::endl;
+              << "   midavg = " << magic_enum::enum_name(midavg_) << std::endl;
   }
 
   // determine capacity and initial temperature rates

--- a/src/thermo/src/implicit/4C_thermo_timint_genalpha.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_genalpha.hpp
@@ -70,7 +70,7 @@ namespace Thermo
     //@{
 
     //! Return name
-    enum Thermo::DynamicType method_name() const override { return Thermo::dyna_genalpha; }
+    enum Thermo::DynamicType method_name() const override { return Thermo::DynamicType::GenAlpha; }
 
     //! Consistent predictor with constant temperatures
     //! and consistent temperature rates and temperatures

--- a/src/thermo/src/implicit/4C_thermo_timint_impl.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_impl.cpp
@@ -12,6 +12,7 @@
 #include "4C_thermo_aux.hpp"
 #include "4C_thermo_ele_action.hpp"
 #include "4C_thermo_timint.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 
@@ -356,8 +357,7 @@ Thermo::ConvergenceStatus Thermo::TimIntImpl::solve()
       return newton_full();
     // catch problems
     default:
-      FOUR_C_THROW("Solution technique \"{}\" is not implemented",
-          Thermo::nonlin_sol_tech_string(itertype_).c_str());
+      FOUR_C_THROW("Solution technique \"{}\" is not implemented", itertype_);
       return Thermo::conv_nonlin_fail;  // compiler happiness
   }
 }

--- a/src/thermo/src/implicit/4C_thermo_timint_ost.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_ost.hpp
@@ -143,7 +143,10 @@ namespace Thermo
     //@{
 
     //! Return name
-    enum Thermo::DynamicType method_name() const override { return Thermo::dyna_onesteptheta; }
+    enum Thermo::DynamicType method_name() const override
+    {
+      return Thermo::DynamicType::OneStepTheta;
+    }
 
     //! Consistent predictor with constant temperatures
     //! and consistent temperature rates and temperatures

--- a/src/thermo/src/implicit/4C_thermo_timint_statics.hpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_statics.hpp
@@ -58,7 +58,7 @@ namespace Thermo
     //@{
 
     //! Return name
-    enum Thermo::DynamicType method_name() const override { return Thermo::dyna_statics; }
+    enum Thermo::DynamicType method_name() const override { return Thermo::DynamicType::Statics; }
 
     //! Consistent predictor with constant temperatures
     //! and consistent temperature rates and temperatures

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -21,9 +21,9 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
 
   Core::Utils::SectionSpecs tdyn{"THERMAL DYNAMIC"};
 
-  Core::Utils::string_to_integral_parameter<DynamicType>("DYNAMICTYPE", "OneStepTheta",
-      "type of time integration control", tuple<std::string>("Statics", "OneStepTheta", "GenAlpha"),
-      tuple<DynamicType>(dyna_statics, dyna_onesteptheta, dyna_genalpha), tdyn);
+  tdyn.specs.emplace_back(parameter<Thermo::DynamicType>(
+      "DYNAMICTYPE", {.description = "type of time integration control",
+                         .default_value = Thermo::DynamicType::OneStepTheta}));
 
   // output type
   tdyn.specs.emplace_back(parameter<int>("RESULTSEVERY",

--- a/src/thermo/src/utils/4C_thermo_input.hpp
+++ b/src/thermo/src/utils/4C_thermo_input.hpp
@@ -310,32 +310,6 @@ namespace Thermo
     norm_inf         //!< Maximum/infinity norm
   };
 
-  //! map enum term to std::string
-  static inline std::string vector_norm_string(const enum VectorNorm norm)
-  {
-    switch (norm)
-    {
-      case norm_vague:
-        return "Vague";
-        break;
-      case norm_l1:
-        return "L1";
-        break;
-      case norm_l2:
-        return "L2";
-        break;
-      case norm_rms:
-        return "Rms";
-        break;
-      case norm_inf:
-        return "Inf";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string to vector norm {}", norm);
-        return "";
-    }
-  }
-
   //@}
 
   //! error calculation

--- a/src/thermo/src/utils/4C_thermo_input.hpp
+++ b/src/thermo/src/utils/4C_thermo_input.hpp
@@ -29,36 +29,13 @@ namespace Thermo
   //@{
 
   //! Type of time integrator including statics
-  enum DynamicType
+  enum class DynamicType
   {
-    dyna_undefined,     //!< undefined integrator (sth like a default)
-    dyna_statics,       //!< static analysis
-    dyna_onesteptheta,  //!< one-step-theta time integrator (implicit)
-    dyna_genalpha,      //!< generalised-alpha time integrator (implicit)
+    Undefined,     //!< undefined integrator (sth like a default)
+    Statics,       //!< static analysis
+    OneStepTheta,  //!< one-step-theta time integrator (implicit)
+    GenAlpha,      //!< generalised-alpha time integrator (implicit)
   };  // DynamicType()
-
-  //! Map time integrator to std::string
-  static inline std::string dynamic_type_string(const enum DynamicType name)
-  {
-    switch (name)
-    {
-      case dyna_undefined:
-        return "Undefined";
-        break;
-      case dyna_statics:
-        return "Statics";
-        break;
-      case dyna_onesteptheta:
-        return "OneStepTheta";
-        break;
-      case dyna_genalpha:
-        return "GenAlpha";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for time integrator {}", name);
-        return "";
-    }
-  }  // DynamicTypeString()
 
   //! initial field for scalar transport problem
   enum InitialField
@@ -85,25 +62,6 @@ namespace Thermo
                        //!<  (TR means trapezoidal rule.)
   };  // MidAverageEnum()
 
-  /// Map mid-averaging to std::string
-  static inline std::string mid_average_string(const enum MidAverageEnum name)
-  {
-    switch (name)
-    {
-      case midavg_vague:
-        return "Vague";
-        break;
-      case midavg_imrlike:
-        return "IMR-like";
-      case midavg_trlike:
-        return "TR-like";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for time integrator {}", name);
-        return "";
-    }
-  }
-
   //@}
 
   //! @name Solution technique and related
@@ -115,23 +73,6 @@ namespace Thermo
     soltech_vague,      //!< undefined
     soltech_newtonfull  //!< full Newton-Raphson iteration
   };
-
-  //! Map solution technique enum to std::string
-  static inline std::string nonlin_sol_tech_string(const enum NonlinSolTech name)
-  {
-    switch (name)
-    {
-      case soltech_vague:
-        return "vague";
-        break;
-      case soltech_newtonfull:
-        return "fullnewton";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for solution technique {}", name);
-        return "";
-    }
-  }
 
   /// type of solution techniques
   enum DivContAct
@@ -155,32 +96,6 @@ namespace Thermo
   };
 
 
-  /// Map  enum to string
-  static inline std::string div_cont_act_string(const enum DivContAct name)
-  {
-    switch (name)
-    {
-      case divcont_stop:
-        return "stop";
-        break;
-      case divcont_continue:
-        return "continue";
-        break;
-      case divcont_repeat_step:
-        return "repeat_step";
-        break;
-      case divcont_halve_step:
-        return "halve_step";
-        break;
-      case divcont_repeat_simulation:
-        return "repeat_simulation";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make string for solution div cont technique {}", name);
-        return "";
-    }
-  }
-
   //! Type of predictor
   enum PredEnum
   {
@@ -193,29 +108,6 @@ namespace Thermo
                    //!< inverse of Ktan_{n} due to the application of the Dirichlet BCs (i.e. the
                    //!< reduction to the test space).
   };
-
-  //! Map predictor enum term to std::string
-  static inline std::string pred_enum_string(const PredEnum name)
-  {
-    switch (name)
-    {
-      case pred_vague:
-        return "Vague";
-        break;
-      case pred_consttemp:
-        return "ConstTemp";
-        break;
-      case pred_consttemprate:
-        return "ConstTempRate";
-        break;
-      case pred_tangtemp:
-        return "TangTemp";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for predictor {}", name);
-        return "";
-    }
-  }
 
   //! type of norm to check for convergence
   enum ConvNorm
@@ -246,26 +138,6 @@ namespace Thermo
     heatflux_initial   //!< output of heat flux in initial configuration
   };
 
-  //! Map predictor enum term to std::string
-  static inline std::string heat_flux_string(const HeatFluxType& name)
-  {
-    switch (name)
-    {
-      case heatflux_none:
-        return "none";
-        break;
-      case heatflux_current:
-        return "heatflux_current";
-        break;
-      case heatflux_initial:
-        return "heatflux_initial";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for predictor {}", name);
-        return "";
-    }
-  }
-
   //! Type of thermal gradient output
   //! (this enum represents the input file parameter THERM_TEMPGRAD) CHECK IT!
   enum TempGradType
@@ -274,26 +146,6 @@ namespace Thermo
     tempgrad_current,  //!< output of thermal gradient in current configuration
     tempgrad_initial   //!< output of thermal gradient in initial configuration
   };
-
-  //! Map predictor enum term to std::string
-  static inline std::string temp_grad_string(const TempGradType& name)
-  {
-    switch (name)
-    {
-      case tempgrad_none:
-        return "none";
-        break;
-      case tempgrad_current:
-        return "tempgrad_current";
-        break;
-      case tempgrad_initial:
-        return "tempgrad_initial";
-        break;
-      default:
-        FOUR_C_THROW("Cannot make std::string for predictor {}", name);
-        return "";
-    }
-  }
 
   //@}
 

--- a/src/tsi/4C_tsi_partitioned.cpp
+++ b/src/tsi/4C_tsi_partitioned.cpp
@@ -68,7 +68,7 @@ TSI::Partitioned::Partitioned(MPI_Comm comm)
   const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
   // major switch to different time integrators
   quasistatic_ = (Teuchos::getIntegralValue<Inpar::Solid::DynamicType>(sdyn, "DYNAMICTYPE") ==
-                  Inpar::Solid::dyna_statics);
+                  Inpar::Solid::DynamicType::Statics);
 
   // initialise internal variables with values
   tempincnp_ = std::make_shared<Core::LinAlg::Vector<double>>(*(thermo_field()->tempnp()));

--- a/src/xfem/4C_xfem_coupling_base.hpp
+++ b/src/xfem/4C_xfem_coupling_base.hpp
@@ -17,6 +17,7 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_material_base.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <memory>

--- a/src/xfem/4C_xfem_enum_lists.hpp
+++ b/src/xfem/4C_xfem_enum_lists.hpp
@@ -26,41 +26,6 @@ namespace XFEM
     xstructure = 1
   };
 
-  /// map field name enumerator to string
-  static inline std::string field_name_to_string(const enum FieldName& field)
-  {
-    switch (field)
-    {
-      case structure:
-        return "structure";
-        break;
-      case xstructure:
-        return "xstructure";
-        break;
-      default:
-        FOUR_C_THROW("Unknown FieldName enumerator (enum = {})!", field);
-        break;
-    }
-    return "";
-  }
-
-  /// map field name enumerator to string
-  static inline enum FieldName string_to_field_name(const std::string& name)
-  {
-    enum FieldName field = unknown;
-    if (name == "structure")
-      field = structure;
-    else if (name == "xstructure")
-      field = xstructure;
-    else
-      FOUR_C_THROW(
-          "No known conversion for the given discretization "
-          "name \"{}\"!",
-          name.c_str());
-
-    return field;
-  }
-
   /// map types
   enum MapType
   {

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -14,6 +14,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_mapextractor.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_xfem_discretization.hpp"
 #include "4C_xfem_xfield_field_coupling.hpp"
 #include "4C_xfem_xfield_field_coupling_dofset.hpp"
@@ -747,7 +748,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::MultiFieldMapExtractor::extr
   const std::shared_ptr<const Epetra_Map>& sl_full_map =
       sl_map_extractor(dis_id, map_type).full_map();
 
-  if (!sl_full_map) FOUR_C_THROW("null full map for field {}", field_name_to_string(field).c_str());
+  if (!sl_full_map) FOUR_C_THROW("null full map for field {}", field);
 
   // create a new vector
   std::shared_ptr<Core::LinAlg::Vector<double>> vec =
@@ -772,7 +773,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> XFEM::MultiFieldMapExtractor:
   const std::shared_ptr<const Epetra_Map>& sl_full_map =
       sl_map_extractor(dis_id, map_type).full_map();
 
-  if (!sl_full_map) FOUR_C_THROW("null full map for field {}", field_name_to_string(field).c_str());
+  if (!sl_full_map) FOUR_C_THROW("null full map for field {}", field);
 
   // create a new multi vector
   std::shared_ptr<Core::LinAlg::MultiVector<double>> vec =
@@ -953,7 +954,7 @@ int XFEM::MultiFieldMapExtractor::slave_id(enum FieldName field) const
 {
   std::map<enum FieldName, int>::const_iterator cit = slave_discret_id_map_.find(field);
   if (cit == slave_discret_id_map_.end())
-    FOUR_C_THROW("The slave field \"{}\" could not be found!", field_name_to_string(field).c_str());
+    FOUR_C_THROW("The slave field \"{}\" could not be found!", field);
 
   return cit->second;
 }

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
@@ -23,6 +23,7 @@
 #include "4C_io_control.hpp"
 #include "4C_io_gmsh.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_xfem_dofset.hpp"
 
 FOUR_C_NAMESPACE_OPEN


### PR DESCRIPTION
Also removes a lot of uselesse enum-string conversions. Some are moved to the cpp file.

Follows #528 