### PR TITLE
445 reduce size of docker image

### DIFF
--- a/.github/workflows/docker_prebuilt_4c.yml
+++ b/.github/workflows/docker_prebuilt_4c.yml
@@ -31,7 +31,6 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
@@ -39,9 +38,6 @@ jobs:
           images: ${{ env.IMAGE_NAME }}
           labels: |
             org.opencontainers.image.description=Image containing the built 4C code
-      # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
-      # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
-      # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.
       - name: Build and push Docker image
         id: push
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
@@ -50,4 +46,38 @@ jobs:
           file: docker/prebuilt_4C/Dockerfile
           push: true
           tags: ${{ env.IMAGE_NAME }}:main
+          labels: ${{ steps.meta.outputs.labels }}
+
+  build_4c_minimal_image:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.repository == '4C-multiphysics/4C'
+      }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Log in to the Container registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        with:
+          images: ${{ env.IMAGE_NAME }}-minimal
+          labels: |
+            org.opencontainers.image.description=Image containing the 4C executable
+      - name: Build and push Docker image
+        id: push
+        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75 # v6.9.0
+        with:
+          context: docker/prebuilt_4C_minimal
+          file: docker/prebuilt_4C_minimal/Dockerfile
+          push: true
+          tags: ${{ env.IMAGE_NAME }}-minimal:main
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/prebuilt_4C/Dockerfile
+++ b/docker/prebuilt_4C/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-FROM ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:latest
+FROM ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:main
 LABEL org.opencontainers.image.description="Image containing the built 4C code"
 LABEL org.4c-multiphysics.project=4C
 

--- a/docker/prebuilt_4C_minimal/Dockerfile
+++ b/docker/prebuilt_4C_minimal/Dockerfile
@@ -1,0 +1,44 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+FROM ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:main
+
+USER root
+
+# Remove unnecessary packages
+RUN apt-get update && apt-get -y remove \
+      doxygen \
+      clang* \
+      llvm* \
+  && apt-get -y autoremove \
+  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /usr/share/doc
+
+# Remove testing dependencies
+RUN rm -r /opt/4C-dependencies-testing/
+
+RUN git clone --depth 1 https://github.com/4C-multiphysics/4C.git 4C-source
+
+RUN mkdir 4C-source/build && cd 4C-source/build && \
+  cmake ../ --fresh -DCMAKE_INSTALL_PREFIX=/home/user/4C --preset=docker_minimal && \
+  cmake --build . --target install -- -j `nproc`
+
+RUN ln -s /home/user/4C/bin/4C /usr/local/bin/4C
+
+# Remove build artifacts
+RUN rm -r /home/user/4C-source
+
+# Copy everything to a new image to get rid of the intermediate layers
+FROM scratch
+COPY --from=0 / /
+LABEL org.opencontainers.image.description="Image containing the 4C executable"
+LABEL org.4c-multiphysics.project=4C
+
+USER user
+WORKDIR /home/user
+
+CMD [ "/bin/bash" ]

--- a/docker/prebuilt_4C_minimal/README.md
+++ b/docker/prebuilt_4C_minimal/README.md
@@ -1,0 +1,10 @@
+>**Disclaimer:** this docker image is experimental. There will be modifications in the future.
+
+This `Dockerfile` creates an docker image with a ready to use 4C executable. Compared to
+`prebuilt_4C`, this image only contains the bare minimum to run 4C, so, no source, build folder,
+tests, or other testing infrastructure.
+
+This image is for you if you just want a 4C executable or want to use it as image in GitHub Actions.
+
+The 4C executable is in `/home/user/4C/bin/4C` but can also be directly called with `4C` from
+anywhere via a symlink.

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -99,6 +99,21 @@
         "CMAKE_CXX_COMPILER": "clang++",
         "CMAKE_C_COMPILER": "clang"
       }
+    },
+    {
+      "name": "docker_minimal",
+      "displayName": "Minimal build for Docker image",
+      "description": "Build minimal Docker image without source, build folder, and tests",
+      "inherits": [
+        ".docker_base"
+      ],
+      "cacheVariables": {
+        "FOUR_C_PVPYTHON": "",
+        "FOUR_C_WITH_GOOGLETEST": "OFF",
+        "FOUR_C_BUILD_DOXYGEN": "OFF",
+        "FOUR_C_BUILD_DOCUMENTATION": "OFF",
+        "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "OFF"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Description and Context
Provide a new docker image with only the 4C executable. Some unnecessary packages which are not required to run 4C, like paraview and clang, have been removed. The image with the full 4C build `ghcr.io/4c-multiphysics/4c:main` is 7.53GB. The new `4c-minimal:main` image is now at 2.73GB. Right now, I just remove things from the `4c-dependencies` image. This can be refactored in the future once we have a better way to manage our different docker images.

Additional info
- The PR also fixes an "error" for the prebuilt 4C image. As this image is tagged with main, it should also depend on the dependencies image `main`. This has not caused any harm yet because the dependencies `latest` and `main` tags point to the same image.
- The 4C `install` target only installs the 4C executable. So, `pre_exodus` or the `post-processor` are not available in the `4c-minimal` image.
- The changes of this PR will only be visible once it is merge. But I tested it in my fork. Trust me ;) 
- You can check out the image in [my fork](https://github.com/users/ppraegla/packages/container/4c-minimal/377400868?tag=main)
- This is only a first shot at reducing the image size. It should be possible to reduce the size even further when we remove everything only required for building 4C (gcc, all the *-dev packages, ...)
- This image should be used in GitHub actions when you need a prebuilt 4C

## Related Issues and Pull Requests
Closes #445 
