### PR TITLE
Set state takes a const reference instead of a shared_ptr

### DIFF
--- a/src/adapter/4C_adapter_fld_fluid_fsi.cpp
+++ b/src/adapter/4C_adapter_fld_fluid_fsi.cpp
@@ -416,7 +416,7 @@ void Adapter::FluidFSI::proj_vel_to_div_zero()
   Core::LinAlg::SerialDenseVector elevector3;
 
   discretization()->clear_state();
-  discretization()->set_state("dispnp", dispnp());
+  discretization()->set_state("dispnp", *dispnp());
 
   // loop over all fluid elements
   for (int lid = 0; lid < discretization()->num_my_col_elements(); lid++)

--- a/src/adapter/4C_adapter_fld_poro.cpp
+++ b/src/adapter/4C_adapter_fld_poro.cpp
@@ -46,8 +46,8 @@ void Adapter::FluidPoro::evaluate_no_penetration_cond(
   if (!(discretization()->filled())) FOUR_C_THROW("fill_complete() was not called");
   if (!discretization()->have_dofs()) FOUR_C_THROW("assign_degrees_of_freedom() was not called");
 
-  discretization()->set_state(0, "dispnp", dispnp());
-  discretization()->set_state(0, "scaaf", scaaf());
+  discretization()->set_state(0, "dispnp", *dispnp());
+  discretization()->set_state(0, "scaaf", *scaaf());
 
   Teuchos::ParameterList params;
 
@@ -97,16 +97,16 @@ void Adapter::FluidPoro::evaluate_no_penetration_cond(
         ConstraintMatrix,                        // fluid matrix
         nullptr, nullptr, nullptr, nullptr);
 
-    discretization()->set_state(0, "condVector", condVector);
+    discretization()->set_state(0, "condVector", *condVector);
 
     discretization()->evaluate_condition(params, fluidstrategy, "no_penetration");
   }
   else if (coupltype == PoroElast::fluidstructure)
   {
-    discretization()->set_state(0, "velnp", velnp());
-    discretization()->set_state(0, "gridv", grid_vel());
+    discretization()->set_state(0, "velnp", *velnp());
+    discretization()->set_state(0, "gridv", *grid_vel());
 
-    discretization()->set_state(0, "condVector", condVector);
+    discretization()->set_state(0, "condVector", *condVector);
 
     // set action for elements
     params.set<FLD::BoundaryAction>("action", FLD::no_penetration);

--- a/src/adapter/4C_adapter_str_redairway.cpp
+++ b/src/adapter/4C_adapter_str_redairway.cpp
@@ -81,7 +81,7 @@ void Adapter::StructureRedAirway::calc_vol(std::map<int, double>& V)
 
   // set displacements
   discretization()->clear_state();
-  discretization()->set_state("displacement", dispnp());
+  discretization()->set_state("displacement", *dispnp());
 
   //----------------------------------------------------------------------
   // loop through conditions and evaluate them if they match the criterion

--- a/src/ale/4C_ale.cpp
+++ b/src/ale/4C_ale.cpp
@@ -352,7 +352,7 @@ void ALE::Ale::evaluate_elements()
   eleparams.set<std::string>("action", element_action_string(aletype_));
   eleparams.set<bool>("use spatial configuration", update_sys_mat_every_step());
 
-  discret_->set_state("dispnp", dispnp_);
+  discret_->set_state("dispnp", *dispnp_);
 
   discret_->evaluate(eleparams, sysmat_, residual_);
   discret_->clear_state();
@@ -529,7 +529,7 @@ void ALE::Ale::prepare_time_step()
   if (locsysman_ != nullptr)
   {
     discret_->clear_state();
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
     locsysman_->update(time_, {}, Global::Problem::instance()->function_manager());
     discret_->clear_state();
   }
@@ -796,7 +796,7 @@ bool ALE::Ale::evaluate_element_quality()
     Teuchos::ParameterList eleparams;
 
     discret_->clear_state();
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
 
     for (int i = 0; i < discretization()->num_my_row_elements(); ++i)
     {

--- a/src/art_net/4C_art_net_explicitintegration.cpp
+++ b/src/art_net/4C_art_net_explicitintegration.cpp
@@ -164,7 +164,7 @@ void Arteries::ArtNetExplicitTimeInt::init(const Teuchos::ParameterList& globalt
   // ---------------------------------------------------------------------------------------
   Teuchos::ParameterList eleparams;
   discret_->clear_state();
-  discret_->set_state("qanp", qanp_);
+  discret_->set_state("qanp", *qanp_);
 
   // loop all elements on this proc (including ghosted ones)
 
@@ -298,7 +298,7 @@ void Arteries::ArtNetExplicitTimeInt::solve(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("qanp", qanp_);
+    discret_->set_state("qanp", *qanp_);
 
 
     // call standard loop over all elements
@@ -322,7 +322,7 @@ void Arteries::ArtNetExplicitTimeInt::solve(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("qanp", qanp_);
+    discret_->set_state("qanp", *qanp_);
 
     eleparams.set("time step size", dta_);
     eleparams.set("Wfnp", Wfnp_);
@@ -351,7 +351,7 @@ void Arteries::ArtNetExplicitTimeInt::solve(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("qanp", qanp_);
+    discret_->set_state("qanp", *qanp_);
 
     eleparams.set("time step size", dta_);
     eleparams.set("total time", time_);
@@ -417,7 +417,7 @@ void Arteries::ArtNetExplicitTimeInt::solve(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("qanp", qanp_);
+    discret_->set_state("qanp", *qanp_);
 
     eleparams.set("time step size", dta_);
     eleparams.set("total time", time_);
@@ -465,7 +465,7 @@ void Arteries::ArtNetExplicitTimeInt::solve_scatra()
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("qanp", qanp_);
+    discret_->set_state("qanp", *qanp_);
 
     eleparams.set("time step size", dta_);
     eleparams.set("time", time_);
@@ -799,12 +799,7 @@ void Arteries::ArtNetExplicitTimeInt::calc_postprocessing_values()
 
   // set vector values needed by elements
   discret_->clear_state();
-  //  std::cout<<"On proc("<<myrank_<<"): "<<"postpro setting qanp"<<std::endl;
-  discret_->set_state("qanp", qanp_);
-  //  std::cout<<"On proc("<<myrank_<<"): "<<"postpro setting wfnp"<<std::endl;
-  //  discret_->set_state("Wfnp",Wfnp_);
-  //  std::cout<<"On proc("<<myrank_<<"): "<<"postpro setting wbnp"<<std::endl;
-  //  discret_->set_state("Wbnp",Wbnp_);
+  discret_->set_state("qanp", *qanp_);
 
   eleparams.set("time step size", dta_);
   eleparams.set("total time", time_);

--- a/src/art_net/4C_art_net_impl_stationary.cpp
+++ b/src/art_net/4C_art_net_impl_stationary.cpp
@@ -225,7 +225,7 @@ void Arteries::ArtNetImplStationary::solve_scatra()
     FOUR_C_THROW("this type of coupling is only available for explicit time integration");
 
   // provide scatra discretization with fluid primary variable field
-  scatra_->scatra_field()->discretization()->set_state(1, "one_d_artery_pressure", pressurenp_);
+  scatra_->scatra_field()->discretization()->set_state(1, "one_d_artery_pressure", *pressurenp_);
   scatra_->scatra_field()->prepare_time_step();
 
   // -------------------------------------------------------------------
@@ -280,7 +280,7 @@ void Arteries::ArtNetImplStationary::assemble_mat_and_rhs()
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "pressurenp", pressurenp_);
+  discret_->set_state(0, "pressurenp", *pressurenp_);
 
   // call standard loop over all elements
   discret_->evaluate(eleparams, sysmat_, rhs_);
@@ -582,7 +582,7 @@ void Arteries::ArtNetImplStationary::reconstruct_flow()
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "pressurenp", pressurenp_);
+  discret_->set_state(0, "pressurenp", *pressurenp_);
 
   // enough to loop over row nodes since element-based quantity
   for (int i = 0; i < discret_->num_my_row_elements(); ++i)

--- a/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
+++ b/src/browniandyn/4C_browniandyn_str_model_evaluator.cpp
@@ -255,7 +255,7 @@ bool Solid::ModelEvaluator::BrownianDyn::apply_force_external()
   // set vector values needed by elements
   // -------------------------------------------------------------------------
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_n());
+  discret().set_state(0, "displacement", *global_state().get_dis_n());
   // -------------------------------------------------------------------------
   // Evaluate brownian specific neumann conditions
   // -------------------------------------------------------------------------
@@ -289,8 +289,8 @@ bool Solid::ModelEvaluator::BrownianDyn::apply_force_brownian()
   // set vector values needed by elements
   // -------------------------------------------------------------------------
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state_ptr()->get_dis_np());
-  discret().set_state(0, "velocity", global_state().get_vel_np());
+  discret().set_state(0, "displacement", *global_state_ptr()->get_dis_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
   // -------------------------------------------------------------------------
   // Evaluate Browian (stochastic and damping forces)
   // -------------------------------------------------------------------------
@@ -317,7 +317,7 @@ bool Solid::ModelEvaluator::BrownianDyn::apply_force_stiff_external()
   // set vector values needed by elements
   // -------------------------------------------------------------------------
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_n());
+  discret().set_state(0, "displacement", *global_state().get_dis_n());
   // -------------------------------------------------------------------------
   // Evaluate brownian specific neumann conditions
   // -------------------------------------------------------------------------
@@ -352,8 +352,8 @@ bool Solid::ModelEvaluator::BrownianDyn::apply_force_stiff_brownian()
   // set vector values needed by elements
   // -------------------------------------------------------------------------
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state_ptr()->get_dis_np());
-  discret().set_state(0, "velocity", global_state().get_vel_np());
+  discret().set_state(0, "displacement", *global_state_ptr()->get_dis_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
   // -------------------------------------------------------------------------
   // Evaluate brownian (stochastic and damping) forces
   evaluate_brownian(eval_mat.data(), eval_vec.data());

--- a/src/cardiovascular0d/4C_cardiovascular0d.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d.cpp
@@ -305,7 +305,7 @@ void Utils::Cardiovascular0D::evaluate_d_struct_dp(
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
         params.get<std::shared_ptr<const Core::LinAlg::Vector<double>>>("new disp");
-    actdisc_->set_state("displacement", disp);
+    actdisc_->set_state("displacement", *disp);
 
     // global and local ID of this bc in the redundant vectors
     std::vector<int> gindex(numdof_per_cond);
@@ -493,11 +493,10 @@ void Utils::Cardiovascular0D::evaluate_d_struct_dp(
 
 /*-----------------------------------------------------------------------*
  *-----------------------------------------------------------------------*/
-void Utils::Cardiovascular0D::set_state(const std::string& state,  ///< name of state to set
-    std::shared_ptr<Core::LinAlg::Vector<double>> V                ///< values to set
-)
+void Utils::Cardiovascular0D::set_state(
+    const std::string& state, std::shared_ptr<Core::LinAlg::Vector<double>> V)
 {
-  actdisc_->set_state(state, V);
+  actdisc_->set_state(state, *V);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
@@ -275,7 +275,7 @@ Utils::Cardiovascular0DManager::Cardiovascular0DManager(
     p.set("NumberofID", num_cardiovascular0_did_);
     p.set("scale_timint", sc_timint);
     p.set("time_step_size", ts_size);
-    actdisc_->set_state("displacement", disp);
+    actdisc_->set_state("displacement", *disp);
 
     std::shared_ptr<Core::LinAlg::Vector<double>> v_n_red =
         std::make_shared<Core::LinAlg::Vector<double>>(*redcardiovascular0dmap_);
@@ -377,7 +377,7 @@ void Utils::Cardiovascular0DManager::evaluate_force_stiff(const double time,
       std::make_shared<Core::LinAlg::Vector<double>>(*redcardiovascular0dmap_);
 
   actdisc_->clear_state();
-  actdisc_->set_state("displacement", disp);
+  actdisc_->set_state("displacement", *disp);
 
   // evaluate current 3D volume only
   cardvasc0d_model_->evaluate(
@@ -653,7 +653,7 @@ void Utils::Cardiovascular0DManager::evaluate_neumann_cardiovascular0_d_coupling
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
         params.get<std::shared_ptr<const Core::LinAlg::Vector<double>>>("new disp");
-    actdisc_->set_state("displacement new", disp);
+    actdisc_->set_state("displacement new", *disp);
 
     Core::LinAlg::SerialDenseVector elevector;
     Core::LinAlg::SerialDenseMatrix elematrix;

--- a/src/constraint/4C_constraint.cpp
+++ b/src/constraint/4C_constraint.cpp
@@ -231,11 +231,11 @@ void CONSTRAINTS::Constraint::evaluate_constraint(Teuchos::ParameterList& params
         const std::string action = params.get<std::string>("action");
         std::shared_ptr<Core::LinAlg::Vector<double>> displast =
             params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("old disp");
-        actdisc_->set_state("displacement", displast);
+        actdisc_->set_state("displacement", *displast);
         initialize(params, systemvector2);
         std::shared_ptr<Core::LinAlg::Vector<double>> disp =
             params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("new disp");
-        actdisc_->set_state("displacement", disp);
+        actdisc_->set_state("displacement", *disp);
         params.set("action", action);
       }
 

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -132,7 +132,7 @@ void CONSTRAINTS::ConstrManager::setup(
     // We will always use the third systemvector for this purpose
     p.set("OffsetID", offset_id_);
     p.set("total time", time);
-    actdisc_->set_state("displacement", disp);
+    actdisc_->set_state("displacement", *disp);
     volconstr3d_->initialize(p, *refbaseredundant);
     areaconstr3d_->initialize(p, *refbaseredundant);
     areaconstr2d_->initialize(p, *refbaseredundant);
@@ -162,7 +162,7 @@ void CONSTRAINTS::ConstrManager::setup(
   }
   //----------------------------------------------------------------------------
   //---------------------------------------------------------Monitor Conditions!
-  actdisc_->set_state("displacement", disp);
+  actdisc_->set_state("displacement", *disp);
   min_monitor_id_ = 10000;
   int maxMonitorID = 0;
   volmonitor3d_ =
@@ -257,7 +257,7 @@ void CONSTRAINTS::ConstrManager::evaluate_force_stiff(const double time,
       std::make_shared<Core::LinAlg::Vector<double>>(*redconstrmap_);
 
   actdisc_->clear_state();
-  actdisc_->set_state("displacement", disp);
+  actdisc_->set_state("displacement", *disp);
   volconstr3d_->evaluate(p, stiff, constr_matrix_, fint, refbaseredundant, actredundant);
   areaconstr3d_->evaluate(p, stiff, constr_matrix_, fint, refbaseredundant, actredundant);
   areaconstr2d_->evaluate(p, stiff, constr_matrix_, fint, refbaseredundant, actredundant);
@@ -306,7 +306,7 @@ void CONSTRAINTS::ConstrManager::compute_error(
   std::vector<Core::Conditions::Condition*> constrcond(0);
   Teuchos::ParameterList p;
   p.set("total time", time);
-  actdisc_->set_state("displacement", disp);
+  actdisc_->set_state("displacement", *disp);
 
   std::shared_ptr<Core::LinAlg::Vector<double>> actredundant =
       std::make_shared<Core::LinAlg::Vector<double>>(*redconstrmap_);
@@ -404,7 +404,7 @@ void CONSTRAINTS::ConstrManager::compute_monitor_values(
   std::vector<Core::Conditions::Condition*> monitcond(0);
   monitorvalues_->put_scalar(0.0);
   Teuchos::ParameterList p;
-  actdisc_->set_state("displacement", disp);
+  actdisc_->set_state("displacement", *disp);
 
   Core::LinAlg::Vector<double> actmonredundant(*redmonmap_);
   p.set("OffsetID", min_monitor_id_);
@@ -434,10 +434,10 @@ void CONSTRAINTS::ConstrManager::compute_monitor_values(
     Core::LinAlg::MapExtractor conmerger;
     conmerger.setup(
         *largemap, Core::Utils::shared_ptr_from_ref(*actdisc_->dof_row_map()), constrmap_);
-    actdisc_->set_state("displacement", conmerger.extract_cond_vector(*disp));
+    actdisc_->set_state("displacement", *conmerger.extract_cond_vector(*disp));
   }
   else
-    actdisc_->set_state("displacement", disp);
+    actdisc_->set_state("displacement", *disp);
 
   Core::LinAlg::Vector<double> actmonredundant(*redmonmap_);
   p.set("OffsetID", min_monitor_id_);

--- a/src/constraint/4C_constraint_monitor.cpp
+++ b/src/constraint/4C_constraint_monitor.cpp
@@ -155,11 +155,10 @@ void CONSTRAINTS::Monitor::evaluate_monitor(
 
 /*-----------------------------------------------------------------------*
  *-----------------------------------------------------------------------*/
-void CONSTRAINTS::Monitor::set_state(const std::string& state,  ///< name of state to set
-    std::shared_ptr<Core::LinAlg::Vector<double>> V             ///< values to set
-)
+void CONSTRAINTS::Monitor::set_state(
+    const std::string& state, std::shared_ptr<Core::LinAlg::Vector<double>> V)
 {
-  actdisc_->set_state(state, V);
+  actdisc_->set_state(state, *V);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/constraint/4C_constraint_multipointconstraint.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint.cpp
@@ -50,7 +50,7 @@ void CONSTRAINTS::MPConstraint::set_constr_state(
           Core::LinAlg::create_vector(*(discrit->second)->dof_col_map(), false);
       Core::LinAlg::export_to(V, *tmp);
       (discrit->second)->clear_state();
-      (discrit->second)->set_state(state, tmp);
+      (discrit->second)->set_state(state, *tmp);
     }
   }
 }

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
@@ -562,8 +562,8 @@ void Core::Conditions::LocsysManager::calc_rotation_vector_for_normal_system(
   // Take care for "negative times", where no information about dispnp_ is available
   if (time < 0.0)
   {
-    std::shared_ptr<Core::LinAlg::Vector<double>> zeroVector =
-        Core::LinAlg::create_vector(*discret().dof_row_map(), true);
+    // TODO is the memory management still working?
+    LinAlg::Vector<double> zeroVector(*discret().dof_row_map(), true);
     discret_.set_state("dispnp", zeroVector);
   }
 

--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -1499,8 +1499,7 @@ namespace Core::FE
 
     \note This class will not take ownership or in any way modify the solution vector.
     */
-    void set_state(
-        const std::string& name, std::shared_ptr<const Core::LinAlg::Vector<double>> state)
+    void set_state(const std::string& name, const LinAlg::Vector<double>& state)
     {
       set_state(0, name, state);
     }
@@ -1524,8 +1523,7 @@ namespace Core::FE
 
     \note This class will not take ownership or in any way modify the solution vector.
     */
-    void set_state(unsigned nds, const std::string& name,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> state);
+    void set_state(unsigned nds, const std::string& name, const LinAlg::Vector<double>& state);
 
     /*!
     \brief Get a reference to a data vector at the default dofset (0)

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -89,7 +89,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
   // centers (for linear elements the centers are the superconvergent sampling points!)
   dis.clear_state();
   // Set ALE displacements here
-  dis.set_state(statename, Core::Utils::shared_ptr_from_ref(state));
+  dis.set_state(statename, state);
 
   const Epetra_Map* elementrowmap = dis.element_row_map();
   Core::LinAlg::MultiVector<double> elevec_toberecovered(*elementrowmap, numvec, true);

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -1236,7 +1236,7 @@ void EHL::Monolithic::apply_lubrication_coupl_matrix(
   lubrication_->lubrication_field()->discretization()->clear_state(true);
   // set the variables that are needed by the elements
   lubrication_->lubrication_field()->discretization()->set_state(
-      0, "prenp", lubrication_->lubrication_field()->prenp());
+      0, "prenp", *lubrication_->lubrication_field()->prenp());
 
   set_struct_solution(structure_->dispnp());
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -188,8 +188,8 @@ void FLD::FluidImplicitTimeInt::init()
   // ---------------------------------------------------------------------
   if (alefluid_)
   {
-    discret_->set_state(ndsale_, "dispnp", dispnp_);
-    discret_->set_state(ndsale_, "gridv", gridv_);
+    discret_->set_state(ndsale_, "dispnp", *dispnp_);
+    discret_->set_state(ndsale_, "gridv", *gridv_);
   }
 
   // initialize nonlinear boundary conditions
@@ -439,7 +439,7 @@ void FLD::FluidImplicitTimeInt::init_nonlinear_bc()
     if (alefluid_)
     {
       discret_->clear_state();
-      discret_->set_state(ndsale_, "dispnp", dispnp_);
+      discret_->set_state(ndsale_, "dispnp", *dispnp_);
     }
 
     impedancebc_ = std::make_shared<Utils::FluidImpedanceWrapper>(discret_);
@@ -714,7 +714,7 @@ void FLD::FluidImplicitTimeInt::prepare_time_step()
   if (locsysman_ != nullptr)
   {
     discret_->clear_state();
-    if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+    if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     setup_locsys_dirichlet_bc(time_);
   }
@@ -965,7 +965,7 @@ void FLD::FluidImplicitTimeInt::prepare_solve()
   if ((locsysman_ != nullptr) && (alefluid_))
   {
     discret_->clear_state();
-    discret_->set_state(ndsale_, "dispnp", dispnp_);
+    discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     setup_locsys_dirichlet_bc(time_);
   }
@@ -1038,15 +1038,15 @@ void FLD::FluidImplicitTimeInt::assemble_mat_and_rhs()
   //----------------------------------------------------------------------
   // set general vector values needed by elements
   //----------------------------------------------------------------------
-  discret_->set_state("hist", hist_);
-  discret_->set_state("veln", veln_);
-  discret_->set_state("accam", accam_);
-  discret_->set_state("scaaf", scaaf_);
-  discret_->set_state("scaam", scaam_);
+  discret_->set_state("hist", *hist_);
+  discret_->set_state("veln", *veln_);
+  discret_->set_state("accam", *accam_);
+  discret_->set_state("scaaf", *scaaf_);
+  discret_->set_state("scaam", *scaam_);
   if (alefluid_)
   {
-    discret_->set_state(ndsale_, "dispnp", dispnp_);
-    discret_->set_state(ndsale_, "gridv", gridv_);
+    discret_->set_state(ndsale_, "dispnp", *dispnp_);
+    discret_->set_state(ndsale_, "gridv", *gridv_);
   }
 
   // set scheme-specific element parameters and vector values
@@ -1056,9 +1056,9 @@ void FLD::FluidImplicitTimeInt::assemble_mat_and_rhs()
   {
     eleparams.set("forcing", true);
     if (forcing_->get_map().SameAs(*discret_->dof_row_map()))
-      discret_->set_state("forcing", forcing_);
+      discret_->set_state("forcing", *forcing_);
     else
-      discret_->set_state(1, "forcing", forcing_);
+      discret_->set_state(1, "forcing", *forcing_);
   }
 
   //----------------------------------------------------------------------
@@ -1072,7 +1072,7 @@ void FLD::FluidImplicitTimeInt::assemble_mat_and_rhs()
   if (turbmodel_ == Inpar::FLUID::multifractal_subgrid_scales)
   {
     this->apply_scale_separation_for_les();
-    discret_->set_state("fsscaaf", fsscaaf_);
+    discret_->set_state("fsscaaf", *fsscaaf_);
   }
 
   //----------------------------------------------------------------------
@@ -1210,7 +1210,7 @@ void FLD::FluidImplicitTimeInt::evaluate_mass_matrix()
   // action for elements
   eleparams.set<FLD::Action>("action", FLD::calc_mass_matrix);
 
-  if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+  if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
   discret_->evaluate(eleparams, massmat_, nullptr, nullptr, nullptr, nullptr);
   discret_->clear_state();
@@ -1270,9 +1270,9 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
   if (isimpedancebc_)
   {
     discret_->clear_state();
-    discret_->set_state("velaf", velnp_);
+    discret_->set_state("velaf", *velnp_);
 
-    if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+    if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     // update residual and sysmat with impedance boundary conditions
     impedancebc_->add_impedance_bc_to_residual_and_sysmat(dta_, time_, *residual_, *sysmat_);
@@ -1302,9 +1302,9 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
     // (no contribution due to pressure or continuity equation for Neumann inflow
     // -> no difference between af_genalpha and np_genalpha)
     discret_->clear_state();
-    discret_->set_state("scaaf", scaaf_);
+    discret_->set_state("scaaf", *scaaf_);
     set_state_tim_int();
-    if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+    if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     // evaluate all Neumann inflow boundary conditions
     discret_->evaluate_condition(
@@ -1440,7 +1440,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
       // set required state vectors
       discret_->clear_state();
       set_state_tim_int();
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       // evaluate flow rate
       discret_->evaluate_condition(flowdeppressureparams, flowrates, fdpcondname, fdpcondid);
@@ -1493,7 +1493,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
       flowdeppressureparams.set<double>("area", 0.0);
 
       // set required state vectors
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       // evaluate surface area
       discret_->evaluate_condition(flowdeppressureparams, fdpcondname, fdpcondid);
@@ -1518,7 +1518,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
       // set required state vectors
       discret_->clear_state();
       set_state_tim_int();
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       // evaluate pressure integral
       discret_->evaluate_condition(flowdeppressureparams, fdpcondname, fdpcondid);
@@ -1586,9 +1586,9 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
       // (no contribution due to pressure or continuity equation for Neumann inflow
       // -> no difference between af_genalpha and np_genalpha)
       discret_->clear_state();
-      discret_->set_state("scaaf", scaaf_);
+      discret_->set_state("scaaf", *scaaf_);
       set_state_tim_int();
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       // set values for elements
       const int fdp_cond_id = fdpcond[fdpcondid]->parameters().get<int>("ConditionID");
@@ -1627,7 +1627,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
     // set required state vectors
     set_state_tim_int();
-    if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+    if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     // evaluate all line weak Dirichlet boundary conditions
     discret_->evaluate_condition(
@@ -1660,7 +1660,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
     // set required state vectors
     set_state_tim_int();
-    if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+    if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     // evaluate all line mixed/hybrid Dirichlet boundary conditions
     discret_->evaluate_condition(
@@ -1750,7 +1750,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
       // set required state vectors
       set_state_tim_int();
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
       // discret_->set_state("nodenormal",nodeNormal);
 
       // temporary variable holding the scaled residual contribution
@@ -1834,7 +1834,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
       // set required state vectors
       set_state_tim_int();
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       // set slip coefficient
       Core::Conditions::Condition* currnavierslip = nscond[nscondid];
@@ -1867,8 +1867,8 @@ void FLD::FluidImplicitTimeInt::assemble_edge_based_matand_rhs()
 
     if (alefluid_)
     {
-      discret_->set_state(ndsale_, "dispnp", dispnp_);
-      discret_->set_state(ndsale_, "gridv", gridv_);
+      discret_->set_state(ndsale_, "dispnp", *dispnp_);
+      discret_->set_state(ndsale_, "gridv", *gridv_);
     }
 
     Teuchos::ParameterList params;
@@ -2171,7 +2171,7 @@ void FLD::FluidImplicitTimeInt::update_krylov_space_projection()
       // ... set action for elements to integration of shape functions
       mode_params.set<FLD::Action>("action", FLD::integrate_shape);
 
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       if (xwall_ != nullptr) xwall_->set_x_wall_params(mode_params);
 
@@ -2582,7 +2582,7 @@ void FLD::FluidImplicitTimeInt::ale_update(std::string condName)
         // Evaluate condition to calculate the node normals
         // Note: the normal vectors do not yet have length 1.0
         discret_->clear_state();
-        discret_->set_state(ndsale_, "dispnp", dispnp_);
+        discret_->set_state(ndsale_, "dispnp", *dispnp_);
         discret_->evaluate_condition(eleparams, globalNodeNormals, condName);
         discret_->clear_state();
 
@@ -3014,11 +3014,11 @@ void FLD::FluidImplicitTimeInt::evaluate(
   {
     // account for potentially moving Neumann boundaries
     Teuchos::ParameterList eleparams;
-    discret_->set_state(ndsale_, "dispnp", dispnp_);
+    discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
     // evaluate Neumann conditions
     neumann_loads_->put_scalar(0.0);
-    discret_->set_state("scaaf", scaaf_);
+    discret_->set_state("scaaf", *scaaf_);
     discret_->evaluate_neumann(eleparams, *neumann_loads_);
     discret_->clear_state();
   }
@@ -3997,17 +3997,17 @@ void FLD::FluidImplicitTimeInt::avm3_assemble_mat_and_rhs(Teuchos::ParameterList
 
   // set general vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("hist", hist_);
-  discret_->set_state("veln", veln_);
-  discret_->set_state("accam", accam_);
+  discret_->set_state("hist", *hist_);
+  discret_->set_state("veln", *veln_);
+  discret_->set_state("accam", *accam_);
   // this vector contains only zeros unless SetIterScalarFields is called
   // as this function has not been called yet
   // we have to replace the zeros by ones
   // otherwise nans are occur
   scaaf_->put_scalar(1.0);
-  discret_->set_state("scaaf", scaaf_);
+  discret_->set_state("scaaf", *scaaf_);
   scaam_->put_scalar(1.0);
-  discret_->set_state("scaam", scaam_);
+  discret_->set_state("scaam", *scaam_);
 
   // set fine-scale vector
   // dummy vector initialized with zeros
@@ -4018,15 +4018,15 @@ void FLD::FluidImplicitTimeInt::avm3_assemble_mat_and_rhs(Teuchos::ParameterList
   // expects the state vector "fsvelaf" and "fsscaaf" for loma
   if (fssgv_ != Inpar::FLUID::no_fssgv or turbmodel_ == Inpar::FLUID::multifractal_subgrid_scales)
   {
-    discret_->set_state("fsvelaf", fsvelaf_);
+    discret_->set_state("fsvelaf", *fsvelaf_);
     if (turbmodel_ == Inpar::FLUID::multifractal_subgrid_scales)
-      discret_->set_state("fsscaaf", fsscaaf_);
+      discret_->set_state("fsscaaf", *fsscaaf_);
   }
 
   if (alefluid_)
   {
-    discret_->set_state(ndsale_, "dispnp", dispnp_);
-    discret_->set_state(ndsale_, "gridv", gridv_);
+    discret_->set_state(ndsale_, "dispnp", *dispnp_);
+    discret_->set_state(ndsale_, "gridv", *gridv_);
   }
 
   // set scheme-specific element parameters and vector values
@@ -4038,7 +4038,7 @@ void FLD::FluidImplicitTimeInt::avm3_assemble_mat_and_rhs(Teuchos::ParameterList
   if (forcing_ != nullptr)
   {
     eleparams.set("forcing", true);
-    discret_->set_state("forcing", forcing_);
+    discret_->set_state("forcing", *forcing_);
   }
 
   // element evaluation for getting system matrix
@@ -4107,7 +4107,7 @@ void FLD::FluidImplicitTimeInt::avm3_separation()
   sep_multiply();
 
   // set fine-scale vector
-  discret_->set_state("fsvelaf", fsvelaf_);
+  discret_->set_state("fsvelaf", *fsvelaf_);
 }  // FluidImplicitTimeInt::avm3_separation
 
 
@@ -4756,7 +4756,7 @@ FLD::FluidImplicitTimeInt::evaluate_error_compared_to_analytical_sol()
       // set scheme-specific element parameters and vector values
       set_state_tim_int();
 
-      if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
       // get (squared) error values
       // 0: delta velocity for L2-error norm
@@ -4973,11 +4973,11 @@ double FLD::FluidImplicitTimeInt::evaluate_dt_via_cfl_if_applicable()
 
     if (xwall_ != nullptr) xwall_->set_x_wall_params(eleparams);
 
-    discret_->set_state("velnp", velnp_);
+    discret_->set_state("velnp", *velnp_);
     if (alefluid_)
     {
-      discret_->set_state(ndsale_, "dispnp", dispnp_);
-      discret_->set_state(ndsale_, "gridv", gridv_);
+      discret_->set_state(ndsale_, "dispnp", *dispnp_);
+      discret_->set_state(ndsale_, "gridv", *gridv_);
     }
 
     const Epetra_Map* elementrowmap = discret_->element_row_map();
@@ -5140,7 +5140,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FLD::FluidImplicitTimeInt::integra
 
   // call loop over elements
   discret_->clear_state();
-  if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+  if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
   discret_->evaluate_condition(eleparams, integratedshapefunc, condname);
   discret_->clear_state();
 
@@ -5293,13 +5293,13 @@ void FLD::FluidImplicitTimeInt::linear_relaxation_solve(
 
     // set general vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("hist", hist_);
-    discret_->set_state("veln", veln_);
-    discret_->set_state("accam", accam_);
-    discret_->set_state("scaaf", scaaf_);
-    discret_->set_state("scaam", scaam_);
-    discret_->set_state(ndsale_, "dispnp", griddisp);
-    discret_->set_state(ndsale_, "gridv", zeros_);
+    discret_->set_state("hist", *hist_);
+    discret_->set_state("veln", *veln_);
+    discret_->set_state("accam", *accam_);
+    discret_->set_state("scaaf", *scaaf_);
+    discret_->set_state("scaam", *scaam_);
+    discret_->set_state(ndsale_, "dispnp", *griddisp);
+    discret_->set_state(ndsale_, "gridv", *zeros_);
 
     eleparams.set<FLD::Action>("action", FLD::calc_fluid_systemmat_and_residual);
     eleparams.set<Inpar::FLUID::PhysicalType>("Physical Type", physicaltype_);
@@ -5967,7 +5967,7 @@ void FLD::FluidImplicitTimeInt::apply_scale_separation_for_les()
     }
 
     // set fine-scale vector
-    discret_->set_state("fsvelaf", fsvelaf_);
+    discret_->set_state("fsvelaf", *fsvelaf_);
   }
   else if (turbmodel_ == Inpar::FLUID::dynamic_vreman)
   {
@@ -6027,7 +6027,7 @@ void FLD::FluidImplicitTimeInt::recompute_mean_csgs_b()
     discret_->clear_state();
     set_state_tim_int();
     // set temperature
-    discret_->set_state("scalar", scaaf_);
+    discret_->set_state("scalar", *scaaf_);
     // set thermodynamic pressures
     set_custom_ele_params_apply_nonlinear_boundary_conditions(myparams);
 
@@ -6169,7 +6169,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FLD::FluidImplicitTimeInt::calc_di
 
   // copy row map of mesh displacement to column map (only if ALE is used)
   discret_->clear_state();
-  if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+  if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
   // construct the operator on element level as a column vector
   discret_->evaluate(params, nullptr, nullptr, divop, nullptr, nullptr);
@@ -6288,7 +6288,7 @@ void FLD::FluidImplicitTimeInt::predict_tang_vel_consist_acc()
   // get Dirichlet values at t_{n+1}
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("velnp", velnp_);
+  discret_->set_state("velnp", *velnp_);
 
   // predicted Dirichlet values
   // velnp_ then also holds prescribed new dirichlet values
@@ -6469,12 +6469,12 @@ void FLD::FluidImplicitTimeInt::set_dirichlet_neumann_bc()
   // add problem-dependent parameters, e.g., thermodynamic pressure in case of loma
   set_custom_ele_params_apply_nonlinear_boundary_conditions(eleparams);
 
-  if (alefluid_) discret_->set_state(ndsale_, "dispnp", dispnp_);
+  if (alefluid_) discret_->set_state(ndsale_, "dispnp", *dispnp_);
 
   // evaluate Neumann conditions
   neumann_loads_->put_scalar(0.0);
-  discret_->set_state("scaaf", scaaf_);
-  discret_->set_state("velaf", velaf_);
+  discret_->set_state("scaaf", *scaaf_);
+  discret_->set_state("velaf", *velaf_);
   discret_->evaluate_neumann(eleparams, *neumann_loads_);
   discret_->clear_state();
 }

--- a/src/fluid/4C_fluid_timint_bdf2.cpp
+++ b/src/fluid/4C_fluid_timint_bdf2.cpp
@@ -107,7 +107,7 @@ void FLD::TimIntBDF2::set_old_part_of_righthandside()
 *-----------------------------------------------------------------------*/
 void FLD::TimIntBDF2::set_state_tim_int()
 {
-  discret_->set_state("velaf", velnp_);
+  discret_->set_state("velaf", *velnp_);
 
   return;
 }

--- a/src/fluid/4C_fluid_timint_genalpha.cpp
+++ b/src/fluid/4C_fluid_timint_genalpha.cpp
@@ -308,11 +308,9 @@ void FLD::TimIntGenAlpha::gen_alpha_intermediate_values(
 *-----------------------------------------------------------------------*/
 void FLD::TimIntGenAlpha::set_state_tim_int()
 {
-  discret_->set_state("velaf", velaf_);
-  discret_->set_state("velam", velam_);
-  if (timealgo_ == Inpar::FLUID::timeint_npgenalpha) discret_->set_state("velnp", velnp_);
-
-  return;
+  discret_->set_state("velaf", *velaf_);
+  discret_->set_state("velam", *velam_);
+  if (timealgo_ == Inpar::FLUID::timeint_npgenalpha) discret_->set_state("velnp", *velnp_);
 }
 
 /*----------------------------------------------------------------------*|

--- a/src/fluid/4C_fluid_timint_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_hdg.cpp
@@ -275,10 +275,10 @@ void FLD::TimIntHDG::gen_alpha_intermediate_values()
 *-----------------------------------------------------------------------*/
 void FLD::TimIntHDG::set_state_tim_int()
 {
-  discret_->set_state(0, "velaf", velaf_);
-  discret_->set_state(1, "intvelaf", intvelaf_);
-  discret_->set_state(1, "intaccam", intaccam_);
-  discret_->set_state(1, "intvelnp", intvelnp_);
+  discret_->set_state(0, "velaf", *velaf_);
+  discret_->set_state(1, "intvelaf", *intvelaf_);
+  discret_->set_state(1, "intaccam", *intaccam_);
+  discret_->set_state(1, "intvelnp", *intvelnp_);
 }
 
 /*----------------------------------------------------------------------*
@@ -422,7 +422,7 @@ std::shared_ptr<std::vector<double>> FLD::TimIntHDG::evaluate_error_compared_to_
     case Inpar::FLUID::shear_flow:
     case Inpar::FLUID::fsi_fluid_pusher:
     case Inpar::FLUID::byfunct:
-      discret_->set_state(1, "intvelnp", intvelnp_);
+      discret_->set_state(1, "intvelnp", *intvelnp_);
       break;
     default:
       break;
@@ -478,8 +478,8 @@ namespace
     // call element routine for interpolate HDG to elements
     Teuchos::ParameterList params;
     params.set<FLD::Action>("action", FLD::interpolate_hdg_to_node);
-    dis.set_state(1, "intvelnp", interiorValues);
-    dis.set_state(0, "velnp", traceValues);
+    dis.set_state(1, "intvelnp", *interiorValues);
+    dis.set_state(0, "velnp", *traceValues);
     std::vector<int> dummy;
     Core::LinAlg::SerialDenseMatrix dummyMat;
     Core::LinAlg::SerialDenseVector dummyVec;

--- a/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
+++ b/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
@@ -275,10 +275,10 @@ void FLD::TimIntHDGWeakComp::gen_alpha_intermediate_values()
 *-----------------------------------------------------------------------*/
 void FLD::TimIntHDGWeakComp::set_state_tim_int()
 {
-  discret_->set_state(0, "velaf", velaf_);
-  discret_->set_state(1, "intvelaf", intvelaf_);
-  discret_->set_state(1, "intaccam", intaccam_);
-  discret_->set_state(1, "intvelnp", intvelnp_);
+  discret_->set_state(0, "velaf", *velaf_);
+  discret_->set_state(1, "intvelaf", *intvelaf_);
+  discret_->set_state(1, "intaccam", *intaccam_);
+  discret_->set_state(1, "intvelnp", *intvelnp_);
 }
 
 /*----------------------------------------------------------------------*
@@ -337,7 +337,7 @@ void FLD::TimIntHDGWeakComp::iter_update(
 
   // set state
   set_state_tim_int();
-  discret_->set_state(0, "globaltraceinc", increment);
+  discret_->set_state(0, "globaltraceinc", *increment);
 
   for (int el = 0; el < discret_->num_my_col_elements(); ++el)
   {
@@ -502,7 +502,7 @@ FLD::TimIntHDGWeakComp::evaluate_error_compared_to_analytical_sol()
     }
     case Inpar::FLUID::byfunct:
     {
-      discret_->set_state(1, "intvelnp", intvelnp_);
+      discret_->set_state(1, "intvelnp", *intvelnp_);
 
       // std::vector containing
       // [0]: absolute L2 mixed variable error
@@ -525,7 +525,7 @@ FLD::TimIntHDGWeakComp::evaluate_error_compared_to_analytical_sol()
       // set scheme-specific element parameters and vector values
       set_state_tim_int();
 
-      if (alefluid_) discret_->set_state(2, "dispnp", dispnp_);
+      if (alefluid_) discret_->set_state(2, "dispnp", *dispnp_);
 
       // get (squared) error values
       // 0: delta mixed variable for L2-error norm
@@ -671,8 +671,8 @@ namespace
     // call element routine for interpolate HDG to elements
     Teuchos::ParameterList params;
     params.set<FLD::Action>("action", FLD::interpolate_hdg_to_node);
-    dis.set_state(1, "intvelnp", interiorValues);
-    dis.set_state(0, "velnp", traceValues);
+    dis.set_state(1, "intvelnp", *interiorValues);
+    dis.set_state(0, "velnp", *traceValues);
     std::vector<int> dummy;
     Core::LinAlg::SerialDenseMatrix dummyMat;
     Core::LinAlg::SerialDenseVector dummyVec;

--- a/src/fluid/4C_fluid_timint_ost.cpp
+++ b/src/fluid/4C_fluid_timint_ost.cpp
@@ -92,10 +92,10 @@ void FLD::TimIntOneStepTheta::set_old_part_of_righthandside()
 *-----------------------------------------------------------------------*/
 void FLD::TimIntOneStepTheta::set_state_tim_int()
 {
-  discret_->set_state("velaf", velnp_);
+  discret_->set_state("velaf", *velnp_);
   if (params_->get<bool>("ost new"))
   {
-    if (alefluid_) discret_->set_state("gridvn", gridvn_);
+    if (alefluid_) discret_->set_state("gridvn", *gridvn_);
   }
 }
 

--- a/src/fluid/4C_fluid_timint_poro.cpp
+++ b/src/fluid/4C_fluid_timint_poro.cpp
@@ -192,10 +192,10 @@ void FLD::TimIntPoro::set_custom_ele_params_assemble_mat_and_rhs(Teuchos::Parame
   eleparams.set<Inpar::FLUID::PhysicalType>("Physical Type", physicaltype_);
 
   // just for poroelasticity
-  discret_->set_state("dispn", dispn_);
-  discret_->set_state("accnp", accnp_);
-  discret_->set_state("accn", accn_);
-  discret_->set_state("gridvn", gridvn_);
+  discret_->set_state("dispn", *dispn_);
+  discret_->set_state("accnp", *accnp_);
+  discret_->set_state("accn", *accn_);
+  discret_->set_state("gridvn", *gridvn_);
 
   eleparams.set("total time", time_);
   eleparams.set("delta time", dta_);
@@ -220,10 +220,10 @@ void FLD::TimIntPoro::poro_int_update()
     eleparams.set<Inpar::FLUID::PhysicalType>("Physical Type", physicaltype_);
 
     discret_->clear_state();
-    discret_->set_state("dispnp", dispnp_);
-    discret_->set_state("gridv", gridv_);
-    discret_->set_state("velnp", velnp_);
-    discret_->set_state("scaaf", scaaf_);
+    discret_->set_state("dispnp", *dispnp_);
+    discret_->set_state("gridv", *gridv_);
+    discret_->set_state("velnp", *velnp_);
+    discret_->set_state("scaaf", *scaaf_);
     discret_->evaluate_condition(
         eleparams, sysmat_, nullptr, residual_, nullptr, nullptr, condname);
     discret_->clear_state();
@@ -242,9 +242,9 @@ void FLD::TimIntPoro::poro_int_update()
     eleparams.set<Inpar::FLUID::PhysicalType>("Physical Type", physicaltype_);
 
     discret_->clear_state();
-    discret_->set_state("dispnp", dispnp_);
-    discret_->set_state("gridv", gridv_);
-    discret_->set_state("velnp", velnp_);
+    discret_->set_state("dispnp", *dispnp_);
+    discret_->set_state("gridv", *gridv_);
+    discret_->set_state("velnp", *velnp_);
     discret_->evaluate_condition(
         eleparams, sysmat_, nullptr, residual_, nullptr, nullptr, condname);
     discret_->clear_state();

--- a/src/fluid/4C_fluid_timint_red.cpp
+++ b/src/fluid/4C_fluid_timint_red.cpp
@@ -51,7 +51,7 @@ void FLD::TimIntRedModels::init()
   // create the volumetric-surface-flow condition
   if (alefluid_)
   {
-    discret_->set_state("dispnp", dispn_);
+    discret_->set_state("dispnp", *dispn_);
   }
 
   vol_surf_flow_bc_ = std::make_shared<Utils::FluidVolumetricSurfaceFlowWrapper>(discret_, dta_);
@@ -77,10 +77,10 @@ void FLD::TimIntRedModels::init()
           Global::Problem::instance()->output_control_file(),
           Global::Problem::instance()->spatial_approximation_type());
       discret_->clear_state();
-      discret_->set_state("velaf", zeros_);
+      discret_->set_state("velaf", *zeros_);
       if (alefluid_)
       {
-        discret_->set_state("dispnp", dispnp_);
+        discret_->set_state("dispnp", *dispnp_);
       }
       coupled3D_redDbc_art_ =
           std::make_shared<Utils::FluidCouplingWrapper<Adapter::ArtNet>>(discret_,
@@ -96,10 +96,10 @@ void FLD::TimIntRedModels::init()
           Global::Problem::instance()->output_control_file(),
           Global::Problem::instance()->spatial_approximation_type());
       discret_->clear_state();
-      discret_->set_state("velaf", zeros_);
+      discret_->set_state("velaf", *zeros_);
       if (alefluid_)
       {
-        discret_->set_state("dispnp", dispnp_);
+        discret_->set_state("dispnp", *dispnp_);
       }
       coupled3D_redDbc_airways_ =
           std::make_shared<Utils::FluidCouplingWrapper<Airway::RedAirwayImplicitTimeInt>>(discret_,
@@ -138,7 +138,7 @@ void FLD::TimIntRedModels::do_problem_specific_boundary_conditions()
 {
   if (alefluid_)
   {
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
   }
 
   // Check if one-dimensional artery network problem exist
@@ -164,12 +164,12 @@ void FLD::TimIntRedModels::update_3d_to_reduced_mat_and_rhs()
 {
   discret_->clear_state();
 
-  discret_->set_state("velaf", velnp_);
-  discret_->set_state("hist", hist_);
+  discret_->set_state("velaf", *velnp_);
+  discret_->set_state("hist", *hist_);
 
   if (alefluid_)
   {
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
   }
 
   // Check if one-dimensional artery network problem exist
@@ -437,10 +437,10 @@ void FLD::TimIntRedModels::prepare_time_step()
   FluidImplicitTimeInt::prepare_time_step();
 
   discret_->clear_state();
-  discret_->set_state("velaf", velnp_);
-  discret_->set_state("hist", hist_);
+  discret_->set_state("velaf", *velnp_);
+  discret_->set_state("hist", *hist_);
 
-  if (alefluid_) discret_->set_state("dispnp", dispnp_);
+  if (alefluid_) discret_->set_state("dispnp", *dispnp_);
 
   // Check if one-dimensional artery network problem exist
   if (ART_timeInt_ != nullptr)

--- a/src/fluid/4C_fluid_timint_stat.cpp
+++ b/src/fluid/4C_fluid_timint_stat.cpp
@@ -155,11 +155,7 @@ void FLD::TimIntStationary::solve_stationary_problem()
 /*----------------------------------------------------------------------*
 | set integration-scheme-specific state                        bk 12/13 |
 *-----------------------------------------------------------------------*/
-void FLD::TimIntStationary::set_state_tim_int()
-{
-  discret_->set_state("velaf", velnp_);
-  return;
-}
+void FLD::TimIntStationary::set_state_tim_int() { discret_->set_state("velaf", *velnp_); }
 
 /*----------------------------------------------------------------------*
 | calculate acceleration                                       bk 12/13 |

--- a/src/fluid/4C_fluid_timint_stat_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_stat_hdg.cpp
@@ -140,13 +140,12 @@ void FLD::TimIntStationaryHDG::set_old_part_of_righthandside()
 void FLD::TimIntStationaryHDG::set_state_tim_int()
 {
   const Epetra_Map* intdofrowmap = discret_->dof_row_map(1);
-  std::shared_ptr<Core::LinAlg::Vector<double>> zerovec =
-      Core::LinAlg::create_vector(*intdofrowmap, true);
+  Core::LinAlg::Vector<double> zerovec(*intdofrowmap, true);
 
-  discret_->set_state(0, "velaf", velnp_);
-  discret_->set_state(1, "intvelaf", intvelnp_);  // TODO also fill in intvelnp_!
-  discret_->set_state(1, "intaccam", zerovec);
-  discret_->set_state(1, "intvelnp", intvelnp_);
+  discret_->set_state(0, "velaf", *velnp_);
+  discret_->set_state(1, "intvelaf", *intvelnp_);  // TODO also fill in intvelnp_!
+  discret_->set_state(1, "intaccam", zerovec);     // TODO memory management working?
+  discret_->set_state(1, "intvelnp", *intvelnp_);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/fluid/4C_fluid_utils.cpp
+++ b/src/fluid/4C_fluid_utils.cpp
@@ -276,7 +276,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FLD::Utils::StressManager::integra
   discret_->clear_state();
   if (alefluid_)
   {
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
   }
   discret_->evaluate_condition(eleparams, integratedshapefunc, condname);
   discret_->clear_state();
@@ -312,7 +312,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FLD::Utils::StressManager::calc_wa
   discret_->clear_state();  // TODO: (Thon) Do we really have to to this in here?
   if (alefluid_)
   {
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
   }
   // evaluate the normals of the surface
   discret_->evaluate_condition(eleparams, ndnorm0, "FluidStressCalc");
@@ -844,9 +844,9 @@ std::map<int, double> FLD::Utils::compute_flow_rates(Core::FE::Discretization& d
     // call loop over elements
     dis.clear_state();
 
-    dis.set_state("velaf", velnp);
-    if (dispnp != nullptr) dis.set_state("dispnp", dispnp);
-    if (gridv != nullptr) dis.set_state("gridv", gridv);
+    dis.set_state("velaf", *velnp);
+    if (dispnp != nullptr) dis.set_state("dispnp", *dispnp);
+    if (gridv != nullptr) dis.set_state("gridv", *gridv);
 
     dis.evaluate_condition(eleparams, flowrates, condstring, condID);
     dis.clear_state();
@@ -888,9 +888,9 @@ std::map<int, double> FLD::Utils::compute_volume(Core::FE::Discretization& dis,
 
   // call loop over elements
   dis.clear_state();
-  dis.set_state("velnp", velnp);
-  if (dispnp != nullptr) dis.set_state("dispnp", dispnp);
-  if (gridv != nullptr) dis.set_state("gridv", gridv);
+  dis.set_state("velnp", *velnp);
+  if (dispnp != nullptr) dis.set_state("dispnp", *dispnp);
+  if (gridv != nullptr) dis.set_state("gridv", *gridv);
 
   std::shared_ptr<Core::LinAlg::SerialDenseVector> volumes =
       std::make_shared<Core::LinAlg::SerialDenseVector>(1);
@@ -1025,7 +1025,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> FLD::Utils::project_gradient(
 
       // set given state for element evaluation
       discret.clear_state();
-      discret.set_state("vel", vel);
+      discret.set_state("vel", *vel);
 
       // project velocity gradient of fluid to nodal level via L2 projection
       projected_velgrad = Core::FE::compute_nodal_l2_projection(discret, "vel", numvec, params,

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -1869,7 +1869,7 @@ void FLD::Utils::TotalTractionCorrector::evaluate_velocities(
     {
       Teuchos::ParameterList eleparams;
 
-      discret_->set_state("velaf", velocities);
+      discret_->set_state("velaf", *velocities);
 
       flowrate = mapiter->second->FluidVolumetricSurfaceFlowBc::flow_rate_calculation(
           eleparams, time, "TotalTractionCorrectionCond", FLD::calc_flowrate, mapiter->first);
@@ -1952,7 +1952,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::export_and_set_boundary_values(
   // check if the exporting was successful
   if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
   // Set state
-  discret_->set_state(name, target);
+  discret_->set_state(name, *target);
 }
 
 /*----------------------------------------------------------------------*
@@ -1969,7 +1969,7 @@ void FLD::Utils::TotalTractionCorrector::export_and_set_boundary_values(
   // check if the exporting was successful
   if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
   // Set state
-  discret_->set_state(name, target);
+  discret_->set_state(name, *target);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/fluid/4C_fluid_xwall.cpp
+++ b/src/fluid/4C_fluid_xwall.cpp
@@ -1008,10 +1008,9 @@ void FLD::XWall::calc_tau_w(
   {
     // necessary to set right state (the maps of the state vector and discretization have to be
     // equal)
-    std::shared_ptr<Core::LinAlg::Vector<double>> statevel =
-        std::make_shared<Core::LinAlg::Vector<double>>(*(xwdiscret_->dof_row_map()), true);
+    Core::LinAlg::Vector<double> statevel(*(xwdiscret_->dof_row_map()), true);
     Core::LinAlg::Vector<double> newtauwxwdis(*(xwdiscret_->node_row_map()), true);
-    Core::LinAlg::export_to(velnp, *statevel);
+    Core::LinAlg::export_to(velnp, statevel);
 
     xwdiscret_->set_state("vel", statevel);
 
@@ -1159,9 +1158,9 @@ void FLD::XWall::l2_project_vector(Core::LinAlg::Vector<double>& veln,
   else
     numberofrhs = 3;
 
-  xwdiscret_->set_state("veln", stateveln_);
-  if (accn != nullptr) xwdiscret_->set_state("accn", stateaccn_);
-  if (velnp != nullptr) xwdiscret_->set_state("velnp", statevelnp_);
+  xwdiscret_->set_state("veln", *stateveln_);
+  if (accn != nullptr) xwdiscret_->set_state("accn", *stateaccn_);
+  if (velnp != nullptr) xwdiscret_->set_state("velnp", *statevelnp_);
 
   // set action in order to project nodal enriched values to new shape functions
   Teuchos::ParameterList params;
@@ -1700,12 +1699,10 @@ void FLD::XWallAleFSI::set_x_wall_params_xw_dis(Teuchos::ParameterList& eleparam
   XWall::set_x_wall_params_xw_dis(eleparams);
   // params required for the shape functions
   eleparams.set("incwalldist", incwdistxwdis_);
-  std::shared_ptr<Core::LinAlg::Vector<double>> xwdisdispnp =
-      Core::LinAlg::create_vector(*(xwdiscret_->dof_row_map()), true);
-  Core::LinAlg::export_to(*mydispnp_, *xwdisdispnp);
-  std::shared_ptr<Core::LinAlg::Vector<double>> xwdisgridv =
-      Core::LinAlg::create_vector(*(xwdiscret_->dof_row_map()), true);
-  Core::LinAlg::export_to(*mygridv_, *xwdisgridv);
+  Core::LinAlg::Vector<double> xwdisdispnp(*(xwdiscret_->dof_row_map()), true);
+  Core::LinAlg::export_to(*mydispnp_, xwdisdispnp);
+  Core::LinAlg::Vector<double> xwdisgridv(*(xwdiscret_->dof_row_map()), true);
+  Core::LinAlg::export_to(*mygridv_, xwdisgridv);
 
   xwdiscret_->set_state("dispnp", xwdisdispnp);
   xwdiscret_->set_state("gridv", xwdisgridv);

--- a/src/fluid_turbulence/4C_fluid_turbulence_boxfilter.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_boxfilter.cpp
@@ -178,8 +178,8 @@ void FLD::Boxfilter::apply_box_filter(
 
   // set state vector to pass distributed vector to the element
   discret_->clear_state();
-  discret_->set_state("u and p (trial)", velocity);
-  discret_->set_state("T (trial)", scalar);
+  discret_->set_state("u and p (trial)", *velocity);
+  discret_->set_state("T (trial)", *scalar);
 
   // dummies
   Core::LinAlg::SerialDenseMatrix emat1;
@@ -978,7 +978,7 @@ void FLD::Boxfilter::apply_box_filter_scatra(
 
   // set state vector to pass distributed vector to the element
   scatradiscret_->clear_state();
-  scatradiscret_->set_state("scalar", scalar);
+  scatradiscret_->set_state("scalar", *scalar);
 
   // dummies
   Core::LinAlg::SerialDenseMatrix emat1;

--- a/src/fluid_turbulence/4C_fluid_turbulence_hit_forcing.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_hit_forcing.cpp
@@ -1263,7 +1263,7 @@ namespace FLD
       if (forcing_type_ == Inpar::FLUID::linear_compensation_from_intermediate_spectrum or
           (forcing_type_ == Inpar::FLUID::fixed_power_input and (not is_genalpha_)))
       {
-        discret_->set_state(1, "intvelnp", velnp_);
+        discret_->set_state(1, "intvelnp", *velnp_);
       }
       else
         FOUR_C_THROW(
@@ -1703,7 +1703,7 @@ namespace FLD
       Teuchos::ParameterList params;
       params.set<FLD::Action>("action", FLD::interpolate_hdg_for_hit);
 
-      discret_->set_state(1, "intvelnp", velnp_);
+      discret_->set_state(1, "intvelnp", *velnp_);
 
       std::vector<int> dummy;
       Core::LinAlg::SerialDenseMatrix dummyMat;
@@ -1873,10 +1873,10 @@ namespace FLD
       // this is a dummy, forcing_ should be zero is written in the first components of interpolVec
       discret_->clear_state(true);
 
-      discret_->set_state(1, "intvelnp", velnp_);
+      discret_->set_state(1, "intvelnp", *velnp_);
 
       // this is the real value
-      discret_->set_state(1, "forcing", forcing_);
+      discret_->set_state(1, "forcing", *forcing_);
 
       // for 2nd evaluate
       const Epetra_Map* intdofrowmap = discret_->dof_row_map(1);
@@ -2020,7 +2020,7 @@ namespace FLD
 
     eleparams.set<double>("length", length_);
 
-    discret_->set_state("velnp", velnp_);
+    discret_->set_state("velnp", *velnp_);
 
     const Epetra_Map* elementrowmap = discret_->element_row_map();
     Core::LinAlg::MultiVector<double> massflvec(*elementrowmap, 1, true);

--- a/src/fluid_turbulence/4C_fluid_turbulence_hit_initial_field.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_hit_initial_field.cpp
@@ -1162,7 +1162,7 @@ namespace FLD
     // this is a dummy, should be zero is written in the first components of interpolVec
     intvelnp_->put_scalar(0.0);
     // set dummy
-    discret_->set_state(1, "intvelnp", intvelnp_);
+    discret_->set_state(1, "intvelnp", *intvelnp_);
 
     // for 2nd evaluate
     const Epetra_Map* intdofrowmap = discret_->dof_row_map(1);

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
@@ -575,12 +575,12 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
 
   if (nurbsdis == nullptr) FOUR_C_THROW("Oops. Your discretization is not a NurbsDiscretization.");
 
-  nurbsdis->set_state("velnp", meanvelnp_);
+  nurbsdis->set_state("velnp", *meanvelnp_);
 
   Core::FE::Nurbs::NurbsDiscretization* scatranurbsdis(nullptr);
   if (withscatra_)
   {
-    nurbsdis->set_state("scanp", meanscanp_);
+    nurbsdis->set_state("scanp", *meanscanp_);
 
     scatranurbsdis = dynamic_cast<Core::FE::Nurbs::NurbsDiscretization*>(&(*scatradis_));
     if (scatranurbsdis == nullptr)
@@ -589,7 +589,7 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     if (meanfullphinp_ == nullptr)
       FOUR_C_THROW("std::shared_ptr is nullptr");
     else
-      scatranurbsdis->set_state("phinp_for_statistics", meanfullphinp_);
+      scatranurbsdis->set_state("phinp_for_statistics", *meanfullphinp_);
 
     if (not(scatranurbsdis->dof_row_map())->SameAs(meanfullphinp_->get_map()))
     {

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_cha.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_cha.cpp
@@ -1948,10 +1948,10 @@ void FLD::TurbulenceStatisticsCha::evaluate_integral_mean_values_in_planes()
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("u and p (n+1,converged)", meanvelnp_);
+  discret_->set_state("u and p (n+1,converged)", *meanvelnp_);
   if (alefluid_)
   {
-    discret_->set_state("dispnp", dispnp_);
+    discret_->set_state("dispnp", *dispnp_);
   }
 
   // call loop over elements
@@ -2181,8 +2181,8 @@ void FLD::TurbulenceStatisticsCha::evaluate_loma_integral_mean_values_in_planes(
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("u and p (n+1,converged)", meanvelnp_);
-  discret_->set_state("scalar (n+1,converged)", meanscanp_);
+  discret_->set_state("u and p (n+1,converged)", *meanvelnp_);
+  discret_->set_state("scalar (n+1,converged)", *meanscanp_);
 
   // call loop over elements
   discret_->evaluate(eleparams, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -2397,8 +2397,8 @@ void FLD::TurbulenceStatisticsCha::evaluate_scatra_integral_mean_values_in_plane
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("u and p (n+1,converged)", meanvelnp_);
-  discret_->set_state("scalar (n+1,converged)", meanscanp_);
+  discret_->set_state("u and p (n+1,converged)", *meanvelnp_);
+  discret_->set_state("scalar (n+1,converged)", *meanscanp_);
 
   // call loop over elements
   discret_->evaluate(eleparams, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -2848,9 +2848,9 @@ void FLD::TurbulenceStatisticsCha::add_model_params_multifractal(
 
   // set state vectors for element call
   discret_->clear_state();
-  discret_->set_state("velnp", velnp);
+  discret_->set_state("velnp", *velnp);
   if (fsvelnp == nullptr) FOUR_C_THROW("Haven't got fine-scale velocity!");
-  discret_->set_state("fsvelnp", fsvelnp);
+  discret_->set_state("fsvelnp", *fsvelnp);
 
   // call loop over elements to compute means
   discret_->evaluate(paramsele, nullptr, nullptr, nullptr, nullptr, nullptr);
@@ -3074,7 +3074,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_residuals(
              statevecs.begin();
         state != statevecs.end(); ++state)
     {
-      discret_->set_state(state->first, state->second);
+      discret_->set_state(state->first, *state->second);
     }
 
     if (myxwall_ != nullptr) myxwall_->set_x_wall_params(eleparams_);
@@ -3119,7 +3119,7 @@ void FLD::TurbulenceStatisticsCha::evaluate_residuals(
                scatrastatevecs.begin();
           state != scatrastatevecs.end(); ++state)
       {
-        scatradiscret_->set_state(state->first, state->second);
+        scatradiscret_->set_state(state->first, *state->second);
       }
 
       // call loop over elements to compute means

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_hit.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_hit.cpp
@@ -1849,7 +1849,7 @@ namespace FLD
     Teuchos::ParameterList params;
     params.set<FLD::Action>("action", FLD::interpolate_hdg_for_hit);
 
-    discret_->set_state(1, "intvelnp", velnp);
+    discret_->set_state(1, "intvelnp", *velnp);
 
     std::vector<int> dummy;
     Core::LinAlg::SerialDenseMatrix dummyMat;

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_tgv.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_tgv.cpp
@@ -311,7 +311,7 @@ void FLD::TurbulenceStatisticsTgv::evaluate_residuals(
            statevecs.begin();
       state != statevecs.end(); ++state)
   {
-    discret_->set_state(state->first, state->second);
+    discret_->set_state(state->first, *state->second);
   }
 
   // call loop over elements to compute means

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -743,16 +743,16 @@ void FLD::XFluid::assemble_mat_and_rhs(int itnum)
   // set general vector values needed by elements
   discret_->clear_state();
 
-  discret_->set_state("hist", state_->hist_);
-  discret_->set_state("veln", state_->veln_);
-  discret_->set_state("accam", state_->accam_);
-  discret_->set_state("scaaf", state_->scaaf_);
-  discret_->set_state("scaam", state_->scaam_);
+  discret_->set_state("hist", *state_->hist_);
+  discret_->set_state("veln", *state_->veln_);
+  discret_->set_state("accam", *state_->accam_);
+  discret_->set_state("scaaf", *state_->scaaf_);
+  discret_->set_state("scaam", *state_->scaam_);
 
   if (alefluid_)
   {
-    discret_->set_state("dispnp", state_->dispnp_);
-    discret_->set_state("gridv", state_->gridvnp_);
+    discret_->set_state("dispnp", *state_->dispnp_);
+    discret_->set_state("gridv", *state_->gridvnp_);
   }
 
   set_state_tim_int();
@@ -1553,12 +1553,12 @@ void FLD::XFluid::assemble_mat_and_rhs_gradient_penalty(
     // FOUR_C_THROW("which vectors have to be set for gradient penalty for timeintegration in
     // alefluid?!"); In principle we would not need gridv, as tau is anyway set to 1.0 at the end
     // ...
-    discret_->set_state("dispnp", state_->dispnp_);
-    discret_->set_state("gridv", state_->gridvnp_);
+    discret_->set_state("dispnp", *state_->dispnp_);
+    discret_->set_state("gridv", *state_->gridvnp_);
   }
 
   // set scheme-specific element parameters and vector values
-  discret_->set_state("velaf", vec);
+  discret_->set_state("velaf", *vec);
 
 
 
@@ -1939,7 +1939,7 @@ void FLD::XFluid::compute_error_norms(Core::LinAlg::SerialDenseVector& glob_dom_
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("u and p at time n+1 (converged)", state_->velnp_);
+  discret_->set_state("u and p at time n+1 (converged)", *state_->velnp_);
 
   condition_manager_->set_state();
 
@@ -2857,7 +2857,7 @@ void FLD::XFluid::update_krylov_space_projection()
 
       if (alefluid_)
       {
-        discret_->set_state("dispnp", state_->dispnp_);
+        discret_->set_state("dispnp", *state_->dispnp_);
       }
 
       /*
@@ -4783,7 +4783,7 @@ void FLD::XFluid::set_dirichlet_neumann_bc()
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("velaf", state_->velnp_);
+  discret_->set_state("velaf", *state_->velnp_);
   // predicted dirichlet values
   // velnp then also holds prescribed new dirichlet values
   discret_->evaluate_dirichlet(
@@ -4793,14 +4793,14 @@ void FLD::XFluid::set_dirichlet_neumann_bc()
 
   if (alefluid_)
   {
-    discret_->set_state("dispnp", state_->dispnp_);
+    discret_->set_state("dispnp", *state_->dispnp_);
   }
 
   // set thermodynamic pressure
   eleparams.set("thermodynamic pressure", thermpressaf_);
 
   state_->neumann_loads_->put_scalar(0.0);
-  discret_->set_state("scaaf", state_->scaaf_);
+  discret_->set_state("scaaf", *state_->scaaf_);
 
   XFEM::evaluate_neumann(eleparams, discret_, *state_->neumann_loads_);
 
@@ -4990,7 +4990,7 @@ void FLD::XFluid::predict_tang_vel_consist_acc()
   // get Dirichlet values at t_{n+1}
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("velnp", state_->velnp_);
+  discret_->set_state("velnp", *state_->velnp_);
 
   // predicted Dirichlet values
   // velnp_ then also holds prescribed new dirichlet values
@@ -5435,9 +5435,9 @@ void FLD::XFluid::set_state_tim_int()
 {
   // set scheme-specific element parameters and vector values
   if (timealgo_ == Inpar::FLUID::timeint_afgenalpha)
-    discret_->set_state("velaf", state_->velaf_);
+    discret_->set_state("velaf", *state_->velaf_);
   else
-    discret_->set_state("velaf", state_->velnp_);
+    discret_->set_state("velaf", *state_->velnp_);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
@@ -242,7 +242,7 @@ void FLD::XFluidFluid::evaluate(std::shared_ptr<const Core::LinAlg::Vector<doubl
   {
     mc_xff_->reset_evaluated_trace_estimates();
     if (ale_embfluid_)
-      embedded_fluid_->discretization()->set_state("dispnp", embedded_fluid_->dispnp());
+      embedded_fluid_->discretization()->set_state("dispnp", *embedded_fluid_->dispnp());
   }
 
   // evaluation of background fluid (new cut for full Newton approach)
@@ -372,11 +372,11 @@ void FLD::XFluidFluid::assemble_mat_and_rhs(int itnum  ///< iteration number
     mc_xff_->get_coupling_dis()->clear_state();
     // set velocity and displacement state for embedded fluid
     embedded_fluid_->set_state_tim_int();
-    mc_xff_->get_coupling_dis()->set_state("veln", embedded_fluid_->veln());
+    mc_xff_->get_coupling_dis()->set_state("veln", *embedded_fluid_->veln());
 
     if (ale_embfluid_)
     {
-      mc_xff_->get_coupling_dis()->set_state("dispnp", embedded_fluid_->dispnp());
+      mc_xff_->get_coupling_dis()->set_state("dispnp", *embedded_fluid_->dispnp());
     }
   }
 
@@ -490,7 +490,7 @@ void FLD::XFluidFluid::update_by_increment()
 void FLD::XFluidFluid::add_eos_pres_stab_to_emb_layer()
 {
   if (ale_embfluid_)
-    embedded_fluid_->discretization()->set_state("gridv", embedded_fluid_->grid_vel());
+    embedded_fluid_->discretization()->set_state("gridv", *embedded_fluid_->grid_vel());
 
   Teuchos::ParameterList faceparams;
 
@@ -802,10 +802,10 @@ std::shared_ptr<std::vector<double>> FLD::XFluidFluid::evaluate_error_compared_t
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("u and p at time n+1 (converged)", state_->velnp_);
+  discret_->set_state("u and p at time n+1 (converged)", *state_->velnp_);
 
   mc_xff_->get_cond_dis()->clear_state();
-  mc_xff_->get_cond_dis()->set_state("velaf", embedded_fluid_->velnp());
+  mc_xff_->get_cond_dis()->set_state("velaf", *embedded_fluid_->velnp());
   // mc_xff_->GetCondDis()->set_state("dispnp", embedded_fluid_->Dispnp());
 
   mc_xff_->set_state();
@@ -819,7 +819,7 @@ std::shared_ptr<std::vector<double>> FLD::XFluidFluid::evaluate_error_compared_t
   //---------------------------------------------
   // set vector values needed by elements
   mc_xff_->get_cond_dis()->clear_state();
-  mc_xff_->get_cond_dis()->set_state("u and p at time n+1 (converged)", embedded_fluid_->velnp());
+  mc_xff_->get_cond_dis()->set_state("u and p at time n+1 (converged)", *embedded_fluid_->velnp());
 
   // evaluate domain error norms and interface/boundary error norms at XFEM-interface
   // loop row elements

--- a/src/fpsi/4C_fpsi_coupling.cpp
+++ b/src/fpsi/4C_fpsi_coupling.cpp
@@ -254,27 +254,27 @@ void FPSI::FpsiCoupling::evaluate_coupling_matrixes_rhs()
     poro_field()->fluid_field()->discretization()->clear_state();
 
     poro_field()->fluid_field()->discretization()->set_state(
-        0, "dispnp", poro_field()->fluid_field()->dispnp());
+        0, "dispnp", *poro_field()->fluid_field()->dispnp());
 
     poro_field()->fluid_field()->discretization()->set_state(
-        0, "gridv", poro_field()->fluid_field()->grid_vel());
+        0, "gridv", *poro_field()->fluid_field()->grid_vel());
     poro_field()->fluid_field()->discretization()->set_state(
-        0, "dispn", poro_field()->fluid_field()->dispn());
+        0, "dispn", *poro_field()->fluid_field()->dispn());
     poro_field()->fluid_field()->discretization()->set_state(
-        0, "veln", poro_field()->fluid_field()->veln());
+        0, "veln", *poro_field()->fluid_field()->veln());
     poro_field()->fluid_field()->discretization()->set_state(
-        0, "velaf", poro_field()->fluid_field()->velnp());
+        0, "velaf", *poro_field()->fluid_field()->velnp());
     poro_field()->fluid_field()->discretization()->set_state(
-        0, "velnp", poro_field()->fluid_field()->velnp());
+        0, "velnp", *poro_field()->fluid_field()->velnp());
 
     fluid_field()->discretization()->clear_state();
 
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-    fluid_field()->discretization()->set_state(0, "dispn", fluid_field()->dispn());
-    fluid_field()->discretization()->set_state(0, "veln", fluid_field()->veln());
-    fluid_field()->discretization()->set_state(0, "velaf", fluid_field()->velnp());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+    fluid_field()->discretization()->set_state(0, "dispn", *fluid_field()->dispn());
+    fluid_field()->discretization()->set_state(0, "veln", *fluid_field()->veln());
+    fluid_field()->discretization()->set_state(0, "velaf", *fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
 
     // create the parameters for the discretization
     Teuchos::ParameterList fparams;

--- a/src/fpsi/4C_fpsi_monolithic.cpp
+++ b/src/fpsi/4C_fpsi_monolithic.cpp
@@ -429,7 +429,7 @@ void FPSI::Monolithic::evaluate(std::shared_ptr<const Core::LinAlg::Vector<doubl
   {
     fluid_field()->discretization()->clear_state();
     linesearch_counter = 0.;
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
     meshdispold_ = ale_to_fluid(ale_field()->dispnp());
     porointerfacedisplacementsold_ = fpsi_coupl()->i_porostruct_to_ale(
         *poro_field()->structure_field()->extract_interface_dispnp(true));
@@ -1515,26 +1515,26 @@ void FPSI::Monolithic::fpsifd_check()
   poro_field()->fluid_field()->discretization()->clear_state();
 
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "dispnp", poro_field()->fluid_field()->dispnp());
+      0, "dispnp", *poro_field()->fluid_field()->dispnp());
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "gridv", poro_field()->fluid_field()->grid_vel());
+      0, "gridv", *poro_field()->fluid_field()->grid_vel());
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "dispn", poro_field()->fluid_field()->dispn());
+      0, "dispn", *poro_field()->fluid_field()->dispn());
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "veln", poro_field()->fluid_field()->veln());
+      0, "veln", *poro_field()->fluid_field()->veln());
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "velaf", poro_field()->fluid_field()->velnp());
+      0, "velaf", *poro_field()->fluid_field()->velnp());
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "velnp", poro_field()->fluid_field()->velnp());
+      0, "velnp", *poro_field()->fluid_field()->velnp());
 
   fluid_field()->discretization()->clear_state();
 
-  fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-  fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-  fluid_field()->discretization()->set_state(0, "dispn", fluid_field()->dispn());
-  fluid_field()->discretization()->set_state(0, "veln", fluid_field()->veln());
-  fluid_field()->discretization()->set_state(0, "velaf", fluid_field()->velnp());
-  fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
+  fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+  fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+  fluid_field()->discretization()->set_state(0, "dispn", *fluid_field()->dispn());
+  fluid_field()->discretization()->set_state(0, "veln", *fluid_field()->veln());
+  fluid_field()->discretization()->set_state(0, "velaf", *fluid_field()->velnp());
+  fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
 
   // define and set toggle parameter delta
   const double delta = 1e-8;

--- a/src/fs3i/4C_fs3i_biofilm_fsi.cpp
+++ b/src/fs3i/4C_fs3i_biofilm_fsi.cpp
@@ -453,7 +453,7 @@ void FS3I::BiofilmFSI::inner_timeloop()
     Teuchos::ParameterList eleparams;
     eleparams.set("action", "calc_cur_nodal_normals");
     strudis->clear_state();
-    strudis->set_state("displacement", fsi_->structure_field()->dispnp());
+    strudis->set_state("displacement", *fsi_->structure_field()->dispnp());
     strudis->evaluate_condition(
         eleparams, nullptr, nullptr, nodalnormals, nullptr, nullptr, "FSICoupling");
     strudis->clear_state();

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -605,7 +605,7 @@ void FS3I::PartFPS3I::set_fpsi_solution()
 void FS3I::PartFPS3I::set_struct_scatra_solution()
 {
   fpsi_->poro_field()->structure_field()->discretization()->set_state(
-      1, "scalarfield", (scatravec_[1])->scatra_field()->phinp());
+      1, "scalarfield", *(scatravec_[1])->scatra_field()->phinp());
 }
 
 

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -672,7 +672,7 @@ void FS3I::PartFS3I::set_fsi_solution()
 void FS3I::PartFS3I::set_struct_scatra_solution() const
 {
   fsi_->structure_field()->discretization()->set_state(
-      1, "scalarfield", structure_scalar_to_structure(scatravec_[1]->scatra_field()->phinp()));
+      1, "scalarfield", *structure_scalar_to_structure(scatravec_[1]->scatra_field()->phinp()));
 }
 
 

--- a/src/fs3i/4C_fs3i_partitioned_2wc.cpp
+++ b/src/fs3i/4C_fs3i_partitioned_2wc.cpp
@@ -304,7 +304,7 @@ void FS3I::PartFS3I2Wc::set_scatra_values_in_fsi()
   // (Note potential inconsistencies related to this call in case of generalized-alpha time
   // integration!)
   fsi_->structure_field()->discretization()->set_state(
-      1, "scalarfield", structure_scalar_to_structure(scatravec_[1]->scatra_field()->phinp()));
+      1, "scalarfield", *structure_scalar_to_structure(scatravec_[1]->scatra_field()->phinp()));
 }
 
 

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -317,12 +317,10 @@ std::vector<double> FSI::Utils::SlideAleUtils::centerdisp(
 
   const int dim = Global::Problem::instance()->n_dim();
   // get structure and fluid discretizations  and set stated for element evaluation
-  const std::shared_ptr<Core::LinAlg::Vector<double>> idisptotalcol =
-      Core::LinAlg::create_vector(*structdis->dof_col_map(), true);
-  Core::LinAlg::export_to(*idisptotal, *idisptotalcol);
-  const std::shared_ptr<Core::LinAlg::Vector<double>> idispstepcol =
-      Core::LinAlg::create_vector(*structdis->dof_col_map(), true);
-  Core::LinAlg::export_to(*idispstep, *idispstepcol);
+  Core::LinAlg::Vector<double> idisptotalcol(*structdis->dof_col_map(), true);
+  export_to(*idisptotal, idisptotalcol);
+  Core::LinAlg::Vector<double> idispstepcol(*structdis->dof_col_map(), true);
+  export_to(*idispstep, idispstepcol);
 
   structdis->set_state("displacementtotal", idisptotalcol);
   structdis->set_state("displacementincr", idispstepcol);
@@ -685,12 +683,10 @@ void FSI::Utils::SlideAleUtils::rotation(
   idispstep->update(1.0, idispale, -1.0, *iprojhist_, 0.0);
 
   // get structure and fluid discretizations  and set state for element evaluation
-  const std::shared_ptr<Core::LinAlg::Vector<double>> idispstepcol =
-      Core::LinAlg::create_vector(*mtrdis.dof_col_map(), false);
-  Core::LinAlg::export_to(*idispstep, *idispstepcol);
-  const std::shared_ptr<Core::LinAlg::Vector<double>> idispnpcol =
-      Core::LinAlg::create_vector(*mtrdis.dof_col_map(), false);
-  Core::LinAlg::export_to(idispale, *idispnpcol);
+  Core::LinAlg::Vector<double> idispstepcol(*mtrdis.dof_col_map(), false);
+  export_to(*idispstep, idispstepcol);
+  Core::LinAlg::Vector<double> idispnpcol(*mtrdis.dof_col_map(), false);
+  Core::LinAlg::export_to(idispale, idispnpcol);
 
   mtrdis.set_state("displacementnp", idispnpcol);
   mtrdis.set_state("displacementincr", idispstepcol);

--- a/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
@@ -98,13 +98,13 @@ void XFEM::XfsCouplingManager::set_coupling_states()
   if (mcfsi_->get_averaging_strategy() != Inpar::XFEM::Xfluid_Sided)
   {
     // Set Dispnp (used to calc local coord of gausspoints)
-    struct_->discretization()->set_state("dispnp", struct_->dispnp());
+    struct_->discretization()->set_state("dispnp", *struct_->dispnp());
     // Set Velnp (used for interface integration)
     std::shared_ptr<Core::LinAlg::Vector<double>> fullvelnp =
         std::make_shared<Core::LinAlg::Vector<double>>(struct_->velnp()->get_map(), true);
     fullvelnp->update(1.0, *struct_->dispnp(), -1.0, *struct_->dispn(), 0.0);
     fullvelnp->update(-(dt - 1 / scaling_FSI) * scaling_FSI, *struct_->veln(), scaling_FSI);
-    struct_->discretization()->set_state("velaf", fullvelnp);
+    struct_->discretization()->set_state("velaf", *fullvelnp);
   }
 }
 

--- a/src/levelset/4C_levelset_algorithm_reinit.cpp
+++ b/src/levelset/4C_levelset_algorithm_reinit.cpp
@@ -362,7 +362,7 @@ void ScaTra::LevelSetAlgorithm::calc_node_based_reinit_vel()
 
       discret_->clear_state();  // TODO Caution if called from nonlinear_solve
       // set initial phi, i.e., solution of level-set equation
-      discret_->set_state("phizero", initialphireinit_);
+      discret_->set_state("phizero", *initialphireinit_);
 
       switch (reinitaction_)
       {
@@ -371,7 +371,7 @@ void ScaTra::LevelSetAlgorithm::calc_node_based_reinit_vel()
           // set phin as phi used for velocity
           // note:read as phinp in sysmat_nodal_vel()
 #ifdef USE_PHIN_FOR_VEL
-          discret_->set_state("phinp", phin_);
+          discret_->set_state("phinp", *phin_);
 #else
           discret_->set_state("phinp", phinp_);
 #endif
@@ -379,7 +379,7 @@ void ScaTra::LevelSetAlgorithm::calc_node_based_reinit_vel()
         }
         case Inpar::ScaTra::reinitaction_ellipticeq:
         {
-          discret_->set_state("phinp", phinp_);
+          discret_->set_state("phinp", *phinp_);
           break;
         }
         default:
@@ -464,8 +464,8 @@ void ScaTra::LevelSetAlgorithm::correction_reinit()
 
   // set state vectors
   discret_->clear_state();
-  discret_->set_state("phizero", initialphireinit_);
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phizero", *initialphireinit_);
+  discret_->set_state("phinp", *phinp_);
 
 
   // call loop over elements

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -77,9 +77,9 @@ void ScaTra::LevelSetAlgorithm::add_problem_specific_parameters_and_vectors(
     if (reinitaction_ == Inpar::ScaTra::reinitaction_sussman)
     {
       // set initial phi, i.e., solution of level-set equation
-      discret_->set_state("phizero", initialphireinit_);
+      discret_->set_state("phizero", *initialphireinit_);
       // TODO: RM if not needed
-      discret_->set_state("phin", phin_);
+      discret_->set_state("phin", *phin_);
 
 #ifndef USE_PHIN_FOR_VEL
       if (useprojectedreinitvel_ == Inpar::ScaTra::vel_reinit_node_based)
@@ -268,8 +268,8 @@ void ScaTra::LevelSetAlgorithm::evaluate_error_compared_to_analytical_sol()
 
         // set vector values needed by elements
         discret_->clear_state();
-        discret_->set_state("phinp", phinp_);
-        discret_->set_state("phiref", phiref);
+        discret_->set_state("phinp", *phinp_);
+        discret_->set_state("phiref", *phiref);
 
         // get error and volume
         std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -453,8 +453,8 @@ void ScaTra::LevelSetAlgorithm::apply_contact_point_boundary_condition()
   }
 
   // update velocity vectors
-  discret_->set_state(nds_vel(), "convective velocity field", convel_new);
-  discret_->set_state(nds_vel(), "velocity field", convel_new);
+  discret_->set_state(nds_vel(), "convective velocity field", *convel_new);
+  discret_->set_state(nds_vel(), "velocity field", *convel_new);
 
   return;
 }
@@ -896,8 +896,8 @@ void ScaTra::LevelSetAlgorithm::manipulate_fluid_field_for_gfunc()
   }
 
   // update velocity vectors
-  discret_->set_state(nds_vel(), "convective velocity field", conveltmp);
-  discret_->set_state(nds_vel(), "velocity field", conveltmp);
+  discret_->set_state(nds_vel(), "convective velocity field", *conveltmp);
+  discret_->set_state(nds_vel(), "velocity field", *conveltmp);
 
 
   return;
@@ -911,7 +911,7 @@ void ScaTra::LevelSetAlgorithm::mass_center_using_smoothing()
 {
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   // create the parameters for the error calculation
   Teuchos::ParameterList eleparams;

--- a/src/loma/4C_loma_algorithm.cpp
+++ b/src/loma/4C_loma_algorithm.cpp
@@ -701,10 +701,10 @@ void LowMach::Algorithm::evaluate_loma_od_block_mat_fluid(
 
   // set general vector values needed by elements
   fluid_field()->discretization()->clear_state();
-  fluid_field()->discretization()->set_state(0, "hist", fluid_field()->hist());
-  fluid_field()->discretization()->set_state(0, "accam", fluid_field()->accam());
-  fluid_field()->discretization()->set_state(0, "scaaf", fluid_field()->scaaf());
-  fluid_field()->discretization()->set_state(0, "scaam", fluid_field()->scaam());
+  fluid_field()->discretization()->set_state(0, "hist", *fluid_field()->hist());
+  fluid_field()->discretization()->set_state(0, "accam", *fluid_field()->accam());
+  fluid_field()->discretization()->set_state(0, "scaaf", *fluid_field()->scaaf());
+  fluid_field()->discretization()->set_state(0, "scaam", *fluid_field()->scaam());
 
   // set time-integration-scheme-specific element parameters and vector values
   if (fluid_field()->tim_int_scheme() == Inpar::FLUID::timeint_afgenalpha)
@@ -720,7 +720,7 @@ void LowMach::Algorithm::evaluate_loma_od_block_mat_fluid(
         std::dynamic_pointer_cast<ScaTra::ScaTraTimIntLoma>(scatra_field())->therm_press_dt_am());
 
     // set velocity vector
-    fluid_field()->discretization()->set_state(0, "velaf", fluid_field()->velaf());
+    fluid_field()->discretization()->set_state(0, "velaf", *fluid_field()->velaf());
   }
   else if (fluid_field()->tim_int_scheme() == Inpar::FLUID::timeint_one_step_theta)
   {
@@ -735,7 +735,7 @@ void LowMach::Algorithm::evaluate_loma_od_block_mat_fluid(
         std::dynamic_pointer_cast<ScaTra::ScaTraTimIntLoma>(scatra_field())->therm_press_dt_np());
 
     // set velocity vector
-    fluid_field()->discretization()->set_state(0, "velaf", fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "velaf", *fluid_field()->velnp());
   }
   else
     FOUR_C_THROW("Time integration scheme not supported");

--- a/src/lubrication/src/4C_lubrication_timint_implicit.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_implicit.cpp
@@ -304,7 +304,7 @@ void Lubrication::TimIntImpl::set_height_field_pure_lub(const int nds)
     }
   }
   // provide lubrication discretization with height
-  discret_->set_state(nds, "height", height);
+  discret_->set_state(nds, "height", *height);
 
 }  // Lubrication::TimIntImpl::set_height_field_pure_lub
 
@@ -348,7 +348,7 @@ void Lubrication::TimIntImpl::set_average_velocity_field_pure_lub(const int nds)
     }
   }
   // provide lubrication discretization with velocity
-  discret_->set_state(nds, "av_tang_vel", vel);
+  discret_->set_state(nds, "av_tang_vel", *vel);
 
 }  // Lubrication::TimIntImpl::set_average_velocity_field_pure_lub
 /*----------------------------------------------------------------------*
@@ -443,7 +443,7 @@ void Lubrication::TimIntImpl::apply_mesh_movement(
     nds_disp_ = nds;
 
     // provide lubrication discretization with displacement field
-    discret_->set_state(nds_disp_, "dispnp", dispnp);
+    discret_->set_state(nds_disp_, "dispnp", *dispnp);
   }  // if (isale_)
 
   return;
@@ -852,7 +852,7 @@ void Lubrication::TimIntImpl::set_height_field(
     const int nds, std::shared_ptr<const Core::LinAlg::Vector<double>> gap)
 {
   if (gap == nullptr) FOUR_C_THROW("Gap vector is empty.");
-  discret_->set_state(nds, "height", gap);
+  discret_->set_state(nds, "height", *gap);
 
   return;
 }
@@ -865,7 +865,7 @@ void Lubrication::TimIntImpl::set_height_dot_field(
     const int nds, std::shared_ptr<const Core::LinAlg::Vector<double>> heightdot)
 {
   if (heightdot == nullptr) FOUR_C_THROW("hdot vector is empty.");
-  discret_->set_state(nds, "heightdot", heightdot);
+  discret_->set_state(nds, "heightdot", *heightdot);
 
   return;
 }
@@ -879,7 +879,7 @@ void Lubrication::TimIntImpl::set_relative_velocity_field(
   if (nds >= discret_->num_dof_sets())
     FOUR_C_THROW("Too few dofsets on lubrication discretization!");
   if (rel_vel == nullptr) FOUR_C_THROW("no velocity provided.");
-  discret_->set_state(nds, "rel_tang_vel", rel_vel);
+  discret_->set_state(nds, "rel_tang_vel", *rel_vel);
 }
 
 /*----------------------------------------------------------------------*
@@ -892,7 +892,7 @@ void Lubrication::TimIntImpl::set_average_velocity_field(
     FOUR_C_THROW("Too few dofsets on lubrication discretization!");
   if (av_vel == nullptr) FOUR_C_THROW("no velocity provided");
 
-  discret_->set_state(nds, "av_tang_vel", av_vel);
+  discret_->set_state(nds, "av_tang_vel", *av_vel);
 }
 
 /*----------------------------------------------------------------------*
@@ -1069,7 +1069,7 @@ void Lubrication::TimIntImpl::evaluate_error_compared_to_analytical_sol()
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("prenp", prenp_);
+  discret_->set_state("prenp", *prenp_);
 
   // get (squared) error values
   std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -1161,7 +1161,7 @@ void Lubrication::TimIntImpl::output_mean_pressures(const int num)
   {
     // set pressure values needed by elements
     discret_->clear_state();
-    discret_->set_state("prenp", prenp_);
+    discret_->set_state("prenp", *prenp_);
     // set action for elements
     Teuchos::ParameterList eleparams;
     eleparams.set<Lubrication::Action>("action", Lubrication::calc_mean_pressures);

--- a/src/lubrication/src/4C_lubrication_timint_stat.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_stat.cpp
@@ -96,7 +96,7 @@ void Lubrication::TimIntStationary::add_neumann_to_residual()
 void Lubrication::TimIntStationary::add_time_integration_specific_vectors(
     bool forcedincrementalsolver)
 {
-  discret_->set_state("prenp", prenp_);
+  discret_->set_state("prenp", *prenp_);
 }
 
 

--- a/src/mat/4C_mat_scatra_multiscale_gp.cpp
+++ b/src/mat/4C_mat_scatra_multiscale_gp.cpp
@@ -336,7 +336,7 @@ double Mat::ScatraMultiScaleGP::evaluate_mean_concentration() const
 
   // set micro-scale state vector
   discret.clear_state();
-  discret.set_state("phinp", phinp_);
+  discret.set_state("phinp", *phinp_);
 
   // set parameters for micro-scale elements
   Teuchos::ParameterList eleparams;
@@ -370,7 +370,7 @@ double Mat::ScatraMultiScaleGP::evaluate_mean_concentration_time_derivative() co
 
   // set micro-scale state vector
   discret.clear_state();
-  discret.set_state("phidtnp", phidtnp_);
+  discret.set_state("phidtnp", *phidtnp_);
 
   // set parameters for micro-scale elements
   Teuchos::ParameterList eleparams;

--- a/src/mortar/4C_mortar_interface.cpp
+++ b/src/mortar/4C_mortar_interface.cpp
@@ -2042,7 +2042,7 @@ void Mortar::Interface::set_state(
       Core::LinAlg::export_to(vec, *global);
 
       // set displacements in interface discretization
-      idiscret_->set_state(state_type_to_string(statetype), global);
+      idiscret_->set_state(state_type_to_string(statetype), *global);
 
       // loop over all nodes to set current displacement
       // (use fully overlapping column map)
@@ -2101,7 +2101,7 @@ void Mortar::Interface::set_state(
       Core::LinAlg::export_to(vec, *global);
 
       // set displacements in interface discretization
-      idiscret_->set_state(state_type_to_string(statetype), global);
+      idiscret_->set_state(state_type_to_string(statetype), *global);
 
       // loop over all nodes to set current displacement
       // (use fully overlapping column map)
@@ -4194,7 +4194,7 @@ void Mortar::Interface::create_volume_ghosting(
         Core::LinAlg::export_to(*statevec, *statevecrowmap);
 
         // now set the state again
-        structure_dis->set_state(1, "scalarfield", statevecrowmap);
+        structure_dis->set_state(1, "scalarfield", *statevecrowmap);
       }
 
       break;

--- a/src/poroelast/4C_poroelast_base.cpp
+++ b/src/poroelast/4C_poroelast_base.cpp
@@ -392,12 +392,12 @@ void PoroElast::PoroBase::set_fluid_solution()
 {
   if (matchinggrid_)
   {
-    structure_field()->discretization()->set_state(1, "fluidvel", fluid_field()->velnp());
+    structure_field()->discretization()->set_state(1, "fluidvel", *fluid_field()->velnp());
   }
   else
   {
     structure_field()->discretization()->set_state(
-        1, "fluidvel", volcoupl_->apply_vector_mapping12(*fluid_field()->velnp()));
+        1, "fluidvel", *volcoupl_->apply_vector_mapping12(*fluid_field()->velnp()));
   }
 }
 

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -1024,8 +1024,8 @@ void PoroElast::Monolithic::apply_str_coupl_matrix(
   }
 
   structure_field()->discretization()->clear_state();
-  structure_field()->discretization()->set_state(0, "displacement", structure_field()->dispnp());
-  structure_field()->discretization()->set_state(0, "velocity", structure_field()->velnp());
+  structure_field()->discretization()->set_state(0, "displacement", *structure_field()->dispnp());
+  structure_field()->discretization()->set_state(0, "velocity", *structure_field()->velnp());
 
   // build specific assemble strategy for mechanical-fluid system matrix
   // from the point of view of structure_field:
@@ -1063,27 +1063,27 @@ void PoroElast::Monolithic::apply_fluid_coupl_matrix(
   fluid_field()->discretization()->clear_state();
 
   // set general vector values needed by elements
-  fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-  fluid_field()->discretization()->set_state(0, "dispn", fluid_field()->dispn());
-  fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-  fluid_field()->discretization()->set_state(0, "gridvn", fluid_field()->grid_veln());
-  fluid_field()->discretization()->set_state(0, "veln", fluid_field()->veln());
-  fluid_field()->discretization()->set_state(0, "accnp", fluid_field()->accnp());
-  fluid_field()->discretization()->set_state(0, "accam", fluid_field()->accam());
-  fluid_field()->discretization()->set_state(0, "accn", fluid_field()->accn());
+  fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+  fluid_field()->discretization()->set_state(0, "dispn", *fluid_field()->dispn());
+  fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+  fluid_field()->discretization()->set_state(0, "gridvn", *fluid_field()->grid_veln());
+  fluid_field()->discretization()->set_state(0, "veln", *fluid_field()->veln());
+  fluid_field()->discretization()->set_state(0, "accnp", *fluid_field()->accnp());
+  fluid_field()->discretization()->set_state(0, "accam", *fluid_field()->accam());
+  fluid_field()->discretization()->set_state(0, "accn", *fluid_field()->accn());
 
-  fluid_field()->discretization()->set_state(0, "scaaf", fluid_field()->scaaf());
+  fluid_field()->discretization()->set_state(0, "scaaf", *fluid_field()->scaaf());
 
-  fluid_field()->discretization()->set_state(0, "hist", fluid_field()->hist());
+  fluid_field()->discretization()->set_state(0, "hist", *fluid_field()->hist());
 
   // set scheme-specific element parameters and vector values
   if (fluid_field()->tim_int_scheme() == Inpar::FLUID::timeint_npgenalpha or
       fluid_field()->tim_int_scheme() == Inpar::FLUID::timeint_npgenalpha)
-    fluid_field()->discretization()->set_state(0, "velaf", fluid_field()->velaf());
+    fluid_field()->discretization()->set_state(0, "velaf", *fluid_field()->velaf());
   else
-    fluid_field()->discretization()->set_state(0, "velaf", fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "velaf", *fluid_field()->velnp());
 
-  fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
+  fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
 
   // build specific assemble strategy for the fluid-mechanical system matrix
   // from the point of view of fluid_field:
@@ -1112,10 +1112,10 @@ void PoroElast::Monolithic::apply_fluid_coupl_matrix(
     params.set<Inpar::FLUID::PhysicalType>("Physical Type", fluid_field()->physical_type());
 
     fluid_field()->discretization()->clear_state();
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
-    fluid_field()->discretization()->set_state(0, "scaaf", fluid_field()->scaaf());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "scaaf", *fluid_field()->scaaf());
 
     fluid_field()->discretization()->evaluate_condition(params, fluidstrategy, "PoroPartInt");
 
@@ -1131,8 +1131,8 @@ void PoroElast::Monolithic::apply_fluid_coupl_matrix(
     params.set<Inpar::FLUID::PhysicalType>("Physical Type", fluid_field()->physical_type());
 
     fluid_field()->discretization()->clear_state();
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
 
     fluid_field()->discretization()->evaluate_condition(params, fluidstrategy, "PoroPresInt");
 

--- a/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
@@ -375,10 +375,10 @@ void PoroElast::MonolithicSplitNoPenetration::apply_fluid_coupl_matrix(
     params.set<Inpar::FLUID::PhysicalType>("Physical Type", fluid_field()->physical_type());
 
     fluid_field()->discretization()->clear_state();
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
-    fluid_field()->discretization()->set_state(0, "scaaf", fluid_field()->scaaf());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "scaaf", *fluid_field()->scaaf());
 
     // fluid_field()->discretization()->set_state(0,"lambda",
     //    fluid_field()->Interface()->insert_fsi_cond_vector(structure_to_fluid_at_interface(lambdanp_)));
@@ -413,13 +413,13 @@ void PoroElast::MonolithicSplitNoPenetration::apply_fluid_coupl_matrix(
     params.set<Inpar::FLUID::PhysicalType>("Physical Type", fluid_field()->physical_type());
 
     fluid_field()->discretization()->clear_state();
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
-    fluid_field()->discretization()->set_state(0, "scaaf", fluid_field()->scaaf());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "scaaf", *fluid_field()->scaaf());
 
     fluid_field()->discretization()->set_state(0, "lambda",
-        fluid_field()->interface()->insert_fsi_cond_vector(
+        *fluid_field()->interface()->insert_fsi_cond_vector(
             *structure_to_fluid_at_interface(*lambdanp_)));
 
     // build specific assemble strategy for the fluid-mechanical system matrix
@@ -446,9 +446,9 @@ void PoroElast::MonolithicSplitNoPenetration::apply_fluid_coupl_matrix(
     params.set<Inpar::FLUID::PhysicalType>("Physical Type", fluid_field()->physical_type());
 
     fluid_field()->discretization()->clear_state();
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
     //  fluid_field()->discretization()->set_state(0,"scaaf",fluid_field()->Scaaf());
 
     // build specific assemble strategy for the fluid-mechanical system matrix
@@ -475,9 +475,9 @@ void PoroElast::MonolithicSplitNoPenetration::apply_fluid_coupl_matrix(
     params.set<Inpar::FLUID::PhysicalType>("Physical Type", fluid_field()->physical_type());
 
     fluid_field()->discretization()->clear_state();
-    fluid_field()->discretization()->set_state(0, "dispnp", fluid_field()->dispnp());
-    fluid_field()->discretization()->set_state(0, "gridv", fluid_field()->grid_vel());
-    fluid_field()->discretization()->set_state(0, "velnp", fluid_field()->velnp());
+    fluid_field()->discretization()->set_state(0, "dispnp", *fluid_field()->dispnp());
+    fluid_field()->discretization()->set_state(0, "gridv", *fluid_field()->grid_vel());
+    fluid_field()->discretization()->set_state(0, "velnp", *fluid_field()->velnp());
 
     // build specific assemble strategy for the fluid-mechanical system matrix
     // from the point of view of fluid_field:

--- a/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
@@ -142,8 +142,8 @@ void PoroElastScaTra::PoroScatraBase::set_scatra_solution()
   }
 
   // porous structure
-  poro_->structure_field()->discretization()->set_state(2, "scalar", phinp_s);
-  poro_->structure_field()->discretization()->set_state(2, "scalarn", phin_s);
+  poro_->structure_field()->discretization()->set_state(2, "scalar", *phinp_s);
+  poro_->structure_field()->discretization()->set_state(2, "scalarn", *phin_s);
 
   // porous fluid
   poro_->fluid_field()->set_iter_scalar_fields(phinp_f, phin_f, phidtnp,
@@ -207,7 +207,7 @@ void PoroElastScaTra::PoroScatraBase::set_mesh_disp()
     sdispnp = volcoupl_structurescatra_->apply_vector_mapping21(*structure_field()->dispnp());
   }
 
-  scatra_->scatra_field()->discretization()->set_state(1, "displacement", sdispnp);
+  scatra_->scatra_field()->discretization()->set_state(1, "displacement", *sdispnp);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
@@ -1074,17 +1074,17 @@ void PoroElastScaTra::PoroScatraMono::evaluate_od_block_mat_poro()
   porofluiddis->clear_state();
 
   // set general vector values needed by elements
-  porofluiddis->set_state(0, "dispnp", poro_field()->fluid_field()->dispnp());
-  porofluiddis->set_state(0, "gridv", poro_field()->fluid_field()->grid_vel());
-  porofluiddis->set_state(0, "veln", poro_field()->fluid_field()->veln());
-  porofluiddis->set_state(0, "accnp", poro_field()->fluid_field()->accnp());
-  porofluiddis->set_state(0, "hist", poro_field()->fluid_field()->hist());
+  porofluiddis->set_state(0, "dispnp", *poro_field()->fluid_field()->dispnp());
+  porofluiddis->set_state(0, "gridv", *poro_field()->fluid_field()->grid_vel());
+  porofluiddis->set_state(0, "veln", *poro_field()->fluid_field()->veln());
+  porofluiddis->set_state(0, "accnp", *poro_field()->fluid_field()->accnp());
+  porofluiddis->set_state(0, "hist", *poro_field()->fluid_field()->hist());
 
   poro_field()->fluid_field()->discretization()->set_state(
-      0, "scaaf", poro_field()->fluid_field()->scaaf());
+      0, "scaaf", *poro_field()->fluid_field()->scaaf());
 
-  porofluiddis->set_state(0, "velaf", poro_field()->fluid_field()->velnp());
-  porofluiddis->set_state(0, "velnp", poro_field()->fluid_field()->velnp());
+  porofluiddis->set_state(0, "velaf", *poro_field()->fluid_field()->velnp());
+  porofluiddis->set_state(0, "velnp", *poro_field()->fluid_field()->velnp());
 
   // build specific assemble strategy for the fluid-mechanical system matrix
   // from the point of view of fluid_field:
@@ -1119,9 +1119,9 @@ void PoroElastScaTra::PoroScatraMono::evaluate_od_block_mat_poro()
 
   poro_field()->structure_field()->discretization()->clear_state();
   poro_field()->structure_field()->discretization()->set_state(
-      0, "displacement", poro_field()->structure_field()->dispnp());
+      0, "displacement", *poro_field()->structure_field()->dispnp());
   poro_field()->structure_field()->discretization()->set_state(
-      0, "velocity", poro_field()->structure_field()->velnp());
+      0, "velocity", *poro_field()->structure_field()->velnp());
 
   // build specific assemble strategy for mechanical-fluid system matrix
   // from the point of view of structure_field:
@@ -1157,8 +1157,8 @@ void PoroElastScaTra::PoroScatraMono::evaluate_od_block_mat_scatra()
   sparams_struct.set("total time", time());
 
   scatra_field()->discretization()->clear_state();
-  scatra_field()->discretization()->set_state(0, "hist", scatra_field()->hist());
-  scatra_field()->discretization()->set_state(0, "phinp", scatra_field()->phinp());
+  scatra_field()->discretization()->set_state(0, "hist", *scatra_field()->hist());
+  scatra_field()->discretization()->set_state(0, "phinp", *scatra_field()->phinp());
 
   // build specific assemble strategy for mechanical-fluid system matrix
   // from the point of view of structure_field:
@@ -1190,8 +1190,8 @@ void PoroElastScaTra::PoroScatraMono::evaluate_od_block_mat_scatra()
   sparams_fluid.set("total time", time());
 
   scatra_field()->discretization()->clear_state();
-  scatra_field()->discretization()->set_state(0, "hist", scatra_field()->hist());
-  scatra_field()->discretization()->set_state(0, "phinp", scatra_field()->phinp());
+  scatra_field()->discretization()->set_state(0, "hist", *scatra_field()->hist());
+  scatra_field()->discretization()->set_state(0, "phinp", *scatra_field()->phinp());
 
   // build specific assemble strategy for mechanical-fluid system matrix
   // from the point of view of structure_field:

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
@@ -1835,7 +1835,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::evaluate_error_compared_to_analytical_sol(
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("phinp_fluid", phinp_);
+  discret_->set_state("phinp_fluid", *phinp_);
 
   // get (squared) error values
   std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -1997,7 +1997,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::set_state(unsigned nds, const std::string&
     std::shared_ptr<const Core::LinAlg::Vector<double>> state)
 {
   // provide discretization with velocity
-  discret_->set_state(nds, name, state);
+  discret_->set_state(nds, name, *state);
 }
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_ost.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_ost.cpp
@@ -112,10 +112,10 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_neumann_to_residual()
  *---------------------------------------------------------------------------*/
 void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_time_integration_specific_vectors()
 {
-  discret_->set_state("hist", hist_);
-  discret_->set_state("phinp_fluid", phinp_);
-  discret_->set_state("phin_fluid", phin_);
-  discret_->set_state("phidtnp", phidtnp_);
+  discret_->set_state("hist", *hist_);
+  discret_->set_state("phinp_fluid", *phinp_);
+  discret_->set_state("phin_fluid", *phin_);
+  discret_->set_state("phidtnp", *phidtnp_);
 }
 
 
@@ -125,7 +125,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_time_integration_specific_vect
 void POROFLUIDMULTIPHASE::TimIntOneStepTheta::compute_time_derivative()
 {
   // time derivative of phi:
-  // phidt(n+1) = (phi(n+1)-phi(n)) / (theta*dt) + (1-(1/theta))*phidt(n)
+  // *phidt(n+1) = (phi(n+1)-phi(n)) / (theta*dt) + (1-(1/theta))*phidt(n)
   const double fact1 = 1.0 / (theta_ * dt_);
   const double fact2 = 1.0 - (1.0 / theta_);
   phidtnp_->update(fact2, *phidtn_, 0.0);

--- a/src/poromultiphase/4C_poromultiphase_base.cpp
+++ b/src/poromultiphase/4C_poromultiphase_base.cpp
@@ -181,7 +181,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::prepare_time_step()
 {
   increment_time_and_step();
 
-  structure_field()->discretization()->set_state(1, "porofluid", fluid_field()->phinp());
+  structure_field()->discretization()->set_state(1, "porofluid", *fluid_field()->phinp());
 
   if (solve_structure_)
   {

--- a/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
+++ b/src/poromultiphase/4C_poromultiphase_monolithic_twoway.cpp
@@ -285,7 +285,7 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::evaluate(
   if (solve_structure_)
   {
     // (2) set fluid solution in structure field
-    structure_field()->discretization()->set_state(1, "porofluid", fluid_field()->phinp());
+    structure_field()->discretization()->set_state(1, "porofluid", *fluid_field()->phinp());
 
     // (3) evaluate structure
     if (firstcall)  // first call (iterinc_ = 0) --> sx = 0
@@ -557,9 +557,9 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::apply_str_coupl_matrix(
     sparams.set<double>("total time", time());
 
     structure_field()->discretization()->clear_state();
-    structure_field()->discretization()->set_state(0, "displacement", structure_field()->dispnp());
-    structure_field()->discretization()->set_state(0, "velocity", structure_field()->velnp());
-    structure_field()->discretization()->set_state(1, "porofluid", fluid_field()->phinp());
+    structure_field()->discretization()->set_state(0, "displacement", *structure_field()->dispnp());
+    structure_field()->discretization()->set_state(0, "velocity", *structure_field()->velnp());
+    structure_field()->discretization()->set_state(1, "porofluid", *fluid_field()->phinp());
 
     // build specific assemble strategy for mechanical-fluid system matrix
     // from the point of view of structure_field:

--- a/src/poromultiphase/4C_poromultiphase_partitioned_twoway.cpp
+++ b/src/poromultiphase/4C_poromultiphase_partitioned_twoway.cpp
@@ -316,7 +316,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::do_fluid_step()
 void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::set_relaxed_fluid_solution()
 {
   // set fluid solution on structure
-  structure_field()->discretization()->set_state(1, "porofluid", fluidphinp_);
+  structure_field()->discretization()->set_state(1, "porofluid", *fluidphinp_);
 
   return;
 }

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_linebased.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_linebased.cpp
@@ -1042,8 +1042,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::apply_mesh_mov
   }
 
   // set state on artery dis
-  arterydis_->set_state(1, "curr_seg_lengths",
-      std::make_shared<Core::LinAlg::Vector<double>>(*current_seg_lengths_artery_));
+  arterydis_->set_state(
+      1, "curr_seg_lengths", Core::LinAlg::Vector<double>(*current_seg_lengths_artery_));
 }
 
 /*----------------------------------------------------------------------*

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_nonconforming.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_artery_coupling_nonconforming.cpp
@@ -449,9 +449,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate_c
   // set states
   if (contdis_->name() == "porofluid")
   {
-    contdis_->set_state("phinp_fluid", phinp_cont_);
-    contdis_->set_state("phin_fluid", phin_cont_);
-    arterydis_->set_state("one_d_artery_pressure", phinp_art_);
+    contdis_->set_state("phinp_fluid", *phinp_cont_);
+    contdis_->set_state("phin_fluid", *phin_cont_);
+    arterydis_->set_state("one_d_artery_pressure", *phinp_art_);
     if (not evaluate_in_ref_config_ && not contdis_->has_state(1, "velocity field"))
       FOUR_C_THROW(
           "evaluation in current configuration wanted but solid phase velocity not available!");
@@ -459,8 +459,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate_c
   }
   else if (contdis_->name() == "scatra")
   {
-    contdis_->set_state("phinp", phinp_cont_);
-    arterydis_->set_state("one_d_artery_phinp", phinp_art_);
+    contdis_->set_state("phinp", *phinp_cont_);
+    arterydis_->set_state("one_d_artery_phinp", *phinp_art_);
   }
   else
     FOUR_C_THROW(

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_base.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_base.cpp
@@ -427,7 +427,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase::set_scatra_solution()
   poromulti_->set_scatra_solution(ndsporofluid_scatra_, scatra_->scatra_field()->phinp());
   if (artery_coupl_)
     poromulti_->fluid_field()->art_net_tim_int()->discretization()->set_state(
-        2, "one_d_artery_phinp", scatramsht_->art_scatra_field()->phinp());
+        2, "one_d_artery_phinp", *scatramsht_->art_scatra_field()->phinp());
 }
 
 /*------------------------------------------------------------------------*

--- a/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
+++ b/src/poromultiphase_scatra/4C_poromultiphase_scatra_monolithic_twoway.cpp
@@ -603,9 +603,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::apply_scatra_st
 
     scatra_algo()->scatra_field()->discretization()->clear_state();
     scatra_algo()->scatra_field()->discretization()->set_state(
-        0, "hist", scatra_algo()->scatra_field()->hist());
+        0, "hist", *scatra_algo()->scatra_field()->hist());
     scatra_algo()->scatra_field()->discretization()->set_state(
-        0, "phinp", scatra_algo()->scatra_field()->phinp());
+        0, "phinp", *scatra_algo()->scatra_field()->phinp());
 
     // build specific assemble strategy for mechanical-fluid system matrix
     // from the point of view of structure_field:
@@ -649,9 +649,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::
 
   scatra_algo()->scatra_field()->discretization()->clear_state();
   scatra_algo()->scatra_field()->discretization()->set_state(
-      0, "hist", scatra_algo()->scatra_field()->hist());
+      0, "hist", *scatra_algo()->scatra_field()->hist());
   scatra_algo()->scatra_field()->discretization()->set_state(
-      0, "phinp", scatra_algo()->scatra_field()->phinp());
+      0, "phinp", *scatra_algo()->scatra_field()->phinp());
 
 
   // build specific assemble strategy for mechanical-fluid system matrix
@@ -1623,11 +1623,11 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling::
 
   scatramsht_->art_scatra_field()->discretization()->clear_state();
   scatramsht_->art_scatra_field()->discretization()->set_state(
-      0, "phinp", scatramsht_->art_scatra_field()->phinp());
+      0, "phinp", *scatramsht_->art_scatra_field()->phinp());
   scatramsht_->art_scatra_field()->discretization()->set_state(
-      0, "hist", scatramsht_->art_scatra_field()->hist());
+      0, "hist", *scatramsht_->art_scatra_field()->hist());
   scatramsht_->art_scatra_field()->discretization()->set_state(
-      2, "one_d_artery_pressure", poro_field()->fluid_field()->art_net_tim_int()->pressurenp());
+      2, "one_d_artery_pressure", *poro_field()->fluid_field()->art_net_tim_int()->pressurenp());
 
   // build specific assemble strategy for mechanical-fluid system matrix
   Core::FE::AssembleStrategy artscatrastrategy_artery(0,  // scatradofset for row

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -850,10 +850,10 @@ void Airway::RedAirwayImplicitTimeInt::solve(
 
     // Set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("pnp", pnp_);
-    discret_->set_state("on", on_);
-    discret_->set_state("pnm", pnm_);
-    discret_->set_state("intr_ac_link", n_intr_ac_ln_);
+    discret_->set_state("pnp", *pnp_);
+    discret_->set_state("on", *on_);
+    discret_->set_state("pnm", *pnm_);
+    discret_->set_state("intr_ac_link", *n_intr_ac_ln_);
 
     // note: We use an RCP because ParameterList wants something printable and comparable
     Discret::ReducedLung::EvaluationData& evaluation_data =
@@ -936,9 +936,9 @@ void Airway::RedAirwayImplicitTimeInt::solve(
 
     // Set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("pnp", pnp_);
-    discret_->set_state("on", on_);
-    discret_->set_state("pnm", pnm_);
+    discret_->set_state("pnp", *pnp_);
+    discret_->set_state("on", *on_);
+    discret_->set_state("pnm", *pnm_);
 
     // note: We use an RCP because ParameterList wants something printable and comparable
     Discret::ReducedLung::EvaluationData& evaluation_data =
@@ -1056,10 +1056,10 @@ void Airway::RedAirwayImplicitTimeInt::solve(
 
     // Set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("pnp", pnp_);
-    discret_->set_state("on", on_);
-    discret_->set_state("pnm", pnm_);
-    discret_->set_state("intr_ac_link", n_intr_ac_ln_);
+    discret_->set_state("pnp", *pnp_);
+    discret_->set_state("on", *on_);
+    discret_->set_state("pnm", *pnm_);
+    discret_->set_state("intr_ac_link", *n_intr_ac_ln_);
 
     // note: We use an RCP because ParameterList wants something printable and comparable
     Discret::ReducedLung::EvaluationData& evaluation_data =
@@ -1140,7 +1140,7 @@ void Airway::RedAirwayImplicitTimeInt::solve(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("pnp", pnp_);
+    discret_->set_state("pnp", *pnp_);
 
     // note: We use an RCP because ParameterList wants something printable and comparable
     Discret::ReducedLung::EvaluationData& evaluation_data =
@@ -1664,10 +1664,10 @@ void Airway::RedAirwayImplicitTimeInt::eval_residual(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("pnp", pnp_);
-    discret_->set_state("on", on_);
-    discret_->set_state("pnm", pnm_);
-    discret_->set_state("intr_ac_link", n_intr_ac_ln_);
+    discret_->set_state("pnp", *pnp_);
+    discret_->set_state("on", *on_);
+    discret_->set_state("pnm", *pnm_);
+    discret_->set_state("intr_ac_link", *n_intr_ac_ln_);
 
     // note: We use an RCP because ParameterList wants something printable and comparable
     Discret::ReducedLung::EvaluationData& evaluation_data =
@@ -1746,9 +1746,9 @@ void Airway::RedAirwayImplicitTimeInt::eval_residual(
 
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("pnp", pnp_);
-    discret_->set_state("on", on_);
-    discret_->set_state("pnm", pnm_);
+    discret_->set_state("pnp", *pnp_);
+    discret_->set_state("on", *on_);
+    discret_->set_state("pnm", *pnm_);
     //    discret_->set_state("qcnp",qcnp_);
     //    discret_->set_state("qcn" ,qcn_ );
     //    discret_->set_state("qcnm",qcnm_);

--- a/src/scatra/4C_scatra_timint_bdf2.cpp
+++ b/src/scatra/4C_scatra_timint_bdf2.cpp
@@ -191,7 +191,7 @@ void ScaTra::TimIntBDF2::avm3_separation()
   Sep_->multiply(false, *phinp_, *fsphinp_);
 
   // set fine-scale vector
-  discret_->set_state("fsphinp", fsphinp_);
+  discret_->set_state("fsphinp", *fsphinp_);
 }
 
 /*----------------------------------------------------------------------*
@@ -227,8 +227,8 @@ void ScaTra::TimIntBDF2::add_time_integration_specific_vectors(bool forcedincrem
   // call base class routine
   ScaTraTimIntImpl::add_time_integration_specific_vectors(forcedincrementalsolver);
 
-  discret_->set_state("hist", hist_);
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("hist", *hist_);
+  discret_->set_state("phinp", *phinp_);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_cardiac_monodomain.cpp
+++ b/src/scatra/4C_scatra_timint_cardiac_monodomain.cpp
@@ -164,7 +164,7 @@ void ScaTra::TimIntCardiacMonodomain::element_material_time_update()
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   // go to elements
   discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);

--- a/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme.cpp
@@ -109,7 +109,7 @@ void ScaTra::TimIntCardiacMonodomainOST::add_time_integration_specific_vectors(
 {
   // Call function from baseclass
   TimIntOneStepTheta::add_time_integration_specific_vectors(forcedincrementalsolver);
-  discret_->set_state("phin", phin_);
+  discret_->set_state("phin", *phin_);
 
   return;
 }
@@ -294,7 +294,7 @@ void ScaTra::TimIntCardiacMonodomainGenAlpha::add_time_integration_specific_vect
   // Call function from baseclass
   TimIntGenAlpha::add_time_integration_specific_vectors(forcedincrementalsolver);
 
-  if (incremental_ or forcedincrementalsolver) discret_->set_state("phin", phin_);
+  if (incremental_ or forcedincrementalsolver) discret_->set_state("phin", *phin_);
 
   return;
 }

--- a/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme_hdg.cpp
@@ -66,9 +66,9 @@ void ScaTra::TimIntCardiacMonodomainHDG::element_material_time_update()
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
       "action", ScaTra::Action::time_update_material, eleparams);
 
-  discret_->set_state("phiaf", phinp_);
-  discret_->set_state(nds_intvar_, "intphin", intphin_);
-  discret_->set_state(0, "phin", phin_);
+  discret_->set_state("phiaf", *phinp_);
+  discret_->set_state(nds_intvar_, "intphin", *intphin_);
+  discret_->set_state(0, "phin", *phin_);
 
 
   Core::LinAlg::SerialDenseMatrix dummyMat;

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -564,7 +564,7 @@ void ScaTra::ScaTraTimIntElch::add_problem_specific_parameters_and_vectors(
     Teuchos::ParameterList& params  //!< parameter list
 )
 {
-  discret_->set_state("dctoggle", dctoggle_);
+  discret_->set_state("dctoggle", *dctoggle_);
 }
 
 /*----------------------------------------------------------------------*
@@ -699,7 +699,7 @@ void ScaTra::ScaTraTimIntElch::evaluate_error_compared_to_analytical_sol()
       eleparams.set<Inpar::ScaTra::CalcError>("calcerrorflag", calcerror_);
 
       // set vector values needed by elements
-      discret_->set_state("phinp", phinp_);
+      discret_->set_state("phinp", *phinp_);
 
       // get (squared) error values
       std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -747,7 +747,7 @@ void ScaTra::ScaTraTimIntElch::evaluate_error_compared_to_analytical_sol()
       eleparams.set<Inpar::ScaTra::CalcError>("calcerrorflag", calcerror_);
 
       // set vector values needed by elements
-      discret_->set_state("phinp", phinp_);
+      discret_->set_state("phinp", *phinp_);
 
       // get (squared) error values
       std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -779,7 +779,7 @@ void ScaTra::ScaTraTimIntElch::evaluate_error_compared_to_analytical_sol()
       eleparams.set<Inpar::ScaTra::CalcError>("calcerrorflag", calcerror_);
 
       // set vector values needed by elements
-      discret_->set_state("phinp", phinp_);
+      discret_->set_state("phinp", *phinp_);
 
       // get (squared) error values
       std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -987,9 +987,9 @@ ScaTra::ScaTraTimIntElch::evaluate_single_electrode_info(
     const int condid, const std::string& condstring)
 {
   // set vector values needed by elements
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
   // needed for double-layer capacity!
-  discret_->set_state("phidtnp", phidtnp_);
+  discret_->set_state("phidtnp", *phidtnp_);
 
   // create parameter list
   Teuchos::ParameterList eleparams;
@@ -1042,8 +1042,8 @@ ScaTra::ScaTraTimIntElch::evaluate_single_electrode_info_point(
     std::shared_ptr<Core::Conditions::Condition> condition)
 {
   // add state vectors to discretization
-  discret_->set_state("phinp", phinp_);
-  discret_->set_state("phidtnp", phidtnp_);  // needed for double layer capacity
+  discret_->set_state("phinp", *phinp_);
+  discret_->set_state("phidtnp", *phidtnp_);  // needed for double layer capacity
 
   // add state vectors according to time integration scheme
   add_time_integration_specific_vectors();
@@ -1359,8 +1359,8 @@ void ScaTra::ScaTraTimIntElch::evaluate_electrode_info_interior()
       const int condid = condition->parameters().get<int>("ConditionID");
 
       // add state vectors to discretization
-      discret_->set_state("phinp", phinp_);
-      discret_->set_state("phidtnp", phidtnp_);
+      discret_->set_state("phinp", *phinp_);
+      discret_->set_state("phidtnp", *phidtnp_);
 
       // create parameter list
       Teuchos::ParameterList condparams;
@@ -1482,7 +1482,7 @@ void ScaTra::ScaTraTimIntElch::evaluate_cell_voltage()
       if (conditionspoint.empty())
       {
         // add state vector to discretization
-        discret_->set_state("phinp", phinp_);
+        discret_->set_state("phinp", *phinp_);
 
         // create parameter list
         Teuchos::ParameterList condparams;
@@ -1664,7 +1664,7 @@ void ScaTra::ScaTraTimIntElch::setup_nat_conv()
   if (num_scal() < 1) FOUR_C_THROW("Error since numscal = {}. Not allowed since < 1", num_scal());
   c0_.resize(num_scal());
 
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   // set action for elements
   Teuchos::ParameterList eleparams;
@@ -2769,7 +2769,7 @@ void ScaTra::ScaTraTimIntElch::linearization_nernst_condition()
 
   // add element parameters and set state vectors according to time-integration scheme
   // we need here concentration at t+np
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   std::string condstring("ElchBoundaryKinetics");
   // evaluate ElchBoundaryKinetics conditions at time t_{n+1} or t_{n+alpha_F}

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -338,7 +338,7 @@ void ScaTra::ScaTraTimIntElchSCL::add_problem_specific_parameters_and_vectors(
 {
   ScaTra::ScaTraTimIntElch::add_problem_specific_parameters_and_vectors(params);
 
-  discret_->set_state("phinp", phinp());
+  discret_->set_state("phinp", *phinp());
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_genalpha.cpp
+++ b/src/scatra/4C_scatra_timint_genalpha.cpp
@@ -248,7 +248,7 @@ void ScaTra::TimIntGenAlpha::avm3_separation()
     fsphiaf_->put_scalar(0.01);
 
   // set fine-scale vector
-  discret_->set_state("fsphinp", fsphiaf_);
+  discret_->set_state("fsphinp", *fsphiaf_);
 }
 
 
@@ -296,14 +296,14 @@ void ScaTra::TimIntGenAlpha::add_time_integration_specific_vectors(bool forcedin
   // call base class routine
   ScaTraTimIntImpl::add_time_integration_specific_vectors(forcedincrementalsolver);
 
-  discret_->set_state("phinp", phiaf_);
+  discret_->set_state("phinp", *phiaf_);
 
   if (incremental_ or forcedincrementalsolver)
-    discret_->set_state("hist", phidtam_);
+    discret_->set_state("hist", *phidtam_);
   else
   {
-    discret_->set_state("hist", hist_);
-    discret_->set_state("phin", phin_);
+    discret_->set_state("hist", *hist_);
+    discret_->set_state("phin", *phin_);
   }
 }
 

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -221,10 +221,10 @@ void ScaTra::TimIntHDG::set_theta()
 void ScaTra::TimIntHDG::add_time_integration_specific_vectors(bool forcedincrementalsolver)
 {
   // set hdg vector and interior variables vector
-  discret_->set_state(0, "phin", phin_);
-  discret_->set_state(0, "phiaf", phinp_);
-  discret_->set_state(nds_intvar_, "intphinp", intphinp_);
-  discret_->set_state(nds_intvar_, "intphin", intphin_);
+  discret_->set_state(0, "phin", *phin_);
+  discret_->set_state(0, "phiaf", *phinp_);
+  discret_->set_state(nds_intvar_, "intphinp", *intphinp_);
+  discret_->set_state(nds_intvar_, "intphin", *intphin_);
 }  // add_time_integration_specific_vectors
 
 /*----------------------------------------------------------------------*
@@ -302,8 +302,8 @@ namespace
     Teuchos::ParameterList eleparams;
     Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
         "action", ScaTra::Action::interpolate_hdg_to_node, eleparams);
-    dis.set_state(0, "phiaf", traceValues);
-    dis.set_state(nds_intvar_, "intphinp", interiorValues);
+    dis.set_state(0, "phiaf", *traceValues);
+    dis.set_state(nds_intvar_, "intphinp", *interiorValues);
     Core::Elements::LocationArray la(ndofs);
     Core::LinAlg::SerialDenseMatrix dummyMat;
     Core::LinAlg::SerialDenseVector dummyVec;
@@ -521,10 +521,10 @@ void ScaTra::TimIntHDG::set_initial_field(
           "action", ScaTra::Action::set_initial_field, eleparams);
       eleparams.set<int>("funct", startfuncno);
 
-      discret_->set_state("phiaf", phinp_);
-      discret_->set_state("phin", phin_);
-      discret_->set_state(nds_intvar_, "intphin", intphin_);
-      discret_->set_state(nds_intvar_, "intphinp", intphinp_);
+      discret_->set_state("phiaf", *phinp_);
+      discret_->set_state("phin", *phin_);
+      discret_->set_state(nds_intvar_, "intphin", *intphin_);
+      discret_->set_state(nds_intvar_, "intphinp", *intphinp_);
 
       Core::LinAlg::SerialDenseMatrix dummyMat;
       Core::LinAlg::SerialDenseVector updateVec1, updateVec2, dummyVec;
@@ -647,10 +647,10 @@ void ScaTra::TimIntHDG::update_interior_variables(
   Teuchos::ParameterList eleparams;
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
       "action", ScaTra::Action::update_interior_variables, eleparams);
-  discret_->set_state("phiaf", phinp_);
-  discret_->set_state("phin", phin_);
-  discret_->set_state(nds_intvar_, "intphin", intphin_);
-  discret_->set_state(nds_intvar_, "intphinp", intphinp_);
+  discret_->set_state("phiaf", *phinp_);
+  discret_->set_state("phin", *phin_);
+  discret_->set_state(nds_intvar_, "intphin", *intphin_);
+  discret_->set_state(nds_intvar_, "intphinp", *intphinp_);
 
   Core::LinAlg::SerialDenseMatrix dummyMat;
   Core::LinAlg::SerialDenseVector dummyVec;
@@ -720,10 +720,10 @@ void ScaTra::TimIntHDG::fd_check()
   update_interior_variables(intphitemp);
 
   discret_->clear_state(true);
-  discret_->set_state("phiaf", phinp_);
-  discret_->set_state(nds_intvar_, "intphin", intphin_);
-  discret_->set_state(0, "phin", phin_);
-  discret_->set_state(nds_intvar_, "intphinp", intphitemp);
+  discret_->set_state("phiaf", *phinp_);
+  discret_->set_state(nds_intvar_, "intphin", *intphin_);
+  discret_->set_state(0, "phin", *phin_);
+  discret_->set_state(nds_intvar_, "intphinp", *intphitemp);
   Teuchos::ParameterList eleparams;
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
       "action", ScaTra::Action::calc_mat_and_rhs, eleparams);
@@ -792,10 +792,10 @@ void ScaTra::TimIntHDG::fd_check()
 
       discret_->clear_state(true);
 
-      discret_->set_state("phiaf", phinp_);
-      discret_->set_state(nds_intvar_, "intphin", intphin_);
-      discret_->set_state(0, "phin", phin_);
-      discret_->set_state(nds_intvar_, "intphinp", intphitemp);
+      discret_->set_state("phiaf", *phinp_);
+      discret_->set_state(nds_intvar_, "intphin", *intphin_);
+      discret_->set_state(0, "phin", *phin_);
+      discret_->set_state(nds_intvar_, "intphinp", *intphitemp);
 
       Teuchos::ParameterList eleparams;
       Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
@@ -964,8 +964,8 @@ std::shared_ptr<Core::LinAlg::SerialDenseVector> ScaTra::TimIntHDG::compute_erro
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("phiaf", phinp_);
-  discret_->set_state(nds_intvar_, "intphinp", intphinp_);
+  discret_->set_state("phiaf", *phinp_);
+  discret_->set_state(nds_intvar_, "intphinp", *intphinp_);
   // get (squared) error values
   // The error is computed for the transported scalar and its gradient. Notice that so far only
   // the L2 error is computed, feel free to extend the calculations to any error measure needed
@@ -1007,10 +1007,10 @@ void ScaTra::TimIntHDG::calc_mat_initial()
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
       "action", ScaTra::Action::calc_mat_initial, eleparams);
 
-  discret_->set_state("phiaf", phinp_);
-  discret_->set_state("phin", phin_);
-  discret_->set_state(nds_intvar_, "intphin", intphin_);
-  discret_->set_state(nds_intvar_, "intphinp", intphinp_);
+  discret_->set_state("phiaf", *phinp_);
+  discret_->set_state("phin", *phin_);
+  discret_->set_state(nds_intvar_, "intphin", *intphin_);
+  discret_->set_state(nds_intvar_, "intphinp", *intphinp_);
 
   std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix1, systemmatrix2;
   std::shared_ptr<Core::LinAlg::Vector<double>> systemvector1, systemvector2, systemvector3;
@@ -1097,8 +1097,8 @@ void ScaTra::TimIntHDG::adapt_degree()
   Core::LinAlg::SerialDenseMatrix dummyMat;
   Core::LinAlg::SerialDenseVector dummyVec;
 
-  discret_->set_state("phiaf", phinp_);
-  discret_->set_state(nds_intvar_, "intphinp", intphinp_);
+  discret_->set_state("phiaf", *phinp_);
+  discret_->set_state(nds_intvar_, "intphinp", *intphinp_);
 
   // get cpu time
   //  const double tccalcerr = Teuchos::Time::wallTime();

--- a/src/scatra/4C_scatra_timint_heterogeneous_reaction_strategy.cpp
+++ b/src/scatra/4C_scatra_timint_heterogeneous_reaction_strategy.cpp
@@ -50,22 +50,22 @@ void ScaTra::HeterogeneousReactionStrategy::evaluate_meshtying()
       "action", ScaTra::Action::calc_heteroreac_mat_and_rhs, condparams);
 
   // set global state vectors according to time-integration scheme
-  discret_->set_state("phinp", scatratimint_->phiafnp());
-  discret_->set_state("hist", scatratimint_->hist());
+  discret_->set_state("phinp", *scatratimint_->phiafnp());
+  discret_->set_state("hist", *scatratimint_->hist());
 
   // provide scatra discretization with convective velocity
   discret_->set_state(scatratimint_->nds_vel(), "convective velocity field",
-      scatratimint_->discretization()->get_state(
+      *scatratimint_->discretization()->get_state(
           scatratimint_->nds_vel(), "convective velocity field"));
 
   // provide scatra discretization with velocity
   discret_->set_state(scatratimint_->nds_vel(), "velocity field",
-      scatratimint_->discretization()->get_state(scatratimint_->nds_vel(), "velocity field"));
+      *scatratimint_->discretization()->get_state(scatratimint_->nds_vel(), "velocity field"));
 
   if (scatratimint_->is_ale())
   {
     discret_->set_state(scatratimint_->nds_disp(), "dispnp",
-        scatratimint_->discretization()->get_state(scatratimint_->nds_disp(), "dispnp"));
+        *scatratimint_->discretization()->get_state(scatratimint_->nds_disp(), "dispnp"));
   }
 
   discret_->evaluate(condparams, scatratimint_->system_matrix(), scatratimint_->residual());
@@ -209,7 +209,7 @@ void ScaTra::HeterogeneousReactionStrategy::evaluate_condition(Teuchos::Paramete
 void ScaTra::HeterogeneousReactionStrategy::set_state(unsigned nds, const std::string& name,
     std::shared_ptr<const Core::LinAlg::Vector<double>> state)
 {
-  discret_->set_state(nds, name, state);
+  discret_->set_state(nds, name, *state);
   return;
 }
 

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -692,7 +692,7 @@ void ScaTra::ScaTraTimIntImpl::setup_nat_conv()
   if (num_scal() < 1) FOUR_C_THROW("Error since numscal = {}. Not allowed since < 1", num_scal());
   c0_.resize(num_scal());
 
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   // set action for elements
   Teuchos::ParameterList eleparams;
@@ -1298,10 +1298,10 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field()
   }
 
   // provide scatra discretization with convective velocity
-  discret_->set_state(nds_vel(), "convective velocity field", convel);
+  discret_->set_state(nds_vel(), "convective velocity field", *convel);
 
   // provide scatra discretization with velocity
-  discret_->set_state(nds_vel(), "velocity field", vel);
+  discret_->set_state(nds_vel(), "velocity field", *vel);
 }
 
 /*----------------------------------------------------------------------*
@@ -1363,9 +1363,9 @@ void ScaTra::ScaTraTimIntImpl::set_external_force()
     }
   }
 
-  discret_->set_state(nds_vel(), "external_force", external_force);
-  discret_->set_state(nds_vel(), "intrinsic_mobility", intrinsic_mobility);
-  discret_->set_state(nds_vel(), "force_velocity", force_velocity);
+  discret_->set_state(nds_vel(), "external_force", *external_force);
+  discret_->set_state(nds_vel(), "intrinsic_mobility", *intrinsic_mobility);
+  discret_->set_state(nds_vel(), "force_velocity", *force_velocity);
 }
 
 /*----------------------------------------------------------------------*
@@ -1386,7 +1386,7 @@ void ScaTra::ScaTraTimIntImpl::set_wall_shear_stresses(
     FOUR_C_THROW("Maps are NOT identical. Emergency!");
 #endif
 
-  discret_->set_state(nds_wall_shear_stress(), "WallShearStress", wss);
+  discret_->set_state(nds_wall_shear_stress(), "WallShearStress", *wss);
 }
 
 /*----------------------------------------------------------------------*
@@ -1415,7 +1415,7 @@ void ScaTra::ScaTraTimIntImpl::set_pressure_field(
     FOUR_C_THROW("Maps are NOT identical. Emergency!");
 #endif
 
-  discret_->set_state(nds_pressure(), "Pressure", pressure);
+  discret_->set_state(nds_pressure(), "Pressure", *pressure);
 }
 
 /*----------------------------------------------------------------------*
@@ -1509,23 +1509,23 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field(
     fsvelswitch = false;
 
   // provide scatra discretization with convective velocity
-  discret_->set_state(nds_vel(), "convective velocity field", convvel);
+  discret_->set_state(nds_vel(), "convective velocity field", *convvel);
 
   // provide scatra discretization with velocity
   if (vel != nullptr)
-    discret_->set_state(nds_vel(), "velocity field", vel);
+    discret_->set_state(nds_vel(), "velocity field", *vel);
   else
   {
     // if velocity vector is not provided by the respective algorithm, we
     // assume that it equals the given convective velocity:
-    discret_->set_state(nds_vel(), "velocity field", convvel);
+    discret_->set_state(nds_vel(), "velocity field", *convvel);
   }
 
   // provide scatra discretization with acceleration field if required
-  if (acc != nullptr) discret_->set_state(nds_vel(), "acceleration field", acc);
+  if (acc != nullptr) discret_->set_state(nds_vel(), "acceleration field", *acc);
 
   // provide scatra discretization with fine-scale convective velocity if required
-  if (fsvelswitch) discret_->set_state(nds_vel(), "fine-scale velocity field", fsvel);
+  if (fsvelswitch) discret_->set_state(nds_vel(), "fine-scale velocity field", *fsvel);
 }
 
 /*----------------------------------------------------------------------*
@@ -1663,7 +1663,7 @@ void ScaTra::ScaTraTimIntImpl::apply_mesh_movement(
     if (dispnp == nullptr) FOUR_C_THROW("Got null pointer for displacements!");
 
     // provide scatra discretization with displacement field
-    discret_->set_state(nds_disp(), "dispnp", dispnp);
+    discret_->set_state(nds_disp(), "dispnp", *dispnp);
   }  // if (isale_)
 }
 
@@ -2772,7 +2772,7 @@ void ScaTra::ScaTraTimIntImpl::assemble_mat_and_rhs()
   // set external volume force (required, e.g., for forced homogeneous isotropic turbulence)
   if (homisoturb_forcing_ != nullptr) homisoturb_forcing_->update_forcing(step_);
 
-  if (forcing_ != nullptr) discret_->set_state("forcing", forcing_);
+  if (forcing_ != nullptr) discret_->set_state("forcing", *forcing_);
 
   // add problem specific time-integration parameters
   add_problem_specific_parameters_and_vectors(eleparams);
@@ -3767,7 +3767,7 @@ void ScaTra::ScaTraTimIntImpl::calc_mean_micro_concentration()
 
   if (nds_micro() < 0) FOUR_C_THROW("must set number of dofset for micro scale concentrations");
 
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   Teuchos::ParameterList eleparams;
 

--- a/src/scatra/4C_scatra_timint_implicit_service.cpp
+++ b/src/scatra/4C_scatra_timint_implicit_service.cpp
@@ -115,7 +115,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> ScaTra::ScaTraTimIntImpl::cal
       "action", ScaTra::Action::calc_flux_domain, params);
 
   // provide discretization with state vector
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
 
   // evaluate flux vector field inside the whole computational domain (e.g., for visualization of
   // particle path lines)
@@ -808,7 +808,7 @@ void ScaTra::ScaTraTimIntImpl::surface_permeability(
     // TODO: (thon) this is not a nice way of using the mean concentration instead of phinp!
     // Note: meanconc_ is not cleared by calling 'discret_->ClearState()', hence if you
     // don't want to do this replacement here any more call 'ClearMeanConcentration()'
-    discret_->set_state("phinp", mean_conc_);
+    discret_->set_state("phinp", *mean_conc_);
 
     if (myrank_ == 0)
       std::cout << "Replacing 'phinp' by 'meanconc_' in the evaluation of the surface permeability"
@@ -817,7 +817,7 @@ void ScaTra::ScaTraTimIntImpl::surface_permeability(
 
   if (membrane_conc_ == nullptr)
     FOUR_C_THROW("Membrane concentration must already been saved before calling this function!");
-  discret_->set_state("MembraneConcentration", membrane_conc_);
+  discret_->set_state("MembraneConcentration", *membrane_conc_);
 
   // test if all necessary ingredients had been set
   if (not discret_->has_state(nds_wall_shear_stress(), "WallShearStress"))
@@ -867,7 +867,7 @@ void ScaTra::ScaTraTimIntImpl::kedem_katchalsky(
 
   if (membrane_conc_ == nullptr)
     FOUR_C_THROW("Membrane concentration must already been saved before calling this function!");
-  discret_->set_state("MembraneConcentration", membrane_conc_);
+  discret_->set_state("MembraneConcentration", *membrane_conc_);
 
   // Evaluate condition
   discret_->evaluate_condition(
@@ -1278,7 +1278,7 @@ void ScaTra::ScaTraTimIntImpl::output_integr_reac(const int num)
     if (!discret_->have_dofs()) FOUR_C_THROW("assign_degrees_of_freedom() was not called");
 
     // set scalar values needed by elements
-    discret_->set_state("phinp", phinp_);
+    discret_->set_state("phinp", *phinp_);
     // set action for elements
     Teuchos::ParameterList eleparams;
     Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
@@ -1728,7 +1728,7 @@ ScaTra::ScaTraTimIntImpl::compute_superconvergent_patch_recovery(
     FOUR_C_THROW("input map is not a dof row map of the fluid");
 
   // set given state for element evaluation
-  discret_->set_state(statename, state);
+  discret_->set_state(statename, *state);
 
   switch (dim)
   {
@@ -2105,7 +2105,7 @@ void ScaTra::ScaTraTimIntImpl::evaluate_error_compared_to_analytical_sol()
       }
 
       // set vector values needed by elements
-      discret_->set_state("phinp", phinp_);
+      discret_->set_state("phinp", *phinp_);
 
       // get (squared) error values
       std::shared_ptr<Core::LinAlg::SerialDenseVector> errors =
@@ -2177,7 +2177,7 @@ void ScaTra::ScaTraTimIntImpl::evaluate_error_compared_to_analytical_sol()
         eleparams.set<int>("error function number", errorfunctnumber);
 
         // set state vector needed by elements
-        discret_->set_state("phinp", phinp_);
+        discret_->set_state("phinp", *phinp_);
 
         // get (squared) error values
         Core::LinAlg::SerialDenseVector errors(4 * num_dof_per_node());
@@ -2368,7 +2368,7 @@ void ScaTra::OutputScalarsStrategyBase::prepare_evaluate(
   const std::shared_ptr<Core::FE::Discretization>& discret = scatratimint->discret_;
 
   // add state vector to discretization
-  discret->set_state("phinp", scatratimint->phinp_);
+  discret->set_state("phinp", *scatratimint->phinp_);
 
   // set action for elements
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(

--- a/src/scatra/4C_scatra_timint_loma.cpp
+++ b/src/scatra/4C_scatra_timint_loma.cpp
@@ -130,7 +130,7 @@ void ScaTra::ScaTraTimIntLoma::compute_initial_mass()
 {
   // set scalar values needed by elements
   discret_->clear_state();
-  discret_->set_state("phinp", phin_);
+  discret_->set_state("phinp", *phin_);
   // set action for elements
   Teuchos::ParameterList eleparams;
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
@@ -172,7 +172,7 @@ void ScaTra::ScaTraTimIntLoma::compute_therm_pressure_from_mass_cons()
 {
   // set scalar values needed by elements
   discret_->clear_state();
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("phinp", *phinp_);
   // set action for elements
   Teuchos::ParameterList eleparams;
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(

--- a/src/scatra/4C_scatra_timint_loma_genalpha.cpp
+++ b/src/scatra/4C_scatra_timint_loma_genalpha.cpp
@@ -132,7 +132,7 @@ void ScaTra::TimIntLomaGenAlpha::compute_therm_pressure()
 
   // set scalar values needed by elements
   discret_->clear_state();
-  discret_->set_state("phinp", phiaf_);
+  discret_->set_state("phinp", *phiaf_);
 
   // set action for elements
   Core::Utils::add_enum_class_to_parameter_list<ScaTra::Action>(
@@ -366,7 +366,7 @@ void ScaTra::TimIntLomaGenAlpha::add_therm_press_to_parameter_list(
   params.set("thermodynamic pressure", thermpressaf_);
   params.set("thermodynamic pressure at n+alpha_M", thermpressam_);
   params.set("time derivative of thermodynamic pressure", thermpressdtaf_);
-  discret_->set_state("phiam", phiam_);
+  discret_->set_state("phiam", *phiam_);
   return;
 }
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
@@ -356,7 +356,7 @@ void ScaTra::MeshtyingStrategyArtery::prepare_time_step() const
  *--------------------------------------------------------------------------*/
 void ScaTra::MeshtyingStrategyArtery::set_artery_pressure() const
 {
-  artscatradis_->set_state(2, "one_d_artery_pressure", arttimint_->pressurenp());
+  artscatradis_->set_state(2, "one_d_artery_pressure", *arttimint_->pressurenp());
   return;
 }
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -603,7 +603,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
         std::shared_ptr<Core::LinAlg::Vector<double>> iphinp =
             std::make_shared<Core::LinAlg::Vector<double>>(*idiscret.dof_col_map(), false);
         Core::LinAlg::export_to(*scatratimint_->phiafnp(), *iphinp);
-        idiscret.set_state("iphinp", iphinp);
+        idiscret.set_state("iphinp", *iphinp);
 
         // create parameter list for mortar integration cells
         Teuchos::ParameterList params;
@@ -1345,7 +1345,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
                 "action", ScaTra::BoundaryAction::calc_s2icoupling_growthgrowth, condparams);
 
             // set history vector associated with discrete scatra-scatra interface layer thicknesses
-            scatratimint_->discretization()->set_state(2, "growthhist", growthhist_);
+            scatratimint_->discretization()->set_state(2, "growthhist", *growthhist_);
 
             // evaluate main-diagonal linearizations and corresponding residuals
             scatratimint_->discretization()->evaluate_condition(
@@ -3442,17 +3442,17 @@ void ScaTra::MeshtyingStrategyS2I::add_time_integration_specific_vectors() const
     interfacemaps_->insert_vector(
         *icoup_->master_to_slave(*interfacemaps_->extract_vector(*(scatratimint_->phiafnp()), 2)),
         1, *imasterphi_on_slave_side_np_);
-    scatratimint_->discretization()->set_state("imasterphinp", imasterphi_on_slave_side_np_);
+    scatratimint_->discretization()->set_state("imasterphinp", *imasterphi_on_slave_side_np_);
 
     if (has_capacitive_contributions_)
     {
       interfacemaps_->insert_vector(
           *interfacemaps_->extract_vector(*(scatratimint_->phidtnp()), 1), 1, *islavephidtnp_);
-      scatratimint_->discretization()->set_state("islavephidtnp", islavephidtnp_);
+      scatratimint_->discretization()->set_state("islavephidtnp", *islavephidtnp_);
       interfacemaps_->insert_vector(
           *icoup_->master_to_slave(*interfacemaps_->extract_vector(*(scatratimint_->phidtnp()), 2)),
           1, *imasterphidt_on_slave_side_np_);
-      scatratimint_->discretization()->set_state("imasterphidtnp", imasterphidt_on_slave_side_np_);
+      scatratimint_->discretization()->set_state("imasterphidtnp", *imasterphidt_on_slave_side_np_);
     }
   }
 
@@ -3467,7 +3467,7 @@ void ScaTra::MeshtyingStrategyS2I::add_time_integration_specific_vectors() const
                                                                                : growthn_;
 
     // set state vector
-    scatratimint_->discretization()->set_state(2, "growth", growth);
+    scatratimint_->discretization()->set_state(2, "growth", *growth);
   }
 }
 

--- a/src/scatra/4C_scatra_timint_ost.cpp
+++ b/src/scatra/4C_scatra_timint_ost.cpp
@@ -198,7 +198,7 @@ void ScaTra::TimIntOneStepTheta::avm3_separation()
   Sep_->multiply(false, *phinp_, *fsphinp_);
 
   // set fine-scale vector
-  discret_->set_state("fsphinp", fsphinp_);
+  discret_->set_state("fsphinp", *fsphinp_);
 }
 
 /*----------------------------------------------------------------------*
@@ -234,8 +234,8 @@ void ScaTra::TimIntOneStepTheta::add_time_integration_specific_vectors(bool forc
   // call base class routine
   ScaTraTimIntImpl::add_time_integration_specific_vectors(forcedincrementalsolver);
 
-  discret_->set_state("hist", hist_);
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("hist", *hist_);
+  discret_->set_state("phinp", *phinp_);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_poromulti.cpp
+++ b/src/scatra/4C_scatra_timint_poromulti.cpp
@@ -95,7 +95,7 @@ void ScaTra::ScaTraTimIntPoroMulti::set_l2_flux_of_multi_fluid(
     }
 
     // provide scatra discretization with convective velocity
-    discret_->set_state(nds_vel(), statename.str(), phaseflux);
+    discret_->set_state(nds_vel(), statename.str(), *phaseflux);
   }
 }  // ScaTraTimIntImpl::SetSolutionFields
 
@@ -110,8 +110,8 @@ void ScaTra::ScaTraTimIntPoroMulti::set_solution_field_of_multi_fluid(
     FOUR_C_THROW("Too few dofsets on scatra discretization!");
 
   // provide scatra discretization with fluid primary variable field
-  discret_->set_state(nds_pressure(), "phinp_fluid", phinp_fluid);
-  discret_->set_state(nds_pressure(), "phin_fluid", phin_fluid);
+  discret_->set_state(nds_pressure(), "phinp_fluid", *phinp_fluid);
+  discret_->set_state(nds_pressure(), "phin_fluid", *phin_fluid);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_stat.cpp
+++ b/src/scatra/4C_scatra_timint_stat.cpp
@@ -151,7 +151,7 @@ void ScaTra::TimIntStationary::avm3_separation()
   Sep_->multiply(false, *phinp_, *fsphinp_);
 
   // set fine-scale vector
-  discret_->set_state("fsphinp", fsphinp_);
+  discret_->set_state("fsphinp", *fsphinp_);
 }
 
 
@@ -163,8 +163,8 @@ void ScaTra::TimIntStationary::add_time_integration_specific_vectors(bool forced
   // call base class routine
   ScaTraTimIntImpl::add_time_integration_specific_vectors(forcedincrementalsolver);
 
-  discret_->set_state("hist", hist_);
-  discret_->set_state("phinp", phinp_);
+  discret_->set_state("hist", *hist_);
+  discret_->set_state("phinp", *phinp_);
 }
 
 

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -123,7 +123,7 @@ void SSI::SSICouplingMatchingVolume::set_mechanical_stress_state(
     Core::FE::Discretization& scatradis,
     std::shared_ptr<const Core::LinAlg::Vector<double>> stress_state, unsigned nds)
 {
-  scatradis.set_state(nds, "mechanicalStressState", stress_state);
+  scatradis.set_state(nds, "mechanicalStressState", *stress_state);
 }
 
 /*----------------------------------------------------------------------*/
@@ -154,7 +154,7 @@ void SSI::SSICouplingMatchingVolume::set_velocity_fields(
 void SSI::SSICouplingMatchingVolume::set_scalar_field(Core::FE::Discretization& dis,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phi, unsigned nds)
 {
-  dis.set_state(nds, "scalarfield", phi);
+  dis.set_state(nds, "scalarfield", *phi);
 }
 
 /*----------------------------------------------------------------------*/
@@ -162,7 +162,7 @@ void SSI::SSICouplingMatchingVolume::set_scalar_field(Core::FE::Discretization& 
 void SSI::SSICouplingMatchingVolume::set_scalar_field_micro(Core::FE::Discretization& dis,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phi, unsigned nds)
 {
-  dis.set_state(nds, "MicroCon", phi);
+  dis.set_state(nds, "MicroCon", *phi);
 }
 
 /*----------------------------------------------------------------------*/
@@ -170,7 +170,7 @@ void SSI::SSICouplingMatchingVolume::set_scalar_field_micro(Core::FE::Discretiza
 void SSI::SSICouplingMatchingVolume::set_temperature_field(
     Core::FE::Discretization& structdis, std::shared_ptr<const Core::LinAlg::Vector<double>> temp)
 {
-  structdis.set_state(2, "temperature", temp);
+  structdis.set_state(2, "temperature", *temp);
 }
 
 /*----------------------------------------------------------------------*/
@@ -178,7 +178,7 @@ void SSI::SSICouplingMatchingVolume::set_temperature_field(
 void SSI::SSICouplingMatchingVolumeAndBoundary::set_temperature_field(
     Core::FE::Discretization& structdis, std::shared_ptr<const Core::LinAlg::Vector<double>> temp)
 {
-  structdis.set_state(2, "temperature", temp);
+  structdis.set_state(2, "temperature", *temp);
 }
 
 /*----------------------------------------------------------------------*/
@@ -429,7 +429,7 @@ void SSI::SSICouplingNonMatchingVolume::set_velocity_fields(
 void SSI::SSICouplingNonMatchingVolume::set_scalar_field(Core::FE::Discretization& dis,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phi, unsigned nds)
 {
-  dis.set_state(nds, "scalarfield", volcoupl_structurescatra_->apply_vector_mapping12(*phi));
+  dis.set_state(nds, "scalarfield", *volcoupl_structurescatra_->apply_vector_mapping12(*phi));
 }
 
 /*----------------------------------------------------------------------*/
@@ -629,7 +629,7 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::set_velocity_fields(
 void SSI::SSICouplingMatchingVolumeAndBoundary::set_scalar_field(Core::FE::Discretization& dis,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phi, unsigned nds)
 {
-  dis.set_state(nds, "scalarfield", phi);
+  dis.set_state(nds, "scalarfield", *phi);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -385,7 +385,7 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::evaluate_bulk_side(
   // First: Set parameters to elements
   pre_evaluate(scatra_manifold_coupling);
 
-  scatra_->scatra_field()->discretization()->set_state("phinp", scatra_->scatra_field()->phinp());
+  scatra_->scatra_field()->discretization()->set_state("phinp", *scatra_->scatra_field()->phinp());
 
   // Second: Evaluate condition
   {
@@ -611,7 +611,7 @@ void SSI::ScaTraManifoldScaTraFluxEvaluator::evaluate_scatra_manifold_inflow()
   inflow_.clear();
   domainintegral_.clear();
 
-  scatra_->scatra_field()->discretization()->set_state("phinp", scatra_->scatra_field()->phinp());
+  scatra_->scatra_field()->discretization()->set_state("phinp", *scatra_->scatra_field()->phinp());
 
   for (const auto& scatra_manifold_coupling : scatra_manifold_couplings_)
   {

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -1675,6 +1675,6 @@ void SSI::SsiMono::set_scatra_manifold_solution(const Core::LinAlg::Vector<doubl
     auto manifold_on_scatra_cond = coup->coupling_adapter()->slave_to_master(*manifold_cond);
     coup->scatra_map_extractor()->insert_cond_vector(*manifold_on_scatra_cond, *manifold_on_scatra);
   }
-  scatra_field()->discretization()->set_state(0, "manifold_on_scatra", manifold_on_scatra);
+  scatra_field()->discretization()->set_state(0, "manifold_on_scatra", *manifold_on_scatra);
 }
 FOUR_C_NAMESPACE_CLOSE

--- a/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssi/4C_ssi_monolithic_evaluate_OffDiag.cpp
@@ -204,7 +204,7 @@ void SSI::ScatraStructureOffDiagCoupling::evaluate_off_diag_block_structure_scat
   structure_->discretization()->clear_state();
 
   // set the current displacement state vector
-  structure_->discretization()->set_state("displacement", structure_->dispnp());
+  structure_->discretization()->set_state("displacement", *structure_->dispnp());
 
   // create strategy for assembly of structure-scatra matrix block
   Core::FE::AssembleStrategy strategystructurescatra(

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -160,8 +160,8 @@ void SSTI::SSTIAlgorithm::setup()
 
   // pass initial scalar field to structural discretization to correctly compute initial
   // accelerations
-  problem->get_dis("structure")->set_state(1, "scalarfield", scatra_->scatra_field()->phinp());
-  problem->get_dis("structure")->set_state(2, "temperature", thermo_->scatra_field()->phinp());
+  problem->get_dis("structure")->set_state(1, "scalarfield", *scatra_->scatra_field()->phinp());
+  problem->get_dis("structure")->set_state(2, "temperature", *thermo_->scatra_field()->phinp());
 
   // set up structural base algorithm
   struct_adapterbase_ptr_->setup();
@@ -289,8 +289,8 @@ void SSTI::SSTIAlgorithm::distribute_structure_solution()
 void SSTI::SSTIAlgorithm::distribute_scatra_solution()
 {
   structure_field()->discretization()->set_state(
-      1, "scalarfield", scatra_->scatra_field()->phinp());
-  thermo_field()->discretization()->set_state(2, "scatra", scatra_->scatra_field()->phinp());
+      1, "scalarfield", *scatra_->scatra_field()->phinp());
+  thermo_field()->discretization()->set_state(2, "scatra", *scatra_->scatra_field()->phinp());
 
   if (interfacemeshtying_)
   {
@@ -302,7 +302,7 @@ void SSTI::SSTIAlgorithm::distribute_scatra_solution()
             *meshtying_strategy_scatra_->interface_maps()->extract_vector(
                 *scatra_field()->phinp(), 2)),
         1, *imasterphinp);
-    thermo_field()->discretization()->set_state(2, "imasterscatra", imasterphinp);
+    thermo_field()->discretization()->set_state(2, "imasterscatra", *imasterphinp);
   }
 }
 
@@ -311,9 +311,9 @@ void SSTI::SSTIAlgorithm::distribute_scatra_solution()
 void SSTI::SSTIAlgorithm::distribute_thermo_solution()
 {
   structure_field()->discretization()->set_state(
-      2, "temperature", thermo_->scatra_field()->phinp());
+      2, "temperature", *thermo_->scatra_field()->phinp());
 
-  scatra_field()->discretization()->set_state(2, "thermo", thermo_->scatra_field()->phinp());
+  scatra_field()->discretization()->set_state(2, "thermo", *thermo_->scatra_field()->phinp());
 
   if (interfacemeshtying_)
   {
@@ -334,11 +334,11 @@ void SSTI::SSTIAlgorithm::distribute_thermo_solution()
         1, *islavetempnp);
 
     // set master side temperature to thermo discretization
-    thermo_field()->discretization()->set_state(3, "imastertemp", imastertempnp);
+    thermo_field()->discretization()->set_state(3, "imastertemp", *imastertempnp);
 
     // set master and slave side temperature to scatra discretization
-    scatra_field()->discretization()->set_state(2, "islavetemp", islavetempnp);
-    scatra_field()->discretization()->set_state(2, "imastertemp", imastertempnp);
+    scatra_field()->discretization()->set_state(2, "islavetemp", *islavetempnp);
+    scatra_field()->discretization()->set_state(2, "imastertemp", *imastertempnp);
   }
 }
 

--- a/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
+++ b/src/ssti/4C_ssti_monolithic_evaluate_OffDiag.cpp
@@ -168,7 +168,7 @@ void SSTI::ThermoStructureOffDiagCoupling::evaluate_off_diag_block_structure_the
 
   structure_->discretization()->clear_state();
 
-  structure_->discretization()->set_state("displacement", structure_->dispnp());
+  structure_->discretization()->set_state("displacement", *structure_->dispnp());
 
   // create strategy for assembly of structure-thermo matrix block
   Core::FE::AssembleStrategy strategystructurescatra(

--- a/src/sti/4C_sti_algorithm.cpp
+++ b/src/sti/4C_sti_algorithm.cpp
@@ -300,7 +300,7 @@ void STI::Algorithm::transfer_scatra_to_thermo(
     const std::shared_ptr<const Core::LinAlg::Vector<double>> scatra) const
 {
   // pass scatra degrees of freedom to thermo discretization
-  thermo_->scatra_field()->discretization()->set_state(2, "scatra", scatra);
+  thermo_->scatra_field()->discretization()->set_state(2, "scatra", *scatra);
 
   // transfer state vector for evaluation of scatra-scatra interface mesh tying
   if (thermo_->scatra_field()->s2_i_meshtying())
@@ -317,7 +317,7 @@ void STI::Algorithm::transfer_scatra_to_thermo(
             *strategyscatra_->coupling_adapter()->master_to_slave(
                 *strategyscatra_->interface_maps()->extract_vector(*scatra, 2)),
             1, *imasterphinp);
-        thermo_->scatra_field()->discretization()->set_state(2, "imasterscatra", imasterphinp);
+        thermo_->scatra_field()->discretization()->set_state(2, "imasterscatra", *imasterphinp);
 
         break;
       }
@@ -346,7 +346,7 @@ void STI::Algorithm::transfer_scatra_to_thermo(
             const std::shared_ptr<Core::LinAlg::Vector<double>> iscatra =
                 std::make_shared<Core::LinAlg::Vector<double>>(*thermodis.dof_row_map(1));
             Core::LinAlg::export_to(*scatra, *iscatra);
-            thermodis.set_state(1, "scatra", iscatra);
+            thermodis.set_state(1, "scatra", *iscatra);
           }
         }
 
@@ -367,7 +367,7 @@ void STI::Algorithm::transfer_thermo_to_scatra(
     const std::shared_ptr<const Core::LinAlg::Vector<double>> thermo) const
 {
   // pass thermo degrees of freedom to scatra discretization
-  scatra_->scatra_field()->discretization()->set_state(2, "thermo", thermo);
+  scatra_->scatra_field()->discretization()->set_state(2, "thermo", *thermo);
 
   // transfer state vector for evaluation of scatra-scatra interface mesh tying
   if (scatra_->scatra_field()->s2_i_meshtying() and
@@ -395,7 +395,7 @@ void STI::Algorithm::transfer_thermo_to_scatra(
         const std::shared_ptr<Core::LinAlg::Vector<double>> ithermo =
             std::make_shared<Core::LinAlg::Vector<double>>(*scatradis.dof_row_map(1));
         Core::LinAlg::export_to(*thermo, *ithermo);
-        scatradis.set_state(1, "thermo", ithermo);
+        scatradis.set_state(1, "thermo", *ithermo);
       }
     }
   }

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -199,8 +199,8 @@ MultiScale::MicroStatic::MicroStatic(const int microdisnum, const double V0)
     p.set("delta time", dt_);
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("residual displacement", zeros_);
-    discret_->set_state("displacement", dis_);
+    discret_->set_state("residual displacement", *zeros_);
+    discret_->set_state("displacement", *dis_);
 
     discret_->evaluate(p, stiff_, nullptr, fintn_, nullptr, nullptr);
     discret_->clear_state();
@@ -228,7 +228,7 @@ MultiScale::MicroStatic::MicroStatic(const int microdisnum, const double V0)
   double my_micro_discretization_density_integration = 0.0;
 
   // create the parameters for the discretization
-  discret_->set_state("displacement", dis_);
+  discret_->set_state("displacement", *dis_);
   Core::Elements::LocationArray la(discret_->num_dof_sets());
   for (const auto* ele : discret_->my_row_element_range())
   {
@@ -313,8 +313,8 @@ void MultiScale::MicroStatic::predict_const_dis(Core::LinAlg::Matrix<3, 3>* defg
     // set vector values needed by elements
     discret_->clear_state();
     disi_->put_scalar(0.0);
-    discret_->set_state("residual displacement", disi_);
-    discret_->set_state("displacement", disn_);
+    discret_->set_state("residual displacement", *disi_);
+    discret_->set_state("displacement", *disn_);
     fintn_->put_scalar(0.0);  // initialise internal force vector
 
     discret_->evaluate(p, stiff_, nullptr, fintn_, nullptr, nullptr);
@@ -395,8 +395,8 @@ void MultiScale::MicroStatic::predict_tang_dis(Core::LinAlg::Matrix<3, 3>* defgr
     // set vector values needed by elements
     discret_->clear_state();
     disi_->put_scalar(0.0);
-    discret_->set_state("residual displacement", disi_);
-    discret_->set_state("displacement", disn_);
+    discret_->set_state("residual displacement", *disi_);
+    discret_->set_state("displacement", *disn_);
     fintn_->put_scalar(0.0);  // initialise internal force vector
 
     discret_->evaluate(p, stiff_, nullptr, fintn_, nullptr, nullptr);
@@ -480,8 +480,8 @@ void MultiScale::MicroStatic::predict_tang_dis(Core::LinAlg::Matrix<3, 3>* defgr
     // set vector values needed by elements
     discret_->clear_state();
     disi_->put_scalar(0.0);
-    discret_->set_state("residual displacement", disi_);
-    discret_->set_state("displacement", disn_);
+    discret_->set_state("residual displacement", *disi_);
+    discret_->set_state("displacement", *disn_);
     fintn_->put_scalar(0.0);  // initialise internal force vector
 
     discret_->evaluate(p, stiff_, nullptr, fintn_, nullptr, nullptr);
@@ -571,8 +571,8 @@ void MultiScale::MicroStatic::full_newton()
       // everything on the microscale "lives" at the pseudo generalized midpoint
       // -> we solve our quasi-static problem there and only update data to the "end"
       // of the time step after having finished a macroscopic dt
-      discret_->set_state("residual displacement", disi_);
-      discret_->set_state("displacement", disn_);
+      discret_->set_state("residual displacement", *disi_);
+      discret_->set_state("displacement", *disn_);
       fintn_->put_scalar(0.0);  // initialise internal force vector
 
       discret_->evaluate(p, stiff_, nullptr, fintn_, nullptr, nullptr);
@@ -638,8 +638,8 @@ void MultiScale::MicroStatic::prepare_output()
     p.set<Inpar::Solid::StrainType>("ioplstrain", ioplstrain_);
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("residual displacement", zeros_);
-    discret_->set_state("displacement", disn_);
+    discret_->set_state("residual displacement", *zeros_);
+    discret_->set_state("displacement", *disn_);
     discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
     discret_->clear_state();
   }

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -975,7 +975,7 @@ void Solid::TimInt::determine_mass_damp_consist_accel()
   {
     // compute new inner radius
     discret_->clear_state();
-    discret_->set_state(0, "displacement", (*dis_)(0));
+    discret_->set_state(0, "displacement", *(*dis_)(0));
 
     // create the parameters for the discretization
     Teuchos::ParameterList p;
@@ -998,16 +998,16 @@ void Solid::TimInt::determine_mass_damp_consist_accel()
     // set vector values needed by elements
     discret_->clear_state();
     // extended set_state(0,...) in case of multiple dofsets (e.g. TSI)
-    discret_->set_state(0, "residual displacement", zeros_);
-    discret_->set_state(0, "displacement", (*dis_)(0));
-    discret_->set_state(0, "velocity", (*vel_)(0));
+    discret_->set_state(0, "residual displacement", *zeros_);
+    discret_->set_state(0, "displacement", *(*dis_)(0));
+    discret_->set_state(0, "velocity", *(*vel_)(0));
 
     // The acceleration is only used as a dummy here and should not be applied inside an element,
     // since this is not the consistent initial acceleration vector which will be determined later
     // on
-    discret_->set_state(0, "acceleration", acc_aux);
+    discret_->set_state(0, "acceleration", *acc_aux);
 
-    if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", (*vel_)(0));
+    if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", *(*vel_)(0));
 
     discret_->evaluate(p, stiff_, mass_, fint, nullptr, fintn_str_);
     discret_->clear_state();
@@ -2292,8 +2292,8 @@ void Solid::TimInt::determine_stress_strain()
     // set vector values needed by elements
     discret_->clear_state();
     // extended set_state(0,...) in case of multiple dofsets (e.g. TSI)
-    discret_->set_state(0, "residual displacement", zeros_);
-    discret_->set_state(0, "displacement", disn_);
+    discret_->set_state(0, "residual displacement", *zeros_);
+    discret_->set_state(0, "displacement", *disn_);
 
     std::shared_ptr<Core::LinAlg::SparseOperator> system_matrix = nullptr;
     std::shared_ptr<Core::LinAlg::Vector<double>> system_vector = nullptr;
@@ -2318,7 +2318,7 @@ void Solid::TimInt::determine_energy()
 
       // set vector values needed by elements
       discret_->clear_state();
-      discret_->set_state("displacement", disn_);
+      discret_->set_state("displacement", *disn_);
       // get energies
       std::shared_ptr<Core::LinAlg::SerialDenseVector> energies =
           std::make_shared<Core::LinAlg::SerialDenseVector>(1);
@@ -2494,10 +2494,10 @@ void Solid::TimInt::apply_force_external(const double time,
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "displacement", dis);
-  discret_->set_state(0, "displacement new", disn);
+  discret_->set_state(0, "displacement", *dis);
+  discret_->set_state(0, "displacement new", *disn);
 
-  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", vel);
+  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", *vel);
 
   discret_->evaluate_neumann(p, fext);
 }
@@ -2595,10 +2595,10 @@ void Solid::TimInt::apply_force_internal(const double time, const double dt,
   if (pressure_ != nullptr) p.set("volume", 0.0);
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state("residual displacement", disi);  // these are incremental
-  discret_->set_state("displacement", dis);
+  discret_->set_state("residual displacement", *disi);  // these are incremental
+  discret_->set_state("displacement", *dis);
 
-  if (damping_ == Inpar::Solid::damp_material) discret_->set_state("velocity", vel);
+  if (damping_ == Inpar::Solid::damp_material) discret_->set_state("velocity", *vel);
   // fintn_->PutScalar(0.0);  // initialise internal force vector
   discret_->evaluate(p, nullptr, nullptr, fint, nullptr, nullptr);
 

--- a/src/structure/4C_structure_timint_centrdiff.cpp
+++ b/src/structure/4C_structure_timint_centrdiff.cpp
@@ -276,7 +276,7 @@ void Solid::TimIntCentrDiff::update_step_element()
 
   // Add displacements
   discret_->clear_state();
-  discret_->set_state("displacement", (*dis_)(0));
+  discret_->set_state("displacement", *(*dis_)(0));
   // go to elements
   discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
 }

--- a/src/structure/4C_structure_timint_expl.cpp
+++ b/src/structure/4C_structure_timint_expl.cpp
@@ -107,10 +107,10 @@ void Solid::TimIntExpl::apply_force_external(const double time,  //!< evaluation
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "displacement", dis);
-  discret_->set_state(0, "displacement new", dis);
+  discret_->set_state(0, "displacement", *dis);
+  discret_->set_state(0, "displacement new", *dis);
 
-  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", vel);
+  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", *vel);
   // get load vector
   discret_->evaluate_neumann(p, fext);
 

--- a/src/structure/4C_structure_timint_genalpha.cpp
+++ b/src/structure/4C_structure_timint_genalpha.cpp
@@ -784,7 +784,7 @@ void Solid::TimIntGenAlpha::update_step_element()
 
   // go to elements
   discret_->clear_state();
-  discret_->set_state("displacement", (*dis_)(0));
+  discret_->set_state("displacement", *(*dis_)(0));
 
   if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
@@ -798,8 +798,8 @@ void Solid::TimIntGenAlpha::update_step_element()
      * rule has to be implemented in the element, otherwise displacements,
      * velocities and accelerations remain unchanged.
      */
-    discret_->set_state("velocity", (*vel_)(0));
-    discret_->set_state("acceleration", (*acc_)(0));
+    discret_->set_state("velocity", *(*vel_)(0));
+    discret_->set_state("acceleration", *(*acc_)(0));
 
     std::shared_ptr<Core::LinAlg::Vector<double>> update_disp;
     update_disp = Core::LinAlg::create_vector(*dof_row_map_view(), true);

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -832,9 +832,9 @@ void Solid::TimIntImpl::apply_force_stiff_external(const double time,  //!< eval
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "displacement", dis);
+  discret_->set_state(0, "displacement", *dis);
 
-  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", vel);
+  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", *vel);
   // get load vector
   const Teuchos::ParameterList& sdyn = Global::Problem::instance()->structural_dynamic_params();
   bool loadlin = (sdyn.get<bool>("LOADLIN"));
@@ -843,7 +843,7 @@ void Solid::TimIntImpl::apply_force_stiff_external(const double time,  //!< eval
     discret_->evaluate_neumann(p, fext);
   else
   {
-    discret_->set_state(0, "displacement new", disn);
+    discret_->set_state(0, "displacement new", *disn);
     discret_->evaluate_neumann(p, fext, fextlin.get());
   }
 
@@ -876,9 +876,9 @@ void Solid::TimIntImpl::apply_force_stiff_internal(const double time, const doub
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "residual displacement", disi);
-  discret_->set_state(0, "displacement", dis);
-  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", vel);
+  discret_->set_state(0, "residual displacement", *disi);
+  discret_->set_state(0, "displacement", *dis);
+  if (damping_ == Inpar::Solid::damp_material) discret_->set_state(0, "velocity", *vel);
   // fintn_->PutScalar(0.0);  // initialise internal force vector
 
   /* Additionally we hand in "fint_str_"
@@ -930,10 +930,10 @@ void Solid::TimIntImpl::apply_force_stiff_internal_and_inertial(const double tim
   }
 
   discret_->clear_state();
-  discret_->set_state(0, "residual displacement", disi);
-  discret_->set_state(0, "displacement", dis);
-  discret_->set_state(0, "velocity", vel);
-  discret_->set_state(0, "acceleration", acc);
+  discret_->set_state(0, "residual displacement", *disi);
+  discret_->set_state(0, "displacement", *dis);
+  discret_->set_state(0, "velocity", *vel);
+  discret_->set_state(0, "acceleration", *acc);
 
   /* Additionally we hand in "fint_str_"
    * This is usually nullptr unless we do line search in
@@ -4166,11 +4166,11 @@ void Solid::TimIntImpl::use_block_matrix(
     if (pressure_ != nullptr) p.set("volume", 0.0);
     // set vector values needed by elements
     discret_->clear_state();
-    discret_->set_state("residual displacement", zeros_);
-    discret_->set_state("displacement", (*dis_)(0));
-    discret_->set_state(0, "velocity", (*vel_)(0));
-    discret_->set_state(0, "acceleration", (*acc_)(0));
-    if (damping_ == Inpar::Solid::damp_material) discret_->set_state("velocity", (*vel_)(0));
+    discret_->set_state("residual displacement", *zeros_);
+    discret_->set_state("displacement", *(*dis_)(0));
+    discret_->set_state(0, "velocity", *(*vel_)(0));
+    discret_->set_state(0, "acceleration", *(*acc_)(0));
+    if (damping_ == Inpar::Solid::damp_material) discret_->set_state("velocity", *(*vel_)(0));
 
     discret_->evaluate(p, stiff_, mass_, fint, finert, nullptr);
     discret_->clear_state();

--- a/src/structure/4C_structure_timint_ost.cpp
+++ b/src/structure/4C_structure_timint_ost.cpp
@@ -650,7 +650,7 @@ void Solid::TimIntOneStepTheta::update_step_element()
   p.set("action", "calc_struct_update_istep");
   // go to elements
   discret_->clear_state();
-  discret_->set_state("displacement", (*dis_)(0));
+  discret_->set_state("displacement", *(*dis_)(0));
 
   if (have_nonlinear_mass() == Inpar::Solid::MassLin::ml_none)
   {
@@ -662,8 +662,8 @@ void Solid::TimIntOneStepTheta::update_step_element()
     // and accelerations at the end of time step (currently only necessary for Kirchhoff beams)
     // An corresponding update rule has to be implemented in the element, otherwise
     // displacements, velocities and accelerations remain unchange.
-    discret_->set_state("velocity", (*vel_)(0));
-    discret_->set_state("acceleration", (*acc_)(0));
+    discret_->set_state("velocity", *(*vel_)(0));
+    discret_->set_state("acceleration", *(*acc_)(0));
 
     std::shared_ptr<Core::LinAlg::Vector<double>> update_disp;
     update_disp = Core::LinAlg::create_vector(*dof_row_map_view(), true);

--- a/src/structure/4C_structure_timint_prestress.cpp
+++ b/src/structure/4C_structure_timint_prestress.cpp
@@ -73,7 +73,7 @@ void Solid::TimIntPrestress::update_step_element()
       // action for elements
       p.set("action", "calc_struct_prestress_update");
       discret_->clear_state();
-      discret_->set_state(0, "residual displacement", zeros_);
+      discret_->set_state(0, "residual displacement", *zeros_);
     }
     else
     {
@@ -88,7 +88,7 @@ void Solid::TimIntPrestress::update_step_element()
   p.set("delta time", (*dt_)[0]);
 
   // go to elements
-  discret_->set_state("displacement", (*dis_)(0));
+  discret_->set_state("displacement", *(*dis_)(0));
   discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
 
 

--- a/src/structure/4C_structure_timint_statics.cpp
+++ b/src/structure/4C_structure_timint_statics.cpp
@@ -430,7 +430,7 @@ void Solid::TimIntStatics::update_step_element()
   p.set("action", "calc_struct_update_istep");
   // go to elements
   discret_->clear_state();
-  discret_->set_state("displacement", (*dis_)(0));
+  discret_->set_state("displacement", *(*dis_)(0));
 
   discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
   discret_->clear_state();

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -292,8 +292,8 @@ bool Solid::ModelEvaluator::Structure::initialize_inertia_and_damping()
   // set vector values needed by elements
   // --> initially zero !!!
   discret().clear_state();
-  discret().set_state(0, "residual displacement", zeros);
-  discret().set_state(0, "displacement", zeros);
+  discret().set_state(0, "residual displacement", *zeros);
+  discret().set_state(0, "displacement", *zeros);
 
   // set action type and evaluation matrix and vector pointers
   static_contributions(eval_mat.data(), eval_vec.data());
@@ -325,9 +325,9 @@ bool Solid::ModelEvaluator::Structure::apply_force_internal()
 
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "residual displacement", dis_incr_ptr_);
-  discret().set_state(0, "displacement", global_state().get_dis_np());
-  discret().set_state(0, "velocity", global_state().get_vel_np());
+  discret().set_state(0, "residual displacement", *dis_incr_ptr_);
+  discret().set_state(0, "displacement", *global_state().get_dis_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
 
   // set action type and evaluation matrix and vector pointers
   static_contributions(eval_vec.data());
@@ -354,10 +354,10 @@ bool Solid::ModelEvaluator::Structure::apply_force_external()
   eval_data().set_action_type(Core::Elements::none);
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_n());
+  discret().set_state(0, "displacement", *global_state().get_dis_n());
   if (eval_data().get_damping_type() == Inpar::Solid::damp_material)
-    discret().set_state(0, "velocity", global_state().get_vel_n());
-  discret().set_state(0, "displacement new", global_state().get_dis_np());
+    discret().set_state(0, "velocity", *global_state().get_vel_n());
+  discret().set_state(0, "displacement new", *global_state().get_dis_np());
   evaluate_neumann(*global_state().get_fext_np(), nullptr);
 
   return eval_error_check();
@@ -373,17 +373,18 @@ bool Solid::ModelEvaluator::Structure::apply_force_stiff_external()
 
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_n());
+  discret().set_state(0, "displacement", *global_state().get_dis_n());
 
   if (eval_data().get_damping_type() == Inpar::Solid::damp_material)
-    discret().set_state(0, "velocity", global_state().get_vel_n());
+    discret().set_state(0, "velocity", *global_state().get_vel_n());
 
   // get load vector
   if (!tim_int().get_data_sdyn().get_load_lin())
     evaluate_neumann(*global_state().get_fext_np(), nullptr);
   else
   {
-    discret().set_state(0, "displacement new", global_state().get_dis_np());
+    discret().set_state(0, "displacement new", *global_state().get_dis_np());
+
     /* Add the linearization of the external force to the stiffness
      * matrix. */
     evaluate_neumann(*global_state().get_fext_np(), Core::Utils::shared_ptr_from_ref(*stiff_ptr_));
@@ -417,9 +418,9 @@ bool Solid::ModelEvaluator::Structure::apply_force_stiff_internal()
 
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "residual displacement", dis_incr_ptr_);
-  discret().set_state(0, "displacement", global_state().get_dis_np());
-  discret().set_state(0, "velocity", global_state().get_vel_np());
+  discret().set_state(0, "residual displacement", *dis_incr_ptr_);
+  discret().set_state(0, "displacement", *global_state().get_dis_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
 
   // set action types and evaluate matrices/vectors
   static_contributions(eval_mat.data(), eval_vec.data());
@@ -475,7 +476,7 @@ void Solid::ModelEvaluator::Structure::material_damping_contributions(
   // (reset the action type to be independent of the calling order)
   eval_data().set_action_type(Core::Elements::struct_calc_nlnstiff);
   // set the discretization state
-  discret().set_state(0, "velocity", global_state().get_vel_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
   // reset damping matrix
   damp().zero();
   // add the stiffness matrix as well (also for the apply_force case!)
@@ -501,8 +502,8 @@ void Solid::ModelEvaluator::Structure::inertial_contributions(
     eval_data().set_action_type(Core::Elements::struct_calc_nlnstiffmass);
 
   // set the discretization state
-  discret().set_state(0, "velocity", global_state().get_vel_np());
-  discret().set_state(0, "acceleration", global_state().get_acc_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
+  discret().set_state(0, "acceleration", *global_state().get_acc_np());
   // reset the mass matrix
   mass().zero();
   // set mass matrix
@@ -525,8 +526,8 @@ void Solid::ModelEvaluator::Structure::inertial_contributions(
   // overwrite element action
   eval_data().set_action_type(Core::Elements::struct_calc_internalinertiaforce);
   // set the discretization state
-  discret().set_state(0, "velocity", global_state().get_vel_np());
-  discret().set_state(0, "acceleration", global_state().get_acc_np());
+  discret().set_state(0, "velocity", *global_state().get_vel_np());
+  discret().set_state(0, "acceleration", *global_state().get_acc_np());
 
   // set inertial vector if necessary
   eval_vec[1] = get_inertial_force();
@@ -876,7 +877,7 @@ void Solid::ModelEvaluator::Structure::evaluate_analytical_error()
   {
     // Set vector values needed by elements
     discret().clear_state();
-    discret().set_state(0, "displacement", global_state().get_dis_np());
+    discret().set_state(0, "displacement", *global_state().get_dis_np());
 
     // Call the error evaluator
     Teuchos::ParameterList evaluation_parameters;
@@ -992,8 +993,8 @@ void Solid::ModelEvaluator::Structure::output_runtime_structure_postprocess_stre
 
     // Set vector values needed by elements.
     discret().clear_state();
-    discret().set_state(0, "displacement", global_state().get_dis_np());
-    discret().set_state(0, "residual displacement", dis_incr_ptr_);
+    discret().set_state(0, "displacement", *global_state().get_dis_np());
+    discret().set_state(0, "residual displacement", *dis_incr_ptr_);
 
     // global_state().get_dis_np()->print(std::cout);
 
@@ -1121,8 +1122,8 @@ void Solid::ModelEvaluator::Structure::output_runtime_structure_gauss_point_data
         *discret().node_col_map(), *discret().element_row_map());
 
     discret().clear_state();
-    discret().set_state(0, "displacement", global_state().get_dis_np());
-    discret().set_state(0, "residual displacement", dis_incr_ptr_);
+    discret().set_state(0, "displacement", *global_state().get_dis_np());
+    discret().set_state(0, "residual displacement", *dis_incr_ptr_);
 
     std::array<std::shared_ptr<Core::LinAlg::Vector<double>>, 3> eval_vec = {
         nullptr, nullptr, nullptr};
@@ -1438,8 +1439,8 @@ void Solid::ModelEvaluator::Structure::run_recover()
 {
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "residual displacement", dis_incr_ptr_);
-  discret().set_state(0, "displacement", global_state().get_dis_np());
+  discret().set_state(0, "residual displacement", *dis_incr_ptr_);
+  discret().set_state(0, "displacement", *global_state().get_dis_np());
   // set the element action
   eval_data().set_action_type(Core::Elements::struct_calc_recover);
   // set the matrix and vector pointers to nullptr
@@ -1537,7 +1538,7 @@ void Solid::ModelEvaluator::Structure::evaluate_jacobian_contributions_from_elem
 
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_np());
+  discret().set_state(0, "displacement", *global_state().get_dis_np());
 
   eval_mat[0] = Core::Utils::shared_ptr_from_ref(*stiff_ptc_ptr_);
 
@@ -1584,7 +1585,7 @@ void Solid::ModelEvaluator::Structure::update_step_element()
 
   // go to elements
   discret().clear_state();
-  discret().set_state("displacement", global_state().get_dis_n());
+  discret().set_state("displacement", *global_state().get_dis_n());
 
   // set dummy evaluation vectors and matrices
   std::array<std::shared_ptr<Core::LinAlg::Vector<double>>, 3> eval_vec = {
@@ -1624,8 +1625,8 @@ void Solid::ModelEvaluator::Structure::determine_stress_strain()
 
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_np());
-  discret().set_state(0, "residual displacement", dis_incr_ptr_);
+  discret().set_state(0, "displacement", *global_state().get_dis_np());
+  discret().set_state(0, "residual displacement", *dis_incr_ptr_);
 
   // set dummy evaluation vectors and matrices
   std::array<std::shared_ptr<Core::LinAlg::Vector<double>>, 3> eval_vec = {
@@ -1650,8 +1651,8 @@ void Solid::ModelEvaluator::Structure::determine_strain_energy(
 
   // set state vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "displacement", Core::Utils::shared_ptr_from_ref(disnp));
-  discret().set_state(0, "residual displacement", dis_incr_ptr_);
+  discret().set_state(0, "displacement", disnp);
+  discret().set_state(0, "residual displacement", *dis_incr_ptr_);
 
   // set dummy evaluation vectors and matrices
   std::array<std::shared_ptr<Core::LinAlg::Vector<double>>, 3> eval_vec = {
@@ -1712,7 +1713,7 @@ void Solid::ModelEvaluator::Structure::determine_energy(const Core::LinAlg::Vect
   }
 }
 
-/*----------------------------------------------------------------------------*
+/*----------------------------------------------------------------------------*ö
  *----------------------------------------------------------------------------*/
 void Solid::ModelEvaluator::Structure::output_step_state(
     Core::IO::DiscretizationWriter& iowriter) const
@@ -2121,10 +2122,10 @@ void Solid::ModelEvaluator::Structure::create_backup_state(const Core::LinAlg::V
 
   // set vector values needed by elements
   discret().clear_state();
-  discret().set_state(0, "displacement", global_state().get_dis_np());
+  discret().set_state(0, "displacement", *global_state().get_dis_np());
   std::shared_ptr<const Core::LinAlg::Vector<double>> dir_displ =
       global_state().extract_displ_entries(dir);
-  discret().set_state(0, "residual displacement", dir_displ);
+  discret().set_state(0, "residual displacement", *dir_displ);
 
   // set dummy evaluation vectors and matrices
   std::array<std::shared_ptr<Core::LinAlg::Vector<double>>, 3> eval_vec = {

--- a/src/structure_new/src/utils/4C_structure_new_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_dbc.cpp
@@ -151,7 +151,7 @@ void Solid::Dbc::update_loc_sys_manager()
 {
   if (!is_loc_sys()) return;
 
-  discret_ptr()->set_state("dispnp", g_state().get_dis_np());
+  discret_ptr()->set_state("dispnp", *g_state().get_dis_np());
   locsysman_ptr_->update(
       g_state().get_time_np(), {}, Global::Problem::instance()->function_manager());
   discret_ptr()->clear_state();

--- a/src/thermo/src/implicit/4C_thermo_timint.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.cpp
@@ -210,8 +210,8 @@ void Thermo::TimInt::determine_capa_consist_temp_rate()
     // set vector values needed by elements
     discret_->clear_state();
     // set_state(0,...) in case of multiple dofsets (e.g. TSI)
-    discret_->set_state(0, "residual temperature", zeros_);
-    discret_->set_state(0, "temperature", (*temp_)(0));
+    discret_->set_state(0, "residual temperature", *zeros_);
+    discret_->set_state(0, "temperature", *(*temp_)(0));
 
     // calculate the capacity matrix onto tang_, instead of buildung 2 matrices
     discret_->evaluate(p, nullptr, tang_, fint, nullptr, nullptr);
@@ -416,7 +416,7 @@ void Thermo::TimInt::write_runtime_output()
       p.set<Thermo::Action>("action", Thermo::calc_thermo_energy);
 
       discret_->clear_state();
-      discret_->set_state(0, "temperature", (*temp_)(0));
+      discret_->set_state(0, "temperature", *(*temp_)(0));
 
       std::shared_ptr<Core::LinAlg::SerialDenseVector> energies =
           std::make_shared<Core::LinAlg::SerialDenseVector>(1);
@@ -592,8 +592,8 @@ void Thermo::TimInt::output_heatflux_tempgrad(bool& datawritten)
   // set vector values needed by elements
   discret_->clear_state();
   // set_state(0,...) in case of multiple dofsets (e.g. TSI)
-  discret_->set_state(0, "residual temperature", zeros_);
-  discret_->set_state(0, "temperature", (*temp_)(0));
+  discret_->set_state(0, "residual temperature", *zeros_);
+  discret_->set_state(0, "temperature", *(*temp_)(0));
 
   auto heatflux = std::make_shared<Core::LinAlg::Vector<double>>(*discret_->dof_row_map(), true);
 
@@ -680,7 +680,7 @@ void Thermo::TimInt::apply_force_external(const double time,   //!< evaluation t
   // set vector values needed by elements
   discret_->clear_state();
   // set_state(0,...) in case of multiple dofsets (e.g. TSI)
-  discret_->set_state(0, "temperature", temp);
+  discret_->set_state(0, "temperature", *temp);
   // get load vector
   discret_->evaluate_neumann(p, fext);
   discret_->clear_state();
@@ -721,8 +721,8 @@ void Thermo::TimInt::apply_force_external_conv(Teuchos::ParameterList& p,
 
   // set vector values needed by elements
   discret_->clear_state();
-  discret_->set_state(0, "old temperature", tempn);  // T_n (*temp_)(0)
-  discret_->set_state(0, "temperature", temp);       // T_{n+1} tempn_
+  discret_->set_state(0, "old temperature", *tempn);  // T_n (*temp_)(0)
+  discret_->set_state(0, "temperature", *temp);       // T_{n+1} tempn_
 
   // get load vector
   // use general version of evaluate_condition()
@@ -758,8 +758,8 @@ void Thermo::TimInt::apply_force_tang_internal(
   // set vector values needed by elements
   discret_->clear_state();
   // set_state(0,...) in case of multiple dofsets (e.g. TSI)
-  discret_->set_state(0, "residual temperature", tempi);
-  discret_->set_state(0, "temperature", temp);
+  discret_->set_state(0, "residual temperature", *tempi);
+  discret_->set_state(0, "temperature", *temp);
 
   discret_->evaluate(p, tang, nullptr, fint, nullptr, nullptr);
 
@@ -795,10 +795,10 @@ void Thermo::TimInt::apply_force_tang_internal(
   // set vector values needed by elements
   discret_->clear_state();
   // set_state(0,...) in case of multiple dofsets (e.g. TSI)
-  discret_->set_state(0, "residual temperature", tempi);
-  discret_->set_state(0, "temperature", temp);
+  discret_->set_state(0, "residual temperature", *tempi);
+  discret_->set_state(0, "temperature", *temp);
   // required for linearization of T-dependent capacity
-  discret_->set_state(0, "last temperature", (*temp_)(0));
+  discret_->set_state(0, "last temperature", *(*temp_)(0));
 
   // in case of genalpha extract midpoint temperature rate R_{n+alpha_m}
   // extract it after ClearState() is called.
@@ -806,7 +806,7 @@ void Thermo::TimInt::apply_force_tang_internal(
   {
     std::shared_ptr<const Core::LinAlg::Vector<double>> ratem =
         p.get<std::shared_ptr<const Core::LinAlg::Vector<double>>>("mid-temprate");
-    if (ratem != nullptr) discret_->set_state(0, "mid-temprate", ratem);
+    if (ratem != nullptr) discret_->set_state(0, "mid-temprate", *ratem);
   }
 
   // call the element evaluate()
@@ -841,8 +841,8 @@ void Thermo::TimInt::apply_force_internal(
   // set vector values needed by elements
   discret_->clear_state();
   // set_state(0,...) in case of multiple dofsets (e.g. TSI)
-  discret_->set_state(0, "residual temperature", tempi);
-  discret_->set_state(0, "temperature", temp);
+  discret_->set_state(0, "residual temperature", *tempi);
+  discret_->set_state(0, "temperature", *temp);
 
   // call the element evaluate()
   discret_->evaluate(p, nullptr, nullptr, fint, nullptr, nullptr);
@@ -952,7 +952,7 @@ std::shared_ptr<std::vector<double>> Thermo::TimInt::evaluate_error_compared_to_
       eleparams.set<Thermo::CalcError>("calculate error", calcerror_);
       eleparams.set<int>("error function number", errorfunctno_);
 
-      discret_->set_state("temperature", tempn_);
+      discret_->set_state("temperature", *tempn_);
 
       // get (squared) error values
       // 0: delta temperature for L2-error norm

--- a/src/thermo/src/implicit/4C_thermo_timint_ost.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_ost.cpp
@@ -336,7 +336,7 @@ void Thermo::TimIntOneStepTheta::update_step_element()
   // action for elements
   p.set<Thermo::Action>("action", Thermo::calc_thermo_update_istep);
   // go to elements
-  discret_->set_state(0, "temperature", tempn_);
+  discret_->set_state(0, "temperature", *tempn_);
   discret_->evaluate(p, nullptr, nullptr, nullptr, nullptr, nullptr);
 
 }  // update_step_element()

--- a/src/tsi/4C_tsi_algorithm.cpp
+++ b/src/tsi/4C_tsi_algorithm.cpp
@@ -105,10 +105,10 @@ TSI::Algorithm::Algorithm(MPI_Comm comm)
         Inpar::TSI::Monolithic)
     {
       if (matchinggrid_)
-        structdis->set_state(1, "temperature", thermo_field()->tempnp());
+        structdis->set_state(1, "temperature", *thermo_field()->tempnp());
       else
         structdis->set_state(
-            1, "temperature", volcoupl_->apply_vector_mapping12(*thermo_field()->tempnp()));
+            1, "temperature", *volcoupl_->apply_vector_mapping12(*thermo_field()->tempnp()));
     }
 
     adapterbase_ptr->setup();
@@ -411,15 +411,15 @@ void TSI::Algorithm::apply_thermo_coupling_state(
 {
   if (matchinggrid_)
   {
-    if (temp != nullptr) structure_field()->discretization()->set_state(1, "temperature", temp);
+    if (temp != nullptr) structure_field()->discretization()->set_state(1, "temperature", *temp);
     if (temp_res != nullptr)
-      structure_field()->discretization()->set_state(1, "residual temperature", temp_res);
+      structure_field()->discretization()->set_state(1, "residual temperature", *temp_res);
   }
   else
   {
     if (temp != nullptr)
       structure_field()->discretization()->set_state(
-          1, "temperature", volcoupl_->apply_vector_mapping12(*temp));
+          1, "temperature", *volcoupl_->apply_vector_mapping12(*temp));
   }
 
   // set new temperatures to contact
@@ -440,17 +440,17 @@ void TSI::Algorithm::apply_struct_coupling_state(
 {
   if (matchinggrid_)
   {
-    if (disp != nullptr) thermo_field()->discretization()->set_state(1, "displacement", disp);
-    if (vel != nullptr) thermo_field()->discretization()->set_state(1, "velocity", vel);
+    if (disp != nullptr) thermo_field()->discretization()->set_state(1, "displacement", *disp);
+    if (vel != nullptr) thermo_field()->discretization()->set_state(1, "velocity", *vel);
   }
   else
   {
     if (disp != nullptr)
       thermo_field()->discretization()->set_state(
-          1, "displacement", volcoupl_->apply_vector_mapping21(*disp));
+          1, "displacement", *volcoupl_->apply_vector_mapping21(*disp));
     if (vel != nullptr)
       thermo_field()->discretization()->set_state(
-          1, "velocity", volcoupl_->apply_vector_mapping21(*vel));
+          1, "velocity", *volcoupl_->apply_vector_mapping21(*vel));
   }
 }  // apply_struct_coupling_state()
 

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -90,10 +90,10 @@ TSI::Monolithic::Monolithic(MPI_Comm comm, const Teuchos::ParameterList& sdynpar
   if (thermo_field()->tempnp() == nullptr) FOUR_C_THROW("this is nullptr");
 
   if (matchinggrid_)
-    structure_field()->discretization()->set_state(1, "temperature", thermo_field()->tempnp());
+    structure_field()->discretization()->set_state(1, "temperature", *thermo_field()->tempnp());
   else
     structure_field()->discretization()->set_state(
-        1, "temperature", volcoupl_->apply_vector_mapping12(*thermo_field()->tempnp()));
+        1, "temperature", *volcoupl_->apply_vector_mapping12(*thermo_field()->tempnp()));
 
   // setup structural time integrator with initial temperature
   structure_->setup();
@@ -1873,7 +1873,7 @@ void TSI::Monolithic::apply_str_coupl_matrix(
   sparams.set("total time", time());
 
   structure_field()->discretization()->clear_state(true);
-  structure_field()->discretization()->set_state(0, "displacement", structure_field()->dispnp());
+  structure_field()->discretization()->set_state(0, "displacement", *structure_field()->dispnp());
 
   apply_thermo_coupling_state(thermo_field()->tempnp());
 
@@ -2016,7 +2016,7 @@ void TSI::Monolithic::apply_thermo_coupl_matrix(
 
   thermo_field()->discretization()->clear_state(true);
   // set the variables that are needed by the elements
-  thermo_field()->discretization()->set_state(0, "temperature", thermo_field()->tempnp());
+  thermo_field()->discretization()->set_state(0, "temperature", *thermo_field()->tempnp());
 
   apply_struct_coupling_state(structure_field()->dispnp(), vel_);
 
@@ -2107,7 +2107,7 @@ void TSI::Monolithic::apply_thermo_coupl_matrix_conv_bc(
     // clear all states set in discretization
     thermo_field()->discretization()->clear_state(true);
     // set the variables that are needed by the elements
-    thermo_field()->discretization()->set_state(0, "temperature", thermo_field()->tempnp());
+    thermo_field()->discretization()->set_state(0, "temperature", *thermo_field()->tempnp());
     apply_struct_coupling_state(structure_field()->dispnp(), vel_);
 
     // build specific assemble strategy for the thermal-mechanical system matrix
@@ -2765,17 +2765,17 @@ void TSI::Monolithic::apply_struct_coupling_state(
 {
   if (matchinggrid_)
   {
-    if (disp != nullptr) thermo_field()->discretization()->set_state(1, "displacement", disp);
-    if (vel != nullptr) thermo_field()->discretization()->set_state(1, "velocity", vel);
+    if (disp != nullptr) thermo_field()->discretization()->set_state(1, "displacement", *disp);
+    if (vel != nullptr) thermo_field()->discretization()->set_state(1, "velocity", *vel);
   }
   else
   {
     if (disp != nullptr)
       thermo_field()->discretization()->set_state(
-          1, "displacement", volcoupl_->apply_vector_mapping21(*disp));
+          1, "displacement", *volcoupl_->apply_vector_mapping21(*disp));
     if (vel != nullptr)
       thermo_field()->discretization()->set_state(
-          1, "velocity", volcoupl_->apply_vector_mapping21(*vel));
+          1, "velocity", *volcoupl_->apply_vector_mapping21(*vel));
   }
 }  // apply_struct_coupling_state()
 

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -219,9 +219,9 @@ void XFEM::MeshCoupling::set_state()
   // set general vector values of cutterdis needed by background element evaluate routine
   clear_state();
 
-  cutter_dis_->set_state("ivelnp", ivelnp_);
-  cutter_dis_->set_state("iveln", iveln_);
-  cutter_dis_->set_state("idispnp", idispnp_);
+  cutter_dis_->set_state("ivelnp", *ivelnp_);
+  cutter_dis_->set_state("iveln", *iveln_);
+  cutter_dis_->set_state("idispnp", *idispnp_);
 }
 
 /*--------------------------------------------------------------------------*
@@ -231,9 +231,9 @@ void XFEM::MeshCoupling::set_state_displacement()
   // set general vector values of cutterdis needed by background element evaluate routine
   clear_state();
 
-  cutter_dis_->set_state("idispnp", idispnp_);
-  cutter_dis_->set_state("idispn", idispn_);
-  cutter_dis_->set_state("idispnpi", idispnpi_);
+  cutter_dis_->set_state("idispnp", *idispnp_);
+  cutter_dis_->set_state("idispn", *idispn_);
+  cutter_dis_->set_state("idispnpi", *idispnpi_);
 }
 
 /*--------------------------------------------------------------------------*


### PR DESCRIPTION
## Description and Context
The set_state method of the discretization takes a std::shared_ptr<const Core::LinAlg::Vector<double>> so far. I suggest moving to a const reference instead. The relevant change to the code is only in `src/core/fem/src/discretization/4C_fem_discretization.hpp`. The rest is only consistent adaptations to that.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
