### PR TITLE
Remove static functions from structure headers

### DIFF
--- a/src/ale/4C_ale_ale3_evaluate.cpp
+++ b/src/ale/4C_ale_ale3_evaluate.cpp
@@ -13,6 +13,7 @@
 #include "4C_fem_nurbs_discretization.hpp"
 #include "4C_mat_elasthyper.hpp"
 #include "4C_mat_stvenantkirchhoff.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/beam3/4C_beam3_euler_bernoulli_input.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_input.cpp
@@ -10,6 +10,7 @@
 #include "4C_mat_material_factory.hpp"
 #include "4C_material_base.hpp"
 #include "4C_material_parameter_base.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/beam3/4C_beam3_kirchhoff_input.cpp
+++ b/src/beam3/4C_beam3_kirchhoff_input.cpp
@@ -11,6 +11,7 @@
 #include "4C_mat_material_factory.hpp"
 #include "4C_material_base.hpp"
 #include "4C_material_parameter_base.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/beam3/4C_beam3_reissner_input.cpp
+++ b/src/beam3/4C_beam3_reissner_input.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_material_factory.hpp"
 #include "4C_material_base.hpp"
 #include "4C_material_parameter_base.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <vector>
 

--- a/src/contact/4C_contact_nitsche_integrator_ssi_elch.cpp
+++ b/src/contact/4C_contact_nitsche_integrator_ssi_elch.cpp
@@ -18,6 +18,7 @@
 #include "4C_scatra_ele_parameter_elch.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
 #include "4C_solid_3D_ele_calc_lib.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
@@ -17,6 +17,7 @@
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_fluid_murnaghantait.hpp"
 #include "4C_mat_newtonianfluid.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_shared_ptr_from_ref.hpp"
 
 #include <Teuchos_BLAS.hpp>

--- a/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
@@ -21,6 +21,7 @@
 #include "4C_mat_fluidporo.hpp"
 #include "4C_mat_structporo.hpp"
 #include "4C_mat_stvenantkirchhoff.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/fsi/src/4C_fsi_dyn.cpp
+++ b/src/fsi/src/4C_fsi_dyn.cpp
@@ -57,6 +57,7 @@
 #include "4C_poroelast_utils_setup.hpp"
 #include "4C_rebalance_binning_based.hpp"
 #include "4C_solid_3D_ele.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 #include "4C_utils_result_test.hpp"
 #include "4C_xfem_discretization.hpp"

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -30,6 +30,7 @@
 #include "4C_inpar_validparameters.hpp"
 #include "4C_io_control.hpp"
 #include "4C_structure_aux.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_Time.hpp>

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -35,6 +35,7 @@
 #include "4C_mat_scatra_multiscale.hpp"
 #include "4C_particle_engine_particlereader.hpp"
 #include "4C_rebalance_graph_based.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_xfem_discretization.hpp"
 #include "4C_xfem_discretization_utils.hpp"
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -11,6 +11,7 @@
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_geometry_type.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -19,6 +20,49 @@ namespace Inpar
 {
   namespace Solid
   {
+    std::string pred_enum_string(const PredEnum name)
+    {
+      switch (name)
+      {
+        case pred_vague:
+          return "Vague";
+        case pred_constdis:
+          return "ConstDis";
+        case pred_constvel:
+          return "ConstVel";
+        case pred_constacc:
+          return "ConstAcc";
+        case pred_constdisvelacc:
+          return "ConstDisVelAcc";
+        case pred_tangdis:
+          return "TangDis";
+        case pred_tangdis_constfext:
+          return "TangDisConstFext";
+        case pred_constdispres:
+          return "ConstDisPres";
+        case pred_constdisvelaccpres:
+          return "ConstDisVelAccPres";
+        default:
+          FOUR_C_THROW("Cannot make std::string for predictor {}", name);
+          exit(EXIT_FAILURE);
+      }
+    }
+
+    std::string kinem_type_string(const KinemType kinem_type)
+    {
+      switch (kinem_type)
+      {
+        case Inpar::Solid::KinemType::vague:
+          return "vague";
+        case Inpar::Solid::KinemType::linear:
+          return "linear";
+        case Inpar::Solid::KinemType::nonlinearTotLag:
+          return "nonlinear";
+      }
+
+      FOUR_C_THROW("Unknown kinematic type {}", kinem_type);
+    }
+
     void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
     {
       using Teuchos::tuple;

--- a/src/inpar/4C_inpar_structure.hpp
+++ b/src/inpar/4C_inpar_structure.hpp
@@ -12,7 +12,6 @@
 #include "4C_config.hpp"
 
 #include "4C_io_input_spec.hpp"
-#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <map>
@@ -40,28 +39,6 @@ namespace Inpar
       ps_mulf    ///< prestressing: mulf
     };
 
-    /// Map element technology to string
-    static inline std::string ele_tech_string(const enum EleTech name  ///< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case EleTech::eas:
-          return "EAS";
-          break;
-        case EleTech::fbar:
-          return "FBar";
-          break;
-        case EleTech::rotvec:
-          return "rotationvectorDOFs";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string for element technology {}", name);
-          break;
-      }
-      return "";
-    }
-
     /// Type of the used models/conditions
     /// necessary for the model evaluator
     enum ModelType : int
@@ -84,99 +61,6 @@ namespace Inpar
                                    ///< monolithic or partitioned coupling
       model_constraints = 12,      ///< evaluate the contributions of the constraint framework
       model_multiscale = 13        ///< consider multi scale simulations
-    };
-
-    /// Map model type to string
-    static inline std::string model_type_string(const enum ModelType name  ///< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case model_structure:
-          return "Structure";
-          break;
-        case model_contact:
-          return "Contact";
-          break;
-        case model_meshtying:
-          return "Meshtying";
-          break;
-        case model_cardiovascular0d:
-          return "Cardiovascular0D";
-          break;
-        case model_springdashpot:
-          return "SpringDashpot";
-          break;
-        case model_lag_pen_constraint:
-          return "Lag-Pen-Constraint";
-          break;
-        case model_monolithic_coupling:
-          return "Monolithic-Coupling";
-          break;
-        case model_partitioned_coupling:
-          return "Partitioned-Coupling";
-          break;
-        case model_beam_interaction_old:
-          return "BeamInteractionOld";
-          break;
-        case model_browniandyn:
-          return "BrownianDyn";
-          break;
-        case model_beaminteraction:
-          return "BeamInteraction";
-          break;
-        case model_basic_coupling:
-          return "Basic-Coupling";
-          break;
-        case model_constraints:
-          return "Constraints";
-          break;
-        case model_multiscale:
-          return "Multiscale";
-          break;
-
-        default:
-          FOUR_C_THROW("Cannot make std::string for model type {}", name);
-          return "";
-      }
-    };
-
-    //! Map model std::string to enum
-    inline enum ModelType string_to_model_type(const std::string& name)
-    {
-      ModelType type = model_vague;
-      if (name == "Structure")
-        type = model_structure;
-      else if (name == "Contact")
-        type = model_contact;
-      else if (name == "Meshtying")
-        type = model_meshtying;
-      else if (name == "Cardiovascular0D")
-        type = model_cardiovascular0d;
-      else if (name == "SpringDashpot")
-        type = model_springdashpot;
-      else if (name == "Lag-Pen-Constraint")
-        type = model_lag_pen_constraint;
-      else if (name == "Monolithic-Coupling")
-        type = model_monolithic_coupling;
-      else if (name == "Partitioned-Coupling")
-        type = model_partitioned_coupling;
-      else if (name == "BeamInteractionOld")
-        type = model_beam_interaction_old;
-      else if (name == "BrownianDyn")
-        type = model_browniandyn;
-      else if (name == "BeamInteraction")
-        type = model_beaminteraction;
-      else if (name == "Basic-Coupling")
-        type = model_basic_coupling;
-      else if (name == "Constraints")
-        type = model_constraints;
-      else if (name == "Multiscale")
-        type = model_multiscale;
-      else
-        FOUR_C_THROW("Unknown Inpar::Solid::ModelType with name '{}'.", name.c_str());
-
-      return type;
     };
 
     /// @name Time integration
@@ -262,34 +146,7 @@ namespace Inpar
     };
 
     /// Map predictor enum term to std::string
-    static inline std::string pred_enum_string(const PredEnum name  ///< identifier
-    )
-    {
-      switch (name)
-      {
-        case pred_vague:
-          return "Vague";
-        case pred_constdis:
-          return "ConstDis";
-        case pred_constvel:
-          return "ConstVel";
-        case pred_constacc:
-          return "ConstAcc";
-        case pred_constdisvelacc:
-          return "ConstDisVelAcc";
-        case pred_tangdis:
-          return "TangDis";
-        case pred_tangdis_constfext:
-          return "TangDisConstFext";
-        case pred_constdispres:
-          return "ConstDisPres";
-        case pred_constdisvelaccpres:
-          return "ConstDisVelAccPres";
-        default:
-          FOUR_C_THROW("Cannot make std::string for predictor {}", name);
-          exit(EXIT_FAILURE);
-      }
-    }
+    std::string pred_enum_string(const PredEnum name);
 
     //!@}
 
@@ -342,48 +199,6 @@ namespace Inpar
                                      ///< of 3D0D-coupled problem
     };
 
-    /// Map  enum to string
-    static inline std::string div_cont_act_string(const enum DivContAct name  ///< enum to convert
-    )
-    {
-      switch (name)
-      {
-        case divcont_stop:
-          return "stop";
-          break;
-        case divcont_continue:
-          return "continue";
-          break;
-        case divcont_repeat_step:
-          return "repeat_step";
-          break;
-        case divcont_halve_step:
-          return "halve_step";
-          break;
-        case divcont_adapt_step:
-          return "adapt_step";
-          break;
-        case divcont_rand_adapt_step:
-          return "rand_adapt_step";
-          break;
-        case divcont_rand_adapt_step_ele_err:
-          return "rand_adapt_step_ele_err";
-          break;
-        case divcont_repeat_simulation:
-          return "repeat_simulation";
-          break;
-        case divcont_adapt_penaltycontact:
-          return "adapt_penaltycontact";
-          break;
-        case divcont_adapt_3D0Dptc_ele_err:
-          return "adapt_3D0Dptc_ele_err";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make string for solution div cont technique {}", name);
-          return "";
-      }
-    }
-
     /// Handling of non-converged nonlinear solver
     enum ConvergenceStatus
     {
@@ -428,27 +243,6 @@ namespace Inpar
       stc_curr,          ///< Non-symmetric STC
       stc_currsym        ///< Symmetric STC
     };
-
-    /// map convergence check to enum term
-    static inline std::string stc_string(const enum StcScale name  ///< enum term
-    )
-    {
-      switch (name)
-      {
-        case stc_inactive:
-          return "stc_inactive";
-          break;
-        case stc_curr:
-          return "stc_curr";
-          break;
-        case stc_currsym:
-          return "stc_currsym";
-          break;
-        default:
-          FOUR_C_THROW("Cannot make std::string for stc method {}", name);
-          return "";
-      }
-    }
 
     /// @name Constraints (global, geometric)
     //!@{
@@ -576,20 +370,7 @@ namespace Inpar
       nonlinearTotLag  ///< nonlinear kinematics Total Lagrange
     };
 
-    static inline std::string kinem_type_string(const KinemType kinem_type)
-    {
-      switch (kinem_type)
-      {
-        case Inpar::Solid::KinemType::vague:
-          return "vague";
-        case Inpar::Solid::KinemType::linear:
-          return "linear";
-        case Inpar::Solid::KinemType::nonlinearTotLag:
-          return "nonlinear";
-      }
-
-      FOUR_C_THROW("Unknown kinematic type {}", kinem_type);
-    }
+    std::string kinem_type_string(const KinemType kinem_type);
     //!@}
 
     /// set the structure parameters

--- a/src/mat/4C_mat_so3_material.cpp
+++ b/src/mat/4C_mat_so3_material.cpp
@@ -1,0 +1,55 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_mat_so3_material.hpp"
+
+#include "4C_utils_enum.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+
+void Mat::So3Material::evaluate_non_lin_mass(const Core::LinAlg::Matrix<3, 3>* defgrd,
+    const Core::LinAlg::Matrix<6, 1>* glstrain, Teuchos::ParameterList& params,
+    Core::LinAlg::Matrix<6, 1>* linmass_disp, Core::LinAlg::Matrix<6, 1>* linmass_vel, int gp,
+    int eleGID)
+{
+  FOUR_C_THROW("Material of type {} does not support evaluation of nonlinear mass matrix",
+      this->material_type());
+}
+
+
+void Mat::So3Material::strain_energy(
+    const Core::LinAlg::Matrix<6, 1>& glstrain, double& psi, int gp, int eleGID) const
+{
+  FOUR_C_THROW(
+      "Material of type {} does not support calculation of strain energy", this->material_type());
+}
+
+
+void Mat::So3Material::evaluate_cauchy_n_dir_and_derivatives(
+    const Core::LinAlg::Matrix<3, 3>& defgrd, const Core::LinAlg::Matrix<3, 1>& n,
+    const Core::LinAlg::Matrix<3, 1>& dir, double& cauchy_n_dir,
+    Core::LinAlg::Matrix<3, 1>* d_cauchyndir_dn, Core::LinAlg::Matrix<3, 1>* d_cauchyndir_ddir,
+    Core::LinAlg::Matrix<9, 1>* d_cauchyndir_dF, Core::LinAlg::Matrix<9, 9>* d2_cauchyndir_dF2,
+    Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
+    Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
+    const double* concentration, const double* temp, double* d_cauchyndir_dT,
+    Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT)
+{
+  FOUR_C_THROW("evaluate_cauchy_n_dir_and_derivatives not implemented for material of type {}",
+      this->material_type());
+}
+
+
+void Mat::So3Material::evaluate_linearization_od(const Core::LinAlg::Matrix<3, 3>& defgrd,
+    double concentration, Core::LinAlg::Matrix<9, 1>* d_F_dx)
+{
+  FOUR_C_THROW(
+      "evaluate_linearization_od not implemented for material of type {}", this->material_type());
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/mat/4C_mat_so3_material.hpp
+++ b/src/mat/4C_mat_so3_material.hpp
@@ -61,11 +61,7 @@ namespace Mat
     virtual void evaluate_non_lin_mass(const Core::LinAlg::Matrix<3, 3>* defgrd,
         const Core::LinAlg::Matrix<6, 1>* glstrain, Teuchos::ParameterList& params,
         Core::LinAlg::Matrix<6, 1>* linmass_disp, Core::LinAlg::Matrix<6, 1>* linmass_vel, int gp,
-        int eleGID)
-    {
-      FOUR_C_THROW("Material of type {} does not support evaluation of nonlinear mass matrix",
-          this->material_type());
-    }
+        int eleGID);
 
     /*!
      * @brief Evaluate the strain energy function (for hyperelastic materials only)
@@ -76,11 +72,7 @@ namespace Mat
      * @param[in] eleGID   Global element ID
      */
     virtual void strain_energy(
-        const Core::LinAlg::Matrix<6, 1>& glstrain, double& psi, int gp, int eleGID) const
-    {
-      FOUR_C_THROW("Material of type {} does not support calculation of strain energy",
-          this->material_type());
-    }
+        const Core::LinAlg::Matrix<6, 1>& glstrain, double& psi, int gp, int eleGID) const;
 
     /*!
      * @brief Evaluate the Cauchy stress contracted with normal and direction vector and
@@ -138,11 +130,7 @@ namespace Mat
         Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_dn,
         Core::LinAlg::Matrix<9, 3>* d2_cauchyndir_dF_ddir, int gp, int eleGID,
         const double* concentration, const double* temp, double* d_cauchyndir_dT,
-        Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT)
-    {
-      FOUR_C_THROW("evaluate_cauchy_n_dir_and_derivatives not implemented for material of type {}",
-          this->material_type());
-    }
+        Core::LinAlg::Matrix<9, 1>* d2_cauchyndir_dF_dT);
 
     /*!
      * @brief Evaluate the derivative of the deformation gradient w.r.t. degree of freedom x
@@ -152,11 +140,7 @@ namespace Mat
      * @param[out] d_F_dx       Derivative of deformation gradient w.r.t. degree of freedom x
      */
     virtual void evaluate_linearization_od(const Core::LinAlg::Matrix<3, 3>& defgrd,
-        double concentration, Core::LinAlg::Matrix<9, 1>* d_F_dx)
-    {
-      FOUR_C_THROW("evaluate_linearization_od not implemented for material of type {}",
-          this->material_type());
-    }
+        double concentration, Core::LinAlg::Matrix<9, 1>* d_F_dx);
     //@}
 
     /*!
@@ -311,6 +295,7 @@ namespace Mat
     virtual bool needs_defgrd() const { return false; }
     //@}
   };
+
 }  // namespace Mat
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mixture/4C_mixture_constituent_elasthyperbase.cpp
+++ b/src/mixture/4C_mixture_constituent_elasthyperbase.cpp
@@ -13,6 +13,7 @@
 #include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mixture_prestress_strategy.hpp"
+#include "4C_utils_enum.hpp"
 
 
 

--- a/src/mixture/4C_mixture_constituent_solidmaterial.cpp
+++ b/src/mixture/4C_mixture_constituent_solidmaterial.cpp
@@ -12,6 +12,7 @@
 #include "4C_mat_mixture.hpp"
 #include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
+#include "4C_utils_enum.hpp"
 
 
 

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -31,6 +31,7 @@
 #include "4C_mortar_manager_base.hpp"
 #include "4C_structure_aux.hpp"
 #include "4C_structure_new_model_evaluator_contact.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_Time.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
+++ b/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
@@ -14,6 +14,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_structure_aux.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -287,9 +288,8 @@ void PoroElast::MonolithicMeshtying::print_newton_iter_header_stream(std::ostrin
 {
   oss << "------------------------------------------------------------" << std::endl;
   oss << "                   Newton-Raphson Scheme                    " << std::endl;
-  oss << "                NormRES " << magic_enum::enum_name(vectornormfres_);
-  oss << "     NormINC " << magic_enum::enum_name(vectornorminc_) << "                    "
-      << std::endl;
+  oss << "                NormRES " << vectornormfres_;
+  oss << "     NormINC " << vectornorminc_ << "                    " << std::endl;
   oss << "------------------------------------------------------------" << std::endl;
 
   // enter converged state etc

--- a/src/poroelast/4C_poroelast_utils.cpp
+++ b/src/poroelast/4C_poroelast_utils.cpp
@@ -26,6 +26,7 @@
 #include "4C_solid_poro_3D_ele_pressure_based.hpp"
 #include "4C_solid_poro_3D_ele_pressure_velocity_based.hpp"
 #include "4C_solid_poro_3D_ele_pressure_velocity_based_p1.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_w1_poro_eletypes.hpp"
 #include "4C_w1_poro_p1_eletypes.hpp"
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
@@ -25,6 +25,7 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_linear_solver_method_parameters.hpp"
 #include "4C_porofluid_pressure_based_elast_utils.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.cpp
@@ -16,6 +16,7 @@
 #include "4C_mat_structporo.hpp"
 #include "4C_porofluid_pressure_based_ele_calc_utils.hpp"
 #include "4C_porofluid_pressure_based_ele_variablemanager.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_SerialDenseSolver.hpp>

--- a/src/rigidsphere/4C_rigidsphere_evaluate.cpp
+++ b/src/rigidsphere/4C_rigidsphere_evaluate.cpp
@@ -18,6 +18,7 @@
 #include "4C_mat_stvenantkirchhoff.hpp"
 #include "4C_rigidsphere.hpp"
 #include "4C_structure_new_elements_paramsinterface.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -24,6 +24,7 @@
 #include "4C_mat_scatra_chemotaxis.hpp"
 #include "4C_mat_scatra_reaction.hpp"
 #include "4C_scatra_ele_calc_utils.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
@@ -20,6 +20,7 @@
 #include "4C_scatra_ele_parameter_boundary.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_calc_advanced_reaction.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_advanced_reaction.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_so3_material.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_calc_poro_reac.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro_reac.cpp
@@ -14,6 +14,7 @@
 #include "4C_mat_structporo.hpp"
 #include "4C_mat_structporo_reaction_ecm.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/scatra_ele/4C_scatra_ele_calc_poro_reac_ECM.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro_reac_ECM.cpp
@@ -16,6 +16,7 @@
 #include "4C_mat_structporo.hpp"
 #include "4C_mat_structporo_reaction_ecm.hpp"
 #include "4C_scatra_ele_parameter_std.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_singleton_owner.hpp"
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/shell7p/4C_shell7p_utils.cpp
+++ b/src/shell7p/4C_shell7p_utils.cpp
@@ -12,6 +12,7 @@
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_shell7p_ele.hpp"
 #include "4C_shell7p_ele_scatra.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -51,17 +51,9 @@ namespace
             Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes<celltype>}),
         parameter<int>("MAT"),
         get_kinem_type_input_spec(),
-        deprecated_selection<Discret::Elements::PrestressTechnology>("PRESTRESS_TECH",
-            {
-                {Discret::Elements::prestress_technology_string(
-                     Discret::Elements::PrestressTechnology::mulf),
-                    Discret::Elements::PrestressTechnology::mulf},
-                {Discret::Elements::prestress_technology_string(
-                     Discret::Elements::PrestressTechnology::none),
-                    Discret::Elements::PrestressTechnology::none},
-            },
-            {.description = "The technology used for prestressing",
-                .default_value = Discret::Elements::PrestressTechnology::none}),
+        parameter<Discret::Elements::PrestressTechnology>(
+            "PRESTRESS_TECH", {.description = "The technology used for prestressing",
+                                  .default_value = Discret::Elements::PrestressTechnology::none}),
         parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
         parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
         parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),

--- a/src/solid_3D_ele/4C_solid_3D_ele_factory.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_factory.cpp
@@ -18,7 +18,10 @@
 #include "4C_solid_3D_ele_calc_mulf_fbar.hpp"
 #include "4C_solid_3D_ele_calc_shell_ans.hpp"
 #include "4C_solid_3D_ele_properties.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
+
+#include <magic_enum/magic_enum_switch.hpp>
 
 #include <type_traits>
 
@@ -203,13 +206,13 @@ Discret::Elements::SolidCalcVariant Discret::Elements::create_solid_calculation_
   return Core::FE::cell_type_switch<Internal::ImplementedSolidCellTypes>(celltype,
       [&](auto celltype_t)
       {
-        return switch_kinematic_type(element_properties.kintype,
+        return magic_enum::enum_switch(
             [&](auto kinemtype_t)
             {
-              return element_technology_switch(element_properties.element_technology,
+              return magic_enum::enum_switch(
                   [&](auto eletech_t)
                   {
-                    return prestress_technology_switch(element_properties.prestress_technology,
+                    return magic_enum::enum_switch(
                         [&](auto prestress_tech_t) -> SolidCalcVariant
                         {
                           constexpr Core::FE::CellType celltype_c = celltype_t();
@@ -230,11 +233,13 @@ Discret::Elements::SolidCalcVariant Discret::Elements::create_solid_calculation_
                               Inpar::Solid::kinem_type_string(element_properties.kintype).c_str(),
                               element_technology_string(element_properties.element_technology)
                                   .c_str(),
-                              prestress_technology_string(element_properties.prestress_technology)
-                                  .c_str());
-                        });
-                  });
-            });
+                              element_properties.prestress_technology);
+                        },
+                        element_properties.prestress_technology);
+                  },
+                  element_properties.element_technology);
+            },
+            element_properties.kintype);
       });
 }
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_factory_lib.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_factory_lib.hpp
@@ -109,33 +109,6 @@ namespace Discret::Elements
   template <typename T>
   constexpr bool is_valid_type = Internal::IsValidTypeTrait<T>::value;
 
-  /*!
-   * @brief An automatic switch from runtime kinematic type to constexpr kinematic type.
-   *
-   * @tparam Function
-   * @param kinem_type
-   * @param fct : A callable function that has operators for each kinematic-type integral
-   * constants
-   * @return auto
-   */
-  template <typename Function>
-  auto switch_kinematic_type(Inpar::Solid::KinemType kinem_type, Function fct)
-  {
-    switch (kinem_type)
-    {
-      case Inpar::Solid::KinemType::linear:
-        return fct(
-            std::integral_constant<Inpar::Solid::KinemType, Inpar::Solid::KinemType::linear>{});
-      case Inpar::Solid::KinemType::nonlinearTotLag:
-        return fct(std::integral_constant<Inpar::Solid::KinemType,
-            Inpar::Solid::KinemType::nonlinearTotLag>{});
-      case Inpar::Solid::KinemType::vague:
-        return fct(
-            std::integral_constant<Inpar::Solid::KinemType, Inpar::Solid::KinemType::vague>{});
-    }
-
-    FOUR_C_THROW("Your kinematic type is unknown: {}", kinem_type);
-  }
 }  // namespace Discret::Elements
 
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_properties.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_properties.cpp
@@ -9,10 +9,34 @@
 
 #include "4C_solid_3D_ele_properties.hpp"
 
-#include "4C_comm_parobject.hpp"
 #include "4C_solid_scatra_3D_ele_factory.hpp"
+#include "4C_utils_enum.hpp"
 
 FOUR_C_NAMESPACE_OPEN
+
+std::string Discret::Elements::element_technology_string(const ElementTechnology ele_tech)
+{
+  switch (ele_tech)
+  {
+    case ElementTechnology::none:
+      return "none";
+    case ElementTechnology::fbar:
+      return "fbar";
+    case ElementTechnology::eas_mild:
+      return "eas_mild";
+    case ElementTechnology::eas_full:
+      return "eas_full";
+    case ElementTechnology::shell_ans:
+      return "shell_ans";
+    case ElementTechnology::shell_eas:
+      return "shell_eas";
+    case ElementTechnology::shell_eas_ans:
+      return "shell_eas_ans";
+  }
+
+  FOUR_C_THROW("Unknown element technology {}", ele_tech);
+}
+
 
 void Discret::Elements::add_to_pack(Core::Communication::PackBuffer& data,
     const Discret::Elements::SolidElementProperties& properties)

--- a/src/solid_3D_ele/4C_solid_3D_ele_properties.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_properties.hpp
@@ -14,6 +14,7 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <string>
+
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::Communication
@@ -35,86 +36,13 @@ namespace Discret::Elements
     shell_eas_ans
   };
 
-  static inline std::string element_technology_string(const ElementTechnology ele_tech)
-  {
-    switch (ele_tech)
-    {
-      case ElementTechnology::none:
-        return "none";
-      case ElementTechnology::fbar:
-        return "fbar";
-      case ElementTechnology::eas_mild:
-        return "eas_mild";
-      case ElementTechnology::eas_full:
-        return "eas_full";
-      case ElementTechnology::shell_ans:
-        return "shell_ans";
-      case ElementTechnology::shell_eas:
-        return "shell_eas";
-      case ElementTechnology::shell_eas_ans:
-        return "shell_eas_ans";
-    }
-
-    FOUR_C_THROW("Unknown element technology {}", ele_tech);
-  }
-
-  template <typename Function>
-  auto element_technology_switch(ElementTechnology eletech, Function fct)
-  {
-    switch (eletech)
-    {
-      case ElementTechnology::none:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::none>{});
-      case ElementTechnology::fbar:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::fbar>{});
-      case ElementTechnology::eas_mild:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::eas_mild>{});
-      case ElementTechnology::eas_full:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::eas_full>{});
-      case ElementTechnology::shell_ans:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::shell_ans>{});
-      case ElementTechnology::shell_eas:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::shell_eas>{});
-      case ElementTechnology::shell_eas_ans:
-        return fct(std::integral_constant<ElementTechnology, ElementTechnology::shell_eas_ans>{});
-    }
-
-    FOUR_C_THROW("Your element technology is unknown: {}", eletech);
-  }
+  std::string element_technology_string(const ElementTechnology ele_tech);
 
   enum class PrestressTechnology
   {
     none,
     mulf
   };
-
-  static inline std::string prestress_technology_string(const PrestressTechnology prestress_tech)
-  {
-    switch (prestress_tech)
-    {
-      case PrestressTechnology::none:
-        return "none";
-      case PrestressTechnology::mulf:
-        return "mulf";
-    }
-
-    FOUR_C_THROW("Unknown prestress technology {}", prestress_tech);
-  }
-
-  template <typename Function>
-  auto prestress_technology_switch(PrestressTechnology prestress_technology, Function fct)
-  {
-    switch (prestress_technology)
-    {
-      case PrestressTechnology::none:
-        return fct(std::integral_constant<PrestressTechnology, PrestressTechnology::none>{});
-      case PrestressTechnology::mulf:
-        return fct(std::integral_constant<PrestressTechnology, PrestressTechnology::mulf>{});
-    }
-
-    FOUR_C_THROW("Your prestress technology is unknown: {}", prestress_technology);
-  }
-
 
   /*!
    *  @brief struct for managing solid element properties

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -43,17 +43,9 @@ namespace
             {.description = "Whether to use linear kinematics (small displacements) or nonlinear "
                             "kinematics (large displacements)"}),
         parameter<std::string>("TYPE"),
-        deprecated_selection<Discret::Elements::PrestressTechnology>("PRESTRESS_TECH",
-            {
-                {Discret::Elements::prestress_technology_string(
-                     Discret::Elements::PrestressTechnology::mulf),
-                    Discret::Elements::PrestressTechnology::mulf},
-                {Discret::Elements::prestress_technology_string(
-                     Discret::Elements::PrestressTechnology::none),
-                    Discret::Elements::PrestressTechnology::none},
-            },
-            {.description = "The technology used for prestressing",
-                .default_value = Discret::Elements::PrestressTechnology::none}),
+        parameter<Discret::Elements::PrestressTechnology>(
+            "PRESTRESS_TECH", {.description = "The technology used for prestressing",
+                                  .default_value = Discret::Elements::PrestressTechnology::none}),
         parameter<std::optional<std::vector<double>>>("RAD", {.size = 3}),
         parameter<std::optional<std::vector<double>>>("AXI", {.size = 3}),
         parameter<std::optional<std::vector<double>>>("CIR", {.size = 3}),

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_factory.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_factory.cpp
@@ -11,6 +11,9 @@
 #include "4C_inpar_scatra.hpp"
 #include "4C_solid_3D_ele_factory_lib.hpp"
 #include "4C_solid_3D_ele_properties.hpp"
+#include "4C_utils_enum.hpp"
+
+#include <magic_enum/magic_enum_switch.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -119,13 +122,13 @@ Discret::Elements::create_solid_scatra_calculation_interface(Core::FE::CellType 
   return Core::FE::cell_type_switch<Internal::ImplementedSolidScatraCellTypes>(celltype,
       [&](auto celltype_t)
       {
-        return switch_kinematic_type(element_properties.kintype,
+        return magic_enum::enum_switch(
             [&](auto kinemtype_t)
             {
-              return element_technology_switch(element_properties.element_technology,
+              return magic_enum::enum_switch(
                   [&](auto eletech_t)
                   {
-                    return prestress_technology_switch(element_properties.prestress_technology,
+                    return magic_enum::enum_switch(
                         [&](auto prestress_tech_t) -> SolidScatraCalcVariant
                         {
                           constexpr Core::FE::CellType celltype_c = celltype_t();
@@ -143,15 +146,16 @@ Discret::Elements::create_solid_scatra_calculation_interface(Core::FE::CellType 
                               "Your element formulation with cell type {}, kinematic type {},"
                               " element technology {} and prestress type {} does not exist in the "
                               "solid-scatra context.",
-                              Core::FE::celltype_string<celltype_t()>,
-                              Inpar::Solid::kinem_type_string(element_properties.kintype).c_str(),
+                              Core::FE::celltype_string<celltype_t()>, element_properties.kintype,
                               element_technology_string(element_properties.element_technology)
                                   .c_str(),
-                              prestress_technology_string(element_properties.prestress_technology)
-                                  .c_str());
-                        });
-                  });
-            });
+                              element_properties.prestress_technology);
+                        },
+                        element_properties.prestress_technology);
+                  },
+                  element_properties.element_technology);
+            },
+            element_properties.kintype);
       });
 }
 

--- a/src/stru_multi/4C_stru_multi_microstatic_npsupport.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic_npsupport.cpp
@@ -14,6 +14,7 @@
 #include "4C_inpar_material.hpp"
 #include "4C_mat_micromaterial.hpp"
 #include "4C_stru_multi_microstatic.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <hdf5.h>
 

--- a/src/structure/4C_structure_timada.cpp
+++ b/src/structure/4C_structure_timada.cpp
@@ -19,11 +19,38 @@
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_structure_aux.hpp"
 #include "4C_structure_timint.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <iostream>
 
 FOUR_C_NAMESPACE_OPEN
 
+
+namespace
+{
+  std::string map_kind_enum_to_string(Inpar::Solid::TimAdaKind term)
+  {
+    switch (term)
+    {
+      case Inpar::Solid::timada_kind_zienxie:
+        return "ZienkiewiczXie";
+        break;
+      case Inpar::Solid::timada_kind_ab2:
+        return "AdamsBashforth2";
+        break;
+      case Inpar::Solid::timada_kind_expleuler:
+        return "ExplicitEuler";
+        break;
+      case Inpar::Solid::timada_kind_centraldiff:
+        return "CentralDifference";
+        break;
+      default:
+        FOUR_C_THROW("Cannot cope with name enum {}", term);
+        return "";
+        break;
+    }
+  }
+}  // namespace
 
 /*----------------------------------------------------------------------*/
 /* Constructor */
@@ -454,6 +481,8 @@ void Solid::TimAda::output_step_size()
                     << std::endl;
   }
 }
+
+std::string Solid::TimAda::method_title() const { return map_kind_enum_to_string(method_name()); }
 
 /*----------------------------------------------------------------------*/
 /* Print constants */

--- a/src/structure/4C_structure_timada.hpp
+++ b/src/structure/4C_structure_timada.hpp
@@ -59,33 +59,6 @@ namespace Solid
   class TimAda
   {
    public:
-    //! Provide the name as std::string
-    static std::string map_kind_enum_to_string(
-        const enum Inpar::Solid::TimAdaKind term  //!< the enum
-    )
-    {
-      switch (term)
-      {
-        case Inpar::Solid::timada_kind_zienxie:
-          return "ZienkiewiczXie";
-          break;
-        case Inpar::Solid::timada_kind_ab2:
-          return "AdamsBashforth2";
-          break;
-        case Inpar::Solid::timada_kind_expleuler:
-          return "ExplicitEuler";
-          break;
-        case Inpar::Solid::timada_kind_centraldiff:
-          return "CentralDifference";
-          break;
-        default:
-          FOUR_C_THROW("Cannot cope with name enum {}", term);
-          return "";
-          break;
-      }
-      return "";  // make compiler happy
-    }
-
     //! List type of local error control
     enum CtrlEnum
     {
@@ -273,7 +246,7 @@ namespace Solid
     virtual enum Inpar::Solid::TimAdaKind method_name() const = 0;
 
     //! Provide the name as std::string
-    std::string method_title() const { return map_kind_enum_to_string(method_name()); }
+    std::string method_title() const;
 
     //! Provide local order of accuracy based upon linear test equation
     //! for displacements

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -44,11 +44,13 @@
 #include "4C_stru_multi_microstatic.hpp"
 #include "4C_structure_resulttest.hpp"
 #include "4C_structure_timint_genalpha.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_TimeMonitor.hpp>
 
 #include <algorithm>
 #include <iostream>
+
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/

--- a/src/structure/4C_structure_timint_impl_nox.cpp
+++ b/src/structure/4C_structure_timint_impl_nox.cpp
@@ -11,6 +11,7 @@
 #include "4C_structure_timint_impl.hpp"
 #include "4C_structure_timint_noxgroup.hpp"
 #include "4C_structure_timint_noxlinsys.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
 

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -23,6 +23,7 @@
 #include "4C_structure_new_nox_nln_str_linearsystem.hpp"
 #include "4C_structure_new_timint_base.hpp"
 #include "4C_structure_new_timint_noxinterface.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_epetra_exceptions.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -26,9 +26,8 @@
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_model_evaluator_factory.hpp"
 #include "4C_structure_new_resulttest.hpp"
-#include "4C_structure_new_timint_basedataio_monitor_dbc.hpp"
-#include "4C_structure_new_timint_basedataio_runtime_vtk_output.hpp"
 #include "4C_structure_new_timint_basedataio_runtime_vtp_output.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -26,6 +26,7 @@
 #include "4C_structure_new_model_evaluator_meshtying.hpp"
 #include "4C_structure_new_timint_basedatasdyn.hpp"
 #include "4C_structure_new_utils.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <NOX_Epetra_Vector.H>
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
@@ -482,8 +483,7 @@ Solid::TimeInt::BaseDataGlobalState::get_element_technology_map_extractor(
     const enum Inpar::Solid::EleTech etech) const
 {
   if (mapextractors_.find(etech) == mapextractors_.end())
-    FOUR_C_THROW("Could not find element technology \"{}\" in map extractors.",
-        Inpar::Solid::ele_tech_string(etech).c_str());
+    FOUR_C_THROW("Could not find element technology \"{}\" in map extractors.", etech);
 
   return mapextractors_.at(etech);
 }
@@ -564,6 +564,18 @@ void Solid::TimeInt::BaseDataGlobalState::setup_rot_vec_map_extractor(
   maps[1] = rotvecdofmap;
 
   multimapext.setup(*dof_row_map_view(), maps);
+}
+
+Core::LinAlg::Map Solid::TimeInt::BaseDataGlobalState::block_map(
+    const Inpar::Solid::ModelType& mt) const
+{
+  if (model_maps_.find(mt) == model_maps_.end())
+    FOUR_C_THROW(
+        "There is no block map for the given "
+        "modeltype \"{}\".",
+        mt);
+
+  return *(model_maps_.at(mt));
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
@@ -587,16 +587,7 @@ namespace Solid
       };
 
       /// Returns Core::LinAlg::Map of the given model
-      Core::LinAlg::Map block_map(const Inpar::Solid::ModelType& mt) const
-      {
-        if (model_maps_.find(mt) == model_maps_.end())
-          FOUR_C_THROW(
-              "There is no block map for the given "
-              "modeltype \"{}\".",
-              Inpar::Solid::model_type_string(mt).c_str());
-
-        return *(model_maps_.at(mt));
-      };
+      Core::LinAlg::Map block_map(const Inpar::Solid::ModelType& mt) const;
 
       /** \brief Returns the Block id of the given model type.
        *

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -19,6 +19,7 @@
 #include "4C_linear_solver_method.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_linear_solver_method_parameters.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 
@@ -80,8 +81,7 @@ std::shared_ptr<Solid::SOLVER::Factory::LinSolMap> Solid::SOLVER::Factory::build
         (*linsolvers)[*mt_iter] = build_cardiovascular0_d_lin_solver(sdyn, actdis);
         break;
       default:
-        FOUR_C_THROW("No idea which solver to use for the given model type {}",
-            model_type_string(*mt_iter).c_str());
+        FOUR_C_THROW("No idea which solver to use for the given model type {}", *mt_iter);
     }
   }
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
@@ -15,6 +15,7 @@
 #include "4C_structure_new_model_evaluator_factory.hpp"
 #include "4C_structure_new_model_evaluator_structure.hpp"
 #include "4C_structure_new_timint_base.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -660,8 +661,7 @@ Solid::ModelEvaluator::Generic& Solid::ModelEvaluatorManager::evaluator(
   // sanity check, if there is a model evaluator for the given model type
   Solid::ModelEvaluatorManager::Map::const_iterator me_iter = me_map_ptr_->find(mt);
   if (me_iter == me_map_ptr_->end())
-    FOUR_C_THROW("There is no model evaluator for the model type {}",
-        Inpar::Solid::model_type_string(mt).c_str());
+    FOUR_C_THROW("There is no model evaluator for the model type {}", mt);
 
   return *(me_iter->second);
 }
@@ -675,8 +675,7 @@ const Solid::ModelEvaluator::Generic& Solid::ModelEvaluatorManager::evaluator(
   // sanity check, if there is a model evaluator for the given model type
   Solid::ModelEvaluatorManager::Map::const_iterator me_iter = me_map_ptr_->find(mt);
   if (me_iter == me_map_ptr_->end())
-    FOUR_C_THROW("There is no model evaluator for the model type {}",
-        Inpar::Solid::model_type_string(mt).c_str());
+    FOUR_C_THROW("There is no model evaluator for the model type {}", mt);
 
   return *(me_iter->second);
 }

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -21,6 +21,7 @@
 #include "4C_structure_new_timint_basedataglobalstate.hpp"
 #include "4C_structure_new_timint_basedataio.hpp"
 #include "4C_structure_new_timint_basedataio_monitor_dbc.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 

--- a/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
@@ -14,6 +14,7 @@
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_structure_new_model_evaluator_data.hpp"
 #include "4C_structure_new_timint_base.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <optional>

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -28,6 +28,7 @@
 #include "4C_structure_new_model_evaluator_meshtying.hpp"
 #include "4C_structure_new_nln_linearsystem_scaling.hpp"
 #include "4C_structure_new_timint_basedatasdyn.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -148,7 +149,7 @@ enum NOX::Nln::SolutionType Solid::Nln::convert_model_type2_sol_type(
         FOUR_C_THROW(
             "The corresponding solution-type was not found. "
             "Given string: {}",
-            Inpar::Solid::model_type_string(modeltype).c_str());
+            modeltype);
       break;
   }
 

--- a/src/thermo/src/element/4C_thermo_ele_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.cpp
@@ -25,6 +25,7 @@
 #include "4C_thermo_ele_action.hpp"
 #include "4C_thermo_element.hpp"  // only for visualization of element data
 #include "4C_thermo_input.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_function.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>

--- a/src/tsi/4C_tsi_dyn.cpp
+++ b/src/tsi/4C_tsi_dyn.cpp
@@ -17,6 +17,7 @@
 #include "4C_tsi_monolithic.hpp"
 #include "4C_tsi_partitioned.hpp"
 #include "4C_tsi_utils.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/w1/4C_w1_eas.cpp
+++ b/src/w1/4C_w1_eas.cpp
@@ -11,6 +11,7 @@
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mat_stvenantkirchhoff.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_w1.hpp"
 

--- a/src/w1/4C_w1_mat.cpp
+++ b/src/w1/4C_w1_mat.cpp
@@ -15,6 +15,7 @@
 #include "4C_mat_structporo.hpp"
 #include "4C_mat_stvenantkirchhoff.hpp"
 #include "4C_poroelast_utils.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_w1.hpp"
 


### PR DESCRIPTION
Following #482, the compile time increased significantly (as we already realized in the PR). The present PR (re)moves many string-enum converter functions that are instantiated ~500 times since they are defined in a central `structure` header. While this should help to decrease the compile time, the change would even make sense in isolation. Many converters were unused; some can be directly replaced with `magic_enum` features.