### PR TITLE
Make LinAlg::DataAccess a scoped enum

### DIFF
--- a/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
@@ -268,12 +268,12 @@ void Adapter::CouplingEhlMortar::condense_contact(
 
   // get the separate blocks of the 2x2 TSI block system
   // View mode!!! Since we actually want to add things there
-  std::shared_ptr<Core::LinAlg::SparseMatrix> kss =
-      std::make_shared<Core::LinAlg::SparseMatrix>(sysmat->matrix(0, 0), Core::LinAlg::Copy);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> kst =
-      std::make_shared<Core::LinAlg::SparseMatrix>(sysmat->matrix(0, 1), Core::LinAlg::Copy);
-  Core::LinAlg::SparseMatrix kts(sysmat->matrix(1, 0), Core::LinAlg::Copy);
-  Core::LinAlg::SparseMatrix ktt(sysmat->matrix(1, 1), Core::LinAlg::Copy);
+  std::shared_ptr<Core::LinAlg::SparseMatrix> kss = std::make_shared<Core::LinAlg::SparseMatrix>(
+      sysmat->matrix(0, 0), Core::LinAlg::DataAccess::Copy);
+  std::shared_ptr<Core::LinAlg::SparseMatrix> kst = std::make_shared<Core::LinAlg::SparseMatrix>(
+      sysmat->matrix(0, 1), Core::LinAlg::DataAccess::Copy);
+  Core::LinAlg::SparseMatrix kts(sysmat->matrix(1, 0), Core::LinAlg::DataAccess::Copy);
+  Core::LinAlg::SparseMatrix ktt(sysmat->matrix(1, 1), Core::LinAlg::DataAccess::Copy);
 
   // get some maps
   std::shared_ptr<Epetra_Map> gdisp_DofRowMap = std::make_shared<Epetra_Map>(kss->row_map());
@@ -322,10 +322,10 @@ void Adapter::CouplingEhlMortar::condense_contact(
   if (interface_->active_nodes()->NumGlobalElements() == 0)
   {
     sysmat->reset();
-    sysmat->assign(0, 0, Core::LinAlg::Copy, *kss);
-    sysmat->assign(0, 1, Core::LinAlg::Copy, *kst);
-    sysmat->assign(1, 0, Core::LinAlg::Copy, kts);
-    sysmat->assign(1, 1, Core::LinAlg::Copy, ktt);
+    sysmat->assign(0, 0, Core::LinAlg::DataAccess::Copy, *kss);
+    sysmat->assign(0, 1, Core::LinAlg::DataAccess::Copy, *kst);
+    sysmat->assign(1, 0, Core::LinAlg::DataAccess::Copy, kts);
+    sysmat->assign(1, 1, Core::LinAlg::DataAccess::Copy, ktt);
     return;
   }
 
@@ -506,7 +506,7 @@ void Adapter::CouplingEhlMortar::condense_contact(
   // to be able to apply dirichlet values for contact symmetry condition
   Core::LinAlg::SparseMatrix tmpkss(
       *gdisp_DofRowMap, 100, false, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  sysmat->assign(0, 0, Core::LinAlg::Copy, tmpkss);
+  sysmat->assign(0, 0, Core::LinAlg::DataAccess::Copy, tmpkss);
 
   // get references to the blocks (just for convenience)
   Core::LinAlg::SparseMatrix& kss_new = sysmat->matrix(0, 0);

--- a/src/ale/4C_ale_meshtying.cpp
+++ b/src/ale/4C_ale_meshtying.cpp
@@ -711,10 +711,10 @@ int ALE::Meshtying::solve_meshtying(Core::LinAlg::Solver& solver,
     split_vector_based_on3x3(*residual, *res);
 
     // assign blocks to the solution matrix
-    sysmatsolve->assign(0, 0, Core::LinAlg::View, sysmatnew->matrix(0, 0));
-    sysmatsolve->assign(0, 1, Core::LinAlg::View, sysmatnew->matrix(0, 1));
-    sysmatsolve->assign(1, 0, Core::LinAlg::View, sysmatnew->matrix(1, 0));
-    sysmatsolve->assign(1, 1, Core::LinAlg::View, sysmatnew->matrix(1, 1));
+    sysmatsolve->assign(0, 0, Core::LinAlg::DataAccess::View, sysmatnew->matrix(0, 0));
+    sysmatsolve->assign(0, 1, Core::LinAlg::DataAccess::View, sysmatnew->matrix(0, 1));
+    sysmatsolve->assign(1, 0, Core::LinAlg::DataAccess::View, sysmatnew->matrix(1, 0));
+    sysmatsolve->assign(1, 1, Core::LinAlg::DataAccess::View, sysmatnew->matrix(1, 1));
     sysmatsolve->complete();
 
     mergedmatrix = sysmatsolve->merge();

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
@@ -1015,11 +1015,11 @@ int Utils::Cardiovascular0DManager::solve(Core::LinAlg::SparseMatrix& mat_struct
     mergedsol = std::make_shared<Core::LinAlg::Vector<double>>(*mergedmap_R);
 
     // use BlockMatrix
-    blockmat->assign(0, 0, Core::LinAlg::View, *mat_structstiff_R);
-    blockmat->assign(1, 0, Core::LinAlg::View, *mat_dcardvasc0d_dd_R);
-    blockmat->assign(
-        0, 1, Core::LinAlg::View, *Core::LinAlg::matrix_transpose(*mat_dstruct_dcv0ddof_R));
-    blockmat->assign(1, 1, Core::LinAlg::View, *mat_cardvasc0dstiff);
+    blockmat->assign(0, 0, Core::LinAlg::DataAccess::View, *mat_structstiff_R);
+    blockmat->assign(1, 0, Core::LinAlg::DataAccess::View, *mat_dcardvasc0d_dd_R);
+    blockmat->assign(0, 1, Core::LinAlg::DataAccess::View,
+        *Core::LinAlg::matrix_transpose(*mat_dstruct_dcv0ddof_R));
+    blockmat->assign(1, 1, Core::LinAlg::DataAccess::View, *mat_cardvasc0dstiff);
     blockmat->complete();
 
     // export 0D part of rhs
@@ -1040,11 +1040,11 @@ int Utils::Cardiovascular0DManager::solve(Core::LinAlg::SparseMatrix& mat_struct
     mergedsol = std::make_shared<Core::LinAlg::Vector<double>>(*mergedmap);
 
     // use BlockMatrix
-    blockmat->assign(0, 0, Core::LinAlg::View, mat_structstiff);
+    blockmat->assign(0, 0, Core::LinAlg::DataAccess::View, mat_structstiff);
     blockmat->assign(
-        1, 0, Core::LinAlg::View, *Core::LinAlg::matrix_transpose(*mat_dcardvasc0d_dd));
-    blockmat->assign(0, 1, Core::LinAlg::View, *mat_dstruct_dcv0ddof);
-    blockmat->assign(1, 1, Core::LinAlg::View, *mat_cardvasc0dstiff);
+        1, 0, Core::LinAlg::DataAccess::View, *Core::LinAlg::matrix_transpose(*mat_dcardvasc0d_dd));
+    blockmat->assign(0, 1, Core::LinAlg::DataAccess::View, *mat_dstruct_dcv0ddof);
+    blockmat->assign(1, 1, Core::LinAlg::DataAccess::View, *mat_cardvasc0dstiff);
     blockmat->complete();
 
     // export 0D part of rhs

--- a/src/constraint/4C_constraint_solver.cpp
+++ b/src/constraint/4C_constraint_solver.cpp
@@ -357,9 +357,9 @@ void CONSTRAINTS::ConstraintSolver::solve_simple(Core::LinAlg::SparseMatrix& sti
   std::shared_ptr<Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>> mat =
       std::make_shared<Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>>(
           dommapext, rowmapext, 81, false, false);
-  mat->assign(0, 0, Core::LinAlg::View, stiff);
-  mat->assign(0, 1, Core::LinAlg::View, constr);
-  mat->assign(1, 0, Core::LinAlg::View, constrTrans);
+  mat->assign(0, 0, Core::LinAlg::DataAccess::View, stiff);
+  mat->assign(0, 1, Core::LinAlg::DataAccess::View, constr);
+  mat->assign(1, 0, Core::LinAlg::DataAccess::View, constrTrans);
   mat->complete();
 
   // merged rhs using Export

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -3175,10 +3175,10 @@ void CONTACT::LagrangeStrategy::build_saddle_point_system(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>> mat =
         std::dynamic_pointer_cast<
             Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>>(blockMat);
-    mat->assign(0, 0, Core::LinAlg::View, *stiffmt);
-    mat->assign(0, 1, Core::LinAlg::View, *trkdz);
-    mat->assign(1, 0, Core::LinAlg::View, *trkzd);
-    mat->assign(1, 1, Core::LinAlg::View, *trkzz);
+    mat->assign(0, 0, Core::LinAlg::DataAccess::View, *stiffmt);
+    mat->assign(0, 1, Core::LinAlg::DataAccess::View, *trkdz);
+    mat->assign(1, 0, Core::LinAlg::DataAccess::View, *trkzd);
+    mat->assign(1, 1, Core::LinAlg::DataAccess::View, *trkzz);
     mat->complete();
 
     // we also need merged rhs here

--- a/src/contact/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_tsi.cpp
@@ -279,14 +279,14 @@ void CONTACT::LagrangeStrategyTsi::evaluate(
 
   // get the separate blocks of the 2x2 TSI block system
   // View mode!!! Since we actually want to add things there
-  std::shared_ptr<Core::LinAlg::SparseMatrix> kss =
-      std::make_shared<Core::LinAlg::SparseMatrix>(sysmat->matrix(0, 0), Core::LinAlg::Copy);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> kst =
-      std::make_shared<Core::LinAlg::SparseMatrix>(sysmat->matrix(0, 1), Core::LinAlg::Copy);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> kts =
-      std::make_shared<Core::LinAlg::SparseMatrix>(sysmat->matrix(1, 0), Core::LinAlg::Copy);
-  std::shared_ptr<Core::LinAlg::SparseMatrix> ktt =
-      std::make_shared<Core::LinAlg::SparseMatrix>(sysmat->matrix(1, 1), Core::LinAlg::Copy);
+  std::shared_ptr<Core::LinAlg::SparseMatrix> kss = std::make_shared<Core::LinAlg::SparseMatrix>(
+      sysmat->matrix(0, 0), Core::LinAlg::DataAccess::Copy);
+  std::shared_ptr<Core::LinAlg::SparseMatrix> kst = std::make_shared<Core::LinAlg::SparseMatrix>(
+      sysmat->matrix(0, 1), Core::LinAlg::DataAccess::Copy);
+  std::shared_ptr<Core::LinAlg::SparseMatrix> kts = std::make_shared<Core::LinAlg::SparseMatrix>(
+      sysmat->matrix(1, 0), Core::LinAlg::DataAccess::Copy);
+  std::shared_ptr<Core::LinAlg::SparseMatrix> ktt = std::make_shared<Core::LinAlg::SparseMatrix>(
+      sysmat->matrix(1, 1), Core::LinAlg::DataAccess::Copy);
   kss->un_complete();
   kts->un_complete();
 
@@ -552,10 +552,10 @@ void CONTACT::LagrangeStrategyTsi::evaluate(
   if (gactivenodes_->NumGlobalElements() == 0)
   {
     sysmat->reset();
-    sysmat->assign(0, 0, Core::LinAlg::Copy, *kss);
-    sysmat->assign(0, 1, Core::LinAlg::Copy, *kst);
-    sysmat->assign(1, 0, Core::LinAlg::Copy, *kts);
-    sysmat->assign(1, 1, Core::LinAlg::Copy, *ktt);
+    sysmat->assign(0, 0, Core::LinAlg::DataAccess::Copy, *kss);
+    sysmat->assign(0, 1, Core::LinAlg::DataAccess::Copy, *kst);
+    sysmat->assign(1, 0, Core::LinAlg::DataAccess::Copy, *kts);
+    sysmat->assign(1, 1, Core::LinAlg::DataAccess::Copy, *ktt);
     return;
   }
 
@@ -669,7 +669,7 @@ void CONTACT::LagrangeStrategyTsi::evaluate(
   // to be able to apply dirichlet values for contact symmetry condition
   Core::LinAlg::SparseMatrix tmpkss(
       *gdisprowmap_, 100, false, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  sysmat->assign(0, 0, Core::LinAlg::Copy, tmpkss);
+  sysmat->assign(0, 0, Core::LinAlg::DataAccess::Copy, tmpkss);
 
   // get references to the blocks (just for convenience)
   Core::LinAlg::SparseMatrix& kss_new = sysmat->matrix(0, 0);

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -3851,10 +3851,10 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
         trkdz->un_complete();
         trkdz->complete(*gmap, *problem_dofs());
 
-        mat->assign(0, 0, Core::LinAlg::View, *stiffmt);
-        mat->assign(0, 1, Core::LinAlg::View, *trkdz);
-        mat->assign(1, 0, Core::LinAlg::View, *trkgd);
-        mat->assign(1, 1, Core::LinAlg::View, *trkgg);
+        mat->assign(0, 0, Core::LinAlg::DataAccess::View, *stiffmt);
+        mat->assign(0, 1, Core::LinAlg::DataAccess::View, *trkdz);
+        mat->assign(1, 0, Core::LinAlg::DataAccess::View, *trkgd);
+        mat->assign(1, 1, Core::LinAlg::DataAccess::View, *trkgg);
         mat->complete();
       }
       // BOTH_SIDED DISCRETE WEAR
@@ -3899,10 +3899,10 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
         trkdz->un_complete();
         trkdz->complete(*gmap, *problem_dofs());
 
-        mat->assign(0, 0, Core::LinAlg::View, *stiffmt);
-        mat->assign(0, 1, Core::LinAlg::View, *trkdz);
-        mat->assign(1, 0, Core::LinAlg::View, *trkgd);
-        mat->assign(1, 1, Core::LinAlg::View, *trkgg);
+        mat->assign(0, 0, Core::LinAlg::DataAccess::View, *stiffmt);
+        mat->assign(0, 1, Core::LinAlg::DataAccess::View, *trkdz);
+        mat->assign(1, 0, Core::LinAlg::DataAccess::View, *trkgd);
+        mat->assign(1, 1, Core::LinAlg::DataAccess::View, *trkgg);
         mat->complete();
       }
     }
@@ -3920,10 +3920,10 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
       std::shared_ptr<Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>>
           mat = std::dynamic_pointer_cast<
               Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>>(blockMat);
-      mat->assign(0, 0, Core::LinAlg::View, *stiffmt);
-      mat->assign(0, 1, Core::LinAlg::View, *trkdz);
-      mat->assign(1, 0, Core::LinAlg::View, *trkzd);
-      mat->assign(1, 1, Core::LinAlg::View, *trkzz);
+      mat->assign(0, 0, Core::LinAlg::DataAccess::View, *stiffmt);
+      mat->assign(0, 1, Core::LinAlg::DataAccess::View, *trkdz);
+      mat->assign(1, 0, Core::LinAlg::DataAccess::View, *trkzd);
+      mat->assign(1, 1, Core::LinAlg::DataAccess::View, *trkzz);
       mat->complete();
     }
 

--- a/src/contact/4C_contact_meshtying_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_lagrange_strategy.cpp
@@ -811,9 +811,9 @@ void CONTACT::MtLagrangeStrategy::build_saddle_point_system(
         std::dynamic_pointer_cast<
             Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>>(blockMat);
 
-    mat->assign(0, 0, Core::LinAlg::View, *stiffmt);
-    mat->assign(0, 1, Core::LinAlg::View, *constrmt);
-    mat->assign(1, 0, Core::LinAlg::View, trconstrmt);
+    mat->assign(0, 0, Core::LinAlg::DataAccess::View, *stiffmt);
+    mat->assign(0, 1, Core::LinAlg::DataAccess::View, *constrmt);
+    mat->assign(1, 0, Core::LinAlg::DataAccess::View, trconstrmt);
     mat->complete();
 
     // we also need merged rhs here

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -396,7 +396,8 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
     default:
     {
       p_jac_ = Teuchos::rcp(
-          block_mat.clone(Core::LinAlg::View, keep_row_col_index, keep_row_col_index).release());
+          block_mat.clone(Core::LinAlg::DataAccess::View, keep_row_col_index, keep_row_col_index)
+              .release());
       p_jac_->complete();
 
       Teuchos::RCP<Core::LinAlg::BlockSparseMatrixBase> active_block_mat =

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -485,10 +485,10 @@ Core::LinAlg::block_matrix2x2(Core::LinAlg::SparseMatrix& A00, Core::LinAlg::Spa
   // std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> Cb =
   // std::dynamic_pointer_cast<Core::LinAlg::BlockSparseMatrixBase>(C);
   // assign matrices
-  C->assign(0, 0, Core::LinAlg::View, A00);
-  C->assign(0, 1, Core::LinAlg::View, A01);
-  C->assign(1, 0, Core::LinAlg::View, A10);
-  C->assign(1, 1, Core::LinAlg::View, A11);
+  C->assign(0, 0, Core::LinAlg::DataAccess::View, A00);
+  C->assign(0, 1, Core::LinAlg::DataAccess::View, A01);
+  C->assign(1, 0, Core::LinAlg::DataAccess::View, A10);
+  C->assign(1, 1, Core::LinAlg::DataAccess::View, A11);
 
   C->complete();
 

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.hpp
@@ -285,12 +285,12 @@ namespace Core::LinAlg
     /// clone the full block sparse matrix
 
     /** Do not forget to call Complete() after cloning, even if you
-     *  use Core::LinAlg::View! */
+     *  use Core::LinAlg::DataAccess::View! */
     std::unique_ptr<BlockSparseMatrixBase> clone(DataAccess access) override;
 
     /// clone only a part of the block sparse matrix
     /** Do not forget to call Complete() after cloning, even if you
-     *  use Core::LinAlg::View!
+     *  use Core::LinAlg::DataAccess::View!
      *
      *  \param[in] access : consider copy or view of block matrices
      *  \param[in] row_block_ids : ID's of the row blocks to clone

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -85,7 +85,7 @@ Core::LinAlg::SparseMatrix::SparseMatrix(std::shared_ptr<Epetra_CrsMatrix> matri
       savegraph_(savegraph),
       matrixtype_(matrixtype)
 {
-  if (access == Copy)
+  if (access == DataAccess::Copy)
   {
     if (matrixtype_ == CRS_MATRIX)
       sysmat_ = std::make_shared<Epetra_CrsMatrix>(*matrix);
@@ -122,7 +122,7 @@ Core::LinAlg::SparseMatrix::SparseMatrix(const SparseMatrix& mat, DataAccess acc
       savegraph_(mat.savegraph_),
       matrixtype_(mat.matrixtype_)
 {
-  if (access == Copy)
+  if (access == DataAccess::Copy)
   {
     // We do not care for exception proved code, so this is ok.
     *this = mat;
@@ -262,7 +262,7 @@ Core::LinAlg::SparseMatrix& Core::LinAlg::SparseMatrix::operator=(const SparseMa
  *----------------------------------------------------------------------*/
 void Core::LinAlg::SparseMatrix::assign(DataAccess access, const SparseMatrix& mat)
 {
-  if (access == Copy)
+  if (access == DataAccess::Copy)
   {
     // We do not care for exception proved code, so this is ok.
     *this = mat;

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -139,7 +139,7 @@ namespace Core::LinAlg
       \param mat matrix to assign from
       \param access how to treat this assignment: Copy or View
      */
-    SparseMatrix(const SparseMatrix& mat, DataAccess access = Copy);
+    SparseMatrix(const SparseMatrix& mat, DataAccess access = DataAccess::Copy);
 
     /// Assignment operator. Makes a deep copy.
     SparseMatrix& operator=(const SparseMatrix& mat);

--- a/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
@@ -32,8 +32,8 @@ namespace Core::LinAlg
   /*! \enum Core::LinAlg::DataAccess
    *  \brief Handling of data access (Copy or View)
    *
-   *  If set to Core::LinAlg::Copy, user data will be copied at construction.
-   *  If set to Core::LinAlg::View, user data will be encapsulated and used throughout
+   *  If set to Core::LinAlg::DataAccess::Copy, user data will be copied at construction.
+   *  If set to Core::LinAlg::DataAccess::View, user data will be encapsulated and used throughout
    *  the life of the object.
    *
    *  \note A separate Core::LinAlg::DataAccess is necessary in order to resolve
@@ -43,7 +43,7 @@ namespace Core::LinAlg
    *  Use plain 'Copy' or 'View' for construction of any Epetra matrix object.
    *
    */
-  enum DataAccess
+  enum class DataAccess
   {
     Copy,  ///< deep copy
     View   ///< reference to original data

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
@@ -133,7 +133,7 @@ Core::LinAlg::SparseMatrix Core::LinAlg::create_interpolation_matrix(const Spars
   auto prolongation_operator = MueLu::Utilities<SC, LO, GO, NO>::Op2NonConstEpetraCrs(Ptent);
 
   Core::LinAlg::SparseMatrix prolongator(
-      std::make_shared<Epetra_CrsMatrix>(*prolongation_operator), Core::LinAlg::View);
+      std::make_shared<Epetra_CrsMatrix>(*prolongation_operator), Core::LinAlg::DataAccess::View);
 
   return prolongator;
 }

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -295,7 +295,7 @@ std::shared_ptr<Core::LinAlg::Graph> Core::LinAlg::threshold_matrix_graph(
 std::shared_ptr<Core::LinAlg::Graph> Core::LinAlg::enrich_matrix_graph(
     const SparseMatrix& A, int power)
 {
-  SparseMatrix A_copy(A, Core::LinAlg::Copy);
+  SparseMatrix A_copy(A, Core::LinAlg::DataAccess::Copy);
   A_copy.complete();
 
   for (int pow = 0; pow < power - 1; pow++)
@@ -330,7 +330,7 @@ bool Core::LinAlg::split_matrix2x2(std::shared_ptr<Epetra_CrsMatrix> A,
   Core::LinAlg::MultiMapExtractor extractor(A->RowMap(), maps);
 
   // create SparseMatrix view to input matrix A
-  SparseMatrix a(A, View);
+  SparseMatrix a(A, DataAccess::View);
 
   // split matrix into pieces, where main diagonal blocks are square
   Ablock = Core::LinAlg::split_matrix<DefaultBlockMatrixStrategy>(a, extractor, extractor);
@@ -383,10 +383,10 @@ bool Core::LinAlg::split_matrix2x2(std::shared_ptr<Core::LinAlg::SparseMatrix> A
   Ablock->complete();
   // extract internal data from Ablock in std::shared_ptr form and let Ablock die
   // (this way, internal data from Ablock will live)
-  A11 = std::make_shared<SparseMatrix>((*Ablock)(0, 0), View);
-  A12 = std::make_shared<SparseMatrix>((*Ablock)(0, 1), View);
-  A21 = std::make_shared<SparseMatrix>((*Ablock)(1, 0), View);
-  A22 = std::make_shared<SparseMatrix>((*Ablock)(1, 1), View);
+  A11 = std::make_shared<SparseMatrix>((*Ablock)(0, 0), DataAccess::View);
+  A12 = std::make_shared<SparseMatrix>((*Ablock)(0, 1), DataAccess::View);
+  A21 = std::make_shared<SparseMatrix>((*Ablock)(1, 0), DataAccess::View);
+  A22 = std::make_shared<SparseMatrix>((*Ablock)(1, 1), DataAccess::View);
 
   return true;
 }

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -329,7 +329,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::matrix_transpose(const
 
   Epetra_CrsMatrix* a_prime = &(dynamic_cast<Epetra_CrsMatrix&>(transposer(*A.epetra_matrix())));
   matrix = std::make_shared<SparseMatrix>(Core::Utils::shared_ptr_from_ref(*a_prime),
-      Core::LinAlg::Copy, A.explicit_dirichlet(), A.save_graph());
+      Core::LinAlg::DataAccess::Copy, A.explicit_dirichlet(), A.save_graph());
 
   return matrix;
 }

--- a/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_manipulation_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_manipulation_test.np2.cpp
@@ -43,7 +43,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     const double tol = 1.1;
     std::shared_ptr<Core::LinAlg::SparseMatrix> A_thresh =
@@ -70,7 +70,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     const double tol = 1e-5;
     std::shared_ptr<Core::LinAlg::SparseMatrix> A_thresh =
@@ -97,7 +97,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     const double tol = 1e-5;
     std::shared_ptr<Core::LinAlg::Graph> G = Core::LinAlg::threshold_matrix_graph(A_sparse, tol);
@@ -122,7 +122,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     {
       const int power = 0;
@@ -188,7 +188,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     {
       const int power = 3;

--- a/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_math_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_math_test.np2.cpp
@@ -43,7 +43,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     std::shared_ptr<Core::LinAlg::SparseMatrix> A_inverse = Core::LinAlg::matrix_sparse_inverse(
         A_sparse, std::make_shared<Core::LinAlg::Graph>(A->Graph()));
@@ -82,7 +82,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     std::shared_ptr<Core::LinAlg::SparseMatrix> A_inverse = Core::LinAlg::matrix_sparse_inverse(
         A_sparse, std::make_shared<Core::LinAlg::Graph>(A->Graph()));
@@ -133,7 +133,7 @@ namespace
         Core::Communication::as_epetra_comm(comm_), A);
     if (err != 0) FOUR_C_THROW("Matrix read failed.");
     std::shared_ptr<Epetra_CrsMatrix> A_crs = Core::Utils::shared_ptr_from_ref(*A);
-    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::Copy);
+    Core::LinAlg::SparseMatrix A_sparse(A_crs, Core::LinAlg::DataAccess::Copy);
 
     {
       const double tol = 1e-8;

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_hierarchies.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_hierarchies.cpp
@@ -247,8 +247,8 @@ void Core::LinearSolver::AMGNxN::Hierarchies::setup()
           myA = this_level->Get<Teuchos::RCP<Matrix>>("A");
           myAcrs = MueLuUtils::Op2NonConstEpetraCrs(myA);
           myAspa = Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(
-              Core::Utils::shared_ptr_from_ref(*myAcrs), Core::LinAlg::Copy, explicitdirichlet,
-              savegraph);
+              Core::Utils::shared_ptr_from_ref(*myAcrs), Core::LinAlg::DataAccess::Copy,
+              explicitdirichlet, savegraph);
           A_level[level] = myAspa;
         }
         else
@@ -282,8 +282,8 @@ void Core::LinearSolver::AMGNxN::Hierarchies::setup()
             myA = this_level->Get<Teuchos::RCP<Matrix>>("P");
             myAcrs = MueLuUtils::Op2NonConstEpetraCrs(myA);
             myAspa = Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(
-                Core::Utils::shared_ptr_from_ref(*myAcrs), Core::LinAlg::Copy, explicitdirichlet,
-                savegraph);
+                Core::Utils::shared_ptr_from_ref(*myAcrs), Core::LinAlg::DataAccess::Copy,
+                explicitdirichlet, savegraph);
             P_level[level - 1] = myAspa;
           }
           else
@@ -294,8 +294,8 @@ void Core::LinearSolver::AMGNxN::Hierarchies::setup()
             myA = this_level->Get<Teuchos::RCP<Matrix>>("R");
             myAcrs = MueLuUtils::Op2NonConstEpetraCrs(myA);
             myAspa = Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(
-                Core::Utils::shared_ptr_from_ref(*myAcrs), Core::LinAlg::Copy, explicitdirichlet,
-                savegraph);
+                Core::Utils::shared_ptr_from_ref(*myAcrs), Core::LinAlg::DataAccess::Copy,
+                explicitdirichlet, savegraph);
             R_level[level - 1] = myAspa;
           }
           else

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -80,7 +80,7 @@ void Core::LinearSolver::AmGnxnPreconditioner::setup(
 
   // Create own copy of the system matrix in order to allow reusing the preconditioner
   a_ = A;
-  a_ = a_->clone(Core::LinAlg::Copy);
+  a_ = a_->clone(Core::LinAlg::DataAccess::Copy);
   a_->complete();
 
   // Determine number of blocks
@@ -382,8 +382,8 @@ void Core::LinearSolver::AmGnxnOperator::setup()
   {
     for (int j = 0; j < NumBlocks; j++)
     {
-      Teuchos::RCP<Core::LinAlg::SparseMatrix> Aij =
-          Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(a_->matrix(i, j), Core::LinAlg::View);
+      Teuchos::RCP<Core::LinAlg::SparseMatrix> Aij = Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(
+          a_->matrix(i, j), Core::LinAlg::DataAccess::View);
       Able->set_matrix(Aij, i, j);
     }
   }
@@ -523,8 +523,8 @@ void Core::LinearSolver::BlockSmootherOperator::setup()
   {
     for (int j = 0; j < NumBlocks; j++)
     {
-      Teuchos::RCP<Core::LinAlg::SparseMatrix> Aij =
-          Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(a_->matrix(i, j), Core::LinAlg::View);
+      Teuchos::RCP<Core::LinAlg::SparseMatrix> Aij = Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(
+          a_->matrix(i, j), Core::LinAlg::DataAccess::View);
       Able->set_matrix(Aij, i, j);
     }
   }

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_smoothers.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_smoothers.cpp
@@ -183,7 +183,7 @@ void Core::LinearSolver::AMGNxN::MergeAndSolve::setup(BlockedMatrix matrix)
   }
 
   // Set matrix
-  block_sparse_matrix_ = matrix.get_block_sparse_matrix(Core::LinAlg::View);
+  block_sparse_matrix_ = matrix.get_block_sparse_matrix(Core::LinAlg::DataAccess::View);
   sparse_matrix_ = block_sparse_matrix_->merge();
   a_ = std::dynamic_pointer_cast<Epetra_Operator>(sparse_matrix_->epetra_matrix());
   auto crsA = std::dynamic_pointer_cast<Epetra_CrsMatrix>(a_);
@@ -594,7 +594,7 @@ void Core::LinearSolver::AMGNxN::SingleFieldAMG::setup()
       myAcrs = MueLuUtils::Op2NonConstEpetraCrs(myA);
       myAspa =
           Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(Core::Utils::shared_ptr_from_ref(*myAcrs),
-              Core::LinAlg::Copy, explicitdirichlet, savegraph);
+              Core::LinAlg::DataAccess::Copy, explicitdirichlet, savegraph);
       Avec[level] = myAspa;
     }
     else
@@ -610,7 +610,7 @@ void Core::LinearSolver::AMGNxN::SingleFieldAMG::setup()
         myAcrs = MueLuUtils::Op2NonConstEpetraCrs(myA);
         myAspa =
             Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(Core::Utils::shared_ptr_from_ref(*myAcrs),
-                Core::LinAlg::Copy, explicitdirichlet, savegraph);
+                Core::LinAlg::DataAccess::Copy, explicitdirichlet, savegraph);
         Pvec[level - 1] = myAspa;
       }
       else
@@ -624,7 +624,7 @@ void Core::LinearSolver::AMGNxN::SingleFieldAMG::setup()
         myAcrs = MueLuUtils::Op2NonConstEpetraCrs(myA);
         myAspa =
             Teuchos::make_rcp<Core::LinAlg::SparseMatrix>(Core::Utils::shared_ptr_from_ref(*myAcrs),
-                Core::LinAlg::Copy, explicitdirichlet, savegraph);
+                Core::LinAlg::DataAccess::Copy, explicitdirichlet, savegraph);
         Rvec[level - 1] = myAspa;
       }
       else

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_direct.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_direct.cpp
@@ -58,7 +58,7 @@ void Core::LinearSolver::DirectSolver<MatrixType, VectorType>::setup(
   projector_ = projector;
   if (projector_ != nullptr)
   {
-    Core::LinAlg::SparseMatrix A_view(crsA, Core::LinAlg::View);
+    Core::LinAlg::SparseMatrix A_view(crsA, Core::LinAlg::DataAccess::View);
     std::shared_ptr<Core::LinAlg::SparseMatrix> A2 = projector_->project(A_view);
 
     crsA = A2->epetra_matrix();

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.cpp
@@ -67,7 +67,8 @@ void Core::LinearSolver::TekoPreconditioner::setup(bool create, Epetra_Operator*
 
         auto crsA =
             std::dynamic_pointer_cast<Epetra_CrsMatrix>(Core::Utils::shared_ptr_from_ref(*matrix));
-        Core::LinAlg::SparseMatrix sparseA = Core::LinAlg::SparseMatrix(crsA, LinAlg::View);
+        Core::LinAlg::SparseMatrix sparseA =
+            Core::LinAlg::SparseMatrix(crsA, LinAlg::DataAccess::View);
 
         A = Core::LinAlg::split_matrix<Core::LinAlg::DefaultBlockMatrixStrategy>(
             sparseA, *extractor, *extractor);
@@ -223,7 +224,7 @@ void Core::LinearSolver::LU2x2SpaiStrategy::initialize_state(
     auto A_crs = Teuchos::rcp_dynamic_cast<const Epetra_CrsMatrix>(A_op->epetra_op(), true);
     const Core::LinAlg::SparseMatrix A_sparse(
         Core::Utils::shared_ptr_from_ref(*Teuchos::rcp_const_cast<Epetra_CrsMatrix>(A_crs)),
-        Core::LinAlg::Copy);
+        Core::LinAlg::DataAccess::Copy);
 
     // sparse inverse calculation
     std::shared_ptr<Core::LinAlg::SparseMatrix> A_thresh =

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -824,7 +824,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::master_
 
   // create a SparseMatrix that wraps the new CrsMatrix.
   return std::make_shared<Core::LinAlg::SparseMatrix>(
-      permsm, Core::LinAlg::View, sm.explicit_dirichlet(), sm.save_graph());
+      permsm, Core::LinAlg::DataAccess::View, sm.explicit_dirichlet(), sm.save_graph());
 }
 
 
@@ -853,7 +853,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::slave_t
 
   // create a SparseMatrix that wraps the new CrsMatrix.
   return std::make_shared<Core::LinAlg::SparseMatrix>(
-      permsm, Core::LinAlg::View, sm.explicit_dirichlet(), sm.save_graph());
+      permsm, Core::LinAlg::DataAccess::View, sm.explicit_dirichlet(), sm.save_graph());
 }
 
 

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -520,7 +520,7 @@ void EHL::Monolithic::setup_system_matrix()
   k_ss->apply_dirichlet(*structure_field()->get_dbc_map_extractor()->cond_map(), true);
 
   // Assign k_ss to system matrix
-  systemmatrix_->assign(0, 0, Core::LinAlg::View, *k_ss);
+  systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *k_ss);
 
 
   //---------------------------------------------------------------------------------
@@ -566,7 +566,7 @@ void EHL::Monolithic::setup_system_matrix()
   k_sl_->apply_dirichlet(*structure_field()->get_dbc_map_extractor()->cond_map(), false);
 
   // Assign k_sl to system matrix
-  systemmatrix_->assign(0, 1, Core::LinAlg::View, *(k_sl_));
+  systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, *(k_sl_));
 
 
   //-----------------------------------------------------------------------------------
@@ -578,7 +578,7 @@ void EHL::Monolithic::setup_system_matrix()
       lubrication_->lubrication_field()->system_matrix();
 
   // Assign k_ll to system matrix
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, *(k_ll));
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *(k_ll));
 
 
   //----------------------------------------------------------------------------------------
@@ -663,7 +663,7 @@ void EHL::Monolithic::setup_system_matrix()
   if (inf_gap_toggle_lub_ != nullptr) k_ls_->apply_dirichlet(*inf_gap_toggle_lub_, false);
 
   // Assign k_ls to system matrix
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, *k_ls_);
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *k_ls_);
 
   // Finished...
   systemmatrix_->complete();
@@ -1886,7 +1886,7 @@ void EHL::Monolithic::apply_dbc()
 {
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_ss =
       std::make_shared<Core::LinAlg::SparseMatrix>(systemmatrix_->matrix(0, 0).epetra_matrix(),
-          Core::LinAlg::Copy, true, false, Core::LinAlg::SparseMatrix::CRS_MATRIX);
+          Core::LinAlg::DataAccess::Copy, true, false, Core::LinAlg::SparseMatrix::CRS_MATRIX);
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_sl =
       std::make_shared<Core::LinAlg::SparseMatrix>(systemmatrix_->matrix(0, 1));
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_ls =
@@ -1907,10 +1907,10 @@ void EHL::Monolithic::apply_dbc()
   }
 
   systemmatrix_->un_complete();
-  systemmatrix_->assign(0, 0, Core::LinAlg::View, *k_ss);
-  systemmatrix_->assign(0, 1, Core::LinAlg::View, *k_sl);
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, *k_ls);
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, *k_ll);
+  systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *k_ss);
+  systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, *k_sl);
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *k_ls);
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *k_ll);
   systemmatrix_->complete();
 
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1906,8 +1906,8 @@ void FLD::FluidImplicitTimeInt::evaluate_fluid_edge_based(
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_linalg =
       std::make_shared<Core::LinAlg::SparseMatrix>(
-          std::static_pointer_cast<Epetra_CrsMatrix>(sysmat_FE), Core::LinAlg::View, true, false,
-          Core::LinAlg::SparseMatrix::FE_MATRIX);
+          std::static_pointer_cast<Epetra_CrsMatrix>(sysmat_FE), Core::LinAlg::DataAccess::View,
+          true, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
 
   const int numrowintfaces = facediscret_->num_my_row_faces();
 

--- a/src/fluid/4C_fluid_meshtying.cpp
+++ b/src/fluid/4C_fluid_meshtying.cpp
@@ -608,10 +608,10 @@ void FLD::Meshtying::solve_meshtying(Core::LinAlg::Solver& solver,
 
         split_vector_based_on3x3(*residual, *res);
         // assign blocks to the solution matrix
-        sysmatsolve->assign(0, 0, Core::LinAlg::View, sysmatnew->matrix(0, 0));
-        sysmatsolve->assign(0, 1, Core::LinAlg::View, sysmatnew->matrix(0, 1));
-        sysmatsolve->assign(1, 0, Core::LinAlg::View, sysmatnew->matrix(1, 0));
-        sysmatsolve->assign(1, 1, Core::LinAlg::View, sysmatnew->matrix(1, 1));
+        sysmatsolve->assign(0, 0, Core::LinAlg::DataAccess::View, sysmatnew->matrix(0, 0));
+        sysmatsolve->assign(0, 1, Core::LinAlg::DataAccess::View, sysmatnew->matrix(0, 1));
+        sysmatsolve->assign(1, 0, Core::LinAlg::DataAccess::View, sysmatnew->matrix(1, 0));
+        sysmatsolve->assign(1, 1, Core::LinAlg::DataAccess::View, sysmatnew->matrix(1, 1));
         sysmatsolve->complete();
       }
 
@@ -655,10 +655,10 @@ void FLD::Meshtying::solve_meshtying(Core::LinAlg::Solver& solver,
 
 
         // assign blocks to the solution matrix
-        sysmatsolve->assign(0, 0, Core::LinAlg::View, sysmatnew->matrix(0, 0));
-        sysmatsolve->assign(0, 1, Core::LinAlg::View, sysmatnew->matrix(0, 1));
-        sysmatsolve->assign(1, 0, Core::LinAlg::View, sysmatnew->matrix(1, 0));
-        sysmatsolve->assign(1, 1, Core::LinAlg::View, sysmatnew->matrix(1, 1));
+        sysmatsolve->assign(0, 0, Core::LinAlg::DataAccess::View, sysmatnew->matrix(0, 0));
+        sysmatsolve->assign(0, 1, Core::LinAlg::DataAccess::View, sysmatnew->matrix(0, 1));
+        sysmatsolve->assign(1, 0, Core::LinAlg::DataAccess::View, sysmatnew->matrix(1, 0));
+        sysmatsolve->assign(1, 1, Core::LinAlg::DataAccess::View, sysmatnew->matrix(1, 1));
         sysmatsolve->complete();
 
         mergedmatrix = sysmatsolve->merge();

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
@@ -429,14 +429,14 @@ void FLD::XFluidFluid::assemble_mat_and_rhs(int itnum  ///< iteration number
       std::dynamic_pointer_cast<Core::LinAlg::BlockSparseMatrixBase>(xff_state_->xffluidsysmat_);
   if (sysmat_block != nullptr)
   {
-    sysmat_block->assign(1, 1, Core::LinAlg::View, *xff_state_->sysmat_);
-    sysmat_block->assign(1, 0, Core::LinAlg::View, *coup_state->C_xs_);
-    sysmat_block->assign(0, 1, Core::LinAlg::View, *coup_state->C_sx_);
+    sysmat_block->assign(1, 1, Core::LinAlg::DataAccess::View, *xff_state_->sysmat_);
+    sysmat_block->assign(1, 0, Core::LinAlg::DataAccess::View, *coup_state->C_xs_);
+    sysmat_block->assign(0, 1, Core::LinAlg::DataAccess::View, *coup_state->C_sx_);
     embedded_fluid_->system_matrix()->un_complete();
     embedded_fluid_->system_matrix()->add(*coup_state->C_ss_, false, 1.0, 1.0);
     std::shared_ptr<Core::LinAlg::SparseMatrix> alesysmat_sparse =
         std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(embedded_fluid_->system_matrix());
-    sysmat_block->assign(0, 0, Core::LinAlg::View, *alesysmat_sparse);
+    sysmat_block->assign(0, 0, Core::LinAlg::DataAccess::View, *alesysmat_sparse);
   }
   else
   {
@@ -517,8 +517,8 @@ void FLD::XFluidFluid::add_eos_pres_stab_to_emb_layer()
   // TODO: think about the dirichlet and savegraph flags when ApplyDirichlet or Zero is called
   std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_linalg =
       std::make_shared<Core::LinAlg::SparseMatrix>(
-          std::static_pointer_cast<Epetra_CrsMatrix>(sysmat_FE), Core::LinAlg::View, true, true,
-          Core::LinAlg::SparseMatrix::FE_MATRIX);
+          std::static_pointer_cast<Epetra_CrsMatrix>(sysmat_FE), Core::LinAlg::DataAccess::View,
+          true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
 
   //------------------------------------------------------------
   // loop over row faces

--- a/src/fpsi/4C_fpsi_monolithic.cpp
+++ b/src/fpsi/4C_fpsi_monolithic.cpp
@@ -1564,7 +1564,7 @@ void FPSI::Monolithic::fpsifd_check()
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> sparse = systemmatrix_->merge();
 
-  Core::LinAlg::SparseMatrix sparse_copy(*sparse, Core::LinAlg::Copy);
+  Core::LinAlg::SparseMatrix sparse_copy(*sparse, Core::LinAlg::DataAccess::Copy);
 
 
   std::cout << "\n****************** FPSI finite difference check ******************" << std::endl;
@@ -1643,7 +1643,7 @@ void FPSI::Monolithic::fpsifd_check()
   int err = stiff_approx->FillComplete();
   if (err) FOUR_C_THROW("FD_Check: FillComplete failed with err-code: {}", err);
 
-  Core::LinAlg::SparseMatrix temp(stiff_approx, Core::LinAlg::Copy);
+  Core::LinAlg::SparseMatrix temp(stiff_approx, Core::LinAlg::DataAccess::Copy);
 
   std::shared_ptr<Epetra_CrsMatrix> stiff_approx_sparse = temp.epetra_matrix();
 

--- a/src/fpsi/4C_fpsi_monolithic_plain.cpp
+++ b/src/fpsi/4C_fpsi_monolithic_plain.cpp
@@ -306,28 +306,34 @@ void FPSI::MonolithicPlain::setup_system_matrix(Core::LinAlg::BlockSparseMatrixB
   // build block matrix
   /*----------------------------------------------------------------------*/
   // insert poro
-  mat.assign(structure_block_, structure_block_, Core::LinAlg::View, p->matrix(0, 0));
-  mat.assign(structure_block_, porofluid_block_, Core::LinAlg::View, p->matrix(0, 1));
-  mat.assign(porofluid_block_, porofluid_block_, Core::LinAlg::View, p->matrix(1, 1));
-  mat.assign(porofluid_block_, structure_block_, Core::LinAlg::View, p->matrix(1, 0));
+  mat.assign(structure_block_, structure_block_, Core::LinAlg::DataAccess::View, p->matrix(0, 0));
+  mat.assign(structure_block_, porofluid_block_, Core::LinAlg::DataAccess::View, p->matrix(0, 1));
+  mat.assign(porofluid_block_, porofluid_block_, Core::LinAlg::DataAccess::View, p->matrix(1, 1));
+  mat.assign(porofluid_block_, structure_block_, Core::LinAlg::DataAccess::View, p->matrix(1, 0));
 
   // Assign fii + Coupling Parts
-  mat.assign(fluid_block_, fluid_block_, Core::LinAlg::View, *f);
+  mat.assign(fluid_block_, fluid_block_, Core::LinAlg::DataAccess::View, *f);
 
   // Assign C_fp
-  mat.assign(fluid_block_, structure_block_, Core::LinAlg::View, fpsi_coupl()->c_fp().matrix(0, 0));
-  mat.assign(fluid_block_, porofluid_block_, Core::LinAlg::View, fpsi_coupl()->c_fp().matrix(0, 1));
+  mat.assign(fluid_block_, structure_block_, Core::LinAlg::DataAccess::View,
+      fpsi_coupl()->c_fp().matrix(0, 0));
+  mat.assign(fluid_block_, porofluid_block_, Core::LinAlg::DataAccess::View,
+      fpsi_coupl()->c_fp().matrix(0, 1));
 
   // Assign C_pf
-  mat.assign(structure_block_, fluid_block_, Core::LinAlg::View, fpsi_coupl()->c_pf().matrix(0, 0));
-  mat.assign(porofluid_block_, fluid_block_, Core::LinAlg::View, fpsi_coupl()->c_pf().matrix(1, 0));
+  mat.assign(structure_block_, fluid_block_, Core::LinAlg::DataAccess::View,
+      fpsi_coupl()->c_pf().matrix(0, 0));
+  mat.assign(porofluid_block_, fluid_block_, Core::LinAlg::DataAccess::View,
+      fpsi_coupl()->c_pf().matrix(1, 0));
 
   // Assign C_pa
-  mat.assign(structure_block_, ale_i_block_, Core::LinAlg::View, fpsi_coupl()->c_pa().matrix(0, 0));
-  mat.assign(porofluid_block_, ale_i_block_, Core::LinAlg::View, fpsi_coupl()->c_pa().matrix(1, 0));
+  mat.assign(structure_block_, ale_i_block_, Core::LinAlg::DataAccess::View,
+      fpsi_coupl()->c_pa().matrix(0, 0));
+  mat.assign(porofluid_block_, ale_i_block_, Core::LinAlg::DataAccess::View,
+      fpsi_coupl()->c_pa().matrix(1, 0));
 
   // Assign C_fa
-  mat.assign(fluid_block_, ale_i_block_, Core::LinAlg::View, fpsi_coupl()->c_fa());
+  mat.assign(fluid_block_, ale_i_block_, Core::LinAlg::DataAccess::View, fpsi_coupl()->c_fa());
 
   // ALE Condensation
   Core::LinAlg::SparseMatrix& aii = a->matrix(aidx_other, aidx_other);
@@ -339,7 +345,7 @@ void FPSI::MonolithicPlain::setup_system_matrix(Core::LinAlg::BlockSparseMatrixB
       mat.matrix(ale_i_block_, structure_block_), true,
       false);  // Add
 
-  mat.assign(ale_i_block_, ale_i_block_, Core::LinAlg::View, aii);
+  mat.assign(ale_i_block_, ale_i_block_, Core::LinAlg::DataAccess::View, aii);
 
   // Insert condensed Fluid Blocks: Fgg and Fgi (+ Fg_gFPSI) --> g is on the FSI-Interface
   if (FSI_Interface_exists_)

--- a/src/fs3i/4C_fs3i.cpp
+++ b/src/fs3i/4C_fs3i.cpp
@@ -669,7 +669,7 @@ void FS3I::FS3IBase::setup_coupled_scatra_matrix()
             *scatra2, *(scatrafieldexvec_[1]), *(scatrafieldexvec_[1]));
     blockscatra2->complete();
 
-    scatrasystemmatrix_->assign(1, 1, Core::LinAlg::View, blockscatra2->matrix(0, 0));
+    scatrasystemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, blockscatra2->matrix(0, 0));
 
     (*sibtransform_)(blockscatra2->full_row_map(), blockscatra2->full_col_map(),
         blockscatra2->matrix(0, 1), 1.0, Coupling::Adapter::CouplingSlaveConverter(*scatracoup_),
@@ -681,13 +681,13 @@ void FS3I::FS3IBase::setup_coupled_scatra_matrix()
         Coupling::Adapter::CouplingSlaveConverter(*scatracoup_), *scatra1, true, true);
 
     // fluid scatra
-    scatrasystemmatrix_->assign(0, 0, Core::LinAlg::View, *scatra1);
+    scatrasystemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *scatra1);
   }
   else
   {
     // conventional contributions
-    scatrasystemmatrix_->assign(0, 0, Core::LinAlg::View, *scatra1);
-    scatrasystemmatrix_->assign(1, 1, Core::LinAlg::View, *scatra2);
+    scatrasystemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *scatra1);
+    scatrasystemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *scatra2);
 
     // additional contributions due to interface permeability (-> coupling terms)
     // contribution of the same field

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
@@ -481,18 +481,18 @@ void FSI::FluidFluidMonolithicFluidSplitNoNOX::setup_system_matrix()
 
   lfgi->complete(fgi.domain_map(), s->range_map());
 
-  systemmatrix_->assign(0, 1, Core::LinAlg::View, *lfgi);
+  systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, *lfgi);
 
   Core::LinAlg::SparseMatrix lfig(fig.row_map(), 81, false);
   (*figtransform_)(f->full_row_map(), f->full_col_map(), fig, timescale,
       Coupling::Adapter::CouplingSlaveConverter(coupsf), systemmatrix_->matrix(1, 0));
 
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, fii);
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, fii);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1.,
       Coupling::Adapter::CouplingSlaveConverter(coupsa), systemmatrix_->matrix(2, 0));
 
-  systemmatrix_->assign(2, 2, Core::LinAlg::View, aii);
+  systemmatrix_->assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*----------------------------------------------------------------------*/
   // add optional blocks from fluid linearization with respect to mesh motion
@@ -529,12 +529,12 @@ void FSI::FluidFluidMonolithicFluidSplitNoNOX::setup_system_matrix()
 
       lfmgi.complete(aii.domain_map(), s->range_map());
 
-      systemmatrix_->assign(0, 2, Core::LinAlg::View, lfmgi);
+      systemmatrix_->assign(0, 2, Core::LinAlg::DataAccess::View, lfmgi);
     }
   }
 
   // finally assign structure block
-  systemmatrix_->matrix(0, 0).assign(Core::LinAlg::View, *s);
+  systemmatrix_->matrix(0, 0).assign(Core::LinAlg::DataAccess::View, *s);
 
   // done. make sure all blocks are filled.
   systemmatrix_->complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
@@ -363,7 +363,7 @@ void FSI::FluidFluidMonolithicStructureSplitNoNOX::setup_system_matrix()
   // interface meshes.
   f->un_complete();
 
-  systemmatrix_->assign(0, 0, Core::LinAlg::View, s->matrix(0, 0));
+  systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, s->matrix(0, 0));
 
   (*sigtransform_)(s->full_row_map(), s->full_col_map(), s->matrix(0, 1), 1. / timescale,
       Coupling::Adapter::CouplingMasterConverter(coupsf), systemmatrix_->matrix(0, 1));
@@ -380,12 +380,12 @@ void FSI::FluidFluidMonolithicStructureSplitNoNOX::setup_system_matrix()
   lsgi->complete(s->matrix(1, 0).domain_map(), f->range_map());
 
   // systemmatrix_->Assign(1,1,View,*f);
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, *lsgi);
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *lsgi);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1. / timescale,
       Coupling::Adapter::CouplingSlaveConverter(icoupfa), systemmatrix_->matrix(2, 1));
 
-  systemmatrix_->assign(2, 2, Core::LinAlg::View, aii);
+  systemmatrix_->assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*----------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block
@@ -412,13 +412,13 @@ void FSI::FluidFluidMonolithicStructureSplitNoNOX::setup_system_matrix()
 
     lfmgi.complete(aii.domain_map(), f->range_map());
 
-    systemmatrix_->assign(1, 2, Core::LinAlg::View, lfmgi);
+    systemmatrix_->assign(1, 2, Core::LinAlg::DataAccess::View, lfmgi);
   }
 
   f->complete();
 
   // finally assign fluid block
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, *f);
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *f);
 
   // done. make sure all blocks are filled.
   systemmatrix_->complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
@@ -710,10 +710,10 @@ void FSI::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSparseMat
       laig = Core::LinAlg::matrix_multiply(*laig, false, *stcmat, false, false, false, true);
     }
 
-    mat.assign(2, 0, Core::LinAlg::View, *laig);
+    mat.assign(2, 0, Core::LinAlg::DataAccess::View, *laig);
   }
 
-  mat.assign(2, 2, Core::LinAlg::View, aii);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*----------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block
@@ -792,7 +792,7 @@ void FSI::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSparseMat
   }
 
   // finally assign structure block
-  mat.matrix(0, 0).assign(Core::LinAlg::View, *s);
+  mat.matrix(0, 0).assign(Core::LinAlg::DataAccess::View, *s);
 
   // done. make sure all blocks are filled.
   mat.complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
@@ -651,7 +651,7 @@ void FSI::MonolithicStructureSplit::setup_system_matrix(Core::LinAlg::BlockSpars
   // interface meshes.
   f->un_complete();
 
-  mat.assign(0, 0, Core::LinAlg::View, s->matrix(0, 0));
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, s->matrix(0, 0));
 
   (*sigtransform_)(s->full_row_map(), s->full_col_map(), s->matrix(0, 1), 1. / timescale,
       Coupling::Adapter::CouplingMasterConverter(coupsf), mat.matrix(0, 1));
@@ -666,11 +666,11 @@ void FSI::MonolithicStructureSplit::setup_system_matrix(Core::LinAlg::BlockSpars
 
   lsgi->complete(s->matrix(1, 0).domain_map(), f->range_map());
 
-  mat.assign(1, 0, Core::LinAlg::View, *lsgi);
+  mat.assign(1, 0, Core::LinAlg::DataAccess::View, *lsgi);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1. / timescale,
       Coupling::Adapter::CouplingSlaveConverter(icoupfa), mat.matrix(2, 1));
-  mat.assign(2, 2, Core::LinAlg::View, aii);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*----------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block
@@ -695,13 +695,13 @@ void FSI::MonolithicStructureSplit::setup_system_matrix(Core::LinAlg::BlockSpars
 
     lfmgi.complete(aii.domain_map(), f->range_map());
 
-    mat.assign(1, 2, Core::LinAlg::View, lfmgi);
+    mat.assign(1, 2, Core::LinAlg::DataAccess::View, lfmgi);
   }
 
   f->complete();
 
   // finally assign fluid block
-  mat.assign(1, 1, Core::LinAlg::View, *f);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, *f);
 
   // done. make sure all blocks are filled.
   mat.complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
@@ -875,10 +875,10 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
     laig = Core::LinAlg::matrix_multiply(*laig, false, *stcmat, false, false, false, true);
   }
 
-  mat.assign(2, 0, Core::LinAlg::View, *laig);
+  mat.assign(2, 0, Core::LinAlg::DataAccess::View, *laig);
 
   // ---------Addressing contribution to block (4,4)
-  mat.assign(2, 2, Core::LinAlg::View, aii);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*--------------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block
@@ -940,7 +940,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
     if (stcalgo == Inpar::Solid::stc_currsym)
       lfmgi = Core::LinAlg::matrix_multiply(*stcmat, true, *lfmgi, false, true, true, false);
     lfmgi->scale((1. - stiparam) / (1. - ftiparam));
-    mat.assign(0, 2, Core::LinAlg::View, *lfmgi);
+    mat.assign(0, 2, Core::LinAlg::DataAccess::View, *lfmgi);
   }
 
   if (stcalgo != Inpar::Solid::stc_inactive)
@@ -952,7 +952,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
   }
 
   // finally assign structure matrix to block (0,0)
-  mat.assign(0, 0, Core::LinAlg::View, *s);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *s);
 
   // done. make sure all blocks are filled.
   mat.complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
@@ -857,7 +857,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   // Block numbering in comments ranges from (1,1) to (6,6).
 
   // ---------Addressing contribution to blocks (1,1),(1,2),(2,1),(2,2)
-  mat.assign(0, 0, Core::LinAlg::View, *solidblock);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *solidblock);
 
   // ---------Addressing contribution to blocks (3,3),(3,4),(4,3),(4,4)
   Core::LinAlg::SparseMatrix aux_fluidblock(fluidblock->full_row_map(), 108, false);
@@ -878,17 +878,17 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   aux_ale_inner_interf->scale(1. / fluid_timescale);
   aux_ale_inner_interf->complete(fluidblock->domain_map(), aux_ale_inner_interf->range_map(), true);
 
-  mat.assign(2, 1, Core::LinAlg::View, *aux_ale_inner_interf);
+  mat.assign(2, 1, Core::LinAlg::DataAccess::View, *aux_ale_inner_interf);
 
   // ---------Addressing contribution to block (5,5)
-  mat.assign(2, 2, Core::LinAlg::View, ale_inner_inner);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, ale_inner_inner);
 
   // ---------Addressing contribution to block (6,2)
   std::shared_ptr<Core::LinAlg::SparseMatrix> aux_mortar_m =
       Mortar::matrix_row_transform_gids(*mortar_m, *lag_mult_dof_map_);
   aux_mortar_m->complete(solidblock->domain_map(), *lag_mult_dof_map_, true);
 
-  mat.assign(3, 0, Core::LinAlg::View, *aux_mortar_m);
+  mat.assign(3, 0, Core::LinAlg::DataAccess::View, *aux_mortar_m);
 
   // ---------Addressing contribution to block (2,6)
   aux_mortar_m = Mortar::matrix_row_transform_gids(*mortar_m, *lag_mult_dof_map_);
@@ -896,7 +896,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   aux_mortar_m_trans.add(*aux_mortar_m, true, -1.0 * (1.0 - solid_time_int_param), 0.0);
   aux_mortar_m_trans.complete(*lag_mult_dof_map_, solidblock->range_map(), true);
 
-  mat.assign(0, 3, Core::LinAlg::View, aux_mortar_m_trans);
+  mat.assign(0, 3, Core::LinAlg::DataAccess::View, aux_mortar_m_trans);
 
   // ---------Addressing contribution to block (6,4)
   std::shared_ptr<Core::LinAlg::SparseMatrix> aux_mortar_d =
@@ -905,7 +905,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   aux_mortar_d->scale(-1.0 / fluid_timescale);
   aux_mortar_d->complete(fluidblock->full_domain_map(), *lag_mult_dof_map_, true);
 
-  mat.assign(3, 1, Core::LinAlg::View, *aux_mortar_d);
+  mat.assign(3, 1, Core::LinAlg::DataAccess::View, *aux_mortar_d);
 
   // ---------Addressing contribution to block (4,6)
   aux_mortar_d = Mortar::matrix_row_transform_gids(*mortar_d, *lag_mult_dof_map_);
@@ -914,7 +914,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
       *aux_mortar_d, true, 1.0 * (1.0 - fluid_time_int_param) / fluid_res_scale, 0.0);
   aux_mortar_d_trans.complete(*lag_mult_dof_map_, fluidblock->full_range_map(), true);
 
-  mat.assign(1, 3, Core::LinAlg::View, aux_mortar_d_trans);
+  mat.assign(1, 3, Core::LinAlg::DataAccess::View, aux_mortar_d_trans);
 
   /*--------------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block
@@ -956,7 +956,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   }
 
   // finally assign fluid matrix to block (1,1)
-  mat.assign(1, 1, Core::LinAlg::View, aux_fluidblock);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, aux_fluidblock);
 
   // done. make sure all blocks are filled.
   mat.complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
@@ -762,7 +762,7 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
   // Contributions to blocks in system matrix are listed separately.
   // Block numbering in comments ranges from (1,1) to (4,4).
 
-  mat.assign(0, 0, Core::LinAlg::View, s->matrix(0, 0));
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, s->matrix(0, 0));
 
   // ----------Addressing contribution to block (1,3)
   std::shared_ptr<Core::LinAlg::SparseMatrix> sig =
@@ -772,7 +772,7 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
   lsig.add(*sig, false, 1. / timescale, 0.0);
   lsig.complete(f->domain_map(), sig->range_map());
 
-  mat.assign(0, 1, Core::LinAlg::View, lsig);
+  mat.assign(0, 1, Core::LinAlg::DataAccess::View, lsig);
 
   // ----------Addressing contribution to block (3,1)
   std::shared_ptr<Core::LinAlg::SparseMatrix> sgi =
@@ -782,7 +782,7 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
   lsgi.add(*sgi, false, (1. - ftiparam) / ((1. - stiparam) * scale), 0.0);
   lsgi.complete(sgi->domain_map(), f->range_map());
 
-  mat.assign(1, 0, Core::LinAlg::View, lsgi);
+  mat.assign(1, 0, Core::LinAlg::DataAccess::View, lsgi);
 
   // ----------Addressing contribution to block (3,3)
   std::shared_ptr<Core::LinAlg::SparseMatrix> sgg =
@@ -790,11 +790,11 @@ void FSI::MortarMonolithicStructureSplit::setup_system_matrix(
   sgg = matrix_multiply(*mortarp, true, *sgg, false, false, false, true);
 
   f->add(*sgg, false, (1. - ftiparam) / ((1. - stiparam) * scale * timescale), 1.0);
-  mat.assign(1, 1, Core::LinAlg::View, *f);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, *f);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1. / timescale,
       Coupling::Adapter::CouplingSlaveConverter(interface_fluid_ale_coupling()), mat.matrix(2, 1));
-  mat.assign(2, 2, Core::LinAlg::View, aii);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*--------------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
@@ -866,10 +866,10 @@ void FSI::SlidingMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSp
     laig = Core::LinAlg::matrix_multiply(*laig, false, *stcmat, false, false, false, true);
   }
 
-  mat.assign(2, 0, Core::LinAlg::View, *laig);
+  mat.assign(2, 0, Core::LinAlg::DataAccess::View, *laig);
 
   // ---------Addressing contribution to block (4,4)
-  mat.assign(2, 2, Core::LinAlg::View, aii);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*--------------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block
@@ -931,7 +931,7 @@ void FSI::SlidingMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSp
     if (stcalgo == Inpar::Solid::stc_currsym)
       lfmgi = Core::LinAlg::matrix_multiply(*stcmat, true, *lfmgi, false, true, true, false);
     lfmgi->scale((1. - stiparam) / (1. - ftiparam));
-    mat.assign(0, 2, Core::LinAlg::View, *lfmgi);
+    mat.assign(0, 2, Core::LinAlg::DataAccess::View, *lfmgi);
   }
 
   s->complete();
@@ -948,7 +948,7 @@ void FSI::SlidingMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSp
     s->un_complete();
   }
   // finally assign structure matrix to block (0,0)
-  mat.assign(0, 0, Core::LinAlg::View, *s);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *s);
 
   // done. make sure all blocks are filled.
   mat.complete();

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
@@ -727,7 +727,7 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
   // Contributions to blocks in system matrix are listed separately.
   // Block numbering in comments ranges from (1,1) to (4,4).
 
-  mat.assign(0, 0, Core::LinAlg::View, s->matrix(0, 0));
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, s->matrix(0, 0));
 
   // ----------Addressing contribution to block (1,3)
   std::shared_ptr<Core::LinAlg::SparseMatrix> sig =
@@ -737,7 +737,7 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
   lsig.add(*sig, false, 1. / timescale, 0.0);
   lsig.complete(f->domain_map(), sig->range_map());
 
-  mat.assign(0, 1, Core::LinAlg::View, lsig);
+  mat.assign(0, 1, Core::LinAlg::DataAccess::View, lsig);
 
   // ----------Addressing contribution to block (3,1)
   std::shared_ptr<Core::LinAlg::SparseMatrix> sgi =
@@ -747,7 +747,7 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
   lsgi.add(*sgi, false, (1. - ftiparam) / ((1. - stiparam) * scale), 0.0);
   lsgi.complete(sgi->domain_map(), f->range_map());
 
-  mat.assign(1, 0, Core::LinAlg::View, lsgi);
+  mat.assign(1, 0, Core::LinAlg::DataAccess::View, lsgi);
 
   // ----------Addressing contribution to block (3,3)
   std::shared_ptr<Core::LinAlg::SparseMatrix> sgg =
@@ -755,11 +755,11 @@ void FSI::SlidingMonolithicStructureSplit::setup_system_matrix(
   sgg = matrix_multiply(*mortarp, true, *sgg, false, false, false, true);
 
   f->add(*sgg, false, (1. - ftiparam) / ((1. - stiparam) * scale * timescale), 1.0);
-  mat.assign(1, 1, Core::LinAlg::View, *f);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, *f);
 
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1. / timescale,
       Coupling::Adapter::CouplingSlaveConverter(interface_fluid_ale_coupling()), mat.matrix(2, 1));
-  mat.assign(2, 2, Core::LinAlg::View, aii);
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, aii);
 
   /*--------------------------------------------------------------------------*/
   // add optional fluid linearization with respect to mesh motion block

--- a/src/fsi_xfem/4C_fsi_xfem_XFAcoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFAcoupling_manager.cpp
@@ -120,7 +120,7 @@ void XFEM::XfaCouplingManager::add_coupling_matrix(
   // ALE Condensation
   Core::LinAlg::SparseMatrix& aii = a->matrix(aidx_other, aidx_other);
 
-  systemmatrix.assign(idx_[1], idx_[1], Core::LinAlg::View, aii);
+  systemmatrix.assign(idx_[1], idx_[1], Core::LinAlg::DataAccess::View, aii);
 
   if (ale_struct_coupling_ != nullptr)
   {

--- a/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
@@ -152,8 +152,10 @@ void XFEM::XfsCouplingManager::add_coupling_matrix(
         ->scale(scaling * scaling_FSI);  //<   1/(theta_f*dt) * 1/(theta_FSI*dt) = 1/weight(t^f_np)
                                          //* 1/weight(t^FSI_np)
 
-    systemmatrix.assign(idx_[0], idx_[1], Core::LinAlg::View, *xfluid_->c_sx_matrix(cond_name_));
-    systemmatrix.assign(idx_[1], idx_[0], Core::LinAlg::View, *xfluid_->c_xs_matrix(cond_name_));
+    systemmatrix.assign(
+        idx_[0], idx_[1], Core::LinAlg::DataAccess::View, *xfluid_->c_sx_matrix(cond_name_));
+    systemmatrix.assign(
+        idx_[1], idx_[0], Core::LinAlg::DataAccess::View, *xfluid_->c_xs_matrix(cond_name_));
   }
   else if (probtype == Core::ProblemType::fpsi_xfem || is_xfluidfluid)
   {

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
@@ -508,7 +508,7 @@ void FSI::MonolithicXFEM::setup_system_matrix()
     s->scale(scaling_S);
 
     // assign the structure sysmat diagonal block
-    systemmatrix_->assign(structp_block_, structp_block_, Core::LinAlg::View, *s);
+    systemmatrix_->assign(structp_block_, structp_block_, Core::LinAlg::DataAccess::View, *s);
   }
   else  // we use a block structure for poro
   {
@@ -517,13 +517,13 @@ void FSI::MonolithicXFEM::setup_system_matrix()
     ps->un_complete();
     ps->scale(scaling_S);
     systemmatrix_->assign(
-        structp_block_, structp_block_, Core::LinAlg::View, ps->matrix(0, 0));  // psps
+        structp_block_, structp_block_, Core::LinAlg::DataAccess::View, ps->matrix(0, 0));  // psps
     systemmatrix_->assign(
-        fluidp_block_, structp_block_, Core::LinAlg::View, ps->matrix(1, 0));  // pfps
+        fluidp_block_, structp_block_, Core::LinAlg::DataAccess::View, ps->matrix(1, 0));  // pfps
     systemmatrix_->assign(
-        structp_block_, fluidp_block_, Core::LinAlg::View, ps->matrix(0, 1));  // pspf
+        structp_block_, fluidp_block_, Core::LinAlg::DataAccess::View, ps->matrix(0, 1));  // pspf
     systemmatrix_->assign(
-        fluidp_block_, fluidp_block_, Core::LinAlg::View, ps->matrix(1, 1));  // pfpf
+        fluidp_block_, fluidp_block_, Core::LinAlg::DataAccess::View, ps->matrix(1, 1));  // pfpf
   }
 
   /*----------------------------------------------------------------------*/
@@ -534,7 +534,7 @@ void FSI::MonolithicXFEM::setup_system_matrix()
   f->scale(scaling_F);  //<  1/(theta_f*dt) = 1/weight(t^f_np)
 
   // assign the fluid diagonal block
-  systemmatrix_->assign(fluid_block_, fluid_block_, Core::LinAlg::View, *f);
+  systemmatrix_->assign(fluid_block_, fluid_block_, Core::LinAlg::DataAccess::View, *f);
 
   // Add Coupling Sysmat
   for (auto coupit = coup_man_.begin(); coupit != coup_man_.end(); ++coupit)

--- a/src/loma/4C_loma_algorithm.cpp
+++ b/src/loma/4C_loma_algorithm.cpp
@@ -631,7 +631,7 @@ void LowMach::Algorithm::setup_mono_loma_matrix()
   mat_ff->un_complete();
 
   // assign matrix block
-  lomasystemmatrix_->assign(0, 0, Core::LinAlg::View, *mat_ff);
+  lomasystemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *mat_ff);
 
   //----------------------------------------------------------------------
   // 2nd diagonal block (lower right): scatra weighting - scatra solution
@@ -643,7 +643,7 @@ void LowMach::Algorithm::setup_mono_loma_matrix()
   mat_ss->un_complete();
 
   // assign matrix block
-  lomasystemmatrix_->assign(1, 1, Core::LinAlg::View, *mat_ss);
+  lomasystemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *mat_ss);
 
   // complete loma block matrix
   lomasystemmatrix_->complete();
@@ -663,7 +663,7 @@ void LowMach::Algorithm::setup_mono_loma_matrix()
   mat_fs->un_complete();
 
   // assign matrix block
-  lomasystemmatrix_->assign(0, 1, Core::LinAlg::View, *mat_fs);
+  lomasystemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, *mat_fs);
 
   //----------------------------------------------------------------------
   // 2nd off-diagonal block (lower left): scatra weighting - fluid solution
@@ -681,7 +681,7 @@ void LowMach::Algorithm::setup_mono_loma_matrix()
   mat_sf->un_complete();
 
   // assign matrix block
-  lomasystemmatrix_->assign(1, 0, Core::LinAlg::View, *mat_sf);
+  lomasystemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *mat_sf);
 
   // complete loma block matrix
   lomasystemmatrix_->complete();

--- a/src/mortar/4C_mortar_utils.cpp
+++ b/src/mortar/4C_mortar_utils.cpp
@@ -379,7 +379,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Mortar::matrix_row_transform(
 
   // output matrix
   std::shared_ptr<Core::LinAlg::SparseMatrix> outmat =
-      std::make_shared<Core::LinAlg::SparseMatrix>(permmat, Core::LinAlg::Copy, true);
+      std::make_shared<Core::LinAlg::SparseMatrix>(permmat, Core::LinAlg::DataAccess::Copy, true);
 
   return outmat;
 }
@@ -413,7 +413,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Mortar::matrix_row_col_transform(
 
   // output matrix
   std::shared_ptr<Core::LinAlg::SparseMatrix> outmat =
-      std::make_shared<Core::LinAlg::SparseMatrix>(permmat, Core::LinAlg::Copy, false);
+      std::make_shared<Core::LinAlg::SparseMatrix>(permmat, Core::LinAlg::DataAccess::Copy, false);
 
   return outmat;
 }
@@ -1024,7 +1024,7 @@ void Mortar::Utils::mortar_matrix_condensation(
       std::shared_ptr<Core::LinAlg::SparseMatrix> new_matrix =
           std::make_shared<Core::LinAlg::SparseMatrix>(k->matrix(row, col));
       mortar_matrix_condensation(new_matrix, p.at(row), p.at(col) /*,row!=col*/);
-      cond_mat->assign(row, col, Core::LinAlg::Copy, *new_matrix);
+      cond_mat->assign(row, col, Core::LinAlg::DataAccess::Copy, *new_matrix);
     }
 
   cond_mat->complete();

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -549,13 +549,13 @@ void PoroElast::Monolithic::setup_system_matrix(Core::LinAlg::BlockSparseMatrixB
   }
 
   // assign structure part to the Poroelasticity matrix
-  mat.assign(0, 0, Core::LinAlg::View, *k_ss);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *k_ss);
   // assign coupling part to the Poroelasticity matrix
-  mat.assign(0, 1, Core::LinAlg::View, *k_sf);
+  mat.assign(0, 1, Core::LinAlg::DataAccess::View, *k_sf);
   // assign fluid part to the poroelasticity matrix
-  mat.assign(1, 1, Core::LinAlg::View, *k_ff);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, *k_ff);
   // assign coupling part to the Poroelasticity matrix
-  mat.assign(1, 0, Core::LinAlg::View, *k_fs);
+  mat.assign(1, 0, Core::LinAlg::DataAccess::View, *k_fs);
 
   /*----------------------------------------------------------------------*/
   // done. make sure all blocks are filled.
@@ -1183,7 +1183,7 @@ void PoroElast::Monolithic::apply_fluid_coupl_matrix(
   Core::LinAlg::Vector<double> rhs_copy(*dof_row_map(), true);
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> sparse = systemmatrix_->merge();
-  Core::LinAlg::SparseMatrix sparse_copy(sparse->epetra_matrix(), Core::LinAlg::Copy);
+  Core::LinAlg::SparseMatrix sparse_copy(sparse->epetra_matrix(), Core::LinAlg::DataAccess::Copy);
 
   bool output = false;
   if (output)
@@ -1287,7 +1287,7 @@ void PoroElast::Monolithic::apply_fluid_coupl_matrix(
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> stiff_approx_sparse = nullptr;
   stiff_approx_sparse =
-      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::Copy);
+      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::DataAccess::Copy);
 
   stiff_approx_sparse->add(sparse_copy, false, -1.0, 1.0);
 
@@ -1911,9 +1911,9 @@ void PoroElast::Monolithic::eval_poro_mortar()
               structure_field()->write_access_dispnp(), k_ss, k_sf, rhs_s, step(), iter_, false);
 
           // Assign modified matrixes & vectors
-          systemmatrix_->assign(0, 0, Core::LinAlg::Copy,
+          systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::Copy,
               *std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(k_ss));
-          systemmatrix_->assign(0, 1, Core::LinAlg::Copy,
+          systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::Copy,
               *std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(k_sf));
           extractor()->insert_vector(*rhs_s, 0, *rhs_);
 
@@ -1936,8 +1936,8 @@ void PoroElast::Monolithic::eval_poro_mortar()
             costrategy.evaluate_poro_no_pen_contact(k_fs, f, frhs);
 
             // Assign modified matrixes & vectors
-            systemmatrix_->assign(1, 1, Core::LinAlg::Copy, *f);
-            systemmatrix_->assign(1, 0, Core::LinAlg::Copy, *k_fs);
+            systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::Copy, *f);
+            systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::Copy, *k_fs);
 
             extractor()->insert_vector(*frhs, 1, *rhs_);
           }
@@ -1983,7 +1983,7 @@ void PoroElast::Monolithic::eval_poro_mortar()
         costrategy.evaluate_meshtying_poro_off_diag(k_sf);
 
         // Assign modified matrix
-        systemmatrix_->assign(0, 1, Core::LinAlg::Copy, *k_sf);
+        systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::Copy, *k_sf);
       }
     }
   }

--- a/src/poroelast/4C_poroelast_monolithicfluidsplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicfluidsplit.cpp
@@ -241,7 +241,7 @@ void PoroElast::MonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
   mat.matrix(1, 0).add(k_fs->matrix(0, 1), false, 1.0, 1.0);
 
   // pure structure part
-  mat.assign(0, 0, Core::LinAlg::View, *s);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *s);
 
   // structure coupling part
   mat.matrix(0, 1).add(k_sf->matrix(0, 0), false, 1.0, 0.0);

--- a/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
+++ b/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
@@ -98,8 +98,8 @@ void PoroElast::MonolithicMeshtying::evaluate(
       fluid_field()->dof_row_map());
 
   // assign modified parts of system matrix into full system matrix
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, *f);
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, *k_fs);
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *f);
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *k_fs);
 
   // assign modified part of RHS vector into full RHS vector
   extractor()->insert_vector(*frhs, 1, *rhs_);

--- a/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit_nopenetration.cpp
@@ -289,7 +289,7 @@ void PoroElast::MonolithicSplitNoPenetration::setup_system_matrix(
 
   /*----------------------------------------------------------------------*/
   // pure structural part
-  mat.assign(0, 0, Core::LinAlg::View, *s);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *s);
 
   // structure coupling part
   mat.matrix(0, 1).add(k_sf->matrix(sidx_other, fidx_other), false, 1.0, 0.0);
@@ -501,7 +501,7 @@ void PoroElast::MonolithicSplitNoPenetration::apply_fluid_coupl_matrix(
   //------------------------------invert D Matrix!-----------------------------------------------
   tmp_k_D->complete();
   std::shared_ptr<Core::LinAlg::SparseMatrix> invd =
-      std::make_shared<Core::LinAlg::SparseMatrix>(*tmp_k_D, Core::LinAlg::Copy);
+      std::make_shared<Core::LinAlg::SparseMatrix>(*tmp_k_D, Core::LinAlg::DataAccess::Copy);
   // invd->Complete();
 
   std::shared_ptr<Core::LinAlg::Vector<double>> diag =
@@ -588,7 +588,7 @@ void PoroElast::MonolithicSplitNoPenetration::update()
 
   // copy D matrix from current time step to old D matrix
   k_dn_ = std::make_shared<Core::LinAlg::SparseMatrix>(
-      *k_d_, Core::LinAlg::Copy);  // store D-Matrix from last timestep
+      *k_d_, Core::LinAlg::DataAccess::Copy);  // store D-Matrix from last timestep
 }
 
 void PoroElast::MonolithicSplitNoPenetration::output(bool forced_writerestart)
@@ -687,7 +687,7 @@ void PoroElast::MonolithicSplitNoPenetration::read_restart(const int step)
 
     // copy D matrix from current time step to old D matrix
     k_dn_ = std::make_shared<Core::LinAlg::SparseMatrix>(
-        *k_d_, Core::LinAlg::Copy);  // store D-Matrix from last timestep
+        *k_d_, Core::LinAlg::DataAccess::Copy);  // store D-Matrix from last timestep
   }
 }
 

--- a/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
@@ -181,7 +181,7 @@ void PoroElast::MonolithicStructureSplit::setup_system_matrix(
   mat.matrix(0, 1).add(k_sf->matrix(0, 1), false, 1.0, 1.0);
 
   // pure fluid part
-  mat.assign(1, 1, Core::LinAlg::View, *f);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, *f);
 
   // fluid coupling part
   mat.matrix(1, 0).add(k_fs->matrix(0, 0), false, 1.0, 0.0);

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
@@ -441,10 +441,10 @@ void PoroElastScaTra::PoroScatraMono::setup_system_matrix()
   mat_pp->un_complete();
 
   // assign matrix block
-  systemmatrix_->assign(0, 0, Core::LinAlg::View, mat_pp->matrix(0, 0));
-  systemmatrix_->assign(0, 1, Core::LinAlg::View, mat_pp->matrix(0, 1));
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, mat_pp->matrix(1, 0));
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, mat_pp->matrix(1, 1));
+  systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, mat_pp->matrix(0, 0));
+  systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, mat_pp->matrix(0, 1));
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, mat_pp->matrix(1, 0));
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, mat_pp->matrix(1, 1));
 
   //----------------------------------------------------------------------
   // 2nd diagonal block (lower right): scatra weighting - scatra solution
@@ -456,7 +456,7 @@ void PoroElastScaTra::PoroScatraMono::setup_system_matrix()
   mat_ss->un_complete();
 
   // assign matrix block
-  systemmatrix_->assign(2, 2, Core::LinAlg::View, *mat_ss);
+  systemmatrix_->assign(2, 2, Core::LinAlg::DataAccess::View, *mat_ss);
 
   // complete scatra block matrix
   systemmatrix_->complete();
@@ -479,8 +479,8 @@ void PoroElastScaTra::PoroScatraMono::setup_system_matrix()
   k_pfs_->un_complete();
 
   // assign matrix block
-  systemmatrix_->assign(0, 2, Core::LinAlg::View, *(k_pss_));
-  systemmatrix_->assign(1, 2, Core::LinAlg::View, *(k_pfs_));
+  systemmatrix_->assign(0, 2, Core::LinAlg::DataAccess::View, *(k_pss_));
+  systemmatrix_->assign(1, 2, Core::LinAlg::DataAccess::View, *(k_pfs_));
 
   //----------------------------------------------------------------------
   // 2nd off-diagonal block (lower left): scatra weighting - poro solution
@@ -499,8 +499,8 @@ void PoroElastScaTra::PoroScatraMono::setup_system_matrix()
   k_spf_->un_complete();
 
   // assign matrix block
-  systemmatrix_->assign(2, 0, Core::LinAlg::View, *(k_sps_));
-  systemmatrix_->assign(2, 1, Core::LinAlg::View, *(k_spf_));
+  systemmatrix_->assign(2, 0, Core::LinAlg::DataAccess::View, *(k_sps_));
+  systemmatrix_->assign(2, 1, Core::LinAlg::DataAccess::View, *(k_spf_));
 
   // complete block matrix
   systemmatrix_->complete();
@@ -1244,7 +1244,7 @@ void PoroElastScaTra::PoroScatraMono::fd_check()
   Core::LinAlg::Vector<double> rhs_copy(*dof_row_map(), true);
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> sparse = systemmatrix_->merge();
-  Core::LinAlg::SparseMatrix sparse_copy(*sparse, Core::LinAlg::Copy);
+  Core::LinAlg::SparseMatrix sparse_copy(*sparse, Core::LinAlg::DataAccess::Copy);
 
 
   const int zeilennr = -1;
@@ -1332,7 +1332,7 @@ void PoroElastScaTra::PoroScatraMono::fd_check()
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> stiff_approx_sparse = nullptr;
   stiff_approx_sparse =
-      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::Copy);
+      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::DataAccess::Copy);
 
   stiff_approx_sparse->add(sparse_copy, false, -1.0, 1.0);
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
@@ -436,13 +436,13 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::setup_system_matrix(
   k_ff->un_complete();
 
   // assign structure part to the Poroelasticity matrix
-  mat.assign(0, 0, Core::LinAlg::View, *k_ss);
+  mat.assign(0, 0, Core::LinAlg::DataAccess::View, *k_ss);
   // assign coupling part to the Poroelasticity matrix
-  mat.assign(0, 1, Core::LinAlg::View, *k_sf);
+  mat.assign(0, 1, Core::LinAlg::DataAccess::View, *k_sf);
   // assign fluid part to the poroelasticity matrix
-  mat.assign(1, 1, Core::LinAlg::View, *k_ff);
+  mat.assign(1, 1, Core::LinAlg::DataAccess::View, *k_ff);
   // assign coupling part to the Poroelasticity matrix
-  mat.assign(1, 0, Core::LinAlg::View, *k_fs);
+  mat.assign(1, 0, Core::LinAlg::DataAccess::View, *k_fs);
 
   /*----------------------------------------------------------------------*/
   // done. make sure all blocks are filled.
@@ -1058,7 +1058,7 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::poro_fd_check()
   Core::LinAlg::Vector<double> rhs_copy(*dof_row_map(), true);
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> sparse = systemmatrix_->merge();
-  Core::LinAlg::SparseMatrix sparse_copy(sparse->epetra_matrix(), Core::LinAlg::Copy);
+  Core::LinAlg::SparseMatrix sparse_copy(sparse->epetra_matrix(), Core::LinAlg::DataAccess::Copy);
 
 
   const int zeilennr = -1;
@@ -1147,7 +1147,7 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::poro_fd_check()
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> stiff_approx_sparse = nullptr;
   stiff_approx_sparse =
-      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::Copy);
+      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::DataAccess::Copy);
 
   stiff_approx_sparse->add(sparse_copy, false, -1.0, 1.0);
 
@@ -1385,11 +1385,11 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWayArteryCoupling::setup_system_
   PoroMultiPhaseMonolithicTwoWay::setup_system_matrix(mat);
 
   // pure artery part
-  mat.assign(2, 2, Core::LinAlg::View, artery_porofluid_sysmat()->matrix(1, 1));
+  mat.assign(2, 2, Core::LinAlg::DataAccess::View, artery_porofluid_sysmat()->matrix(1, 1));
   // artery-porofluid part
-  mat.assign(2, 1, Core::LinAlg::View, artery_porofluid_sysmat()->matrix(1, 0));
+  mat.assign(2, 1, Core::LinAlg::DataAccess::View, artery_porofluid_sysmat()->matrix(1, 0));
   // porofluid-artery part
-  mat.assign(1, 2, Core::LinAlg::View, artery_porofluid_sysmat()->matrix(0, 1));
+  mat.assign(1, 2, Core::LinAlg::DataAccess::View, artery_porofluid_sysmat()->matrix(0, 1));
 
   return;
 }

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.cpp
@@ -226,7 +226,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_matrix(
   blockartery->complete();
 
   // inner artery dofs
-  sysmat->assign(1, 1, Core::LinAlg::View, blockartery->matrix(0, 0));
+  sysmat->assign(1, 1, Core::LinAlg::DataAccess::View, blockartery->matrix(0, 0));
 
   (*sibtransform_)(blockartery->full_row_map(), blockartery->full_col_map(),
       blockartery->matrix(0, 1), 1.0, Coupling::Adapter::CouplingSlaveConverter(*artcontfieldcoup_),
@@ -240,7 +240,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_matrix(
       Coupling::Adapter::CouplingSlaveConverter(*artcontfieldcoup_), *sysmat_cont, true, true);
 
   // continuous field
-  sysmat->assign(0, 0, Core::LinAlg::View, *sysmat_cont);
+  sysmat->assign(0, 0, Core::LinAlg::DataAccess::View, *sysmat_cont);
   // complete
   sysmat->complete();
 }

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
@@ -225,7 +225,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_syst
   sysmat.matrix(1, 1).apply_dirichlet((dbcmap_art_with_collapsed), true);
   // Assign view to 3D system matrix (such that it now includes also contributions from coupling)
   // this is important! Monolithic algorithms use this matrix
-  sysmat_cont.assign(Core::LinAlg::View, sysmat.matrix(0, 0));
+  sysmat_cont.assign(Core::LinAlg::DataAccess::View, sysmat.matrix(0, 0));
 }
 
 /*----------------------------------------------------------------------*

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
@@ -435,11 +435,12 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::setup_system_ma
   // assign matrix block
   if (solve_structure_)
   {
-    systemmatrix_->assign(0, 0, Core::LinAlg::View, mat_pp->matrix(0, 0));
-    systemmatrix_->assign(0, 1, Core::LinAlg::View, mat_pp->matrix(0, 1));
-    systemmatrix_->assign(1, 0, Core::LinAlg::View, mat_pp->matrix(1, 0));
+    systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, mat_pp->matrix(0, 0));
+    systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, mat_pp->matrix(0, 1));
+    systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, mat_pp->matrix(1, 0));
   }
-  systemmatrix_->assign(struct_offset_, struct_offset_, Core::LinAlg::View, mat_pp->matrix(1, 1));
+  systemmatrix_->assign(
+      struct_offset_, struct_offset_, Core::LinAlg::DataAccess::View, mat_pp->matrix(1, 1));
 
   //----------------------------------------------------------------------
   // 2nd diagonal block (lower right): scatra weighting - scatra solution
@@ -453,7 +454,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::setup_system_ma
   mat_ss->un_complete();
 
   // assign matrix block
-  systemmatrix_->assign(struct_offset_ + 1, struct_offset_ + 1, Core::LinAlg::View, *mat_ss);
+  systemmatrix_->assign(
+      struct_offset_ + 1, struct_offset_ + 1, Core::LinAlg::DataAccess::View, *mat_ss);
 
   // complete scatra block matrix
   systemmatrix_->complete();
@@ -480,8 +482,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::setup_system_ma
   k_pfs->un_complete();
 
   // assign matrix block
-  // systemmatrix_->Assign(0,2,Core::LinAlg::View,*(k_pss_)); --> zero
-  systemmatrix_->assign(struct_offset_, struct_offset_ + 1, Core::LinAlg::View, *(k_pfs));
+  // systemmatrix_->Assign(0,2,Core::LinAlg::DataAccess::View,*(k_pss_)); --> zero
+  systemmatrix_->assign(
+      struct_offset_, struct_offset_ + 1, Core::LinAlg::DataAccess::View, *(k_pfs));
 
   //----------------------------------------------------------------------
   // 2nd off-diagonal block k_sp (lower left): scatra weighting - poro solution
@@ -513,8 +516,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::setup_system_ma
   k_spf->un_complete();
 
   // assign matrix block
-  if (solve_structure_) systemmatrix_->assign(2, 0, Core::LinAlg::View, *(k_sps));
-  systemmatrix_->assign(struct_offset_ + 1, struct_offset_, Core::LinAlg::View, *(k_spf));
+  if (solve_structure_) systemmatrix_->assign(2, 0, Core::LinAlg::DataAccess::View, *(k_sps));
+  systemmatrix_->assign(
+      struct_offset_ + 1, struct_offset_, Core::LinAlg::DataAccess::View, *(k_spf));
 
   // complete block matrix
   systemmatrix_->complete();
@@ -1093,7 +1097,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::poro_multi_phas
   Core::LinAlg::Vector<double> rhs_copy(*dof_row_map(), true);
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> sparse = systemmatrix_->merge();
-  Core::LinAlg::SparseMatrix sparse_copy(*sparse, Core::LinAlg::Copy);
+  Core::LinAlg::SparseMatrix sparse_copy(*sparse, Core::LinAlg::DataAccess::Copy);
 
 
   const int zeilennr = -1;
@@ -1180,7 +1184,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::poro_multi_phas
 
   std::shared_ptr<Core::LinAlg::SparseMatrix> stiff_approx_sparse = nullptr;
   stiff_approx_sparse =
-      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::Copy);
+      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_approx, Core::LinAlg::DataAccess::Copy);
 
   stiff_approx_sparse->add(sparse_copy, false, -1.0, 1.0);
 
@@ -1471,23 +1475,23 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling::s
 
   // artery part
   systemmatrix_->assign(
-      struct_offset_ + 2, struct_offset_ + 2, Core::LinAlg::View, mat_pp->matrix(2, 2));
+      struct_offset_ + 2, struct_offset_ + 2, Core::LinAlg::DataAccess::View, mat_pp->matrix(2, 2));
   // artery-porofluid part
   systemmatrix_->assign(
-      struct_offset_ + 2, struct_offset_, Core::LinAlg::View, mat_pp->matrix(2, 1));
+      struct_offset_ + 2, struct_offset_, Core::LinAlg::DataAccess::View, mat_pp->matrix(2, 1));
   // porofluid-artery part
   systemmatrix_->assign(
-      struct_offset_, struct_offset_ + 2, Core::LinAlg::View, mat_pp->matrix(1, 2));
+      struct_offset_, struct_offset_ + 2, Core::LinAlg::DataAccess::View, mat_pp->matrix(1, 2));
 
   // -------------------------------------------------------------------------arteryscatra-scatra
   // arteryscatra part
-  systemmatrix_->assign(struct_offset_ + 3, struct_offset_ + 3, Core::LinAlg::View,
+  systemmatrix_->assign(struct_offset_ + 3, struct_offset_ + 3, Core::LinAlg::DataAccess::View,
       scatramsht_->combined_system_matrix()->matrix(1, 1));
   // scatra-arteryscatra part
-  systemmatrix_->assign(struct_offset_ + 1, struct_offset_ + 3, Core::LinAlg::View,
+  systemmatrix_->assign(struct_offset_ + 1, struct_offset_ + 3, Core::LinAlg::DataAccess::View,
       scatramsht_->combined_system_matrix()->matrix(0, 1));
   // arteryscatra-scatra part
-  systemmatrix_->assign(struct_offset_ + 3, struct_offset_ + 1, Core::LinAlg::View,
+  systemmatrix_->assign(struct_offset_ + 3, struct_offset_ + 1, Core::LinAlg::DataAccess::View,
       scatramsht_->combined_system_matrix()->matrix(1, 0));
 
   if (nodal_coupl_inactive_)
@@ -1504,7 +1508,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling::s
     k_asa->apply_dirichlet(*scatramsht_->art_scatra_field()->dirich_maps()->cond_map(), false);
 
     // arteryscatra-scatra part
-    systemmatrix_->assign(struct_offset_ + 3, struct_offset_ + 2, Core::LinAlg::View, *k_asa);
+    systemmatrix_->assign(
+        struct_offset_ + 3, struct_offset_ + 2, Core::LinAlg::DataAccess::View, *k_asa);
   }
 
   systemmatrix_->complete();

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -3733,7 +3733,7 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
           // multipliers
           Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>
               extendedsystemmatrix(*extendedmaps_, *extendedmaps_);
-          extendedsystemmatrix.assign(0, 0, Core::LinAlg::View, *sparsematrix);
+          extendedsystemmatrix.assign(0, 0, Core::LinAlg::DataAccess::View, *sparsematrix);
           if (lmside_ == Inpar::S2I::side_slave)
           {
             extendedsystemmatrix.matrix(0, 1).add(*D_, true, 1., 0.);
@@ -3809,12 +3809,13 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
 
               // assemble extended system matrix including rows and columns associated with
               // scatra-scatra interface layer thickness variables
-              extendedsystemmatrix_->assign(0, 0, Core::LinAlg::View, *sparsematrix);
-              extendedsystemmatrix_->assign(0, 1, Core::LinAlg::View,
+              extendedsystemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *sparsematrix);
+              extendedsystemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View,
                   *std::dynamic_pointer_cast<const Core::LinAlg::SparseMatrix>(scatragrowthblock_));
-              extendedsystemmatrix_->assign(1, 0, Core::LinAlg::View,
+              extendedsystemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View,
                   *std::dynamic_pointer_cast<const Core::LinAlg::SparseMatrix>(growthscatrablock_));
-              extendedsystemmatrix_->assign(1, 1, Core::LinAlg::View, *growthgrowthblock_);
+              extendedsystemmatrix_->assign(
+                  1, 1, Core::LinAlg::DataAccess::View, *growthgrowthblock_);
 
               break;
             }
@@ -3836,19 +3837,19 @@ void ScaTra::MeshtyingStrategyS2I::solve(const std::shared_ptr<Core::LinAlg::Sol
               for (int iblock = 0; iblock < nblockmaps; ++iblock)
               {
                 for (int jblock = 0; jblock < nblockmaps; ++jblock)
-                  extendedsystemmatrix_->assign(iblock, jblock, Core::LinAlg::View,
+                  extendedsystemmatrix_->assign(iblock, jblock, Core::LinAlg::DataAccess::View,
                       blocksparsematrix->matrix(iblock, jblock));
-                extendedsystemmatrix_->assign(iblock, nblockmaps, Core::LinAlg::View,
+                extendedsystemmatrix_->assign(iblock, nblockmaps, Core::LinAlg::DataAccess::View,
                     std::dynamic_pointer_cast<const Core::LinAlg::BlockSparseMatrixBase>(
                         scatragrowthblock_)
                         ->matrix(iblock, 0));
-                extendedsystemmatrix_->assign(nblockmaps, iblock, Core::LinAlg::View,
+                extendedsystemmatrix_->assign(nblockmaps, iblock, Core::LinAlg::DataAccess::View,
                     std::dynamic_pointer_cast<const Core::LinAlg::BlockSparseMatrixBase>(
                         growthscatrablock_)
                         ->matrix(0, iblock));
               }
               extendedsystemmatrix_->assign(
-                  nblockmaps, nblockmaps, Core::LinAlg::View, *growthgrowthblock_);
+                  nblockmaps, nblockmaps, Core::LinAlg::DataAccess::View, *growthgrowthblock_);
 
               break;
             }

--- a/src/ssi/4C_ssi_str_model_evaluator_partitioned.cpp
+++ b/src/ssi/4C_ssi_str_model_evaluator_partitioned.cpp
@@ -107,7 +107,7 @@ bool Solid::ModelEvaluator::PartitionedSSI::assemble_jacobian(
     jac_new.apply_dirichlet(*slavemaps);
 
     // replace old Jacobian by new one
-    jac_sparse.assign(Core::LinAlg::View, jac_new);
+    jac_sparse.assign(Core::LinAlg::DataAccess::View, jac_new);
   }
 
   return true;

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -797,7 +797,7 @@ void STI::Monolithic::assemble_mat_and_rhs()
           for (int iblock = 0; iblock < nblockmapsscatra; ++iblock)
           {
             for (int jblock = 0; jblock < nblockmapsscatra; ++jblock)
-              blocksystemmatrix->assign(iblock, jblock, Core::LinAlg::View,
+              blocksystemmatrix->assign(iblock, jblock, Core::LinAlg::DataAccess::View,
                   scatra_field()->block_system_matrix()->matrix(iblock, jblock));
 
             // perform second condensation before assigning matrix blocks
@@ -864,12 +864,12 @@ void STI::Monolithic::assemble_mat_and_rhs()
             // assign matrix blocks directly
             else
             {
-              blocksystemmatrix->assign(iblock, nblockmapsscatra, Core::LinAlg::View,
+              blocksystemmatrix->assign(iblock, nblockmapsscatra, Core::LinAlg::DataAccess::View,
                   std::dynamic_pointer_cast<const Core::LinAlg::BlockSparseMatrixBase>(
                       scatrathermo_domain_interface)
                       ->matrix(iblock, 0));
 
-              blocksystemmatrix->assign(nblockmapsscatra, iblock, Core::LinAlg::View,
+              blocksystemmatrix->assign(nblockmapsscatra, iblock, Core::LinAlg::DataAccess::View,
                   std::dynamic_pointer_cast<const Core::LinAlg::BlockSparseMatrixBase>(
                       thermoscatra_domain_interface)
                       ->matrix(0, iblock));
@@ -928,8 +928,8 @@ void STI::Monolithic::assemble_mat_and_rhs()
           // assign thermo-thermo matrix block directly
           else
           {
-            blocksystemmatrix->assign(nblockmapsscatra, nblockmapsscatra, Core::LinAlg::View,
-                *thermo_field()->system_matrix());
+            blocksystemmatrix->assign(nblockmapsscatra, nblockmapsscatra,
+                Core::LinAlg::DataAccess::View, *thermo_field()->system_matrix());
           }
 
           break;
@@ -938,7 +938,8 @@ void STI::Monolithic::assemble_mat_and_rhs()
         case Core::LinAlg::MatrixType::sparse:
         {
           // construct global system matrix by assigning matrix blocks
-          blocksystemmatrix->assign(0, 0, Core::LinAlg::View, *scatra_field()->system_matrix());
+          blocksystemmatrix->assign(
+              0, 0, Core::LinAlg::DataAccess::View, *scatra_field()->system_matrix());
 
           // perform second condensation before assigning matrix blocks
           if (condensationthermo_)
@@ -1032,13 +1033,14 @@ void STI::Monolithic::assemble_mat_and_rhs()
           // assign matrix blocks directly
           else
           {
-            blocksystemmatrix->assign(0, 1, Core::LinAlg::View,
+            blocksystemmatrix->assign(0, 1, Core::LinAlg::DataAccess::View,
                 *std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(
                     scatrathermo_domain_interface));
-            blocksystemmatrix->assign(1, 0, Core::LinAlg::View,
+            blocksystemmatrix->assign(1, 0, Core::LinAlg::DataAccess::View,
                 *std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(
                     thermoscatra_domain_interface));
-            blocksystemmatrix->assign(1, 1, Core::LinAlg::View, *thermo_field()->system_matrix());
+            blocksystemmatrix->assign(
+                1, 1, Core::LinAlg::DataAccess::View, *thermo_field()->system_matrix());
           }
 
           break;

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -1034,7 +1034,8 @@ void Solid::TimInt::determine_mass_damp_consist_accel()
   // constant matrix mass_ later on. This is necessary since we need the original mass matrix mass_
   // (without blanked rows) on the Dirichlet DoFs in order to calculate correct reaction forces
   // (Christoph Meier)
-  mass = std::make_shared<Core::LinAlg::SparseMatrix>(*mass_matrix(), Core::LinAlg::Copy);
+  mass =
+      std::make_shared<Core::LinAlg::SparseMatrix>(*mass_matrix(), Core::LinAlg::DataAccess::Copy);
 
   /* calculate consistent initial accelerations
    * WE MISS:

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
@@ -212,7 +212,7 @@ namespace Solid
           const Core::LinAlg::SparseMatrix& matrix, const Inpar::Solid::ModelType& mt,
           const MatBlockType& bt) const
       {
-        assign_model_block(jac, matrix, mt, bt, Core::LinAlg::View);
+        assign_model_block(jac, matrix, mt, bt, Core::LinAlg::DataAccess::View);
       };
       void assign_model_block(Core::LinAlg::SparseOperator& jac,
           const Core::LinAlg::SparseMatrix& matrix, const Inpar::Solid::ModelType& mt,

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
@@ -276,7 +276,7 @@ void Solid::Nln::LinSystem::StcScaling::scaleLinearSystem(Epetra_LinearProblem& 
   Epetra_CrsMatrix* stiffmat = dynamic_cast<Epetra_CrsMatrix*>(problem.GetMatrix());
   std::shared_ptr<Epetra_CrsMatrix> stiff_epetra = Core::Utils::shared_ptr_from_ref(*stiffmat);
   std::shared_ptr<Core::LinAlg::SparseMatrix> stiff_linalg =
-      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_epetra, Core::LinAlg::View);
+      std::make_shared<Core::LinAlg::SparseMatrix>(stiff_epetra, Core::LinAlg::DataAccess::View);
 
   // get rhs
   Core::LinAlg::VectorView rhs_view(*dynamic_cast<Epetra_Vector*>(problem.GetRHS()));

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -1110,7 +1110,7 @@ void TSI::Monolithic::setup_system_matrix()
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_ss = structure_field()->system_matrix();
 
   // assign structure part to the TSI matrix
-  systemmatrix_->assign(0, 0, Core::LinAlg::View, *k_ss);
+  systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *k_ss);
 
   /*----------------------------------------------------------------------*/
   // structural block k_st (3nxn)
@@ -1130,7 +1130,7 @@ void TSI::Monolithic::setup_system_matrix()
   k_st_->un_complete();
 
   // assign thermo part to the TSI matrix
-  systemmatrix_->assign(0, 1, Core::LinAlg::View, *(k_st_));
+  systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, *(k_st_));
 
   /*----------------------------------------------------------------------*/
   // pure thermo part k_tt (nxn)
@@ -1143,7 +1143,7 @@ void TSI::Monolithic::setup_system_matrix()
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_tt = thermo_field()->system_matrix();
 
   // assign thermo part to the TSI matrix
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, *(k_tt));
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *(k_tt));
 
   /*----------------------------------------------------------------------*/
   // thermo part k_ts (nx3n)
@@ -1162,7 +1162,7 @@ void TSI::Monolithic::setup_system_matrix()
 
   if (!matchinggrid_) k_ts_ = volcoupl_->apply_matrix_mapping21(*k_ts_);
 
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, *k_ts_);
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *k_ts_);
 
   /*----------------------------------------------------------------------*/
   // done. make sure all blocks are filled.
@@ -2836,7 +2836,7 @@ void TSI::Monolithic::apply_dbc()
 {
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_ss =
       std::make_shared<Core::LinAlg::SparseMatrix>(systemmatrix_->matrix(0, 0).epetra_matrix(),
-          Core::LinAlg::Copy, true, false, Core::LinAlg::SparseMatrix::CRS_MATRIX);
+          Core::LinAlg::DataAccess::Copy, true, false, Core::LinAlg::SparseMatrix::CRS_MATRIX);
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_st =
       std::make_shared<Core::LinAlg::SparseMatrix>(systemmatrix_->matrix(0, 1));
   std::shared_ptr<Core::LinAlg::SparseMatrix> k_ts =
@@ -2868,10 +2868,10 @@ void TSI::Monolithic::apply_dbc()
 
 
   systemmatrix_->un_complete();
-  systemmatrix_->assign(0, 0, Core::LinAlg::View, *k_ss);
-  systemmatrix_->assign(0, 1, Core::LinAlg::View, *k_st);
-  systemmatrix_->assign(1, 0, Core::LinAlg::View, *k_ts);
-  systemmatrix_->assign(1, 1, Core::LinAlg::View, *k_tt);
+  systemmatrix_->assign(0, 0, Core::LinAlg::DataAccess::View, *k_ss);
+  systemmatrix_->assign(0, 1, Core::LinAlg::DataAccess::View, *k_st);
+  systemmatrix_->assign(1, 0, Core::LinAlg::DataAccess::View, *k_ts);
+  systemmatrix_->assign(1, 1, Core::LinAlg::DataAccess::View, *k_tt);
   systemmatrix_->complete();
 
 


### PR DESCRIPTION
Before this change, the `Copy` and `View` Identifiers were floating around in the `LinAlg` namespace. I might want to use the name `View` for a general helper mentioned here https://github.com/4C-multiphysics/4C/pull/554#discussion_r2009062933