### PR TITLE
Create LinAlg::View for our wrappers

### DIFF
--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -3767,12 +3767,12 @@ void Wear::LagrangeStrategyWear::build_saddle_point_system(
     // ***************************************************************************************************
     // export inactive wear rhs
     Core::LinAlg::Vector<double> WearCondRhsexpM(*gmdofnrowmap_);
-    Core::LinAlg::VectorView wear_cond_rhs_m_view(*wear_cond_rhs_m_);
+    Core::LinAlg::View wear_cond_rhs_m_view(*wear_cond_rhs_m_);
     Core::LinAlg::export_to(wear_cond_rhs_m_view, WearCondRhsexpM);
 
     // export inactive wear rhs
     Core::LinAlg::Vector<double> inactiveWearRhsexpM(*gmdofnrowmap_);
-    Core::LinAlg::VectorView inactive_wear_rhs_m_view(*inactive_wear_rhs_m_);
+    Core::LinAlg::View inactive_wear_rhs_m_view(*inactive_wear_rhs_m_);
     Core::LinAlg::export_to(inactive_wear_rhs_m_view, inactiveWearRhsexpM);
 
     wearrhsM->update(1.0, WearCondRhsexpM, 1.0);

--- a/src/core/fem/tests/utils/4C_fem_general_element_dof_matrix_test.cpp
+++ b/src/core/fem/tests/utils/4C_fem_general_element_dof_matrix_test.cpp
@@ -45,7 +45,7 @@ namespace
     expect_dof_matrix_equal(dof_matrix);
   }
 
-  TEST(ElementDofMatrixTest, TestVectorView)
+  TEST(ElementDofMatrixTest, TestView)
   {
     const auto vec = get_dof_array<std::vector<double>>();
     const Core::LinAlg::Matrix<2, 4> dof_matrix =
@@ -98,7 +98,7 @@ namespace
     }
   }
 
-  TEST(ElementDofMatrixTest, GetVectorView)
+  TEST(ElementDofMatrixTest, GetView)
   {
     const auto arr = get_dof_array<std::array<double, 8>>();
     const Core::LinAlg::Matrix<2, 4> dof_matrix =

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -269,7 +269,7 @@ int Core::LinAlg::BlockSparseMatrixBase::Apply(
               "failed to apply vector to matrix block ({},{}): err={}", rblock, cblock, err);
         rowresult->Update(1.0, *rowy, 1.0);
       }
-      VectorView Y_view(Y);
+      View Y_view(Y);
       rangemaps_.insert_vector(*rowresult, rblock, Y_view);
     }
   }
@@ -290,7 +290,7 @@ int Core::LinAlg::BlockSparseMatrixBase::Apply(
         if (err != 0) FOUR_C_THROW("failed to apply vector to matrix: err={}", err);
         rowresult->Update(1.0, *rowy, 1.0);
       }
-      VectorView Y_view(Y);
+      View Y_view(Y);
       rangemaps_.insert_vector(*rowresult, rblock, Y_view);
     }
   }

--- a/src/core/linalg/src/sparse/4C_linalg_projected_precond.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_projected_precond.cpp
@@ -43,7 +43,7 @@ int Core::LinAlg::LinalgPrecondOperator::ApplyInverse(
   // of problem
   if (project_)
   {
-    VectorView Y_view(Y);
+    View Y_view(Y);
     projector_->apply_p(Y_view);
   }
 

--- a/src/core/linalg/src/sparse/4C_linalg_view.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_view.hpp
@@ -1,0 +1,102 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_VIEW_HPP
+#define FOUR_C_LINALG_VIEW_HPP
+
+
+#include "4C_config.hpp"
+
+#include <boost/proto/detail/template_arity.hpp>
+
+#include <memory>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  /**
+   * A helper struct to easily specify that one of our linear algebra classes is a wrapper for
+   * another class. This struct should be specialized for each of our linear algebra classes and
+   * contain a single typedef `type` for the class that is wrapped.
+   */
+  template <typename T>
+  struct WrapperFor
+  {
+    static_assert("You need to specialize this struct for the wrapper class.");
+  };
+
+  namespace Internal
+  {
+    /**
+     * Helper type to work with const and non-const references.
+     */
+    template <typename T>
+    using WrapperForWithQualifiers = std::conditional_t<std::is_const_v<std::remove_reference_t<T>>,
+        const typename WrapperFor<std::decay_t<T>>::type,
+        typename WrapperFor<std::decay_t<T>>::type>;
+  }  // namespace Internal
+
+  /**
+   * Concept for a SourceType which can be viewed as a WrapperType. The WrapperType must have a
+   * static method create_view which takes a SourceType and returns a shared pointer to a
+   * WrapperType.
+   */
+  template <typename SourceType>
+  concept Viewable = requires(SourceType source) {
+    {
+      Internal::WrapperForWithQualifiers<SourceType>::create_view(source)
+    } -> std::same_as<std::shared_ptr<Internal::WrapperForWithQualifiers<SourceType>>>;
+  };
+
+  /**
+   * Temporary helper class for migration from raw Trilinos classes to our own wrappers. Views one
+   * of the Trilinos linear algebra types as one of ours. It is the users responsibility to ensure
+   * that the viewed source object outlives the view.
+   */
+  template <typename WrapperType>
+  class View
+  {
+   public:
+    /**
+     * Construct a view from a source object.
+     */
+    template <Viewable SourceType>
+    View(SourceType& source) : view_(WrapperType::create_view(source))
+    {
+    }
+
+    // Make the class hard to misuse and disallow copy and move.
+    View(const View& other) = delete;
+    View& operator=(const View& other) = delete;
+    View(View&& other) = delete;
+    View& operator=(View&& other) = delete;
+    ~View() = default;
+
+    //! Allow implicit conversion to the WrapperType for easy use in new interfaces.
+    //! The view should behave like an object of the WrapperType.
+    operator WrapperType&() { return *view_; }
+
+    //! For easier interoperability with existing code, allow access to the shared pointer.
+    std::shared_ptr<WrapperType>& get_non_owning_shared_ptr_ref() { return view_; }
+
+   private:
+    //! Source content wrapped in our own type.
+    std::shared_ptr<WrapperType> view_;
+  };
+
+
+  // Deduction guide
+  template <typename SourceType>
+  View(SourceType&) -> View<Internal::WrapperForWithQualifiers<SourceType>>;
+
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+
+#endif

--- a/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
@@ -157,7 +157,7 @@ namespace
     a.PutScalar(1.0);
     // Scope in which a is modified by the view
     {
-      Core::LinAlg::VectorView a_view(a);
+      Core::LinAlg::View a_view(a);
 
       double norm = 0.0;
       ((Core::LinAlg::Vector<double>&)a_view).norm_2(&norm);
@@ -166,7 +166,7 @@ namespace
       ((Core::LinAlg::Vector<double>&)a_view).put_scalar(2.0);
     }
     const Epetra_Vector& a_const = a;
-    Core::LinAlg::VectorView a_view_const(a_const);
+    Core::LinAlg::View a_view_const(a_const);
     // Change must be reflected in a
     double norm = 0.0;
     static_cast<const Core::LinAlg::Vector<double>&>(a_view_const).norm_2(&norm);
@@ -272,7 +272,7 @@ namespace
     {
       const auto put_scalar = [](Core::LinAlg::MultiVector<double>& v, double s)
       { v.PutScalar(s); };
-      Core::LinAlg::VectorView view_mv2((Epetra_MultiVector&)mv2);
+      Core::LinAlg::View view_mv2((Epetra_MultiVector&)mv2);
       put_scalar(view_mv2, 4.0);
     }
     EXPECT_EQ(means_multi_vector(mv), (std::vector{1., 4., 1.}));

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -357,7 +357,7 @@ int Core::LinearSolver::AmGnxnOperator::ApplyInverse(
 
   v_->solve(Xbl, Ybl, true);
 
-  Core::LinAlg::VectorView Y_view(Y);
+  Core::LinAlg::View Y_view(Y);
   for (int i = 0; i < NumBlocks; i++) domain_ex.insert_vector(*(Ybl.get_vector(i)), i, Y_view);
 
   return 0;
@@ -475,7 +475,7 @@ int Core::LinearSolver::BlockSmootherOperator::ApplyInverse(
 
   s_->solve(Xbl, Ybl, true);
 
-  Core::LinAlg::VectorView Y_view(Y);
+  Core::LinAlg::View Y_view(Y);
   for (int i = 0; i < NumBlocks; i++) domain_ex.insert_vector(*(Ybl.get_vector(i)), i, Y_view);
 
 

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -618,8 +618,8 @@ std::shared_ptr<Epetra_FEVector> Coupling::Adapter::Coupling::master_to_slave(
   std::shared_ptr<Epetra_FEVector> sv =
       std::make_shared<Epetra_FEVector>(*slavedofmap_, mv.NumVectors());
 
-  Core::LinAlg::VectorView sv_view(*sv);
-  Core::LinAlg::VectorView mv_view(mv);
+  Core::LinAlg::View sv_view(*sv);
+  Core::LinAlg::View mv_view(mv);
   master_to_slave(mv_view, sv_view);
 
   return sv;
@@ -634,8 +634,8 @@ std::shared_ptr<Epetra_FEVector> Coupling::Adapter::Coupling::slave_to_master(
   std::shared_ptr<Epetra_FEVector> mv =
       std::make_shared<Epetra_FEVector>(*masterdofmap_, sv.NumVectors());
 
-  Core::LinAlg::VectorView sv_view(sv);
-  Core::LinAlg::VectorView mv_view(*mv);
+  Core::LinAlg::View sv_view(sv);
+  Core::LinAlg::View mv_view(*mv);
   slave_to_master(sv_view, mv_view);
 
   return mv;

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -533,7 +533,7 @@ void EHL::Base::setup_unprojectable_dbc()
 
   std::shared_ptr<Core::LinAlg::Vector<double>> exp =
       std::make_shared<Core::LinAlg::Vector<double>>(*ada_strDisp_to_lubPres_->master_dof_map());
-  Core::LinAlg::VectorView inf_gap_toggle_view(inf_gap_toggle);
+  Core::LinAlg::View inf_gap_toggle_view(inf_gap_toggle);
   Core::LinAlg::export_to(inf_gap_toggle_view, *exp);
   inf_gap_toggle_lub_ = ada_strDisp_to_lubPres_->master_to_slave(*exp);
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
@@ -28,7 +28,7 @@ void NOX::FSI::Group::capture_system_state()
 {
   // we know we already have the first linear system calculated
 
-  Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+  Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
   mfsi_.setup_rhs(rhs_view, true);
   mfsi_.setup_system_matrix();
 
@@ -65,7 +65,7 @@ void NOX::FSI::Group::capture_system_state()
   {
     if (not isValidRHS)
     {
-      Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+      Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
       mfsi_.setup_rhs(rhs_view);
       isValidRHS = true;
     }
@@ -78,11 +78,11 @@ void NOX::FSI::Group::capture_system_state()
  *----------------------------------------------------------------------*/
 ::NOX::Abstract::Group::ReturnType NOX::FSI::Group::computeNewton(Teuchos::ParameterList& p)
 {
-  Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+  Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
   mfsi_.scale_system(rhs_view);
 
   ::NOX::Abstract::Group::ReturnType status = ::NOX::Epetra::Group::computeNewton(p);
-  Core::LinAlg::VectorView newton_vector_view(NewtonVector.getEpetraVector());
+  Core::LinAlg::View newton_vector_view(NewtonVector.getEpetraVector());
 
   mfsi_.unscale_solution(newton_vector_view, rhs_view);
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -123,7 +123,7 @@ bool NOX::FSI::LinearSystem::applyJacobianInverse(
 
   std::shared_ptr<Core::LinAlg::Vector<double>> fres =
       std::make_shared<Core::LinAlg::Vector<double>>(input.getEpetraVector());
-  Core::LinAlg::VectorView disi = Core::LinAlg::VectorView(result.getEpetraVector());
+  Core::LinAlg::View disi = Core::LinAlg::View(result.getEpetraVector());
 
   // get the hopefully adaptive linear solver convergence tolerance
   solver_->params()
@@ -133,7 +133,7 @@ bool NOX::FSI::LinearSystem::applyJacobianInverse(
   Core::LinAlg::SolverParams solver_params;
   solver_params.refactor = true;
   solver_params.reset = callcount_ == 0;
-  solver_->solve(jac_ptr_, disi.get_non_owning_rcp_ref(), fres, solver_params);
+  solver_->solve(jac_ptr_, disi.get_non_owning_shared_ptr_ref(), fres, solver_params);
 
   callcount_ += 1;
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
@@ -113,7 +113,7 @@ void NOX::Nln::Group::computeX(
   skipUpdateX_ = false;
 
   // Some call further down will perform a const-cast on d. fixme
-  Core::LinAlg::VectorView d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
+  Core::LinAlg::View d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
   prePostOperatorPtr_->run_pre_compute_x(grp, d_view, step, *this);
 
 
@@ -154,7 +154,7 @@ void NOX::Nln::Group::set_skip_update_x(bool skipUpdateX) { skipUpdateX_ = skipU
 ::NOX::Abstract::Group::ReturnType NOX::Nln::Group::computeF()
 {
   {
-    Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+    Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
     prePostOperatorPtr_->run_pre_compute_f(rhs_view, *this);
   }
 
@@ -171,7 +171,7 @@ void NOX::Nln::Group::set_skip_update_x(bool skipUpdateX) { skipUpdateX_ = skipU
   isValidRHS = true;
 
   {
-    Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+    Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
     prePostOperatorPtr_->run_post_compute_f(rhs_view, *this);
   }
   return ::NOX::Abstract::Group::Ok;
@@ -194,7 +194,7 @@ void NOX::Nln::Group::set_skip_update_x(bool skipUpdateX) { skipUpdateX_ = skipU
   {
     isValidRHS = false;
     {
-      Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+      Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
       prePostOperatorPtr_->run_pre_compute_f(rhs_view, *this);
     }
     bool status = false;
@@ -212,7 +212,7 @@ void NOX::Nln::Group::set_skip_update_x(bool skipUpdateX) { skipUpdateX_ = skipU
 
     ret = ::NOX::Abstract::Group::Ok;
     {
-      Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+      Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
       prePostOperatorPtr_->run_post_compute_f(rhs_view, *this);
     }
   }
@@ -220,7 +220,7 @@ void NOX::Nln::Group::set_skip_update_x(bool skipUpdateX) { skipUpdateX_ = skipU
   else
   {
     {
-      Core::LinAlg::VectorView rhs_view(RHSVector.getEpetraVector());
+      Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
       prePostOperatorPtr_->run_pre_compute_f(rhs_view, *this);
     }
     ret = ::NOX::Abstract::Group::Ok;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -299,8 +299,8 @@ bool NOX::Nln::LinearSystem::applyJacobianInverse(Teuchos::ParameterList& linear
   Epetra_LinearProblem linProblem;
   int linsol_status;
   {
-    Core::LinAlg::VectorView result_view(result.getEpetraVector());
-    Core::LinAlg::VectorView nonConstInput_view(nonConstInput.getEpetraVector());
+    Core::LinAlg::View result_view(result.getEpetraVector());
+    Core::LinAlg::View nonConstInput_view(nonConstInput.getEpetraVector());
     set_linear_problem_for_solve(linProblem, jacobian(), result_view, nonConstInput_view);
 
     // ************* Begin linear system scaling *****************
@@ -331,11 +331,11 @@ bool NOX::Nln::LinearSystem::applyJacobianInverse(Teuchos::ParameterList& linear
 
     auto matrix = Core::Utils::shared_ptr_from_ref(*linProblem.GetOperator());
 
-    Core::LinAlg::VectorView x(*linProblem.GetLHS());
-    Core::LinAlg::VectorView b(*linProblem.GetRHS());
+    Core::LinAlg::View x(*linProblem.GetLHS());
+    Core::LinAlg::View b(*linProblem.GetRHS());
 
-    linsol_status = currSolver->solve_with_multi_vector(
-        matrix, x.get_non_owning_rcp_ref(), b.get_non_owning_rcp_ref(), solver_params);
+    linsol_status = currSolver->solve_with_multi_vector(matrix, x.get_non_owning_shared_ptr_ref(),
+        b.get_non_owning_shared_ptr_ref(), solver_params);
 
     if (linsol_status)
     {
@@ -390,7 +390,7 @@ bool NOX::Nln::LinearSystem::compute_f_and_jacobian(
     const ::NOX::Epetra::Vector& x, ::NOX::Epetra::Vector& rhs)
 {
   {
-    Core::LinAlg::VectorView rhs_view(rhs.getEpetraVector());
+    Core::LinAlg::View rhs_view(rhs.getEpetraVector());
     prePostOperatorPtr_->run_pre_compute_f_and_jacobian(
         rhs_view, jacobian(), Core::LinAlg::Vector<double>(x.getEpetraVector()), *this);
   }
@@ -400,7 +400,7 @@ bool NOX::Nln::LinearSystem::compute_f_and_jacobian(
           ->compute_f_and_jacobian(x.getEpetraVector(), rhs.getEpetraVector(), jacobian());
 
   {
-    Core::LinAlg::VectorView rhs_view(rhs.getEpetraVector());
+    Core::LinAlg::View rhs_view(rhs.getEpetraVector());
     prePostOperatorPtr_->run_post_compute_f_and_jacobian(
         rhs_view, jacobian(), Core::LinAlg::Vector<double>(x.getEpetraVector()), *this);
   }
@@ -413,7 +413,7 @@ bool NOX::Nln::LinearSystem::compute_correction_system(const enum CorrectionType
     const ::NOX::Abstract::Group& grp, const ::NOX::Epetra::Vector& x, ::NOX::Epetra::Vector& rhs)
 {
   {
-    Core::LinAlg::VectorView rhs_view(rhs.getEpetraVector());
+    Core::LinAlg::View rhs_view(rhs.getEpetraVector());
     prePostOperatorPtr_->run_pre_compute_f_and_jacobian(
         rhs_view, jacobian(), Core::LinAlg::Vector<double>(x.getEpetraVector()), *this);
   }
@@ -424,7 +424,7 @@ bool NOX::Nln::LinearSystem::compute_correction_system(const enum CorrectionType
               type, grp, x.getEpetraVector(), rhs.getEpetraVector(), jacobian());
 
   {
-    Core::LinAlg::VectorView rhs_view(rhs.getEpetraVector());
+    Core::LinAlg::View rhs_view(rhs.getEpetraVector());
     prePostOperatorPtr_->run_post_compute_f_and_jacobian(
         rhs_view, jacobian(), Core::LinAlg::Vector<double>(x.getEpetraVector()), *this);
   }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
@@ -66,7 +66,7 @@ void NOX::Nln::SINGLESTEP::Group::computeX(
 void NOX::Nln::SINGLESTEP::Group::computeX(
     const NOX::Nln::SINGLESTEP::Group& grp, const ::NOX::Epetra::Vector& d, double step)
 {
-  Core::LinAlg::VectorView d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
+  Core::LinAlg::View d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
   prePostOperatorPtr_->run_pre_compute_x(grp, d_view, step, *this);
 
   if (isPreconditioner()) sharedLinearSystem.getObject(this)->destroyPreconditioner();

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
@@ -928,7 +928,7 @@ NOX::Nln::GROUP::PrePostOp::PseudoTransient::eval_pseudo_transient_f_update(
     }
     case NOX::Nln::Solver::PseudoTransient::scale_op_element_based:
     {
-      Core::LinAlg::VectorView xUpdate_view(xUpdate->getEpetraVector());
+      Core::LinAlg::View xUpdate_view(xUpdate->getEpetraVector());
       scaling_matrix_op_ptr_->multiply(false, xUpdate_view, xUpdate_view);
       xUpdate->scale(ptcsolver_.get_inverse_pseudo_time_step());
 

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -139,13 +139,13 @@ bool NOX::Solid::LinearSystem::applyJacobianInverse(
   {
     std::shared_ptr<Core::LinAlg::Vector<double>> fres =
         std::make_shared<Core::LinAlg::Vector<double>>(input.getEpetraVector());
-    Core::LinAlg::VectorView result_view(result.getEpetraVector());
+    Core::LinAlg::View result_view(result.getEpetraVector());
     Core::LinAlg::SparseMatrix* J = dynamic_cast<Core::LinAlg::SparseMatrix*>(jacPtr_.get());
     Core::LinAlg::SolverParams solver_params;
     solver_params.refactor = true;
     solver_params.reset = callcount_ == 0;
     structureSolver_->solve(
-        J->epetra_operator(), result_view.get_non_owning_rcp_ref(), fres, solver_params);
+        J->epetra_operator(), result_view.get_non_owning_shared_ptr_ref(), fres, solver_params);
     callcount_ += 1;
   }
   else

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -243,7 +243,7 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::run_pre_apply_jacobian_inverse(
     const ::NOX::Abstract::Vector& rhs, ::NOX::Abstract::Vector& result,
     const ::NOX::Abstract::Vector& xold, const NOX::Nln::Group& grp)
 {
-  Core::LinAlg::VectorView result_view(extract_epetra_vector(result));
+  Core::LinAlg::View result_view(extract_epetra_vector(result));
 
   // Some inherited classes break const-correctness. Thus, we need to provide something
   // that may be safely const_casted. fixme
@@ -261,7 +261,7 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::run_post_apply_jacobian_inverse(
     const ::NOX::Abstract::Vector& rhs, ::NOX::Abstract::Vector& result,
     const ::NOX::Abstract::Vector& xold, const NOX::Nln::Group& grp)
 {
-  Core::LinAlg::VectorView result_view(extract_epetra_vector(result));
+  Core::LinAlg::View result_view(extract_epetra_vector(result));
   impl_.model_eval().run_post_apply_jacobian_inverse(
       copy_to_our_vector(rhs), result_view, copy_to_our_vector(xold), grp);
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -828,7 +828,7 @@ Solid::ModelEvaluator::Contact::assemble_force_of_models(
 {
   std::shared_ptr<::NOX::Epetra::Vector> force_nox = global_state().create_global_vector();
   {
-    Core::LinAlg::VectorView force_view(force_nox->getEpetraVector());
+    Core::LinAlg::View force_view(force_nox->getEpetraVector());
     integrator().assemble_force(force_view, without_these_models);
   }
 

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
@@ -279,7 +279,7 @@ void Solid::Nln::LinSystem::StcScaling::scaleLinearSystem(Epetra_LinearProblem& 
       std::make_shared<Core::LinAlg::SparseMatrix>(stiff_epetra, Core::LinAlg::DataAccess::View);
 
   // get rhs
-  Core::LinAlg::VectorView rhs_view(*dynamic_cast<Epetra_Vector*>(problem.GetRHS()));
+  Core::LinAlg::View rhs_view(*dynamic_cast<Epetra_Vector*>(problem.GetRHS()));
   Core::LinAlg::Vector<double>& rhs(rhs_view);
 
   // right multiplication of stiffness matrix
@@ -310,7 +310,7 @@ void Solid::Nln::LinSystem::StcScaling::unscaleLinearSystem(Epetra_LinearProblem
       Core::LinAlg::create_vector(problem.GetLHS()->Map(), true);
   Epetra_MultiVector* disi = problem.GetLHS();
 
-  Core::LinAlg::VectorView disi_view(*disi);
+  Core::LinAlg::View disi_view(*disi);
   stcmat_->multiply(false, disi_view, *disisdc);
   disi->Update(1.0, *disisdc, 0.0);
 }

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -89,7 +89,7 @@ bool Solid::TimeInt::NoxInterface::computeF(
 {
   check_init_setup();
 
-  Core::LinAlg::VectorView F_view(F);
+  Core::LinAlg::View F_view(F);
   if (not int_ptr_->apply_force(Core::LinAlg::Vector<double>(x), F_view)) return false;
 
   /* Apply the DBC on the right hand side, since we need the Dirichlet free
@@ -128,7 +128,7 @@ bool Solid::TimeInt::NoxInterface::compute_f_and_jacobian(
   Core::LinAlg::SparseOperator* jac_ptr = dynamic_cast<Core::LinAlg::SparseOperator*>(&jac);
   FOUR_C_ASSERT(jac_ptr != nullptr, "Dynamic cast failed!");
 
-  Core::LinAlg::VectorView rhs_view(rhs);
+  Core::LinAlg::View rhs_view(rhs);
   if (not int_ptr_->apply_force_stiff(Core::LinAlg::Vector<double>(x), rhs_view, *jac_ptr))
     return false;
 
@@ -158,7 +158,7 @@ bool Solid::TimeInt::NoxInterface::compute_correction_system(
   std::vector<Inpar::Solid::ModelType> constraint_models;
   find_constraint_models(&grp, constraint_models);
 
-  Core::LinAlg::VectorView rhs_view(rhs);
+  Core::LinAlg::View rhs_view(rhs);
   if (not int_ptr_->apply_correction_system(
           type, constraint_models, Core::LinAlg::Vector<double>(x), rhs_view, *jac_ptr))
     return false;

--- a/src/structure_new/src/utils/4C_structure_new_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_dbc.cpp
@@ -495,7 +495,7 @@ void NOX::Nln::LinSystem::PrePostOp::Dbc::run_pre_apply_jacobian_inverse(
     const NOX::Nln::LinearSystem& linsys)
 {
   ::NOX::Epetra::Vector& rhs_epetra = dynamic_cast<::NOX::Epetra::Vector&>(rhs);
-  Core::LinAlg::VectorView rhs_view(rhs_epetra.getEpetraVector());
+  Core::LinAlg::View rhs_view(rhs_epetra.getEpetraVector());
   std::shared_ptr<Core::LinAlg::SparseOperator> jac_ptr = Core::Utils::shared_ptr_from_ref(jac);
   // apply the dirichlet condition and rotate the system if desired
   dbc_ptr_->apply_dirichlet_to_local_system(*jac_ptr, rhs_view);


### PR DESCRIPTION
We frequently want to view Epetra datastructure as if they were our own wrapper. This class enables such a behavior with minimal modifications in the wrapper classes. We already had a basic version for vectors and I realized we can generalize it a little bit, to work for any combination of source type and wrapper type. 

Should help with some issues in #554 