### PR TITLE
Add dummy job to set up docker image with deal.II

### DIFF
--- a/.github/workflows/docker_dealii.yml
+++ b/.github/workflows/docker_dealii.yml
@@ -1,0 +1,20 @@
+name: Docker with deal.II
+
+on:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  PROJECT_NAMESPACE: 4c-multiphysics
+  IMAGE_SUFFIX: dependencies
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dummy:
+    steps:
+      - shell: bash
+        run: echo "Dummy job"
+    runs-on: ubuntu-latest


### PR DESCRIPTION
I need to get this workflow onto main so I can manually trigger the build within https://github.com/4C-multiphysics/4C/pull/558.

Part of #506 