### PR TITLE
Remove a do-nothing pre-evaluate

### DIFF
--- a/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
@@ -87,13 +87,6 @@ Discret::Elements::FluidEleCalcPoro<distype>::FluidEleCalcPoro()
 }
 
 template <Core::FE::CellType distype>
-void Discret::Elements::FluidEleCalcPoro<distype>::pre_evaluate(Teuchos::ParameterList& params,
-    Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization)
-{
-  // do nothing
-}
-
-template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcPoro<distype>::evaluate_service(Discret::Elements::Fluid* ele,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
     Core::FE::Discretization& discretization, std::vector<int>& lm,
@@ -306,8 +299,6 @@ int Discret::Elements::FluidEleCalcPoro<distype>::evaluate(Discret::Elements::Fl
   Core::LinAlg::Matrix<(nsd_ + 1) * nen_, 1> elevec1(elevec1_epetra, true);
   // elevec2 and elevec3 are currently not in use
 
-  pre_evaluate(params, ele, discretization);
-
   // call inner evaluate (does not know about element or discretization object)
   int result = evaluate(params, ebofoaf, elemat1, elevec1, evelaf, epreaf, evelnp, eveln, eprenp,
       epren, emhist, echist, epressnp_timederiv, epressam_timederiv, epressn_timederiv, eaccam,
@@ -463,8 +454,6 @@ int Discret::Elements::FluidEleCalcPoro<distype>::evaluate_od(Discret::Elements:
   // get node coordinates and number of elements per node
   Core::Geo::fill_initial_position_array<distype, nsd_, Core::LinAlg::Matrix<nsd_, nen_>>(
       ele, Base::xyze_);
-
-  pre_evaluate(params, ele, discretization);
 
   // call inner evaluate (does not know about element or discretization object)
   return evaluate_od(params, ebofoaf, elemat1, elevec1, evelaf, epreaf, evelnp, eveln, eprenp,

--- a/src/fluid_ele/4C_fluid_ele_calc_poro.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro.hpp
@@ -900,14 +900,6 @@ namespace Discret
           const Core::LinAlg::Matrix<nsd_, nen_ * nsd_>& lin_resM_Dus_gridvel,
           Core::LinAlg::Matrix<nen_, nen_ * nsd_>& ecoupl_p);
 
-      //! do some evaluation before actual element matrix assembly
-      void pre_evaluate(
-          Teuchos::ParameterList&
-              params,  //!< ParameterList for communication between control routine and elements
-          Discret::Elements::Fluid* ele,            //!< fluid element
-          Core::FE::Discretization& discretization  //!< pointer to discretization for de-assembly
-      );
-
       //! computation of material derivatives
       double setup_material_derivatives();
 

--- a/src/fluid_ele/4C_fluid_ele_calc_poro_p1.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro_p1.cpp
@@ -188,8 +188,6 @@ int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate(Discret::Elements::
   Core::LinAlg::Matrix<(nsd_ + 1) * nen_, 1> elevec1(elevec1_epetra, true);
   // elemat2 and elevec2+3 are currently not in use
 
-  Base::pre_evaluate(params, ele, discretization);
-
   // call inner evaluate (does not know about element or discretization object)
   int result = Base::evaluate(params, ebofoaf, elemat1, elevec1, evelaf, epreaf, evelnp, eveln,
       eprenp, epren, emhist, echist, epressnp_timederiv, epressam_timederiv, epressn_timederiv,
@@ -408,8 +406,6 @@ int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate_od(Discret::Element
   // get node coordinates and number of elements per node
   Core::Geo::fill_initial_position_array<distype, nsd_, Core::LinAlg::Matrix<nsd_, nen_>>(
       ele, Base::xyze_);
-
-  Base::pre_evaluate(params, ele, discretization);
 
   // call inner evaluate (does not know about element or discretization object)
   int result = evaluate_od(params, ebofoaf, elemat1, elevec1, evelaf, epreaf, evelnp, eveln, eprenp,


### PR DESCRIPTION
I am investigating if we need `ElementType::pre_evaluate` in its current form. I suspect we don't . Anyway, this PR removes a similar function that is clearly useless.