### PR TITLE
Use InputFile::match_section

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -769,10 +769,8 @@ namespace Core::IO
           }
         }
 
-        std::stringstream ss;
-        ss << tree_with_small_sections;
-        std::string yaml_str = ss.str();
-        Core::Communication::broadcast(yaml_str, /*root*/ 0, pimpl_->comm_);
+        auto serialized_tree = ryml::emitrs_yaml<std::string>(tree_with_small_sections);
+        Core::Communication::broadcast(serialized_tree, /*root*/ 0, pimpl_->comm_);
       }
       else
       {

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -309,6 +309,12 @@ namespace Core::IO
                std::all_of(section_name.begin() + 5, section_name.end(),
                    [](const char c) { return std::isdigit(c); });
       }
+
+      bool is_legacy_section(const std::string& section_name) const
+      {
+        return std::ranges::any_of(
+            legacy_section_names_, [&](const auto& name) { return name == section_name; });
+      }
     };
 
   }  // namespace Internal
@@ -878,6 +884,11 @@ namespace Core::IO
   InputFile::FragmentIteratorRange InputFile::in_section_rank_0_only(
       const std::string& section_name) const
   {
+    FOUR_C_ASSERT_ALWAYS(pimpl_->is_legacy_section(section_name),
+        "You tried to process section '{}' on rank 0 only, but this feature is meant for special "
+        "legacy sections. Please use match_section() instead.",
+        section_name);
+
     if (Core::Communication::my_mpi_rank(pimpl_->comm_) == 0 &&
         pimpl_->content_by_section_.contains(section_name))
     {

--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -40,11 +40,8 @@ namespace Core::IO
    * This class encapsulates input files independent of their format.
    *
    * Objects of this class read the content of a file and grant access to it. The input is not
-   * yet interpreted in any way. Input files contain different sections. A section either contains
-   * key-value pairs or a list of arbitrary lines of text. The content is accessed via the
-   * in_section() function which return InputFile::Fragment objects. These hide what exactly is
-   * contained and in which format. The content can be matched against an expected InputSpec to
-   * extract meaningful data.
+   * yet interpreted in any way. Input files contain different sections. The content can be matched
+   * against an expected InputSpec via match_section() to extract meaningful data.
    *
    * Sections may appear in an arbitrary order and each section name must be unique. An exception is
    * the special section named "INCLUDES" which can contain a list of other files that should be
@@ -52,7 +49,7 @@ namespace Core::IO
    *
    * Three file formats are supported: the custom .dat file format and the standard .yaml (or .yml)
    * and .json formats. The format of a file is detected based on its ending. If the ending is not
-   * one of the above mentioned, the file is assumed to be in the .dat format.
+   * one of the above-mentioned, the file is assumed to be in the .dat format.
    * Included files do not have to use the same format as the including file.
    *
    * The following example shows the structure of a .dat file:
@@ -86,6 +83,7 @@ namespace Core::IO
    * SECTION2:
    *   - A line with content that is not a key-value pair.
    *   - It can contain anything.
+   *   - We call these unstructured sections "legacy sections".
    * @endcode
    *
    *
@@ -213,31 +211,10 @@ namespace Core::IO
      */
     [[nodiscard]] std::filesystem::path file_for_section(const std::string& section_name) const;
 
-    /**
-     * Get a range of Fragments inside a section. A Fragment always contains meaningful content,
-     * i.e., something other than whitespace or comments. The usual way to interact with the
-     * Fragments is as follows:
-     *
-     * @code
-     *   for (const auto& input_fragment : input.in_section("section_name"))
-     *   {
-     *      auto parameters = fragment.match(spec);
-     *   }
-     * @endcode
-     *
-     * @return A range of Fragments which encapsulate the content of the section. Use the
-     * Fragment::match() function to extract the content.
-     *
-     * @note This is a collective call that needs to be called on all MPI ranks in the
-     * communicator associated with this object. Depending on the section size, the content
-     * might need to be distributed from rank 0 to all other ranks. This happens automatically.
-     */
-    FragmentIteratorRange in_section(const std::string& section_name) const;
 
     /**
-     * This function is similar to in_section(), but it only returns the lines on rank 0 and
-     * returns an empty range on all other ranks. This is useful for sections that might be huge
-     * and are not processed on all ranks.
+     * Returns the lines in a section on rank 0 and returns an empty range on all other ranks. This
+     * only works for legacy sections.
      */
     FragmentIteratorRange in_section_rank_0_only(const std::string& section_name) const;
 
@@ -247,7 +224,7 @@ namespace Core::IO
      * that you do not need to pass an InputSpec to this function, since the InputFile object
      * already knows about the expected format of the section. Nevertheless, this function only
      * makes sense for sections with a known InputSpec. Legacy string sections cannot use this
-     * function and must be processed with in_section() or in_section_rank_0_only().
+     * function and must be processed with in_section_rank_0_only().
      */
     void match_section(const std::string& section_name, InputParameterContainer& container) const;
 

--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -89,9 +89,9 @@ namespace Core::IO
    * @endcode
    *
    *
-   * @note The file is only read on rank 0 to save memory. Sections that are huge are only
-   * distributed to other ranks if they are accessed through line_in_section(). If you only
-   * want to read a section on rank 0, use in_section_rank_0_only().
+   * @note The file is only read on rank 0 to save memory. All sections are broadcast to all other
+   * ranks, except for the legacy sections (see the constructor). Legacy sections need to be
+   * consumed on rank 0 with the help of in_section_rank_0_only().
    */
   class InputFile
   {

--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <optional>
 #include <ostream>
+#include <ranges>
 #include <string>
 #include <typeindex>
 #include <vector>
@@ -50,6 +51,8 @@ namespace Core::IO
      */
     using List = std::vector<InputParameterContainer>;
 
+    using GroupStorage = std::map<std::string, InputParameterContainer>;
+
     /**
      * \brief Add @data to the container at the given key @name.
      *
@@ -67,6 +70,11 @@ namespace Core::IO
      * Access group @p name. This function throws an error if the group does not exist.
      */
     [[nodiscard]] const InputParameterContainer& group(const std::string& name) const;
+
+    /**
+     * Get a range view of all groups in the container.
+     */
+    [[nodiscard]] auto groups() const;
 
     /**
      * Check if a group with the name @p name exists.
@@ -265,6 +273,11 @@ namespace Core::IO::Internal::InputParameterContainerImplementation
 
 }  // namespace Core::IO::Internal::InputParameterContainerImplementation
 
+
+inline auto Core::IO::InputParameterContainer::groups() const
+{
+  return std::ranges::subrange(groups_);
+}
 
 
 template <typename T>

--- a/src/core/io/tests/4C_io_input_file_test.cpp
+++ b/src/core/io/tests/4C_io_input_file_test.cpp
@@ -21,12 +21,12 @@ namespace
 {
   using namespace FourC;
 
-  void check_section(
+  void check_section_rank_0_only(
       Core::IO::InputFile& input, const std::string& section, const std::vector<std::string>& lines)
   {
     SCOPED_TRACE("Checking section " + section);
     ASSERT_TRUE(input.has_section(section));
-    auto section_lines = input.in_section(section);
+    auto section_lines = input.in_section_rank_0_only(section);
     std::vector<std::string> section_lines_str;
     std::ranges::copy(section_lines | std::views::transform([](const auto& line)
                                           { return std::string{line.get_as_dat_style_string()}; }),
@@ -57,10 +57,12 @@ namespace
     EXPECT_TRUE(input.has_section("EMPTY"));
     EXPECT_FALSE(input.has_section("NONEXISTENT SECTION"));
 
-    check_section(input, "SECTION WITH SPACES", {"line in section with spaces"});
-    check_section(input, "SECTION/WITH/SLASHES", {"line in section with slashes"});
-    check_section(input, "SHORT SECTION", std::vector<std::string>(3, "line in short section"));
-    check_section(input, "PARTICLES", std::vector<std::string>(30, "line in long section"));
+    check_section_rank_0_only(input, "SECTION WITH SPACES", {"line in section with spaces"});
+    check_section_rank_0_only(input, "SECTION/WITH/SLASHES", {"line in section with slashes"});
+    check_section_rank_0_only(
+        input, "SHORT SECTION", std::vector<std::string>(3, "line in short section"));
+    check_section_rank_0_only(
+        input, "PARTICLES", std::vector<std::string>(30, "line in long section"));
   }
 
   TEST(InputFile, HasIncludes)
@@ -86,11 +88,11 @@ namespace
     EXPECT_EQ(input.file_for_section("INCLUDED SECTION 1a").filename(), "include1a.dat");
     EXPECT_EQ(input.file_for_section("SECTION 1").filename(), "main.dat");
 
-    check_section(input, "INCLUDED SECTION 1a", std::vector<std::string>(2, "line"));
-    check_section(input, "INCLUDED SECTION 1b", std::vector<std::string>(2, "line"));
-    check_section(input, "INCLUDED SECTION 2", std::vector<std::string>(2, "line"));
-    check_section(input, "INCLUDED SECTION 3", std::vector<std::string>(2, "line"));
-    check_section(input, "PARTICLES", std::vector<std::string>(5, "line"));
+    check_section_rank_0_only(input, "INCLUDED SECTION 1a", std::vector<std::string>(2, "line"));
+    check_section_rank_0_only(input, "INCLUDED SECTION 1b", std::vector<std::string>(2, "line"));
+    check_section_rank_0_only(input, "INCLUDED SECTION 2", std::vector<std::string>(2, "line"));
+    check_section_rank_0_only(input, "INCLUDED SECTION 3", std::vector<std::string>(2, "line"));
+    check_section_rank_0_only(input, "PARTICLES", std::vector<std::string>(5, "line"));
   }
 
   TEST(InputFile, CyclicIncludes)
@@ -122,7 +124,8 @@ namespace
     EXPECT_FALSE(input.has_section("EMPTY"));
     EXPECT_FALSE(input.has_section("NONEXISTENT SECTION"));
 
-    check_section(input, "SECTION WITH LINES", {"first line", "second line", "third line"});
+    check_section_rank_0_only(
+        input, "SECTION WITH LINES", {"first line", "second line", "third line"});
   }
 
   TEST(InputFile, YamlIncludes)
@@ -146,8 +149,9 @@ namespace
         comm};
     input.read(input_file_name);
 
-    check_section(input, "INCLUDED SECTION 1", std::vector<std::string>(2, "line"));
-    check_section(input, "SECTION WITH SUBSTRUCTURE", {"MAT 1 THERMO COND 1 2 3 CAPA 2"});
+    check_section_rank_0_only(input, "INCLUDED SECTION 1", std::vector<std::string>(2, "line"));
+    check_section_rank_0_only(
+        input, "SECTION WITH SUBSTRUCTURE", {"MAT 1 THERMO COND 1 2 3 CAPA 2"});
 
     EXPECT_EQ(input.file_for_section("INCLUDED SECTION 2").filename(), "included.yaml");
 


### PR DESCRIPTION
`InputFile::match_section` is the user-friendly interface to the input file. It gives you the data from the section in a `InputParameterContainter` with the same structure as the `InputSpec` you set up for that section. This PR uses this function for materials and conditions. Finally, the `in_section` function is moved into the internals.

Depends on #576 :heavy_check_mark: 