### PR TITLE
Implement a Tensor class on-top of our fixed-size matrix routines

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix.hpp
@@ -44,7 +44,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(
+    constexpr inline void multiply(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e left*\e right
@@ -62,7 +62,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(
+    constexpr inline void multiply_nn(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e left*\e right^T
@@ -81,7 +81,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(
+    constexpr inline void multiply_nt(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e left^T*\e right
@@ -100,7 +100,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(
+    constexpr inline void multiply_tn(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e left^T*\e right^T
@@ -120,7 +120,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(
+    constexpr inline void multiply_tt(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e infac * \e left*\e right
@@ -140,7 +140,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e infac * \e left*\e right
@@ -160,7 +160,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_nn(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e infac * \e left*\e right^T
@@ -181,7 +181,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_nt(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e infac * \e left^T*\e right
@@ -202,7 +202,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_tn(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e infac * \e left^T*\e right^T
@@ -224,7 +224,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_tt(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right);
 
     /// Multiplication: \e out = \e outfac * \e out + \e infac * \e left*\e right
@@ -246,7 +246,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right);
 
@@ -269,7 +269,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_nn(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right);
 
@@ -293,7 +293,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_nt(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right);
 
@@ -317,7 +317,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_tn(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right);
 
@@ -342,7 +342,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_tt(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right);
 
@@ -400,7 +400,7 @@ namespace Core::LinAlg
       \return determinant
      */
     template <unsigned int i, unsigned int j, class ValueType>
-    inline ValueType trace(const ValueType* mat);
+    constexpr inline ValueType trace(const ValueType* mat);
 
     /// Copy: \e out = \e in
     /*!
@@ -413,7 +413,7 @@ namespace Core::LinAlg
         pointer to the matrix to be copied, size (\c i)x(\c j)
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeIn>
-    inline void update(ValueTypeOut* out, const ValueTypeIn* in);
+    constexpr inline void update(ValueTypeOut* out, const ValueTypeIn* in);
 
     /// Scaled copy: \e out = \e infac * \e in
     /*!
@@ -429,7 +429,8 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeInfac,
         class ValueTypeIn>
-    inline void update(ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in);
+    constexpr inline void update(
+        ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in);
 
     /// Addition: \e out = \e outfac * \e out + \e infac * \e in
     /*!
@@ -447,8 +448,8 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeOutfac,
         class ValueTypeInfac, class ValueTypeIn>
-    inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out, const ValueTypeInfac infac,
-        const ValueTypeIn* in);
+    constexpr inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out,
+        const ValueTypeInfac infac, const ValueTypeIn* in);
 
     /// Addition: \e out = \e left + \e right
     /*!
@@ -465,7 +466,8 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void update(ValueTypeOut* out, const ValueTypeLeft* left, const ValueTypeRight* right);
+    constexpr inline void update(
+        ValueTypeOut* out, const ValueTypeLeft* left, const ValueTypeRight* right);
 
     /// Addition: \e out = \e leftfac * \e left + \e rightfac * \e right
     /*!
@@ -487,8 +489,8 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeftfac,
         class ValueTypeLeft, class ValueTypeRightfac, class ValueTypeRight>
-    inline void update(ValueTypeOut* out, const ValueTypeLeftfac leftfac, const ValueTypeLeft* left,
-        const ValueTypeRightfac rightfac, const ValueTypeRight* right);
+    constexpr inline void update(ValueTypeOut* out, const ValueTypeLeftfac leftfac,
+        const ValueTypeLeft* left, const ValueTypeRightfac rightfac, const ValueTypeRight* right);
 
     /// Addition: \e out = \e outfac * \e out + \e leftfac * \e left + \e rightfac * \e right
     /*!
@@ -512,7 +514,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeOutfac,
         class ValueTypeLeftfac, class ValueTypeLeft, class ValueTypeRightfac, class ValueTypeRight>
-    inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeLeftfac leftfac, const ValueTypeLeft* left, const ValueTypeRightfac rightfac,
         const ValueTypeRight* right);
 
@@ -527,7 +529,7 @@ namespace Core::LinAlg
         pointer to the matrix to be copied, size (\c j)x(\c i)
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeIn>
-    inline void update_t(ValueTypeOut* out, const ValueTypeIn* in);
+    constexpr inline void update_t(ValueTypeOut* out, const ValueTypeIn* in);
 
     /// Scaled transposed copy: \e out = \e infac * \e in^T
     /*!
@@ -543,7 +545,8 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeInfac,
         class ValueTypeIn>
-    inline void update_t(ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in);
+    constexpr inline void update_t(
+        ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in);
 
     /// Transposed addition: \e out = \e outfac * \e out + \e infac * \e in^T
     /*!
@@ -561,7 +564,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeOutfac,
         class ValueTypeInfac, class ValueTypeIn>
-    inline void update_t(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void update_t(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeIn* in);
 
     /// Multiply element-wise, \e out(m,n) = \e out(m,n)*\e in(m,n)
@@ -575,7 +578,7 @@ namespace Core::LinAlg
         pointer to second factor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(ValueType* out, const ValueType* in);
+    constexpr inline void elementwise_multiply(ValueType* out, const ValueType* in);
 
     /// Multiply element-wise, \e out(m,n) = \e fac*\e out(m,n)*\e in(m,n)
     /*!
@@ -590,7 +593,8 @@ namespace Core::LinAlg
         pointer to second factor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(const ValueType fac, ValueType* out, const ValueType* in);
+    constexpr inline void elementwise_multiply(
+        const ValueType fac, ValueType* out, const ValueType* in);
 
     /// Multiply element-wise, \e out(m,n) = \e left(m,n)*\e right(m,n)
     /*!
@@ -605,7 +609,8 @@ namespace Core::LinAlg
         pointer to second factor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(ValueType* out, const ValueType* left, const ValueType* right);
+    constexpr inline void elementwise_multiply(
+        ValueType* out, const ValueType* left, const ValueType* right);
 
     /// Multiply element-wise, \e out(m,n) = \e infac*\e left(m,n)*\e right(m,n)
     /*!
@@ -622,7 +627,7 @@ namespace Core::LinAlg
          pointer to second factor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(
+    constexpr inline void elementwise_multiply(
         ValueType* out, const ValueType infac, const ValueType* left, const ValueType* right);
 
     /// Multiply element-wise, \e out(m,n) = \e outfac*\e out(m,n) + \e infac*\e left(m,n)*\e
@@ -635,8 +640,8 @@ namespace Core::LinAlg
       factor, size (\c i)x(\c j) \param right pointer to second factor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(const ValueType outfac, ValueType* out, const ValueType infac,
-        const ValueType* left, const ValueType* right);
+    constexpr inline void elementwise_multiply(const ValueType outfac, ValueType* out,
+        const ValueType infac, const ValueType* left, const ValueType* right);
 
     /// Divide element-wise, \e out(m,n) = \e out(m,n)/\e in(m,n)
     /*!
@@ -649,7 +654,7 @@ namespace Core::LinAlg
         pointer to divisor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(ValueType* out, const ValueType* in);
+    constexpr inline void elementwise_divide(ValueType* out, const ValueType* in);
 
     /// Divide element-wise, \e out(m,n) = \e fac*\e out(m,n)/\e in(m,n)
     /*!
@@ -664,7 +669,8 @@ namespace Core::LinAlg
         pointer to divisor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(const ValueType fac, ValueType* out, const ValueType* in);
+    constexpr inline void elementwise_divide(
+        const ValueType fac, ValueType* out, const ValueType* in);
 
     /// Divide element-wise, \e out(m,n) = \e left(m,n)/\e right(m,n)
     /*!
@@ -679,7 +685,8 @@ namespace Core::LinAlg
         pointer to divisor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(ValueType* out, const ValueType* left, const ValueType* right);
+    constexpr inline void elementwise_divide(
+        ValueType* out, const ValueType* left, const ValueType* right);
 
     /// Divide element-wise, \e out(m,n) = \e infac*\e left(m,n)/\e right(m,n)
     /*!
@@ -696,7 +703,7 @@ namespace Core::LinAlg
          pointer to divisor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(
+    constexpr inline void elementwise_divide(
         ValueType* out, const ValueType infac, const ValueType* left, const ValueType* right);
 
     /// Divide element-wise, \e out(m,n) = \e outfac*\e out(m,n) + \e infac*\e left(m,n)/\e
@@ -709,8 +716,8 @@ namespace Core::LinAlg
       size (\c i)x(\c j) \param right pointer to divisor, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(const ValueType outfac, ValueType* out, const ValueType infac,
-        const ValueType* left, const ValueType* right);
+    constexpr inline void elementwise_divide(const ValueType outfac, ValueType* out,
+        const ValueType infac, const ValueType* left, const ValueType* right);
 
     /// Scale matrix
     /*!
@@ -723,7 +730,7 @@ namespace Core::LinAlg
         pointer to the matrix, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void scale_matrix(const ValueType factor, ValueType* mat);
+    constexpr inline void scale_matrix(const ValueType factor, ValueType* mat);
 
     /// Dot product
     /*!
@@ -738,7 +745,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeft,
         class ValueTypeRight>
-    inline ValueTypeOut dot(const ValueTypeLeft* left, const ValueTypeRight* right);
+    constexpr inline ValueTypeOut dot(const ValueTypeLeft* left, const ValueTypeRight* right);
 
     /// Set matrix to zero
     /*!
@@ -751,7 +758,7 @@ namespace Core::LinAlg
         pointer to the matrix, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void clear_matrix(ValueType* mat);
+    constexpr inline void clear_matrix(ValueType* mat);
 
     /// Fill matrix with scalar value
     /*!
@@ -764,7 +771,7 @@ namespace Core::LinAlg
         pointer to the matrix, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void put_scalar(const ValueType scalar, ValueType* mat);
+    constexpr inline void put_scalar(const ValueType scalar, ValueType* mat);
 
     /// Calculate absolute values of a matrix
     /*!
@@ -777,7 +784,7 @@ namespace Core::LinAlg
         pointer to the matrix the values are read from, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void abs(ValueType* out, const ValueType* in);
+    constexpr inline void abs(ValueType* out, const ValueType* in);
 
     /// Calculate reciprocal values of a matrix
     /*!
@@ -791,7 +798,7 @@ namespace Core::LinAlg
         pointer to the matrix the values are read from, size (\c i)x(\c j)
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void reciprocal(ValueType* out, const ValueType* in);
+    constexpr inline void reciprocal(ValueType* out, const ValueType* in);
 
     /// 1-norm
     /*!
@@ -805,7 +812,7 @@ namespace Core::LinAlg
       \return 1-norm of \e mat
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType norm1(const ValueType* mat);
+    constexpr inline ValueType norm1(const ValueType* mat);
 
     /// 2-norm (Euclidean norm)
     /*!
@@ -816,7 +823,7 @@ namespace Core::LinAlg
       \return 2-norm of \e mat
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType norm2(const ValueType* mat);
+    constexpr inline ValueType norm2(const ValueType* mat);
 
     /// Inf-norm
     /*!
@@ -828,7 +835,7 @@ namespace Core::LinAlg
       \return inf-norm of \e mat
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType norm_inf(const ValueType* mat);
+    constexpr inline ValueType norm_inf(const ValueType* mat);
 
     /// Minimum value of a matrix
     /*!
@@ -839,7 +846,7 @@ namespace Core::LinAlg
       \return minimum value of \e mat
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType min_value(const ValueType* mat);
+    constexpr inline ValueType min_value(const ValueType* mat);
 
     /// Maximum value of a matrix
     /*!
@@ -850,7 +857,7 @@ namespace Core::LinAlg
       \return maximum value of \e mat
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType max_value(const ValueType* mat);
+    constexpr inline ValueType max_value(const ValueType* mat);
 
     /// Mean value of a matrix
     /*!
@@ -861,7 +868,7 @@ namespace Core::LinAlg
       \return mean value of \e mat
      */
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType mean_value(const ValueType* mat);
+    constexpr inline ValueType mean_value(const ValueType* mat);
 
 
     /*
@@ -871,7 +878,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(
+    constexpr inline void multiply(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -897,7 +904,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(
+    constexpr inline void multiply_nn(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -923,7 +930,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(
+    constexpr inline void multiply_nt(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -949,7 +956,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(
+    constexpr inline void multiply_tn(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -975,7 +982,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(
+    constexpr inline void multiply_tt(
         ValueTypeOut* out, const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1001,7 +1008,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1027,7 +1034,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_nn(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1053,7 +1060,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_nt(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1079,7 +1086,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_tn(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1105,7 +1112,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(ValueTypeOut* out, const ValueTypeInfac infac,
+    constexpr inline void multiply_tt(ValueTypeOut* out, const ValueTypeInfac infac,
         const ValueTypeLeft* const left, const ValueTypeRight* const right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1131,7 +1138,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right)
     {
@@ -1158,7 +1165,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_nn(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right)
     {
@@ -1185,7 +1192,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_nt(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right)
     {
@@ -1212,7 +1219,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_tn(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right)
     {
@@ -1239,7 +1246,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, unsigned int k,
         class ValueTypeOutfac, class ValueTypeInfac, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void multiply_tt(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeLeft* const left,
         const ValueTypeRight* const right)
     {
@@ -1448,7 +1455,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType trace(const ValueType* mat)
+    constexpr inline ValueType trace(const ValueType* mat)
     {
       static_assert(i == j, "Matrix must be square");
       static_assert(i > 0, "0x0 matrices are not supported for the trace");
@@ -1467,7 +1474,7 @@ namespace Core::LinAlg
     /* add matrices */
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeIn>
-    inline void update(ValueTypeOut* out, const ValueTypeIn* in)
+    constexpr inline void update(ValueTypeOut* out, const ValueTypeIn* in)
     {
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeIn>)
       {
@@ -1485,7 +1492,8 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeInfac,
         class ValueTypeIn>
-    inline void update(ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in)
+    constexpr inline void update(
+        ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeIn>)
@@ -1497,8 +1505,8 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeOutfac,
         class ValueTypeInfac, class ValueTypeIn>
-    inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out, const ValueTypeInfac infac,
-        const ValueTypeIn* in)
+    constexpr inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out,
+        const ValueTypeInfac infac, const ValueTypeIn* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeIn>)
@@ -1520,7 +1528,8 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void update(ValueTypeOut* out, const ValueTypeLeft* left, const ValueTypeRight* right)
+    constexpr inline void update(
+        ValueTypeOut* out, const ValueTypeLeft* left, const ValueTypeRight* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeLeft>)
@@ -1534,8 +1543,8 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeftfac,
         class ValueTypeLeft, class ValueTypeRightfac, class ValueTypeRight>
-    inline void update(ValueTypeOut* out, const ValueTypeLeftfac leftfac, const ValueTypeLeft* left,
-        const ValueTypeRightfac rightfac, const ValueTypeRight* right)
+    constexpr inline void update(ValueTypeOut* out, const ValueTypeLeftfac leftfac,
+        const ValueTypeLeft* left, const ValueTypeRightfac rightfac, const ValueTypeRight* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeLeft>)
@@ -1550,7 +1559,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeOutfac,
         class ValueTypeLeftfac, class ValueTypeLeft, class ValueTypeRightfac, class ValueTypeRight>
-    inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void update(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeLeftfac leftfac, const ValueTypeLeft* left, const ValueTypeRightfac rightfac,
         const ValueTypeRight* right)
     {
@@ -1575,7 +1584,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeIn>
-    inline void update_t(ValueTypeOut* out, const ValueTypeIn* in)
+    constexpr inline void update_t(ValueTypeOut* out, const ValueTypeIn* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeIn>)
@@ -1587,7 +1596,8 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeInfac,
         class ValueTypeIn>
-    inline void update_t(ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in)
+    constexpr inline void update_t(
+        ValueTypeOut* out, const ValueTypeInfac infac, const ValueTypeIn* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if constexpr (std::is_same_v<ValueTypeOut, ValueTypeIn>)
@@ -1599,7 +1609,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeOutfac,
         class ValueTypeInfac, class ValueTypeIn>
-    inline void update_t(const ValueTypeOutfac outfac, ValueTypeOut* out,
+    constexpr inline void update_t(const ValueTypeOutfac outfac, ValueTypeOut* out,
         const ValueTypeInfac infac, const ValueTypeIn* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1622,7 +1632,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(ValueType* out, const ValueType* in)
+    constexpr inline void elementwise_multiply(ValueType* out, const ValueType* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != in, "'out' and 'in' point to same memory location");
@@ -1632,7 +1642,8 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(const ValueType fac, ValueType* out, const ValueType* in)
+    constexpr inline void elementwise_multiply(
+        const ValueType fac, ValueType* out, const ValueType* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != in, "'out' and 'in' point to same memory location");
@@ -1642,7 +1653,8 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(ValueType* out, const ValueType* left, const ValueType* right)
+    constexpr inline void elementwise_multiply(
+        ValueType* out, const ValueType* left, const ValueType* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != left, "'out' and 'left' point to same memory location");
@@ -1653,7 +1665,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(
+    constexpr inline void elementwise_multiply(
         ValueType* out, const ValueType infac, const ValueType* left, const ValueType* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1665,8 +1677,8 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_multiply(const ValueType outfac, ValueType* out, const ValueType infac,
-        const ValueType* left, const ValueType* right)
+    constexpr inline void elementwise_multiply(const ValueType outfac, ValueType* out,
+        const ValueType infac, const ValueType* left, const ValueType* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != left, "'out' and 'left' point to same memory location");
@@ -1686,7 +1698,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(ValueType* out, const ValueType* in)
+    constexpr inline void elementwise_divide(ValueType* out, const ValueType* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != in, "'out' and 'in' point to same memory location");
@@ -1696,7 +1708,8 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(const ValueType fac, ValueType* out, const ValueType* in)
+    constexpr inline void elementwise_divide(
+        const ValueType fac, ValueType* out, const ValueType* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != in, "'out' and 'in' point to same memory location");
@@ -1711,7 +1724,8 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(ValueType* out, const ValueType* left, const ValueType* right)
+    constexpr inline void elementwise_divide(
+        ValueType* out, const ValueType* left, const ValueType* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != left, "'out' and 'left' point to same memory location");
@@ -1722,7 +1736,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(
+    constexpr inline void elementwise_divide(
         ValueType* out, const ValueType infac, const ValueType* left, const ValueType* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1734,8 +1748,8 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void elementwise_divide(const ValueType outfac, ValueType* out, const ValueType infac,
-        const ValueType* left, const ValueType* right)
+    constexpr inline void elementwise_divide(const ValueType outfac, ValueType* out,
+        const ValueType infac, const ValueType* left, const ValueType* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != left, "'out' and 'left' point to same memory location");
@@ -1755,7 +1769,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void scale_matrix(const ValueType factor, ValueType* mat)
+    constexpr inline void scale_matrix(const ValueType factor, ValueType* mat)
     {
       *mat *= factor;
       for (unsigned int c = 1; c < i * j; ++c) *(++mat) *= factor;
@@ -1763,7 +1777,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeft,
         class ValueTypeRight>
-    inline ValueTypeOut dot(const ValueTypeLeft* left, const ValueTypeRight* right)
+    constexpr inline ValueTypeOut dot(const ValueTypeLeft* left, const ValueTypeRight* right)
     {
       ValueTypeOut res = (*left) * (*right);
       for (unsigned int c = 1; c < i * j; ++c)
@@ -1777,7 +1791,7 @@ namespace Core::LinAlg
 
     template <class ValueTypeOut, unsigned int i, unsigned int j, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void crossproduct(
+    constexpr inline void crossproduct(
         ValueTypeOut* out, const ValueTypeLeft* left, const ValueTypeRight* right)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -1790,7 +1804,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void clear_matrix(ValueType* mat)
+    constexpr inline void clear_matrix(ValueType* mat)
     {
       // the memset method is needed for arbitrary precision (cln) data types instead of the fill
       // method std::memset(mat,0,i*j*sizeof(value_type));
@@ -1799,7 +1813,7 @@ namespace Core::LinAlg
 
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void put_scalar(const ValueType scalar, ValueType* mat)
+    constexpr inline void put_scalar(const ValueType scalar, ValueType* mat)
     {
       *mat = scalar;
       for (unsigned int c = 1; c < i * j; ++c)
@@ -1810,7 +1824,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void abs(ValueType* out, const ValueType* in)
+    constexpr inline void abs(ValueType* out, const ValueType* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != in, "'out' and 'in' point to same memory location");
@@ -1825,7 +1839,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline void reciprocal(ValueType* out, const ValueType* in)
+    constexpr inline void reciprocal(ValueType* out, const ValueType* in)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       FOUR_C_ASSERT(out != in, "'out' and 'in' point to same memory location");
@@ -1840,7 +1854,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType norm1(const ValueType* mat)
+    constexpr inline ValueType norm1(const ValueType* mat)
     {
       ValueType result = *mat >= 0 ? *mat : -(*mat);
       for (unsigned int c = 1; c < i * j; ++c)
@@ -1852,7 +1866,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType norm2(const ValueType* mat)
+    constexpr inline ValueType norm2(const ValueType* mat)
     {
       ValueType result = (*mat) * (*mat);
       for (unsigned int c = 1; c < i * j; ++c)
@@ -1864,7 +1878,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType norm_inf(const ValueType* mat)
+    constexpr inline ValueType norm_inf(const ValueType* mat)
     {
       ValueType result = Core::MathOperations<ValueType>::abs(*mat);
       ValueType tmp;
@@ -1878,7 +1892,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType min_value(const ValueType* mat)
+    constexpr inline ValueType min_value(const ValueType* mat)
     {
       ValueType result = *mat;
       for (unsigned int c = 1; c < i * j; ++c)
@@ -1890,7 +1904,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType max_value(const ValueType* mat)
+    constexpr inline ValueType max_value(const ValueType* mat)
     {
       ValueType result = *mat;
       for (unsigned int c = 1; c < i * j; ++c)
@@ -1902,7 +1916,7 @@ namespace Core::LinAlg
     }
 
     template <class ValueType, unsigned int i, unsigned int j>
-    inline ValueType mean_value(const ValueType* mat)
+    constexpr inline ValueType mean_value(const ValueType* mat)
     {
       ValueType result = *mat;
       for (unsigned int c = 1; c < i * j; ++c) result += *(++mat);
@@ -2225,7 +2239,7 @@ namespace Core::LinAlg
       \param scalar
         value to fill matrix with
      */
-    inline void put_scalar(const ValueType scalar)
+    constexpr inline void put_scalar(const ValueType scalar)
     {
       DenseFunctions::put_scalar<ValueType, rows, cols>(scalar, data());
     }
@@ -2239,7 +2253,7 @@ namespace Core::LinAlg
       \return dot product
      */
     template <class ValueTypeOut = ValueType, class ValueTypeOther>
-    inline ValueTypeOut dot(const Matrix<rows, cols, ValueTypeOther>& other) const
+    constexpr inline ValueTypeOut dot(const Matrix<rows, cols, ValueTypeOther>& other) const
     {
       return DenseFunctions::dot<ValueTypeOut, rows, cols>(data(), other.values());
     }
@@ -2266,7 +2280,7 @@ namespace Core::LinAlg
       \param other
         matrix to read values from
      */
-    inline void abs(const Matrix<rows, cols, ValueType>& other)
+    constexpr inline void abs(const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::abs<ValueType, rows, cols>(data(), other.values());
     }
@@ -2278,7 +2292,7 @@ namespace Core::LinAlg
       \param other
         matrix to read values from
      */
-    inline void reciprocal(const Matrix<rows, cols, ValueType>& other)
+    constexpr inline void reciprocal(const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::reciprocal<ValueType, rows, cols>(data(), other.values());
     }
@@ -2303,7 +2317,7 @@ namespace Core::LinAlg
         matrix to copy
      */
     template <class ValueTypeOther>
-    inline void update(const Matrix<rows, cols, ValueTypeOther>& other)
+    constexpr inline void update(const Matrix<rows, cols, ValueTypeOther>& other)
     {
       DenseFunctions::update<ValueType, rows, cols>(data(), other.values());
     }
@@ -2317,7 +2331,8 @@ namespace Core::LinAlg
       \param other
         matrix to read from
      */
-    inline void update(const ValueType scalarOther, const Matrix<rows, cols, ValueType>& other)
+    constexpr inline void update(
+        const ValueType scalarOther, const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::update<ValueType, rows, cols>(data(), scalarOther, other.values());
     }
@@ -2334,7 +2349,7 @@ namespace Core::LinAlg
         scaling factor for \e this
      */
     template <class ValueTypeScalarOther, class ValueTypeOther, class ValueTypeScalarThis>
-    inline void update(const ValueTypeScalarOther scalarOther,
+    constexpr inline void update(const ValueTypeScalarOther scalarOther,
         const Matrix<rows, cols, ValueTypeOther>& other, const ValueTypeScalarThis scalarThis)
     {
       DenseFunctions::update<ValueType, rows, cols>(
@@ -2351,7 +2366,7 @@ namespace Core::LinAlg
         second matrix to add
      */
     template <class ValueTypeLeft, class ValueTypeRight>
-    inline void update(const Matrix<rows, cols, ValueTypeLeft>& left,
+    constexpr inline void update(const Matrix<rows, cols, ValueTypeLeft>& left,
         const Matrix<rows, cols, ValueTypeRight>& right)
     {
       DenseFunctions::update<ValueType, rows, cols>(data(), left.values(), right.values());
@@ -2372,7 +2387,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeScalarLeft, class ValueTypeLeft, class ValueTypeScalarRight,
         class ValueTypeRight>
-    inline void update(const ValueTypeScalarLeft scalarLeft,
+    constexpr inline void update(const ValueTypeScalarLeft scalarLeft,
         const Matrix<rows, cols, ValueTypeLeft>& left, const ValueTypeScalarRight scalarRight,
         const Matrix<rows, cols, ValueTypeRight>& right)
     {
@@ -2397,7 +2412,7 @@ namespace Core::LinAlg
      */
     template <class ValueTypeScalarLeft, class ValueTypeLeft, class ValueTypeScalarRight,
         class ValueTypeRight, class ValueTypeScalarThis>
-    inline void update(const ValueTypeScalarLeft scalarLeft,
+    constexpr inline void update(const ValueTypeScalarLeft scalarLeft,
         const Matrix<rows, cols, ValueTypeLeft>& left, const ValueTypeScalarRight scalarRight,
         const Matrix<rows, cols, ValueTypeRight>& right, const ValueTypeScalarThis scalarThis)
     {
@@ -2413,7 +2428,7 @@ namespace Core::LinAlg
         matrix to copy
      */
     template <class ValueTypeOther>
-    inline void update_t(const Matrix<cols, rows, ValueTypeOther>& other)
+    constexpr inline void update_t(const Matrix<cols, rows, ValueTypeOther>& other)
     {
       DenseFunctions::update_t<ValueType, rows, cols>(data(), other.values());
     }
@@ -2428,7 +2443,7 @@ namespace Core::LinAlg
         matrix to read from
      */
     template <class ValueTypeOtherScalar, class ValueTypeOther>
-    inline void update_t(
+    constexpr inline void update_t(
         const ValueTypeOtherScalar scalarOther, const Matrix<cols, rows, ValueTypeOther>& other)
     {
       DenseFunctions::update_t<ValueType, rows, cols>(data(), scalarOther, other.values());
@@ -2446,7 +2461,7 @@ namespace Core::LinAlg
         scaling factor for \e this
      */
     template <class ValueTypeOtherScalar, class ValueTypeOther, class ValueTypeThisScalar>
-    inline void update_t(const ValueTypeOtherScalar scalarOther,
+    constexpr inline void update_t(const ValueTypeOtherScalar scalarOther,
         const Matrix<cols, rows, ValueTypeOther>& other, const ValueTypeThisScalar scalarThis)
     {
       DenseFunctions::update_t<ValueType, rows, cols>(
@@ -2460,7 +2475,7 @@ namespace Core::LinAlg
       \param other
         factor
      */
-    inline void elementwise_multiply(const Matrix<rows, cols, ValueType>& other)
+    constexpr inline void elementwise_multiply(const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::elementwise_multiply<ValueType, rows, cols>(data(), other.values());
     }
@@ -2474,7 +2489,7 @@ namespace Core::LinAlg
       \param other
         factor
      */
-    inline void elementwise_multiply(
+    constexpr inline void elementwise_multiply(
         const ValueType scalar, const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::elementwise_multiply<ValueType, rows, cols>(scalar, data(), other.values());
@@ -2489,7 +2504,7 @@ namespace Core::LinAlg
       \param right
         second factor
      */
-    inline void elementwise_multiply(
+    constexpr inline void elementwise_multiply(
         const Matrix<rows, cols, ValueType>& left, const Matrix<rows, cols, ValueType>& right)
     {
       DenseFunctions::elementwise_multiply<ValueType, rows, cols>(
@@ -2508,7 +2523,7 @@ namespace Core::LinAlg
       \param right
         second factor
      */
-    inline void elementwise_multiply(const ValueType scalarOther,
+    constexpr inline void elementwise_multiply(const ValueType scalarOther,
         const Matrix<rows, cols, ValueType>& left, const Matrix<rows, cols, ValueType>& right)
     {
       DenseFunctions::elementwise_multiply<ValueType, rows, cols>(
@@ -2530,7 +2545,7 @@ namespace Core::LinAlg
       \param scalarThis
         scaling factor for \e this
      */
-    inline void elementwise_multiply(const ValueType scalarOther,
+    constexpr inline void elementwise_multiply(const ValueType scalarOther,
         const Matrix<rows, cols, ValueType>& left, const Matrix<rows, cols, ValueType>& right,
         const ValueType scalarThis)
     {
@@ -2545,7 +2560,7 @@ namespace Core::LinAlg
       \param other
         factor
      */
-    inline void elementwise_divide(const Matrix<rows, cols, ValueType>& other)
+    constexpr inline void elementwise_divide(const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::elementwise_divide<ValueType, rows, cols>(data(), other.values());
     }
@@ -2559,7 +2574,7 @@ namespace Core::LinAlg
       \param other
         factor
      */
-    inline void elementwise_divide(
+    constexpr inline void elementwise_divide(
         const ValueType scalar, const Matrix<rows, cols, ValueType>& other)
     {
       DenseFunctions::elementwise_divide<ValueType, rows, cols>(scalar, data(), other.values());
@@ -2574,7 +2589,7 @@ namespace Core::LinAlg
       \param right
         divisor
      */
-    inline void elementwise_divide(
+    constexpr inline void elementwise_divide(
         const Matrix<rows, cols, ValueType>& left, const Matrix<rows, cols, ValueType>& right)
     {
       DenseFunctions::elementwise_divide<ValueType, rows, cols>(
@@ -2593,7 +2608,7 @@ namespace Core::LinAlg
       \param right
         divisor
      */
-    inline void elementwise_divide(const ValueType scalarOther,
+    constexpr inline void elementwise_divide(const ValueType scalarOther,
         const Matrix<rows, cols, ValueType>& left, const Matrix<rows, cols, ValueType>& right)
     {
       DenseFunctions::elementwise_divide<ValueType, rows, cols>(
@@ -2615,7 +2630,7 @@ namespace Core::LinAlg
       \param scalarThis
         scaling factor for \e this
      */
-    inline void elementwise_divide(const ValueType scalarOther,
+    constexpr inline void elementwise_divide(const ValueType scalarOther,
         const Matrix<rows, cols, ValueType>& left, const Matrix<rows, cols, ValueType>& right,
         const ValueType scalarThis)
     {
@@ -2630,13 +2645,19 @@ namespace Core::LinAlg
 
       \return 1-norm
      */
-    inline ValueType norm1() const { return DenseFunctions::norm1<ValueType, rows, cols>(data()); }
+    constexpr inline ValueType norm1() const
+    {
+      return DenseFunctions::norm1<ValueType, rows, cols>(data());
+    }
 
     /// Calculate 2-norm (Euclidean norm)
     /*!
       \return 2-norm
      */
-    inline ValueType norm2() const { return DenseFunctions::norm2<ValueType, rows, cols>(data()); }
+    constexpr inline ValueType norm2() const
+    {
+      return DenseFunctions::norm2<ValueType, rows, cols>(data());
+    }
 
     /// Calculate inf-norm
     /*!
@@ -2644,7 +2665,7 @@ namespace Core::LinAlg
 
       \return inf-norm
      */
-    inline ValueType norm_inf() const
+    constexpr inline ValueType norm_inf() const
     {
       return DenseFunctions::norm_inf<ValueType, rows, cols>(data());
     }
@@ -2653,7 +2674,7 @@ namespace Core::LinAlg
     /*!
       \return minimum value
      */
-    inline ValueType min_value() const
+    constexpr inline ValueType min_value() const
     {
       return DenseFunctions::min_value<ValueType, rows, cols>(data());
     }
@@ -2662,7 +2683,7 @@ namespace Core::LinAlg
     /*!
       \return maximum value
      */
-    inline ValueType max_value() const
+    constexpr inline ValueType max_value() const
     {
       return DenseFunctions::max_value<ValueType, rows, cols>(data());
     }
@@ -2671,7 +2692,7 @@ namespace Core::LinAlg
     /*!
       \return mean value
      */
-    inline ValueType mean_value() const
+    constexpr inline ValueType mean_value() const
     {
       return DenseFunctions::mean_value<ValueType, rows, cols>(data());
     }
@@ -2686,7 +2707,7 @@ namespace Core::LinAlg
         second factor
      */
     template <unsigned int inner, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply(const Matrix<rows, inner, ValueTypeLeft>& left,
+    constexpr inline void multiply(const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right)
     {
       DenseFunctions::multiply<ValueType, rows, inner, cols>(data(), left.values(), right.values());
@@ -2700,7 +2721,7 @@ namespace Core::LinAlg
         second factor
      */
     template <unsigned int inner, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nn(const Matrix<rows, inner, ValueTypeLeft>& left,
+    constexpr inline void multiply_nn(const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right)
     {
       DenseFunctions::multiply<ValueType, rows, inner, cols>(data(), left.values(), right.values());
@@ -2714,7 +2735,7 @@ namespace Core::LinAlg
         second factor
      */
     template <unsigned int inner, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_nt(const Matrix<rows, inner, ValueTypeLeft>& left,
+    constexpr inline void multiply_nt(const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<cols, inner, ValueTypeRight>& right)
     {
       DenseFunctions::multiply_nt<ValueType, rows, inner, cols>(
@@ -2729,7 +2750,7 @@ namespace Core::LinAlg
         second factor
      */
     template <unsigned int inner, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tn(const Matrix<inner, rows, ValueTypeLeft>& left,
+    constexpr inline void multiply_tn(const Matrix<inner, rows, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right)
     {
       DenseFunctions::multiply_tn<ValueType, rows, inner, cols>(
@@ -2744,7 +2765,7 @@ namespace Core::LinAlg
         second factor
      */
     template <unsigned int inner, class ValueTypeLeft, class ValueTypeRight>
-    inline void multiply_tt(const Matrix<inner, rows, ValueTypeLeft>& left,
+    constexpr inline void multiply_tt(const Matrix<inner, rows, ValueTypeLeft>& left,
         const Matrix<cols, inner, ValueTypeRight>& right)
     {
       DenseFunctions::multiply_tt<ValueType, rows, inner, cols>(
@@ -2763,7 +2784,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void multiply(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply(const ValueTypeScalarOther scalarOthers,
         const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right)
     {
@@ -2784,7 +2805,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void multiply_nn(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_nn(const ValueTypeScalarOther scalarOthers,
         const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right)
     {
@@ -2803,7 +2824,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void multiply_nt(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_nt(const ValueTypeScalarOther scalarOthers,
         const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<cols, inner, ValueTypeRight>& right)
     {
@@ -2822,7 +2843,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void multiply_tn(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_tn(const ValueTypeScalarOther scalarOthers,
         const Matrix<inner, rows, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right)
     {
@@ -2841,7 +2862,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight>
-    inline void multiply_tt(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_tt(const ValueTypeScalarOther scalarOthers,
         const Matrix<inner, rows, ValueTypeLeft>& left,
         const Matrix<cols, inner, ValueTypeRight>& right)
     {
@@ -2864,7 +2885,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight, class ValueTypeScalarThis>
-    inline void multiply(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply(const ValueTypeScalarOther scalarOthers,
         const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right, const ValueTypeScalarThis scalarThis)
     {
@@ -2885,7 +2906,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight, class ValueTypeScalarThis>
-    inline void multiply_nn(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_nn(const ValueTypeScalarOther scalarOthers,
         const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right, const ValueTypeScalarThis scalarThis)
     {
@@ -2906,7 +2927,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight, class ValueTypeScalarThis>
-    inline void multiply_nt(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_nt(const ValueTypeScalarOther scalarOthers,
         const Matrix<rows, inner, ValueTypeLeft>& left,
         const Matrix<cols, inner, ValueTypeRight>& right, const ValueTypeScalarThis scalarThis)
     {
@@ -2927,7 +2948,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight, class ValueTypeScalarThis>
-    inline void multiply_tn(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_tn(const ValueTypeScalarOther scalarOthers,
         const Matrix<inner, rows, ValueTypeLeft>& left,
         const Matrix<inner, cols, ValueTypeRight>& right, const ValueTypeScalarThis scalarThis)
     {
@@ -2948,7 +2969,7 @@ namespace Core::LinAlg
      */
     template <unsigned int inner, class ValueTypeScalarOther, class ValueTypeLeft,
         class ValueTypeRight, class ValueTypeScalarThis>
-    inline void multiply_tt(const ValueTypeScalarOther scalarOthers,
+    constexpr inline void multiply_tt(const ValueTypeScalarOther scalarOthers,
         const Matrix<inner, rows, ValueTypeLeft>& left,
         const Matrix<cols, inner, ValueTypeRight>& right, const ValueTypeScalarThis scalarThis)
     {

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix.hpp
@@ -388,6 +388,20 @@ namespace Core::LinAlg
     template <class ValueType, unsigned int i, unsigned int j>
     inline ValueType determinant(const ValueType* mat);
 
+    /// Compute
+    /*!
+      Computes and returns the trace of \e mat. To keep a common
+      interface there are two template parameters \c i and \c j, but they
+      must be the same number. The size of \e mat is expected to be
+      (\c i)x(\c j), and it must be square.
+
+      \param mat
+        pointer to the matrix, size (\c i)x(\c j)
+      \return determinant
+     */
+    template <unsigned int i, unsigned int j, class ValueType>
+    inline ValueType trace(const ValueType* mat);
+
     /// Copy: \e out = \e in
     /*!
       Copy \e in to \e out. This function takes two template parameters \c i and
@@ -1431,6 +1445,22 @@ namespace Core::LinAlg
       }
 
       return determinant_large_matrix(i, j, mat);
+    }
+
+    template <class ValueType, unsigned int i, unsigned int j>
+    inline ValueType trace(const ValueType* mat)
+    {
+      static_assert(i == j, "Matrix must be square");
+      static_assert(i > 0, "0x0 matrices are not supported for the trace");
+
+      ValueType trace = *mat;
+      for (unsigned int c = 1; c < i; ++c)
+      {
+        mat += i + 1;
+        trace += *mat;
+      }
+
+      return trace;
     }
 
 

--- a/src/core/linalg/src/dense/4C_linalg_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor.hpp
@@ -1,0 +1,940 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_TENSOR_HPP
+#define FOUR_C_LINALG_TENSOR_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_tensor_meta_utils.hpp"
+
+#include <algorithm>
+#include <array>
+#include <concepts>
+#include <cstddef>
+#include <cstring>
+#include <span>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  template <typename Tensor>
+  concept TensorConcept = requires(const Tensor& t) {
+    { t.data() } -> std::convertible_to<const typename Tensor::value_type*>;
+  };
+
+  template <typename Tensor>
+  concept Rank1TensorConcept = TensorConcept<Tensor> && Tensor::rank() == 1;
+
+  template <typename Tensor>
+  concept Rank2TensorConcept = TensorConcept<Tensor> && Tensor::rank() == 2;
+
+  template <typename Tensor>
+  concept SquareTensor =
+      Rank2TensorConcept<Tensor> && Tensor::template extent<0>() == Tensor::template extent<1>();
+
+
+  namespace Internal
+  {
+
+    enum class StorageType
+    {
+      owning,
+      view
+    };
+
+    /*!
+     * @brief General tensor class for dense tensors of arbitrary rank
+     *
+     * This class is designed for small tensors typically used in physics simulations, such as
+     * strains, stresses, and linearizations at the Gauss point level. The tensor dimensions are
+     * usually small (e.g., 2x2 or 3x3), with a rank of 1 or 2, and rarely rank 4. This
+     * results in typically 9 or fewer entries (rarely 81 for 4-tensors in 3D). The data is
+     * stored on the stack avoiding dynamic memory allocation and ensuring efficient memory access
+     * via typically high locality.
+     *
+     * Key characteristics:
+     * - **Stack Allocation**: The tensor's data (if it is owning) is stored on the stack, avoiding
+     * the overhead of dynamic memory allocation.
+     * - **Temporary Objects**: Operations on tensors may create temporary objects, but these do not
+     *   involve dynamic memory allocation, ensuring efficient computation.
+     * - **Use Case**: This class is ideal for small-scale tensor operations at the Gauss point
+     * level in finite element simulations. It allows to write physical equations close to their
+     * pendant on paper.
+     *
+     * Comparison with @p LinAlg::Matrix:
+     * - **Tensor**: Designed for small, fixed-size data stored on the stack. Suitable for
+     * operations at the Gauss point level (e.g., strains, stresses).
+     * - **Matrix**: Designed for larger, dynamically allocated data. Suitable for element-level
+     *   calculations (e.g., stiffness and mass matrices). For example, a stiffness matrix for a
+     *   hex27 element may have dimensions 81x81 with 6561 entries, requiring dynamic memory
+     * allocation.
+     *
+     * Shared Backend:
+     * Both @p LinAlg::Tensor and @p LinAlg::Matrix share the same backend for matrix and vector
+     * operations, ensuring consistency and avoiding duplication of functionality.
+     *
+     * @tparam Number Type of the tensor elements (e.g., `double`).
+     * @tparam storage_type Specifies whether the tensor owns its data (`StorageType::owning`) or is
+     * a view (`StorageType::view`).
+     * @tparam n Dimensions of the tensor, specified as a variadic template parameter.
+     */
+    template <typename Number, StorageType storage_type, std::size_t... n>
+    class Tensor
+    {
+     public:
+      using value_type = Number;
+      using shape_type = std::integer_sequence<std::size_t, n...>;
+
+      static constexpr std::size_t rank_ = sizeof...(n);
+      static constexpr std::size_t size_ = (n * ...);
+
+      static_assert(storage_type == StorageType::view or
+                        std::is_same_v<std::remove_cv_t<value_type>, value_type>,
+          "Owning Tensor must have a non-const, non-volatile value_type");
+      static_assert(storage_type == StorageType::owning or
+                        std::is_same_v<std::remove_volatile_t<value_type>, value_type>,
+          "TensorView must have a non-volatile value_type");
+      static_assert(sizeof...(n) > 0, "Tensor must have at least rank one");
+      static_assert(
+          []() constexpr
+          {
+            std::array shape = {n...};
+            return std::ranges::all_of(shape, [](auto dim) { return dim > 0; });
+          }(),
+          "The extents of all axes must larger than zero");
+
+      // Container is either a std::array for an owning tensor or a std::span for a view
+      using ContainerType = std::conditional_t<storage_type == StorageType::owning,
+          std::array<Number, size_>, std::span<Number, size_>>;
+
+     private:
+      ContainerType data_;
+
+     public:
+      /*!
+       * @brief Default constructor
+       *
+       * @note Only an owning tensor has the default constructor
+       */
+      Tensor()
+        requires(std::is_default_constructible_v<ContainerType>)
+      = default;
+
+      Tensor(const Tensor&) = default;
+
+      /*!
+       * @brief Move constructor
+       *
+       * @note Copy operation of a view is cheap, so we don't need to have a move constructor
+       */
+      Tensor(Tensor&&) noexcept
+        requires(storage_type == StorageType::owning)
+      = default;
+      Tensor& operator=(const Tensor&) noexcept = default;
+
+      /*!
+       * @brief Move assignment operator
+       *
+       * @note Copy operation of a view is cheap, so we don't need to have a move assignment
+       * operator
+       */
+      Tensor& operator=(Tensor&&) noexcept
+        requires(storage_type == StorageType::owning)
+      = default;
+      ~Tensor() = default;
+
+      /*!
+       * @brief Construct an owning tensor from given data
+       *
+       * You can assign the tensor via
+       *
+       * @code
+       * Tensor<double, 3, 4> A = {{
+       *     {1.0, 2.0, 3.0, 4.0},
+       *     {5.0, 6.0, 7.0, 8.0},
+       *     {9.0, 10.0, 11.0, 12.0}
+       * }};
+       * @endcode
+       *
+       */
+      Tensor(const TensorInitializerList<Number, n...>::type& lst)
+        requires(std::is_default_constructible_v<ContainerType>);
+
+      /*!
+       * @brief Create a view on an owning tensor
+       */
+      Tensor(Tensor<Number, StorageType::owning, n...>& view_on)
+        requires(storage_type == StorageType::view)
+          : data_(view_on.container())
+      {
+      }
+
+      /*!
+       * @brief Create a constant view on a const owning tensor
+       */
+      Tensor(const Tensor<std::remove_cv_t<Number>, StorageType::owning, n...>& view_on)
+        requires(storage_type == StorageType::view && std::is_const_v<Number>)
+          : data_(view_on.container())
+      {
+      }
+
+      /*!
+       * @brief Create a copy of a view
+       */
+      Tensor(const Tensor<std::remove_cv_t<Number>, StorageType::view, n...>& other)
+        requires(storage_type == StorageType::owning)
+      {
+        std::ranges::copy(other.container(), data_.begin());
+      }
+
+      /*!
+       * @brief Access to the underlying raw data of the tensor
+       *
+       * @return Number*
+       */
+      [[nodiscard]] Number* data() { return data_.data(); }
+
+      /*!
+       * @brief Access to the underlying raw data of the tensor for readonly access
+       *
+       * @return Number*
+       */
+      [[nodiscard]] const Number* data() const { return data_.data(); }
+
+      /*!
+       * @brief Access to the underlying container (std::array or std::span, depending on whether it
+       * is owning or a view)
+       *
+       * @return Number*
+       */
+      [[nodiscard]] ContainerType& container() { return data_; }
+
+      /*!
+       * @brief Access to the underlying readonly container (std::array or std::span, depending on
+       * whether it is owning or a view)
+       *
+       * @return Number*
+       */
+      [[nodiscard]] const ContainerType& container() const { return data_; }
+
+      /*!
+       * @brief Indexing operator to access individual values of the tensor (without bound checks)
+       *
+       * @param i
+       * @return Number&
+       */
+      [[nodiscard]] Number& operator()(decltype(n)... i);
+
+      /*!
+       * @brief Indexing operator to access individual values of the tensor in readonly mode
+       * (without bound checks)
+       *
+       * @param i
+       * @return Number&
+       */
+      [[nodiscard]] const Number& operator()(decltype(n)... i) const;
+
+      /*!
+       * @brief Indexing operator to access individual values of the tensor (with bound checks)
+       *
+       * @param i
+       * @return Number&
+       */
+      [[nodiscard]] Number& at(decltype(n)... i);
+
+      /*!
+       * @brief Indexing operator to access individual values of the tensor in readonly mode
+       * (with bound checks)
+       *
+       * @param i
+       * @return Number&
+       */
+      [[nodiscard]] const Number& at(decltype(n)... i) const;
+
+      [[nodiscard]] static constexpr std::size_t rank() { return rank_; }
+      [[nodiscard]] static constexpr std::size_t size() { return size_; }
+
+      /*!
+       * @brief Returns the dimension of the i-th axis of the tensor
+       *
+       * @tparam i
+       */
+      template <std::size_t i>
+        requires(i < rank())
+      [[nodiscard]] static constexpr auto extent()
+      {
+        return std::get<i>(std::make_tuple(n...));
+      }
+
+      /*!
+       * @brief Returns a std::tuple of the shape of the tensor
+       *
+       * @return constexpr auto
+       */
+      [[nodiscard]] static constexpr auto shape() { return std::make_tuple(n...); }
+
+      /*!
+       * @brief Fills the tensor with the given value
+       *
+       * @param value
+       */
+      constexpr void fill(const Number& value) { std::ranges::fill(data_, value); }
+    };
+
+    // actual implementations
+
+    template <typename Number, Internal::StorageType storage_type, std::size_t... n>
+    Tensor<Number, storage_type, n...>::Tensor(const TensorInitializerList<Number, n...>::type& lst)
+      requires(std::is_default_constructible_v<ContainerType>)
+    {
+      constexpr std::array<std::size_t, size()> index_mapping = order_type_mapping<n...>();
+      for (std::size_t i = 0; i < size(); ++i)
+      {
+        data_[index_mapping[i]] = *(get_view_to_first_element<Number, n...>(lst) + i);
+      }
+    }
+
+    template <typename Number, Internal::StorageType storage_type, std::size_t... n>
+    Number& Tensor<Number, storage_type, n...>::operator()(decltype(n)... i)
+    {
+      return data_[get_flat_index<OrderType::column_major, TensorBoundCheck::no_check, n...>(i...)];
+    }
+
+    template <typename Number, Internal::StorageType storage_type, std::size_t... n>
+    const Number& Tensor<Number, storage_type, n...>::operator()(decltype(n)... i) const
+    {
+      return data_[get_flat_index<OrderType::column_major, TensorBoundCheck::no_check, n...>(i...)];
+    }
+
+    template <typename Number, Internal::StorageType storage_type, std::size_t... n>
+    Number& Tensor<Number, storage_type, n...>::at(decltype(n)... i)
+    {
+      return data_[get_flat_index<OrderType::column_major, TensorBoundCheck::check, n...>(i...)];
+    }
+
+    template <typename Number, Internal::StorageType storage_type, std::size_t... n>
+    const Number& Tensor<Number, storage_type, n...>::at(decltype(n)... i) const
+    {
+      return data_[get_flat_index<OrderType::column_major, TensorBoundCheck::check, n...>(i...)];
+    }
+  }  // namespace Internal
+
+  /*!
+   * @brief An owning, dense tensor of arbitrary rank
+   *
+   * @copydetails Internal::Tensor
+   */
+  template <typename T, std::size_t... n>
+  using Tensor = Internal::Tensor<T, Internal::StorageType::owning, n...>;  // owns the memory
+
+  /*!
+   * @brief A dense view to a Tensor of arbitrary rank
+   *
+   * @copydetails Internal::Tensor
+   */
+  template <typename T, std::size_t... n>
+  using TensorView = Internal::Tensor<T, Internal::StorageType::view, n...>;  // view onto's other
+                                                                              // memory
+
+  // Implementation of tensor operations
+
+  namespace Internal
+  {
+    template <typename T, typename S1>
+    struct SameShapeTensorResult;
+
+    template <typename T, std::size_t... s>
+    struct SameShapeTensorResult<T, std::integer_sequence<std::size_t, s...>>
+    {
+      using type = Tensor<T, StorageType::owning, s...>;
+    };
+
+
+    template <typename T, typename S1, typename S2>
+    struct DyadicProductTensorResult;
+
+    template <typename T, std::size_t... s1, std::size_t... s2>
+    struct DyadicProductTensorResult<T, std::integer_sequence<std::size_t, s1...>,
+        std::integer_sequence<std::size_t, s2...>>
+    {
+      using type = Tensor<T, StorageType::owning, s1..., s2...>;
+    };
+
+    template <typename T, typename Shape, std::size_t... new_order>
+    struct ReorderAxisTensorHelper;
+
+    template <typename T, std::size_t... shape, std::size_t... new_order>
+    struct ReorderAxisTensorHelper<T, std::integer_sequence<std::size_t, shape...>, new_order...>
+    {
+      static consteval std::size_t get_axis(std::size_t t)
+      {
+        constexpr std::array<std::size_t, sizeof...(shape)> tensor_shape = {shape...};
+        return tensor_shape[t];
+      }
+
+      static consteval std::tuple<decltype(shape)...> get_new_index(
+          std::tuple<decltype(shape)...> old_index)
+      {
+        auto make_array_from_tuple = [](auto&&... args) constexpr
+        { return std::array<std::size_t, sizeof...(args)>{args...}; };
+
+        std::array<std::size_t, sizeof...(shape)> old_index_array =
+            std::apply(make_array_from_tuple, old_index);
+
+        std::array<std::size_t, sizeof...(shape)> new_order_array = {new_order...};
+        std::array<std::size_t, sizeof...(shape)> new_index_array;
+        for (std::size_t i = 0; i < sizeof...(shape); ++i)
+        {
+          auto where_is_it = std::ranges::find(new_order_array, i);
+
+          new_index_array[i] = old_index_array[std::distance(new_order_array.begin(), where_is_it)];
+        }
+
+        return std::tuple_cat(new_index_array);
+      }
+
+      static consteval std::array<std::size_t, (shape * ...)> get_index_mapping()
+      {
+        std::array<std::size_t, (shape * ...)> index_mapping = {0};
+
+        for (std::size_t i = 0; i < (shape * ...); ++i)
+        {
+          auto old_index = get_md_index<OrderType::column_major, TensorBoundCheck::no_check,
+              get_axis(new_order)...>(i);
+
+          auto new_index = get_new_index(old_index);
+
+          index_mapping[i] = std::apply(
+              get_flat_index<OrderType::column_major, TensorBoundCheck::no_check, shape...>,
+              new_index);
+        }
+
+        return index_mapping;
+      }
+
+      using result_type = Tensor<T, StorageType::owning, get_axis(new_order)...>;
+    };
+  }  // namespace Internal
+
+  /*!
+   * @brief Computes and returns the determinant of a square tensor of rank 2
+   *
+   * @param A
+   * @return auto
+   */
+  constexpr auto det(const SquareTensor auto& A);
+
+  /*!
+   * @brief Computes and returns the trace of a square tensor of rank 2
+   *
+   * @param A
+   * @return auto
+   */
+  constexpr auto trace(const SquareTensor auto& A);
+
+  /*!
+   * @brief Computes and returns the inverse of a square tensor of rank 2
+   *
+   * @param A
+   * @return auto
+   */
+  auto inv(const SquareTensor auto& A);
+
+  /*!
+   * @brief Computes and returns the transpose of a rank 2 tensor
+   *
+   * @param A
+   * @return auto
+   */
+  constexpr auto transpose(const Rank2TensorConcept auto& A);
+
+  /*!
+   * @brief Computes the dot product of a rank-2 tensor and a rank-1 tensor.
+   *
+   * This function performs the matrix-vector multiplication A * b, where A is a rank-2 tensor
+   * (matrix) and b is a rank-1 tensor (vector). The number of columns in A must match the size of
+   * b.
+   *
+   * @tparam TensorLeft The type of the rank-2 tensor (matrix).
+   * @tparam TensorRight The type of the rank-1 tensor (vector).
+   * @param A The rank-2 tensor (matrix).
+   * @param b The rank-1 tensor (vector).
+   * @return A rank-1 tensor (vector) resulting from the dot product.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank2TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
+             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& A, const TensorRight& b);
+
+  /*!
+   * @brief Computes the dot product of a rank-1 tensor and a rank-2 tensor.
+   *
+   * This function performs the vector-matrix multiplication a * B, where a is a rank-1 tensor
+   * (vector) and B is a rank-2 tensor (matrix). The size of a must match the number of rows in B.
+   *
+   * @tparam TensorLeft The type of the rank-1 tensor (vector).
+   * @tparam TensorRight The type of the rank-2 tensor (matrix).
+   * @param a The rank-1 tensor (vector).
+   * @param B The rank-2 tensor (matrix).
+   * @return A rank-1 tensor (vector) resulting from the dot product.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank1TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
+             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& a, const TensorRight& B);
+
+  /*!
+   * @brief Computes the dot product of two rank-2 tensors.
+   *
+   * This function performs the matrix-matrix multiplication A * B, where A and B are rank-2 tensors
+   * (matrices). The number of columns in A must match the number of rows in B.
+   *
+   * @tparam TensorLeft The type of the first rank-2 tensor (matrix).
+   * @tparam TensorRight The type of the second rank-2 tensor (matrix).
+   * @param A The first rank-2 tensor (matrix).
+   * @param B The second rank-2 tensor (matrix).
+   * @return A rank-2 tensor (matrix) resulting from the dot product.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
+             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Computes the double dot product of two rank-2 tensors.
+   *
+   * This function computes the double dot product of two rank-2 tensors (matrices) A and B, which
+   * is defined as the sum of the element-wise products of the corresponding elements in A and B.
+   *
+   * @tparam TensorLeft The type of the first rank-2 tensor (matrix).
+   * @tparam TensorRight The type of the second rank-2 tensor (matrix).
+   * @param A The first rank-2 tensor (matrix).
+   * @param B The second rank-2 tensor (matrix).
+   * @return A scalar value representing the double dot product.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
+             TensorLeft::template extent<0>() == TensorRight::template extent<0>() &&
+             TensorLeft::template extent<1>() == TensorRight::template extent<1>())
+  constexpr auto ddot(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Adds two tensors element-wise and returns the resulting tensor.
+   *
+   * This function performs an element-wise addition of two tensors with the same shape.
+   * The resulting tensor will have the same shape as the input tensors.
+   *
+   * @tparam TensorLeft The type of the first tensor.
+   * @tparam TensorRight The type of the second tensor.
+   * @param A The first tensor.
+   * @param B The second tensor.
+   * @return A tensor containing the element-wise sum of the input tensors.
+   *
+   * @note The input tensors must have the same shape, as enforced by the `requires` clause.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+  constexpr auto add(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Subtracts two tensors element-wise and returns the resulting tensor.
+   *
+   * This function performs an element-wise subtraction of two tensors with the same shape.
+   * The resulting tensor will have the same shape as the input tensors.
+   *
+   * @tparam TensorLeft The type of the first tensor.
+   * @tparam TensorRight The type of the second tensor.
+   * @param A The first tensor.
+   * @param B The second tensor.
+   * @return A tensor containing the element-wise subtraction of the input tensors.
+   *
+   * @note The input tensors must have the same shape, as enforced by the `requires` clause.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+  constexpr auto subtract(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Return a tensor scaled by a scalar
+   *
+   * @tparam Tensor
+   * @tparam Scalar
+   */
+  template <typename Tensor, typename Scalar>
+    requires(std::is_arithmetic_v<Scalar>)
+  constexpr auto scale(const Tensor& tensor, const Scalar& b);
+
+  /*!
+   * @brief Returns the dyadic product of two tensors with arbitrary rank
+   *
+   * @tparam TensorLeft
+   * @tparam TensorRight
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight>)
+  constexpr auto dyadic(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Reorders the axes of a tensor (generalization of transpose)
+   *
+   * Given the tensor A of shape (2, 3, 4), @p reorder_axis<0, 2, 1>(A) will return a tensor of the
+   * shape (2, 4, 3), i.e., the the order given in the template brackets is the new order of the
+   * axes.
+   *
+   * @tparam new_order
+   * @return A tensor with the axes reordered according to @p new_order
+   */
+  template <std::size_t... new_order>
+  constexpr auto reorder_axis(auto tensor)
+    requires(TensorConcept<decltype(tensor)> && sizeof...(new_order) == decltype(tensor)::rank());
+
+  namespace Internal
+  {
+    // The underlying class of Tensor is in the Internal namespace, so we need to define these
+    // operators also there.
+
+    /*!
+     * @brief Add another tensor onto this tensor
+     *
+     * @tparam OtherTensor
+     */
+    template <typename OtherTensor, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    constexpr Tensor<Number, storage_type, n...>& operator+=(
+        Tensor<Number, storage_type, n...>& tensor, const OtherTensor& B);
+
+    /*!
+     * @brief Subtract another tensor from this tensor
+     *
+     * @tparam OtherTensor
+     */
+    template <typename OtherTensor, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    constexpr Tensor<Number, storage_type, n...>& operator-=(
+        Tensor<Number, storage_type, n...>& tensor, const OtherTensor& B);
+
+    /*!
+     * @brief Scale the tensor with a scalar value
+     *
+     * @tparam OtherTensor
+     */
+    template <typename Scalar, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr Tensor<Number, storage_type, n...>& operator*=(
+        Tensor<Number, storage_type, n...>& tensor, const Scalar b);
+
+    /*!
+     * @brief Scales the tensor with the inverse of the scalar value b
+     *
+     * @tparam Scalar
+     * @tparam Number
+     * @tparam storage_type
+     * @tparam n
+     */
+    template <typename Scalar, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr Tensor<Number, storage_type, n...>& operator/=(
+        Tensor<Number, storage_type, n...>& tensor, const Scalar b);
+
+    template <typename TensorLeft, typename TensorRight>
+      requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+    constexpr auto operator+(const TensorLeft& A, const TensorRight& B)
+    {
+      return add(A, B);
+    }
+    template <typename TensorLeft, typename TensorRight>
+      requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+    constexpr auto operator-(const TensorLeft& A, const TensorRight& B)
+    {
+      return subtract(A, B);
+    }
+
+    template <typename Scalar, typename Tensor>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr auto operator+(const Scalar b, const Tensor& tensor)
+    {
+      return add_scalar(tensor, b);
+    }
+
+    template <typename Scalar, typename Tensor>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr auto operator*(const Tensor& tensor, const Scalar b)
+    {
+      return scale(tensor, b);
+    }
+
+    template <typename Scalar, typename Tensor>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr auto operator*(const Scalar b, const Tensor& tensor)
+    {
+      return scale(tensor, b);
+    }
+
+    template <typename Scalar, typename Tensor>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr auto operator/(const Tensor& tensor, const Scalar b)
+    {
+      return scale(tensor, Scalar(1) / b);
+    }
+
+    template <typename TensorLeft, typename TensorRight>
+    constexpr auto operator*(const TensorLeft& A, const TensorRight& B)
+    {
+      return dot(A, B);
+    }
+
+    template <typename TensorLeft, typename TensorRight>
+      requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+    constexpr bool operator==(const TensorLeft& A, const TensorRight& B)
+    {
+      return std::ranges::equal(A.container(), B.container());
+    }
+
+    template <typename TensorLeft, typename TensorRight>
+      requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+    constexpr bool operator!=(const TensorLeft& A, const TensorRight& B)
+    {
+      return !std::ranges::equal(A.container(), B.container());
+    }
+  }  // namespace Internal
+
+
+  // Actual implementations
+  constexpr auto det(const SquareTensor auto& A)
+  {
+    using Tensor = std::remove_cvref_t<decltype(A)>;
+    using value_type = Tensor::value_type;
+    constexpr std::size_t n = Tensor::template extent<0>();
+
+    return DenseFunctions::determinant<value_type, n, n>(A.data());
+  }
+
+  constexpr auto trace(const SquareTensor auto& A)
+  {
+    using Tensor = std::remove_cvref_t<decltype(A)>;
+    using value_type = Tensor::value_type;
+    constexpr std::size_t n = Tensor::template extent<0>();
+
+    return DenseFunctions::trace<value_type, n, n>(A.data());
+  }
+
+  auto inv(const SquareTensor auto& A)
+  {
+    using Tensor = std::remove_cvref_t<decltype(A)>;
+    using value_type = Tensor::value_type;
+    constexpr std::size_t n = Tensor::template extent<0>();
+
+    Core::LinAlg::Tensor<value_type, n, n> dest;
+    DenseFunctions::invert<value_type, n, n>(dest.data(), A.data());
+    return dest;
+  }
+
+  constexpr auto transpose(const Rank2TensorConcept auto& A) { return reorder_axis<1, 0>(A); }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank2TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
+             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& A, const TensorRight& b)
+  {
+    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
+                                std::declval<typename TensorRight::value_type>());
+    constexpr std::size_t m = TensorLeft::template extent<0>();
+    constexpr std::size_t n = TensorLeft::template extent<1>();
+
+    Tensor<value_type, m> dest;
+    DenseFunctions::multiply<value_type, m, n, 1>(dest.data(), A.data(), b.data());
+    return dest;
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank1TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
+             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& a, const TensorRight& B)
+  {
+    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
+                                std::declval<typename TensorRight::value_type>());
+    constexpr std::size_t m = TensorRight::template extent<0>();
+    constexpr std::size_t n = TensorRight::template extent<1>();
+
+    Tensor<value_type, n> dest;
+    DenseFunctions::multiply<value_type, 1, m, n>(dest.data(), a.data(), B.data());
+    return dest;
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
+             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& A, const TensorRight& B)
+  {
+    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
+                                std::declval<typename TensorRight::value_type>());
+    constexpr std::size_t m = TensorLeft::template extent<0>();
+    constexpr std::size_t k = TensorLeft::template extent<1>();
+    constexpr std::size_t n = TensorRight::template extent<1>();
+
+    Core::LinAlg::Tensor<value_type, n, m> dest;
+    DenseFunctions::multiply<value_type, m, k, n>(dest.data(), A.data(), B.data());
+    return dest;
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
+             TensorLeft::template extent<0>() == TensorRight::template extent<0>() &&
+             TensorLeft::template extent<1>() == TensorRight::template extent<1>())
+  constexpr auto ddot(const TensorLeft& A, const TensorRight& B)
+  {
+    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
+                                std::declval<typename TensorRight::value_type>());
+    constexpr std::size_t m = TensorLeft::template extent<0>();
+    constexpr std::size_t n = TensorLeft::template extent<1>();
+
+    return DenseFunctions::dot<value_type, m, n>(A.data(), B.data());
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+  constexpr auto add(const TensorLeft& A, const TensorRight& B)
+  {
+    using result_value_type = decltype(std::declval<typename TensorLeft::value_type>() +
+                                       std::declval<typename TensorRight::value_type>());
+
+    typename Internal::SameShapeTensorResult<result_value_type,
+        typename TensorLeft::shape_type>::type tens_out{};
+    DenseFunctions::update<result_value_type, TensorLeft::size(), 1>(
+        tens_out.data(), A.data(), B.data());
+
+    return tens_out;
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type>)
+  constexpr auto subtract(const TensorLeft& A, const TensorRight& B)
+  {
+    using result_value_type = decltype(std::declval<typename TensorLeft::value_type>() +
+                                       std::declval<typename TensorRight::value_type>());
+
+    typename Internal::SameShapeTensorResult<result_value_type,
+        typename TensorLeft::shape_type>::type tens_out{};
+    DenseFunctions::update<result_value_type, TensorLeft::size(), 1>(
+        tens_out.data(), 1.0, A.data(), -1.0, B.data());
+
+    return tens_out;
+  }
+
+  template <typename Tensor, typename Scalar>
+    requires(std::is_arithmetic_v<Scalar>)
+  constexpr auto scale(const Tensor& tensor, const Scalar& b)
+  {
+    using result_value_type =
+        decltype(std::declval<Scalar>() + std::declval<typename Tensor::value_type>());
+
+    typename Internal::SameShapeTensorResult<result_value_type, typename Tensor::shape_type>::type
+        tens_out = tensor;
+
+    tens_out *= b;
+
+    return tens_out;
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight>)
+  constexpr auto dyadic(const TensorLeft& A, const TensorRight& B)
+  {
+    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
+                                std::declval<typename TensorRight::value_type>());
+
+    typename Internal::DyadicProductTensorResult<value_type, typename TensorLeft::shape_type,
+        typename TensorRight::shape_type>::type dest{};
+
+    DenseFunctions::multiply<value_type, TensorLeft::size(), 1, TensorRight::size()>(
+        dest.data(), A.data(), B.data());
+
+    return dest;
+  }
+
+  template <std::size_t... new_order>
+  constexpr auto reorder_axis(auto tensor)
+    requires(TensorConcept<decltype(tensor)> && sizeof...(new_order) == decltype(tensor)::rank())
+  {
+    constexpr std::array new_order_array = {new_order...};
+    static_assert(std::ranges::max(new_order_array) < tensor.rank(),
+        "Invalid tensor axis reordering. An axis index is out of bounds.");
+    static_assert(
+        [new_order_array]() constexpr
+        {
+          std::array sorted_indices = new_order_array;
+          std::ranges::sort(sorted_indices);
+          return std::ranges::adjacent_find(sorted_indices) == std::end(sorted_indices);
+        }(),
+        "All indices must be unique during reordering!");
+
+    using Tensor = decltype(tensor);
+    typename Internal::ReorderAxisTensorHelper<typename Tensor::value_type,
+        typename Tensor::shape_type, new_order...>::result_type result;
+
+    constexpr std::array<std::size_t, result.size()> index_reorder =
+        Internal::ReorderAxisTensorHelper<typename Tensor::value_type, typename Tensor::shape_type,
+            new_order...>::get_index_mapping();
+
+    std::transform(index_reorder.begin(), index_reorder.end(), result.data(),
+        [&tensor](const auto& i) { return tensor.container()[i]; });
+
+    return result;
+  }
+
+  namespace Internal
+  {
+    template <typename OtherTensor, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    constexpr Tensor<Number, storage_type, n...>& operator+=(
+        Tensor<Number, storage_type, n...>& tensor, const OtherTensor& B)
+    {
+      DenseFunctions::update<typename Tensor<Number, storage_type, n...>::value_type,
+          OtherTensor::size(), 1>(1.0, tensor.data(), 1.0, B.data());
+      return tensor;
+    }
+
+    template <typename OtherTensor, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    constexpr Tensor<Number, storage_type, n...>& operator-=(
+        Tensor<Number, storage_type, n...>& tensor, const OtherTensor& B)
+    {
+      DenseFunctions::update<typename Tensor<Number, storage_type, n...>::value_type,
+          OtherTensor::size(), 1>(1.0, tensor.data(), -1.0, B.data());
+      return tensor;
+    }
+
+    template <typename Scalar, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr Tensor<Number, storage_type, n...>& operator*=(
+        Tensor<Number, storage_type, n...>& tensor, const Scalar b)
+    {
+      for (auto& value : tensor.container()) value *= b;
+      return tensor;
+    }
+
+    template <typename Scalar, typename Number, StorageType storage_type, std::size_t... n>
+      requires(std::is_arithmetic_v<Scalar>)
+    constexpr Tensor<Number, storage_type, n...>& operator/=(
+        Tensor<Number, storage_type, n...>& tensor, const Scalar b)
+    {
+      tensor *= Scalar(1.0) / b;
+      return tensor;
+    }
+  }  // namespace Internal
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/src/dense/4C_linalg_tensor_meta_utils.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_meta_utils.hpp
@@ -1,0 +1,213 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_TENSOR_META_UTILS_HPP
+#define FOUR_C_LINALG_TENSOR_META_UTILS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_utils_exceptions.hpp"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <numeric>
+#include <sstream>
+#include <tuple>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg::Internal
+{
+  enum class TensorBoundCheck : std::uint8_t
+  {
+    no_check,
+    check_with_assertions,
+    check
+  };
+
+  enum class OrderType : bool
+  {
+    row_major,
+    column_major
+  };
+
+  template <OrderType order_type, std::size_t... n>
+  consteval std::array<std::size_t, sizeof...(n)> get_index_offset()
+  {
+    constexpr std::array<std::size_t, sizeof...(n)> shape = {n...};
+    std::array<std::size_t, sizeof...(n)> index_offset = {1};
+
+    if constexpr (order_type == OrderType::column_major)
+    {
+      index_offset[0] = 1;
+      std::partial_sum(
+          shape.begin(), shape.end() - 1, index_offset.begin() + 1, std::multiplies<>());
+    }
+    else
+    {
+      index_offset[sizeof...(n) - 1] = 1;
+
+      std::partial_sum(
+          shape.rbegin(), shape.rend() - 1, index_offset.rbegin() + 1, std::multiplies<>());
+    }
+    return index_offset;
+  }
+
+  template <std::size_t... n>
+  void check_bounds(decltype(n)... i)
+  {
+    constexpr std::array<std::size_t, sizeof...(n)> shape = {n...};
+
+    std::array<std::size_t, sizeof...(n)> index = {i...};
+
+    auto join = [](const auto& array) -> std::string
+    {
+      std::ostringstream joined_string;
+      auto begin = array.begin();
+      if (array.begin() != array.end())
+      {
+        joined_string << *begin++;
+        for (; begin != array.end(); ++begin) joined_string << ',' << *begin;
+      }
+      return joined_string.str();
+    };
+
+    FOUR_C_ASSERT_ALWAYS(std::inner_product(index.begin(), index.end(), shape.begin(), 0,
+                             std::plus<>(), std::greater_equal<>()) == 0,
+        "Given index is out of bounds. Given index is ({}) but Tensor has shape ({}).", join(index),
+        join(shape));
+  }
+
+  template <OrderType order_type, TensorBoundCheck bound_check, std::size_t... n>
+  constexpr std::size_t get_flat_index(decltype(n)... i)
+  {
+    if constexpr (bound_check == TensorBoundCheck::check) check_bounds<n...>(i...);
+    if constexpr (bound_check == TensorBoundCheck::check_with_assertions)
+    {
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+      check_bounds<n...>(i...);
+#endif
+    }
+
+    constexpr std::array<std::size_t, sizeof...(n)> index_offset =
+        get_index_offset<order_type, n...>();
+
+    std::array<std::size_t, sizeof...(n)> index = {i...};
+
+    return std::inner_product(index.begin(), index.end(), index_offset.begin(), std::size_t(0));
+  }
+
+  template <OrderType order_type, TensorBoundCheck bound_check, std::size_t... n>
+  constexpr std::tuple<decltype(n)...> get_md_index(std::size_t flat_index)
+  {
+    if constexpr (bound_check == TensorBoundCheck::check)
+    {
+      FOUR_C_ASSERT_ALWAYS(
+          flat_index < (n * ...), "flat index must be smaller than the tensor size!");
+    }
+    if constexpr (bound_check == TensorBoundCheck::check_with_assertions)
+    {
+      FOUR_C_ASSERT(flat_index < (n * ...), "flat index must be smaller than the tensor size!");
+    }
+    static_assert(
+        order_type == OrderType::column_major, "Currently only column major order is supported");
+
+    std::array<std::size_t, sizeof...(n)> multi_index{};
+    constexpr std::array<std::size_t, sizeof...(n)> index_offset =
+        get_index_offset<order_type, n...>();
+
+    for (std::size_t i = sizeof...(n); i > 0; i--)
+    {
+      std::size_t index = flat_index / index_offset[i - 1];
+      flat_index = flat_index % index_offset[i - 1];
+      multi_index[i - 1] = index;
+    }
+
+    return std::tuple_cat(multi_index);
+  }
+
+  template <typename Number, std::size_t... n>
+  struct TensorInitializerList;
+
+  template <typename Number, std::size_t n1>
+  struct TensorInitializerList<Number, n1>
+  {
+    // Note, we use C-style arrays here so that we get size checks when initializing with brace
+    // initializers
+    using type = Number[n1];
+  };
+
+  template <typename Number, std::size_t n1, std::size_t... n>
+  struct TensorInitializerList<Number, n1, n...>
+  {
+    // Note, we use C-style arrays here so that we get size checks when initializing with brace
+    // initializers
+    using type = typename TensorInitializerList<Number, n...>::type[n1];
+  };
+
+  template <typename Number, std::size_t... n>
+  const Number* get_view_to_first_element(
+      const typename TensorInitializerList<Number, n...>::type& lst)
+  {
+    // This is to get a view to the first element in the nested array
+    return static_cast<const Number*>(static_cast<const void*>(&lst));
+  }
+
+  // A helper class to loop over each dimension of a multi-rank tensor in row major order
+  template <std::size_t, std::size_t... n>
+  struct MultiDimensionalForRowMajor;
+
+  template <std::size_t rank, std::size_t n1>
+  struct MultiDimensionalForRowMajor<rank, n1>
+  {
+    static constexpr void multi_for(auto function, const auto& index)
+    {
+      for (std::size_t i = 0; i < n1; ++i)
+      {
+        function(std::tuple_cat(index, std::make_tuple(i)));
+      }
+    }
+  };
+
+  template <std::size_t rank, std::size_t n1, std::size_t... n>
+  struct MultiDimensionalForRowMajor<rank, n1, n...>
+  {
+    static constexpr void multi_for(auto function, const auto& index)
+    {
+      for (std::size_t i = 0; i < n1; ++i)
+      {
+        MultiDimensionalForRowMajor<rank, n...>::multi_for(
+            function, std::tuple_cat(index, std::make_tuple(i)));
+      }
+    }
+  };
+
+  template <std::size_t... n>
+  consteval std::array<std::size_t, (n * ...)> order_type_mapping()
+  {
+    std::array<std::size_t, (n * ...)> order_type_mapping{};
+
+    std::size_t i = 0;
+    MultiDimensionalForRowMajor<sizeof...(n), n...>::multi_for(
+        [&](const auto& index)
+        {
+          order_type_mapping[i] = std::apply(
+              get_flat_index<OrderType::column_major, TensorBoundCheck::no_check, n...>, index);
+
+          ++i;
+        },
+        std::make_tuple());
+
+    return order_type_mapping;
+  }
+}  // namespace Core::LinAlg::Internal
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/tests/4C_linalg_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_operations_test.cpp
@@ -1,0 +1,436 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_tensor.hpp"
+
+#include <type_traits>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  namespace math = Core::LinAlg;
+
+  enum class StorageType
+  {
+    owning,
+    view
+  };
+
+  template <StorageType storage_type, typename T, std::size_t... n>
+  class TensorHolder;
+
+  template <typename T, std::size_t... n>
+  class TensorHolder<StorageType::owning, T, n...>
+  {
+   public:
+    template <typename... U>
+    TensorHolder(U&&... u) : tens_(std::forward<U>(u)...)
+    {
+    }
+
+    math::Tensor<T, n...>& get_tensor() { return tens_; };
+
+   private:
+    math::Tensor<T, n...> tens_;
+  };
+
+  template <typename T, std::size_t... n>
+  class TensorHolder<StorageType::view, T, n...>
+  {
+   public:
+    template <typename... U>
+    TensorHolder(U&&... u) : tens_(std::forward<U>(u)...), tens_view_(tens_)
+    {
+    }
+
+    math::TensorView<T, n...>& get_tensor() { return tens_view_; };
+
+
+   private:
+    math::Tensor<T, n...> tens_;
+    math::TensorView<T, n...> tens_view_;
+  };
+
+  template <typename T>
+  class TensorOperationsTest : public testing::Test
+  {
+   public:
+    static constexpr StorageType STORAGE_TYPE = T();
+  };
+
+  using MyTypes = ::testing::Types<std::integral_constant<StorageType, StorageType::owning>,
+      std::integral_constant<StorageType, StorageType::view>>;
+  TYPED_TEST_SUITE(TensorOperationsTest, MyTypes);
+
+
+  TYPED_TEST(TensorOperationsTest, Determinant)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 3> t{};
+    EXPECT_EQ(math::det(t.get_tensor()), 0.0);
+
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 2> t2{
+        math::Tensor<double, 2, 2>{{{1.0, 2.0}, {3.0, 4.0}}}};
+    EXPECT_EQ(math::det(t2.get_tensor()), -2.0);
+  }
+
+
+  TYPED_TEST(TensorOperationsTest, Trace)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 3> t{};
+    EXPECT_EQ(math::trace(t.get_tensor()), 0.0);
+
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 2> t2{
+        math::Tensor<double, 2, 2>{{{1.0, 2.0}, {3.0, 4.0}}}};
+    EXPECT_EQ(math::trace(t2.get_tensor()), 5.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Inverse)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 2> t{
+        math::Tensor<double, 2, 2>{{{1.0, 2.0}, {3.0, 4.0}}}};
+
+    math::Tensor<double, 2, 2> t_inv = math::inv(t.get_tensor());
+
+    EXPECT_EQ(t_inv(0, 0), -2.0);
+    EXPECT_EQ(t_inv(1, 1), -0.5);
+    EXPECT_EQ(t_inv(0, 1), 1.0);
+    EXPECT_EQ(t_inv(1, 0), 1.5);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Transpose)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> t{math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }}};
+
+    math::Tensor<double, 2, 3> t_t = math::transpose(t.get_tensor());
+
+    EXPECT_EQ(t_t.at(0, 0), 1.0);
+    EXPECT_EQ(t_t.at(0, 1), 3.0);
+    EXPECT_EQ(t_t.at(0, 2), 5.0);
+    EXPECT_EQ(t_t.at(1, 0), 2.0);
+    EXPECT_EQ(t_t.at(1, 1), 4.0);
+    EXPECT_EQ(t_t.at(1, 2), 6.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Mat_dot_Vec)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2> b = math::Tensor<double, 2>{{1.0, 2.0}};
+
+    math::Tensor<double, 3> Axb = math::dot(A.get_tensor(), b.get_tensor());
+
+    EXPECT_EQ(Axb.at(0), 5.0);
+    EXPECT_EQ(Axb.at(1), 11.0);
+    EXPECT_EQ(Axb.at(2), 17.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Mat_dot_Mat)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 3> B = math::Tensor<double, 2, 3>{{
+        {1.0, 2.0, 3.0},
+        {3.0, 4.0, 5.0},
+    }};
+
+    math::Tensor<double, 3, 3> AxB = math::dot(A.get_tensor(), B.get_tensor());
+
+    EXPECT_EQ(AxB.at(0, 0), 7.0);
+    EXPECT_EQ(AxB.at(0, 1), 10.0);
+    EXPECT_EQ(AxB.at(0, 2), 13.0);
+
+    EXPECT_EQ(AxB.at(1, 0), 15.0);
+    EXPECT_EQ(AxB.at(1, 1), 22.0);
+    EXPECT_EQ(AxB.at(1, 2), 29.0);
+
+    EXPECT_EQ(AxB.at(2, 0), 23.0);
+    EXPECT_EQ(AxB.at(2, 1), 34.0);
+    EXPECT_EQ(AxB.at(2, 2), 45.0);
+  }
+
+
+
+  TYPED_TEST(TensorOperationsTest, Vec_dot_Mat)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{{1.0, 2.0, 3.0}};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> B = math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }};
+
+    math::Tensor<double, 2> a_dot_B = math::dot(a.get_tensor(), B.get_tensor());
+
+    EXPECT_EQ(a_dot_B.at(0), 22.0);
+    EXPECT_EQ(a_dot_B.at(1), 28.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Mat_ddot_Mat)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> B = math::Tensor<double, 3, 2>{{
+        {2.0, 3.0},
+        {4.0, 5.0},
+        {6.0, 7.0},
+    }};
+
+    double A_ddot_B = math::ddot(A.get_tensor(), B.get_tensor());
+
+    EXPECT_EQ(A_ddot_B, 112.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Mat_dyadic_Mat)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 3> B = math::Tensor<double, 2, 3>{{
+        {1.0, 2.0, 3.0},
+        {3.0, 4.0, 5.0},
+    }};
+
+    math::Tensor<double, 3, 2, 2, 3> AxB = math::dyadic(A.get_tensor(), B.get_tensor());
+
+    for (std::size_t i = 0; i < A.get_tensor().template extent<0>(); ++i)
+    {
+      for (std::size_t j = 0; j < A.get_tensor().template extent<1>(); ++j)
+      {
+        for (std::size_t k = 0; k < B.get_tensor().template extent<0>(); ++k)
+        {
+          for (std::size_t l = 0; l < B.get_tensor().template extent<1>(); ++l)
+          {
+            EXPECT_EQ(AxB.at(i, j, k, l), A.get_tensor()(i, j) * B.get_tensor()(k, l));
+          }
+        }
+      }
+    }
+  }
+
+  TYPED_TEST(TensorOperationsTest, Mat_dyadic_Vec)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
+        {1.0, 2.0},
+        {3.0, 4.0},
+        {5.0, 6.0},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2> b = math::Tensor<double, 2>{
+        {1.0, 2.0},
+    };
+
+    math::Tensor<double, 3, 2, 2> Axb = math::dyadic(A.get_tensor(), b.get_tensor());
+
+    for (std::size_t i = 0; i < A.get_tensor().template extent<0>(); ++i)
+    {
+      for (std::size_t j = 0; j < A.get_tensor().template extent<1>(); ++j)
+      {
+        for (std::size_t k = 0; k < b.get_tensor().template extent<0>(); ++k)
+        {
+          EXPECT_EQ(Axb.at(i, j, k), A.get_tensor()(i, j) * b.get_tensor()(k));
+        }
+      }
+    }
+  }
+
+  TYPED_TEST(TensorOperationsTest, Vec_dyadic_Vec)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{
+        {1.0, 2.0, 3.0},
+    };
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2> b = math::Tensor<double, 2>{
+        {1.0, 2.0},
+    };
+
+    math::Tensor<double, 3, 2> axb = math::dyadic(a.get_tensor(), b.get_tensor());
+
+    for (std::size_t i = 0; i < a.get_tensor().template extent<0>(); ++i)
+    {
+      for (std::size_t j = 0; j < b.get_tensor().template extent<0>(); ++j)
+      {
+        EXPECT_EQ(axb.at(i, j), a.get_tensor()(i) * b.get_tensor()(j));
+      }
+    }
+  }
+
+  TYPED_TEST(TensorOperationsTest, Addition)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{
+        {1.0, 2.0, 3.0},
+    };
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> b = math::Tensor<double, 3>{
+        {2.0, 3.0, 4.0},
+    };
+
+    math::Tensor<double, 3> a_plus_b = math::add(a.get_tensor(), b.get_tensor());
+
+    EXPECT_EQ(a_plus_b(0), 3.0);
+    EXPECT_EQ(a_plus_b(1), 5.0);
+    EXPECT_EQ(a_plus_b(2), 7.0);
+
+    math::Tensor<double, 3> a_plus_b2 = a.get_tensor() + b.get_tensor();
+
+    EXPECT_EQ(a_plus_b(0), 3.0);
+    EXPECT_EQ(a_plus_b(1), 5.0);
+    EXPECT_EQ(a_plus_b(2), 7.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Subtract)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{
+        {1.0, 2.0, 3.0},
+    };
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> b = math::Tensor<double, 3>{
+        {2.0, 4.0, 6.0},
+    };
+
+    math::Tensor<double, 3> a_negative_b = math::subtract(a.get_tensor(), b.get_tensor());
+
+    EXPECT_EQ(a_negative_b(0), -1.0);
+    EXPECT_EQ(a_negative_b(1), -2.0);
+    EXPECT_EQ(a_negative_b(2), -3.0);
+
+    math::Tensor<double, 3> a_negative_b2 = a.get_tensor() - b.get_tensor();
+
+    EXPECT_EQ(a_negative_b2(0), -1.0);
+    EXPECT_EQ(a_negative_b2(1), -2.0);
+    EXPECT_EQ(a_negative_b2(2), -3.0);
+
+    a.get_tensor() -= b.get_tensor();
+
+    EXPECT_EQ(a.get_tensor()(0), -1.0);
+    EXPECT_EQ(a.get_tensor()(1), -2.0);
+    EXPECT_EQ(a.get_tensor()(2), -3.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, Division)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{
+        {1.0, 2.0, 3.0},
+    };
+
+    math::Tensor<double, 3> a_divide = a.get_tensor() / 3.0;
+
+    EXPECT_EQ(a_divide(0), 1.0 / 3.0);
+    EXPECT_EQ(a_divide(1), 2.0 / 3.0);
+    EXPECT_EQ(a_divide(2), 1.0);
+
+    a.get_tensor() /= 3.0;
+
+    EXPECT_EQ(a.get_tensor()(0), 1.0 / 3.0);
+    EXPECT_EQ(a.get_tensor()(1), 2.0 / 3.0);
+    EXPECT_EQ(a.get_tensor()(2), 1.0);
+  }
+
+  TEST(TensorOperationsTest, Equality)
+  {
+    Core::LinAlg::Tensor<double, 3> a = {
+        {1.0, 2.0, 3.0},
+    };
+    Core::LinAlg::Tensor<double, 3> a1 = {
+        {1.0, 2.0, 3.0},
+    };
+    Core::LinAlg::Tensor<double, 3> b = {
+        {1.0, 2.0, 3.1},
+    };
+
+    Core::LinAlg::TensorView<double, 3> a_view = a;
+    Core::LinAlg::TensorView<double, 3> b_view = b;
+
+    EXPECT_TRUE(a == a1);
+    EXPECT_TRUE(a1 == a);
+    EXPECT_TRUE(a_view == a1);
+    EXPECT_TRUE(a1 == a_view);
+    EXPECT_FALSE(a_view == b);
+    EXPECT_FALSE(b == a_view);
+    EXPECT_FALSE(a == b_view);
+    EXPECT_FALSE(b_view == a);
+
+    EXPECT_FALSE(a != a1);
+    EXPECT_FALSE(a1 != a);
+    EXPECT_FALSE(a_view != a1);
+    EXPECT_FALSE(a1 != a_view);
+    EXPECT_TRUE(a_view != b);
+    EXPECT_TRUE(b != a_view);
+    EXPECT_TRUE(a != b_view);
+    EXPECT_TRUE(b_view != a);
+  }
+
+  TEST(TensorOperationsTest, ReorderAxis)
+  {
+    Core::LinAlg::Tensor<double, 3, 2> A = {{
+        {1.0, 2.0},
+        {4.0, 5.0},
+        {6.0, 7.0},
+    }};
+
+    Core::LinAlg::Tensor<double, 2, 3> B = Core::LinAlg::reorder_axis<1, 0>(A);
+
+    EXPECT_DOUBLE_EQ(B(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(B(0, 1), 4.0);
+    EXPECT_DOUBLE_EQ(B(0, 2), 6.0);
+    EXPECT_DOUBLE_EQ(B(1, 0), 2.0);
+    EXPECT_DOUBLE_EQ(B(1, 1), 5.0);
+    EXPECT_DOUBLE_EQ(B(1, 2), 7.0);
+
+
+    Core::LinAlg::Tensor<double, 4, 3, 2> A2 = {{
+        {{0.00, 0.01}, {0.10, 0.11}},
+        {{1.00, 1.01}, {1.10, 1.11}},
+        {{2.00, 2.01}, {2.10, 2.11}},
+        {{3.00, 3.01}, {3.10, 3.11}},
+    }};
+
+    Core::LinAlg::Tensor<double, 3, 4, 2> B2 = Core::LinAlg::reorder_axis<1, 0, 2>(A2);
+
+    for (int i = 0; i < 4; ++i)
+    {
+      for (int j = 0; j < 3; ++j)
+      {
+        for (int k = 0; k < 2; ++k)
+        {
+          EXPECT_DOUBLE_EQ(B2.at(j, i, k), A2.at(i, j, k));
+        }
+      }
+    }
+
+    Core::LinAlg::Tensor<double, 2, 4, 3> B3 = Core::LinAlg::reorder_axis<2, 0, 1>(A2);
+
+    for (int i = 0; i < 4; ++i)
+    {
+      for (int j = 0; j < 3; ++j)
+      {
+        for (int k = 0; k < 2; ++k)
+        {
+          EXPECT_DOUBLE_EQ(B3.at(k, i, j), A2.at(i, j, k));
+        }
+      }
+    }
+  }
+
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_tensor_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_test.cpp
@@ -1,0 +1,203 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_tensor.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+
+
+  TEST(TensorTest, TestConstructability)
+  {
+    // Tensor should be default constructible
+    static_assert(std::is_default_constructible_v<Core::LinAlg::Tensor<double, 3>>);
+  }
+
+  TEST(TensorTest, DefaultConstruct1Tensor)
+  {
+    Core::LinAlg::Tensor<double, 3> t{};
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+  }
+
+  TEST(TensorTest, DefaultConstruct2Tensor)
+  {
+    Core::LinAlg::Tensor<double, 2, 2> t{};
+    EXPECT_DOUBLE_EQ(t(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0, 1), 0.0);
+    EXPECT_DOUBLE_EQ(t(1, 0), 0.0);
+    EXPECT_DOUBLE_EQ(t(1, 1), 0.0);
+  }
+
+  TEST(TensorTest, InitializationAndIndexing1Tensor)
+  {
+    Core::LinAlg::Tensor<double, 3> t = {{0.0, 1.0, 2.0}};
+
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+    EXPECT_DOUBLE_EQ(t(1), 1.0);
+    EXPECT_DOUBLE_EQ(t(2), 2.0);
+  }
+
+  TEST(TensorTest, InitializationAndIndexing2Tensor)
+  {
+    Core::LinAlg::Tensor<double, 3, 2> t = {{{0.0, 0.1}, {1.0, 1.1}, {2.0, 2.1}}};
+
+    EXPECT_DOUBLE_EQ(t(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(t(1, 0), 1.0);
+    EXPECT_DOUBLE_EQ(t(1, 1), 1.1);
+    EXPECT_DOUBLE_EQ(t(2, 0), 2.0);
+    EXPECT_DOUBLE_EQ(t(2, 1), 2.1);
+  }
+
+  TEST(TensorTest, InitializationAndIndexing3Tensor)
+  {
+    Core::LinAlg::Tensor<double, 3, 2, 2> t = {{
+        {{0.00, 0.01}, {0.10, 0.11}},
+        {{1.00, 1.01}, {1.10, 1.11}},
+        {{2.00, 2.01}, {2.10, 2.11}},
+    }};
+
+    EXPECT_DOUBLE_EQ(t(0, 0, 0), 0.00);
+    EXPECT_DOUBLE_EQ(t(0, 0, 1), 0.01);
+
+    EXPECT_DOUBLE_EQ(t(0, 1, 0), 0.10);
+    EXPECT_DOUBLE_EQ(t(0, 1, 1), 0.11);
+
+    EXPECT_DOUBLE_EQ(t(1, 0, 0), 1.00);
+    EXPECT_DOUBLE_EQ(t(1, 0, 1), 1.01);
+
+    EXPECT_DOUBLE_EQ(t(1, 1, 0), 1.10);
+    EXPECT_DOUBLE_EQ(t(1, 1, 1), 1.11);
+
+    EXPECT_DOUBLE_EQ(t(2, 0, 0), 2.00);
+    EXPECT_DOUBLE_EQ(t(2, 0, 1), 2.01);
+
+    EXPECT_DOUBLE_EQ(t(2, 1, 0), 2.10);
+    EXPECT_DOUBLE_EQ(t(2, 1, 1), 2.11);
+  }
+
+  TEST(TensorTest, InitializationAndIndexing4Tensor)
+  {
+    Core::LinAlg::Tensor<double, 3, 2, 2, 2> t = {{
+        {{{0.000, 0.001}, {0.010, 0.011}}, {{0.100, 0.101}, {0.110, 0.111}}},
+        {{{1.000, 1.001}, {1.010, 1.011}}, {{1.100, 1.101}, {1.110, 1.111}}},
+        {{{2.000, 2.001}, {2.010, 2.011}}, {{2.100, 2.101}, {2.110, 2.111}}},
+    }};
+
+    EXPECT_DOUBLE_EQ(t(0, 0, 0, 0), 0.000);
+    EXPECT_DOUBLE_EQ(t(0, 0, 0, 1), 0.001);
+    EXPECT_DOUBLE_EQ(t(0, 0, 1, 0), 0.010);
+    EXPECT_DOUBLE_EQ(t(0, 0, 1, 1), 0.011);
+    EXPECT_DOUBLE_EQ(t(0, 1, 0, 0), 0.100);
+    EXPECT_DOUBLE_EQ(t(0, 1, 0, 1), 0.101);
+    EXPECT_DOUBLE_EQ(t(0, 1, 1, 0), 0.110);
+    EXPECT_DOUBLE_EQ(t(0, 1, 1, 1), 0.111);
+
+    EXPECT_DOUBLE_EQ(t(1, 0, 0, 0), 1.000);
+    EXPECT_DOUBLE_EQ(t(1, 0, 0, 1), 1.001);
+    EXPECT_DOUBLE_EQ(t(1, 0, 1, 0), 1.010);
+    EXPECT_DOUBLE_EQ(t(1, 0, 1, 1), 1.011);
+    EXPECT_DOUBLE_EQ(t(1, 1, 0, 0), 1.100);
+    EXPECT_DOUBLE_EQ(t(1, 1, 0, 1), 1.101);
+    EXPECT_DOUBLE_EQ(t(1, 1, 1, 0), 1.110);
+    EXPECT_DOUBLE_EQ(t(1, 1, 1, 1), 1.111);
+
+    EXPECT_DOUBLE_EQ(t(2, 0, 0, 0), 2.000);
+    EXPECT_DOUBLE_EQ(t(2, 0, 0, 1), 2.001);
+    EXPECT_DOUBLE_EQ(t(2, 0, 1, 0), 2.010);
+    EXPECT_DOUBLE_EQ(t(2, 0, 1, 1), 2.011);
+    EXPECT_DOUBLE_EQ(t(2, 1, 0, 0), 2.100);
+    EXPECT_DOUBLE_EQ(t(2, 1, 0, 1), 2.101);
+    EXPECT_DOUBLE_EQ(t(2, 1, 1, 0), 2.110);
+    EXPECT_DOUBLE_EQ(t(2, 1, 1, 1), 2.111);
+  }
+
+  TEST(TensorTest, AlignmentSameAsMatrix)
+  {
+    Core::LinAlg::Tensor<double, 2, 2> t = {{{0.0, 0.1}, {1.0, 1.1}}};
+    Core::LinAlg::Matrix<2, 2> m(t.data());
+
+    EXPECT_DOUBLE_EQ(m(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(m(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(m(1, 0), 1.0);
+    EXPECT_DOUBLE_EQ(m(1, 1), 1.1);
+  }
+
+
+  TEST(TensorViewTest, TestConstructability)
+  {
+    // TensorView should not be default constructable
+    static_assert(!std::is_default_constructible_v<Core::LinAlg::TensorView<double, 3>>);
+
+    // TensorView should be constructable from Tensor&
+    static_assert(std::is_constructible_v<Core::LinAlg::TensorView<double, 3>,
+        Core::LinAlg::Tensor<double, 3>&>);
+
+    // const TensorView should be constructable from const Tensor&
+    static_assert(std::is_constructible_v<Core::LinAlg::TensorView<const double, 3>,
+        const Core::LinAlg::Tensor<double, 3>&>);
+
+    // TensorView should not be constructable from Tensor&&
+    static_assert(!std::is_constructible_v<Core::LinAlg::TensorView<double, 3>,
+        Core::LinAlg::Tensor<double, 3>&&>);
+
+    // TensorView should NOT be constructable from const Tensor&
+    static_assert(!std::is_constructible_v<Core::LinAlg::TensorView<double, 3>,
+        const Core::LinAlg::Tensor<double, 3>&>);
+
+    // TensorView should be constructible from another TensorView
+    static_assert(std::is_constructible_v<Core::LinAlg::TensorView<double, 3>,
+        Core::LinAlg::TensorView<double, 3>>);
+
+    // TensorView should NOT be constructible from another const TensorView
+    static_assert(!std::is_constructible_v<Core::LinAlg::TensorView<double, 3>,
+        Core::LinAlg::TensorView<const double, 3>>);
+
+    // const TensorView should be constructible from another const TensorView
+    static_assert(std::is_constructible_v<Core::LinAlg::TensorView<const double, 3>,
+        Core::LinAlg::TensorView<const double, 3>>);
+  }
+
+  TEST(TensorViewTest, MutableTensorView)
+  {
+    Core::LinAlg::Tensor<double, 3> t{};
+
+    Core::LinAlg::TensorView<double, 3> t_view(t);
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0), 0.0);
+
+    t_view(1) = 2.0;
+
+    EXPECT_DOUBLE_EQ(t(1), 2.0);
+
+    // this is the actual ultimate test whether they work on the same data
+    EXPECT_EQ(t_view.data(), t.data());
+  }
+
+  TEST(TensorViewTest, ConstantTensorView)
+  {
+    const Core::LinAlg::Tensor<double, 3> t{};
+    Core::LinAlg::TensorView<const double, 3> t_view(t);
+
+    // this is the actual ultimate test whether they work on the same data
+    EXPECT_EQ(t_view.data(), t.data());
+  }
+
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
This is a first draft of a tensor class in 4C. Only few tensor operations are defined.

~~Currently, I'm using [Fastor](https://github.com/romeric/Fastor) as the backend for tensor operations.~~

I'm using the same internals as the `Core::LinAlg::Matrix`. This ensures that
(a) we use the same internal ordering of the values for tensors of rank 2
(b) we don't use different math kernels for basically the same thing.
This has of course the drawback that our own implementation is less flexible and also not really optimized for current hardware. But we might want to switch to a more powerful backend and then tensors and matrices profit the same.

Note, the Tensor as suggested here is just a different object but the mathematicals are identical. Tensor operations are more flexible, but also not faster than our existing LinAlg::Matrix, except maybe that the values are not dynamically allocated.

```cpp
Core::LinAlg::Tensor<double, 3, 3> A = {{
  {1.1, 1.2, 1.3},
  {2.1, 2.2, 2.3},
  {3.1, 3.2, 3.3},
}};
Core::LinAlg::Tensor<double, 3> b = {{1.0, 2.0, 3.0}};

double det = Core::LinAlg::det(A);
double trace = Core::LinAlg::trace(A);
Core::LinAlg::Tensor<double, 3, 3> A_inv = Core::LinAlg::inv(A);

Core::LinAlg::Tensor<double, 3> c = Core::LinAlg::dot(A, b);
double d = Core::LinAlg::double_contraction(A, A);

Core::LinAlg::Tensor<double, 3, 3, 3, 3> E = Core::LinAlg::dyadic(A, A);

// supports addition of two tensors
Core::LinAlg::Tensor<double, 3, 3> B = A + A;

// also supports views to other tensors
Core::LinAlg::TensorView<double, 3, 3> A_view(A);
```

#62