### PR TITLE
Enhance build time analysis with ninjatracing

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -136,6 +136,11 @@ jobs:
           repository: aras-p/ClangBuildAnalyzer
           ref: bae0cb488cce944bfc3da9850a69ad621701ebef # version 1.6.0
           path: ClangBuildAnalyzer
+      - uses: actions/checkout@v4
+        with:
+          repository: nico/ninjatracing
+          ref: a669e3644cf22b29cbece31dbed2cfbf34e5f48e # no releases for this repo, this is a stable commit
+          path: ninjatracing
       - name: Build ClangBuildAnalyzer
         run: |
           cd $GITHUB_WORKSPACE/ClangBuildAnalyzer
@@ -150,12 +155,22 @@ jobs:
           $GITHUB_WORKSPACE/ClangBuildAnalyzer/build/ClangBuildAnalyzer --all $GITHUB_WORKSPACE/build time_trace.bin
           $GITHUB_WORKSPACE/ClangBuildAnalyzer/build/ClangBuildAnalyzer --analyze time_trace.bin > $GITHUB_WORKSPACE/clang18_compile_time_report.txt
           cat $GITHUB_WORKSPACE/clang18_compile_time_report.txt
+      - name: Aggregate trace
+        run: |
+          $GITHUB_WORKSPACE/ninjatracing/ninjatracing -e $GITHUB_WORKSPACE/build/.ninja_log > $GITHUB_WORKSPACE/clang18_compile_time_trace.json
       - name: Upload report
         uses: actions/upload-artifact@v4
         with:
           name: clang18_compile_time_report.txt
           path: |
             ${{ github.workspace }}/clang18_compile_time_report.txt
+          retention-days: 90
+      - name: Upload trace
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang18_compile_time_trace.json
+          path: |
+            ${{ github.workspace }}/clang18_compile_time_trace.json
           retention-days: 90
 
   clang18_test:


### PR DESCRIPTION
I learned about this nice tool [ninjatracing](https://github.com/nico/ninjatracing) which allows to embed the detailed output from `-ftime-trace` within the project-wide info in .ninja_log. The results can be viewed as a flame graph like this (e.g. here: https://ui.perfetto.dev/):

![image](https://github.com/user-attachments/assets/dc0001a0-d791-493a-b26c-df4c3c8d55b3)

This PR adds this information to the existing nightly job and provides the trace as an artifact.

Credit for the idea: https://www.youtube.com/watch?v=Oih3K-3eZ4Y