### PR TITLE
InputSpec: refactor internals and add better errors

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -820,9 +820,7 @@ namespace Core::IO
         // the input of the functions is restructured.
         auto spec = pimpl_->valid_sections_.at("FUNCT<n>");
         spec.impl().data.name = name;
-        dynamic_cast<
-            Internal::InputSpecTypeErasedImplementation<InputSpecBuilders::Internal::ListSpec>&>(
-            spec.impl())
+        dynamic_cast<Internal::InputSpecTypeErasedImplementation<Internal::ListSpec>&>(spec.impl())
             .wrapped.name = name;
         pimpl_->valid_sections_.emplace(name, std::move(spec));
       }
@@ -921,8 +919,9 @@ namespace Core::IO
     {
       // Dat format has too little structure and the interpretation of line breaks differs
       // depending on the expected spec.
-      const auto* list_spec = dynamic_cast<const Internal::InputSpecTypeErasedImplementation<
-          InputSpecBuilders::Internal::ListSpec>*>(&spec.impl());
+      const auto* list_spec =
+          dynamic_cast<const Internal::InputSpecTypeErasedImplementation<Internal::ListSpec>*>(
+              &spec.impl());
 
       if (list_spec)
       {

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -13,7 +13,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-Core::IO::InputSpec::InputSpec(std::unique_ptr<Internal::InputSpecTypeErasedBase> pimpl)
+Core::IO::InputSpec::InputSpec(std::unique_ptr<Internal::InputSpecImpl> pimpl)
     : pimpl_(std::move(pimpl))
 {
 }
@@ -92,13 +92,13 @@ void Core::IO::InputSpec::emit_metadata(YamlNodeRef yaml) const
   pimpl_->emit_metadata(root);
 }
 
-Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl()
+Core::IO::Internal::InputSpecImpl& Core::IO::InputSpec::impl()
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
   return *pimpl_;
 }
 
-const Core::IO::Internal::InputSpecTypeErasedBase& Core::IO::InputSpec::impl() const
+const Core::IO::Internal::InputSpecImpl& Core::IO::InputSpec::impl() const
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
   return *pimpl_;

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -24,7 +24,7 @@ namespace Core::IO
 
   namespace Internal
   {
-    class InputSpecTypeErasedBase;
+    class InputSpecImpl;
   }  // namespace Internal
 
   struct InputSpecEmitOptions
@@ -48,7 +48,7 @@ namespace Core::IO
 
     ~InputSpec();
 
-    InputSpec(std::unique_ptr<Internal::InputSpecTypeErasedBase> pimpl);
+    InputSpec(std::unique_ptr<Internal::InputSpecImpl> pimpl);
 
     InputSpec(const InputSpec& other);
     InputSpec& operator=(const InputSpec& other);
@@ -93,17 +93,17 @@ namespace Core::IO
      * definition is known. There is nothing you can or should do with this function in the user
      * code.
      */
-    Internal::InputSpecTypeErasedBase& impl();
+    Internal::InputSpecImpl& impl();
 
     /**
      * Access the opaque implementation class. This is used in the implementation files where the
      * definition is known. There is nothing you can or should do with this function in the user
      * code.
      */
-    [[nodiscard]] const Internal::InputSpecTypeErasedBase& impl() const;
+    [[nodiscard]] const Internal::InputSpecImpl& impl() const;
 
    private:
-    std::unique_ptr<Internal::InputSpecTypeErasedBase> pimpl_;
+    std::unique_ptr<Internal::InputSpecImpl> pimpl_;
   };
 }  // namespace Core::IO
 

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -261,9 +261,9 @@ namespace
         "Expected", "Fully matched", "Partially matched", "Defaulted"};
     std::string indent = std::string(depth, ' ');
 
-    switch (entry.type)
+    switch (entry.spec->impl().data.type)
     {
-      case MatchEntry::Type::parameter:
+      case InputSpecType::parameter:
       {
         out << indent;
         out << std::format("{} {} parameter '{}'", state_symbol[static_cast<int>(entry.state)],
@@ -276,7 +276,7 @@ namespace
         out << '\n';
         break;
       }
-      case MatchEntry::Type::group:
+      case InputSpecType::group:
       {
         out << indent;
         out << std::format("{} {} group '{}'\n", state_symbol[static_cast<int>(entry.state)],
@@ -290,7 +290,7 @@ namespace
         }
         break;
       }
-      case MatchEntry::Type::list:
+      case InputSpecType::list:
       {
         out << indent;
         out << std::format("{} {} list '{}'\n", state_symbol[static_cast<int>(entry.state)],
@@ -305,9 +305,9 @@ namespace
 
           if (entry.children.front()->state == MatchEntry::State::matched)
           {
-            auto* list_spec = dynamic_cast<
-                const InputSpecTypeErasedImplementation<InputSpecBuilders::Internal::ListSpec>*>(
-                &entry.spec->impl());
+            auto* list_spec =
+                dynamic_cast<const InputSpecTypeErasedImplementation<Internal::ListSpec>*>(
+                    &entry.spec->impl());
             FOUR_C_ASSERT(list_spec != nullptr, "Internal error: ListSpec expected.");
 
             const int n_actual_entries = partially_matched_list_node.num_children();
@@ -328,7 +328,7 @@ namespace
         }
         break;
       }
-      case MatchEntry::Type::all_of:
+      case InputSpecType::all_of:
       {
         out << indent << "{\n";
         for (const auto* child : entry.children)
@@ -338,7 +338,7 @@ namespace
         out << indent << "}\n";
         break;
       }
-      case MatchEntry::Type::one_of:
+      case InputSpecType::one_of:
       {
         // one_of can print way too much information, so we try to figure out what the best match
         // was.
@@ -408,7 +408,7 @@ namespace
         break;
       }
       default:
-        FOUR_C_ASSERT(false, "Internal error: unknown MatchEntry::Type.");
+        FOUR_C_ASSERT(false, "Internal error: unknown InputSpecType.");
     }
   }
 
@@ -452,9 +452,9 @@ namespace
     std::vector<ryml::id_type> matched_node_ids{node.id()};
     for (const auto& entry : entries)
     {
-      switch (entry.type)
+      switch (entry.spec->impl().data.type)
       {
-        case MatchEntry::Type::parameter:
+        case InputSpecType::parameter:
         {
           if (entry.state == MatchEntry::State::matched)
           {
@@ -462,7 +462,7 @@ namespace
           }
           break;
         }
-        case MatchEntry::Type::group:
+        case InputSpecType::group:
         {
           if (entry.state != MatchEntry::State::unmatched)
           {
@@ -472,7 +472,7 @@ namespace
           }
           break;
         }
-        case MatchEntry::Type::list:
+        case InputSpecType::list:
         {
           if (entry.state == MatchEntry::State::matched)
           {
@@ -481,7 +481,7 @@ namespace
           }
           break;
         }
-        case MatchEntry::Type::selection:
+        case InputSpecType::selection:
         {
           if (entry.state == MatchEntry::State::matched)
           {
@@ -570,15 +570,13 @@ Core::IO::Internal::MatchEntry& Core::IO::Internal::MatchEntry::append_child(
 void MatchEntry::reset()
 {
   state = State::unmatched;
-  type = Type::unknown;
   matched_node = ryml::npos;
   children.clear();
   tree->erase_everything_after(*this);
 }
 
 
-InputSpecTypeErasedBase::InputSpecTypeErasedBase(InputSpecTypeErasedBase::CommonData data)
-    : data(std::move(data))
+InputSpecImpl::InputSpecImpl(InputSpecImpl::CommonData data) : data(std::move(data))
 {
   const auto check_for_unprintable_chars =
       [](const std::string& check_string, const auto& field_type)
@@ -614,13 +612,13 @@ InputSpecTypeErasedBase::InputSpecTypeErasedBase(InputSpecTypeErasedBase::Common
   check_for_unprintable_chars(this->data.name, "name");
 }
 
-std::string Core::IO::Internal::InputSpecTypeErasedBase::description_one_line() const
+std::string Core::IO::Internal::InputSpecImpl::description_one_line() const
 {
   return Core::Utils::trim(data.description);
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::GroupSpec::parse(
+void Core::IO::Internal::GroupSpec::parse(
     Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
 {
   FOUR_C_ASSERT(!name.empty(), "Internal error: group name must not be empty.");
@@ -634,10 +632,9 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::parse(
   container.group(name) = subcontainer;
 }
 
-bool Core::IO::InputSpecBuilders::Internal::GroupSpec::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::GroupSpec::match(ConstYamlNodeRef node,
     Core::IO::InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::group;
   FOUR_C_ASSERT(!name.empty(), "Internal error: group name must not be empty.");
   const auto group_name = ryml::to_csubstr(name);
 
@@ -679,7 +676,7 @@ bool Core::IO::InputSpecBuilders::Internal::GroupSpec::match(ConstYamlNodeRef no
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::GroupSpec::set_default_value(
+void Core::IO::Internal::GroupSpec::set_default_value(
     Core::IO::InputParameterContainer& container) const
 {
   FOUR_C_ASSERT(!name.empty(), "Internal error: group name must not be empty.");
@@ -690,8 +687,7 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::set_default_value(
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::GroupSpec::print(
-    std::ostream& stream, std::size_t indent) const
+void Core::IO::Internal::GroupSpec::print(std::ostream& stream, std::size_t indent) const
 {
   stream << "// " << std::string(indent, ' ') << name << ":\n";
   indent += 2;
@@ -702,7 +698,7 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::print(
   }
 }
 
-void Core::IO::InputSpecBuilders::Internal::GroupSpec::emit_metadata(ryml::NodeRef node) const
+void Core::IO::Internal::GroupSpec::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
   node["name"] << name;
@@ -726,8 +722,8 @@ void Core::IO::InputSpecBuilders::Internal::GroupSpec::emit_metadata(ryml::NodeR
 }
 
 
-bool InputSpecBuilders::Internal::GroupSpec::emit(YamlNodeRef node,
-    const InputParameterContainer& container, const InputSpecEmitOptions& options) const
+bool Internal::GroupSpec::emit(YamlNodeRef node, const InputParameterContainer& container,
+    const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
   ChildNodeCheckpoint checkpoint(node);
@@ -756,7 +752,7 @@ bool InputSpecBuilders::Internal::GroupSpec::emit(YamlNodeRef node,
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::AllOfSpec::parse(
+void Core::IO::Internal::AllOfSpec::parse(
     Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
 {
   // Parse into a separate container to avoid side effects if parsing fails.
@@ -766,10 +762,9 @@ void Core::IO::InputSpecBuilders::Internal::AllOfSpec::parse(
 }
 
 
-bool Core::IO::InputSpecBuilders::Internal::AllOfSpec::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::AllOfSpec::match(ConstYamlNodeRef node,
     Core::IO::InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::all_of;
   std::vector<ryml::id_type> parsed_node_ids;
 
   // Parse into a separate container to avoid side effects if parsing fails.
@@ -791,7 +786,7 @@ bool Core::IO::InputSpecBuilders::Internal::AllOfSpec::match(ConstYamlNodeRef no
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::AllOfSpec::set_default_value(
+void Core::IO::Internal::AllOfSpec::set_default_value(
     Core::IO::InputParameterContainer& container) const
 {
   for (const auto& spec : specs)
@@ -801,8 +796,7 @@ void Core::IO::InputSpecBuilders::Internal::AllOfSpec::set_default_value(
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::AllOfSpec::print(
-    std::ostream& stream, std::size_t indent) const
+void Core::IO::Internal::AllOfSpec::print(std::ostream& stream, std::size_t indent) const
 {
   // Only print an "<all_of>" header if it is not present at the top-level.
   if (indent > 0)
@@ -817,7 +811,7 @@ void Core::IO::InputSpecBuilders::Internal::AllOfSpec::print(
   }
 }
 
-void Core::IO::InputSpecBuilders::Internal::AllOfSpec::emit_metadata(ryml::NodeRef node) const
+void Core::IO::Internal::AllOfSpec::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
 
@@ -839,8 +833,8 @@ void Core::IO::InputSpecBuilders::Internal::AllOfSpec::emit_metadata(ryml::NodeR
 }
 
 
-bool InputSpecBuilders::Internal::AllOfSpec::emit(YamlNodeRef node,
-    const InputParameterContainer& container, const InputSpecEmitOptions& options) const
+bool Internal::AllOfSpec::emit(YamlNodeRef node, const InputParameterContainer& container,
+    const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
   ChildNodeCheckpoint checkpoint(node);
@@ -856,7 +850,7 @@ bool InputSpecBuilders::Internal::AllOfSpec::emit(YamlNodeRef node,
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::OneOfSpec::parse(
+void Core::IO::Internal::OneOfSpec::parse(
     Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
 {
   ValueParser::BacktrackScope backtrack_scope(parser);
@@ -914,10 +908,9 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::parse(
 }
 
 
-bool Core::IO::InputSpecBuilders::Internal::OneOfSpec::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::OneOfSpec::match(ConstYamlNodeRef node,
     Core::IO::InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::one_of;
   InputParameterContainer subcontainer;
 
   std::size_t matched_index = 0;
@@ -959,15 +952,14 @@ bool Core::IO::InputSpecBuilders::Internal::OneOfSpec::match(ConstYamlNodeRef no
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::OneOfSpec::set_default_value(
+void Core::IO::Internal::OneOfSpec::set_default_value(
     Core::IO::InputParameterContainer& container) const
 {
   FOUR_C_THROW("Implementation error: OneOfSpec cannot have a default value.");
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::OneOfSpec::print(
-    std::ostream& stream, std::size_t indent) const
+void Core::IO::Internal::OneOfSpec::print(std::ostream& stream, std::size_t indent) const
 {
   stream << "// " << std::string(indent, ' ') << "<one_of>:\n";
   for (const auto& spec : specs)
@@ -976,7 +968,7 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::print(
   }
 }
 
-void Core::IO::InputSpecBuilders::Internal::OneOfSpec::emit_metadata(ryml::NodeRef node) const
+void Core::IO::Internal::OneOfSpec::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
 
@@ -994,8 +986,8 @@ void Core::IO::InputSpecBuilders::Internal::OneOfSpec::emit_metadata(ryml::NodeR
 }
 
 
-bool InputSpecBuilders::Internal::OneOfSpec::emit(YamlNodeRef node,
-    const InputParameterContainer& container, const InputSpecEmitOptions& options) const
+bool Internal::OneOfSpec::emit(YamlNodeRef node, const InputParameterContainer& container,
+    const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
   ChildNodeCheckpoint checkpoint(node);
@@ -1016,11 +1008,11 @@ bool InputSpecBuilders::Internal::OneOfSpec::emit(YamlNodeRef node,
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::ListSpec::parse(
+void Core::IO::Internal::ListSpec::parse(
     Core::IO::ValueParser& parser, Core::IO::InputParameterContainer& container) const
 {
-  FOUR_C_ASSERT_ALWAYS(
-      data.size != dynamic_size, "ListSpec with dynamic size cannot be parsed from dat.");
+  FOUR_C_ASSERT_ALWAYS(data.size != InputSpecBuilders::dynamic_size,
+      "ListSpec with dynamic size cannot be parsed from dat.");
 
   parser.consume(name);
 
@@ -1033,10 +1025,9 @@ void Core::IO::InputSpecBuilders::Internal::ListSpec::parse(
 }
 
 
-bool Core::IO::InputSpecBuilders::Internal::ListSpec::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::ListSpec::match(ConstYamlNodeRef node,
     Core::IO::InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::list;
   FOUR_C_ASSERT(!name.empty(), "Internal error: list name must not be empty.");
   const auto list_name = ryml::to_csubstr(name);
 
@@ -1088,7 +1079,7 @@ bool Core::IO::InputSpecBuilders::Internal::ListSpec::match(ConstYamlNodeRef nod
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::ListSpec::set_default_value(
+void Core::IO::Internal::ListSpec::set_default_value(
     Core::IO::InputParameterContainer& container) const
 {
   std::vector<InputParameterContainer> default_list(data.size);
@@ -1102,15 +1093,14 @@ void Core::IO::InputSpecBuilders::Internal::ListSpec::set_default_value(
 }
 
 
-void Core::IO::InputSpecBuilders::Internal::ListSpec::print(
-    std::ostream& stream, std::size_t indent) const
+void Core::IO::Internal::ListSpec::print(std::ostream& stream, std::size_t indent) const
 {
   stream << "// " << std::string(indent, ' ') << "list '" << name << "'"
          << " with entries:\n";
   spec.impl().print(stream, indent + 2);
 }
 
-void Core::IO::InputSpecBuilders::Internal::ListSpec::emit_metadata(ryml::NodeRef node) const
+void Core::IO::Internal::ListSpec::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
 
@@ -1128,8 +1118,8 @@ void Core::IO::InputSpecBuilders::Internal::ListSpec::emit_metadata(ryml::NodeRe
 }
 
 
-bool InputSpecBuilders::Internal::ListSpec::emit(YamlNodeRef node,
-    const InputParameterContainer& container, const InputSpecEmitOptions& options) const
+bool Internal::ListSpec::emit(YamlNodeRef node, const InputParameterContainer& container,
+    const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
   ChildNodeCheckpoint checkpoint(node);
@@ -1160,15 +1150,15 @@ namespace
   // Nesting all_of or one_of within another spec of that same type is the same as pulling the
   // nested specs up into the parent spec. An additional predicate can be used to filter the nested
   // specs that may be flattened.
-  template <typename SpecType>
+  template <typename InputSpecType>
   std::vector<Core::IO::InputSpec> flatten_nested(std::vector<Core::IO::InputSpec> specs,
-      std::function<bool(const SpecType&)> predicate = nullptr)
+      std::function<bool(const InputSpecType&)> predicate = nullptr)
   {
     std::vector<Core::IO::InputSpec> flattened_specs;
     for (auto&& spec : specs)
     {
       if (auto* nested =
-              dynamic_cast<Core::IO::Internal::InputSpecTypeErasedImplementation<SpecType>*>(
+              dynamic_cast<Core::IO::Internal::InputSpecTypeErasedImplementation<InputSpecType>*>(
                   &spec.impl());
           nested && (!predicate || predicate(nested->wrapped)))
       {
@@ -1217,12 +1207,13 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::group(
         name.c_str());
   }
 
-  IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
+  InputSpecImpl::CommonData common_data{
       .name = name,
       .description = data.description,
       .required = data.required.value(),
       .has_default_value = data.defaultable,
       .n_specs = count_contained_specs(flattened_specs) + 1,
+      .type = InputSpecType::group,
   };
 
   return IO::Internal::make_spec(
@@ -1249,12 +1240,13 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::all_of(std::vector<InputSpec> s
   // Generate a description of the form "group {a, b, c}".
   std::string description = "all_of " + describe(flattened_specs);
 
-  IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
+  InputSpecImpl::CommonData common_data{
       .name = "",
       .description = description,
       .required = any_required,
       .has_default_value = all_have_default_values(flattened_specs),
       .n_specs = count_contained_specs(flattened_specs) + 1,
+      .type = InputSpecType::all_of,
   };
 
   return IO::Internal::make_spec(
@@ -1303,12 +1295,13 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::one_of(std::vector<InputSpec> s
   }
 
   std::string description = "one_of " + describe(flattened_specs);
-  IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
+  InputSpecImpl::CommonData common_data{
       .name = "",
       .description = description,
       .required = true,
       .has_default_value = false,
       .n_specs = count_contained_specs(flattened_specs) + 1,
+      .type = InputSpecType::one_of,
   };
 
   GroupData group_data{
@@ -1326,7 +1319,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::one_of(std::vector<InputSpec> s
 Core::IO::InputSpec Core::IO::InputSpecBuilders::list(
     std::string name, Core::IO::InputSpec spec, ListData data)
 {
-  IO::Internal::InputSpecTypeErasedBase::CommonData common_data{
+  InputSpecImpl::CommonData common_data{
       .name = name,
       .description = data.description,
       .required = data.required,
@@ -1334,6 +1327,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::list(
       // a default value.
       .has_default_value = spec.impl().has_default_value() && data.size != dynamic_size,
       .n_specs = spec.impl().data.n_specs + 1,
+      .type = InputSpecType::list,
   };
 
   return IO::Internal::make_spec(

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -270,20 +270,7 @@ namespace Core::IO
         defaulted,
       };
 
-      enum class Type : std::uint8_t
-      {
-        unknown,
-        parameter,
-        selection,
-        group,
-        all_of,
-        one_of,
-        list,
-      };
-
       State state{State::unmatched};
-      Type type{Type::unknown};
-
 
       /**
        * Append a child for the @p in_spec to the current entry and return a reference to it. This
@@ -331,7 +318,23 @@ namespace Core::IO
       ConstYamlNodeRef node_;
     };
 
-    class InputSpecTypeErasedBase
+
+    /**
+     * Distinguish between different types of specs in the implementation.
+     */
+    enum class InputSpecType : std::uint8_t
+    {
+      parameter,
+      group,
+      list,
+      selection,
+      all_of,
+      one_of,
+      deprecated_selection,
+    };
+
+
+    class InputSpecImpl
     {
      public:
       /**
@@ -365,14 +368,20 @@ namespace Core::IO
          * that the minimum value is 1. This value can be used to reserve memory ahead of time.
          */
         std::size_t n_specs;
+
+        /**
+         * The type of the spec.
+         */
+        InputSpecType type;
       };
 
-      virtual ~InputSpecTypeErasedBase() = default;
+
+      virtual ~InputSpecImpl() = default;
 
       /**
        * @param data The common data of the spec.
        */
-      InputSpecTypeErasedBase(CommonData data);
+      InputSpecImpl(CommonData data);
 
       virtual void parse(ValueParser& parser, InputParameterContainer& container) const = 0;
 
@@ -398,7 +407,7 @@ namespace Core::IO
 
       [[nodiscard]] virtual std::string pretty_type_name() const = 0;
 
-      [[nodiscard]] virtual std::unique_ptr<InputSpecTypeErasedBase> clone() const = 0;
+      [[nodiscard]] virtual std::unique_ptr<InputSpecImpl> clone() const = 0;
 
       void print(std::ostream& stream, std::size_t indent) const { do_print(stream, indent); }
 
@@ -416,10 +425,10 @@ namespace Core::IO
       CommonData data;
 
      protected:
-      InputSpecTypeErasedBase(const InputSpecTypeErasedBase&) = default;
-      InputSpecTypeErasedBase& operator=(const InputSpecTypeErasedBase&) = default;
-      InputSpecTypeErasedBase(InputSpecTypeErasedBase&&) noexcept = default;
-      InputSpecTypeErasedBase& operator=(InputSpecTypeErasedBase&&) noexcept = default;
+      InputSpecImpl(const InputSpecImpl&) = default;
+      InputSpecImpl& operator=(const InputSpecImpl&) = default;
+      InputSpecImpl(InputSpecImpl&&) noexcept = default;
+      InputSpecImpl& operator=(InputSpecImpl&&) noexcept = default;
 
      private:
       virtual void do_print(std::ostream& stream, std::size_t indent) const = 0;
@@ -429,11 +438,11 @@ namespace Core::IO
     concept StoresType = requires(T t) { typename T::StoredType; };
 
     template <typename T>
-    struct InputSpecTypeErasedImplementation : public InputSpecTypeErasedBase
+    struct InputSpecTypeErasedImplementation : public InputSpecImpl
     {
       template <typename T2>
       explicit InputSpecTypeErasedImplementation(T2&& wrapped, CommonData data)
-          : InputSpecTypeErasedBase(std::move(data)), wrapped(std::forward<T2>(wrapped))
+          : InputSpecImpl(std::move(data)), wrapped(std::forward<T2>(wrapped))
       {
       }
 
@@ -515,7 +524,7 @@ namespace Core::IO
         }
       }
 
-      [[nodiscard]] std::unique_ptr<InputSpecTypeErasedBase> clone() const override
+      [[nodiscard]] std::unique_ptr<InputSpecImpl> clone() const override
       {
         return std::make_unique<InputSpecTypeErasedImplementation<T>>(wrapped, data);
       }
@@ -524,7 +533,7 @@ namespace Core::IO
     };
 
     template <typename T>
-    InputSpec make_spec(T&& wrapped, InputSpecTypeErasedBase::CommonData data)
+    InputSpec make_spec(T&& wrapped, InputSpecImpl::CommonData data)
     {
       return InputSpec(std::make_unique<InputSpecTypeErasedImplementation<std::decay_t<T>>>(
           std::forward<T>(wrapped), std::move(data)));
@@ -703,211 +712,214 @@ namespace Core::IO
        */
       int size{dynamic_size};
     };
+  }  // namespace InputSpecBuilders
 
-    namespace Internal
+  namespace Internal
+  {
+    template <typename T>
+    struct ParameterData
     {
-      template <typename T>
-      struct ParameterData
+      using StoredType = T;
+
+      std::string description{};
+
+      std::variant<std::monostate, StoredType> default_value{};
+
+      InputSpecBuilders::ParameterCallback on_parse_callback{nullptr};
+
+      std::array<InputSpecBuilders::Size, rank<T>()> size{};
+    };
+
+    template <typename T>
+    struct DeprecatedSelectionData
+    {
+      using StoredType = T;
+
+      std::string description{};
+
+      std::variant<std::monostate, StoredType> default_value{};
+
+      InputSpecBuilders::ParameterCallback on_parse_callback{nullptr};
+    };
+
+    template <SupportedType T>
+    struct ParameterSpec
+    {
+      std::string name;
+      using StoredType = T;
+      ParameterData<T> data;
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+      [[nodiscard]] bool has_correct_size(
+          const T& val, const InputParameterContainer& container) const;
+    };
+
+    /**
+     * Note that a DeprecatedSelectionSpec can store any type since we never need to read or write
+     * values of this type.
+     */
+    template <typename T>
+    struct DeprecatedSelectionSpec
+    {
+      std::string name;
+      using StoredType = T;
+      //! The type that is used in the input file.
+      using InputType =
+          std::conditional_t<OptionalType<T>, std::optional<std::string>, std::string>;
+      using ChoiceMap = std::map<InputType, StoredType>;
+      DeprecatedSelectionData<T> data;
+      ChoiceMap choices;
+      //! The string representation of the choices.
+      std::string choices_string;
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+      void print(std::ostream& stream, std::size_t indent) const;
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+    };
+
+    //! Helper for selection().
+    template <typename T>
+      requires(std::is_enum_v<T>)
+    struct BasedOn
+    {
+      std::string selector{"type"};
+      std::map<T, InputSpec> choices;
+    };
+
+    template <typename T>
+      requires(std::is_enum_v<T>)
+    struct SelectionSpec
+    {
+      std::string group_name;
+      BasedOn<T> based_on;
+      InputSpecBuilders::SelectionData data;
+      InputSpec selector_spec;
+
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+      void print(std::ostream& stream, std::size_t indent) const;
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+      void set_default_value(InputParameterContainer& container) const;
+    };
+
+    struct GroupSpec
+    {
+      std::string name;
+      InputSpecBuilders::GroupData data;
+      std::vector<InputSpec> specs;
+
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+      void set_default_value(InputParameterContainer& container) const;
+      void print(std::ostream& stream, std::size_t indent) const;
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+    };
+
+    struct AllOfSpec
+    {
+      InputSpecBuilders::GroupData data;
+      std::vector<InputSpec> specs;
+
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+      void set_default_value(InputParameterContainer& container) const;
+      void print(std::ostream& stream, std::size_t indent) const;
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+    };
+
+    struct OneOfSpec
+    {
+      // A one_of spec is essentially an unnamed group with additional logic to ensure that
+      // exactly one of the contained specs is present.
+      InputSpecBuilders::GroupData data;
+      std::vector<InputSpec> specs;
+
+      //! This callback may be used to perform additional actions after parsing one of the specs.
+      //! The index of the parsed spec as given inside #specs is passed as an argument.
+      std::function<void(InputParameterContainer& container, std::size_t index)> on_parse_callback;
+
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+
+      void set_default_value(InputParameterContainer& container) const;
+
+      void print(std::ostream& stream, std::size_t indent) const;
+
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+    };
+
+    struct ListSpec
+    {
+      //! The name of the list.
+      std::string name;
+      //! The spec that fits the list elements.
+      InputSpec spec;
+
+      InputSpecBuilders::ListData data;
+
+      void parse(ValueParser& parser, InputParameterContainer& container) const;
+      bool match(ConstYamlNodeRef node, InputParameterContainer& container,
+          IO::Internal::MatchEntry& match_entry) const;
+      void set_default_value(InputParameterContainer& container) const;
+      void print(std::ostream& stream, std::size_t indent) const;
+      void emit_metadata(ryml::NodeRef node) const;
+      bool emit(YamlNodeRef node, const InputParameterContainer& container,
+          const InputSpecEmitOptions& options) const;
+    };
+
+
+    //! Helper to create selection() specs.
+    //! Note that the type can be anything since we never read or write values of this type.
+    template <typename T>
+    [[nodiscard]] InputSpec selection_internal(std::string name,
+        std::map<std::string, RemoveOptional<T>> choices,
+        InputSpecBuilders::ParameterDataIn<T> data = {});
+
+
+    struct SizeChecker
+    {
+      constexpr bool operator()(const auto& val, std::size_t* size_info) const { return true; }
+
+      template <typename U>
+      constexpr bool operator()(const std::vector<U>& v, std::size_t* size_info) const
       {
-        using StoredType = T;
+        return ((*size_info == InputSpecBuilders::dynamic_size) || (v.size() == *size_info)) &&
+               std::ranges::all_of(
+                   v, [&](const auto& val) { return this->operator()(val, size_info + 1); });
+      }
 
-        std::string description{};
-
-        std::variant<std::monostate, StoredType> default_value{};
-
-        ParameterCallback on_parse_callback{nullptr};
-
-        std::array<Size, rank<T>()> size{};
-      };
-
-      template <typename T>
-      struct DeprecatedSelectionData
+      template <typename U>
+      constexpr bool operator()(const std::map<std::string, U>& m, std::size_t* size_info) const
       {
-        using StoredType = T;
+        return ((*size_info == InputSpecBuilders::dynamic_size) || (m.size() == *size_info)) &&
+               std::ranges::all_of(
+                   m, [&](const auto& val) { return this->operator()(val.second, size_info + 1); });
+      }
+    };
+  }  // namespace Internal
 
-        std::string description{};
-
-        std::variant<std::monostate, StoredType> default_value{};
-
-        ParameterCallback on_parse_callback{nullptr};
-      };
-
-      template <SupportedType T>
-      struct ParameterSpec
-      {
-        std::string name;
-        using StoredType = T;
-        ParameterData<T> data;
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-        [[nodiscard]] bool has_correct_size(
-            const T& val, const InputParameterContainer& container) const;
-      };
-
-      /**
-       * Note that a DeprecatedSelectionSpec can store any type since we never need to read or write
-       * values of this type.
-       */
-      template <typename T>
-      struct DeprecatedSelectionSpec
-      {
-        std::string name;
-        using StoredType = T;
-        //! The type that is used in the input file.
-        using InputType =
-            std::conditional_t<OptionalType<T>, std::optional<std::string>, std::string>;
-        using ChoiceMap = std::map<InputType, StoredType>;
-        DeprecatedSelectionData<T> data;
-        ChoiceMap choices;
-        //! The string representation of the choices.
-        std::string choices_string;
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-        void print(std::ostream& stream, std::size_t indent) const;
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-      };
-
-      //! Helper for selection().
-      template <typename T>
-        requires(std::is_enum_v<T>)
-      struct BasedOn
-      {
-        std::string selector{"type"};
-        std::map<T, InputSpec> choices;
-      };
-
-      template <typename T>
-        requires(std::is_enum_v<T>)
-      struct SelectionSpec
-      {
-        std::string group_name;
-        BasedOn<T> based_on;
-        SelectionData data;
-        InputSpec selector_spec;
-
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-        void print(std::ostream& stream, std::size_t indent) const;
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-        void set_default_value(InputParameterContainer& container) const;
-      };
-
-      struct GroupSpec
-      {
-        std::string name;
-        GroupData data;
-        std::vector<InputSpec> specs;
-
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-        void set_default_value(InputParameterContainer& container) const;
-        void print(std::ostream& stream, std::size_t indent) const;
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-      };
-
-      struct AllOfSpec
-      {
-        GroupData data;
-        std::vector<InputSpec> specs;
-
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-        void set_default_value(InputParameterContainer& container) const;
-        void print(std::ostream& stream, std::size_t indent) const;
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-      };
-
-      struct OneOfSpec
-      {
-        // A one_of spec is essentially an unnamed group with additional logic to ensure that
-        // exactly one of the contained specs is present.
-        GroupData data;
-        std::vector<InputSpec> specs;
-
-        //! This callback may be used to perform additional actions after parsing one of the specs.
-        //! The index of the parsed spec as given inside #specs is passed as an argument.
-        std::function<void(InputParameterContainer& container, std::size_t index)>
-            on_parse_callback;
-
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-
-        void set_default_value(InputParameterContainer& container) const;
-
-        void print(std::ostream& stream, std::size_t indent) const;
-
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-      };
-
-      struct ListSpec
-      {
-        //! The name of the list.
-        std::string name;
-        //! The spec that fits the list elements.
-        InputSpec spec;
-
-        ListData data;
-
-        void parse(ValueParser& parser, InputParameterContainer& container) const;
-        bool match(ConstYamlNodeRef node, InputParameterContainer& container,
-            IO::Internal::MatchEntry& match_entry) const;
-        void set_default_value(InputParameterContainer& container) const;
-        void print(std::ostream& stream, std::size_t indent) const;
-        void emit_metadata(ryml::NodeRef node) const;
-        bool emit(YamlNodeRef node, const InputParameterContainer& container,
-            const InputSpecEmitOptions& options) const;
-      };
-
-
-      //! Helper to create selection() specs.
-      //! Note that the type can be anything since we never read or write values of this type.
-      template <typename T>
-      [[nodiscard]] InputSpec selection_internal(std::string name,
-          std::map<std::string, RemoveOptional<T>> choices, ParameterDataIn<T> data = {});
-
-
-      struct SizeChecker
-      {
-        constexpr bool operator()(const auto& val, std::size_t* size_info) const { return true; }
-
-        template <typename U>
-        constexpr bool operator()(const std::vector<U>& v, std::size_t* size_info) const
-        {
-          return ((*size_info == dynamic_size) || (v.size() == *size_info)) &&
-                 std::ranges::all_of(
-                     v, [&](const auto& val) { return this->operator()(val, size_info + 1); });
-        }
-
-        template <typename U>
-        constexpr bool operator()(const std::map<std::string, U>& m, std::size_t* size_info) const
-        {
-          return ((*size_info == dynamic_size) || (m.size() == *size_info)) &&
-                 std::ranges::all_of(m,
-                     [&](const auto& val) { return this->operator()(val.second, size_info + 1); });
-        }
-      };
-    }  // namespace Internal
-
+  namespace InputSpecBuilders
+  {
     /**
      * Create a normal parameter with given @p name. All parameters are parameterized by a struct
      * which contains the optional `description` and `default_value` fields. The following examples
@@ -1324,7 +1336,7 @@ namespace Core::IO
 // --- template definitions --- //
 
 template <Core::IO::SupportedType T>
-void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::parse(
+void Core::IO::Internal::ParameterSpec<T>::parse(
     ValueParser& parser, InputParameterContainer& container) const
 {
   if (parser.peek() == name)
@@ -1354,7 +1366,10 @@ void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::parse(
 
         FOUR_C_THROW("Reading a vector from a dat-style string requires a known size.");
       }
-      int operator()(const SizeCallback& callback) const { return callback(container); }
+      int operator()(const InputSpecBuilders::SizeCallback& callback) const
+      {
+        return callback(container);
+      }
       InputParameterContainer& container;
     };
 
@@ -1375,10 +1390,9 @@ void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::parse(
 
 
 template <Core::IO::SupportedType T>
-bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::ParameterSpec<T>::match(ConstYamlNodeRef node,
     InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::parameter;
   auto spec_name = ryml::to_csubstr(name);
 
   // If we are not even in a map, we refuse to do anything and let the MatchTree handle this case.
@@ -1432,8 +1446,7 @@ bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::match(ConstYamlNod
 
 
 template <Core::IO::SupportedType T>
-void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit_metadata(
-    ryml::NodeRef node) const
+void Core::IO::Internal::ParameterSpec<T>::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
   node["name"] << name;
@@ -1445,7 +1458,10 @@ void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit_metadata(
     struct DynamicSizeVisitor
     {
       int operator()(int size) const { return size; }
-      int operator()(const SizeCallback& callback) const { return dynamic_size; }
+      int operator()(const InputSpecBuilders::SizeCallback& callback) const
+      {
+        return InputSpecBuilders::dynamic_size;
+      }
     };
 
     std::array<std::size_t, rank<T>()> size_info;
@@ -1468,7 +1484,7 @@ void Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit_metadata(
 }
 
 template <Core::IO::SupportedType T>
-bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit(YamlNodeRef node,
+bool Core::IO::Internal::ParameterSpec<T>::emit(YamlNodeRef node,
     const InputParameterContainer& container, const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
@@ -1503,7 +1519,7 @@ bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::emit(YamlNodeRef n
 
 
 template <Core::IO::SupportedType T>
-bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::has_correct_size(
+bool Core::IO::Internal::ParameterSpec<T>::has_correct_size(
     const T& val, const InputParameterContainer& container) const
 {
   if constexpr (rank<T>() == 0)
@@ -1515,11 +1531,11 @@ bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::has_correct_size(
     struct SizeVisitor
     {
       int operator()(int size) const { return size; }
-      int operator()(const SizeCallback& callback) const
+      int operator()(const InputSpecBuilders::SizeCallback& callback) const
       {
         // For yaml, we do not validate the size based on the callback. This feature can be removed
         // once we remove dat.
-        return dynamic_size;
+        return InputSpecBuilders::dynamic_size;
       }
       const InputParameterContainer& container;
     };
@@ -1536,7 +1552,7 @@ bool Core::IO::InputSpecBuilders::Internal::ParameterSpec<T>::has_correct_size(
 
 
 template <typename T>
-void Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::parse(
+void Core::IO::Internal::DeprecatedSelectionSpec<T>::parse(
     ValueParser& parser, InputParameterContainer& container) const
 {
   if (parser.peek() == name)
@@ -1570,10 +1586,9 @@ void Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::parse(
 
 
 template <typename T>
-bool Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::DeprecatedSelectionSpec<T>::match(ConstYamlNodeRef node,
     InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::parameter;
   auto spec_name = ryml::to_csubstr(name);
 
   // If we are not even in a map, we refuse to do anything and let the MatchTree handle this case.
@@ -1626,7 +1641,7 @@ bool Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::match(Co
 }
 
 template <typename T>
-void Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::print(
+void Core::IO::Internal::DeprecatedSelectionSpec<T>::print(
     std::ostream& stream, std::size_t indent) const
 {
   stream << "// " << std::string(indent, ' ') << name;
@@ -1656,8 +1671,7 @@ void Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::print(
 }
 
 template <typename T>
-void Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::emit_metadata(
-    ryml::NodeRef node) const
+void Core::IO::Internal::DeprecatedSelectionSpec<T>::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
   node["name"] << name;
@@ -1690,7 +1704,7 @@ void Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::emit_met
 }
 
 template <typename T>
-bool Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::emit(YamlNodeRef node,
+bool Core::IO::Internal::DeprecatedSelectionSpec<T>::emit(YamlNodeRef node,
     const InputParameterContainer& container, const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
@@ -1737,7 +1751,7 @@ bool Core::IO::InputSpecBuilders::Internal::DeprecatedSelectionSpec<T>::emit(Yam
 
 template <typename T>
   requires(std::is_enum_v<T>)
-void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::parse(
+void Core::IO::Internal::SelectionSpec<T>::parse(
     ValueParser& parser, InputParameterContainer& container) const
 {
   if (parser.peek() == group_name)
@@ -1765,10 +1779,9 @@ void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::parse(
 
 template <typename T>
   requires(std::is_enum_v<T>)
-bool Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::match(ConstYamlNodeRef node,
+bool Core::IO::Internal::SelectionSpec<T>::match(ConstYamlNodeRef node,
     InputParameterContainer& container, IO::Internal::MatchEntry& match_entry) const
 {
-  match_entry.type = IO::Internal::MatchEntry::Type::selection;
   const auto group_name_substr = ryml::to_csubstr(group_name);
 
   const bool group_node_is_input = node.node.has_key() && (node.node.key() == group_name);
@@ -1810,8 +1823,7 @@ bool Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::match(ConstYamlNod
 
 template <typename T>
   requires(std::is_enum_v<T>)
-void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::print(
-    std::ostream& stream, std::size_t indent) const
+void Core::IO::Internal::SelectionSpec<T>::print(std::ostream& stream, std::size_t indent) const
 {
   stream << "// " << std::string(indent, ' ') << group_name;
   selector_spec.impl().print(stream, indent + 2);
@@ -1828,8 +1840,7 @@ void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::print(
 
 template <typename T>
   requires(std::is_enum_v<T>)
-void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::emit_metadata(
-    ryml::NodeRef node) const
+void Core::IO::Internal::SelectionSpec<T>::emit_metadata(ryml::NodeRef node) const
 {
   node |= ryml::MAP;
   node["name"] << group_name;
@@ -1856,7 +1867,7 @@ void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::emit_metadata(
 
 template <typename T>
   requires(std::is_enum_v<T>)
-bool Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::emit(YamlNodeRef node,
+bool Core::IO::Internal::SelectionSpec<T>::emit(YamlNodeRef node,
     const InputParameterContainer& container, const InputSpecEmitOptions& options) const
 {
   node.node |= ryml::MAP;
@@ -1883,7 +1894,7 @@ bool Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::emit(YamlNodeRef n
 
 template <typename T>
   requires(std::is_enum_v<T>)
-void Core::IO::InputSpecBuilders::Internal::SelectionSpec<T>::set_default_value(
+void Core::IO::Internal::SelectionSpec<T>::set_default_value(
     InputParameterContainer& container) const
 {
   FOUR_C_THROW("Internal error: set_default_value() called on a SelectionSpec.");
@@ -1934,6 +1945,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::parameter(
           .required = !(internal_data.default_value.index() == 1),
           .has_default_value = internal_data.default_value.index() == 1,
           .n_specs = 1,
+          .type = Internal::InputSpecType::parameter,
       });
 }
 
@@ -1967,13 +1979,14 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
           .has_default_value = false,
           // one for the group, one for the selector, plus the number of specs for the choices.
           .n_specs = 2 + max_specs_for_choices,
+          .type = Internal::InputSpecType::selection,
       });
 }
 
 
 template <typename T>
-Core::IO::InputSpec Core::IO::InputSpecBuilders::Internal::selection_internal(
-    std::string name, std::map<std::string, RemoveOptional<T>> choices, ParameterDataIn<T> data)
+Core::IO::InputSpec Core::IO::Internal::selection_internal(std::string name,
+    std::map<std::string, RemoveOptional<T>> choices, InputSpecBuilders::ParameterDataIn<T> data)
 {
   FOUR_C_ASSERT_ALWAYS(!choices.empty(), "Selection must have at least one choice.");
 
@@ -2037,6 +2050,7 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::Internal::selection_internal(
           .required = !has_default_value,
           .has_default_value = has_default_value,
           .n_specs = 1,
+          .type = InputSpecType::deprecated_selection,
       });
 }
 


### PR DESCRIPTION
The first commit shuffles some code around (in the implementation). The second commit enhances various user-facing error messages when input does not match the specification.