### PR TITLE
CI: new job to compile with no optional dependencies

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -221,6 +221,55 @@ jobs:
           yaml_extension_short: .4C.yml
           json_extension: .4C.json
 
+  gcc13_no_optional_dependencies_build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:9d85686c
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - uses: ./.github/actions/build_4C
+        with:
+          cmake-preset: docker_no_optional_dependencies
+          build-targets: full
+          build-directory: ${{ github.workspace }}/build
+          use-ccache: "true"
+      - uses: ./.github/actions/upload_4C_build
+        with:
+          build-directory: ${{ github.workspace }}/build
+          retention-days: 1
+
+  gcc13_no_optional_dependencies_test:
+    needs: gcc13_no_optional_dependencies_build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:9d85686c
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: gcc13_no_optional_dependencies_build
+          destination: ${{ github.workspace }}/build
+      - name: Test
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          ctest -L minimal -j `nproc` --output-on-failure
+
   ensure_all_tests_pass:
     needs:
       - gcc13_assertions_test
@@ -230,6 +279,8 @@ jobs:
       - clang18_test_minimal
       - clang18_test_install
       - clang18_verify_schema
+      - gcc13_no_optional_dependencies_build
+      - gcc13_no_optional_dependencies_test
     runs-on: ubuntu-latest
     if: always() && github.ref != 'refs/heads/main'
     steps:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -226,6 +226,91 @@ jobs:
           junit-report-base-name: clang18_test_report
           retention-days: 2
 
+  gcc13_no_optional_dependencies_build:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:9d85686c
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      test-chunks: ${{ steps.set-matrix.outputs.chunk-array }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - uses: ./.github/actions/build_4C
+        with:
+          cmake-preset: docker_no_optional_dependencies
+          build-targets: full
+          build-directory: ${{ github.workspace }}/build
+          use-ccache: "false"
+      - uses: ./.github/actions/upload_4C_build
+        with:
+          build-directory: ${{ github.workspace }}/build
+          retention-days: 1
+      - uses: ./.github/actions/chunk_test_suite
+        id: set-matrix
+        with:
+          build-directory: ${{ github.workspace }}/build
+          source-directory: ${{ github.workspace }}
+          number-of-chunks: 15
+          junit-report-artifact-name: gcc13_no_optional_dependencies_test_report.xml
+
+  gcc13_no_optional_dependencies_test:
+    needs: gcc13_no_optional_dependencies_build
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:9d85686c
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    strategy:
+      fail-fast: false
+      matrix:
+        test-chunk: ${{fromJson(needs.gcc13_no_optional_dependencies_build.outputs.test-chunks)}}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: gcc13_no_optional_dependencies_build
+          destination: ${{ github.workspace }}/build
+      - name: Test
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/gcc13_no_optional_dependencies_test_report-$TEST_CHUNK.xml
+        env:
+          TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: gcc13_no_optional_dependencies_test_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/gcc13_no_optional_dependencies_test_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
+  gcc13_no_optional_dependencies_test_report:
+    needs: gcc13_no_optional_dependencies_test
+    runs-on: ubuntu-latest
+    if: success() || failure()
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github
+      - uses: ./.github/actions/merge_junit_report_artifacts
+        with:
+          junit-report-base-name: gcc13_no_optional_dependencies_test_report
+          retention-days: 2
+
   gcc13_asan_build:
     runs-on: ubuntu-latest
     container:

--- a/cmake/functions/four_c_configure_dependency.cmake
+++ b/cmake/functions/four_c_configure_dependency.cmake
@@ -210,6 +210,18 @@ function(four_c_configure_dependency _package_name)
     FOUR_C_WITH_${_package_name_sanitized} "Build 4C with ${_package_name}" ${_parsed_DEFAULT}
     )
 
+  if(${_parsed_DEFAULT} STREQUAL "ON")
+    if(NOT FOUR_C_WITH_${_package_name_sanitized})
+      message(
+        FATAL_ERROR
+          "The dependency ${_package_name} is required, so you cannot set option "
+          "FOUR_C_WITH_${_package_name_sanitized} to OFF. "
+          "Please set 'FOUR_C_WITH_${_package_name_sanitized}' to ON "
+          "(or remove the manually set variable)."
+        )
+    endif()
+  endif()
+
   if(FOUR_C_WITH_${_package_name_sanitized})
     if(${_package_name}_ROOT)
       message(

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -114,6 +114,19 @@
         "FOUR_C_BUILD_DOCUMENTATION": "OFF",
         "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "OFF"
       }
+    },
+    {
+      "name": "docker_no_optional_dependencies",
+      "displayName": "Build with all optional dependencies turned off",
+      "description": "Build with all optional dependencies turned off",
+      "inherits": [
+        ".docker_base"
+      ],
+      "cacheVariables": {
+        "FOUR_C_WITH_ARBORX": "OFF",
+        "FOUR_C_WITH_BACKTRACE": "OFF",
+        "FOUR_C_WITH_MIRCO": "OFF"
+      }
     }
   ]
 }


### PR DESCRIPTION
This new job turns off the dependencies that are optional. I only added a minimal test in PRs. I propose to test this in PRs, since it should not be slower than the rest of the pipeline. The question is how we should add this to nightly. Yes/no? With full tests?

Closes #509, Useful first step to test #506 