### PR TITLE
Update MIRCO shape factors and git tag

### DIFF
--- a/cmake/configure/configure_MIRCO.cmake
+++ b/cmake/configure/configure_MIRCO.cmake
@@ -26,7 +26,7 @@ else() # Fetch MIRCO from GIT repository
   set(TRILINOS_IN_MIRCO "OFF")
 
   set(MIRCO_GIT_REPO "https://github.com/imcs-compsim/MIRCO.git")
-  set(MIRCO_GIT_TAG "8a8ae9c703a762459995d56d36292b77ff6c1985")
+  set(MIRCO_GIT_TAG "100f8ab0e10090f625c283f0a8b7d13fc5fb55eb")
 
   fetchcontent_declare(
     mirco

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
@@ -84,14 +84,6 @@ void CONTACT::CONSTITUTIVELAW::MircoConstitutiveLawParams::set_parameters()
   // Composite Young's modulus
   composite_youngs_ = pow(((1 - pow(nu1, 2)) / E1 + (1 - pow(nu2, 2)) / E2), -1);
 
-  // Composite Shear modulus
-  double G1 = E1 / (2 * (1 + nu1));
-  double G2 = E2 / (2 * (1 + nu2));
-  double CompositeShear = pow(((2 - nu1) / (4 * G1) + (2 - nu2) / (4 * G2)), -1);
-
-  // Composite Poisson's ratio
-  composite_poissons_ratio_ = composite_youngs_ / (2 * CompositeShear) - 1;
-
   grid_size_ = lateral_length_ / (pow(2, resolution_) + 1);
 
   // Shape factors (See section 3.3 of https://doi.org/10.1007/s00466-019-01791-3)
@@ -141,10 +133,9 @@ double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate(double gap, CONT
   double pressure = 0.0;
   MIRCO::Evaluate(pressure, -(gap + params_.get_offset()), params_.get_lateral_length(),
       params_.get_grid_size(), params_.get_tolerance(), params_.get_max_iteration(),
-      params_.get_composite_youngs(), params_.get_composite_poissons_ratio(),
-      params_.get_warm_starting_flag(), params_.get_compliance_correction(), topology,
-      roughNode->get_max_topology_height(), *params_.get_mesh_grid(),
-      params_.get_pressure_green_fun_flag());
+      params_.get_composite_youngs(), params_.get_warm_starting_flag(),
+      params_.get_compliance_correction(), topology, roughNode->get_max_topology_height(),
+      *params_.get_mesh_grid(), params_.get_pressure_green_fun_flag());
 
   return (-1 * pressure);
 }  // end of mirco_coconstlaw evaluate
@@ -170,15 +161,13 @@ double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate_deriv(
   // using backward difference approach
   MIRCO::Evaluate(pressure1, -1.0 * (gap + params_.get_offset()), params_.get_lateral_length(),
       params_.get_grid_size(), params_.get_tolerance(), params_.get_max_iteration(),
-      params_.get_composite_youngs(), params_.get_composite_poissons_ratio(),
-      params_.get_warm_starting_flag(), params_.get_compliance_correction(), topology,
-      roughNode->get_max_topology_height(), *params_.get_mesh_grid(),
-      params_.get_pressure_green_fun_flag());
+      params_.get_composite_youngs(), params_.get_warm_starting_flag(),
+      params_.get_compliance_correction(), topology, roughNode->get_max_topology_height(),
+      *params_.get_mesh_grid(), params_.get_pressure_green_fun_flag());
   MIRCO::Evaluate(pressure2,
       -(1 - params_.get_finite_difference_fraction()) * (gap + params_.get_offset()),
       params_.get_lateral_length(), params_.get_grid_size(), params_.get_tolerance(),
-      params_.get_max_iteration(), params_.get_composite_youngs(),
-      params_.get_composite_poissons_ratio(), params_.get_warm_starting_flag(),
+      params_.get_max_iteration(), params_.get_composite_youngs(), params_.get_warm_starting_flag(),
       params_.get_compliance_correction(), topology, roughNode->get_max_topology_height(),
       *params_.get_mesh_grid(), params_.get_pressure_green_fun_flag());
   return ((pressure1 - pressure2) /

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
@@ -105,7 +105,7 @@ void CONTACT::CONSTITUTIVELAW::MircoConstitutiveLawParams::set_parameters()
   // http://dx.doi.org/10.1134/s1029959914040109
   const std::map<int, double> shape_factors_pressure{{1, 0.961389237917602}, {2, 0.924715342432435},
       {3, 0.899837531880697}, {4, 0.884976751041942}, {5, 0.876753783192863},
-      {6, 0.872397956576882}, {7, 0.871958228537090}, {8, 0.882669916668780}};
+      {6, 0.872397956576882}, {7, 0.8701463093314326}, {8, 0.8689982669426167}};
 
   // The following force based constants are taken from Table 1 of Bonari et al. (2020).
   // https://doi.org/10.1007/s00466-019-01791-3

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
@@ -45,7 +45,6 @@ namespace CONTACT
       double get_max_iteration() const { return max_iteration_; };
       bool get_warm_starting_flag() const { return warm_starting_flag_; };
       double get_composite_youngs() const { return composite_youngs_; };
-      double get_composite_poissons_ratio() const { return composite_poissons_ratio_; };
       double get_grid_size() const { return grid_size_; };
       double get_compliance_correction() const { return elastic_compliance_correction_; };
       double get_finite_difference_fraction() const { return finite_difference_fraction_; };
@@ -70,7 +69,6 @@ namespace CONTACT
       int max_iteration_;
       bool warm_starting_flag_;
       double composite_youngs_;
-      double composite_poissons_ratio_;
       double grid_size_;
       double elastic_compliance_correction_;
       Teuchos::Ptr<std::vector<double>> meshgrid_;

--- a/unittests/contact_constitutivelaw/4C_mirco_pressure_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_mirco_pressure_contactconstitutivelaw_test.threads2.cpp
@@ -108,13 +108,13 @@ namespace
     // 0< gap < offset
     EXPECT_ANY_THROW(coconstlaw_->evaluate(-0.25, cnode.get()));
     // offset < gap
-    EXPECT_NEAR(coconstlaw_->evaluate(-12.0, cnode.get()), -0.0005861475487657709, 1.e-10);
+    EXPECT_NEAR(coconstlaw_->evaluate(-12.0, cnode.get()), -0.0004784628885090747, 1.e-10);
   }
 
   //! test member function EvaluateDeriv
   TEST_F(MircoConstitutiveLawPressureTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-12.0, cnode.get()), 1.56329102801896e-04, 1.e-10);
+    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-12.0, cnode.get()), 1.17161352338802e-04, 1.e-10);
     EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
   }
 }  // namespace


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

The shape factors for the pressure-based Green's function were earlier calculated using the MATLAB bem code and gave erroneous values for n=7 and n=8. Therefore, those are updated using Tamaas. Also, the git tag of MIRCO in 4C has been updated.

Calculation of composite Poisson's ratio has been removed as the composite Young's modulus (E*), calculated in MIRCO, already accounts for the Poisson's ratio, i.e., 1/E* = (1-nu^2)/E. See https://github.com/imcs-compsim/MIRCO/pull/100

The results of the MIRCO unittests have been updated for the pressure-based Green's function because of the updated influence coefficient matrix generation in MIRCO.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Closes #399 