### PR TITLE
Validate size read from_parameter for yaml files

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -1548,12 +1548,7 @@ bool Core::IO::Internal::ParameterSpec<T>::has_correct_size(
     struct SizeVisitor
     {
       int operator()(int size) const { return size; }
-      int operator()(const InputSpecBuilders::SizeCallback& callback) const
-      {
-        // For yaml, we do not validate the size based on the callback. This feature can be removed
-        // once we remove dat.
-        return InputSpecBuilders::dynamic_size;
-      }
+      int operator()(const InputSpecBuilders::SizeCallback& callback) const { return callback(container); }
       const InputParameterContainer& container;
     };
 

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -1548,7 +1548,10 @@ bool Core::IO::Internal::ParameterSpec<T>::has_correct_size(
     struct SizeVisitor
     {
       int operator()(int size) const { return size; }
-      int operator()(const InputSpecBuilders::SizeCallback& callback) const { return callback(container); }
+      int operator()(const InputSpecBuilders::SizeCallback& callback) const
+      {
+        return callback(container);
+      }
       const InputParameterContainer& container;
     };
 

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -1572,11 +1572,11 @@ v:
     }
 
     {
-      SCOPED_TRACE("Wrong size from_parameter not validated in yaml.");
+      SCOPED_TRACE("Wrong size from_parameter");
       ryml::Tree tree = init_yaml_tree_with_exceptions();
       ryml::parse_in_arena(R"(num: 2
 v:
-  - key1: [1, 2, 3] # inner most vector is too long but we do not check for this in yaml
+  - key1: [1, 2, 3]
     key2: [3, 4]
   - key1: [5, 6])",
           &tree);
@@ -1584,7 +1584,7 @@ v:
       ConstYamlNodeRef node(root, "");
 
       InputParameterContainer container;
-      spec.match(node, container);
+      EXPECT_THROW(spec.match(node, container), Core::Exception);
     }
 
     {


### PR DESCRIPTION
I was trying to be too clever here and thought we don't need the check. 


Error looks like this now:

```
Could not match this input

DESIGN SURF DIRICH CONDITIONS:
  - E: 1
    NUMDOF: 3
    ONOFF: [1,1,1]
    VAL: [0,0,0]
    FUNCT: [0,0,0,4]


against the given input specification. This was the best attempt to match the input:

[!] Candidate list 'DESIGN SURF DIRICH CONDITIONS'
  [!] The following list entry did not match:
    {
      [ ] Matched parameter 'E'
      [ ] Matched parameter 'NUMDOF'
      [ ] Matched parameter 'ONOFF'
      [ ] Matched parameter 'VAL'
      [!] Candidate parameter 'FUNCT' (value has incorrect size)
      [ ] Defaulted deprecated_selection 'TAG'
    }
```