### PR TITLE
[Kokkos] Global scope guard for unit testing

### DIFF
--- a/src/core/fem/tests/geometric_search/4C_fem_geometric_search_distributed_test.np3.cpp
+++ b/src/core/fem/tests/geometric_search/4C_fem_geometric_search_distributed_test.np3.cpp
@@ -27,10 +27,6 @@ namespace
   class GeometricSearchDistributed : public ::testing::Test
   {
    public:
-    static void SetUpTestSuite() { Kokkos::initialize(); }
-
-    static void TearDownTestSuite() { Kokkos::finalize(); }
-
     GeometricSearchDistributed()
     {
       comm_ = MPI_COMM_WORLD;

--- a/src/core/fem/tests/geometric_search/4C_fem_geometric_search_test.cpp
+++ b/src/core/fem/tests/geometric_search/4C_fem_geometric_search_test.cpp
@@ -27,10 +27,6 @@ namespace
   class GeometricSearch : public ::testing::Test
   {
    public:
-    static void SetUpTestSuite() { Kokkos::initialize(); }
-
-    static void TearDownTestSuite() { Kokkos::finalize(); }
-
     GeometricSearch() { verbosity_ = Core::IO::minimal; }
 
    protected:

--- a/unittests/4C_gtest_main_mpi_test.cpp
+++ b/unittests/4C_gtest_main_mpi_test.cpp
@@ -11,6 +11,7 @@
 
 #include "4C_utils_singleton_owner.hpp"
 
+#include <Kokkos_Core.hpp>
 #include <mpi.h>
 
 int main(int argc, char* argv[])
@@ -28,6 +29,9 @@ int main(int argc, char* argv[])
   {
     ~CleanUpMPI() { MPI_Finalize(); }
   } cleanup;
+
+  // Kokkos should be initialized right after MPI.
+  Kokkos::ScopeGuard kokkos_guard{};
 
   Core::Utils::SingletonOwnerRegistry::ScopeGuard guard;
 


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title states. This PR adds a global scope guard for all unit tests, so we don't need to handle each case individually with `Kokkos::initialize()` and `Kokkos::finalize()`. Thus also removing the existence of those.