### PR TITLE
Fix enum printing via magic_enum

### DIFF
--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -209,68 +209,6 @@ namespace Core::IO::Internal::InputParameterContainerImplementation
           Core::Utils::try_demangle(data.type().name()).c_str());
     }
   }
-
-  // Default printer if not printable.
-  template <typename T>
-  struct PrintHelper
-  {
-    void operator()(std::ostream& os, const std::any& data) { os << "<not printable> "; }
-  };
-
-  template <typename T>
-  concept StreamInsertable = requires(std::ostream& os, const T& t) { os << t; };
-
-  // Specialization for stream insert.
-  template <StreamInsertable T>
-  struct PrintHelper<T>
-  {
-    void operator()(std::ostream& os, const std::any& data) { os << std::any_cast<T>(data) << " "; }
-  };
-
-  template <StreamInsertable T>
-  struct PrintHelper<std::optional<T>>
-  {
-    void operator()(std::ostream& os, const std::any& data)
-    {
-      auto val = std::any_cast<std::optional<T>>(data);
-      if (val.has_value())
-        PrintHelper<T>{}(os, *val);
-      else
-        os << "none ";
-    }
-  };
-
-  // Specialization for vectors.
-  template <typename T>
-  struct PrintHelper<std::vector<T>>
-  {
-    void operator()(std::ostream& os, const std::any& data)
-    {
-      FOUR_C_ASSERT(typeid(std::vector<T>) == data.type(), "Implementation error.");
-      const auto& vec = std::any_cast<std::vector<T>>(data);
-      for (const auto& v : vec)
-      {
-        PrintHelper<T>{}(os, v);
-      }
-    }
-  };
-
-  // Specialization for maps.
-  template <typename Key, typename Value>
-  struct PrintHelper<std::map<Key, Value>>
-  {
-    void operator()(std::ostream& os, const std::any& data)
-    {
-      FOUR_C_ASSERT(typeid(std::map<Key, Value>) == data.type(), "Implementation error.");
-      const auto& map = std::any_cast<std::map<Key, Value>>(data);
-      for (const auto& [key, value] : map)
-      {
-        os << key << " : ";
-        PrintHelper<Value>{}(os, value);
-      }
-    }
-  };
-
 }  // namespace Core::IO::Internal::InputParameterContainerImplementation
 
 

--- a/src/core/io/src/4C_io_input_parameter_container.templates.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.templates.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_io_input_parameter_container.hpp"
+#include "4C_utils_enum.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 
@@ -19,6 +20,71 @@ FOUR_C_NAMESPACE_OPEN
 // The add() function requires expensive-to-include Teuchos headers, but it is rarely needed, since
 // most user code only reads from the InputParameterContainer. Therefore, we put the implementation
 // into this special templates file.
+namespace Core::IO::Internal::InputParameterContainerImplementation
+{
+  // Default printer if not printable.
+  template <typename T>
+  struct PrintHelper
+  {
+    void operator()(std::ostream& os, const std::any& data) { os << "<not printable> "; }
+  };
+
+  template <typename T>
+  concept StreamInsertable = requires(std::ostream& os, const T& t) { os << t; };
+
+  // Specialization for stream insert.
+  template <StreamInsertable T>
+  struct PrintHelper<T>
+  {
+    void operator()(std::ostream& os, const std::any& data) { os << std::any_cast<T>(data) << " "; }
+  };
+
+  template <StreamInsertable T>
+  struct PrintHelper<std::optional<T>>
+  {
+    void operator()(std::ostream& os, const std::any& data)
+    {
+      auto val = std::any_cast<std::optional<T>>(data);
+      if (val.has_value())
+        PrintHelper<T>{}(os, *val);
+      else
+        os << "none ";
+    }
+  };
+
+  // Specialization for vectors.
+  template <typename T>
+  struct PrintHelper<std::vector<T>>
+  {
+    void operator()(std::ostream& os, const std::any& data)
+    {
+      FOUR_C_ASSERT(typeid(std::vector<T>) == data.type(), "Implementation error.");
+      const auto& vec = std::any_cast<std::vector<T>>(data);
+      for (const auto& v : vec)
+      {
+        PrintHelper<T>{}(os, v);
+      }
+    }
+  };
+
+  // Specialization for maps.
+  template <typename Key, typename Value>
+  struct PrintHelper<std::map<Key, Value>>
+  {
+    void operator()(std::ostream& os, const std::any& data)
+    {
+      FOUR_C_ASSERT(typeid(std::map<Key, Value>) == data.type(), "Implementation error.");
+      const auto& map = std::any_cast<std::map<Key, Value>>(data);
+      for (const auto& [key, value] : map)
+      {
+        os << key << " : ";
+        PrintHelper<Value>{}(os, value);
+      }
+    }
+  };
+}  // namespace Core::IO::Internal::InputParameterContainerImplementation
+
+
 
 template <typename T>
 void Core::IO::InputParameterContainer::add(const std::string& name, const T& data)
@@ -40,6 +106,7 @@ void Core::IO::InputParameterContainer::ensure_type_action_registered()
     };
   }
 }
+
 
 // --- Declare that these templates are instantiated for some types --- //
 

--- a/src/core/io/tests/4C_io_input_parameter_container_test.cpp
+++ b/src/core/io/tests/4C_io_input_parameter_container_test.cpp
@@ -11,6 +11,8 @@
 
 #include <Teuchos_ParameterList.hpp>
 
+#include <ostream>
+
 namespace
 {
   using namespace FourC;
@@ -60,7 +62,7 @@ namespace
         pl.get<std::vector<Teuchos::ParameterList>>("list")[1].sublist("group").get<int>("b"), 2);
   }
 
-  TEST(InputParameterContainerTest, StreamInsertableEnum)
+  TEST(InputParameterContainerTest, PrintEnum)
   {
     enum class TestEnum
     {
@@ -70,11 +72,11 @@ namespace
     };
 
     InputParameterContainer container;
-    container.add("enum", TestEnum::A);
+    container.add("test_enum", TestEnum::A);
 
-    // check that the enum is stream-insertable
-    static_assert(
-        Core::IO::Internal::InputParameterContainerImplementation::StreamInsertable<TestEnum>,
-        "TestEnum must be stream-insertable");
+    // check print output
+    std::ostringstream print_output{""};
+    container.print(print_output);
+    EXPECT_EQ(print_output.str(), "test_enum : A ");
   }
 }  // namespace

--- a/src/core/io/tests/4C_io_input_parameter_container_test.cpp
+++ b/src/core/io/tests/4C_io_input_parameter_container_test.cpp
@@ -59,4 +59,22 @@ namespace
     EXPECT_EQ(
         pl.get<std::vector<Teuchos::ParameterList>>("list")[1].sublist("group").get<int>("b"), 2);
   }
+
+  TEST(InputParameterContainerTest, StreamInsertableEnum)
+  {
+    enum class TestEnum
+    {
+      A,
+      B,
+      C
+    };
+
+    InputParameterContainer container;
+    container.add("enum", TestEnum::A);
+
+    // check that the enum is stream-insertable
+    static_assert(
+        Core::IO::Internal::InputParameterContainerImplementation::StreamInsertable<TestEnum>,
+        "TestEnum must be stream-insertable");
+  }
 }  // namespace


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
- Enums were previously not recognized as StreamInsertable concepts due to namespace / lookup issues.
- This was fixed by moving the PrintHelper functions to the corresponding parameter container template file and including the corresponding enum utilities file.
- A dedicated unit test was added checking the stream-insertability.

Fixed by @sebproell and me.



## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Fixes the bug discussed in [588](https://github.com/4C-multiphysics/4C/pull/588#discussion_r2021107936) 