### PR TITLE
Replace CMAKE with PROJECT dirs

### DIFF
--- a/apps/global_full/CMakeLists.txt
+++ b/apps/global_full/CMakeLists.txt
@@ -26,14 +26,14 @@ if(FOUR_C_ENABLE_METADATA_GENERATION)
     add_custom_command(
       TARGET ${FOUR_C_EXECUTABLE_NAME}
       POST_BUILD
-      COMMAND ${CMAKE_COMMAND} -E rm -f ${CMAKE_BINARY_DIR}/4C_metadata.yaml
-      COMMAND ${CMAKE_COMMAND} -E rm -f ${CMAKE_BINARY_DIR}/4C_schema.json
+      COMMAND ${CMAKE_COMMAND} -E rm -f ${PROJECT_BINARY_DIR}/4C_metadata.yaml
+      COMMAND ${CMAKE_COMMAND} -E rm -f ${PROJECT_BINARY_DIR}/4C_schema.json
       COMMAND
         ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS} "$<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>"
-        -p > ${CMAKE_BINARY_DIR}/4C_metadata.yaml
+        -p > ${PROJECT_BINARY_DIR}/4C_metadata.yaml
       COMMAND
         ${FOUR_C_PYTHON_VENV_BUILD}/bin/python ${PROJECT_SOURCE_DIR}/utilities/create_json_schema.py
-        ${CMAKE_BINARY_DIR}/4C_metadata.yaml ${CMAKE_BINARY_DIR}/4C_schema.json
+        ${PROJECT_BINARY_DIR}/4C_metadata.yaml ${PROJECT_BINARY_DIR}/4C_schema.json
       COMMENT "Creating JSON schema file for input"
       )
   else()

--- a/cmake/configure/configure_ArborX.cmake
+++ b/cmake/configure/configure_ArborX.cmake
@@ -36,7 +36,7 @@ else() # Fetch ArborX from GIT repository
 endif()
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/ArborX.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/ArborX.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/ArborX.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/ArborX.cmake
   @ONLY
   )

--- a/cmake/configure/configure_Backtrace.cmake
+++ b/cmake/configure/configure_Backtrace.cmake
@@ -14,13 +14,13 @@ if(Backtrace_FOUND)
   target_link_libraries(four_c_all_enabled_external_dependencies INTERFACE Backtrace::Backtrace)
 
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/Backtrace.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/templates/Backtrace.cmake
+    ${PROJECT_SOURCE_DIR}/cmake/templates/Backtrace.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/templates/Backtrace.cmake
     @ONLY
     )
   include(GNUInstallDirs)
   install(
-    FILES ${CMAKE_SOURCE_DIR}/cmake/modules/FindBacktrace.cmake
+    FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindBacktrace.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C/modules
     )
 endif()

--- a/cmake/configure/configure_Boost.cmake
+++ b/cmake/configure/configure_Boost.cmake
@@ -32,8 +32,8 @@ if(Boost_FOUND)
     )
 
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/Boost.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/templates/Boost.cmake
+    ${PROJECT_SOURCE_DIR}/cmake/templates/Boost.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/templates/Boost.cmake
     @ONLY
     )
 endif()

--- a/cmake/configure/configure_CLN.cmake
+++ b/cmake/configure/configure_CLN.cmake
@@ -14,13 +14,13 @@ if(CLN_FOUND)
   target_link_libraries(four_c_all_enabled_external_dependencies INTERFACE cln::cln)
 
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/CLN.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/templates/CLN.cmake
+    ${PROJECT_SOURCE_DIR}/cmake/templates/CLN.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/templates/CLN.cmake
     @ONLY
     )
   include(GNUInstallDirs)
   install(
-    FILES ${CMAKE_SOURCE_DIR}/cmake/modules/FindCLN.cmake
+    FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindCLN.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C/modules
     )
 endif()

--- a/cmake/configure/configure_FFTW.cmake
+++ b/cmake/configure/configure_FFTW.cmake
@@ -14,13 +14,13 @@ if(FFTW_FOUND)
   target_link_libraries(four_c_all_enabled_external_dependencies INTERFACE fftw::fftw)
 
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/FFTW.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/templates/FFTW.cmake
+    ${PROJECT_SOURCE_DIR}/cmake/templates/FFTW.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/templates/FFTW.cmake
     @ONLY
     )
   include(GNUInstallDirs)
   install(
-    FILES ${CMAKE_SOURCE_DIR}/cmake/modules/FindFFTW.cmake
+    FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindFFTW.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C/modules
     )
 endif()

--- a/cmake/configure/configure_HDF5.cmake
+++ b/cmake/configure/configure_HDF5.cmake
@@ -21,8 +21,8 @@ if(HDF5_FOUND)
   message(STATUS "HDF5 HL libraries: ${HDF5_HL_LIBRARIES}")
   target_link_libraries(four_c_all_enabled_external_dependencies INTERFACE HDF5::HDF5 hdf5::hdf5_hl)
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/HDF5.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/templates/HDF5.cmake
+    ${PROJECT_SOURCE_DIR}/cmake/templates/HDF5.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/templates/HDF5.cmake
     @ONLY
     )
 endif()

--- a/cmake/configure/configure_MIRCO.cmake
+++ b/cmake/configure/configure_MIRCO.cmake
@@ -40,7 +40,7 @@ else() # Fetch MIRCO from GIT repository
 endif()
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/MIRCO.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/MIRCO.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/MIRCO.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/MIRCO.cmake
   @ONLY
   )

--- a/cmake/configure/configure_MPI.cmake
+++ b/cmake/configure/configure_MPI.cmake
@@ -30,7 +30,7 @@ if(NOT FOUR_C_MPI_LINKAGE_OK)
 endif()
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/MPI.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/MPI.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/MPI.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/MPI.cmake
   @ONLY
   )

--- a/cmake/configure/configure_Qhull.cmake
+++ b/cmake/configure/configure_Qhull.cmake
@@ -14,13 +14,13 @@ if(QHULL_FOUND)
   target_link_libraries(four_c_all_enabled_external_dependencies INTERFACE qhull::qhull)
 
   configure_file(
-    ${CMAKE_SOURCE_DIR}/cmake/templates/Qhull.cmake.in
-    ${CMAKE_BINARY_DIR}/cmake/templates/Qhull.cmake
+    ${PROJECT_SOURCE_DIR}/cmake/templates/Qhull.cmake.in
+    ${PROJECT_BINARY_DIR}/cmake/templates/Qhull.cmake
     @ONLY
     )
   include(GNUInstallDirs)
   install(
-    FILES ${CMAKE_SOURCE_DIR}/cmake/modules/FindQhull.cmake
+    FILES ${PROJECT_SOURCE_DIR}/cmake/modules/FindQhull.cmake
     DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C/modules
     )
 endif()

--- a/cmake/configure/configure_Trilinos.cmake
+++ b/cmake/configure/configure_Trilinos.cmake
@@ -53,7 +53,7 @@ target_link_libraries(
   )
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/Trilinos.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/Trilinos.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/Trilinos.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/Trilinos.cmake
   @ONLY
   )

--- a/cmake/configure/configure_magic_enum.cmake
+++ b/cmake/configure/configure_magic_enum.cmake
@@ -21,7 +21,7 @@ set(FOUR_C_MAGIC_ENUM_ROOT "${CMAKE_INSTALL_PREFIX}/share/cmake/magic_enum")
 four_c_add_external_dependency(four_c_all_enabled_external_dependencies magic_enum::magic_enum)
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/magic_enum.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/magic_enum.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/magic_enum.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/magic_enum.cmake
   @ONLY
   )

--- a/cmake/configure/configure_ryml.cmake
+++ b/cmake/configure/configure_ryml.cmake
@@ -21,7 +21,7 @@ set(FOUR_C_RYML_ROOT "${CMAKE_INSTALL_PREFIX}/lib/cmake/ryml")
 four_c_add_external_dependency(four_c_all_enabled_external_dependencies ryml::ryml)
 
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/ryml.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/ryml.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/ryml.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/ryml.cmake
   @ONLY
   )

--- a/cmake/functions/four_c_auto_define_module.cmake
+++ b/cmake/functions/four_c_auto_define_module.cmake
@@ -117,7 +117,7 @@ function(four_c_auto_define_module)
               ${PROJECT_SOURCE_DIR}/src
     )
   include(GNUInstallDirs)
-  file(RELATIVE_PATH _relative_path ${CMAKE_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR})
+  file(RELATIVE_PATH _relative_path ${PROJECT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR})
   target_include_directories(
     ${_target}_deps
     INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>

--- a/cmake/functions/four_c_auto_define_tests.cmake
+++ b/cmake/functions/four_c_auto_define_tests.cmake
@@ -40,7 +40,7 @@ function(_set_up_unit_test_target _module_under_test _target)
     ${PROJECT_SOURCE_DIR}/unittests/4C_gtest_main_mpi_test.cpp ${assert_mpi_file} ${_parsed_SOURCE}
     )
   # Store unit test executables directly inside the tests/ directory
-  set_target_properties(${_target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/tests)
+  set_target_properties(${_target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
 
   # Do not try to build tests as unity files.
   set_target_properties(${_target} PROPERTIES UNITY_BUILD OFF)
@@ -179,7 +179,7 @@ function(four_c_auto_define_tests)
 
       # Use the same support file directory for all flavors
       set(FOUR_C_TEST_SUPPORT_FILE_DIR
-          "${CMAKE_BINARY_DIR}/tests/support_files/${_test_name_base}/"
+          "${PROJECT_BINARY_DIR}/tests/support_files/${_test_name_base}/"
           )
       target_compile_definitions(
         ${_current_test_name}
@@ -235,7 +235,7 @@ function(four_c_add_support_files_to_test _test_name_base)
 
   endif()
 
-  set(FOUR_C_TEST_SUPPORT_FILE_DIR "${CMAKE_BINARY_DIR}/tests/support_files/${_test_name_base}/")
+  set(FOUR_C_TEST_SUPPORT_FILE_DIR "${PROJECT_BINARY_DIR}/tests/support_files/${_test_name_base}/")
 
   foreach(_support_file ${_parsed_SUPPORT_FILES})
     # Get file name relative to current list file

--- a/cmake/python/set_up_python.cmake
+++ b/cmake/python/set_up_python.cmake
@@ -58,7 +58,7 @@ if(Python3_VERSION VERSION_LESS "3.8")
   message(FATAL_ERROR "Python version must be at least 3.8, but found ${Python3_VERSION}")
 endif()
 
-set(FOUR_C_PYTHON_VENV_BUILD "${CMAKE_BINARY_DIR}/python_venv_build_test")
+set(FOUR_C_PYTHON_VENV_BUILD "${PROJECT_BINARY_DIR}/python_venv_build_test")
 
 _execute_process(
   PROCESS_COMMAND
@@ -79,7 +79,7 @@ _execute_process(
   ${FOUR_C_PYTHON_VENV_BUILD}/bin/pip
   install
   -r
-  ${CMAKE_SOURCE_DIR}/cmake/python/requirements.txt
+  ${PROJECT_SOURCE_DIR}/cmake/python/requirements.txt
   )
 
 message(

--- a/cmake/setup_install.cmake
+++ b/cmake/setup_install.cmake
@@ -13,14 +13,14 @@ function(_add_dependency_to_settings _package_name)
   # Append the dependency info to the target settings
   if(FOUR_C_WITH_${_package_name_SANITIZED})
     # Append a tab at the start of each line of content
-    file(READ ${CMAKE_BINARY_DIR}/cmake/templates/${_package_name}.cmake _content)
+    file(READ ${PROJECT_BINARY_DIR}/cmake/templates/${_package_name}.cmake _content)
     string(REPLACE "\n" "\n\t" _content_with_tab "${_content}")
     file(
-      APPEND ${CMAKE_BINARY_DIR}/cmake/templates/4CSettings.cmake
+      APPEND ${PROJECT_BINARY_DIR}/cmake/templates/4CSettings.cmake
       "\nif(FOUR_C_WITH_${_package_name_SANITIZED})\n\t"
       )
-    file(APPEND ${CMAKE_BINARY_DIR}/cmake/templates/4CSettings.cmake "${_content_with_tab}")
-    file(APPEND ${CMAKE_BINARY_DIR}/cmake/templates/4CSettings.cmake "\nendif()\n")
+    file(APPEND ${PROJECT_BINARY_DIR}/cmake/templates/4CSettings.cmake "${_content_with_tab}")
+    file(APPEND ${PROJECT_BINARY_DIR}/cmake/templates/4CSettings.cmake "\nendif()\n")
   endif()
 endfunction()
 
@@ -63,8 +63,8 @@ install(
 
 # create the settings file
 configure_file(
-  ${CMAKE_SOURCE_DIR}/cmake/templates/4CSettings.cmake.in
-  ${CMAKE_BINARY_DIR}/cmake/templates/4CSettings.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/templates/4CSettings.cmake.in
+  ${PROJECT_BINARY_DIR}/cmake/templates/4CSettings.cmake
   @ONLY
   )
 
@@ -84,7 +84,7 @@ _add_dependency_to_settings(magic_enum)
 
 # install
 install(
-  FILES ${CMAKE_BINARY_DIR}/cmake/templates/4CSettings.cmake
+  FILES ${PROJECT_BINARY_DIR}/cmake/templates/4CSettings.cmake
   DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C
   )
 
@@ -92,17 +92,17 @@ install(
 include(CMakePackageConfigHelpers)
 set(FOUR_C_VERSION_STRING "${FOUR_C_VERSION_MAJOR}.${FOUR_C_VERSION_MINOR}")
 configure_package_config_file(
-  cmake/templates/4CConfig.cmake.in ${CMAKE_BINARY_DIR}/cmake/templates/4CConfig.cmake
+  cmake/templates/4CConfig.cmake.in ${PROJECT_BINARY_DIR}/cmake/templates/4CConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C
   )
 write_basic_package_version_file(
-  ${CMAKE_BINARY_DIR}/cmake/templates/4CConfigVersion.cmake
+  ${PROJECT_BINARY_DIR}/cmake/templates/4CConfigVersion.cmake
   VERSION ${FOUR_C_VERSION_STRING}
   COMPATIBILITY ExactVersion
   )
 
 install(
-  FILES ${CMAKE_BINARY_DIR}/cmake/templates/4CConfig.cmake
-        ${CMAKE_BINARY_DIR}/cmake/templates/4CConfigVersion.cmake
+  FILES ${PROJECT_BINARY_DIR}/cmake/templates/4CConfig.cmake
+        ${PROJECT_BINARY_DIR}/cmake/templates/4CConfigVersion.cmake
   DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/4C
   )

--- a/cmake/setup_tests.cmake
+++ b/cmake/setup_tests.cmake
@@ -53,17 +53,17 @@ endif()
 # setup test for installation
 set(FOURC_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/cmake/4C)
 configure_file(
-  ${CMAKE_SOURCE_DIR}/tests/install_test/main.cpp.in
-  ${CMAKE_BINARY_DIR}/tests/install_test/main.cpp
+  ${PROJECT_SOURCE_DIR}/tests/install_test/main.cpp.in
+  ${PROJECT_BINARY_DIR}/tests/install_test/main.cpp
   @ONLY
   )
 configure_file(
-  ${CMAKE_SOURCE_DIR}/tests/install_test/CMakeLists.txt.in
-  ${CMAKE_BINARY_DIR}/tests/install_test/CMakeLists.txt
+  ${PROJECT_SOURCE_DIR}/tests/install_test/CMakeLists.txt.in
+  ${PROJECT_BINARY_DIR}/tests/install_test/CMakeLists.txt
   @ONLY
   )
 configure_file(
-  ${CMAKE_SOURCE_DIR}/tests/install_test/test_install.sh.in
-  ${CMAKE_BINARY_DIR}/tests/install_test/test_install.sh
+  ${PROJECT_SOURCE_DIR}/tests/install_test/test_install.sh.in
+  ${PROJECT_BINARY_DIR}/tests/install_test/test_install.sh
   @ONLY
   )


### PR DESCRIPTION
I want to use 4C in another project, but configure failed since the scripts that configure our external dependencies were not found.