### PR TITLE
Check filename before reading file in --to-yaml

### DIFF
--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -350,8 +350,6 @@ int main(int argc, char* argv[])
     {
       std::filesystem::path inputfile_name = argv[2];
       std::filesystem::path outputfile_name;
-      Core::IO::InputFile input_file = Global::set_up_input_file(lcomm);
-      input_file.read(inputfile_name);
       if (argc == 3)
       {
         outputfile_name = inputfile_name.replace_extension("4C.yaml");
@@ -368,6 +366,8 @@ int main(int argc, char* argv[])
       {
         outputfile_name = argv[3];
       }
+      Core::IO::InputFile input_file = Global::set_up_input_file(lcomm);
+      input_file.read(inputfile_name);
       std::ofstream output_file(outputfile_name);
       input_file.write_as_yaml(output_file);
       printf("The input file has been converted to yaml format");


### PR DESCRIPTION
The --to-yaml converter aborts when the output file already exists. To avoid the unnessary reading of the input file in this case, the reading of the file is now done after checking the output file. This will save some seconds.

This is useful for converting large files. The converter now aborts after 10 seconds instead of 30 seconds for a input file of 3 GB. 