### PR TITLE
Remove section specs helper

### DIFF
--- a/src/ale/4C_ale_input.cpp
+++ b/src/ale/4C_ale_input.cpp
@@ -20,76 +20,73 @@ void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs adyn{"ALE DYNAMIC"};
+  list["ALE DYNAMIC"] = all_of({
 
-  adyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.1}));
-  adyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "max number of time steps", .default_value = 41}));
-  adyn.specs.emplace_back(
-      parameter<double>("MAXTIME", {.description = "max simulation time", .default_value = 4.0}));
+      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.1}),
 
-  adyn.specs.emplace_back(parameter<ALE::AleDynamic>(
-      "ALE_TYPE", {.description = "ale mesh movement algorithm", .default_value = solid}));
+      parameter<int>("NUMSTEP", {.description = "max number of time steps", .default_value = 41}),
 
-  adyn.specs.emplace_back(parameter<bool>("ASSESSMESHQUALITY",
-      {.description = "Evaluate element quality measure according to [Oddy et al. 1988]",
-          .default_value = false}));
+      parameter<double>("MAXTIME", {.description = "max simulation time", .default_value = 4.0}),
 
-  adyn.specs.emplace_back(parameter<bool>("UPDATEMATRIX",
-      {.description =
-              "Update stiffness matrix in every time step (only for linear/material strategies)",
-          .default_value = false}));
+      parameter<ALE::AleDynamic>(
+          "ALE_TYPE", {.description = "ale mesh movement algorithm", .default_value = solid}),
 
-  adyn.specs.emplace_back(parameter<int>(
-      "MAXITER", {.description = "Maximum number of newton iterations.", .default_value = 1}));
-  adyn.specs.emplace_back(parameter<double>(
-      "TOLRES", {.description = "Absolute tolerance for length scaled L2 residual norm ",
-                    .default_value = 1.0e-06}));
-  adyn.specs.emplace_back(parameter<double>(
-      "TOLDISP", {.description = "Absolute tolerance for length scaled L2 increment norm ",
-                     .default_value = 1.0e-06}));
+      parameter<bool>("ASSESSMESHQUALITY",
+          {.description = "Evaluate element quality measure according to [Oddy et al. 1988]",
+              .default_value = false}),
 
-  adyn.specs.emplace_back(parameter<int>("NUM_INITSTEP", {.description = "", .default_value = 0}));
-  adyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart data every RESTARTEVERY steps", .default_value = 1}));
-  adyn.specs.emplace_back(parameter<int>("RESULTSEVERY",
-      {.description = "write results every RESULTSTEVERY steps", .default_value = 0}));
-  adyn.specs.emplace_back(deprecated_selection<ALE::DivContAct>("DIVERCONT",
-      {
-          {"stop", divcont_stop},
-          {"continue", divcont_continue},
-      },
-      {.description = "What to do if nonlinear solver does not converge?",
-          .default_value = divcont_continue}));
+      parameter<bool>("UPDATEMATRIX", {.description = "Update stiffness matrix in every time step "
+                                                      "(only for linear/material strategies)",
+                                          .default_value = false}),
 
-  adyn.specs.emplace_back(deprecated_selection<ALE::MeshTying>("MESHTYING",
-      {
-          {"no", no_meshtying},
-          {"meshtying", meshtying},
-          {"meshsliding", meshsliding},
-      },
-      {.description = "Flag to (de)activate mesh tying and mesh sliding algorithm",
-          .default_value = no_meshtying}));
+      parameter<int>(
+          "MAXITER", {.description = "Maximum number of newton iterations.", .default_value = 1}),
+      parameter<double>(
+          "TOLRES", {.description = "Absolute tolerance for length scaled L2 residual norm ",
+                        .default_value = 1.0e-06}),
+      parameter<double>(
+          "TOLDISP", {.description = "Absolute tolerance for length scaled L2 increment norm ",
+                         .default_value = 1.0e-06}),
 
-  // Initial displacement
-  adyn.specs.emplace_back(deprecated_selection<ALE::InitialDisp>("INITIALDISP",
-      {
-          {"zero_displacement", initdisp_zero_disp},
-          {"displacement_by_function", initdisp_disp_by_function},
-      },
-      {.description = "Initial displacement for structure problem",
-          .default_value = initdisp_zero_disp}));
+      parameter<int>("NUM_INITSTEP", {.description = "", .default_value = 0}),
+      parameter<int>("RESTARTEVERY",
+          {.description = "write restart data every RESTARTEVERY steps", .default_value = 1}),
+      parameter<int>("RESULTSEVERY",
+          {.description = "write results every RESULTSTEVERY steps", .default_value = 0}),
+      deprecated_selection<ALE::DivContAct>("DIVERCONT",
+          {
+              {"stop", divcont_stop},
+              {"continue", divcont_continue},
+          },
+          {.description = "What to do if nonlinear solver does not converge?",
+              .default_value = divcont_continue}),
 
-  // Function to evaluate initial displacement
-  adyn.specs.emplace_back(parameter<int>(
-      "STARTFUNCNO", {.description = "Function for Initial displacement", .default_value = -1}));
+      deprecated_selection<ALE::MeshTying>("MESHTYING",
+          {
+              {"no", no_meshtying},
+              {"meshtying", meshtying},
+              {"meshsliding", meshsliding},
+          },
+          {.description = "Flag to (de)activate mesh tying and mesh sliding algorithm",
+              .default_value = no_meshtying}),
 
-  // linear solver id used for scalar ale problems
-  adyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for ale problems...", .default_value = -1}));
+      // Initial displacement
+      deprecated_selection<ALE::InitialDisp>("INITIALDISP",
+          {
+              {"zero_displacement", initdisp_zero_disp},
+              {"displacement_by_function", initdisp_disp_by_function},
+          },
+          {.description = "Initial displacement for structure problem",
+              .default_value = initdisp_zero_disp}),
 
-  adyn.move_into_collection(list);
+      // Function to evaluate initial displacement
+      parameter<int>(
+          "STARTFUNCNO", {.description = "Function for Initial displacement", .default_value = -1}),
+
+      // linear solver id used for scalar ale problems
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "number of linear solver used for ale problems...",
+                               .default_value = -1})});
 }
 
 

--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -20,197 +20,203 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs beamcontact{"BEAM CONTACT"};
+  list["BEAM CONTACT"] = all_of({
 
-  beamcontact.specs.emplace_back(deprecated_selection<BeamContact::Strategy>("BEAMS_STRATEGY",
-      {
-          {"None", bstr_none},
-          {"none", bstr_none},
-          {"Penalty", bstr_penalty},
-          {"penalty", bstr_penalty},
-          {"Gmshonly", bstr_gmshonly},
-          {"gmshonly", bstr_gmshonly},
-      },
-      {.description = "Type of employed solving strategy", .default_value = bstr_none}));
+      deprecated_selection<BeamContact::Strategy>("BEAMS_STRATEGY",
+          {
+              {"None", bstr_none},
+              {"none", bstr_none},
+              {"Penalty", bstr_penalty},
+              {"penalty", bstr_penalty},
+              {"Gmshonly", bstr_gmshonly},
+              {"gmshonly", bstr_gmshonly},
+          },
+          {.description = "Type of employed solving strategy", .default_value = bstr_none}),
 
-  beamcontact.specs.emplace_back(deprecated_selection<BeamContact::Modelevaluator>("MODELEVALUATOR",
-      {
-          {"Old", bstr_old},
-          {"old", bstr_old},
-          {"Standard", bstr_standard},
-          {"standard", bstr_standard},
-      },
-      {.description = "Type of model evaluator", .default_value = bstr_old}));
+      deprecated_selection<BeamContact::Modelevaluator>("MODELEVALUATOR",
+          {
+              {"Old", bstr_old},
+              {"old", bstr_old},
+              {"Standard", bstr_standard},
+              {"standard", bstr_standard},
+          },
+          {.description = "Type of model evaluator", .default_value = bstr_old}),
 
-  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_NEWGAP",
-      {.description = "choose between original or enhanced gapfunction", .default_value = false}));
+      parameter<bool>(
+          "BEAMS_NEWGAP", {.description = "choose between original or enhanced gapfunction",
+                              .default_value = false}),
 
-  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_SEGCON",
-      {.description = "choose between beam contact with and without subsegment generation",
-          .default_value = false}));
+      parameter<bool>("BEAMS_SEGCON",
+          {.description = "choose between beam contact with and without subsegment generation",
+              .default_value = false}),
 
-  beamcontact.specs.emplace_back(parameter<bool>(
-      "BEAMS_DEBUG", {.description = "This flag can be used for testing purposes. When it is "
-                                     "switched on, some sanity checks are not performed!",
-                         .default_value = false}));
+      parameter<bool>(
+          "BEAMS_DEBUG", {.description = "This flag can be used for testing purposes. When it is "
+                                         "switched on, some sanity checks are not performed!",
+                             .default_value = false}),
 
-  beamcontact.specs.emplace_back(parameter<bool>(
-      "BEAMS_INACTIVESTIFF", {.description = "Always apply contact stiffness in first Newton step "
-                                             "for pairs which have active in last time step",
-                                 .default_value = false}));
+      parameter<bool>("BEAMS_INACTIVESTIFF",
+          {.description = "Always apply contact stiffness in first Newton step "
+                          "for pairs which have active in last time step",
+              .default_value = false}),
 
-  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_BTSOL",
-      {.description = "decide, if also the contact between beams and solids is possible",
-          .default_value = false}));
+      parameter<bool>("BEAMS_BTSOL",
+          {.description = "decide, if also the contact between beams and solids is possible",
+              .default_value = false}),
 
-  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_ENDPOINTPENALTY",
-      {.description = "Additional consideration of endpoint-line and endpoint-endpoint contacts",
-          .default_value = false}));
+      parameter<bool>("BEAMS_ENDPOINTPENALTY",
+          {.description =
+                  "Additional consideration of endpoint-line and endpoint-endpoint contacts",
+              .default_value = false}),
 
-  beamcontact.specs.emplace_back(deprecated_selection<BeamContact::Smoothing>("BEAMS_SMOOTHING",
-      {
-          {"None", bsm_none},
-          {"none", bsm_none},
-          {"Cpp", bsm_cpp},
-          {"cpp", bsm_cpp},
-      },
-      {.description = "Application of smoothed tangent field", .default_value = bsm_none}));
+      deprecated_selection<BeamContact::Smoothing>("BEAMS_SMOOTHING",
+          {
+              {"None", bsm_none},
+              {"none", bsm_none},
+              {"Cpp", bsm_cpp},
+              {"cpp", bsm_cpp},
+          },
+          {.description = "Application of smoothed tangent field", .default_value = bsm_none}),
 
-  beamcontact.specs.emplace_back(parameter<bool>("BEAMS_DAMPING",
-      {.description = "Application of a contact damping force", .default_value = false}));
+      parameter<bool>("BEAMS_DAMPING",
+          {.description = "Application of a contact damping force", .default_value = false}),
 
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_BTBPENALTYPARAM",
-      {.description = "Penalty parameter for beam-to-beam point contact", .default_value = 0.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_BTBLINEPENALTYPARAM",
-      {.description = "Penalty parameter per unit length for beam-to-beam line contact",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_BTSPENALTYPARAM",
-      {.description = "Penalty parameter for beam-to-solid contact", .default_value = 0.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_DAMPINGPARAM",
-      {.description = "Damping parameter for contact damping force", .default_value = -1000.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_DAMPREGPARAM1",
-      {.description =
-              "First (at gap1, with gap1>gap2) regularization parameter for contact damping force",
-          .default_value = -1000.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_DAMPREGPARAM2",
-      {.description =
-              "Second (at gap2, with gap1>gap2) regularization parameter for contact damping force",
-          .default_value = -1000.0}));
-  beamcontact.specs.emplace_back(parameter<double>(
-      "BEAMS_MAXDISISCALEFAC", {.description = "Scale factor in order to limit maximal iterative "
-                                               "displacement increment (resiudal displacement)",
-                                   .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_MAXDELTADISSCALEFAC",
-      {.description = "Scale factor in order to limit maximal displacement per time step",
-          .default_value = 1.0}));
+      parameter<double>("BEAMS_BTBPENALTYPARAM",
+          {.description = "Penalty parameter for beam-to-beam point contact",
+              .default_value = 0.0}),
+      parameter<double>("BEAMS_BTBLINEPENALTYPARAM",
+          {.description = "Penalty parameter per unit length for beam-to-beam line contact",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_BTSPENALTYPARAM",
+          {.description = "Penalty parameter for beam-to-solid contact", .default_value = 0.0}),
+      parameter<double>("BEAMS_DAMPINGPARAM",
+          {.description = "Damping parameter for contact damping force", .default_value = -1000.0}),
+      parameter<double>(
+          "BEAMS_DAMPREGPARAM1", {.description = "First (at gap1, with gap1>gap2) regularization "
+                                                 "parameter for contact damping force",
+                                     .default_value = -1000.0}),
+      parameter<double>(
+          "BEAMS_DAMPREGPARAM2", {.description = "Second (at gap2, with gap1>gap2) regularization "
+                                                 "parameter for contact damping force",
+                                     .default_value = -1000.0}),
+      parameter<double>("BEAMS_MAXDISISCALEFAC",
+          {.description = "Scale factor in order to limit maximal iterative "
+                          "displacement increment (resiudal displacement)",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_MAXDELTADISSCALEFAC",
+          {.description = "Scale factor in order to limit maximal displacement per time step",
+              .default_value = 1.0}),
 
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PERPSHIFTANGLE1",
-      {.description = "Lower shift angle (in degrees) for penalty scaling of large-angle-contact",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PERPSHIFTANGLE2",
-      {.description = "Upper shift angle (in degrees) for penalty scaling of large-angle-contact",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PARSHIFTANGLE1",
-      {.description = "Lower shift angle (in degrees) for penalty scaling of small-angle-contact",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PARSHIFTANGLE2",
-      {.description = "Upper shift angle (in degrees) for penalty scaling of small-angle-contact",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_SEGANGLE",
-      {.description = "Maximal angle deviation allowed for contact search segmentation",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<int>("BEAMS_NUMINTEGRATIONINTERVAL",
-      {.description = "Number of integration intervals per element", .default_value = 1}));
+      parameter<double>("BEAMS_PERPSHIFTANGLE1",
+          {.description =
+                  "Lower shift angle (in degrees) for penalty scaling of large-angle-contact",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_PERPSHIFTANGLE2",
+          {.description =
+                  "Upper shift angle (in degrees) for penalty scaling of large-angle-contact",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_PARSHIFTANGLE1",
+          {.description =
+                  "Lower shift angle (in degrees) for penalty scaling of small-angle-contact",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_PARSHIFTANGLE2",
+          {.description =
+                  "Upper shift angle (in degrees) for penalty scaling of small-angle-contact",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_SEGANGLE",
+          {.description = "Maximal angle deviation allowed for contact search segmentation",
+              .default_value = -1.0}),
+      parameter<int>("BEAMS_NUMINTEGRATIONINTERVAL",
+          {.description = "Number of integration intervals per element", .default_value = 1}),
 
-  beamcontact.specs.emplace_back(deprecated_selection<BeamContact::PenaltyLaw>("BEAMS_PENALTYLAW",
-      {
-          {"LinPen", pl_lp},
-          {"QuadPen", pl_qp},
-          {"LinNegQuadPen", pl_lnqp},
-          {"LinPosQuadPen", pl_lpqp},
-          {"LinPosCubPen", pl_lpcp},
-          {"LinPosDoubleQuadPen", pl_lpdqp},
-          {"LinPosExpPen", pl_lpep},
-      },
-      {.description = "Applied Penalty Law", .default_value = pl_lp}));
+      deprecated_selection<BeamContact::PenaltyLaw>("BEAMS_PENALTYLAW",
+          {
+              {"LinPen", pl_lp},
+              {"QuadPen", pl_qp},
+              {"LinNegQuadPen", pl_lnqp},
+              {"LinPosQuadPen", pl_lpqp},
+              {"LinPosCubPen", pl_lpcp},
+              {"LinPosDoubleQuadPen", pl_lpdqp},
+              {"LinPosExpPen", pl_lpep},
+          },
+          {.description = "Applied Penalty Law", .default_value = pl_lp}),
 
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PENREGPARAM_G0",
-      {.description =
-              "First penalty regularization parameter G0 >=0: For gap<G0 contact is active!",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PENREGPARAM_F0",
-      {.description = "Second penalty regularization parameter F0 >=0: F0 represents the force at "
-                      "the transition point between regularized and linear force law!",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_PENREGPARAM_C0",
-      {.description = "Third penalty regularization parameter C0 >=0: C0 has different physical "
-                      "meanings for the different penalty laws!",
-          .default_value = -1.0}));
-  beamcontact.specs.emplace_back(parameter<double>("BEAMS_GAPSHIFTPARAM",
-      {.description = "Parameter to shift penalty law!", .default_value = 0.0}));
-  beamcontact.specs.emplace_back(parameter<double>(
-      "BEAMS_BASICSTIFFGAP", {.description = "For gaps > -BEAMS_BASICSTIFFGAP, only the basic part "
-                                             "of the contact linearization is applied!",
-                                 .default_value = -1.0}));
+      parameter<double>("BEAMS_PENREGPARAM_G0",
+          {.description =
+                  "First penalty regularization parameter G0 >=0: For gap<G0 contact is active!",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_PENREGPARAM_F0",
+          {.description =
+                  "Second penalty regularization parameter F0 >=0: F0 represents the force at "
+                  "the transition point between regularized and linear force law!",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_PENREGPARAM_C0",
+          {.description =
+                  "Third penalty regularization parameter C0 >=0: C0 has different physical "
+                  "meanings for the different penalty laws!",
+              .default_value = -1.0}),
+      parameter<double>("BEAMS_GAPSHIFTPARAM",
+          {.description = "Parameter to shift penalty law!", .default_value = 0.0}),
+      parameter<double>("BEAMS_BASICSTIFFGAP",
+          {.description = "For gaps > -BEAMS_BASICSTIFFGAP, only the basic part "
+                          "of the contact linearization is applied!",
+              .default_value = -1.0}),
 
-  // enable octree search and determine type of bounding box (aabb = axis aligned, cobb =
-  // cylindrical oriented)
-  beamcontact.specs.emplace_back(deprecated_selection<BeamContact::OctreeType>("BEAMS_OCTREE",
-      {
-          {"None", boct_none},
-          {"none", boct_none},
-          {"octree_axisaligned", boct_aabb},
-          {"octree_cylorient", boct_cobb},
-          {"octree_spherical", boct_spbb},
-      },
-      {.description = "octree and bounding box type for octree search routine",
-          .default_value = boct_none}));
+      // enable octree search and determine type of bounding box (aabb = axis aligned, cobb =
+      // cylindrical oriented)
+      deprecated_selection<BeamContact::OctreeType>("BEAMS_OCTREE",
+          {
+              {"None", boct_none},
+              {"none", boct_none},
+              {"octree_axisaligned", boct_aabb},
+              {"octree_cylorient", boct_cobb},
+              {"octree_spherical", boct_spbb},
+          },
+          {.description = "octree and bounding box type for octree search routine",
+              .default_value = boct_none}),
 
-  beamcontact.specs.emplace_back(parameter<bool>(
-      "BEAMS_ADDITEXT", {.description = "Switch between No==multiplicative extrusion factor and "
-                                        "Yes==additive extrusion factor",
-                            .default_value = true}));
-  beamcontact.specs.emplace_back(parameter<std::string>("BEAMS_EXTVAL",
-      {.description = "extrusion value(s) of the bounding box, Depending on BEAMS_ADDITIVEEXTFAC "
-                      "is either  additive or multiplicative. Give one or two values.",
-          .default_value = "-1.0"}));
+      parameter<bool>("BEAMS_ADDITEXT",
+          {.description = "Switch between No==multiplicative extrusion factor and "
+                          "Yes==additive extrusion factor",
+              .default_value = true}),
+      parameter<std::string>("BEAMS_EXTVAL",
+          {.description =
+                  "extrusion value(s) of the bounding box, Depending on BEAMS_ADDITIVEEXTFAC "
+                  "is either  additive or multiplicative. Give one or two values.",
+              .default_value = "-1.0"}),
 
-  beamcontact.specs.emplace_back(parameter<int>(
-      "BEAMS_TREEDEPTH", {.description = "max. tree depth of the octree", .default_value = 6}));
-  beamcontact.specs.emplace_back(parameter<int>("BEAMS_BOXESINOCT",
-      {.description = "max number of bounding boxes in any leaf octant", .default_value = 8}));
-
-  beamcontact.move_into_collection(list);
-
-  /*------------------------------------------------------------------------*/
+      parameter<int>(
+          "BEAMS_TREEDEPTH", {.description = "max. tree depth of the octree", .default_value = 6}),
+      parameter<int>("BEAMS_BOXESINOCT",
+          {.description = "max number of bounding boxes in any leaf octant",
+              .default_value =
+                  8})}); /*------------------------------------------------------------------------*/
   /* parameters for visualization of beam contact via output at runtime */
 
-  Core::Utils::SectionSpecs beamcontact_vtk_sublist{beamcontact, "RUNTIME VTK OUTPUT"};
+  list["BEAM CONTACT/RUNTIME VTK OUTPUT"] = all_of({
 
-  // whether to write visualization output for beam contact
-  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>("VTK_OUTPUT_BEAM_CONTACT",
-      {.description = "write visualization output for beam contact", .default_value = false}));
+      // whether to write visualization output for beam contact
+      parameter<bool>("VTK_OUTPUT_BEAM_CONTACT",
+          {.description = "write visualization output for beam contact", .default_value = false}),
 
-  // output interval regarding steps: write output every INTERVAL_STEPS steps
-  beamcontact_vtk_sublist.specs.emplace_back(parameter<int>("INTERVAL_STEPS",
-      {.description = "write visualization output at runtime every INTERVAL_STEPS steps",
-          .default_value = -1}));
+      // output interval regarding steps: write output every INTERVAL_STEPS steps
+      parameter<int>("INTERVAL_STEPS",
+          {.description = "write visualization output at runtime every INTERVAL_STEPS steps",
+              .default_value = -1}),
 
-  // whether to write output in every iteration of the nonlinear solver
-  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>(
-      "EVERY_ITERATION", {.description = "write output in every iteration of the nonlinear solver",
-                             .default_value = false}));
+      // whether to write output in every iteration of the nonlinear solver
+      parameter<bool>("EVERY_ITERATION",
+          {.description = "write output in every iteration of the nonlinear solver",
+              .default_value = false}),
 
-  // whether to write visualization output for contact forces
-  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>("CONTACT_FORCES",
-      {.description = "write visualization output for contact forces", .default_value = false}));
+      // whether to write visualization output for contact forces
+      parameter<bool>("CONTACT_FORCES",
+          {.description = "write visualization output for contact forces", .default_value = false}),
 
-  // whether to write visualization output for gaps
-  beamcontact_vtk_sublist.specs.emplace_back(parameter<bool>(
-      "GAPS", {.description = "write visualization output for gap, i.e. penetration",
-                  .default_value = false}));
-
-  beamcontact_vtk_sublist.move_into_collection(list);
+      // whether to write visualization output for gaps
+      parameter<bool>(
+          "GAPS", {.description = "write visualization output for gap, i.e. penetration",
+                      .default_value = false})});
 }
 
 /**

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.cpp
@@ -22,107 +22,106 @@ void BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for potential-based beam interaction */
-  Core::Utils::SectionSpecs beampotential{"BEAM POTENTIAL"};
+  list["BEAM POTENTIAL"] = all_of({
 
-  // TODO change to vector and remove default value
-  beampotential.specs.emplace_back(parameter<std::string>(
-      "POT_LAW_EXPONENT", {.description = "negative(!) exponent(s)  $m_i$ of potential law  "
-                                          "$\\Phi(r) = \\sum_i (k_i * r^{-m_i}).$",
-                              .default_value = "1.0"}));
+      // TODO change to vector and remove default value
+      parameter<std::string>(
+          "POT_LAW_EXPONENT", {.description = "negative(!) exponent(s)  $m_i$ of potential law  "
+                                              "$\\Phi(r) = \\sum_i (k_i * r^{-m_i}).$",
+                                  .default_value = "1.0"}),
 
-  // TODO change to vector and remove default value
-  beampotential.specs.emplace_back(parameter<std::string>("POT_LAW_PREFACTOR",
-      {.description = "prefactor(s) $k_i$ of potential law $\\Phi(r) = \\sum_i (k_i * r^{-m_i})$.",
-          .default_value = "0.0"}));
+      // TODO change to vector and remove default value
+      parameter<std::string>("POT_LAW_PREFACTOR",
+          {.description =
+                  "prefactor(s) $k_i$ of potential law $\\Phi(r) = \\sum_i (k_i * r^{-m_i})$.",
+              .default_value = "0.0"}),
 
-  // TODO remove default value
-  beampotential.specs.emplace_back(parameter<BeamPotential::Type>("TYPE",
-      {.description = "Type of potential interaction: surface (default) or volume potential",
-          .default_value = BeamPotential::Type::surface}));
+      // TODO remove default value
+      parameter<BeamPotential::Type>("TYPE",
+          {.description = "Type of potential interaction: surface (default) or volume potential",
+              .default_value = BeamPotential::Type::surface}),
 
-  // TODO remove default value
-  beampotential.specs.emplace_back(parameter<BeamPotential::Strategy>("STRATEGY",
-      {.description = "strategy to evaluate interaction potential: double/single length specific, "
-                      "small/large separation approximation, ...",
-          .default_value = BeamPotential::Strategy::double_length_specific_large_separations}));
+      // TODO remove default value
+      parameter<BeamPotential::Strategy>("STRATEGY",
+          {.description =
+                  "strategy to evaluate interaction potential: double/single length specific, "
+                  "small/large separation approximation, ...",
+              .default_value = BeamPotential::Strategy::double_length_specific_large_separations}),
 
-  beampotential.specs.emplace_back(parameter<std::optional<double>>("CUTOFF_RADIUS",
-      {.description =
-              "Neglect all potential contributions at separation largerthan this cutoff radius"}));
+      parameter<std::optional<double>>(
+          "CUTOFF_RADIUS", {.description = "Neglect all potential contributions at separation "
+                                           "largerthan this cutoff radius"}),
 
-  // TODO subgroup regularization
-  beampotential.specs.emplace_back(parameter<BeamPotential::RegularizationType>(
-      "REGULARIZATION_TYPE", {.description = "Type of regularization applied to the force law",
-                                 .default_value = BeamPotential::RegularizationType::none}));
+      // TODO subgroup regularization
+      parameter<BeamPotential::RegularizationType>(
+          "REGULARIZATION_TYPE", {.description = "Type of regularization applied to the force law",
+                                     .default_value = BeamPotential::RegularizationType::none}),
 
-  beampotential.specs.emplace_back(parameter<double>("REGULARIZATION_SEPARATION",
-      {.description = "Use regularization of force law at separations smaller than this separation",
-          .default_value = -1.0}));
+      parameter<double>("REGULARIZATION_SEPARATION",
+          {.description =
+                  "Use regularization of force law at separations smaller than this separation",
+              .default_value = -1.0}),
 
-  beampotential.specs.emplace_back(parameter<int>("N_INTEGRATION_SEGMENTS",
-      {.description = "Number of integration segments used per beam element", .default_value = 1}));
+      parameter<int>("N_INTEGRATION_SEGMENTS",
+          {.description = "Number of integration segments used per beam element",
+              .default_value = 1}),
 
-  beampotential.specs.emplace_back(parameter<int>("N_GAUSS_POINTS",
-      {.description = "Number of Gauss points used per integration segment", .default_value = 10}));
+      parameter<int>(
+          "N_GAUSS_POINTS", {.description = "Number of Gauss points used per integration segment",
+                                .default_value = 10}),
 
-  beampotential.specs.emplace_back(parameter<bool>("AUTOMATIC_DIFFERENTIATION",
-      {.description = "apply automatic differentiation via FAD?", .default_value = false}));
+      parameter<bool>("AUTOMATIC_DIFFERENTIATION",
+          {.description = "apply automatic differentiation via FAD?", .default_value = false}),
 
-  beampotential.specs.emplace_back(parameter<MasterSlaveChoice>(
-      "CHOICE_MASTER_SLAVE", {.description = "According to which rule shall the role of master and "
-                                             "slave be assigned to beam elements?",
-                                 .default_value = MasterSlaveChoice::smaller_eleGID_is_slave}));
+      parameter<MasterSlaveChoice>("CHOICE_MASTER_SLAVE",
+          {.description = "According to which rule shall the role of master and "
+                          "slave be assigned to beam elements?",
+              .default_value = MasterSlaveChoice::smaller_eleGID_is_slave}),
 
-  beampotential.specs.emplace_back(parameter<std::optional<double>>("POTENTIAL_REDUCTION_LENGTH",
-      {.description =
-              "Within this length of the master beam end point the potential is smoothly "
-              "reduced to one half to account for infinitely long master beam surrogates."}));
-
-  beampotential.move_into_collection(list);
-
-  /*------------------------------------------------------------------------*/
+      parameter<std::optional<double>>("POTENTIAL_REDUCTION_LENGTH",
+          {.description =
+                  "Within this length of the master beam end point the potential is smoothly "
+                  "reduced to one half to account for infinitely long master beam "
+                  "surrogates."})}); /*------------------------------------------------------------------------*/
   /* parameters for visualization of potential-based beam interactions via output at runtime */
 
-  Core::Utils::SectionSpecs beampotential_output_sublist{beampotential, "RUNTIME VTK OUTPUT"};
+  list["BEAM POTENTIAL/RUNTIME VTK OUTPUT"] = all_of({
 
+      // whether to write visualization output for beam contact
+      parameter<bool>("VTK_OUTPUT_BEAM_POTENTIAL",
+          {.description = "write visualization output for potential-based beam interactions",
+              .default_value = false}),
 
-  // whether to write visualization output for beam contact
-  beampotential_output_sublist.specs.emplace_back(parameter<bool>("VTK_OUTPUT_BEAM_POTENTIAL",
-      {.description = "write visualization output for potential-based beam interactions",
-          .default_value = false}));
+      // output interval regarding steps: write output every INTERVAL_STEPS steps
+      parameter<int>(
+          "INTERVAL_STEPS", {.description = "write output at runtime every INTERVAL_STEPS steps",
+                                .default_value = 1}),
 
-  // output interval regarding steps: write output every INTERVAL_STEPS steps
-  beampotential_output_sublist.specs.emplace_back(parameter<int>("INTERVAL_STEPS",
-      {.description = "write output at runtime every INTERVAL_STEPS steps", .default_value = 1}));
+      // whether to write output in every iteration of the nonlinear solver
+      parameter<bool>("EVERY_ITERATION",
+          {.description = "write output in every iteration of the nonlinear solver",
+              .default_value = false}),
 
-  // whether to write output in every iteration of the nonlinear solver
-  beampotential_output_sublist.specs.emplace_back(parameter<bool>(
-      "EVERY_ITERATION", {.description = "write output in every iteration of the nonlinear solver",
-                             .default_value = false}));
+      // whether to write visualization output for forces
+      parameter<bool>("FORCES",
+          {.description = "write visualization output for forces", .default_value = false}),
 
-  // whether to write visualization output for forces
-  beampotential_output_sublist.specs.emplace_back(parameter<bool>(
-      "FORCES", {.description = "write visualization output for forces", .default_value = false}));
+      // whether to write visualization output for moments
+      parameter<bool>("MOMENTS",
+          {.description = "write visualization output for moments", .default_value = false}),
 
-  // whether to write visualization output for moments
-  beampotential_output_sublist.specs.emplace_back(parameter<bool>("MOMENTS",
-      {.description = "write visualization output for moments", .default_value = false}));
-
-  // whether to write visualization output for forces/moments separately for each element pair
-  beampotential_output_sublist.specs.emplace_back(
+      // whether to write visualization output for forces/moments separately for each element pair
       parameter<bool>("WRITE_FORCE_MOMENT_PER_ELEMENTPAIR",
           {.description =
                   "write visualization output for forces/moments separately for each element pair",
-              .default_value = false}));
+              .default_value = false}),
 
-  // whether to write out the UIDs (uid_0_beam_1_gid, uid_1_beam_2_gid, uid_2_gp_id)
-  beampotential_output_sublist.specs.emplace_back(parameter<bool>(
-      "WRITE_UIDS", {.description = "write out the unique ID's for each visualization point,i.e., "
-                                    "master and slave beam element global ID (uid_0_beam_1_gid, "
-                                    "uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
-                        .default_value = false}));
-
-  beampotential_output_sublist.move_into_collection(list);
+      // whether to write out the UIDs (uid_0_beam_1_gid, uid_1_beam_2_gid, uid_2_gp_id)
+      parameter<bool>("WRITE_UIDS",
+          {.description = "write out the unique ID's for each visualization point,i.e., "
+                          "master and slave beam element global ID (uid_0_beam_1_gid, "
+                          "uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
+              .default_value = false})});
 }
 
 void BeamPotential::set_valid_conditions(

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -17,52 +17,48 @@ void BrownianDynamics::set_valid_parameters(std::map<std::string, Core::IO::Inpu
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs browniandyn_list{"BROWNIAN DYNAMICS"};
+  list["BROWNIAN DYNAMICS"] = all_of({
 
-  browniandyn_list.specs.emplace_back(parameter<bool>(
-      "BROWNDYNPROB", {.description = "switch Brownian dynamics on/off", .default_value = false}));
+      parameter<bool>("BROWNDYNPROB",
+          {.description = "switch Brownian dynamics on/off", .default_value = false}),
 
-  // Reading double parameter for viscosity of background fluid
-  browniandyn_list.specs.emplace_back(
-      parameter<double>("VISCOSITY", {.description = "viscosity", .default_value = 0.0}));
+      // Reading double parameter for viscosity of background fluid
+      parameter<double>("VISCOSITY", {.description = "viscosity", .default_value = 0.0}),
 
-  // Reading double parameter for thermal energy in background fluid (temperature * Boltzmann
-  // constant)
-  browniandyn_list.specs.emplace_back(
-      parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}));
+      // Reading double parameter for thermal energy in background fluid (temperature * Boltzmann
+      // constant)
+      parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}),
 
-  // cutoff for random forces, which determines the maximal value
-  browniandyn_list.specs.emplace_back(parameter<double>(
-      "MAXRANDFORCE", {.description = "Any random force beyond MAXRANDFORCE*(standard dev.) will "
-                                      "be omitted and redrawn. -1.0 means no bounds.'",
-                          .default_value = -1.0}));
+      // cutoff for random forces, which determines the maximal value
+      parameter<double>("MAXRANDFORCE",
+          {.description = "Any random force beyond MAXRANDFORCE*(standard dev.) will "
+                          "be omitted and redrawn. -1.0 means no bounds.'",
+              .default_value = -1.0}),
 
-  // time interval in which random numbers are constant
-  browniandyn_list.specs.emplace_back(parameter<double>("TIMESTEP",
-      {.description = "Within this time interval the random numbers remain constant. -1.0 ",
-          .default_value = -1.0}));
+      // time interval in which random numbers are constant
+      parameter<double>("TIMESTEP",
+          {.description = "Within this time interval the random numbers remain constant. -1.0 ",
+              .default_value = -1.0}),
 
-  // the way how damping coefficient values for beams are specified
-  browniandyn_list.specs.emplace_back(deprecated_selection<BeamDampingCoefficientSpecificationType>(
-      "BEAMS_DAMPING_COEFF_SPECIFIED_VIA",
-      {
-          {"cylinder_geometry_approx", BrownianDynamics::cylinder_geometry_approx},
-          {"Cylinder_geometry_approx", BrownianDynamics::cylinder_geometry_approx},
-          {"input_file", BrownianDynamics::input_file},
-          {"Input_file", BrownianDynamics::input_file},
-      },
-      {.description = "In which way are damping coefficient values for beams specified?",
-          .default_value = BrownianDynamics::cylinder_geometry_approx}));
+      // the way how damping coefficient values for beams are specified
+      deprecated_selection<BeamDampingCoefficientSpecificationType>(
+          "BEAMS_DAMPING_COEFF_SPECIFIED_VIA",
+          {
+              {"cylinder_geometry_approx", BrownianDynamics::cylinder_geometry_approx},
+              {"Cylinder_geometry_approx", BrownianDynamics::cylinder_geometry_approx},
+              {"input_file", BrownianDynamics::input_file},
+              {"Input_file", BrownianDynamics::input_file},
+          },
+          {.description = "In which way are damping coefficient values for beams specified?",
+              .default_value = BrownianDynamics::cylinder_geometry_approx}),
 
-  // values for damping coefficients of beams if they are specified via input file
-  // (per unit length, NOT yet multiplied by fluid viscosity)
-  browniandyn_list.specs.emplace_back(parameter<std::string>("BEAMS_DAMPING_COEFF_PER_UNITLENGTH",
-      {.description = "values for beam damping coefficients (per unit length and NOT yet "
-                      "multiplied by fluid viscosity): translational perpendicular/parallel to "
-                      "beam axis, rotational around axis",
-          .default_value = "0.0 0.0 0.0"}));
-
-  browniandyn_list.move_into_collection(list);
+      // values for damping coefficients of beams if they are specified via input file
+      // (per unit length, NOT yet multiplied by fluid viscosity)
+      parameter<std::string>("BEAMS_DAMPING_COEFF_PER_UNITLENGTH",
+          {.description = "values for beam damping coefficients (per unit length and NOT yet "
+                          "multiplied by fluid viscosity): translational perpendicular/parallel to "
+                          "beam axis, rotational around axis",
+              .default_value = "0.0 0.0 0.0"})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact/4C_contact_input.cpp
+++ b/src/contact/4C_contact_input.cpp
@@ -20,196 +20,201 @@ void CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& l
   using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for structural meshtying and contact */
-  Core::Utils::SectionSpecs scontact{"CONTACT DYNAMIC"};
+  list["CONTACT DYNAMIC"] = all_of({
 
-  scontact.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for meshtying and contact",
-                           .default_value = -1}));
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "number of linear solver used for meshtying and contact",
+                               .default_value = -1}),
 
-  scontact.specs.emplace_back(parameter<bool>("RESTART_WITH_CONTACT",
-      {.description = "Must be chosen if a non-contact simulation is to be restarted with contact",
-          .default_value = false}));
+      parameter<bool>("RESTART_WITH_CONTACT",
+          {.description =
+                  "Must be chosen if a non-contact simulation is to be restarted with contact",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<CONTACT::AdhesionType>("ADHESION",
-      {.description = "Type of adhesion law", .default_value = CONTACT::AdhesionType::none}));
+      parameter<CONTACT::AdhesionType>("ADHESION",
+          {.description = "Type of adhesion law", .default_value = CONTACT::AdhesionType::none}),
 
-  scontact.specs.emplace_back(deprecated_selection<CONTACT::FrictionType>("FRICTION",
-      {
-          {"None", CONTACT::FrictionType::none},
-          {"Stick", CONTACT::FrictionType::stick},
-          {"Tresca", CONTACT::FrictionType::tresca},
-          {"Coulomb", CONTACT::FrictionType::coulomb},
-      },
-      {.description = "Type of friction law", .default_value = CONTACT::FrictionType::none}));
+      deprecated_selection<CONTACT::FrictionType>("FRICTION",
+          {
+              {"None", CONTACT::FrictionType::none},
+              {"Stick", CONTACT::FrictionType::stick},
+              {"Tresca", CONTACT::FrictionType::tresca},
+              {"Coulomb", CONTACT::FrictionType::coulomb},
+          },
+          {.description = "Type of friction law", .default_value = CONTACT::FrictionType::none}),
 
-  scontact.specs.emplace_back(parameter<bool>(
-      "FRLESS_FIRST", {.description = "If chosen the first time step of a newly in contact slave "
-                                      "node is regarded as frictionless",
-                          .default_value = false}));
+      parameter<bool>("FRLESS_FIRST",
+          {.description = "If chosen the first time step of a newly in contact slave "
+                          "node is regarded as frictionless",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<bool>("GP_SLIP_INCR",
-      {.description =
-              "If chosen the slip increment is computed gp-wise which results to a non-objective "
-              "quantity, but this would be consistent to wear and tsi calculations.",
-          .default_value = false}));
+      parameter<bool>("GP_SLIP_INCR",
+          {.description = "If chosen the slip increment is computed gp-wise which results to a "
+                          "non-objective "
+                          "quantity, but this would be consistent to wear and tsi calculations.",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(deprecated_selection<CONTACT::SolvingStrategy>("STRATEGY",
-      {
-          {"LagrangianMultipliers", CONTACT::SolvingStrategy::lagmult},
-          {"lagrange", CONTACT::SolvingStrategy::lagmult},
-          {"Lagrange", CONTACT::SolvingStrategy::lagmult},
-          {"penalty", CONTACT::SolvingStrategy::penalty},
-          {"Penalty", CONTACT::SolvingStrategy::penalty},
-          {"Uzawa", CONTACT::SolvingStrategy::uzawa},
-          {"Nitsche", CONTACT::SolvingStrategy::nitsche},
-          {"Ehl", CONTACT::SolvingStrategy::ehl},
-          {"MultiScale", CONTACT::SolvingStrategy::multiscale},
-      },
-      {.description = "Type of employed solving strategy",
-          .default_value = CONTACT::SolvingStrategy::lagmult}));
+      deprecated_selection<CONTACT::SolvingStrategy>("STRATEGY",
+          {
+              {"LagrangianMultipliers", CONTACT::SolvingStrategy::lagmult},
+              {"lagrange", CONTACT::SolvingStrategy::lagmult},
+              {"Lagrange", CONTACT::SolvingStrategy::lagmult},
+              {"penalty", CONTACT::SolvingStrategy::penalty},
+              {"Penalty", CONTACT::SolvingStrategy::penalty},
+              {"Uzawa", CONTACT::SolvingStrategy::uzawa},
+              {"Nitsche", CONTACT::SolvingStrategy::nitsche},
+              {"Ehl", CONTACT::SolvingStrategy::ehl},
+              {"MultiScale", CONTACT::SolvingStrategy::multiscale},
+          },
+          {.description = "Type of employed solving strategy",
+              .default_value = CONTACT::SolvingStrategy::lagmult}),
 
-  scontact.specs.emplace_back(deprecated_selection<CONTACT::SystemType>("SYSTEM",
-      {
-          {"Condensed", CONTACT::SystemType::condensed},
-          {"condensed", CONTACT::SystemType::condensed},
-          {"cond", CONTACT::SystemType::condensed},
-          {"Condensedlagmult", CONTACT::SystemType::condensed_lagmult},
-          {"condensedlagmult", CONTACT::SystemType::condensed_lagmult},
-          {"condlm", CONTACT::SystemType::condensed_lagmult},
-          {"SaddlePoint", CONTACT::SystemType::saddlepoint},
-          {"Saddlepoint", CONTACT::SystemType::saddlepoint},
-          {"saddlepoint", CONTACT::SystemType::saddlepoint},
-          {"sp", CONTACT::SystemType::saddlepoint},
-          {"none", CONTACT::SystemType::none},
-      },
-      {.description = "Type of linear system setup / solution",
-          .default_value = CONTACT::SystemType::condensed}));
+      deprecated_selection<CONTACT::SystemType>("SYSTEM",
+          {
+              {"Condensed", CONTACT::SystemType::condensed},
+              {"condensed", CONTACT::SystemType::condensed},
+              {"cond", CONTACT::SystemType::condensed},
+              {"Condensedlagmult", CONTACT::SystemType::condensed_lagmult},
+              {"condensedlagmult", CONTACT::SystemType::condensed_lagmult},
+              {"condlm", CONTACT::SystemType::condensed_lagmult},
+              {"SaddlePoint", CONTACT::SystemType::saddlepoint},
+              {"Saddlepoint", CONTACT::SystemType::saddlepoint},
+              {"saddlepoint", CONTACT::SystemType::saddlepoint},
+              {"sp", CONTACT::SystemType::saddlepoint},
+              {"none", CONTACT::SystemType::none},
+          },
+          {.description = "Type of linear system setup / solution",
+              .default_value = CONTACT::SystemType::condensed}),
 
-  scontact.specs.emplace_back(parameter<double>("PENALTYPARAM",
-      {.description = "Penalty parameter for penalty / Uzawa augmented solution strategy",
-          .default_value = 0.0}));
-  scontact.specs.emplace_back(parameter<double>("PENALTYPARAMTAN",
-      {.description =
-              "Tangential penalty parameter for penalty / Uzawa augmented solution strategy",
-          .default_value = 0.0}));
-  scontact.specs.emplace_back(parameter<int>(
-      "UZAWAMAXSTEPS", {.description = "Maximum no. of Uzawa steps for Uzawa solution strategy",
-                           .default_value = 10}));
-  scontact.specs.emplace_back(parameter<double>(
-      "UZAWACONSTRTOL", {.description = "Tolerance of constraint norm for Uzawa solution strategy",
-                            .default_value = 1.0e-8}));
+      parameter<double>("PENALTYPARAM",
+          {.description = "Penalty parameter for penalty / Uzawa augmented solution strategy",
+              .default_value = 0.0}),
+      parameter<double>("PENALTYPARAMTAN",
+          {.description =
+                  "Tangential penalty parameter for penalty / Uzawa augmented solution strategy",
+              .default_value = 0.0}),
+      parameter<int>(
+          "UZAWAMAXSTEPS", {.description = "Maximum no. of Uzawa steps for Uzawa solution strategy",
+                               .default_value = 10}),
+      parameter<double>("UZAWACONSTRTOL",
+          {.description = "Tolerance of constraint norm for Uzawa solution strategy",
+              .default_value = 1.0e-8}),
 
-  scontact.specs.emplace_back(parameter<bool>("SEMI_SMOOTH_NEWTON",
-      {.description = "If chosen semi-smooth Newton concept is applied", .default_value = true}));
+      parameter<bool>(
+          "SEMI_SMOOTH_NEWTON", {.description = "If chosen semi-smooth Newton concept is applied",
+                                    .default_value = true}),
 
-  scontact.specs.emplace_back(parameter<double>("SEMI_SMOOTH_CN",
-      {.description = "Weighting factor cn for semi-smooth PDASS", .default_value = 1.0}));
-  scontact.specs.emplace_back(parameter<double>("SEMI_SMOOTH_CT",
-      {.description = "Weighting factor ct for semi-smooth PDASS", .default_value = 1.0}));
+      parameter<double>("SEMI_SMOOTH_CN",
+          {.description = "Weighting factor cn for semi-smooth PDASS", .default_value = 1.0}),
+      parameter<double>("SEMI_SMOOTH_CT",
+          {.description = "Weighting factor ct for semi-smooth PDASS", .default_value = 1.0}),
 
-  scontact.specs.emplace_back(parameter<bool>("CONTACTFORCE_ENDTIME",
-      {.description = "If chosen, the contact force is not evaluated at the generalized midpoint, "
-                      "but at the end of the time step",
-          .default_value = false}));
+      parameter<bool>("CONTACTFORCE_ENDTIME",
+          {.description =
+                  "If chosen, the contact force is not evaluated at the generalized midpoint, "
+                  "but at the end of the time step",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<bool>("VELOCITY_UPDATE",
-      {.description = "If chosen, velocity update method is applied", .default_value = false}));
+      parameter<bool>("VELOCITY_UPDATE",
+          {.description = "If chosen, velocity update method is applied", .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<bool>("INITCONTACTBYGAP",
-      {.description = "Initialize init contact by weighted gap vector", .default_value = false}));
+      parameter<bool>(
+          "INITCONTACTBYGAP", {.description = "Initialize init contact by weighted gap vector",
+                                  .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<double>("INITCONTACTGAPVALUE",
-      {.description = "Value for initialization of init contact set with gap vector",
-          .default_value = 0.0}));
+      parameter<double>("INITCONTACTGAPVALUE",
+          {.description = "Value for initialization of init contact set with gap vector",
+              .default_value = 0.0}),
 
-  // solver convergence test parameters for contact/meshtying in saddlepoint formulation
-  scontact.specs.emplace_back(deprecated_selection<Inpar::Solid::BinaryOp>(
-      "NORMCOMBI_RESFCONTCONSTR",
-      {
-          {"And", Inpar::Solid::bop_and},
-          {"Or", Inpar::Solid::bop_or},
-      },
-      {.description = "binary operator to combine contact constraints and residual force values",
-          .default_value = Inpar::Solid::bop_and}));
+      // solver convergence test parameters for contact/meshtying in saddlepoint formulation
+      deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFCONTCONSTR",
+          {
+              {"And", Inpar::Solid::bop_and},
+              {"Or", Inpar::Solid::bop_or},
+          },
+          {.description =
+                  "binary operator to combine contact constraints and residual force values",
+              .default_value = Inpar::Solid::bop_and}),
 
-  scontact.specs.emplace_back(deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPLAGR",
-      {
-          {"And", Inpar::Solid::bop_and},
-          {"Or", Inpar::Solid::bop_or},
-      },
-      {.description = "binary operator to combine displacement increments and Lagrange multiplier "
-                      "increment values",
-          .default_value = Inpar::Solid::bop_and}));
+      deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPLAGR",
+          {
+              {"And", Inpar::Solid::bop_and},
+              {"Or", Inpar::Solid::bop_or},
+          },
+          {.description =
+                  "binary operator to combine displacement increments and Lagrange multiplier "
+                  "increment values",
+              .default_value = Inpar::Solid::bop_and}),
 
-  scontact.specs.emplace_back(parameter<double>(
-      "TOLCONTCONSTR", {.description = "tolerance in the contact constraint norm for the newton "
-                                       "iteration (saddlepoint formulation only)",
-                           .default_value = 1.0E-6}));
-  scontact.specs.emplace_back(parameter<double>("TOLLAGR",
-      {.description =
-              "tolerance in the LM norm for the newton iteration (saddlepoint formulation only)",
-          .default_value = 1.0E-6}));
+      parameter<double>("TOLCONTCONSTR",
+          {.description = "tolerance in the contact constraint norm for the newton "
+                          "iteration (saddlepoint formulation only)",
+              .default_value = 1.0E-6}),
+      parameter<double>("TOLLAGR", {.description = "tolerance in the LM norm for the newton "
+                                                   "iteration (saddlepoint formulation only)",
+                                       .default_value = 1.0E-6}),
 
-  scontact.specs.emplace_back(parameter<CONTACT::ConstraintDirection>("CONSTRAINT_DIRECTIONS",
-      {.description = "formulation of constraints in normal/tangential or xyz-direction",
-          .default_value = CONTACT::ConstraintDirection::ntt}));
+      parameter<CONTACT::ConstraintDirection>("CONSTRAINT_DIRECTIONS",
+          {.description = "formulation of constraints in normal/tangential or xyz-direction",
+              .default_value = CONTACT::ConstraintDirection::ntt}),
 
-  scontact.specs.emplace_back(parameter<bool>("NONSMOOTH_GEOMETRIES",
-      {.description = "If chosen the contact algorithm combines mortar and nts formulations. This "
-                      "is needed if contact between entities of different geometric dimension "
-                      "(such as contact between surfaces and lines, or lines and nodes) can occur",
-          .default_value = false}));
+      parameter<bool>("NONSMOOTH_GEOMETRIES",
+          {.description =
+                  "If chosen the contact algorithm combines mortar and nts formulations. This "
+                  "is needed if contact between entities of different geometric dimension "
+                  "(such as contact between surfaces and lines, or lines and nodes) can occur",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<bool>("NONSMOOTH_CONTACT_SURFACE",
-      {.description =
-              "This flag is used to alter the criterion for the evaluation of the so-called "
-              "qualified vectors in the case of a self contact scenario. This is needed as the "
-              "standard criterion is only valid for smooth surfaces and thus has to be altered, if "
-              "the surface that is defined to be a self contact surface is non-smooth!",
-          .default_value = false}));
+      parameter<bool>("NONSMOOTH_CONTACT_SURFACE",
+          {.description =
+                  "This flag is used to alter the criterion for the evaluation of the so-called "
+                  "qualified vectors in the case of a self contact scenario. This is needed as the "
+                  "standard criterion is only valid for smooth surfaces and thus has to be "
+                  "altered, if "
+                  "the surface that is defined to be a self contact surface is non-smooth!",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<double>(
-      "HYBRID_ANGLE_MIN", {.description = "Non-smooth contact: angle between cpp normal and "
-                                          "element normal: begin transition (Mortar)",
-                              .default_value = -1.0}));
-  scontact.specs.emplace_back(parameter<double>(
-      "HYBRID_ANGLE_MAX", {.description = "Non-smooth contact: angle between cpp normal and "
-                                          "element normal: end transition (NTS)",
-                              .default_value = -1.0}));
+      parameter<double>(
+          "HYBRID_ANGLE_MIN", {.description = "Non-smooth contact: angle between cpp normal and "
+                                              "element normal: begin transition (Mortar)",
+                                  .default_value = -1.0}),
+      parameter<double>(
+          "HYBRID_ANGLE_MAX", {.description = "Non-smooth contact: angle between cpp normal and "
+                                              "element normal: end transition (NTS)",
+                                  .default_value = -1.0}),
 
-  scontact.specs.emplace_back(parameter<bool>("CPP_NORMALS",
-      {.description = "If chosen the nodal normal field is created as averaged CPP normal field.",
-          .default_value = false}));
+      parameter<bool>("CPP_NORMALS",
+          {.description =
+                  "If chosen the nodal normal field is created as averaged CPP normal field.",
+              .default_value = false}),
 
-  scontact.specs.emplace_back(parameter<bool>(
-      "TIMING_DETAILS", {.description = "Enable and print detailed contact timings to screen.",
-                            .default_value = false}));
+      parameter<bool>(
+          "TIMING_DETAILS", {.description = "Enable and print detailed contact timings to screen.",
+                                .default_value = false}),
 
-  // --------------------------------------------------------------------------
-  scontact.specs.emplace_back(parameter<double>(
-      "NITSCHE_THETA", {.description = "+1: symmetric, 0: non-symmetric, -1: skew-symmetric",
-                           .default_value = 0.0}));
-  scontact.specs.emplace_back(parameter<double>("NITSCHE_THETA_2",
-      {.description = "+1: Chouly-type, 0: Burman penalty-free (only with theta=-1)",
-          .default_value = 1.0}));
+      // --------------------------------------------------------------------------
+      parameter<double>(
+          "NITSCHE_THETA", {.description = "+1: symmetric, 0: non-symmetric, -1: skew-symmetric",
+                               .default_value = 0.0}),
+      parameter<double>("NITSCHE_THETA_2",
+          {.description = "+1: Chouly-type, 0: Burman penalty-free (only with theta=-1)",
+              .default_value = 1.0}),
 
-  scontact.specs.emplace_back(parameter<CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING",
-      {.description = "how to weight consistency terms in Nitsche contact formulation",
-          .default_value = CONTACT::NitscheWeighting::harmonic}));
+      parameter<CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING",
+          {.description = "how to weight consistency terms in Nitsche contact formulation",
+              .default_value = CONTACT::NitscheWeighting::harmonic}),
 
-  scontact.specs.emplace_back(parameter<bool>("NITSCHE_PENALTY_ADAPTIVE",
-      {.description = "adapt penalty parameter after each converged time step",
-          .default_value = true}));
+      parameter<bool>("NITSCHE_PENALTY_ADAPTIVE",
+          {.description = "adapt penalty parameter after each converged time step",
+              .default_value = true}),
 
-  scontact.specs.emplace_back(parameter<bool>("REGULARIZED_NORMAL_CONTACT",
-      {.description = "add a regularized normal contact formulation", .default_value = false}));
-  scontact.specs.emplace_back(parameter<double>("REGULARIZATION_THICKNESS",
-      {.description = "maximum contact penetration", .default_value = -1.}));
-  scontact.specs.emplace_back(parameter<double>("REGULARIZATION_STIFFNESS",
-      {.description = "initial contact stiffness (i.e. initial \"penalty parameter\")",
-          .default_value = -1.}));
-
-  scontact.move_into_collection(list);
+      parameter<bool>("REGULARIZED_NORMAL_CONTACT",
+          {.description = "add a regularized normal contact formulation", .default_value = false}),
+      parameter<double>("REGULARIZATION_THICKNESS",
+          {.description = "maximum contact penetration", .default_value = -1.}),
+      parameter<double>("REGULARIZATION_STIFFNESS",
+          {.description = "initial contact stiffness (i.e. initial \"penalty parameter\")",
+              .default_value = -1.})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
+++ b/src/core/utils/src/parameters/4C_utils_parameter_list.hpp
@@ -20,35 +20,6 @@ namespace Core
 {
   namespace Utils
   {
-    //! A wrapper to gather InputSpecs for a section. This type is used during migration
-    //! to InputSpec.
-    struct SectionSpecs
-    {
-      SectionSpecs(const std::string& section_name) : section_name(section_name) {}
-      //! Create the concatenated section name
-      SectionSpecs(const SectionSpecs& parent, const std::string& section_name)
-          : section_name(parent.section_name + "/" + section_name)
-      {
-      }
-
-      ~SectionSpecs()
-      {
-        FOUR_C_ASSERT(specs.empty(),
-            "SectionSpecs of '{}' must be moved into a collection before destruction.",
-            section_name.c_str());
-      }
-
-      std::string section_name;
-      std::vector<Core::IO::InputSpec> specs;
-
-      void move_into_collection(std::map<std::string, Core::IO::InputSpec>& map)
-      {
-        FOUR_C_ASSERT(map.contains(section_name) == false,
-            "SectionSpecs of '{}' already exists in the collection.", section_name);
-        map[section_name] = Core::IO::InputSpecBuilders::all_of(std::move(specs));
-      }
-    };
-
     //! add entry as item of enum class @p value to @p list with name @p parameter_name
     template <class EnumType>
     void add_enum_class_to_parameter_list(

--- a/src/cut/4C_cut_input.cpp
+++ b/src/cut/4C_cut_input.cpp
@@ -21,32 +21,29 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs cut_general{"CUT GENERAL"};
+  list["CUT GENERAL"] = all_of({
 
-  // intersection precision (double or cln)
-  cut_general.specs.emplace_back(
+      // intersection precision (double or cln)
       deprecated_selection<FourC::Cut::CutFloatType>("KERNEL_INTERSECTION_FLOATTYPE",
           {
               {"cln", floattype_cln},
               {"double", floattype_double},
           },
           {.description = "The floattype of the cut surface-edge intersection",
-              .default_value = floattype_double}));
+              .default_value = floattype_double}),
 
-  // Computing disctance surface to point precision (double or cln)
-  cut_general.specs.emplace_back(
+      // Computing disctance surface to point precision (double or cln)
       deprecated_selection<FourC::Cut::CutFloatType>("KERNEL_DISTANCE_FLOATTYPE",
           {
               {"cln", floattype_cln},
               {"double", floattype_double},
           },
           {.description = "The floattype of the cut distance computation",
-              .default_value = floattype_double}));
+              .default_value = floattype_double}),
 
-  // A general floattype for Cut::Position for Embedded Elements (compute_distance)
-  // If specified this floattype is used for all computations of Cut::Position with
-  // embedded elements
-  cut_general.specs.emplace_back(
+      // A general floattype for Cut::Position for Embedded Elements (compute_distance)
+      // If specified this floattype is used for all computations of Cut::Position with
+      // embedded elements
       deprecated_selection<FourC::Cut::CutFloatType>("GENERAL_POSITION_DISTANCE_FLOATTYPE",
           {
               {"none", floattype_none},
@@ -55,11 +52,10 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           },
           {.description =
                   "A general floattype for Cut::Position for Embedded Elements (compute_distance)",
-              .default_value = floattype_none}));
+              .default_value = floattype_none}),
 
-  // A general floattype for Cut::Position for Elements (ComputePosition)
-  // If specified this floattype is used for all computations of Cut::Position
-  cut_general.specs.emplace_back(
+      // A general floattype for Cut::Position for Elements (ComputePosition)
+      // If specified this floattype is used for all computations of Cut::Position
       deprecated_selection<FourC::Cut::CutFloatType>("GENERAL_POSITION_POSITION_FLOATTYPE",
           {
               {"none", floattype_none},
@@ -67,10 +63,9 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
               {"double", floattype_double},
           },
           {.description = "A general floattype for Cut::Position Elements (ComputePosition)",
-              .default_value = floattype_none}));
+              .default_value = floattype_none}),
 
-  // Specify which Referenceplanes are used in DirectDivergence
-  cut_general.specs.emplace_back(
+      // Specify which Referenceplanes are used in DirectDivergence
       deprecated_selection<FourC::Cut::CutDirectDivergenceRefplane>("DIRECT_DIVERGENCE_REFPLANE",
           {
               {"all", DirDiv_refplane_all},
@@ -81,38 +76,36 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
               {"none", DirDiv_refplane_none},
           },
           {.description = "Specify which Referenceplanes are used in DirectDivergence",
-              .default_value = DirDiv_refplane_all}));
+              .default_value = DirDiv_refplane_all}),
 
-  // Specify is Cutsides are triangulated
-  cut_general.specs.emplace_back(parameter<bool>("SPLIT_CUTSIDES",
-      {.description = "Split Quad4 CutSides into Tri3-Subtriangles?", .default_value = true}));
+      // Specify is Cutsides are triangulated
+      parameter<bool>("SPLIT_CUTSIDES",
+          {.description = "Split Quad4 CutSides into Tri3-Subtriangles?", .default_value = true}),
 
-  // Do the Selfcut before standard CUT
-  cut_general.specs.emplace_back(
-      parameter<bool>("DO_SELFCUT", {.description = "Do the SelfCut?", .default_value = true}));
+      // Do the Selfcut before standard CUT
+      parameter<bool>("DO_SELFCUT", {.description = "Do the SelfCut?", .default_value = true}),
 
-  // Do meshcorrection in Selfcut
-  cut_general.specs.emplace_back(parameter<bool>("SELFCUT_DO_MESHCORRECTION",
-      {.description = "Do meshcorrection in the SelfCut?", .default_value = true}));
+      // Do meshcorrection in Selfcut
+      parameter<bool>("SELFCUT_DO_MESHCORRECTION",
+          {.description = "Do meshcorrection in the SelfCut?", .default_value = true}),
 
-  // Selfcut meshcorrection multiplicator
-  cut_general.specs.emplace_back(parameter<int>("SELFCUT_MESHCORRECTION_MULTIPLICATOR",
-      {.description =
-              "ISLANDS with maximal size of the bounding box of h*multiplacator will be removed in "
-              "the meshcorrection",
-          .default_value = 30}));
+      // Selfcut meshcorrection multiplicator
+      parameter<int>("SELFCUT_MESHCORRECTION_MULTIPLICATOR",
+          {.description = "ISLANDS with maximal size of the bounding box of h*multiplacator will "
+                          "be removed in "
+                          "the meshcorrection",
+              .default_value = 30}),
 
-  // Cubaturedegree utilized for the numerical integration on the CUT BoundaryCells.
-  cut_general.specs.emplace_back(parameter<int>("BOUNDARYCELL_CUBATURDEGREE",
-      {.description =
-              "Cubaturedegree utilized for the numerical integration on the CUT BoundaryCells.",
-          .default_value = 20}));
+      // Cubaturedegree utilized for the numerical integration on the CUT BoundaryCells.
+      parameter<int>("BOUNDARYCELL_CUBATURDEGREE",
+          {.description =
+                  "Cubaturedegree utilized for the numerical integration on the CUT BoundaryCells.",
+              .default_value = 20}),
 
-  // Integrate inside volume cells
-  cut_general.specs.emplace_back(parameter<bool>("INTEGRATE_INSIDE_CELLS",
-      {.description = "Should the integration be done on inside cells", .default_value = true}));
-
-  cut_general.move_into_collection(list);
+      // Integrate inside volume cells
+      parameter<bool>("INTEGRATE_INSIDE_CELLS",
+          {.description = "Should the integration be done on inside cells",
+              .default_value = true})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/ehl/4C_ehl_input.cpp
+++ b/src/ehl/4C_ehl_input.cpp
@@ -20,154 +20,150 @@ void EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs ehldyn{"ELASTO HYDRO DYNAMIC"};
+  list["ELASTO HYDRO DYNAMIC"] = all_of({
 
-  // Output type
-  ehldyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0.0}));
-  ehldyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
-  // Time loop control
-  ehldyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  ehldyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  ehldyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
-  ehldyn.specs.emplace_back(parameter<bool>(
-      "DIFFTIMESTEPSIZE", {.description = "use different step size for lubrication and solid",
-                              .default_value = false}));
-  ehldyn.specs.emplace_back(parameter<double>(
-      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0.0}));
-  ehldyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
-  ehldyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  ehldyn.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "minimal number of iterations over fields", .default_value = 1}));
+      // Output type
+      parameter<double>(
+          "RESTARTEVERYTIME", {.description = "write restart possibility every RESTARTEVERY steps",
+                                  .default_value = 0.0}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
+      // Time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  // Type of coupling strategy between the two fields
-  ehldyn.specs.emplace_back(deprecated_selection<FieldCoupling>("FIELDCOUPLING",
-      {
-          {"none", coupling_none},
-          {"matching", coupling_matching},
-      },
-      {.description = "Type of coupling strategy between fields", .default_value = coupling_none}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}),
+      parameter<bool>(
+          "DIFFTIMESTEPSIZE", {.description = "use different step size for lubrication and solid",
+                                  .default_value = false}),
+      parameter<double>("RESULTSEVERYTIME",
+          {.description = "increment for writing solution", .default_value = 0.0}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<int>("ITEMIN",
+          {.description = "minimal number of iterations over fields", .default_value = 1}),
 
-  // Coupling strategy for EHL solvers
-  ehldyn.specs.emplace_back(parameter<SolutionSchemeOverFields>("COUPALGO",
-      {.description = "Coupling strategies for EHL solvers", .default_value = ehl_Monolithic}));
+      // Type of coupling strategy between the two fields
+      deprecated_selection<FieldCoupling>("FIELDCOUPLING",
+          {
+              {"none", coupling_none},
+              {"matching", coupling_matching},
+          },
+          {.description = "Type of coupling strategy between fields",
+              .default_value = coupling_none}),
 
-  // set unprojectable nodes to zero pressure via Dirichlet condition
-  ehldyn.specs.emplace_back(parameter<bool>("UNPROJ_ZERO_DBC",
-      {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
-          .default_value = false}));
+      // Coupling strategy for EHL solvers
+      parameter<SolutionSchemeOverFields>("COUPALGO",
+          {.description = "Coupling strategies for EHL solvers", .default_value = ehl_Monolithic}),
 
-  // use dry contact model
-  ehldyn.specs.emplace_back(parameter<bool>("DRY_CONTACT_MODEL",
-      {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
-          .default_value = false}));
+      // set unprojectable nodes to zero pressure via Dirichlet condition
+      parameter<bool>("UNPROJ_ZERO_DBC",
+          {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
+              .default_value = false}),
 
-
-  ehldyn.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      // use dry contact model
+      parameter<bool>("DRY_CONTACT_MODEL",
+          {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
   /* parameters for monolithic EHL */
-  Core::Utils::SectionSpecs ehldynmono{ehldyn, "MONOLITHIC"};
+  list["ELASTO HYDRO DYNAMIC/MONOLITHIC"] = all_of({
 
-  // convergence tolerance of EHL residual
-  ehldynmono.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "tolerance for convergence check of EHL", .default_value = 1e-6}));
-  // Iterationparameters
-  ehldynmono.specs.emplace_back(parameter<double>("TOLINC",
-      {.description = "tolerance for convergence check of EHL-increment in monolithic EHL",
-          .default_value = 1.0e-6}));
+      // convergence tolerance of EHL residual
+      parameter<double>("CONVTOL",
+          {.description = "tolerance for convergence check of EHL", .default_value = 1e-6}),
+      // Iterationparameters
+      parameter<double>("TOLINC",
+          {.description = "tolerance for convergence check of EHL-increment in monolithic EHL",
+              .default_value = 1.0e-6}),
 
-  ehldynmono.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_RESF",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = convnorm_abs}));
+      deprecated_selection<ConvNorm>("NORM_RESF",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = convnorm_abs}),
 
-  ehldynmono.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_INC",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for convergence check of primary variables in EHL",
-          .default_value = convnorm_abs}));
+      deprecated_selection<ConvNorm>("NORM_INC",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for convergence check of primary variables in EHL",
+              .default_value = convnorm_abs}),
 
 
-  ehldynmono.specs.emplace_back(deprecated_selection<BinaryOp>("NORMCOMBI_RESFINC",
-      {
-          {"And", bop_and},
-          {"Or", bop_or},
-          {"Coupl_Or_Single", bop_coupl_or_single},
-          {"Coupl_And_Single", bop_coupl_and_single},
-          {"And_Single", bop_and_single},
-          {"Or_Single", bop_or_single},
-      },
-      {.description = "binary operator to combine primary variables and residual force values",
-          .default_value = bop_coupl_and_single}));
+      deprecated_selection<BinaryOp>("NORMCOMBI_RESFINC",
+          {
+              {"And", bop_and},
+              {"Or", bop_or},
+              {"Coupl_Or_Single", bop_coupl_or_single},
+              {"Coupl_And_Single", bop_coupl_and_single},
+              {"And_Single", bop_and_single},
+              {"Or_Single", bop_or_single},
+          },
+          {.description = "binary operator to combine primary variables and residual force values",
+              .default_value = bop_coupl_and_single}),
 
-  ehldynmono.specs.emplace_back(deprecated_selection<VectorNorm>("ITERNORM",
-      {
-          {"L1", norm_l1},
-          {"L1_Scaled", norm_l1_scaled},
-          {"L2", norm_l2},
-          {"Rms", norm_rms},
-          {"Inf", norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals", .default_value = norm_rms}));
+      deprecated_selection<VectorNorm>("ITERNORM",
+          {
+              {"L1", norm_l1},
+              {"L1_Scaled", norm_l1_scaled},
+              {"L2", norm_l2},
+              {"Rms", norm_rms},
+              {"Inf", norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals", .default_value = norm_rms}),
 
-  ehldynmono.specs.emplace_back(
+
       parameter<double>("PTCDT", {.description = "pseudo time step for pseudo-transient "
                                                  "continuation (PTC) stabilised Newton procedure",
-                                     .default_value = 0.1}));
+                                     .default_value = 0.1}),
 
-  // number of linear solver used for monolithic EHL
-  ehldynmono.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for monolithic EHL problems",
-                           .default_value = -1}));
+      // number of linear solver used for monolithic EHL
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for monolithic EHL problems",
+              .default_value = -1}),
 
-  // convergence criteria adaptivity of monolithic EHL solver
-  ehldynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  ehldynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
+      // convergence criteria adaptivity of monolithic EHL solver
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
 
-  ehldynmono.specs.emplace_back(parameter<bool>("INFNORMSCALING",
-      {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}));
-
-  ehldynmono.move_into_collection(list);
+      parameter<bool>("INFNORMSCALING",
+          {.description = "Scale blocks of matrix with row infnorm?", .default_value = true})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned EHL */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs ehldynpart{ehldyn, "PARTITIONED"};
+  list["ELASTO HYDRO DYNAMIC/PARTITIONED"] = all_of({
 
-  // Solver parameter for relaxation of iterative staggered partitioned EHL
-  ehldynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
-      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
-  ehldynpart.specs.emplace_back(parameter<double>("MINOMEGA",
-      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
-  ehldynpart.specs.emplace_back(parameter<double>(
-      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
+      // Solver parameter for relaxation of iterative staggered partitioned EHL
+      parameter<double>("MAXOMEGA",
+          {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}),
+      parameter<double>("MINOMEGA",
+          {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}),
+      parameter<double>(
+          "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}),
 
-  // convergence tolerance of outer iteration loop
-  ehldynpart.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description = "tolerance for convergence check of outer iteration within partitioned EHL",
-          .default_value = 1e-6}));
-
-  ehldynpart.move_into_collection(list);
+      // convergence tolerance of outer iteration loop
+      parameter<double>("CONVTOL",
+          {.description =
+                  "tolerance for convergence check of outer iteration within partitioned EHL",
+              .default_value = 1e-6})});
 }
 
 

--- a/src/fbi/4C_fbi_input.cpp
+++ b/src/fbi/4C_fbi_input.cpp
@@ -9,7 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_inpar_geometry_pair.hpp"
-#include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -18,106 +17,106 @@ void FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs fbi{"FLUID BEAM INTERACTION"};
-
   /*----------------------------------------------------------------------*/
   /* parameters for beam to fluid meshtying */
+  list["FLUID BEAM INTERACTION"] = all_of({
+      deprecated_selection<BeamToFluidCoupling>("COUPLING",
+          {
+              {"two-way", BeamToFluidCoupling::twoway},
+              {"fluid", BeamToFluidCoupling::fluid},
+              {"solid", BeamToFluidCoupling::solid},
+          },
+          {.description = "Type of FBI coupling", .default_value = BeamToFluidCoupling::twoway}),
 
-  fbi.specs.emplace_back(deprecated_selection<BeamToFluidCoupling>("COUPLING",
-      {
-          {"two-way", BeamToFluidCoupling::twoway},
-          {"fluid", BeamToFluidCoupling::fluid},
-          {"solid", BeamToFluidCoupling::solid},
-      },
-      {.description = "Type of FBI coupling", .default_value = BeamToFluidCoupling::twoway}));
+      parameter<int>("STARTSTEP",
+          {.description = "Time Step at which to begin the fluid beam coupling. Usually "
+                          "this will be the first step.",
+              .default_value = 0}),
 
-  fbi.specs.emplace_back(parameter<int>(
-      "STARTSTEP", {.description = "Time Step at which to begin the fluid beam coupling. Usually "
-                                   "this will be the first step.",
-                       .default_value = 0}));
+      parameter<BeamToFluidPreSortStrategy>(
+          "PRESORT_STRATEGY", {.description = "Presort strategy for the beam elements",
+                                  .default_value = BeamToFluidPreSortStrategy::bruteforce}),
 
-  fbi.specs.emplace_back(parameter<BeamToFluidPreSortStrategy>(
-      "PRESORT_STRATEGY", {.description = "Presort strategy for the beam elements",
-                              .default_value = BeamToFluidPreSortStrategy::bruteforce}));
-
-  fbi.move_into_collection(list);
+  });
 
   /*----------------------------------------------------------------------*/
+  std::vector<Core::IO::InputSpec> beam_to_fluid_meshtying = {
 
-  Core::Utils::SectionSpecs beam_to_fluid_meshtying{fbi, "BEAM TO FLUID MESHTYING"};
+      parameter<BeamToFluidDiscretization>(
+          "MESHTYING_DISCRETIZATION", {.description = "Type of employed meshtying discretization",
+                                          .default_value = BeamToFluidDiscretization::none}),
 
-  beam_to_fluid_meshtying.specs.emplace_back(parameter<BeamToFluidDiscretization>(
-      "MESHTYING_DISCRETIZATION", {.description = "Type of employed meshtying discretization",
-                                      .default_value = BeamToFluidDiscretization::none}));
+      parameter<BeamToFluidConstraintEnforcement>(
+          "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
+                                     .default_value = BeamToFluidConstraintEnforcement::none}),
 
-  beam_to_fluid_meshtying.specs.emplace_back(parameter<BeamToFluidConstraintEnforcement>(
-      "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
-                                 .default_value = BeamToFluidConstraintEnforcement::none}));
+      parameter<double>("PENALTY_PARAMETER",
+          {.description = "Penalty parameter for beam-to-Fluid volume meshtying",
+              .default_value = 0.0}),
 
-  beam_to_fluid_meshtying.specs.emplace_back(parameter<double>(
-      "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-Fluid volume meshtying",
-                               .default_value = 0.0}));
+      parameter<double>("SEARCH_RADIUS",
+          {.description =
+                  "Absolute Search radius for beam-to-fluid volume meshtying. Choose carefully "
+                  "to not blow up memory demand but to still find all interaction pairs!",
+              .default_value = 1000.0}),
 
-  beam_to_fluid_meshtying.specs.emplace_back(parameter<double>("SEARCH_RADIUS",
-      {.description = "Absolute Search radius for beam-to-fluid volume meshtying. Choose carefully "
-                      "to not blow up memory demand but to still find all interaction pairs!",
-          .default_value = 1000.0}));
 
-  beam_to_fluid_meshtying.specs.emplace_back(
       parameter<FBI::BeamToFluidMeshtingMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
           {.description = "Shape function for the mortar Lagrange-multipliers",
-              .default_value = FBI::BeamToFluidMeshtingMortarShapefunctions::none}));
-
+              .default_value = FBI::BeamToFluidMeshtingMortarShapefunctions::none}),
+  };
   // Add the geometry pair input parameters.
   Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_fluid_meshtying);
 
-  beam_to_fluid_meshtying.move_into_collection(list);
+  list["FLUID BEAM INTERACTION/BEAM TO FLUID MESHTYING"] = all_of(beam_to_fluid_meshtying);
+
 
 
   /*----------------------------------------------------------------------*/
 
   // Create subsection for runtime output.
-  Core::Utils::SectionSpecs beam_to_fluid_meshtying_output{
-      beam_to_fluid_meshtying, "RUNTIME VTK OUTPUT"};
+  list["FLUID BEAM INTERACTION/BEAM TO FLUID MESHTYING/RUNTIME VTK OUTPUT"] = all_of({
+      // Whether to write visualization output at all for beam to fluid meshtying.
+      parameter<bool>(
+          "WRITE_OUTPUT", {.description = "Enable / disable beam-to-fluid mesh tying output.",
+                              .default_value = false}),
 
-  // Whether to write visualization output at all for beam to fluid meshtying.
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
-      "WRITE_OUTPUT", {.description = "Enable / disable beam-to-fluid mesh tying output.",
-                          .default_value = false}));
+      parameter<bool>("NODAL_FORCES",
+          {.description = "Enable / disable output of the resulting nodal forces due "
+                          "to beam to Fluid interaction.",
+              .default_value = false}),
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
-      "NODAL_FORCES", {.description = "Enable / disable output of the resulting nodal forces due "
-                                      "to beam to Fluid interaction.",
-                          .default_value = false}));
+      parameter<bool>(
+          "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
+                              .default_value = false}),
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>("SEGMENTATION",
-      {.description = "Enable / disable output of segmentation points.", .default_value = false}));
+      parameter<bool>("INTEGRATION_POINTS",
+          {.description =
+                  "Enable / disable output of used integration points. If the meshtying method "
+                  "has 'forces' at the integration point, they will also be output.",
+              .default_value = false}),
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>("INTEGRATION_POINTS",
-      {.description = "Enable / disable output of used integration points. If the meshtying method "
-                      "has 'forces' at the integration point, they will also be output.",
-          .default_value = false}));
+      parameter<bool>("CONSTRAINT_VIOLATION",
+          {.description = "Enable / disable output of the constraint violation "
+                          "into a output_name.penalty csv file.",
+              .default_value = false}),
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
-      "CONSTRAINT_VIOLATION", {.description = "Enable / disable output of the constraint violation "
-                                              "into a output_name.penalty csv file.",
-                                  .default_value = false}));
+      parameter<bool>("MORTAR_LAMBDA_DISCRET",
+          {.description =
+                  "Enable / disable output of the discrete Lagrange multipliers at the node of "
+                  "the Lagrange multiplier shape functions.",
+              .default_value = false}),
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>("MORTAR_LAMBDA_DISCRET",
-      {.description = "Enable / disable output of the discrete Lagrange multipliers at the node of "
-                      "the Lagrange multiplier shape functions.",
-          .default_value = false}));
+      parameter<bool>("MORTAR_LAMBDA_CONTINUOUS",
+          {.description = "Enable / disable output of the continuous "
+                          "Lagrange multipliers function along the beam.",
+              .default_value = false}),
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(parameter<bool>(
-      "MORTAR_LAMBDA_CONTINUOUS", {.description = "Enable / disable output of the continuous "
-                                                  "Lagrange multipliers function along the beam.",
-                                      .default_value = false}));
 
-  beam_to_fluid_meshtying_output.specs.emplace_back(
       parameter<int>("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS",
-          {.description = "Number of segments for continuous mortar output", .default_value = 5}));
+          {.description = "Number of segments for continuous mortar output", .default_value = 5}),
 
-  beam_to_fluid_meshtying_output.move_into_collection(list);
+  });
 }
 
 void FBI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition>& condlist)

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -8,7 +8,7 @@
 #include "4C_inpar_IO_monitor_structure_dbc.hpp"
 
 #include "4C_io_geometry_type.hpp"
-#include "4C_utils_parameter_list.hpp"
+#include "4C_io_input_spec_builders.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -26,25 +26,22 @@ namespace Inpar
       using namespace Core::IO::InputSpecBuilders;
 
       // related sublist
-      Core::Utils::SectionSpecs sublist_IO{"IO"};
-      Core::Utils::SectionSpecs sublist_IO_monitor_structure_dbc{
-          sublist_IO, "MONITOR STRUCTURE DBC"};
+      list["IO/MONITOR STRUCTURE DBC"] = all_of({
 
-      // output interval regarding steps: write output every INTERVAL_STEPS steps
-      sublist_IO_monitor_structure_dbc.specs.emplace_back(parameter<int>("INTERVAL_STEPS",
-          {.description = "write reaction force output every INTERVAL_STEPS steps",
-              .default_value = -1}));
+          // output interval regarding steps: write output every INTERVAL_STEPS steps
+          parameter<int>("INTERVAL_STEPS",
+              {.description = "write reaction force output every INTERVAL_STEPS steps",
+                  .default_value = -1}),
 
-      // precision for file
-      sublist_IO_monitor_structure_dbc.specs.emplace_back(parameter<int>(
-          "PRECISION_FILE", {.description = "precision for written file", .default_value = 16}));
+          // precision for file
+          parameter<int>(
+              "PRECISION_FILE", {.description = "precision for written file", .default_value = 16}),
 
-      // precision for screen
-      sublist_IO_monitor_structure_dbc.specs.emplace_back(parameter<int>("PRECISION_SCREEN",
-          {.description = "precision for written screen output", .default_value = 5}));
+          // precision for screen
+          parameter<int>("PRECISION_SCREEN",
+              {.description = "precision for written screen output", .default_value = 5}),
 
-      // type of written output file
-      sublist_IO_monitor_structure_dbc.specs.emplace_back(
+          // type of written output file
           deprecated_selection<Inpar::IOMonitorStructureDBC::FileType>("FILE_TYPE",
               {
                   {"csv", Inpar::IOMonitorStructureDBC::csv},
@@ -55,14 +52,12 @@ namespace Inpar
                   {"DATA", Inpar::IOMonitorStructureDBC::data},
               },
               {.description = "type of written output file",
-                  .default_value = Inpar::IOMonitorStructureDBC::csv}));
+                  .default_value = Inpar::IOMonitorStructureDBC::csv}),
 
-      // whether to write output in every iteration of the nonlinear solver
-      sublist_IO_monitor_structure_dbc.specs.emplace_back(parameter<bool>("WRITE_HEADER",
-          {.description = "write information about monitored boundary condition to output file",
-              .default_value = false}));
-
-      sublist_IO_monitor_structure_dbc.move_into_collection(list);
+          // whether to write output in every iteration of the nonlinear solver
+          parameter<bool>("WRITE_HEADER",
+              {.description = "write information about monitored boundary condition to output file",
+                  .default_value = false})});
     }
 
     std::string to_string(FileType type)

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -7,8 +7,8 @@
 
 #include "4C_inpar_IO_runtime_output.hpp"
 
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_visualization_parameters.hpp"
-#include "4C_utils_parameter_list.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -26,63 +26,60 @@ namespace Inpar
       using namespace Core::IO::InputSpecBuilders;
 
       // related sublist
-      Core::Utils::SectionSpecs sublist_IO{"IO"};
-      Core::Utils::SectionSpecs sublist_IO_VTK_structure{sublist_IO, "RUNTIME VTK OUTPUT"};
+      list["IO/RUNTIME VTK OUTPUT"] = all_of({
+
+          // output interval regarding steps: write output every INTERVAL_STEPS steps
+          parameter<int>("INTERVAL_STEPS",
+              {.description = "write visualization output at runtime every INTERVAL_STEPS steps",
+                  .default_value = -1}),
+          parameter<int>("STEP_OFFSET",
+              {.description =
+                      "An offset added to the current step to shift the steps to be written.",
+                  .default_value = 0}),
 
 
-      // output interval regarding steps: write output every INTERVAL_STEPS steps
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<int>("INTERVAL_STEPS",
-          {.description = "write visualization output at runtime every INTERVAL_STEPS steps",
-              .default_value = -1}));
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<int>("STEP_OFFSET",
-          {.description = "An offset added to the current step to shift the steps to be written.",
-              .default_value = 0}));
+          // data format for written numeric data
+          parameter<Core::IO::OutputDataFormat>(
+              "OUTPUT_DATA_FORMAT", {.description = "data format for written numeric data",
+                                        .default_value = Core::IO::OutputDataFormat::binary}),
 
-
-      // data format for written numeric data
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<Core::IO::OutputDataFormat>(
-          "OUTPUT_DATA_FORMAT", {.description = "data format for written numeric data",
-                                    .default_value = Core::IO::OutputDataFormat::binary}));
-
-      // compression level of written output
-      sublist_IO_VTK_structure.specs.emplace_back(
+          // compression level of written output
           parameter<LibB64::CompressionLevel>("COMPRESSION_LEVEL",
               {.description = "Specify the compression level of written vtk output.",
-                  .default_value = LibB64::CompressionLevel::best_speed}));
+                  .default_value = LibB64::CompressionLevel::best_speed}),
 
-      // specify the maximum digits in the number of time steps that shall be written#
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<int>("TIMESTEP_RESERVE_DIGITS",
-          {.description = "Specify the maximum digits in the number of time steps that shall be "
-                          "written. This only affects the number of leading zeros in the output "
-                          "file names.",
-              .default_value = 5}));
+          // specify the maximum digits in the number of time steps that shall be written#
+          parameter<int>("TIMESTEP_RESERVE_DIGITS",
+              {.description =
+                      "Specify the maximum digits in the number of time steps that shall be "
+                      "written. This only affects the number of leading zeros in the output "
+                      "file names.",
+                  .default_value = 5}),
 
-      // whether to write output in every iteration of the nonlinear solver
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("EVERY_ITERATION",
-          {.description = "write output in every iteration of the nonlinear solver",
-              .default_value = false}));
+          // whether to write output in every iteration of the nonlinear solver
+          parameter<bool>("EVERY_ITERATION",
+              {.description = "write output in every iteration of the nonlinear solver",
+                  .default_value = false}),
 
-      // virtual time increment that is added for each nonlinear output state
-      sublist_IO_VTK_structure.specs.emplace_back(
+          // virtual time increment that is added for each nonlinear output state
           parameter<double>("EVERY_ITERATION_VIRTUAL_TIME_INCREMENT",
               {.description = "Specify the virtual time increment that is added for each nonlinear "
                               "output state",
-                  .default_value = 1e-8}));
+                  .default_value = 1e-8}),
 
-      // specify the maximum digits in the number of iterations that shall be written
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<int>("EVERY_ITERATION_RESERVE_DIGITS",
-          {.description = "Specify the maximum digits in the number of iterations that shall be "
-                          "written. This only affects the number of leading zeros in the output "
-                          "file names.",
-              .default_value = 4}));
+          // specify the maximum digits in the number of iterations that shall be written
+          parameter<int>("EVERY_ITERATION_RESERVE_DIGITS",
+              {.description =
+                      "Specify the maximum digits in the number of iterations that shall be "
+                      "written. This only affects the number of leading zeros in the output "
+                      "file names.",
+                  .default_value = 4}),
 
-      // specify the actual visualization writer
-      sublist_IO_VTK_structure.specs.emplace_back(parameter<Core::IO::OutputWriter>(
-          "OUTPUT_WRITER", {.description = "Specify which output writer shall be used to write the "
-                                           "visualization data to disk",
-                               .default_value = Core::IO::OutputWriter::vtu_per_rank}));
-
-      sublist_IO_VTK_structure.move_into_collection(list);
+          // specify the actual visualization writer
+          parameter<Core::IO::OutputWriter>("OUTPUT_WRITER",
+              {.description = "Specify which output writer shall be used to write the "
+                              "visualization data to disk",
+                  .default_value = Core::IO::OutputWriter::vtu_per_rank})});
     }
 
 

--- a/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
@@ -26,48 +26,43 @@ namespace Inpar
         using Teuchos::tuple;
         using namespace Core::IO::InputSpecBuilders;
 
-        // related sublist
-        Core::Utils::SectionSpecs sublist_IO{"IO"};
-        Core::Utils::SectionSpecs sublist_IO_output{sublist_IO, "RUNTIME VTK OUTPUT"};
-        Core::Utils::SectionSpecs sublist_IO_output_fluid{sublist_IO_output, "FLUID"};
+        list["IO/RUNTIME VTK OUTPUT/FLUID"] = all_of({
+            // whether to write output for fluid
+            parameter<bool>(
+                "OUTPUT_FLUID", {.description = "write fluid output", .default_value = false}),
 
-        // whether to write output for fluid
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "OUTPUT_FLUID", {.description = "write fluid output", .default_value = false}));
+            // whether to write velocity state
+            parameter<bool>(
+                "VELOCITY", {.description = "write velocity output", .default_value = false}),
 
-        // whether to write velocity state
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "VELOCITY", {.description = "write velocity output", .default_value = false}));
+            // whether to write pressure state
+            parameter<bool>(
+                "PRESSURE", {.description = "write pressure output", .default_value = false}),
 
-        // whether to write pressure state
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "PRESSURE", {.description = "write pressure output", .default_value = false}));
+            // whether to write acceleration state
+            parameter<bool>("ACCELERATION",
+                {.description = "write acceleration output", .default_value = false}),
 
-        // whether to write acceleration state
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "ACCELERATION", {.description = "write acceleration output", .default_value = false}));
+            // whether to write displacement state
+            parameter<bool>("DISPLACEMENT",
+                {.description = "write displacement output", .default_value = false}),
 
-        // whether to write displacement state
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "DISPLACEMENT", {.description = "write displacement output", .default_value = false}));
+            // whether to write displacement state
+            parameter<bool>("GRIDVELOCITY",
+                {.description = "write grid velocity output", .default_value = false}),
 
-        // whether to write displacement state
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "GRIDVELOCITY", {.description = "write grid velocity output", .default_value = false}));
+            // whether to write element owner
+            parameter<bool>(
+                "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}),
 
-        // whether to write element owner
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}));
+            // whether to write element GIDs
+            parameter<bool>("ELEMENT_GID",
+                {.description = "write 4C internal element GIDs", .default_value = false}),
 
-        // whether to write element GIDs
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>("ELEMENT_GID",
-            {.description = "write 4C internal element GIDs", .default_value = false}));
-
-        // whether to write node GIDs
-        sublist_IO_output_fluid.specs.emplace_back(parameter<bool>(
-            "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}));
-
-        sublist_IO_output_fluid.move_into_collection(list);
+            // whether to write node GIDs
+            parameter<bool>(
+                "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}),
+        });
       }
     }  // namespace FLUID
   }  // namespace IORuntimeOutput

--- a/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
@@ -7,7 +7,7 @@
 
 #include "4C_inpar_IO_runtime_output_fluid.hpp"
 
-#include "4C_utils_parameter_list.hpp"
+#include "4C_io_input_spec_builders.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
@@ -28,98 +28,97 @@ namespace Inpar
         using namespace Core::IO::InputSpecBuilders;
 
         // related sublist
-        Core::Utils::SectionSpecs sublist_IO{"IO"};
-        Core::Utils::SectionSpecs sublist_IO_VTK_structure{sublist_IO, "RUNTIME VTK OUTPUT"};
-        Core::Utils::SectionSpecs sublist_IO_output_beams{sublist_IO_VTK_structure, "BEAMS"};
+        list["IO/RUNTIME VTK OUTPUT/BEAMS"] = all_of({
 
-        // whether to write special output for beam elements
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("OUTPUT_BEAMS",
-            {.description = "write special output for beam elements", .default_value = false}));
+            // whether to write special output for beam elements
+            parameter<bool>("OUTPUT_BEAMS",
+                {.description = "write special output for beam elements", .default_value = false}),
 
-        // whether to write displacement state
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>(
-            "DISPLACEMENT", {.description = "write displacement output", .default_value = false}));
+            // whether to write displacement state
+            parameter<bool>("DISPLACEMENT",
+                {.description = "write displacement output", .default_value = false}),
 
-        // use absolute positions or initial positions for vtu geometry (i.e. point coordinates)
-        // 'absolute positions' requires writing geometry in every output step (default for now)
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>(
-            "USE_ABSOLUTE_POSITIONS", {.description = "use absolute positions or initial positions "
-                                                      "for vtu geometry (i.e. point coordinates)",
-                                          .default_value = true}));
+            // use absolute positions or initial positions for vtu geometry (i.e. point coordinates)
+            // 'absolute positions' requires writing geometry in every output step (default for now)
+            parameter<bool>("USE_ABSOLUTE_POSITIONS",
+                {.description = "use absolute positions or initial positions "
+                                "for vtu geometry (i.e. point coordinates)",
+                    .default_value = true}),
 
-        // write internal (elastic) energy of element
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("INTERNAL_ENERGY_ELEMENT",
-            {.description = "write internal (elastic) energy for each element",
-                .default_value = false}));
+            // write internal (elastic) energy of element
+            parameter<bool>("INTERNAL_ENERGY_ELEMENT",
+                {.description = "write internal (elastic) energy for each element",
+                    .default_value = false}),
 
-        // write kinetic energy of element
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("KINETIC_ENERGY_ELEMENT",
-            {.description = "write kinetic energy for each element", .default_value = false}));
+            // write kinetic energy of element
+            parameter<bool>("KINETIC_ENERGY_ELEMENT",
+                {.description = "write kinetic energy for each element", .default_value = false}),
 
-        // write triads as three orthonormal base vectors at every visualization point
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("TRIAD_VISUALIZATIONPOINT",
-            {.description = "write triads at every visualization point", .default_value = false}));
+            // write triads as three orthonormal base vectors at every visualization point
+            parameter<bool>("TRIAD_VISUALIZATIONPOINT",
+                {.description = "write triads at every visualization point",
+                    .default_value = false}),
 
-        // write material cross-section strains at the Gauss points:
-        // axial & shear strains, twist & curvatures
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("STRAINS_GAUSSPOINT",
-            {.description = "write material cross-section strains at the Gauss points",
-                .default_value = false}));
+            // write material cross-section strains at the Gauss points:
+            // axial & shear strains, twist & curvatures
+            parameter<bool>("STRAINS_GAUSSPOINT",
+                {.description = "write material cross-section strains at the Gauss points",
+                    .default_value = false}),
 
-        // write material cross-section strains at the visualization points:
-        // axial & shear strains, twist & curvatures
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("STRAINS_CONTINUOUS",
-            {.description = "write material cross-section strains at the visualization points",
-                .default_value = false}));
+            // write material cross-section strains at the visualization points:
+            // axial & shear strains, twist & curvatures
+            parameter<bool>("STRAINS_CONTINUOUS",
+                {.description = "write material cross-section strains at the visualization points",
+                    .default_value = false}),
 
-        // write material cross-section stresses at the Gauss points:
-        // axial and shear forces, torque and bending moments
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("MATERIAL_FORCES_GAUSSPOINT",
-            {.description = "write material cross-section stresses at the Gauss points",
-                .default_value = false}));
+            // write material cross-section stresses at the Gauss points:
+            // axial and shear forces, torque and bending moments
+            parameter<bool>("MATERIAL_FORCES_GAUSSPOINT",
+                {.description = "write material cross-section stresses at the Gauss points",
+                    .default_value = false}),
 
-        // write material cross-section stresses at the visualization points:
-        // axial and shear forces, torque and bending moments
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("MATERIAL_FORCES_CONTINUOUS",
-            {.description = "write material cross-section stresses at the visualization points",
-                .default_value = false}));
+            // write material cross-section stresses at the visualization points:
+            // axial and shear forces, torque and bending moments
+            parameter<bool>("MATERIAL_FORCES_CONTINUOUS",
+                {.description = "write material cross-section stresses at the visualization points",
+                    .default_value = false}),
 
-        // write spatial cross-section stresses at the Gauss points:
-        // axial and shear forces, torque and bending moments
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("SPATIAL_FORCES_GAUSSPOINT",
-            {.description = "write material cross-section stresses at the Gauss points",
-                .default_value = false}));
+            // write spatial cross-section stresses at the Gauss points:
+            // axial and shear forces, torque and bending moments
+            parameter<bool>("SPATIAL_FORCES_GAUSSPOINT",
+                {.description = "write material cross-section stresses at the Gauss points",
+                    .default_value = false}),
 
-        // write element filament numbers and type
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("BEAMFILAMENTCONDITION",
-            {.description = "write element filament numbers", .default_value = false}));
+            // write element filament numbers and type
+            parameter<bool>("BEAMFILAMENTCONDITION",
+                {.description = "write element filament numbers", .default_value = false}),
 
-        // write element and network orientation parameter
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("ORIENTATION_PARAMETER",
-            {.description = "write element filament numbers", .default_value = false}));
+            // write element and network orientation parameter
+            parameter<bool>("ORIENTATION_PARAMETER",
+                {.description = "write element filament numbers", .default_value = false}),
 
-        // write crossection forces of periodic RVE
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("RVE_CROSSSECTION_FORCES",
-            {.description = " get sum of all internal forces of  ", .default_value = false}));
+            // write crossection forces of periodic RVE
+            parameter<bool>("RVE_CROSSSECTION_FORCES",
+                {.description = " get sum of all internal forces of  ", .default_value = false}),
 
-        // write reference length of beams
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("REF_LENGTH",
-            {.description = "write reference length of all beams", .default_value = false}));
+            // write reference length of beams
+            parameter<bool>("REF_LENGTH",
+                {.description = "write reference length of all beams", .default_value = false}),
 
-        // write element GIDs
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("ELEMENT_GID",
-            {.description = "write the 4C internal element GIDs", .default_value = false}));
+            // write element GIDs
+            parameter<bool>("ELEMENT_GID",
+                {.description = "write the 4C internal element GIDs", .default_value = false}),
 
-        // write element ghosting information
-        sublist_IO_output_beams.specs.emplace_back(parameter<bool>("ELEMENT_GHOSTING",
-            {.description = "write which processors ghost the elements", .default_value = false}));
+            // write element ghosting information
+            parameter<bool>(
+                "ELEMENT_GHOSTING", {.description = "write which processors ghost the elements",
+                                        .default_value = false}),
 
-        // number of subsegments along a single beam element for visualization
-        sublist_IO_output_beams.specs.emplace_back(parameter<int>("NUMBER_SUBSEGMENTS",
-            {.description = "Number of subsegments along a single beam element for visualization",
-                .default_value = 5}));
-
-        sublist_IO_output_beams.move_into_collection(list);
+            // number of subsegments along a single beam element for visualization
+            parameter<int>("NUMBER_SUBSEGMENTS",
+                {.description =
+                        "Number of subsegments along a single beam element for visualization",
+                    .default_value = 5})});
       }
     }  // namespace Beam
   }  // namespace IORuntimeOutput

--- a/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
@@ -7,7 +7,7 @@
 
 #include "4C_inpar_IO_runtime_output_structure_beams.hpp"
 
-#include "4C_utils_parameter_list.hpp"
+#include "4C_io_input_spec_builders.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
@@ -8,7 +8,7 @@
 #include "4C_inpar_IO_runtime_vtk_output_structure.hpp"
 
 #include "4C_inpar_structure.hpp"
-#include "4C_utils_parameter_list.hpp"
+#include "4C_io_input_spec_builders.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
@@ -28,68 +28,65 @@ namespace Inpar
         using namespace Core::IO::InputSpecBuilders;
 
         // related sublist
-        Core::Utils::SectionSpecs sublist_IO{"IO"};
-        Core::Utils::SectionSpecs sublist_IO_VTK{sublist_IO, "RUNTIME VTK OUTPUT"};
-        Core::Utils::SectionSpecs sublist_IO_VTK_structure{sublist_IO_VTK, "STRUCTURE"};
+        list["IO/RUNTIME VTK OUTPUT/STRUCTURE"] = all_of({
 
-        // whether to write output for structure
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
-            "OUTPUT_STRUCTURE", {.description = "write structure output", .default_value = false}));
+            // whether to write output for structure
+            parameter<bool>("OUTPUT_STRUCTURE",
+                {.description = "write structure output", .default_value = false}),
 
-        // whether to write displacement state
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
-            "DISPLACEMENT", {.description = "write displacement output", .default_value = false}));
+            // whether to write displacement state
+            parameter<bool>("DISPLACEMENT",
+                {.description = "write displacement output", .default_value = false}),
 
-        // whether to write velocity state
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
-            "VELOCITY", {.description = "write velocity output", .default_value = false}));
+            // whether to write velocity state
+            parameter<bool>(
+                "VELOCITY", {.description = "write velocity output", .default_value = false}),
 
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
-            "ACCELERATION", {.description = "write acceleration output", .default_value = false}));
+            parameter<bool>("ACCELERATION",
+                {.description = "write acceleration output", .default_value = false}),
 
-        // whether to write element owner
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
-            "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}));
+            // whether to write element owner
+            parameter<bool>(
+                "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}),
 
-        // whether to write element GIDs
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("ELEMENT_GID",
-            {.description = "write 4C internal element GIDs", .default_value = false}));
+            // whether to write element GIDs
+            parameter<bool>("ELEMENT_GID",
+                {.description = "write 4C internal element GIDs", .default_value = false}),
 
-        // write element ghosting information
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("ELEMENT_GHOSTING",
-            {.description = "write which processors ghost the elements", .default_value = false}));
+            // write element ghosting information
+            parameter<bool>(
+                "ELEMENT_GHOSTING", {.description = "write which processors ghost the elements",
+                                        .default_value = false}),
 
-        // whether to write node GIDs
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>(
-            "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}));
+            // whether to write node GIDs
+            parameter<bool>(
+                "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}),
 
-        // write element material IDs
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("ELEMENT_MAT_ID",
-            {.description = "Output of the material id of each element", .default_value = false}));
+            // write element material IDs
+            parameter<bool>(
+                "ELEMENT_MAT_ID", {.description = "Output of the material id of each element",
+                                      .default_value = false}),
 
-        // whether to write stress and / or strain data
-        sublist_IO_VTK_structure.specs.emplace_back(parameter<bool>("STRESS_STRAIN",
-            {.description = "Write element stress and / or strain  data. The type of stress / "
-                            "strain has to be selected in the --IO input section",
-                .default_value = false}));
+            // whether to write stress and / or strain data
+            parameter<bool>("STRESS_STRAIN",
+                {.description = "Write element stress and / or strain  data. The type of stress / "
+                                "strain has to be selected in the --IO input section",
+                    .default_value = false}),
 
-        // mode to write gauss point data
-        sublist_IO_VTK_structure.specs.emplace_back(
+            // mode to write gauss point data
             parameter<Inpar::Solid::GaussPointDataOutputType>("GAUSS_POINT_DATA_OUTPUT_TYPE",
                 {.description = "Where to write gauss point data. (none, projected to nodes, "
                                 "projected to element center, raw at gauss points)",
-                    .default_value = Inpar::Solid::GaussPointDataOutputType::none}));
+                    .default_value = Inpar::Solid::GaussPointDataOutputType::none}),
 
-        sublist_IO_VTK_structure.specs.emplace_back(
+
             deprecated_selection<Inpar::Solid::OptQuantityType>("OPTIONAL_QUANTITY",
                 {
                     {"No", Inpar::Solid::optquantity_none},
                     {"membranethickness", Inpar::Solid::optquantity_membranethickness},
                 },
                 {.description = "Output of an optional quantity",
-                    .default_value = Inpar::Solid::optquantity_none}));
-
-        sublist_IO_VTK_structure.move_into_collection(list);
+                    .default_value = Inpar::Solid::optquantity_none})});
       }
 
 

--- a/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
@@ -26,41 +26,37 @@ namespace Inpar
       using namespace Core::IO::InputSpecBuilders;
 
       // related sublist
-      Core::Utils::SectionSpecs sublist_IO{"IO"};
-      Core::Utils::SectionSpecs sublist_IO_VTP_structure{
-          sublist_IO, "RUNTIME VTP OUTPUT STRUCTURE"};
+      list["IO/RUNTIME VTP OUTPUT STRUCTURE"] = all_of({
 
+          // output interval regarding steps: write output every INTERVAL_STEPS steps
+          parameter<int>("INTERVAL_STEPS",
+              {.description = "write VTP output at runtime every INTERVAL_STEPS steps",
+                  .default_value = -1}),
+          parameter<int>("STEP_OFFSET",
+              {.description =
+                      "An offset added to the current step to shift the steps to be written.",
+                  .default_value = 0}),
 
-      // output interval regarding steps: write output every INTERVAL_STEPS steps
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<int>("INTERVAL_STEPS",
-          {.description = "write VTP output at runtime every INTERVAL_STEPS steps",
-              .default_value = -1}));
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<int>("STEP_OFFSET",
-          {.description = "An offset added to the current step to shift the steps to be written.",
-              .default_value = 0}));
+          // whether to write output in every iteration of the nonlinear solver
+          parameter<bool>("EVERY_ITERATION",
+              {.description = "write output in every iteration of the nonlinear solver",
+                  .default_value = false}),
 
-      // whether to write output in every iteration of the nonlinear solver
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>("EVERY_ITERATION",
-          {.description = "write output in every iteration of the nonlinear solver",
-              .default_value = false}));
+          // write owner at every visualization point
+          parameter<bool>(
+              "OWNER", {.description = "write owner of every point", .default_value = false}),
 
-      // write owner at every visualization point
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>(
-          "OWNER", {.description = "write owner of every point", .default_value = false}));
+          // write orientation at every visualization point
+          parameter<bool>("ORIENTATIONANDLENGTH",
+              {.description = "write orientation at every point", .default_value = false}),
 
-      // write orientation at every visualization point
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>("ORIENTATIONANDLENGTH",
-          {.description = "write orientation at every point", .default_value = false}));
+          // write number of bonds at every visualization point
+          parameter<bool>("NUMBEROFBONDS",
+              {.description = "write number of bonds of every point", .default_value = false}),
 
-      // write number of bonds at every visualization point
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>("NUMBEROFBONDS",
-          {.description = "write number of bonds of every point", .default_value = false}));
-
-      // write force actin in linker
-      sublist_IO_VTP_structure.specs.emplace_back(parameter<bool>(
-          "LINKINGFORCE", {.description = "write force acting in linker", .default_value = false}));
-
-      sublist_IO_VTP_structure.move_into_collection(list);
+          // write force actin in linker
+          parameter<bool>("LINKINGFORCE",
+              {.description = "write force acting in linker", .default_value = false})});
     }
 
 

--- a/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
@@ -8,7 +8,7 @@
 #include "4C_inpar_IO_runtime_vtp_output_structure.hpp"
 
 #include "4C_io_geometry_type.hpp"
-#include "4C_utils_parameter_list.hpp"
+#include "4C_io_input_spec_builders.hpp"
 
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -12,8 +12,6 @@
 #include "4C_inpar_geometry_pair.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_utils_exceptions.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -54,260 +54,244 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs beaminteraction{"BEAM INTERACTION"};
-
   // Beam to solid volume mesh tying parameters.
-  Core::Utils::SectionSpecs beam_to_solid_volume_mestying{
-      beaminteraction, "BEAM TO SOLID VOLUME MESHTYING"};
-  {
-    beam_to_solid_volume_mestying.specs.emplace_back(parameter<BeamToSolidContactDiscretization>(
-        "CONTACT_DISCRETIZATION", {.description = "Type of employed contact discretization",
-                                      .default_value = BeamToSolidContactDiscretization::none}));
+  std::vector<Core::IO::InputSpec> beam_to_solid_volume_mestying = {
+      parameter<BeamToSolidContactDiscretization>(
+          "CONTACT_DISCRETIZATION", {.description = "Type of employed contact discretization",
+                                        .default_value = BeamToSolidContactDiscretization::none}),
 
-    beam_to_solid_volume_mestying.specs.emplace_back(parameter<BeamToSolidConstraintEnforcement>(
-        "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
-                                   .default_value = BeamToSolidConstraintEnforcement::none}));
+      parameter<BeamToSolidConstraintEnforcement>(
+          "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
+                                     .default_value = BeamToSolidConstraintEnforcement::none}),
 
-    beam_to_solid_volume_mestying.specs.emplace_back(
-        parameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
-            {.description = "Shape function for the mortar Lagrange-multipliers",
-                .default_value = BeamToSolidMortarShapefunctions::none}));
+      parameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
+          {.description = "Shape function for the mortar Lagrange-multipliers",
+              .default_value = BeamToSolidMortarShapefunctions::none}),
 
-    beam_to_solid_volume_mestying.specs.emplace_back(parameter<int>("MORTAR_FOURIER_MODES",
-        {.description = "Number of fourier modes to be used for cross-section mortar coupling",
-            .default_value = -1}));
+      parameter<int>("MORTAR_FOURIER_MODES",
+          {.description = "Number of fourier modes to be used for cross-section mortar coupling",
+              .default_value = -1}),
 
-    beam_to_solid_volume_mestying.specs.emplace_back(parameter<double>(
-        "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-solid volume meshtying",
-                                 .default_value = 0.0}));
+      parameter<double>("PENALTY_PARAMETER",
+          {.description = "Penalty parameter for beam-to-solid volume meshtying",
+              .default_value = 0.0}),
 
-    // Add the geometry pair input parameters.
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_volume_mestying);
 
-    // This option only has an effect during a restart simulation.
-    // - No:  (default) The coupling is treated the same way as during a non restart simulation,
-    //        i.e. the initial configurations (zero displacement) of the beams and solids are
-    //        coupled.
-    // - Yes: The beam and solid states at the restart configuration are coupled. This allows to
-    //        pre-deform the structures and then couple them.
-    beam_to_solid_volume_mestying.specs.emplace_back(parameter<bool>("COUPLE_RESTART_STATE",
-        {.description = "Enable / disable the coupling of the restart configuration.",
-            .default_value = false}));
+      // This option only has an effect during a restart simulation.
+      // - No:  (default) The coupling is treated the same way as during a non restart
+      // simulation,
+      //        i.e. the initial configurations (zero displacement) of the beams and solids are
+      //        coupled.
+      // - Yes: The beam and solid states at the restart configuration are coupled. This allows
+      // to
+      //        pre-deform the structures and then couple them.
+      parameter<bool>("COUPLE_RESTART_STATE",
+          {.description = "Enable / disable the coupling of the restart configuration.",
+              .default_value = false}),
 
-    beam_to_solid_volume_mestying.specs.emplace_back(parameter<BeamToSolidRotationCoupling>(
-        "ROTATION_COUPLING", {.description = "Type of rotational coupling",
-                                 .default_value = BeamToSolidRotationCoupling::none}));
+      parameter<BeamToSolidRotationCoupling>(
+          "ROTATION_COUPLING", {.description = "Type of rotational coupling",
+                                   .default_value = BeamToSolidRotationCoupling::none}),
 
-    beam_to_solid_volume_mestying.specs.emplace_back(
-        parameter<BeamToSolidMortarShapefunctions>("ROTATION_COUPLING_MORTAR_SHAPE_FUNCTION",
-            {.description = "Shape function for the mortar Lagrange-multipliers",
-                .default_value = BeamToSolidMortarShapefunctions::none}));
 
-    beam_to_solid_volume_mestying.specs.emplace_back(
-        parameter<double>("ROTATION_COUPLING_PENALTY_PARAMETER",
-            {.description =
-                    "Penalty parameter for rotational coupling in beam-to-solid volume mesh tying",
-                .default_value = 0.0}));
-  }
+      parameter<BeamToSolidMortarShapefunctions>("ROTATION_COUPLING_MORTAR_SHAPE_FUNCTION",
+          {.description = "Shape function for the mortar Lagrange-multipliers",
+              .default_value = BeamToSolidMortarShapefunctions::none}),
 
-  beam_to_solid_volume_mestying.move_into_collection(list);
+
+      parameter<double>("ROTATION_COUPLING_PENALTY_PARAMETER",
+          {.description = "Penalty parameter for rotational coupling in beam-to-solid volume "
+                          "mesh tying",
+              .default_value = 0.0}),
+  };
+  // Add the geometry pair input parameters.
+  Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_volume_mestying);
+
+  list["BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING"] = all_of(beam_to_solid_volume_mestying);
+
 
   // Beam to solid volume mesh tying output parameters.
-  Core::Utils::SectionSpecs beam_to_solid_volume_mestying_output{
-      beam_to_solid_volume_mestying, "RUNTIME VTK OUTPUT"};
-  {
-    // Whether to write visualization output at all for btsvmt.
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
-        "WRITE_OUTPUT", {.description = "Enable / disable beam-to-solid volume mesh tying output.",
-                            .default_value = false}));
+  list["BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING/RUNTIME VTK OUTPUT"] = all_of({
+      // Whether to write visualization output at all for btsvmt.
+      parameter<bool>("WRITE_OUTPUT",
+          {.description = "Enable / disable beam-to-solid volume mesh tying output.",
+              .default_value = false}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
-        "NODAL_FORCES", {.description = "Enable / disable output of the resulting nodal forces due "
-                                        "to beam to solid interaction.",
-                            .default_value = false}));
+      parameter<bool>("NODAL_FORCES",
+          {.description = "Enable / disable output of the resulting nodal forces due "
+                          "to beam to solid interaction.",
+              .default_value = false}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>("MORTAR_LAMBDA_DISCRET",
-        {.description = "Enable / disable output of the discrete Lagrange multipliers at the node "
-                        "of the Lagrange multiplier shape functions.",
-            .default_value = false}));
+      parameter<bool>("MORTAR_LAMBDA_DISCRET",
+          {.description =
+                  "Enable / disable output of the discrete Lagrange multipliers at the node "
+                  "of the Lagrange multiplier shape functions.",
+              .default_value = false}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
-        "MORTAR_LAMBDA_CONTINUOUS", {.description = "Enable / disable output of the continuous "
-                                                    "Lagrange multipliers function along the beam.",
-                                        .default_value = false}));
+      parameter<bool>("MORTAR_LAMBDA_CONTINUOUS",
+          {.description = "Enable / disable output of the continuous "
+                          "Lagrange multipliers function along the beam.",
+              .default_value = false}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<int>(
-        "MORTAR_LAMBDA_CONTINUOUS_SEGMENTS",
-        {.description = "Number of segments for continuous mortar output", .default_value = 5}));
-    beam_to_solid_volume_mestying_output.specs.emplace_back(
-        parameter<int>("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS_CIRCUMFERENCE",
-            {.description = "Number of segments for continuous mortar output along the beam "
-                            "cross-section circumference",
-                .default_value = 8}));
+      parameter<int>("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS",
+          {.description = "Number of segments for continuous mortar output", .default_value = 5}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>(
-        "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
-                            .default_value = false}));
+      parameter<int>("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS_CIRCUMFERENCE",
+          {.description = "Number of segments for continuous mortar output along the beam "
+                          "cross-section circumference",
+              .default_value = 8}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>("INTEGRATION_POINTS",
-        {.description = "Enable / disable output of used integration points. If the contact method "
-                        "has 'forces' at the integration point, they will also be output.",
-            .default_value = false}));
+      parameter<bool>(
+          "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
+                              .default_value = false}),
 
-    beam_to_solid_volume_mestying_output.specs.emplace_back(parameter<bool>("UNIQUE_IDS",
-        {.description =
-                "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
-            .default_value = false}));
-  }
+      parameter<bool>("INTEGRATION_POINTS",
+          {.description =
+                  "Enable / disable output of used integration points. If the contact method "
+                  "has 'forces' at the integration point, they will also be output.",
+              .default_value = false}),
 
-  beam_to_solid_volume_mestying_output.move_into_collection(list);
+      parameter<bool>("UNIQUE_IDS", {.description = "Enable / disable output of unique IDs (mainly "
+                                                    "for testing of created VTK files).",
+                                        .default_value = false}),
+  });
+
 
   // Beam to solid surface mesh tying parameters.
-  Core::Utils::SectionSpecs beam_to_solid_surface_mestying{
-      beaminteraction, "BEAM TO SOLID SURFACE MESHTYING"};
-  {
-    beam_to_solid_surface_mestying.specs.emplace_back(parameter<BeamToSolidContactDiscretization>(
-        "CONTACT_DISCRETIZATION", {.description = "Type of employed contact discretization",
-                                      .default_value = BeamToSolidContactDiscretization::none}));
+  std::vector<Core::IO::InputSpec> beam_to_solid_surface_meshtying = {
+      parameter<BeamToSolidContactDiscretization>(
+          "CONTACT_DISCRETIZATION", {.description = "Type of employed contact discretization",
+                                        .default_value = BeamToSolidContactDiscretization::none}),
 
-    beam_to_solid_surface_mestying.specs.emplace_back(parameter<BeamToSolidConstraintEnforcement>(
-        "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
-                                   .default_value = BeamToSolidConstraintEnforcement::none}));
+      parameter<BeamToSolidConstraintEnforcement>(
+          "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
+                                     .default_value = BeamToSolidConstraintEnforcement::none}),
 
-    beam_to_solid_surface_mestying.specs.emplace_back(parameter<BeamToSolidSurfaceCoupling>(
-        "COUPLING_TYPE", {.description = "How the coupling constraints are formulated/",
-                             .default_value = BeamToSolidSurfaceCoupling::none}));
+      parameter<BeamToSolidSurfaceCoupling>(
+          "COUPLING_TYPE", {.description = "How the coupling constraints are formulated/",
+                               .default_value = BeamToSolidSurfaceCoupling::none}),
 
-    beam_to_solid_surface_mestying.specs.emplace_back(
-        parameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
-            {.description = "Shape function for the mortar Lagrange-multipliers",
-                .default_value = BeamToSolidMortarShapefunctions::none}));
 
-    beam_to_solid_surface_mestying.specs.emplace_back(parameter<double>("PENALTY_PARAMETER",
-        {.description = "Penalty parameter for beam-to-solid surface meshtying",
-            .default_value = 0.0}));
+      parameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
+          {.description = "Shape function for the mortar Lagrange-multipliers",
+              .default_value = BeamToSolidMortarShapefunctions::none}),
 
-    // Parameters for rotational coupling.
-    beam_to_solid_surface_mestying.specs.emplace_back(parameter<bool>("ROTATIONAL_COUPLING",
-        {.description = "Enable / disable rotational coupling", .default_value = false}));
-    beam_to_solid_surface_mestying.specs.emplace_back(
-        parameter<double>("ROTATIONAL_COUPLING_PENALTY_PARAMETER",
-            {.description = "Penalty parameter for beam-to-solid surface rotational meshtying",
-                .default_value = 0.0}));
-    beam_to_solid_surface_mestying.specs.emplace_back(
-        parameter<BeamToSolidSurfaceRotationCoupling>("ROTATIONAL_COUPLING_SURFACE_TRIAD",
-            {.description = "Construction method for surface triad",
-                .default_value = BeamToSolidSurfaceRotationCoupling::none}));
+      parameter<double>("PENALTY_PARAMETER",
+          {.description = "Penalty parameter for beam-to-solid surface meshtying",
+              .default_value = 0.0}),
 
-    // Add the geometry pair input parameters.
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_surface_mestying);
+      // Parameters for rotational coupling.
+      parameter<bool>("ROTATIONAL_COUPLING",
+          {.description = "Enable / disable rotational coupling", .default_value = false}),
 
-    // Add the surface options.
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(beam_to_solid_surface_mestying);
-  }
+      parameter<double>("ROTATIONAL_COUPLING_PENALTY_PARAMETER",
+          {.description = "Penalty parameter for beam-to-solid surface rotational meshtying",
+              .default_value = 0.0}),
 
-  beam_to_solid_surface_mestying.move_into_collection(list);
+      parameter<BeamToSolidSurfaceRotationCoupling>("ROTATIONAL_COUPLING_SURFACE_TRIAD",
+          {.description = "Construction method for surface triad",
+              .default_value = BeamToSolidSurfaceRotationCoupling::none}),
+  };
+  // Add the geometry pair input parameters.
+  Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_surface_meshtying);
+
+  // Add the surface options.
+  Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(beam_to_solid_surface_meshtying);
+  list["BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING"] =
+      all_of(beam_to_solid_surface_meshtying);
+
 
   // Beam to solid surface contact parameters.
-  Core::Utils::SectionSpecs beam_to_solid_surface_contact{
-      beaminteraction, "BEAM TO SOLID SURFACE CONTACT"};
-  {
-    beam_to_solid_surface_contact.specs.emplace_back(parameter<BeamToSolidContactDiscretization>(
-        "CONTACT_DISCRETIZATION", {.description = "Type of employed contact discretization",
-                                      .default_value = BeamToSolidContactDiscretization::none}));
+  std::vector<Core::IO::InputSpec> beam_to_solid_surface_contact = {
+      parameter<BeamToSolidContactDiscretization>(
+          "CONTACT_DISCRETIZATION", {.description = "Type of employed contact discretization",
+                                        .default_value = BeamToSolidContactDiscretization::none}),
 
-    beam_to_solid_surface_contact.specs.emplace_back(parameter<BeamToSolidConstraintEnforcement>(
-        "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
-                                   .default_value = BeamToSolidConstraintEnforcement::none}));
+      parameter<BeamToSolidConstraintEnforcement>(
+          "CONSTRAINT_STRATEGY", {.description = "Type of employed constraint enforcement strategy",
+                                     .default_value = BeamToSolidConstraintEnforcement::none}),
 
-    beam_to_solid_surface_contact.specs.emplace_back(parameter<double>(
-        "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-solid surface contact",
-                                 .default_value = 0.0}));
+      parameter<double>("PENALTY_PARAMETER",
+          {.description = "Penalty parameter for beam-to-solid surface contact",
+              .default_value = 0.0}),
 
-    beam_to_solid_surface_contact.specs.emplace_back(parameter<BeamToSolidSurfaceContact>(
-        "CONTACT_TYPE", {.description = "How the contact constraints are formulated",
-                            .default_value = BeamToSolidSurfaceContact::none}));
+      parameter<BeamToSolidSurfaceContact>(
+          "CONTACT_TYPE", {.description = "How the contact constraints are formulated",
+                              .default_value = BeamToSolidSurfaceContact::none}),
 
-    beam_to_solid_surface_contact.specs.emplace_back(parameter<BeamToSolidSurfaceContactPenaltyLaw>(
-        "PENALTY_LAW", {.description = "Type of penalty law",
-                           .default_value = BeamToSolidSurfaceContactPenaltyLaw::none}));
+      parameter<BeamToSolidSurfaceContactPenaltyLaw>(
+          "PENALTY_LAW", {.description = "Type of penalty law",
+                             .default_value = BeamToSolidSurfaceContactPenaltyLaw::none}),
 
-    beam_to_solid_surface_contact.specs.emplace_back(parameter<double>("PENALTY_PARAMETER_G0",
-        {.description =
-                "First penalty regularization parameter G0 >=0: For gap<G0 contact is active",
-            .default_value = 0.0}));
+      parameter<double>("PENALTY_PARAMETER_G0",
+          {.description =
+                  "First penalty regularization parameter G0 >=0: For gap<G0 contact is active",
+              .default_value = 0.0}),
 
-    beam_to_solid_surface_contact.specs.emplace_back(
-        parameter<BeamToSolidSurfaceContactMortarDefinedIn>("MORTAR_CONTACT_DEFINED_IN",
-            {.description = "Configuration where the mortar contact is defined",
-                .default_value = BeamToSolidSurfaceContactMortarDefinedIn::none}));
 
-    // Add the geometry pair input parameters.
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_surface_contact);
+      parameter<BeamToSolidSurfaceContactMortarDefinedIn>("MORTAR_CONTACT_DEFINED_IN",
+          {.description = "Configuration where the mortar contact is defined",
+              .default_value = BeamToSolidSurfaceContactMortarDefinedIn::none}),
 
-    // Add the surface options.
-    Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(beam_to_solid_surface_contact);
+      // Define the mortar shape functions for contact
 
-    // Define the mortar shape functions for contact
-    beam_to_solid_surface_contact.specs.emplace_back(
-        parameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
-            {.description = "Shape function for the mortar Lagrange-multipliers",
-                .default_value = BeamToSolidMortarShapefunctions::none}));
-  }
+      parameter<BeamToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
+          {.description = "Shape function for the mortar Lagrange-multipliers",
+              .default_value = BeamToSolidMortarShapefunctions::none}),
+  };
+  // Add the geometry pair input parameters.
+  Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(beam_to_solid_surface_contact);
 
-  beam_to_solid_surface_contact.move_into_collection(list);
+  // Add the surface options.
+  Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(beam_to_solid_surface_contact);
 
-  // Beam to solid surface parameters.
-  Core::Utils::SectionSpecs beam_to_solid_surface{beaminteraction, "BEAM TO SOLID SURFACE"};
+  list["BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT"] = all_of(beam_to_solid_surface_contact);
+
 
   // Beam to solid surface output parameters.
-  Core::Utils::SectionSpecs beam_to_solid_surface_output{
-      beam_to_solid_surface, "RUNTIME VTK OUTPUT"};
-  {
-    // Whether to write visualization output at all.
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
-        "WRITE_OUTPUT", {.description = "Enable / disable beam-to-solid volume mesh tying output.",
-                            .default_value = false}));
+  list["BEAM INTERACTION/BEAM TO SOLID SURFACE/RUNTIME VTK OUTPUT"] = all_of({
+      // Whether to write visualization output at all.
+      parameter<bool>("WRITE_OUTPUT",
+          {.description = "Enable / disable beam-to-solid volume mesh tying output.",
+              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
-        "NODAL_FORCES", {.description = "Enable / disable output of the resulting nodal forces due "
-                                        "to beam to solid interaction.",
-                            .default_value = false}));
+      parameter<bool>("NODAL_FORCES",
+          {.description = "Enable / disable output of the resulting nodal forces due "
+                          "to beam to solid interaction.",
+              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("AVERAGED_NORMALS",
-        {.description = "Enable / disable output of averaged nodal normals on the surface.",
-            .default_value = false}));
+      parameter<bool>("AVERAGED_NORMALS",
+          {.description = "Enable / disable output of averaged nodal normals on the surface.",
+              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("MORTAR_LAMBDA_DISCRET",
-        {.description = "Enable / disable output of the discrete Lagrange multipliers at the node "
-                        "of the Lagrange multiplier shape functions.",
-            .default_value = false}));
+      parameter<bool>("MORTAR_LAMBDA_DISCRET",
+          {.description =
+                  "Enable / disable output of the discrete Lagrange multipliers at the node "
+                  "of the Lagrange multiplier shape functions.",
+              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
-        "MORTAR_LAMBDA_CONTINUOUS", {.description = "Enable / disable output of the continuous "
-                                                    "Lagrange multipliers function along the beam.",
-                                        .default_value = false}));
+      parameter<bool>("MORTAR_LAMBDA_CONTINUOUS",
+          {.description = "Enable / disable output of the continuous "
+                          "Lagrange multipliers function along the beam.",
+              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<int>(
-        "MORTAR_LAMBDA_CONTINUOUS_SEGMENTS",
-        {.description = "Number of segments for continuous mortar output", .default_value = 5}));
+      parameter<int>("MORTAR_LAMBDA_CONTINUOUS_SEGMENTS",
+          {.description = "Number of segments for continuous mortar output", .default_value = 5}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>(
-        "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
-                            .default_value = false}));
+      parameter<bool>(
+          "SEGMENTATION", {.description = "Enable / disable output of segmentation points.",
+                              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("INTEGRATION_POINTS",
-        {.description = "Enable / disable output of used integration points. If the contact method "
-                        "has 'forces' at the integration point, they will also be output.",
-            .default_value = false}));
+      parameter<bool>("INTEGRATION_POINTS",
+          {.description =
+                  "Enable / disable output of used integration points. If the contact method "
+                  "has 'forces' at the integration point, they will also be output.",
+              .default_value = false}),
 
-    beam_to_solid_surface_output.specs.emplace_back(parameter<bool>("UNIQUE_IDS",
-        {.description =
-                "Enable / disable output of unique IDs (mainly for testing of created VTK files).",
-            .default_value = false}));
-  }
-
-  beam_to_solid_surface_output.move_into_collection(list);
+      parameter<bool>("UNIQUE_IDS", {.description = "Enable / disable output of unique IDs (mainly "
+                                                    "for testing of created VTK files).",
+                                        .default_value = false}),
+  });
 }
 
 /**

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -11,8 +11,6 @@
 #include "4C_fem_condition_definition.hpp"
 #include "4C_inpar_beam_to_solid.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -31,9 +31,8 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs beaminteraction{"BEAM INTERACTION"};
+  list["BEAM INTERACTION"] = all_of({
 
-  beaminteraction.specs.emplace_back(
       deprecated_selection<Inpar::BeamInteraction::RepartitionStrategy>("REPARTITIONSTRATEGY",
           {
               {"Adaptive", repstr_adaptive},
@@ -42,116 +41,111 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
               {"everydt", repstr_everydt},
           },
           {.description = "Type of employed repartitioning strategy",
-              .default_value = repstr_adaptive}));
+              .default_value = repstr_adaptive}),
 
-  beaminteraction.specs.emplace_back(parameter<SearchStrategy>(
-      "SEARCH_STRATEGY", {.description = "Type of search strategy used for finding coupling pairs",
-                             .default_value = SearchStrategy::bruteforce_with_binning}));
-
-  beaminteraction.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      parameter<SearchStrategy>("SEARCH_STRATEGY",
+          {.description = "Type of search strategy used for finding coupling pairs",
+              .default_value = SearchStrategy::
+                  bruteforce_with_binning})}); /*----------------------------------------------------------------------*/
   /* parameters for crosslinking submodel */
 
-  Core::Utils::SectionSpecs crosslinking{beaminteraction, "CROSSLINKING"};
+  list["BEAM INTERACTION/CROSSLINKING"] = all_of({
 
-  // remove this some day
-  crosslinking.specs.emplace_back(parameter<bool>(
-      "CROSSLINKER", {.description = "Crosslinker in problem", .default_value = false}));
+      // remove this some day
+      parameter<bool>(
+          "CROSSLINKER", {.description = "Crosslinker in problem", .default_value = false}),
 
-  // bounding box for initial random crosslinker position
-  crosslinking.specs.emplace_back(parameter<std::string>("INIT_LINKER_BOUNDINGBOX",
-      {.description = "Linker are initially set randomly within this bounding box",
-          .default_value = "1e12 1e12 1e12 1e12 1e12 1e12"}));
+      // bounding box for initial random crosslinker position
+      parameter<std::string>("INIT_LINKER_BOUNDINGBOX",
+          {.description = "Linker are initially set randomly within this bounding box",
+              .default_value = "1e12 1e12 1e12 1e12 1e12 1e12"}),
 
-  // time step for stochastic events concerning crosslinking
-  crosslinking.specs.emplace_back(parameter<double>(
-      "TIMESTEP", {.description = "time step for stochastic events concerning crosslinking (e.g. "
-                                  "diffusion, p_link, p_unlink) ",
-                      .default_value = -1.0}));
-  // Reading double parameter for viscosity of background fluid
-  crosslinking.specs.emplace_back(
-      parameter<double>("VISCOSITY", {.description = "viscosity", .default_value = 0.0}));
-  // Reading double parameter for thermal energy in background fluid (temperature * Boltzmann
-  // constant)
-  crosslinking.specs.emplace_back(
-      parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}));
-  // number of initial (are set right in the beginning) crosslinker of certain type
-  crosslinking.specs.emplace_back(parameter<std::string>(
-      "MAXNUMINITCROSSLINKERPERTYPE", {.description = "number of initial crosslinker of certain "
-                                                      "type (additional to NUMCROSSLINKERPERTYPE) ",
-                                          .default_value = "0"}));
-  // number of crosslinker of certain type
-  crosslinking.specs.emplace_back(parameter<std::string>("NUMCROSSLINKERPERTYPE",
-      {.description = "number of crosslinker of certain type ", .default_value = "0"}));
-  // material number characterizing crosslinker type
-  crosslinking.specs.emplace_back(parameter<std::string>("MATCROSSLINKERPERTYPE",
-      {.description = "material number characterizing crosslinker type ", .default_value = "-1"}));
-  // maximal number of binding partner per filament binding spot for each binding spot type
-  crosslinking.specs.emplace_back(parameter<std::string>("MAXNUMBONDSPERFILAMENTBSPOT",
-      {.description = "maximal number of bonds per filament binding spot", .default_value = "1"}));
-  // distance between two binding spots on a filament (same on all filaments)
-  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALGLOBAL",
-      {.description = "distance between two binding spots on all filaments",
-          .default_value = "-1.0"}));
-  // distance between two binding spots on a filament (as percentage of current filament length)
-  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALLOCAL",
-      {.description = "distance between two binding spots on current filament",
-          .default_value = "-1.0"}));
-  // start and end for bspots on a filament in arc parameter (same on each filament independent of
-  // their length)
-  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGEGLOBAL",
-      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
-          .default_value = "-1.0 -1.0"}));
-  // start and end for bspots on a filament in percent of reference filament length
-  crosslinking.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
-      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
-          .default_value = "0.0 1.0"}));
-
-  crosslinking.move_into_collection(list);
+      // time step for stochastic events concerning crosslinking
+      parameter<double>("TIMESTEP",
+          {.description = "time step for stochastic events concerning crosslinking (e.g. "
+                          "diffusion, p_link, p_unlink) ",
+              .default_value = -1.0}),
+      // Reading double parameter for viscosity of background fluid
+      parameter<double>("VISCOSITY", {.description = "viscosity", .default_value = 0.0}),
+      // Reading double parameter for thermal energy in background fluid (temperature * Boltzmann
+      // constant)
+      parameter<double>("KT", {.description = "thermal energy", .default_value = 0.0}),
+      // number of initial (are set right in the beginning) crosslinker of certain type
+      parameter<std::string>("MAXNUMINITCROSSLINKERPERTYPE",
+          {.description = "number of initial crosslinker of certain "
+                          "type (additional to NUMCROSSLINKERPERTYPE) ",
+              .default_value = "0"}),
+      // number of crosslinker of certain type
+      parameter<std::string>("NUMCROSSLINKERPERTYPE",
+          {.description = "number of crosslinker of certain type ", .default_value = "0"}),
+      // material number characterizing crosslinker type
+      parameter<std::string>("MATCROSSLINKERPERTYPE",
+          {.description = "material number characterizing crosslinker type ",
+              .default_value = "-1"}),
+      // maximal number of binding partner per filament binding spot for each binding spot type
+      parameter<std::string>("MAXNUMBONDSPERFILAMENTBSPOT",
+          {.description = "maximal number of bonds per filament binding spot",
+              .default_value = "1"}),
+      // distance between two binding spots on a filament (same on all filaments)
+      parameter<std::string>("FILAMENTBSPOTINTERVALGLOBAL",
+          {.description = "distance between two binding spots on all filaments",
+              .default_value = "-1.0"}),
+      // distance between two binding spots on a filament (as percentage of current filament length)
+      parameter<std::string>("FILAMENTBSPOTINTERVALLOCAL",
+          {.description = "distance between two binding spots on current filament",
+              .default_value = "-1.0"}),
+      // start and end for bspots on a filament in arc parameter (same on each filament independent
+      // of
+      // their length)
+      parameter<std::string>("FILAMENTBSPOTRANGEGLOBAL",
+          {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+              .default_value = "-1.0 -1.0"}),
+      // start and end for bspots on a filament in percent of reference filament length
+      parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
+          {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+              .default_value = "0.0 1.0"})});
 
 
   /*----------------------------------------------------------------------*/
   /* parameters for sphere beam link submodel */
 
-  Core::Utils::SectionSpecs spherebeamlink{beaminteraction, "SPHERE BEAM LINK"};
+  list["BEAM INTERACTION/SPHERE BEAM LINK"] = all_of({
 
-  spherebeamlink.specs.emplace_back(parameter<bool>(
-      "SPHEREBEAMLINKING", {.description = "Integrins in problem", .default_value = false}));
+      parameter<bool>(
+          "SPHEREBEAMLINKING", {.description = "Integrins in problem", .default_value = false}),
 
-  // Reading double parameter for contraction rate for active linker
-  spherebeamlink.specs.emplace_back(parameter<double>(
-      "CONTRACTIONRATE", {.description = "contraction rate of cell (integrin linker) in [microm/s]",
-                             .default_value = 0.0}));
-  // time step for stochastic events concerning sphere beam linking
-  spherebeamlink.specs.emplace_back(parameter<double>(
-      "TIMESTEP", {.description = "time step for stochastic events concerning sphere beam linking "
-                                  "(e.g. catch-slip-bond behavior) ",
-                      .default_value = -1.0}));
-  spherebeamlink.specs.emplace_back(parameter<std::string>("MAXNUMLINKERPERTYPE",
-      {.description = "number of crosslinker of certain type ", .default_value = "0"}));
-  // material number characterizing crosslinker type
-  spherebeamlink.specs.emplace_back(parameter<std::string>("MATLINKERPERTYPE",
-      {.description = "material number characterizing crosslinker type ", .default_value = "-1"}));
-  // distance between two binding spots on a filament (same on all filaments)
-  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALGLOBAL",
-      {.description = "distance between two binding spots on all filaments",
-          .default_value = "-1.0"}));
-  // distance between two binding spots on a filament (as percentage of current filament length)
-  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTINTERVALLOCAL",
-      {.description = "distance between two binding spots on current filament",
-          .default_value = "-1.0"}));
-  // start and end for bspots on a filament in arc parameter (same on each filament independent of
-  // their length)
-  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGEGLOBAL",
-      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
-          .default_value = "-1.0 -1.0"}));
-  // start and end for bspots on a filament in percent of reference filament length
-  spherebeamlink.specs.emplace_back(parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
-      {.description = "Lower and upper arc parameter bound for binding spots on a filament",
-          .default_value = "0.0 1.0"}));
-
-  spherebeamlink.move_into_collection(list);
+      // Reading double parameter for contraction rate for active linker
+      parameter<double>("CONTRACTIONRATE",
+          {.description = "contraction rate of cell (integrin linker) in [microm/s]",
+              .default_value = 0.0}),
+      // time step for stochastic events concerning sphere beam linking
+      parameter<double>("TIMESTEP",
+          {.description = "time step for stochastic events concerning sphere beam linking "
+                          "(e.g. catch-slip-bond behavior) ",
+              .default_value = -1.0}),
+      parameter<std::string>("MAXNUMLINKERPERTYPE",
+          {.description = "number of crosslinker of certain type ", .default_value = "0"}),
+      // material number characterizing crosslinker type
+      parameter<std::string>(
+          "MATLINKERPERTYPE", {.description = "material number characterizing crosslinker type ",
+                                  .default_value = "-1"}),
+      // distance between two binding spots on a filament (same on all filaments)
+      parameter<std::string>("FILAMENTBSPOTINTERVALGLOBAL",
+          {.description = "distance between two binding spots on all filaments",
+              .default_value = "-1.0"}),
+      // distance between two binding spots on a filament (as percentage of current filament length)
+      parameter<std::string>("FILAMENTBSPOTINTERVALLOCAL",
+          {.description = "distance between two binding spots on current filament",
+              .default_value = "-1.0"}),
+      // start and end for bspots on a filament in arc parameter (same on each filament independent
+      // of their length)
+      parameter<std::string>("FILAMENTBSPOTRANGEGLOBAL",
+          {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+              .default_value = "-1.0 -1.0"}),
+      // start and end for bspots on a filament in percent of reference filament length
+      parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
+          {.description = "Lower and upper arc parameter bound for binding spots on a filament",
+              .default_value = "0.0 1.0"})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for beam to ? contact submodel*/
@@ -160,9 +154,8 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
   /*----------------------------------------------------------------------*/
   /* parameters for beam to beam contact */
 
-  Core::Utils::SectionSpecs beamtobeamcontact{beaminteraction, "BEAM TO BEAM CONTACT"};
+  list["BEAM INTERACTION/BEAM TO BEAM CONTACT"] = all_of({
 
-  beamtobeamcontact.specs.emplace_back(
       deprecated_selection<Inpar::BeamInteraction::Strategy>("STRATEGY",
           {
               {"None", bstr_none},
@@ -170,18 +163,15 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
               {"Penalty", bstr_penalty},
               {"penalty", bstr_penalty},
           },
-          {.description = "Type of employed solving strategy", .default_value = bstr_none}));
-
-  beamtobeamcontact.move_into_collection(list);
+          {.description = "Type of employed solving strategy", .default_value = bstr_none})});
 
   // ...
 
   /*----------------------------------------------------------------------*/
   /* parameters for beam to sphere contact */
 
-  Core::Utils::SectionSpecs beamtospherecontact{beaminteraction, "BEAM TO SPHERE CONTACT"};
+  list["BEAM INTERACTION/BEAM TO SPHERE CONTACT"] = all_of({
 
-  beamtospherecontact.specs.emplace_back(
       deprecated_selection<Inpar::BeamInteraction::Strategy>("STRATEGY",
           {
               {"None", bstr_none},
@@ -189,12 +179,11 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
               {"Penalty", bstr_penalty},
               {"penalty", bstr_penalty},
           },
-          {.description = "Type of employed solving strategy", .default_value = bstr_none}));
+          {.description = "Type of employed solving strategy", .default_value = bstr_none}),
 
-  beamtospherecontact.specs.emplace_back(parameter<double>("PENALTY_PARAMETER",
-      {.description = "Penalty parameter for beam-to-rigidsphere contact", .default_value = 0.0}));
-
-  beamtospherecontact.move_into_collection(list);
+      parameter<double>(
+          "PENALTY_PARAMETER", {.description = "Penalty parameter for beam-to-rigidsphere contact",
+                                   .default_value = 0.0})});
 
   // ...
 

--- a/src/inpar/4C_inpar_binningstrategy.cpp
+++ b/src/inpar/4C_inpar_binningstrategy.cpp
@@ -19,36 +19,34 @@ void Inpar::BINSTRATEGY::set_valid_parameters(std::map<std::string, Core::IO::In
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs binningstrategy{"BINNING STRATEGY"};
+  list["BINNING STRATEGY"] = all_of({
+
+      parameter<double>("BIN_SIZE_LOWER_BOUND",
+          {.description =
+                  "Lower bound for bin size. Exact bin size is computed via (Domain edge "
+                  "length)/BIN_SIZE_LOWER_BOUND. This also determines the number of bins in "
+                  "each spatial direction",
+              .default_value = -1.0}),
+
+      parameter<std::string>("BIN_PER_DIR",
+          {.description = "Number of bins per direction (x, y, z) in particle simulations. Either "
+                          "Define this value or  BIN_SIZE_LOWER_BOUND",
+              .default_value = "-1 -1 -1"}),
 
 
-  binningstrategy.specs.emplace_back(parameter<double>("BIN_SIZE_LOWER_BOUND",
-      {.description = "Lower bound for bin size. Exact bin size is computed via (Domain edge "
-                      "length)/BIN_SIZE_LOWER_BOUND. This also determines the number of bins in "
-                      "each spatial direction",
-          .default_value = -1.0}));
+      parameter<std::string>("PERIODICONOFF",
+          {.description = "Turn on/off periodic boundary conditions in each spatial direction",
+              .default_value = "0 0 0"}),
 
-  binningstrategy.specs.emplace_back(parameter<std::string>("BIN_PER_DIR",
-      {.description = "Number of bins per direction (x, y, z) in particle simulations. Either "
-                      "Define this value or  BIN_SIZE_LOWER_BOUND",
-          .default_value = "-1 -1 -1"}));
+      parameter<std::string>("DOMAINBOUNDINGBOX",
+          {.description = "Bounding box for computational domain using binning "
+                          "strategy. Specify diagonal corner  points",
+              .default_value = "1e12 1e12 1e12 1e12 1e12 1e12"}),
 
 
-  binningstrategy.specs.emplace_back(parameter<std::string>("PERIODICONOFF",
-      {.description = "Turn on/off periodic boundary conditions in each spatial direction",
-          .default_value = "0 0 0"}));
-
-  binningstrategy.specs.emplace_back(parameter<std::string>(
-      "DOMAINBOUNDINGBOX", {.description = "Bounding box for computational domain using binning "
-                                           "strategy. Specify diagonal corner  points",
-                               .default_value = "1e12 1e12 1e12 1e12 1e12 1e12"}));
-
-
-  binningstrategy.specs.emplace_back(parameter<Core::Binstrategy::WriteBins>(
-      "WRITEBINS", {.description = "Write none, row or column bins for visualization",
-                       .default_value = Core::Binstrategy::WriteBins::none}));
-
-  binningstrategy.move_into_collection(list);
+      parameter<Core::Binstrategy::WriteBins>(
+          "WRITEBINS", {.description = "Write none, row or column bins for visualization",
+                           .default_value = Core::Binstrategy::WriteBins::none})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_binningstrategy.cpp
+++ b/src/inpar/4C_inpar_binningstrategy.cpp
@@ -8,8 +8,7 @@
 #include "4C_inpar_binningstrategy.hpp"
 
 #include "4C_binstrategy.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -10,8 +10,6 @@
 #include "4C_fem_condition_definition.hpp"
 #include "4C_inpar_validparameters.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -19,48 +19,48 @@ void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 {
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
-  Core::Utils::SectionSpecs andyn{"ARTERIAL DYNAMIC"};
+  list["ARTERIAL DYNAMIC"] = all_of({
 
-  andyn.specs.emplace_back(deprecated_selection<TimeIntegrationScheme>("DYNAMICTYPE",
-      {
-          {"ExpTaylorGalerkin", tay_gal},
-          {"Stationary", stationary},
-      },
-      {.description = "Explicit Taylor Galerkin Scheme", .default_value = tay_gal}));
+      deprecated_selection<TimeIntegrationScheme>("DYNAMICTYPE",
+          {
+              {"ExpTaylorGalerkin", tay_gal},
+              {"Stationary", stationary},
+          },
+          {.description = "Explicit Taylor Galerkin Scheme", .default_value = tay_gal}),
 
-  andyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
-  andyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "Number of Time Steps", .default_value = 0}));
-  andyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  andyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-  andyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
 
-  andyn.specs.emplace_back(parameter<bool>(
-      "SOLVESCATRA", {.description = "Flag to (de)activate solving scalar transport in blood",
-                         .default_value = false}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}),
 
-  // number of linear solver used for arterial dynamics
-  andyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for arterial dynamics", .default_value = -1}));
+      parameter<int>("NUMSTEP", {.description = "Number of Time Steps", .default_value = 0}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
 
-  // initial function number
-  andyn.specs.emplace_back(parameter<int>("INITFUNCNO",
-      {.description = "function number for artery initial field", .default_value = -1}));
+      parameter<bool>(
+          "SOLVESCATRA", {.description = "Flag to (de)activate solving scalar transport in blood",
+                             .default_value = false}),
 
-  // type of initial field
-  andyn.specs.emplace_back(deprecated_selection<InitialField>("INITIALFIELD",
-      {
-          {"zero_field", initfield_zero_field},
-          {"field_by_function", initfield_field_by_function},
-          {"field_by_condition", initfield_field_by_condition},
-      },
-      {.description = "Initial Field for artery problem", .default_value = initfield_zero_field}));
+      // number of linear solver used for arterial dynamics
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "number of linear solver used for arterial dynamics",
+                               .default_value = -1}),
 
-  andyn.move_into_collection(list);
+      // initial function number
+      parameter<int>("INITFUNCNO",
+          {.description = "function number for artery initial field", .default_value = -1}),
+
+      // type of initial field
+      deprecated_selection<InitialField>("INITIALFIELD",
+          {
+              {"zero_field", initfield_zero_field},
+              {"field_by_function", initfield_field_by_function},
+              {"field_by_condition", initfield_field_by_condition},
+          },
+          {.description = "Initial Field for artery problem",
+              .default_value = initfield_zero_field})});
 }
 
 
@@ -70,27 +70,25 @@ void Inpar::ArteryNetwork::set_valid_parameters(std::map<std::string, Core::IO::
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs redtisdyn{"COUPLED REDUCED-D AIRWAYS AND TISSUE DYNAMIC"};
-  redtisdyn.specs.emplace_back(parameter<double>("CONVTOL_P",
-      {.description = "Coupled red_airway and tissue iteration convergence for pressure",
-          .default_value = 1E-6}));
-  redtisdyn.specs.emplace_back(parameter<double>(
-      "CONVTOL_Q", {.description = "Coupled red_airway and tissue iteration convergence for flux",
-                       .default_value = 1E-6}));
-  redtisdyn.specs.emplace_back(parameter<int>(
-      "MAXITER", {.description = "Maximum coupling iterations", .default_value = 5}));
-  redtisdyn.specs.emplace_back(parameter<Relaxtype3D0D>(
-      "RELAXTYPE", {.description = "Dynamic Relaxation Type", .default_value = norelaxation}));
-  redtisdyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
-  redtisdyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "Number of Time Steps", .default_value = 1}));
-  redtisdyn.specs.emplace_back(
-      parameter<double>("MAXTIME", {.description = "", .default_value = 4.0}));
-  redtisdyn.specs.emplace_back(
-      parameter<double>("NORMAL", {.description = "", .default_value = 1.0}));
+  list["COUPLED REDUCED-D AIRWAYS AND TISSUE DYNAMIC"] = all_of({
 
-  redtisdyn.move_into_collection(list);
+      parameter<double>("CONVTOL_P",
+          {.description = "Coupled red_airway and tissue iteration convergence for pressure",
+              .default_value = 1E-6}),
+      parameter<double>("CONVTOL_Q",
+          {.description = "Coupled red_airway and tissue iteration convergence for flux",
+              .default_value = 1E-6}),
+      parameter<int>("MAXITER", {.description = "Maximum coupling iterations", .default_value = 5}),
+      parameter<Relaxtype3D0D>(
+          "RELAXTYPE", {.description = "Dynamic Relaxation Type", .default_value = norelaxation}),
+
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}),
+
+      parameter<int>("NUMSTEP", {.description = "Number of Time Steps", .default_value = 1}),
+
+      parameter<double>("MAXTIME", {.description = "", .default_value = 4.0}),
+
+      parameter<double>("NORMAL", {.description = "", .default_value = 1.0})});
 }
 
 
@@ -228,35 +226,34 @@ void Inpar::ArteryNetwork::set_valid_conditions(
 void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
-  Core::Utils::SectionSpecs biofilmcontrol{"BIOFILM CONTROL"};
+  list["BIOFILM CONTROL"] = all_of({
 
-  biofilmcontrol.specs.emplace_back(parameter<bool>("BIOFILMGROWTH",
-      {.description = "Scatra algorithm for biofilm growth", .default_value = false}));
-  biofilmcontrol.specs.emplace_back(parameter<bool>("AVGROWTH",
-      {.description = "The calculation of growth parameters is based on averaged values",
-          .default_value = false}));
-  biofilmcontrol.specs.emplace_back(parameter<double>("FLUXCOEF",
-      {.description = "Coefficient for growth due to scalar flux", .default_value = 0.0}));
-  biofilmcontrol.specs.emplace_back(parameter<double>("NORMFORCEPOSCOEF",
-      {.description = "Coefficient for erosion due to traction normal surface forces",
-          .default_value = 0.0}));
-  biofilmcontrol.specs.emplace_back(parameter<double>("NORMFORCENEGCOEF",
-      {.description = "Coefficient for erosion due to compression normal surface forces",
-          .default_value = 0.0}));
-  biofilmcontrol.specs.emplace_back(parameter<double>("TANGONEFORCECOEF",
-      {.description = "Coefficient for erosion due to the first tangential surface force",
-          .default_value = 0.0}));
-  biofilmcontrol.specs.emplace_back(parameter<double>("TANGTWOFORCECOEF",
-      {.description = "Coefficient for erosion due to the second tangential surface force",
-          .default_value = 0.0}));
-  biofilmcontrol.specs.emplace_back(parameter<double>(
-      "BIOTIMESTEP", {.description = "Time step size for biofilm growth", .default_value = 0.05}));
-  biofilmcontrol.specs.emplace_back(parameter<int>("BIONUMSTEP",
-      {.description = "Maximum number of steps for biofilm growth", .default_value = 0}));
-  biofilmcontrol.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
-      {.description = "Do you want to write Gmsh postprocessing files?", .default_value = false}));
-
-  biofilmcontrol.move_into_collection(list);
+      parameter<bool>("BIOFILMGROWTH",
+          {.description = "Scatra algorithm for biofilm growth", .default_value = false}),
+      parameter<bool>("AVGROWTH",
+          {.description = "The calculation of growth parameters is based on averaged values",
+              .default_value = false}),
+      parameter<double>("FLUXCOEF",
+          {.description = "Coefficient for growth due to scalar flux", .default_value = 0.0}),
+      parameter<double>("NORMFORCEPOSCOEF",
+          {.description = "Coefficient for erosion due to traction normal surface forces",
+              .default_value = 0.0}),
+      parameter<double>("NORMFORCENEGCOEF",
+          {.description = "Coefficient for erosion due to compression normal surface forces",
+              .default_value = 0.0}),
+      parameter<double>("TANGONEFORCECOEF",
+          {.description = "Coefficient for erosion due to the first tangential surface force",
+              .default_value = 0.0}),
+      parameter<double>("TANGTWOFORCECOEF",
+          {.description = "Coefficient for erosion due to the second tangential surface force",
+              .default_value = 0.0}),
+      parameter<double>("BIOTIMESTEP",
+          {.description = "Time step size for biofilm growth", .default_value = 0.05}),
+      parameter<int>("BIONUMSTEP",
+          {.description = "Maximum number of steps for biofilm growth", .default_value = 0}),
+      parameter<bool>(
+          "OUTPUT_GMSH", {.description = "Do you want to write Gmsh postprocessing files?",
+                             .default_value = false})});
 }
 
 
@@ -282,60 +279,58 @@ void Inpar::ReducedLung::set_valid_parameters(std::map<std::string, Core::IO::In
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs redawdyn{"REDUCED DIMENSIONAL AIRWAYS DYNAMIC"};
+  list["REDUCED DIMENSIONAL AIRWAYS DYNAMIC"] = all_of({
 
-  redawdyn.specs.emplace_back(deprecated_selection<RedAirwaysDyntype>("DYNAMICTYPE",
-      {
-          {"OneStepTheta", one_step_theta},
-      },
-      {.description = "OneStepTheta Scheme", .default_value = one_step_theta}));
+      deprecated_selection<RedAirwaysDyntype>("DYNAMICTYPE",
+          {
+              {"OneStepTheta", one_step_theta},
+          },
+          {.description = "OneStepTheta Scheme", .default_value = one_step_theta}),
 
-  redawdyn.specs.emplace_back(deprecated_selection<RedAirwaysDyntype>("SOLVERTYPE",
-      {
-          {"Linear", linear},
-          {"Nonlinear", nonlinear},
-      },
-      {.description = "Solver type", .default_value = linear}));
+      deprecated_selection<RedAirwaysDyntype>("SOLVERTYPE",
+          {
+              {"Linear", linear},
+              {"Nonlinear", nonlinear},
+          },
+          {.description = "Solver type", .default_value = linear}),
 
-  redawdyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
-  redawdyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "Number of Time Steps", .default_value = 0}));
-  redawdyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-  redawdyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  redawdyn.specs.emplace_back(parameter<double>(
-      "THETA", {.description = "One-step-theta time integration factor", .default_value = 1.0}));
 
-  redawdyn.specs.emplace_back(parameter<int>(
-      "MAXITERATIONS", {.description = "maximum iteration steps", .default_value = 1}));
-  redawdyn.specs.emplace_back(
-      parameter<double>("TOLERANCE", {.description = "tolerance", .default_value = 1.0E-6}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}),
 
-  // number of linear solver used for reduced dimensional airways dynamic
-  redawdyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for reduced dim arterial dynamics",
-          .default_value = -1}));
+      parameter<int>("NUMSTEP", {.description = "Number of Time Steps", .default_value = 0}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<double>(
+          "THETA", {.description = "One-step-theta time integration factor", .default_value = 1.0}),
 
-  redawdyn.specs.emplace_back(parameter<bool>(
-      "SOLVESCATRA", {.description = "Flag to (de)activate solving scalar transport in blood",
-                         .default_value = false}));
+      parameter<int>(
+          "MAXITERATIONS", {.description = "maximum iteration steps", .default_value = 1}),
 
-  redawdyn.specs.emplace_back(parameter<bool>("COMPAWACINTER",
-      {.description = "Flag to (de)activate computation of airway-acinus interdependency",
-          .default_value = false}));
+      parameter<double>("TOLERANCE", {.description = "tolerance", .default_value = 1.0E-6}),
 
-  redawdyn.specs.emplace_back(parameter<bool>("CALCV0PRESTRESS",
-      {.description =
-              "Flag to (de)activate initial acini volume adjustment with pre-stress condition",
-          .default_value = false}));
+      // number of linear solver used for reduced dimensional airways dynamic
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for reduced dim arterial dynamics",
+              .default_value = -1}),
 
-  redawdyn.specs.emplace_back(parameter<double>("TRANSPULMPRESS",
-      {.description = "Transpulmonary pressure needed for recalculation of acini volumes",
-          .default_value = 800.0}));
+      parameter<bool>(
+          "SOLVESCATRA", {.description = "Flag to (de)activate solving scalar transport in blood",
+                             .default_value = false}),
 
-  redawdyn.move_into_collection(list);
+      parameter<bool>("COMPAWACINTER",
+          {.description = "Flag to (de)activate computation of airway-acinus interdependency",
+              .default_value = false}),
+
+      parameter<bool>("CALCV0PRESTRESS",
+          {.description =
+                  "Flag to (de)activate initial acini volume adjustment with pre-stress condition",
+              .default_value = false}),
+
+      parameter<double>("TRANSPULMPRESS",
+          {.description = "Transpulmonary pressure needed for recalculation of acini volumes",
+              .default_value = 800.0})});
 }
 
 

--- a/src/inpar/4C_inpar_cardiac_monodomain.cpp
+++ b/src/inpar/4C_inpar_cardiac_monodomain.cpp
@@ -18,21 +18,20 @@ void Inpar::ElectroPhysiology::set_valid_parameters(
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs epcontrol{"CARDIAC MONODOMAIN CONTROL"};
+  list["CARDIAC MONODOMAIN CONTROL"] = all_of({
 
-  // Parameters for reaction-diffusion systems (for example cardiac electrophysiology)
-  epcontrol.specs.emplace_back(parameter<int>("WRITEMAXINTSTATE",
-      {.description = "number of maximal internal state variables to be postprocessed",
-          .default_value = 0}));
-  epcontrol.specs.emplace_back(parameter<int>("WRITEMAXIONICCURRENTS",
-      {.description = "number of maximal ionic currents to be postprocessed", .default_value = 0}));
+      // Parameters for reaction-diffusion systems (for example cardiac electrophysiology)
+      parameter<int>("WRITEMAXINTSTATE",
+          {.description = "number of maximal internal state variables to be postprocessed",
+              .default_value = 0}),
+      parameter<int>("WRITEMAXIONICCURRENTS",
+          {.description = "number of maximal ionic currents to be postprocessed",
+              .default_value = 0}),
 
-  epcontrol.specs.emplace_back(parameter<double>("ACTTHRES",
-      {.description =
-              "threshold for the potential for computing and postprocessing activation time ",
-          .default_value = 1.0}));
-
-  epcontrol.move_into_collection(list);
+      parameter<double>("ACTTHRES",
+          {.description =
+                  "threshold for the potential for computing and postprocessing activation time ",
+              .default_value = 1.0})});
 }
 
 

--- a/src/inpar/4C_inpar_cardiac_monodomain.cpp
+++ b/src/inpar/4C_inpar_cardiac_monodomain.cpp
@@ -8,8 +8,7 @@
 #include "4C_inpar_cardiac_monodomain.hpp"
 
 #include "4C_fem_condition_definition.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::ElectroPhysiology::set_valid_parameters(

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -20,586 +20,588 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs cardvasc0dstruct{"CARDIOVASCULAR 0D-STRUCTURE COUPLING"};
+  list["CARDIOVASCULAR 0D-STRUCTURE COUPLING"] = all_of({
 
-  cardvasc0dstruct.specs.emplace_back(parameter<double>("TOL_CARDVASC0D_RES",
-      {.description = "tolerance in the cardiovascular0d error norm for the Newton iteration",
-          .default_value = 1.0E-08}));
-  cardvasc0dstruct.specs.emplace_back(parameter<double>("TOL_CARDVASC0D_DOFINCR",
-      {.description =
-              "tolerance in the cardiovascular0d dof increment error norm for the Newton iteration",
-          .default_value = 1.0E-08}));
-  cardvasc0dstruct.specs.emplace_back(parameter<double>("TIMINT_THETA",
-      {.description = "theta for one-step-theta time-integration scheme of Cardiovascular0D",
-          .default_value = 0.5}));
-  cardvasc0dstruct.specs.emplace_back(parameter<bool>("RESTART_WITH_CARDVASC0D",
-      {.description = "Must be chosen if a non-cardiovascular0d simulation is to be restarted as "
-                      "cardiovascular0d-structural coupled problem.",
-          .default_value = false}));
-  cardvasc0dstruct.specs.emplace_back(parameter<bool>("ENHANCED_OUTPUT",
-      {.description = "Set to yes for enhanced output (like e.g. derivative information)",
-          .default_value = false}));
+      parameter<double>("TOL_CARDVASC0D_RES",
+          {.description = "tolerance in the cardiovascular0d error norm for the Newton iteration",
+              .default_value = 1.0E-08}),
+      parameter<double>(
+          "TOL_CARDVASC0D_DOFINCR", {.description = "tolerance in the cardiovascular0d dof "
+                                                    "increment error norm for the Newton iteration",
+                                        .default_value = 1.0E-08}),
+      parameter<double>("TIMINT_THETA",
+          {.description = "theta for one-step-theta time-integration scheme of Cardiovascular0D",
+              .default_value = 0.5}),
+      parameter<bool>("RESTART_WITH_CARDVASC0D",
+          {.description =
+                  "Must be chosen if a non-cardiovascular0d simulation is to be restarted as "
+                  "cardiovascular0d-structural coupled problem.",
+              .default_value = false}),
+      parameter<bool>("ENHANCED_OUTPUT",
+          {.description = "Set to yes for enhanced output (like e.g. derivative information)",
+              .default_value = false}),
 
-  // linear solver id used for monolithic 0D cardiovascular-structural problems
-  cardvasc0dstruct.specs.emplace_back(parameter<int>("LINEAR_COUPLED_SOLVER",
-      {.description = "number of linear solver used for cardiovascular 0D-structural problems",
-          .default_value = -1}));
+      // linear solver id used for monolithic 0D cardiovascular-structural problems
+      parameter<int>("LINEAR_COUPLED_SOLVER",
+          {.description = "number of linear solver used for cardiovascular 0D-structural problems",
+              .default_value = -1}),
 
-  cardvasc0dstruct.specs.emplace_back(deprecated_selection<Cardvasc0DSolveAlgo>("SOLALGORITHM",
-      {
-          {"block", Inpar::Cardiovascular0D::cardvasc0dsolve_block},
-          {"direct", Inpar::Cardiovascular0D::cardvasc0dsolve_direct},
-      },
-      {.description = "", .default_value = Inpar::Cardiovascular0D::cardvasc0dsolve_direct}));
+      deprecated_selection<Cardvasc0DSolveAlgo>("SOLALGORITHM",
+          {
+              {"block", Inpar::Cardiovascular0D::cardvasc0dsolve_block},
+              {"direct", Inpar::Cardiovascular0D::cardvasc0dsolve_direct},
+          },
+          {.description = "", .default_value = Inpar::Cardiovascular0D::cardvasc0dsolve_direct}),
 
-  cardvasc0dstruct.specs.emplace_back(
-      parameter<double>("T_PERIOD", {.description = "periodic time", .default_value = -1.0}));
-  cardvasc0dstruct.specs.emplace_back(parameter<double>(
-      "EPS_PERIODIC", {.description = "tolerance for periodic state", .default_value = 1.0e-16}));
 
-  cardvasc0dstruct.specs.emplace_back(parameter<bool>("PTC_3D0D",
-      {.description = "Set to yes for doing PTC 2x2 block system.", .default_value = false}));
+      parameter<double>("T_PERIOD", {.description = "periodic time", .default_value = -1.0}),
+      parameter<double>("EPS_PERIODIC",
+          {.description = "tolerance for periodic state", .default_value = 1.0e-16}),
 
-  cardvasc0dstruct.specs.emplace_back(parameter<double>(
-      "K_PTC", {.description = "PTC parameter: 0 means normal Newton, ->infty means steepest desc",
-                   .default_value = 0.0}));
+      parameter<bool>("PTC_3D0D",
+          {.description = "Set to yes for doing PTC 2x2 block system.", .default_value = false}),
 
-  cardvasc0dstruct.move_into_collection(list);
+      parameter<double>("K_PTC",
+          {.description = "PTC parameter: 0 means normal Newton, ->infty means steepest desc",
+              .default_value = 0.0})});
+  list["CARDIOVASCULAR 0D-STRUCTURE COUPLING/SYS-PUL CIRCULATION PARAMETERS"] = all_of({
 
-  Core::Utils::SectionSpecs cardvasc0dsyspulcirc{
-      cardvasc0dstruct, "SYS-PUL CIRCULATION PARAMETERS"};
+      parameter<double>(
+          "R_arvalve_max_l", {.description = "maximal left arterial (semilunar) valve resistance",
+                                 .default_value = 0.0}),
+      parameter<double>(
+          "R_arvalve_min_l", {.description = "minimal left arterial (semilunar) valve resistance",
+                                 .default_value = 0.0}),
+      parameter<double>("R_atvalve_max_l",
+          {.description = "maximal left atrial (atrioventricular) valve resistance",
+              .default_value = 0.0}),
+      parameter<double>("R_atvalve_min_l",
+          {.description = "minimal left atrial (atrioventricular) valve resistance",
+              .default_value = 0.0}),
+      parameter<double>(
+          "R_arvalve_max_r", {.description = "maximal right arterial (semilunar) valve resistance",
+                                 .default_value = 0.0}),
+      parameter<double>(
+          "R_arvalve_min_r", {.description = "minimal right arterial (semilunar) valve resistance",
+                                 .default_value = 0.0}),
+      parameter<double>("R_atvalve_max_r",
+          {.description = "maximal right atrial (atrioventricular) valve resistance",
+              .default_value = 0.0}),
+      parameter<double>("R_atvalve_min_r",
+          {.description = "minimal right atrial (atrioventricular) valve resistance",
+              .default_value = 0.0}),
 
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arvalve_max_l",
-      {.description = "maximal left arterial (semilunar) valve resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arvalve_min_l",
-      {.description = "minimal left arterial (semilunar) valve resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_atvalve_max_l", {.description = "maximal left atrial (atrioventricular) valve resistance",
-                             .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_atvalve_min_l", {.description = "minimal left atrial (atrioventricular) valve resistance",
-                             .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_arvalve_max_r", {.description = "maximal right arterial (semilunar) valve resistance",
-                             .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_arvalve_min_r", {.description = "minimal right arterial (semilunar) valve resistance",
-                             .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_atvalve_max_r", {.description = "maximal right atrial (atrioventricular) valve resistance",
-                             .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_atvalve_min_r", {.description = "minimal right atrial (atrioventricular) valve resistance",
-                             .default_value = 0.0}));
 
-  cardvasc0dsyspulcirc.specs.emplace_back(
       deprecated_selection<Cardvasc0DAtriumModel>("ATRIUM_MODEL",
           {
               {"0D", Inpar::Cardiovascular0D::atr_elastance_0d},
               {"3D", Inpar::Cardiovascular0D::atr_structure_3d},
               {"prescribed", Inpar::Cardiovascular0D::atr_prescribed},
           },
-          {.description = "", .default_value = Inpar::Cardiovascular0D::atr_elastance_0d}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Atrium_act_curve_l",
-      {.description = "left atrial activation curve (ONLY for ATRIUM_MODEL '0D'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Atrium_act_curve_r",
-      {.description = "right atrial activation curve (ONLY for ATRIUM_MODEL '0D'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Atrium_prescr_E_curve_l",
-      {.description =
-              "left atrial elastance prescription curve (ONLY for ATRIUM_MODEL 'prescribed'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Atrium_prescr_E_curve_r",
-      {.description =
-              "right atrial elastance prescription curve (ONLY for ATRIUM_MODEL 'prescribed'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "E_at_max_l", {.description = "0D maximum left atrial elastance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "E_at_min_l", {.description = "0D baseline left atrial elastance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "E_at_max_r", {.description = "0D maximum right atrial elastance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "E_at_min_r", {.description = "0D baseline right atrial elastance", .default_value = 0.0}));
+          {.description = "", .default_value = Inpar::Cardiovascular0D::atr_elastance_0d}),
+      parameter<int>("Atrium_act_curve_l",
+          {.description = "left atrial activation curve (ONLY for ATRIUM_MODEL '0D'!)",
+              .default_value = -1}),
+      parameter<int>("Atrium_act_curve_r",
+          {.description = "right atrial activation curve (ONLY for ATRIUM_MODEL '0D'!)",
+              .default_value = -1}),
+      parameter<int>("Atrium_prescr_E_curve_l",
+          {.description =
+                  "left atrial elastance prescription curve (ONLY for ATRIUM_MODEL 'prescribed'!)",
+              .default_value = -1}),
+      parameter<int>("Atrium_prescr_E_curve_r",
+          {.description =
+                  "right atrial elastance prescription curve (ONLY for ATRIUM_MODEL 'prescribed'!)",
+              .default_value = -1}),
+      parameter<double>(
+          "E_at_max_l", {.description = "0D maximum left atrial elastance", .default_value = 0.0}),
+      parameter<double>(
+          "E_at_min_l", {.description = "0D baseline left atrial elastance", .default_value = 0.0}),
+      parameter<double>(
+          "E_at_max_r", {.description = "0D maximum right atrial elastance", .default_value = 0.0}),
+      parameter<double>("E_at_min_r",
+          {.description = "0D baseline right atrial elastance", .default_value = 0.0}),
 
-  cardvasc0dsyspulcirc.specs.emplace_back(
+
       deprecated_selection<Cardvasc0DVentricleModel>("VENTRICLE_MODEL",
           {
               {"3D", Inpar::Cardiovascular0D::ventr_structure_3d},
               {"0D", Inpar::Cardiovascular0D::ventr_elastance_0d},
               {"prescribed", Inpar::Cardiovascular0D::ventr_prescribed},
           },
-          {.description = "", .default_value = Inpar::Cardiovascular0D::ventr_structure_3d}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Ventricle_act_curve_l",
-      {.description = "left ventricular activation curve (ONLY for VENTRICLE_MODEL '0D'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Ventricle_act_curve_r",
-      {.description = "right ventricular activation curve (ONLY for VENTRICLE_MODEL '0D'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>(
-      "Ventricle_prescr_E_curve_l", {.description = "left ventricular elastance prescription curve "
-                                                    "(ONLY for VENTRICLE_MODEL 'prescribed'!)",
-                                        .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<int>("Ventricle_prescr_E_curve_r",
-      {.description = "right ventricular elastance prescription curve (ONLY for "
-                      "VENTRICLE_MODEL 'prescribed'!)",
-          .default_value = -1}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "E_v_max_l", {.description = "0D maximum left ventricular elastance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("E_v_min_l",
-      {.description = "0D baseline left ventricular elastance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("E_v_max_r",
-      {.description = "0D maximum right ventricular elastance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("E_v_min_r",
-      {.description = "0D baseline right ventricular elastance", .default_value = 0.0}));
+          {.description = "", .default_value = Inpar::Cardiovascular0D::ventr_structure_3d}),
+      parameter<int>("Ventricle_act_curve_l",
+          {.description = "left ventricular activation curve (ONLY for VENTRICLE_MODEL '0D'!)",
+              .default_value = -1}),
+      parameter<int>("Ventricle_act_curve_r",
+          {.description = "right ventricular activation curve (ONLY for VENTRICLE_MODEL '0D'!)",
+              .default_value = -1}),
+      parameter<int>("Ventricle_prescr_E_curve_l",
+          {.description = "left ventricular elastance prescription curve "
+                          "(ONLY for VENTRICLE_MODEL 'prescribed'!)",
+              .default_value = -1}),
+      parameter<int>("Ventricle_prescr_E_curve_r",
+          {.description = "right ventricular elastance prescription curve (ONLY for "
+                          "VENTRICLE_MODEL 'prescribed'!)",
+              .default_value = -1}),
+      parameter<double>("E_v_max_l",
+          {.description = "0D maximum left ventricular elastance", .default_value = 0.0}),
+      parameter<double>("E_v_min_l",
+          {.description = "0D baseline left ventricular elastance", .default_value = 0.0}),
+      parameter<double>("E_v_max_r",
+          {.description = "0D maximum right ventricular elastance", .default_value = 0.0}),
+      parameter<double>("E_v_min_r",
+          {.description = "0D baseline right ventricular elastance", .default_value = 0.0}),
 
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "C_ar_sys", {.description = "systemic arterial compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_ar_sys", {.description = "systemic arterial resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "L_ar_sys", {.description = "systemic arterial inertance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "Z_ar_sys", {.description = "systemic arterial impedance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "C_ar_pul", {.description = "pulmonary arterial compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_ar_pul", {.description = "pulmonary arterial resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "L_ar_pul", {.description = "pulmonary arterial inertance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "Z_ar_pul", {.description = "pulmonary arterial impedance", .default_value = 0.0}));
+      parameter<double>(
+          "C_ar_sys", {.description = "systemic arterial compliance", .default_value = 0.0}),
+      parameter<double>(
+          "R_ar_sys", {.description = "systemic arterial resistance", .default_value = 0.0}),
+      parameter<double>(
+          "L_ar_sys", {.description = "systemic arterial inertance", .default_value = 0.0}),
+      parameter<double>(
+          "Z_ar_sys", {.description = "systemic arterial impedance", .default_value = 0.0}),
+      parameter<double>(
+          "C_ar_pul", {.description = "pulmonary arterial compliance", .default_value = 0.0}),
+      parameter<double>(
+          "R_ar_pul", {.description = "pulmonary arterial resistance", .default_value = 0.0}),
+      parameter<double>(
+          "L_ar_pul", {.description = "pulmonary arterial inertance", .default_value = 0.0}),
+      parameter<double>(
+          "Z_ar_pul", {.description = "pulmonary arterial impedance", .default_value = 0.0}),
 
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "C_ven_sys", {.description = "systemic venous compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_ven_sys", {.description = "systemic venous resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "L_ven_sys", {.description = "systemic venous inertance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "C_ven_pul", {.description = "pulmonary venous compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_ven_pul", {.description = "pulmonary venous resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "L_ven_pul", {.description = "pulmonary venous inertance", .default_value = 0.0}));
+      parameter<double>(
+          "C_ven_sys", {.description = "systemic venous compliance", .default_value = 0.0}),
+      parameter<double>(
+          "R_ven_sys", {.description = "systemic venous resistance", .default_value = 0.0}),
+      parameter<double>(
+          "L_ven_sys", {.description = "systemic venous inertance", .default_value = 0.0}),
+      parameter<double>(
+          "C_ven_pul", {.description = "pulmonary venous compliance", .default_value = 0.0}),
+      parameter<double>(
+          "R_ven_pul", {.description = "pulmonary venous resistance", .default_value = 0.0}),
+      parameter<double>(
+          "L_ven_pul", {.description = "pulmonary venous inertance", .default_value = 0.0}),
 
-  // initial conditions
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_vin_l_0", {.description = "initial left ventricular in-flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_at_l_0", {.description = "initial left atrial pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_vout_l_0", {.description = "initial left ventricular out-flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_v_l_0", {.description = "initial left ventricular pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_ar_sys_0", {.description = "initial systemic arterial pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_ar_sys_0", {.description = "initial systemic arterial flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_ven_sys_0", {.description = "initial systemic venous pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_ven_sys_0", {.description = "initial systemic venous flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_vin_r_0", {.description = "initial right ventricular in-flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_at_r_0", {.description = "initial right atrial pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_vout_r_0", {.description = "initial right ventricular out-flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_v_r_0", {.description = "initial right ventricular pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_ar_pul_0", {.description = "initial pulmonary arterial pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_ar_pul_0", {.description = "initial pulmonary arterial flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "p_ven_pul_0", {.description = "initial pulmonary venous pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_ven_pul_0", {.description = "initial pulmonary venous flux", .default_value = 0.0}));
+      // initial conditions
+      parameter<double>(
+          "q_vin_l_0", {.description = "initial left ventricular in-flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_at_l_0", {.description = "initial left atrial pressure", .default_value = 0.0}),
+      parameter<double>(
+          "q_vout_l_0", {.description = "initial left ventricular out-flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_v_l_0", {.description = "initial left ventricular pressure", .default_value = 0.0}),
+      parameter<double>("p_ar_sys_0",
+          {.description = "initial systemic arterial pressure", .default_value = 0.0}),
+      parameter<double>(
+          "q_ar_sys_0", {.description = "initial systemic arterial flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_ven_sys_0", {.description = "initial systemic venous pressure", .default_value = 0.0}),
+      parameter<double>(
+          "q_ven_sys_0", {.description = "initial systemic venous flux", .default_value = 0.0}),
+      parameter<double>(
+          "q_vin_r_0", {.description = "initial right ventricular in-flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_at_r_0", {.description = "initial right atrial pressure", .default_value = 0.0}),
+      parameter<double>("q_vout_r_0",
+          {.description = "initial right ventricular out-flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_v_r_0", {.description = "initial right ventricular pressure", .default_value = 0.0}),
+      parameter<double>("p_ar_pul_0",
+          {.description = "initial pulmonary arterial pressure", .default_value = 0.0}),
+      parameter<double>(
+          "q_ar_pul_0", {.description = "initial pulmonary arterial flux", .default_value = 0.0}),
+      parameter<double>("p_ven_pul_0",
+          {.description = "initial pulmonary venous pressure", .default_value = 0.0}),
+      parameter<double>(
+          "q_ven_pul_0", {.description = "initial pulmonary venous flux", .default_value = 0.0}),
 
-  // unstressed volumes - only for postprocessing matters!
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_at_l_u", {.description = "unstressed volume of left 0D atrium", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_v_l_u", {.description = "unstressed volume of left 0D ventricle", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_ar_sys_u", {.description = "unstressed volume of systemic arteries and capillaries",
-                        .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_ven_sys_u",
-      {.description = "unstressed volume of systemic veins", .default_value = 100.0e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_at_r_u", {.description = "unstressed volume of right 0D atrium", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_v_r_u", {.description = "unstressed volume of right 0D ventricle", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_ar_pul_u", {.description = "unstressed volume of pulmonary arteries and capillaries",
-                        .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_ven_pul_u",
-      {.description = "unstressed volume of pulmonary veins", .default_value = 120.0e3}));
-
-
-
-  // parameters for extended sys pul circulation including periphery
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arspl_sys",
-      {.description = "systemic arterial splanchnic compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arspl_sys",
-      {.description = "systemic arterial splanchnic resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arespl_sys",
-      {.description = "systemic arterial extra-splanchnic compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arespl_sys",
-      {.description = "systemic arterial extra-splanchnic resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_armsc_sys",
-      {.description = "systemic arterial muscular compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_armsc_sys",
-      {.description = "systemic arterial muscular resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arcer_sys",
-      {.description = "systemic arterial cerebral compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arcer_sys",
-      {.description = "systemic arterial cerebral resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_arcor_sys",
-      {.description = "systemic arterial coronary compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_arcor_sys",
-      {.description = "systemic arterial coronary resistance", .default_value = 0.0}));
-
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_venspl_sys",
-      {.description = "systemic venous splanchnic compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_venspl_sys",
-      {.description = "systemic venous splanchnic resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_venespl_sys",
-      {.description = "systemic venous extra-splanchnic compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_venespl_sys",
-      {.description = "systemic venous extra-splanchnic resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_venmsc_sys",
-      {.description = "systemic venous muscular compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_venmsc_sys",
-      {.description = "systemic venous muscular resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_vencer_sys",
-      {.description = "systemic venous cerebral compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_vencer_sys",
-      {.description = "systemic venous cerebral resistance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("C_vencor_sys",
-      {.description = "systemic venous coronary compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("R_vencor_sys",
-      {.description = "systemic venous coronary resistance", .default_value = 0.0}));
-
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "C_cap_pul", {.description = "pulmonary capillary compliance", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "R_cap_pul", {.description = "pulmonary capillary resistance", .default_value = 0.0}));
-
-  // initial conditions for extended sys pul circulation including periphery
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_arperi_sys_0",
-      {.description = "initial systemic peripheral arterial pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arspl_sys_0",
-      {.description = "initial systemic arterial splanchnic flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arespl_sys_0",
-      {.description = "initial systemic arterial extra-splanchnic flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_armsc_sys_0",
-      {.description = "initial systemic arterial muscular flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arcer_sys_0",
-      {.description = "initial systemic arterial cerebral flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_arcor_sys_0",
-      {.description = "initial systemic arterial coronary flux", .default_value = 0.0}));
-
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_venspl_sys_0",
-      {.description = "initial systemic venous splanchnic pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_venspl_sys_0",
-      {.description = "initial systemic venous splanchnic flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_venespl_sys_0",
-      {.description = "initial systemic venous extra-splanchnic pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_venespl_sys_0",
-      {.description = "initial systemic venous extra-splanchnic flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_venmsc_sys_0",
-      {.description = "initial systemic venous muscular pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_venmsc_sys_0",
-      {.description = "initial systemic venous muscular flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_vencer_sys_0",
-      {.description = "initial systemic venous cerebral pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_vencer_sys_0",
-      {.description = "initial systemic venous cerebral flux", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_vencor_sys_0",
-      {.description = "initial systemic venous coronary pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("q_vencor_sys_0",
-      {.description = "initial systemic venous coronary flux", .default_value = 0.0}));
-
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("p_cap_pul_0",
-      {.description = "initial pulmonary capillary pressure", .default_value = 0.0}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "q_cap_pul_0", {.description = "initial pulmonary capillary flux", .default_value = 0.0}));
-
-
-  // unstressed volumes
-  // default values according to Ursino et al. Am J Physiol Heart Circ Physiol (2000), in mm^3
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_arspl_sys_u", {.description = "unstressed volume of systemic splanchnic arteries",
-                           .default_value = 274.4e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_arespl_sys_u", {.description = "unstressed volume of systemic extra-splanchnic arteries",
-                            .default_value = 134.64e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_armsc_sys_u", {.description = "unstressed volume of systemic muscular arteries",
-                           .default_value = 105.8e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_arcer_sys_u", {.description = "unstressed volume of systemic cerebral arteries",
-                           .default_value = 72.13e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_arcor_sys_u",
-      {.description = "unstressed volume of systemic coronary arteries", .default_value = 24.0e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_venspl_sys_u", {.description = "unstressed volume of systemic splanchnic veins",
-                            .default_value = 1121.0e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>(
-      "V_venespl_sys_u", {.description = "unstressed volume of systemic extra-splanchnic veins",
-                             .default_value = 550.0e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_venmsc_sys_u",
-      {.description = "unstressed volume of systemic muscular veins", .default_value = 432.14e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_vencer_sys_u",
-      {.description = "unstressed volume of systemic cerebral veins", .default_value = 294.64e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_vencor_sys_u",
-      {.description = "unstressed volume of systemic coronary veins", .default_value = 98.21e3}));
-  cardvasc0dsyspulcirc.specs.emplace_back(parameter<double>("V_cap_pul_u",
-      {.description = "unstressed volume of pulmonary capillaries", .default_value = 123.0e3}));
-
-  cardvasc0dsyspulcirc.move_into_collection(list);
+      // unstressed volumes - only for postprocessing matters!
+      parameter<double>(
+          "V_at_l_u", {.description = "unstressed volume of left 0D atrium", .default_value = 0.0}),
+      parameter<double>("V_v_l_u",
+          {.description = "unstressed volume of left 0D ventricle", .default_value = 0.0}),
+      parameter<double>(
+          "V_ar_sys_u", {.description = "unstressed volume of systemic arteries and capillaries",
+                            .default_value = 0.0}),
+      parameter<double>("V_ven_sys_u",
+          {.description = "unstressed volume of systemic veins", .default_value = 100.0e3}),
+      parameter<double>("V_at_r_u",
+          {.description = "unstressed volume of right 0D atrium", .default_value = 0.0}),
+      parameter<double>("V_v_r_u",
+          {.description = "unstressed volume of right 0D ventricle", .default_value = 0.0}),
+      parameter<double>(
+          "V_ar_pul_u", {.description = "unstressed volume of pulmonary arteries and capillaries",
+                            .default_value = 0.0}),
+      parameter<double>("V_ven_pul_u",
+          {.description = "unstressed volume of pulmonary veins", .default_value = 120.0e3}),
 
 
 
-  Core::Utils::SectionSpecs cardvascrespir0d{cardvasc0dstruct, "RESPIRATORY PARAMETERS"};
+      // parameters for extended sys pul circulation including periphery
+      parameter<double>("C_arspl_sys",
+          {.description = "systemic arterial splanchnic compliance", .default_value = 0.0}),
+      parameter<double>("R_arspl_sys",
+          {.description = "systemic arterial splanchnic resistance", .default_value = 0.0}),
+      parameter<double>("C_arespl_sys",
+          {.description = "systemic arterial extra-splanchnic compliance", .default_value = 0.0}),
+      parameter<double>("R_arespl_sys",
+          {.description = "systemic arterial extra-splanchnic resistance", .default_value = 0.0}),
+      parameter<double>("C_armsc_sys",
+          {.description = "systemic arterial muscular compliance", .default_value = 0.0}),
+      parameter<double>("R_armsc_sys",
+          {.description = "systemic arterial muscular resistance", .default_value = 0.0}),
+      parameter<double>("C_arcer_sys",
+          {.description = "systemic arterial cerebral compliance", .default_value = 0.0}),
+      parameter<double>("R_arcer_sys",
+          {.description = "systemic arterial cerebral resistance", .default_value = 0.0}),
+      parameter<double>("C_arcor_sys",
+          {.description = "systemic arterial coronary compliance", .default_value = 0.0}),
+      parameter<double>("R_arcor_sys",
+          {.description = "systemic arterial coronary resistance", .default_value = 0.0}),
 
-  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("C_venspl_sys",
+          {.description = "systemic venous splanchnic compliance", .default_value = 0.0}),
+      parameter<double>("R_venspl_sys",
+          {.description = "systemic venous splanchnic resistance", .default_value = 0.0}),
+      parameter<double>("C_venespl_sys",
+          {.description = "systemic venous extra-splanchnic compliance", .default_value = 0.0}),
+      parameter<double>("R_venespl_sys",
+          {.description = "systemic venous extra-splanchnic resistance", .default_value = 0.0}),
+      parameter<double>("C_venmsc_sys",
+          {.description = "systemic venous muscular compliance", .default_value = 0.0}),
+      parameter<double>("R_venmsc_sys",
+          {.description = "systemic venous muscular resistance", .default_value = 0.0}),
+      parameter<double>("C_vencer_sys",
+          {.description = "systemic venous cerebral compliance", .default_value = 0.0}),
+      parameter<double>("R_vencer_sys",
+          {.description = "systemic venous cerebral resistance", .default_value = 0.0}),
+      parameter<double>("C_vencor_sys",
+          {.description = "systemic venous coronary compliance", .default_value = 0.0}),
+      parameter<double>("R_vencor_sys",
+          {.description = "systemic venous coronary resistance", .default_value = 0.0}),
+
+      parameter<double>(
+          "C_cap_pul", {.description = "pulmonary capillary compliance", .default_value = 0.0}),
+      parameter<double>(
+          "R_cap_pul", {.description = "pulmonary capillary resistance", .default_value = 0.0}),
+
+      // initial conditions for extended sys pul circulation including periphery
+      parameter<double>("p_arperi_sys_0",
+          {.description = "initial systemic peripheral arterial pressure", .default_value = 0.0}),
+      parameter<double>("q_arspl_sys_0",
+          {.description = "initial systemic arterial splanchnic flux", .default_value = 0.0}),
+      parameter<double>("q_arespl_sys_0",
+          {.description = "initial systemic arterial extra-splanchnic flux", .default_value = 0.0}),
+      parameter<double>("q_armsc_sys_0",
+          {.description = "initial systemic arterial muscular flux", .default_value = 0.0}),
+      parameter<double>("q_arcer_sys_0",
+          {.description = "initial systemic arterial cerebral flux", .default_value = 0.0}),
+      parameter<double>("q_arcor_sys_0",
+          {.description = "initial systemic arterial coronary flux", .default_value = 0.0}),
+
+      parameter<double>("p_venspl_sys_0",
+          {.description = "initial systemic venous splanchnic pressure", .default_value = 0.0}),
+      parameter<double>("q_venspl_sys_0",
+          {.description = "initial systemic venous splanchnic flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_venespl_sys_0", {.description = "initial systemic venous extra-splanchnic pressure",
+                                 .default_value = 0.0}),
+      parameter<double>("q_venespl_sys_0",
+          {.description = "initial systemic venous extra-splanchnic flux", .default_value = 0.0}),
+      parameter<double>("p_venmsc_sys_0",
+          {.description = "initial systemic venous muscular pressure", .default_value = 0.0}),
+      parameter<double>("q_venmsc_sys_0",
+          {.description = "initial systemic venous muscular flux", .default_value = 0.0}),
+      parameter<double>("p_vencer_sys_0",
+          {.description = "initial systemic venous cerebral pressure", .default_value = 0.0}),
+      parameter<double>("q_vencer_sys_0",
+          {.description = "initial systemic venous cerebral flux", .default_value = 0.0}),
+      parameter<double>("p_vencor_sys_0",
+          {.description = "initial systemic venous coronary pressure", .default_value = 0.0}),
+      parameter<double>("q_vencor_sys_0",
+          {.description = "initial systemic venous coronary flux", .default_value = 0.0}),
+
+      parameter<double>("p_cap_pul_0",
+          {.description = "initial pulmonary capillary pressure", .default_value = 0.0}),
+      parameter<double>(
+          "q_cap_pul_0", {.description = "initial pulmonary capillary flux", .default_value = 0.0}),
+
+
+      // unstressed volumes
+      // default values according to Ursino et al. Am J Physiol Heart Circ Physiol (2000), in mm^3
+      parameter<double>(
+          "V_arspl_sys_u", {.description = "unstressed volume of systemic splanchnic arteries",
+                               .default_value = 274.4e3}),
+      parameter<double>("V_arespl_sys_u",
+          {.description = "unstressed volume of systemic extra-splanchnic arteries",
+              .default_value = 134.64e3}),
+      parameter<double>(
+          "V_armsc_sys_u", {.description = "unstressed volume of systemic muscular arteries",
+                               .default_value = 105.8e3}),
+      parameter<double>(
+          "V_arcer_sys_u", {.description = "unstressed volume of systemic cerebral arteries",
+                               .default_value = 72.13e3}),
+      parameter<double>(
+          "V_arcor_sys_u", {.description = "unstressed volume of systemic coronary arteries",
+                               .default_value = 24.0e3}),
+      parameter<double>(
+          "V_venspl_sys_u", {.description = "unstressed volume of systemic splanchnic veins",
+                                .default_value = 1121.0e3}),
+      parameter<double>(
+          "V_venespl_sys_u", {.description = "unstressed volume of systemic extra-splanchnic veins",
+                                 .default_value = 550.0e3}),
+      parameter<double>(
+          "V_venmsc_sys_u", {.description = "unstressed volume of systemic muscular veins",
+                                .default_value = 432.14e3}),
+      parameter<double>(
+          "V_vencer_sys_u", {.description = "unstressed volume of systemic cerebral veins",
+                                .default_value = 294.64e3}),
+      parameter<double>(
+          "V_vencor_sys_u", {.description = "unstressed volume of systemic coronary veins",
+                                .default_value = 98.21e3}),
+      parameter<double>("V_cap_pul_u", {.description = "unstressed volume of pulmonary capillaries",
+                                           .default_value = 123.0e3})});
+
+
+
+  list["CARDIOVASCULAR 0D-STRUCTURE COUPLING/RESPIRATORY PARAMETERS"] = all_of({
+
       deprecated_selection<Cardvasc0DRespiratoryModel>("RESPIRATORY_MODEL",
           {
               {"None", Inpar::Cardiovascular0D::resp_none},
               {"Standard", Inpar::Cardiovascular0D::resp_standard},
           },
-          {.description = "", .default_value = Inpar::Cardiovascular0D::resp_none}));
+          {.description = "", .default_value = Inpar::Cardiovascular0D::resp_none}),
 
 
-  cardvascrespir0d.specs.emplace_back(
-      parameter<double>("L_alv", {.description = "alveolar inertance", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(
-      parameter<double>("R_alv", {.description = "alveolar resistance", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(
-      parameter<double>("E_alv", {.description = "alveolar elastance", .default_value = 0.0}));
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>("V_lung_tidal",
-      {.description = "tidal volume (the total volume of inspired air, in a single breath)",
-          .default_value = 0.4e6}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_lung_dead", {.description = "dead space volume", .default_value = 0.15e6}));
-  cardvascrespir0d.specs.emplace_back(
+      parameter<double>("L_alv", {.description = "alveolar inertance", .default_value = 0.0}),
+
+      parameter<double>("R_alv", {.description = "alveolar resistance", .default_value = 0.0}),
+
+      parameter<double>("E_alv", {.description = "alveolar elastance", .default_value = 0.0}),
+
+      parameter<double>("V_lung_tidal",
+          {.description = "tidal volume (the total volume of inspired air, in a single breath)",
+              .default_value = 0.4e6}),
+      parameter<double>(
+          "V_lung_dead", {.description = "dead space volume", .default_value = 0.15e6}),
+
       parameter<double>("V_lung_u", {.description = "unstressed lung volume (volume of the lung "
                                                     "when it is fully collapsed outside the body)",
-                                        .default_value = 0.0}));
+                                        .default_value = 0.0}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<int>("U_t_curve",
-      {.description = "time-varying, prescribed pleural pressure curve driven by diaphragm",
-          .default_value = -1}));
-  cardvascrespir0d.specs.emplace_back(
-      parameter<double>("U_m", {.description = "in-breath pressure", .default_value = 0.0}));
+      parameter<int>("U_t_curve",
+          {.description = "time-varying, prescribed pleural pressure curve driven by diaphragm",
+              .default_value = -1}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "fCO2_ext", {.description = "atmospheric CO2 gas fraction", .default_value = 0.03}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "fO2_ext", {.description = "atmospheric O2 gas fraction", .default_value = 0.21}));
+      parameter<double>("U_m", {.description = "in-breath pressure", .default_value = 0.0}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "kappa_CO2", {.description = "diffusion coefficient for CO2 across the hemato-alveolar "
-                                   "membrane, in molar value / (time * pressure)",
-                       .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "kappa_O2", {.description = "diffusion coefficient for O2 across the hemato-alveolar "
-                                  "membrane, in molar value / (time * pressure)",
-                      .default_value = 0.0}));
+      parameter<double>(
+          "fCO2_ext", {.description = "atmospheric CO2 gas fraction", .default_value = 0.03}),
+      parameter<double>(
+          "fO2_ext", {.description = "atmospheric O2 gas fraction", .default_value = 0.21}),
 
-  // should be 22.4 liters per mol !
-  // however we specify it as an input parameter since its decimal power depends on the system of
-  // units your whole model is specified in! i.e. if you have kg - mm - s - mmol, it's 22.4e3 mm^3 /
-  // mmol
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_m_gas", {.description = "molar volume of an ideal gas", .default_value = 22.4e3}));
+      parameter<double>(
+          "kappa_CO2", {.description = "diffusion coefficient for CO2 across the hemato-alveolar "
+                                       "membrane, in molar value / (time * pressure)",
+                           .default_value = 0.0}),
+      parameter<double>(
+          "kappa_O2", {.description = "diffusion coefficient for O2 across the hemato-alveolar "
+                                      "membrane, in molar value / (time * pressure)",
+                          .default_value = 0.0}),
 
-  // should be 47.1 mmHg = 6.279485 kPa !
-  // however we specify it as an input parameter since its decimal power depends on the system of
-  // units your whole model is specified in! i.e. if you have kg - mm - s - mmol, it's 6.279485 kPa
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "p_vap_water_37", {.description = "vapor pressure of water at 37  degrees celsius",
-                            .default_value = 6.279485}));
+      // should be 22.4 liters per mol !
+      // however we specify it as an input parameter since its decimal power depends on the system
+      // of units your whole model is specified in! i.e. if you have kg - mm - s - mmol, it's 22.4e3
+      // mm^3 / mmol
+      parameter<double>(
+          "V_m_gas", {.description = "molar volume of an ideal gas", .default_value = 22.4e3}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "alpha_CO2", {.description = "CO2 solubility constant, in molar value / (volume * pressure)",
-                       .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "alpha_O2", {.description = "O2 solubility constant, in molar value / (volume * pressure)",
-                      .default_value = 0.0}));
+      // should be 47.1 mmHg = 6.279485 kPa !
+      // however we specify it as an input parameter since its decimal power depends on the system
+      // of units your whole model is specified in! i.e. if you have kg - mm - s - mmol,
+      // it's 6.279485 kPa
+      parameter<double>(
+          "p_vap_water_37", {.description = "vapor pressure of water at 37  degrees celsius",
+                                .default_value = 6.279485}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "c_Hb", {.description = "hemoglobin concentration of the blood, in molar value / volume",
-                  .default_value = 0.0}));
+      parameter<double>("alpha_CO2",
+          {.description = "CO2 solubility constant, in molar value / (volume * pressure)",
+              .default_value = 0.0}),
+      parameter<double>("alpha_O2",
+          {.description = "O2 solubility constant, in molar value / (volume * pressure)",
+              .default_value = 0.0}),
 
-
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arspl",
-      {.description = "splanchnic metabolic rate of CO2 production", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arspl",
-      {.description = "splanchnic metabolic rate of O2 consumption", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arespl",
-      {.description = "extra-splanchnic metabolic rate of CO2 production", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arespl",
-      {.description = "extra-splanchnic metabolic rate of O2 consumption", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_armsc",
-      {.description = "muscular metabolic rate of CO2 production", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_armsc",
-      {.description = "muscular metabolic rate of O2 consumption", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arcer",
-      {.description = "cerebral metabolic rate of CO2 production", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arcer",
-      {.description = "cerebral metabolic rate of O2 consumption", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_CO2_arcor",
-      {.description = "coronary metabolic rate of CO2 production", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("M_O2_arcor",
-      {.description = "coronary metabolic rate of O2 consumption", .default_value = 0.0}));
-
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_tissspl", {.description = "splanchnic tissue volume", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_tissespl", {.description = "extra-splanchnic tissue volume", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_tissmsc", {.description = "muscular tissue volume", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_tisscer", {.description = "cerebral tissue volume", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_tisscor", {.description = "coronary tissue volume", .default_value = 1.0}));
+      parameter<double>(
+          "c_Hb", {.description = "hemoglobin concentration of the blood, in molar value / volume",
+                      .default_value = 0.0}),
 
 
-  // initial conditions for respiratory model
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "V_alv_0", {.description = "initial alveolar volume", .default_value = -1.0}));
-  cardvascrespir0d.specs.emplace_back(
-      parameter<double>("q_alv_0", {.description = "initial alveolar flux", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "p_alv_0", {.description = "initial alveolar pressure", .default_value = -1.0}));
+      parameter<double>("M_CO2_arspl",
+          {.description = "splanchnic metabolic rate of CO2 production", .default_value = 0.0}),
+      parameter<double>("M_O2_arspl",
+          {.description = "splanchnic metabolic rate of O2 consumption", .default_value = 0.0}),
+      parameter<double>(
+          "M_CO2_arespl", {.description = "extra-splanchnic metabolic rate of CO2 production",
+                              .default_value = 0.0}),
+      parameter<double>(
+          "M_O2_arespl", {.description = "extra-splanchnic metabolic rate of O2 consumption",
+                             .default_value = 0.0}),
+      parameter<double>("M_CO2_armsc",
+          {.description = "muscular metabolic rate of CO2 production", .default_value = 0.0}),
+      parameter<double>("M_O2_armsc",
+          {.description = "muscular metabolic rate of O2 consumption", .default_value = 0.0}),
+      parameter<double>("M_CO2_arcer",
+          {.description = "cerebral metabolic rate of CO2 production", .default_value = 0.0}),
+      parameter<double>("M_O2_arcer",
+          {.description = "cerebral metabolic rate of O2 consumption", .default_value = 0.0}),
+      parameter<double>("M_CO2_arcor",
+          {.description = "coronary metabolic rate of CO2 production", .default_value = 0.0}),
+      parameter<double>("M_O2_arcor",
+          {.description = "coronary metabolic rate of O2 consumption", .default_value = 0.0}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "fCO2_alv_0", {.description = "initial alveolar CO2 fraction", .default_value = 0.05263}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "fO2_alv_0", {.description = "initial alveolar O2 fraction", .default_value = 0.1368}));
+      parameter<double>(
+          "V_tissspl", {.description = "splanchnic tissue volume", .default_value = 1.0}),
+      parameter<double>(
+          "V_tissespl", {.description = "extra-splanchnic tissue volume", .default_value = 1.0}),
+      parameter<double>(
+          "V_tissmsc", {.description = "muscular tissue volume", .default_value = 1.0}),
+      parameter<double>(
+          "V_tisscer", {.description = "cerebral tissue volume", .default_value = 1.0}),
+      parameter<double>(
+          "V_tisscor", {.description = "coronary tissue volume", .default_value = 1.0}),
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arspl_sys_in_0",
-      {.description = "initial arterial splanchnic in-flux", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arsspl_sys_in_0",
-      {.description = "initial arterial extra-splanchnic in-flux", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("q_armsc_sys_in_0",
-      {.description = "initial arterial muscular in-flux", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arcer_sys_in_0",
-      {.description = "initial arterial cerebral in-flux", .default_value = 0.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("q_arcor_sys_in_0",
-      {.description = "initial arterial coronary in-flux", .default_value = 0.0}));
 
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_at_r_0",
-      {.description = "initial right atrial CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_at_r_0",
-      {.description = "initial right atrial O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_v_r_0",
-      {.description = "initial right ventricular CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_v_r_0",
-      {.description = "initial right ventricular O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ar_pul_0",
-      {.description = "initial pulmonary arterial CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ar_pul_0",
-      {.description = "initial pulmonary arterial O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_cap_pul_0",
-      {.description = "initial pulmonary capillary CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_cap_pul_0",
-      {.description = "initial pulmonary capillary O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ven_pul_0",
-      {.description = "initial pulmonary venous CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ven_pul_0",
-      {.description = "initial pulmonary venous O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_at_l_0",
-      {.description = "initial left atrial CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_at_l_0",
-      {.description = "initial left atrial O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_v_l_0",
-      {.description = "initial left ventricular CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_v_l_0",
-      {.description = "initial left ventricular O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ar_sys_0",
-      {.description = "initial systemic arterial CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ar_sys_0",
-      {.description = "initial systemic arterial O2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arspl_sys_0",
-      {.description = "initial systemic arterial splanchnic CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_arspl_sys_0",
-      {.description = "initial systemic arterial splanchnic O2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arespl_sys_0",
-      {.description = "initial systemic arterial extra-splanchnic CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_arespl_sys_0",
-      {.description = "initial systemic arterial extra-splanchnic O2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_armsc_sys_0",
-      {.description = "initial systemic arterial muscular CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_armsc_sys_0", {.description = "initial systemic arterial muscular O2 partial pressure",
-                              .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arcer_sys_0",
-      {.description = "initial systemic arterial cerebral CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_arcer_sys_0", {.description = "initial systemic arterial cerebral O2 partial pressure",
-                              .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_arcor_sys_0",
-      {.description = "initial systemic arterial coronary CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_arcor_sys_0", {.description = "initial systemic arterial coronary O2 partial pressure",
-                              .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_venspl_sys_0",
-      {.description = "initial systemic venous splanchnic CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_venspl_sys_0", {.description = "initial systemic venous splanchnic O2 partial pressure",
-                               .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_venespl_sys_0",
-      {.description = "initial systemic venous extra-splanchnic CO2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_venespl_sys_0",
-      {.description = "initial systemic venous extra-splanchnic O2 partial pressure",
-          .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppCO2_venmsc_sys_0", {.description = "initial systemic venous muscular CO2 partial pressure",
-                                .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_venmsc_sys_0", {.description = "initial systemic venous muscular O2 partial pressure",
-                               .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppCO2_vencer_sys_0", {.description = "initial systemic venous cerebral CO2 partial pressure",
-                                .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_vencer_sys_0", {.description = "initial systemic venous cerebral O2 partial pressure",
-                               .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppCO2_vencor_sys_0", {.description = "initial systemic venous coronary CO2 partial pressure",
-                                .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>(
-      "ppO2_vencor_sys_0", {.description = "initial systemic venous coronary O2 partial pressure",
-                               .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppCO2_ven_sys_0",
-      {.description = "initial systemic venous CO2 partial pressure", .default_value = 1.0}));
-  cardvascrespir0d.specs.emplace_back(parameter<double>("ppO2_ven_sys_0",
-      {.description = "initial systemic venous O2 partial pressure", .default_value = 1.0}));
+      // initial conditions for respiratory model
+      parameter<double>(
+          "V_alv_0", {.description = "initial alveolar volume", .default_value = -1.0}),
 
-  cardvascrespir0d.move_into_collection(list);
+      parameter<double>("q_alv_0", {.description = "initial alveolar flux", .default_value = 0.0}),
+      parameter<double>(
+          "p_alv_0", {.description = "initial alveolar pressure", .default_value = -1.0}),
 
-  Core::Utils::SectionSpecs mor{"MOR"};
+      parameter<double>(
+          "fCO2_alv_0", {.description = "initial alveolar CO2 fraction", .default_value = 0.05263}),
+      parameter<double>(
+          "fO2_alv_0", {.description = "initial alveolar O2 fraction", .default_value = 0.1368}),
 
-  mor.specs.emplace_back(parameter<std::string>("POD_MATRIX",
-      {.description = "filename of file containing projection matrix", .default_value = "none"}));
+      parameter<double>("q_arspl_sys_in_0",
+          {.description = "initial arterial splanchnic in-flux", .default_value = 0.0}),
+      parameter<double>("q_arsspl_sys_in_0",
+          {.description = "initial arterial extra-splanchnic in-flux", .default_value = 0.0}),
+      parameter<double>("q_armsc_sys_in_0",
+          {.description = "initial arterial muscular in-flux", .default_value = 0.0}),
+      parameter<double>("q_arcer_sys_in_0",
+          {.description = "initial arterial cerebral in-flux", .default_value = 0.0}),
+      parameter<double>("q_arcor_sys_in_0",
+          {.description = "initial arterial coronary in-flux", .default_value = 0.0}),
 
-  mor.move_into_collection(list);
+      parameter<double>("ppCO2_at_r_0",
+          {.description = "initial right atrial CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_at_r_0",
+          {.description = "initial right atrial O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_v_r_0",
+          {.description = "initial right ventricular CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_v_r_0",
+          {.description = "initial right ventricular O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_ar_pul_0",
+          {.description = "initial pulmonary arterial CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_ar_pul_0",
+          {.description = "initial pulmonary arterial O2 partial pressure", .default_value = 1.0}),
+      parameter<double>(
+          "ppCO2_cap_pul_0", {.description = "initial pulmonary capillary CO2 partial pressure",
+                                 .default_value = 1.0}),
+      parameter<double>("ppO2_cap_pul_0",
+          {.description = "initial pulmonary capillary O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_ven_pul_0",
+          {.description = "initial pulmonary venous CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_ven_pul_0",
+          {.description = "initial pulmonary venous O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_at_l_0",
+          {.description = "initial left atrial CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_at_l_0",
+          {.description = "initial left atrial O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_v_l_0",
+          {.description = "initial left ventricular CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_v_l_0",
+          {.description = "initial left ventricular O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_ar_sys_0",
+          {.description = "initial systemic arterial CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_ar_sys_0",
+          {.description = "initial systemic arterial O2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppCO2_arspl_sys_0",
+          {.description = "initial systemic arterial splanchnic CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_arspl_sys_0",
+          {.description = "initial systemic arterial splanchnic O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_arespl_sys_0",
+          {.description = "initial systemic arterial extra-splanchnic CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_arespl_sys_0",
+          {.description = "initial systemic arterial extra-splanchnic O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_armsc_sys_0",
+          {.description = "initial systemic arterial muscular CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_armsc_sys_0",
+          {.description = "initial systemic arterial muscular O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_arcer_sys_0",
+          {.description = "initial systemic arterial cerebral CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_arcer_sys_0",
+          {.description = "initial systemic arterial cerebral O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_arcor_sys_0",
+          {.description = "initial systemic arterial coronary CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_arcor_sys_0",
+          {.description = "initial systemic arterial coronary O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_venspl_sys_0",
+          {.description = "initial systemic venous splanchnic CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_venspl_sys_0",
+          {.description = "initial systemic venous splanchnic O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_venespl_sys_0",
+          {.description = "initial systemic venous extra-splanchnic CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_venespl_sys_0",
+          {.description = "initial systemic venous extra-splanchnic O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_venmsc_sys_0",
+          {.description = "initial systemic venous muscular CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_venmsc_sys_0",
+          {.description = "initial systemic venous muscular O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_vencer_sys_0",
+          {.description = "initial systemic venous cerebral CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_vencer_sys_0",
+          {.description = "initial systemic venous cerebral O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_vencor_sys_0",
+          {.description = "initial systemic venous coronary CO2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppO2_vencor_sys_0",
+          {.description = "initial systemic venous coronary O2 partial pressure",
+              .default_value = 1.0}),
+      parameter<double>("ppCO2_ven_sys_0",
+          {.description = "initial systemic venous CO2 partial pressure", .default_value = 1.0}),
+      parameter<double>("ppO2_ven_sys_0",
+          {.description = "initial systemic venous O2 partial pressure", .default_value = 1.0})});
+
+  list["MOR"] = all_of({
+
+      parameter<std::string>(
+          "POD_MATRIX", {.description = "filename of file containing projection matrix",
+                            .default_value = "none"})});
 }
 
 

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -9,8 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_constraint_framework.cpp
+++ b/src/inpar/4C_inpar_constraint_framework.cpp
@@ -7,8 +7,7 @@
 
 #include "4C_inpar_constraint_framework.hpp"
 
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/inpar/4C_inpar_constraint_framework.cpp
+++ b/src/inpar/4C_inpar_constraint_framework.cpp
@@ -20,30 +20,27 @@ void Inpar::CONSTRAINTS::set_valid_parameters(std::map<std::string, Core::IO::In
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs embeddedmeshcoupling{"EMBEDDED MESH COUPLING"};
-  {
-    embeddedmeshcoupling.specs.emplace_back(parameter<EmbeddedMeshCouplingStrategy>(
-        "COUPLING_STRATEGY", {.description = "Strategy to couple background and overlapping mesh",
-                                 .default_value = EmbeddedMeshCouplingStrategy::none}));
+  list["EMBEDDED MESH COUPLING"] = all_of({
 
-    embeddedmeshcoupling.specs.emplace_back(
-        parameter<SolidToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
-            {.description = "Shape functions that should be use in case of coupling using the "
-                            "Mortar/Lagrange  Multiplier method ",
-                .default_value = SolidToSolidMortarShapefunctions::none}));
+      parameter<EmbeddedMeshCouplingStrategy>(
+          "COUPLING_STRATEGY", {.description = "Strategy to couple background and overlapping mesh",
+                                   .default_value = EmbeddedMeshCouplingStrategy::none}),
 
-    embeddedmeshcoupling.specs.emplace_back(
-        parameter<EmbeddedMeshConstraintEnforcement>("CONSTRAINT_ENFORCEMENT",
-            {.description = "Apply a constraint enforcement in the embedded mesh coupling strategy",
-                .default_value = EmbeddedMeshConstraintEnforcement::none}));
 
-    embeddedmeshcoupling.specs.emplace_back(parameter<double>("CONSTRAINT_ENFORCEMENT_PENALTYPARAM",
-        {.description =
-                "Penalty parameter for the constraint enforcement in embedded mesh coupling",
-            .default_value = 0.0}));
+      parameter<SolidToSolidMortarShapefunctions>("MORTAR_SHAPE_FUNCTION",
+          {.description = "Shape functions that should be use in case of coupling using the "
+                          "Mortar/Lagrange  Multiplier method ",
+              .default_value = SolidToSolidMortarShapefunctions::none}),
 
-    embeddedmeshcoupling.move_into_collection(list);
-  }
+
+      parameter<EmbeddedMeshConstraintEnforcement>("CONSTRAINT_ENFORCEMENT",
+          {.description = "Apply a constraint enforcement in the embedded mesh coupling strategy",
+              .default_value = EmbeddedMeshConstraintEnforcement::none}),
+
+      parameter<double>("CONSTRAINT_ENFORCEMENT_PENALTYPARAM",
+          {.description =
+                  "Penalty parameter for the constraint enforcement in embedded mesh coupling",
+              .default_value = 0.0})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -11,8 +11,6 @@
 #include "4C_inpar_scatra.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_sparseoperator.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_elch.cpp
+++ b/src/inpar/4C_inpar_elch.cpp
@@ -20,45 +20,46 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs elchcontrol{"ELCH CONTROL"};
+  list["ELCH CONTROL"] = all_of({
 
-  elchcontrol.specs.emplace_back(parameter<int>("MOVBOUNDARYITEMAX",
-      {.description = "Maximum number of outer iterations in electrode shape change computations",
-          .default_value = 10}));
-  elchcontrol.specs.emplace_back(parameter<double>("MOVBOUNDARYCONVTOL",
-      {.description =
-              "Convergence check tolerance for outer loop in electrode shape change computations",
-          .default_value = 1e-6}));
-  elchcontrol.specs.emplace_back(parameter<double>(
-      "TEMPERATURE", {.description = "Constant temperature (Kelvin)", .default_value = 298.0}));
-  elchcontrol.specs.emplace_back(parameter<int>("TEMPERATURE_FROM_FUNCT",
-      {.description = "Homogeneous temperature within electrochemistry field that can be time "
-                      "dependent according to function definition",
-          .default_value = -1}));
-  elchcontrol.specs.emplace_back(parameter<double>("FARADAY_CONSTANT",
-      {.description = "Faraday constant (in unit system as chosen in input file)",
-          .default_value = 9.64853399e4}));
-  elchcontrol.specs.emplace_back(parameter<double>("GAS_CONSTANT",
-      {.description = "(universal) gas constant (in unit system as chosen in input file)",
-          .default_value = 8.314472}));
-  // parameter for possible types of ELCH algorithms for deforming meshes
-  elchcontrol.specs.emplace_back(deprecated_selection<Inpar::ElCh::ElchMovingBoundary>(
-      "MOVINGBOUNDARY",
-      {
-          {"No", elch_mov_bndry_no},
-          {"pseudo-transient", elch_mov_bndry_pseudo_transient},
-          {"fully-transient", elch_mov_bndry_fully_transient},
-      },
-      {.description = "ELCH algorithm for deforming meshes", .default_value = elch_mov_bndry_no}));
-  elchcontrol.specs.emplace_back(parameter<double>(
-      "MOLARVOLUME", {.description = "Molar volume for electrode shape change computations",
-                         .default_value = 0.0}));
-  elchcontrol.specs.emplace_back(parameter<double>("MOVBOUNDARYTHETA",
-      {.description = "One-step-theta factor in electrode shape change computations",
-          .default_value = 0.0}));
-  elchcontrol.specs.emplace_back(parameter<bool>(
-      "GALVANOSTATIC", {.description = "flag for galvanostatic mode", .default_value = false}));
-  elchcontrol.specs.emplace_back(
+      parameter<int>("MOVBOUNDARYITEMAX",
+          {.description =
+                  "Maximum number of outer iterations in electrode shape change computations",
+              .default_value = 10}),
+      parameter<double>(
+          "MOVBOUNDARYCONVTOL", {.description = "Convergence check tolerance for outer loop in "
+                                                "electrode shape change computations",
+                                    .default_value = 1e-6}),
+      parameter<double>(
+          "TEMPERATURE", {.description = "Constant temperature (Kelvin)", .default_value = 298.0}),
+      parameter<int>("TEMPERATURE_FROM_FUNCT",
+          {.description = "Homogeneous temperature within electrochemistry field that can be time "
+                          "dependent according to function definition",
+              .default_value = -1}),
+      parameter<double>("FARADAY_CONSTANT",
+          {.description = "Faraday constant (in unit system as chosen in input file)",
+              .default_value = 9.64853399e4}),
+      parameter<double>("GAS_CONSTANT",
+          {.description = "(universal) gas constant (in unit system as chosen in input file)",
+              .default_value = 8.314472}),
+      // parameter for possible types of ELCH algorithms for deforming meshes
+      deprecated_selection<Inpar::ElCh::ElchMovingBoundary>("MOVINGBOUNDARY",
+          {
+              {"No", elch_mov_bndry_no},
+              {"pseudo-transient", elch_mov_bndry_pseudo_transient},
+              {"fully-transient", elch_mov_bndry_fully_transient},
+          },
+          {.description = "ELCH algorithm for deforming meshes",
+              .default_value = elch_mov_bndry_no}),
+      parameter<double>(
+          "MOLARVOLUME", {.description = "Molar volume for electrode shape change computations",
+                             .default_value = 0.0}),
+      parameter<double>("MOVBOUNDARYTHETA",
+          {.description = "One-step-theta factor in electrode shape change computations",
+              .default_value = 0.0}),
+      parameter<bool>(
+          "GALVANOSTATIC", {.description = "flag for galvanostatic mode", .default_value = false}),
+
       deprecated_selection<Inpar::ElCh::ApproxElectResist>("GSTAT_APPROX_ELECT_RESIST",
           {
               {"relation_pot_cur", approxelctresist_relpotcur},
@@ -66,132 +67,132 @@ void Inpar::ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {"effective_length_with_integrated_cond", approxelctresist_efflenintegcond},
           },
           {.description = "relation of potential and current flow",
-              .default_value = approxelctresist_relpotcur}));
-  elchcontrol.specs.emplace_back(parameter<int>("GSTATCONDID_CATHODE",
-      {.description = "condition id of electrode kinetics for cathode", .default_value = 0}));
-  elchcontrol.specs.emplace_back(parameter<int>("GSTATCONDID_ANODE",
-      {.description = "condition id of electrode kinetics for anode", .default_value = 1}));
-  elchcontrol.specs.emplace_back(parameter<double>(
-      "GSTATCONVTOL", {.description = "Convergence check tolerance for galvanostatic mode",
-                          .default_value = 1.e-5}));
-  elchcontrol.specs.emplace_back(parameter<double>(
-      "GSTATCURTOL", {.description = "Current Tolerance", .default_value = 1.e-15}));
-  elchcontrol.specs.emplace_back(parameter<int>("GSTATFUNCTNO",
-      {.description = "function number defining the imposed current curve", .default_value = -1}));
-  elchcontrol.specs.emplace_back(parameter<int>("GSTATITEMAX",
-      {.description = "maximum number of iterations for galvanostatic mode", .default_value = 10}));
-  elchcontrol.specs.emplace_back(parameter<double>("GSTAT_LENGTH_CURRENTPATH",
-      {.description = "average length of the current path", .default_value = 0.0}));
+              .default_value = approxelctresist_relpotcur}),
+      parameter<int>("GSTATCONDID_CATHODE",
+          {.description = "condition id of electrode kinetics for cathode", .default_value = 0}),
+      parameter<int>("GSTATCONDID_ANODE",
+          {.description = "condition id of electrode kinetics for anode", .default_value = 1}),
+      parameter<double>(
+          "GSTATCONVTOL", {.description = "Convergence check tolerance for galvanostatic mode",
+                              .default_value = 1.e-5}),
+      parameter<double>(
+          "GSTATCURTOL", {.description = "Current Tolerance", .default_value = 1.e-15}),
+      parameter<int>(
+          "GSTATFUNCTNO", {.description = "function number defining the imposed current curve",
+                              .default_value = -1}),
+      parameter<int>(
+          "GSTATITEMAX", {.description = "maximum number of iterations for galvanostatic mode",
+                             .default_value = 10}),
+      parameter<double>("GSTAT_LENGTH_CURRENTPATH",
+          {.description = "average length of the current path", .default_value = 0.0}),
 
-  elchcontrol.specs.emplace_back(deprecated_selection<Inpar::ElCh::EquPot>("EQUPOT",
-      {
-          {"Undefined", equpot_undefined},
-          {"ENC", equpot_enc},
-          {"ENC_PDE", equpot_enc_pde},
-          {"ENC_PDE_ELIM", equpot_enc_pde_elim},
-          {"Poisson", equpot_poisson},
-          {"Laplace", equpot_laplace},
-          {"divi", equpot_divi},
-      },
-      {.description = "type of closing equation for electric potential",
-          .default_value = equpot_undefined}));
-  elchcontrol.specs.emplace_back(parameter<bool>("DIFFCOND_FORMULATION",
-      {.description = "Activation of diffusion-conduction formulation", .default_value = false}));
-  elchcontrol.specs.emplace_back(parameter<bool>(
-      "INITPOTCALC", {.description = "Automatically calculate initial field for electric potential",
-                         .default_value = false}));
-  elchcontrol.specs.emplace_back(parameter<bool>("ONLYPOTENTIAL",
-      {.description = "Coupling of general ion transport equation with Laplace equation",
-          .default_value = false}));
-  elchcontrol.specs.emplace_back(parameter<bool>("COUPLE_BOUNDARY_FLUXES",
-      {.description = "Coupling of lithium-ion flux density and electric current density at "
-                      "Dirichlet and Neumann boundaries",
-          .default_value = true}));
-  elchcontrol.specs.emplace_back(parameter<double>("CYCLING_TIMESTEP",
-      {.description = "modified time step size for CCCV cell cycling", .default_value = -1.}));
-  elchcontrol.specs.emplace_back(parameter<bool>("ELECTRODE_INFO_EVERY_STEP",
-      {.description = "the cell voltage, SOC, and C-Rate will be written to the csv file every "
-                      "step, even if RESULTSEVERY is not 1",
-          .default_value = false}));
-
-  elchcontrol.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      deprecated_selection<Inpar::ElCh::EquPot>("EQUPOT",
+          {
+              {"Undefined", equpot_undefined},
+              {"ENC", equpot_enc},
+              {"ENC_PDE", equpot_enc_pde},
+              {"ENC_PDE_ELIM", equpot_enc_pde_elim},
+              {"Poisson", equpot_poisson},
+              {"Laplace", equpot_laplace},
+              {"divi", equpot_divi},
+          },
+          {.description = "type of closing equation for electric potential",
+              .default_value = equpot_undefined}),
+      parameter<bool>(
+          "DIFFCOND_FORMULATION", {.description = "Activation of diffusion-conduction formulation",
+                                      .default_value = false}),
+      parameter<bool>("INITPOTCALC",
+          {.description = "Automatically calculate initial field for electric potential",
+              .default_value = false}),
+      parameter<bool>("ONLYPOTENTIAL",
+          {.description = "Coupling of general ion transport equation with Laplace equation",
+              .default_value = false}),
+      parameter<bool>("COUPLE_BOUNDARY_FLUXES",
+          {.description = "Coupling of lithium-ion flux density and electric current density at "
+                          "Dirichlet and Neumann boundaries",
+              .default_value = true}),
+      parameter<double>("CYCLING_TIMESTEP",
+          {.description = "modified time step size for CCCV cell cycling", .default_value = -1.}),
+      parameter<bool>("ELECTRODE_INFO_EVERY_STEP",
+          {.description = "the cell voltage, SOC, and C-Rate will be written to the csv file every "
+                          "step, even if RESULTSEVERY is not 1",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
   // attention: this list is a sublist of elchcontrol
-  Core::Utils::SectionSpecs elchdiffcondcontrol{elchcontrol, "DIFFCOND"};
+  list["ELCH CONTROL/DIFFCOND"] = all_of({
 
-  elchdiffcondcontrol.specs.emplace_back(parameter<bool>("CURRENT_SOLUTION_VAR",
-      {.description = "Current as a solution variable", .default_value = false}));
-  elchdiffcondcontrol.specs.emplace_back(parameter<bool>("MAT_DIFFCOND_DIFFBASED",
-      {.description =
-              "Coupling terms of chemical diffusion for current equation are based on t and kappa",
-          .default_value = true}));
+      parameter<bool>("CURRENT_SOLUTION_VAR",
+          {.description = "Current as a solution variable", .default_value = false}),
+      parameter<bool>(
+          "MAT_DIFFCOND_DIFFBASED", {.description = "Coupling terms of chemical diffusion for "
+                                                    "current equation are based on t and kappa",
+                                        .default_value = true}),
 
-  /// dilute solution theory (diffusion potential in current equation):
-  ///    A          B
-  ///   |--|  |----------|
-  ///   z_1 + (z_2 - z_1) t_1
-  /// ------------------------ (RT/F kappa (1+f+-) 1/c_k grad c_k)
-  ///      z_1 z_2
-  ///     |________|
-  ///         C
-  //
-  // default: concentrated solution theory according to Newman
-  elchdiffcondcontrol.specs.emplace_back(parameter<double>("MAT_NEWMAN_CONST_A",
-      {.description = "Constant A for the Newman model(term for the concentration overpotential)",
-          .default_value = 2.0}));
-  elchdiffcondcontrol.specs.emplace_back(parameter<double>("MAT_NEWMAN_CONST_B",
-      {.description = "Constant B for the Newman model(term for the concentration overpotential)",
-          .default_value = -2.0}));
-  elchdiffcondcontrol.specs.emplace_back(parameter<double>("MAT_NEWMAN_CONST_C",
-      {.description = "Constant C for the Newman model(term for the concentration overpotential)",
-          .default_value = -1.0}));
-  elchdiffcondcontrol.specs.emplace_back(parameter<double>("PERMITTIVITY_VACUUM",
-      {.description = "Vacuum permittivity", .default_value = 8.8541878128e-12}));
-
-  elchdiffcondcontrol.move_into_collection(list);
+      /// dilute solution theory (diffusion potential in current equation):
+      ///    A          B
+      ///   |--|  |----------|
+      ///   z_1 + (z_2 - z_1) t_1
+      /// ------------------------ (RT/F kappa (1+f+-) 1/c_k grad c_k)
+      ///      z_1 z_2
+      ///     |________|
+      ///         C
+      //
+      // default: concentrated solution theory according to Newman
+      parameter<double>("MAT_NEWMAN_CONST_A",
+          {.description =
+                  "Constant A for the Newman model(term for the concentration overpotential)",
+              .default_value = 2.0}),
+      parameter<double>("MAT_NEWMAN_CONST_B",
+          {.description =
+                  "Constant B for the Newman model(term for the concentration overpotential)",
+              .default_value = -2.0}),
+      parameter<double>("MAT_NEWMAN_CONST_C",
+          {.description =
+                  "Constant C for the Newman model(term for the concentration overpotential)",
+              .default_value = -1.0}),
+      parameter<double>("PERMITTIVITY_VACUUM",
+          {.description = "Vacuum permittivity", .default_value = 8.8541878128e-12})});
 
   /*----------------------------------------------------------------------*/
   // sublist for space-charge layers
-  Core::Utils::SectionSpecs sclcontrol{elchcontrol, "SCL"};
+  list["ELCH CONTROL/SCL"] = all_of({
 
-  sclcontrol.specs.emplace_back(parameter<bool>("ADD_MICRO_MACRO_COUPLING",
-      {.description = "flag for micro macro coupling with scls", .default_value = false}));
-  sclcontrol.specs.emplace_back(parameter<bool>(
-      "COUPLING_OUTPUT", {.description = "write coupled node gids and node coordinates to csv file",
-                             .default_value = false}));
-  sclcontrol.specs.emplace_back(parameter<bool>("INITPOTCALC",
-      {.description = "calculate initial potential field?", .default_value = false}));
-  sclcontrol.specs.emplace_back(parameter<int>(
-      "SOLVER", {.description = "solver for coupled SCL problem", .default_value = -1}));
-  sclcontrol.specs.emplace_back(deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-      {
-          {"undefined", Core::LinAlg::MatrixType::undefined},
-          {"block", Core::LinAlg::MatrixType::block_field},
-          {"sparse", Core::LinAlg::MatrixType::sparse},
-      },
-      {.description = "type of global system matrix in global system of equations",
-          .default_value = Core::LinAlg::MatrixType::undefined}));
-  sclcontrol.specs.emplace_back(parameter<int>("ADAPT_TIME_STEP",
-      {.description =
-              "time step when time step size should be updated to 'ADAPTED_TIME_STEP_SIZE'.",
-          .default_value = -1}));
-  sclcontrol.specs.emplace_back(parameter<double>(
-      "ADAPTED_TIME_STEP_SIZE", {.description = "new time step size.", .default_value = -1.0}));
+      parameter<bool>("ADD_MICRO_MACRO_COUPLING",
+          {.description = "flag for micro macro coupling with scls", .default_value = false}),
+      parameter<bool>("COUPLING_OUTPUT",
+          {.description = "write coupled node gids and node coordinates to csv file",
+              .default_value = false}),
+      parameter<bool>("INITPOTCALC",
+          {.description = "calculate initial potential field?", .default_value = false}),
+      parameter<int>(
+          "SOLVER", {.description = "solver for coupled SCL problem", .default_value = -1}),
+      deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
+          {
+              {"undefined", Core::LinAlg::MatrixType::undefined},
+              {"block", Core::LinAlg::MatrixType::block_field},
+              {"sparse", Core::LinAlg::MatrixType::sparse},
+          },
+          {.description = "type of global system matrix in global system of equations",
+              .default_value = Core::LinAlg::MatrixType::undefined}),
+      parameter<int>("ADAPT_TIME_STEP",
+          {.description =
+                  "time step when time step size should be updated to 'ADAPTED_TIME_STEP_SIZE'.",
+              .default_value = -1}),
+      parameter<double>(
+          "ADAPTED_TIME_STEP_SIZE", {.description = "new time step size.", .default_value = -1.0}),
 
-  sclcontrol.specs.emplace_back(deprecated_selection<ScaTra::InitialField>("INITIALFIELD",
-      {
-          {"zero_field", ScaTra::initfield_zero_field},
-          {"field_by_function", ScaTra::initfield_field_by_function},
-          {"field_by_condition", ScaTra::initfield_field_by_condition},
-      },
-      {.description = "Initial Field for scalar transport problem",
-          .default_value = ScaTra::initfield_zero_field}));
+      deprecated_selection<ScaTra::InitialField>("INITIALFIELD",
+          {
+              {"zero_field", ScaTra::initfield_zero_field},
+              {"field_by_function", ScaTra::initfield_field_by_function},
+              {"field_by_condition", ScaTra::initfield_field_by_condition},
+          },
+          {.description = "Initial Field for scalar transport problem",
+              .default_value = ScaTra::initfield_zero_field}),
 
-  sclcontrol.specs.emplace_back(parameter<int>("INITFUNCNO",
-      {.description = "function number for scalar transport initial field", .default_value = -1}));
-
-  sclcontrol.move_into_collection(list);
+      parameter<int>(
+          "INITFUNCNO", {.description = "function number for scalar transport initial field",
+                            .default_value = -1})});
 }
 
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -11,8 +11,6 @@
 #include "4C_io_geometry_type.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_legacy_enum_definitions_conditions.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -22,258 +22,261 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs fdyn{"FLUID DYNAMIC"};
+  list["FLUID DYNAMIC"] = all_of({
 
-  // physical type of fluid flow (incompressible, varying density, loma, Boussinesq approximation,
-  // temperature-dependent water)
-  fdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE",
-      {
-          {"Incompressible", incompressible},
-          {"Weakly_compressible", weakly_compressible},
-          {"Weakly_compressible_stokes", weakly_compressible_stokes},
-          {"Weakly_compressible_dens_mom", weakly_compressible_dens_mom},
-          {"Weakly_compressible_stokes_dens_mom", weakly_compressible_stokes_dens_mom},
-          {"Artificial_compressibility", artcomp},
-          {"Varying_density", varying_density},
-          {"Loma", loma},
-          {"Temp_dep_water", tempdepwater},
-          {"Boussinesq", boussinesq},
-          {"Stokes", stokes},
-          {"Oseen", oseen},
-      },
-      {.description = "Physical Type", .default_value = incompressible}));
+      // physical type of fluid flow (incompressible, varying density, loma, Boussinesq
+      // approximation,
+      // temperature-dependent water)
+      deprecated_selection<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE",
+          {
+              {"Incompressible", incompressible},
+              {"Weakly_compressible", weakly_compressible},
+              {"Weakly_compressible_stokes", weakly_compressible_stokes},
+              {"Weakly_compressible_dens_mom", weakly_compressible_dens_mom},
+              {"Weakly_compressible_stokes_dens_mom", weakly_compressible_stokes_dens_mom},
+              {"Artificial_compressibility", artcomp},
+              {"Varying_density", varying_density},
+              {"Loma", loma},
+              {"Temp_dep_water", tempdepwater},
+              {"Boussinesq", boussinesq},
+              {"Stokes", stokes},
+              {"Oseen", oseen},
+          },
+          {.description = "Physical Type", .default_value = incompressible}),
 
-  // number of linear solver used for fluid problem
-  fdyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for fluid dynamics", .default_value = -1}));
+      // number of linear solver used for fluid problem
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for fluid dynamics", .default_value = -1}),
 
-  // number of linear solver used for fluid problem (former fluid pressure solver for SIMPLER
-  // preconditioning with fluid)
-  fdyn.specs.emplace_back(parameter<int>(
-      "SIMPLER_SOLVER", {.description = "number of linear solver used for fluid dynamic (ONLY "
-                                        "NECESSARY FOR BlockGaussSeidel solver block within fluid "
-                                        "mehstying case any more!!!!)",
-                            .default_value = -1}));
+      // number of linear solver used for fluid problem (former fluid pressure solver for SIMPLER
+      // preconditioning with fluid)
+      parameter<int>("SIMPLER_SOLVER",
+          {.description = "number of linear solver used for fluid dynamic (ONLY "
+                          "NECESSARY FOR BlockGaussSeidel solver block within fluid "
+                          "mehstying case any more!!!!)",
+              .default_value = -1}),
 
-  // Flag to define the way of calculating stresses and wss
-  fdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::WSSType>("WSS_TYPE",
-      {
-          {"Standard", wss_standard},
-          {"Aggregation", wss_aggregation},
-          {"Mean", wss_mean},
-      },
-      {.description = "which type of stresses and wall shear stress",
-          .default_value = wss_standard}));
+      // Flag to define the way of calculating stresses and wss
+      deprecated_selection<Inpar::FLUID::WSSType>("WSS_TYPE",
+          {
+              {"Standard", wss_standard},
+              {"Aggregation", wss_aggregation},
+              {"Mean", wss_mean},
+          },
+          {.description = "which type of stresses and wall shear stress",
+              .default_value = wss_standard}),
 
-  // Set ML-solver number for smoothing of residual-based calculated wallshearstress via plain
-  // aggregation.
-  fdyn.specs.emplace_back(parameter<int>("WSS_ML_AGR_SOLVER",
-      {.description = "Set ML-solver number for smoothing of residual-based calculated "
-                      "wallshearstress via plain aggregation.",
-          .default_value = -1}));
+      // Set ML-solver number for smoothing of residual-based calculated wallshearstress via plain
+      // aggregation.
+      parameter<int>("WSS_ML_AGR_SOLVER",
+          {.description = "Set ML-solver number for smoothing of residual-based calculated "
+                          "wallshearstress via plain aggregation.",
+              .default_value = -1}),
 
-  fdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::TimeIntegrationScheme>("TIMEINTEGR",
-      {
-          {"Stationary", timeint_stationary},
-          {"Np_Gen_Alpha", timeint_npgenalpha},
-          {"Af_Gen_Alpha", timeint_afgenalpha},
-          {"One_Step_Theta", timeint_one_step_theta},
-          {"BDF2", timeint_bdf2},
-      },
-      {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}));
+      deprecated_selection<Inpar::FLUID::TimeIntegrationScheme>("TIMEINTEGR",
+          {
+              {"Stationary", timeint_stationary},
+              {"Np_Gen_Alpha", timeint_npgenalpha},
+              {"Af_Gen_Alpha", timeint_afgenalpha},
+              {"One_Step_Theta", timeint_one_step_theta},
+              {"BDF2", timeint_bdf2},
+          },
+          {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}),
 
-  fdyn.specs.emplace_back(parameter<Inpar::FLUID::OstContAndPress>("OST_CONT_PRESS",
-      {.description =
-              "One step theta option for time discretization of continuity eq. and pressure",
-          .default_value = Cont_normal_Press_normal}));
+      parameter<Inpar::FLUID::OstContAndPress>("OST_CONT_PRESS",
+          {.description =
+                  "One step theta option for time discretization of continuity eq. and pressure",
+              .default_value = Cont_normal_Press_normal}),
 
-  fdyn.specs.emplace_back(deprecated_selection<Core::IO::GeometryType>("GEOMETRY",
-      {
-          {"full", Core::IO::geometry_full},
-          {"box", Core::IO::geometry_box},
-          {"file", Core::IO::geometry_file},
-      },
-      {.description = "How the geometry is specified", .default_value = Core::IO::geometry_full}));
+      deprecated_selection<Core::IO::GeometryType>("GEOMETRY",
+          {
+              {"full", Core::IO::geometry_full},
+              {"box", Core::IO::geometry_box},
+              {"file", Core::IO::geometry_file},
+          },
+          {.description = "How the geometry is specified",
+              .default_value = Core::IO::geometry_full}),
 
-  fdyn.specs.emplace_back(parameter<Inpar::FLUID::LinearisationAction>("NONLINITER",
-      {.description = "Nonlinear iteration scheme", .default_value = fixed_point_like}));
+      parameter<Inpar::FLUID::LinearisationAction>("NONLINITER",
+          {.description = "Nonlinear iteration scheme", .default_value = fixed_point_like}),
 
-  std::vector<std::string> predictor_valid_input = {"steady_state", "zero_acceleration",
-      "constant_acceleration", "constant_increment", "explicit_second_order_midpoint", "TangVel"};
-  fdyn.specs.emplace_back(deprecated_selection<std::string>("PREDICTOR", predictor_valid_input,
-      {.description = "Predictor for first guess in nonlinear iteration",
-          .default_value = "steady_state"}));
+      deprecated_selection<std::string>("PREDICTOR",
+          {"steady_state", "zero_acceleration", "constant_acceleration", "constant_increment",
+              "explicit_second_order_midpoint", "TangVel"},
+          {.description = "Predictor for first guess in nonlinear iteration",
+              .default_value = "steady_state"}),
 
 
-  fdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::ItNorm>("CONVCHECK",
-      {
-          {"L_2_norm", fncc_L2},
-      },
-      {.description = "Norm for convergence check (relative increments and absolute residuals)",
-          .default_value = fncc_L2}));
+      deprecated_selection<Inpar::FLUID::ItNorm>("CONVCHECK",
+          {
+              {"L_2_norm", fncc_L2},
+          },
+          {.description = "Norm for convergence check (relative increments and absolute residuals)",
+              .default_value = fncc_L2}),
 
-  fdyn.specs.emplace_back(parameter<bool>("INCONSISTENT_RESIDUAL",
-      {.description = "do not evaluate residual after solution has converged (->faster)",
-          .default_value = false}));
+      parameter<bool>("INCONSISTENT_RESIDUAL",
+          {.description = "do not evaluate residual after solution has converged (->faster)",
+              .default_value = false}),
 
-  {
-    std::map<std::string, InitialField> map{
-        {"zero_field", initfield_zero_field},
-        {"field_by_function", initfield_field_by_function},
-        {"disturbed_field_from_function", initfield_disturbed_field_from_function},
-        {"FLAME_VORTEX_INTERACTION", initfield_flame_vortex_interaction},
-        {"BELTRAMI-FLOW", initfield_beltrami_flow},
-        {"KIM-MOIN-FLOW", initfield_kim_moin_flow},
-        {"hit_comte_bellot_corrsin_initial_field", initfield_hit_comte_bellot_corrsin},
-        {"forced_hit_simple_algebraic_spectrum", initfield_forced_hit_simple_algebraic_spectrum},
-        {"forced_hit_numeric_spectrum", initfield_forced_hit_numeric_spectrum},
-        {"forced_hit_passive", initfield_passive_hit_const_input},
-        {"channel_weakly_compressible", initfield_channel_weakly_compressible},
-    };
 
-    fdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::InitialField>("INITIALFIELD", map,
-        {.description = "Initial Field for transport problem",
-            .default_value = initfield_zero_field}));
-  }
 
-  fdyn.specs.emplace_back(parameter<int>("OSEENFIELDFUNCNO",
-      {.description = "function number of Oseen advective field", .default_value = -1}));
+      deprecated_selection<Inpar::FLUID::InitialField>("INITIALFIELD",
+          {
+              {"zero_field", initfield_zero_field},
+              {"field_by_function", initfield_field_by_function},
+              {"disturbed_field_from_function", initfield_disturbed_field_from_function},
+              {"FLAME_VORTEX_INTERACTION", initfield_flame_vortex_interaction},
+              {"BELTRAMI-FLOW", initfield_beltrami_flow},
+              {"KIM-MOIN-FLOW", initfield_kim_moin_flow},
+              {"hit_comte_bellot_corrsin_initial_field", initfield_hit_comte_bellot_corrsin},
+              {"forced_hit_simple_algebraic_spectrum",
+                  initfield_forced_hit_simple_algebraic_spectrum},
+              {"forced_hit_numeric_spectrum", initfield_forced_hit_numeric_spectrum},
+              {"forced_hit_passive", initfield_passive_hit_const_input},
+              {"channel_weakly_compressible", initfield_channel_weakly_compressible},
+          },
+          {.description = "Initial Field for transport problem",
+              .default_value = initfield_zero_field}),
 
-  fdyn.specs.emplace_back(parameter<bool>(
-      "LIFTDRAG", {.description = "Calculate lift and drag forces along specified boundary",
-                      .default_value = false}));
 
-  std::vector<std::string> convform_valid_input = {"convective", "conservative"};
-  fdyn.specs.emplace_back(deprecated_selection<std::string>("CONVFORM", convform_valid_input,
-      {.description = "form of convective term", .default_value = "convective"}));
+      parameter<int>("OSEENFIELDFUNCNO",
+          {.description = "function number of Oseen advective field", .default_value = -1}),
 
-  fdyn.specs.emplace_back(parameter<bool>("NONLINEARBC",
-      {.description = "Flag to activate check for potential nonlinear boundary conditions",
-          .default_value = false}));
+      parameter<bool>(
+          "LIFTDRAG", {.description = "Calculate lift and drag forces along specified boundary",
+                          .default_value = false}),
 
-  fdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::MeshTying>("MESHTYING",
-      {
-          {"no", no_meshtying},
-          {"Condensed_Smat", condensed_smat},
-          {"Condensed_Bmat", condensed_bmat},
-          {"Condensed_Bmat_merged", condensed_bmat_merged},
-      },
-      {.description = "Flag to (de)activate mesh tying algorithm", .default_value = no_meshtying}));
 
-  fdyn.specs.emplace_back(parameter<Inpar::FLUID::Gridvel>(
-      "GRIDVEL", {.description = "scheme for determination of gridvelocity from displacements",
-                     .default_value = BE}));
+      deprecated_selection<std::string>("CONVFORM", {"convective", "conservative"},
+          {.description = "form of convective term", .default_value = "convective"}),
 
-  fdyn.specs.emplace_back(parameter<bool>("ALLDOFCOUPLED",
-      {.description = "all dof (incl. pressure) are coupled", .default_value = true}));
+      parameter<bool>("NONLINEARBC",
+          {.description = "Flag to activate check for potential nonlinear boundary conditions",
+              .default_value = false}),
 
-  fdyn.specs.emplace_back(parameter<CalcError>("CALCERROR",
-      {.description = "Flag to (de)activate error calculations", .default_value = no}));
-  fdyn.specs.emplace_back(parameter<int>(
-      "CALCERRORFUNCNO", {.description = "Function for Error Calculation", .default_value = -1}));
+      deprecated_selection<Inpar::FLUID::MeshTying>("MESHTYING",
+          {
+              {"no", no_meshtying},
+              {"Condensed_Smat", condensed_smat},
+              {"Condensed_Bmat", condensed_bmat},
+              {"Condensed_Bmat_merged", condensed_bmat_merged},
+          },
+          {.description = "Flag to (de)activate mesh tying algorithm",
+              .default_value = no_meshtying}),
 
-  fdyn.specs.emplace_back(parameter<int>("CORRTERMFUNCNO",
-      {.description =
-              "Function for calculation of the correction term for the weakly compressible problem",
-          .default_value = -1}));
+      parameter<Inpar::FLUID::Gridvel>(
+          "GRIDVEL", {.description = "scheme for determination of gridvelocity from displacements",
+                         .default_value = BE}),
 
-  fdyn.specs.emplace_back(parameter<int>("BODYFORCEFUNCNO",
-      {.description =
-              "Function for calculation of the body force for the weakly compressible problem",
-          .default_value = -1}));
+      parameter<bool>("ALLDOFCOUPLED",
+          {.description = "all dof (incl. pressure) are coupled", .default_value = true}),
 
-  fdyn.specs.emplace_back(parameter<double>(
-      "STAB_DEN_REF", {.description = "Reference stabilization parameter for the density for the "
-                                      "HDG weakly compressible formulation",
-                          .default_value = 0.0}));
+      parameter<CalcError>("CALCERROR",
+          {.description = "Flag to (de)activate error calculations", .default_value = no}),
+      parameter<int>("CALCERRORFUNCNO",
+          {.description = "Function for Error Calculation", .default_value = -1}),
 
-  fdyn.specs.emplace_back(parameter<double>(
-      "STAB_MOM_REF", {.description = "Reference stabilization parameter for the momentum for the "
-                                      "HDG weakly compressible formulation",
-                          .default_value = 0.0}));
+      parameter<int>("CORRTERMFUNCNO", {.description = "Function for calculation of the correction "
+                                                       "term for the weakly compressible problem",
+                                           .default_value = -1}),
 
-  fdyn.specs.emplace_back(parameter<int>(
-      "VARVISCFUNCNO", {.description = "Function for calculation of a variable viscosity for the "
-                                       "weakly compressible problem",
-                           .default_value = -1}));
+      parameter<int>("BODYFORCEFUNCNO",
+          {.description =
+                  "Function for calculation of the body force for the weakly compressible problem",
+              .default_value = -1}),
 
-  fdyn.specs.emplace_back(parameter<bool>(
-      "PRESSAVGBC", {.description = "Flag to (de)activate imposition of boundary condition for the "
-                                    "considered element average pressure",
-                        .default_value = false}));
+      parameter<double>("STAB_DEN_REF",
+          {.description = "Reference stabilization parameter for the density for the "
+                          "HDG weakly compressible formulation",
+              .default_value = 0.0}),
 
-  fdyn.specs.emplace_back(
-      parameter<double>("REFMACH", {.description = "Reference Mach number", .default_value = 1.0}));
+      parameter<double>("STAB_MOM_REF",
+          {.description = "Reference stabilization parameter for the momentum for the "
+                          "HDG weakly compressible formulation",
+              .default_value = 0.0}),
 
-  fdyn.specs.emplace_back(parameter<bool>("BLOCKMATRIX",
-      {.description =
-              "Indicates if system matrix should be assembled into a sparse block matrix type.",
-          .default_value = false}));
+      parameter<int>("VARVISCFUNCNO",
+          {.description = "Function for calculation of a variable viscosity for the "
+                          "weakly compressible problem",
+              .default_value = -1}),
 
-  fdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  fdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
+      parameter<bool>("PRESSAVGBC",
+          {.description = "Flag to (de)activate imposition of boundary condition for the "
+                          "considered element average pressure",
+              .default_value = false}),
 
-  fdyn.specs.emplace_back(parameter<bool>("INFNORMSCALING",
-      {.description = "Scale blocks of matrix with row infnorm?", .default_value = false}));
 
-  fdyn.specs.emplace_back(parameter<bool>(
-      "GMSH_OUTPUT", {.description = "write output to gmsh files", .default_value = false}));
-  fdyn.specs.emplace_back(parameter<bool>(
-      "COMPUTE_DIVU", {.description = "Compute divergence of velocity field at the element center",
-                          .default_value = false}));
-  fdyn.specs.emplace_back(parameter<bool>("COMPUTE_EKIN",
-      {.description = "Compute kinetic energy at the end of each time step and write it to file.",
-          .default_value = false}));
-  fdyn.specs.emplace_back(parameter<bool>("NEW_OST",
-      {.description = "Solve the Navier-Stokes equation with the new One Step Theta algorithm",
-          .default_value = false}));  // TODO: To be removed.
-  fdyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  fdyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 20}));
-  fdyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "Total number of Timesteps", .default_value = 1}));
-  fdyn.specs.emplace_back(parameter<int>(
-      "STEADYSTEP", {.description = "steady state check every step", .default_value = -1}));
-  fdyn.specs.emplace_back(parameter<int>(
-      "NUMSTASTEPS", {.description = "Number of Steps for Starting Scheme", .default_value = 0}));
-  fdyn.specs.emplace_back(parameter<int>(
-      "STARTFUNCNO", {.description = "Function for Initial Starting Field", .default_value = -1}));
-  fdyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}));
-  fdyn.specs.emplace_back(parameter<int>("INITSTATITEMAX",
-      {.description = "max number of nonlinear iterations for initial stationary solution",
-          .default_value = 5}));
-  fdyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
-  fdyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  fdyn.specs.emplace_back(parameter<double>(
-      "ALPHA_M", {.description = "Time integration factor", .default_value = 1.0}));
-  fdyn.specs.emplace_back(parameter<double>(
-      "ALPHA_F", {.description = "Time integration factor", .default_value = 1.0}));
-  fdyn.specs.emplace_back(
-      parameter<double>("GAMMA", {.description = "Time integration factor", .default_value = 1.0}));
-  fdyn.specs.emplace_back(parameter<double>(
-      "THETA", {.description = "Time integration factor", .default_value = 0.66}));
+      parameter<double>("REFMACH", {.description = "Reference Mach number", .default_value = 1.0}),
 
-  fdyn.specs.emplace_back(parameter<double>("START_THETA",
-      {.description = "Time integration factor for starting scheme", .default_value = 1.0}));
+      parameter<bool>("BLOCKMATRIX",
+          {.description =
+                  "Indicates if system matrix should be assembled into a sparse block matrix type.",
+              .default_value = false}),
 
-  fdyn.specs.emplace_back(parameter<bool>("STRONG_REDD_3D_COUPLING_TYPE",
-      {.description = "Flag to (de)activate potential Strong 3D redD coupling",
-          .default_value = false}));
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
 
-  fdyn.specs.emplace_back(parameter<int>("VELGRAD_PROJ_SOLVER",
-      {.description = "Number of linear solver used for L2 projection", .default_value = -1}));
+      parameter<bool>("INFNORMSCALING",
+          {.description = "Scale blocks of matrix with row infnorm?", .default_value = false}),
 
-  fdyn.specs.emplace_back(
+      parameter<bool>(
+          "GMSH_OUTPUT", {.description = "write output to gmsh files", .default_value = false}),
+      parameter<bool>("COMPUTE_DIVU",
+          {.description = "Compute divergence of velocity field at the element center",
+              .default_value = false}),
+      parameter<bool>("COMPUTE_EKIN",
+          {.description =
+                  "Compute kinetic energy at the end of each time step and write it to file.",
+              .default_value = false}),
+      parameter<bool>("NEW_OST",
+          {.description = "Solve the Navier-Stokes equation with the new One Step Theta algorithm",
+              .default_value = false}),  // TODO: To be removed.
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 20}),
+
+      parameter<int>("NUMSTEP", {.description = "Total number of Timesteps", .default_value = 1}),
+      parameter<int>(
+          "STEADYSTEP", {.description = "steady state check every step", .default_value = -1}),
+      parameter<int>("NUMSTASTEPS",
+          {.description = "Number of Steps for Starting Scheme", .default_value = 0}),
+      parameter<int>("STARTFUNCNO",
+          {.description = "Function for Initial Starting Field", .default_value = -1}),
+      parameter<int>(
+          "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}),
+      parameter<int>("INITSTATITEMAX",
+          {.description = "max number of nonlinear iterations for initial stationary solution",
+              .default_value = 5}),
+
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}),
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<double>(
+          "ALPHA_M", {.description = "Time integration factor", .default_value = 1.0}),
+      parameter<double>(
+          "ALPHA_F", {.description = "Time integration factor", .default_value = 1.0}),
+
+      parameter<double>("GAMMA", {.description = "Time integration factor", .default_value = 1.0}),
+      parameter<double>("THETA", {.description = "Time integration factor", .default_value = 0.66}),
+
+      parameter<double>("START_THETA",
+          {.description = "Time integration factor for starting scheme", .default_value = 1.0}),
+
+      parameter<bool>("STRONG_REDD_3D_COUPLING_TYPE",
+          {.description = "Flag to (de)activate potential Strong 3D redD coupling",
+              .default_value = false}),
+
+      parameter<int>("VELGRAD_PROJ_SOLVER",
+          {.description = "Number of linear solver used for L2 projection", .default_value = -1}),
+
+
       deprecated_selection<Inpar::FLUID::GradientReconstructionMethod>("VELGRAD_PROJ_METHOD",
           {
               {"none", gradreco_none},
@@ -281,518 +284,215 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               {"L2_projection", gradreco_l2},
           },
           {.description = "Flag to (de)activate gradient reconstruction.",
-              .default_value = gradreco_none}));
+              .default_value = gradreco_none}),
 
-  fdyn.specs.emplace_back(parameter<bool>(
-      "OFF_PROC_ASSEMBLY", {.description = "Do not evaluate ghosted elements but communicate them "
-                                           "--> faster if element call is expensive",
-                               .default_value = false}));
+      parameter<bool>("OFF_PROC_ASSEMBLY",
+          {.description = "Do not evaluate ghosted elements but communicate them "
+                          "--> faster if element call is expensive",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
+  list["FLUID DYNAMIC/NONLINEAR SOLVER TOLERANCES"] = all_of({
 
-  fdyn.move_into_collection(list);
+      parameter<double>(
+          "TOL_VEL_RES", {.description = "Tolerance for convergence check of velocity residual",
+                             .default_value = 1e-6}),
 
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fdyn_nln{fdyn, "NONLINEAR SOLVER TOLERANCES"};
+      parameter<double>(
+          "TOL_VEL_INC", {.description = "Tolerance for convergence check of velocity increment",
+                             .default_value = 1e-6}),
 
-  fdyn_nln.specs.emplace_back(parameter<double>(
-      "TOL_VEL_RES", {.description = "Tolerance for convergence check of velocity residual",
-                         .default_value = 1e-6}));
+      parameter<double>(
+          "TOL_PRES_RES", {.description = "Tolerance for convergence check of pressure residual",
+                              .default_value = 1e-6}),
 
-  fdyn_nln.specs.emplace_back(parameter<double>(
-      "TOL_VEL_INC", {.description = "Tolerance for convergence check of velocity increment",
-                         .default_value = 1e-6}));
-
-  fdyn_nln.specs.emplace_back(parameter<double>(
-      "TOL_PRES_RES", {.description = "Tolerance for convergence check of pressure residual",
-                          .default_value = 1e-6}));
-
-  fdyn_nln.specs.emplace_back(parameter<double>(
-      "TOL_PRES_INC", {.description = "Tolerance for convergence check of pressure increment",
-                          .default_value = 1e-6}));
-
-  fdyn_nln.move_into_collection(list);
+      parameter<double>(
+          "TOL_PRES_INC", {.description = "Tolerance for convergence check of pressure increment",
+                              .default_value = 1e-6})});
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fdyn_stab{fdyn, "RESIDUAL-BASED STABILIZATION"};
-  // this parameter defines various stabilized methods
-  fdyn_stab.specs.emplace_back(deprecated_selection<Inpar::FLUID::StabType>("STABTYPE",
-      {
-          {"no_stabilization", stabtype_nostab},
-          {"residual_based", stabtype_residualbased},
-          {"edge_based", stabtype_edgebased},
-          {"pressure_projection", stabtype_pressureprojection},
-      },
-      {.description = "Apply (un)stabilized fluid formulation. No stabilization is only possible "
-                      "for inf-sup stable elements.Use a residual-based stabilization or, more "
-                      "generally, a stabilization \nbased on the concept of the residual-based "
-                      "variational multiscale method...\nExpecting additional input. Use an "
-                      "edge-based stabilization, especially for XFEM. Alternative: Element/cell "
-                      "based polynomial pressure projection, see Dohrmann/Bochev 2004, IJNMF",
-          .default_value = stabtype_residualbased}));
+  list["FLUID DYNAMIC/RESIDUAL-BASED STABILIZATION"] = all_of({
 
-  fdyn_stab.specs.emplace_back(parameter<bool>(
-      "INCONSISTENT", {.description = "residual based without second derivatives (i.e. only "
-                                      "consistent for tau->0, but faster)",
-                          .default_value = false}));
+      // this parameter defines various stabilized methods
+      deprecated_selection<Inpar::FLUID::StabType>("STABTYPE",
+          {
+              {"no_stabilization", stabtype_nostab},
+              {"residual_based", stabtype_residualbased},
+              {"edge_based", stabtype_edgebased},
+              {"pressure_projection", stabtype_pressureprojection},
+          },
+          {.description =
+                  "Apply (un)stabilized fluid formulation. No stabilization is only possible "
+                  "for inf-sup stable elements.Use a residual-based stabilization or, more "
+                  "generally, a stabilization \nbased on the concept of the residual-based "
+                  "variational multiscale method...\nExpecting additional input. Use an "
+                  "edge-based stabilization, especially for XFEM. Alternative: Element/cell "
+                  "based polynomial pressure projection, see Dohrmann/Bochev 2004, IJNMF",
+              .default_value = stabtype_residualbased}),
 
-  fdyn_stab.specs.emplace_back(parameter<bool>("Reconstruct_Sec_Der",
-      {.description = "residual computed with a reconstruction of the second derivatives via "
-                      "projection or superconvergent patch recovery",
-          .default_value = false}));
+      parameter<bool>(
+          "INCONSISTENT", {.description = "residual based without second derivatives (i.e. only "
+                                          "consistent for tau->0, but faster)",
+                              .default_value = false}),
 
-  // the following parameters are necessary only if a residual based stabilized method is applied
-  fdyn_stab.specs.emplace_back(deprecated_selection<SubscalesTD>("TDS",
-      {
-          {"quasistatic", subscales_quasistatic},
-          {"time_dependent", subscales_time_dependent},
-      },
-      {.description =
-              "Flag to allow time dependency of subscales for residual-based stabilization.",
-          .default_value = subscales_quasistatic}));
+      parameter<bool>("Reconstruct_Sec_Der",
+          {.description = "residual computed with a reconstruction of the second derivatives via "
+                          "projection or superconvergent patch recovery",
+              .default_value = false}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<Transient>("TRANSIENT",
-      {
-          {"no_transient", inertia_stab_drop},
-          {"yes_transient", inertia_stab_keep},
-          {"transient_complete", inertia_stab_keep_complete},
-      },
-      {.description =
-              "Specify how to treat the transient term. Use transient term (recommended for time "
-              "dependent subscales) or use transient term including a linearisation of 1/tau",
-          .default_value = inertia_stab_drop}));
+      // the following parameters are necessary only if a residual based stabilized method is
+      // applied
+      deprecated_selection<SubscalesTD>("TDS",
+          {
+              {"quasistatic", subscales_quasistatic},
+              {"time_dependent", subscales_time_dependent},
+          },
+          {.description =
+                  "Flag to allow time dependency of subscales for residual-based stabilization.",
+              .default_value = subscales_quasistatic}),
 
-  fdyn_stab.specs.emplace_back(parameter<bool>(
-      "PSPG", {.description = "Flag to (de)activate PSPG stabilization.", .default_value = true}));
-  fdyn_stab.specs.emplace_back(parameter<bool>(
-      "SUPG", {.description = "Flag to (de)activate SUPG stabilization.", .default_value = true}));
-  fdyn_stab.specs.emplace_back(parameter<bool>(
-      "GRAD_DIV", {.description = "Flag to (de)activate grad-div term.", .default_value = true}));
+      deprecated_selection<Transient>("TRANSIENT",
+          {
+              {"no_transient", inertia_stab_drop},
+              {"yes_transient", inertia_stab_keep},
+              {"transient_complete", inertia_stab_keep_complete},
+          },
+          {.description =
+                  "Specify how to treat the transient term. Use transient term (recommended for "
+                  "time "
+                  "dependent subscales) or use transient term including a linearisation of 1/tau",
+              .default_value = inertia_stab_drop}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<VStab>("VSTAB",
-      {
-          {"no_vstab", viscous_stab_none},
-          {"vstab_gls", viscous_stab_gls},
-          {"vstab_gls_rhs", viscous_stab_gls_only_rhs},
-          {"vstab_usfem", viscous_stab_usfem},
-          {"vstab_usfem_rhs", viscous_stab_usfem_only_rhs},
-      },
-      {.description = "Flag to (de)activate viscous term in residual-based stabilization. Options: "
-                      "No viscous term in stabilization, or, Viscous stabilization of GLS type, "
-                      "or, Viscous stabilization of GLS type, included only on the right hand "
-                      "side, or, Viscous stabilization of USFEM type, or, Viscous stabilization of "
-                      "USFEM type, included only on the right hand side",
-          .default_value = viscous_stab_none}));
+      parameter<bool>("PSPG",
+          {.description = "Flag to (de)activate PSPG stabilization.", .default_value = true}),
+      parameter<bool>("SUPG",
+          {.description = "Flag to (de)activate SUPG stabilization.", .default_value = true}),
+      parameter<bool>("GRAD_DIV",
+          {.description = "Flag to (de)activate grad-div term.", .default_value = true}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<RStab>("RSTAB",
-      {
-          {"no_rstab", reactive_stab_none},
-          {"rstab_gls", reactive_stab_gls},
-          {"rstab_usfem", reactive_stab_usfem},
-      },
-      {.description = "Flag to (de)activate reactive term in residual-based stabilization.",
-          .default_value = reactive_stab_none}));
+      deprecated_selection<VStab>("VSTAB",
+          {
+              {"no_vstab", viscous_stab_none},
+              {"vstab_gls", viscous_stab_gls},
+              {"vstab_gls_rhs", viscous_stab_gls_only_rhs},
+              {"vstab_usfem", viscous_stab_usfem},
+              {"vstab_usfem_rhs", viscous_stab_usfem_only_rhs},
+          },
+          {.description =
+                  "Flag to (de)activate viscous term in residual-based stabilization. Options: "
+                  "No viscous term in stabilization, or, Viscous stabilization of GLS type, "
+                  "or, Viscous stabilization of GLS type, included only on the right hand "
+                  "side, or, Viscous stabilization of USFEM type, or, Viscous stabilization of "
+                  "USFEM type, included only on the right hand side",
+              .default_value = viscous_stab_none}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<CrossStress>("CROSS-STRESS",
-      {
-          {"no_cross", cross_stress_stab_none},
-          {"yes_cross", cross_stress_stab},
-          {"cross_rhs", cross_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate cross-stress term -> residual-based VMM. Options:No "
-                      "cross-stress term, or,Include the cross-stress term with a linearization of "
-                      "the convective part, or, Include cross-stress term, but only explicitly on "
-                      "right hand side",
-          .default_value = cross_stress_stab_none}));
+      deprecated_selection<RStab>("RSTAB",
+          {
+              {"no_rstab", reactive_stab_none},
+              {"rstab_gls", reactive_stab_gls},
+              {"rstab_usfem", reactive_stab_usfem},
+          },
+          {.description = "Flag to (de)activate reactive term in residual-based stabilization.",
+              .default_value = reactive_stab_none}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<ReynoldsStress>("REYNOLDS-STRESS",
-      {
-          {"no_reynolds", reynolds_stress_stab_none},
-          {"yes_reynolds", reynolds_stress_stab},
-          {"reynolds_rhs", reynolds_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate Reynolds-stress term -> residual-based VMM.",
-          .default_value = reynolds_stress_stab_none}));
+      deprecated_selection<CrossStress>("CROSS-STRESS",
+          {
+              {"no_cross", cross_stress_stab_none},
+              {"yes_cross", cross_stress_stab},
+              {"cross_rhs", cross_stress_stab_only_rhs},
+          },
+          {.description =
+                  "Flag to (de)activate cross-stress term -> residual-based VMM. Options:No "
+                  "cross-stress term, or,Include the cross-stress term with a linearization of "
+                  "the convective part, or, Include cross-stress term, but only explicitly on "
+                  "right hand side",
+              .default_value = cross_stress_stab_none}),
 
-  {
-    std::map<std::string, TauType> map{
-        {"Taylor_Hughes_Zarins", tau_taylor_hughes_zarins},
-        {"Taylor_Hughes_Zarins_wo_dt", tau_taylor_hughes_zarins_wo_dt},
-        {"Taylor_Hughes_Zarins_Whiting_Jansen", tau_taylor_hughes_zarins_whiting_jansen},
-        {"Taylor_Hughes_Zarins_Whiting_Jansen_wo_dt",
-            tau_taylor_hughes_zarins_whiting_jansen_wo_dt},
-        {"Taylor_Hughes_Zarins_scaled", tau_taylor_hughes_zarins_scaled},
-        {"Taylor_Hughes_Zarins_scaled_wo_dt", tau_taylor_hughes_zarins_scaled_wo_dt},
-        {"Franca_Barrenechea_Valentin_Frey_Wall", tau_franca_barrenechea_valentin_frey_wall},
-        {"Franca_Barrenechea_Valentin_Frey_Wall_wo_dt",
-            tau_franca_barrenechea_valentin_frey_wall_wo_dt},
-        {"Shakib_Hughes_Codina", tau_shakib_hughes_codina},
-        {"Shakib_Hughes_Codina_wo_dt", tau_shakib_hughes_codina_wo_dt},
-        {"Codina", tau_codina},
-        {"Codina_wo_dt", tau_codina_wo_dt},
-        {"Codina_convscaled", tau_codina_convscaled},
-        {"Franca_Madureira_Valentin_Badia_Codina", tau_franca_madureira_valentin_badia_codina},
-        {"Franca_Madureira_Valentin_Badia_Codina_wo_dt",
-            tau_franca_madureira_valentin_badia_codina_wo_dt},
-        {"Hughes_Franca_Balestra_wo_dt", tau_hughes_franca_balestra_wo_dt},
-    };
+      deprecated_selection<ReynoldsStress>("REYNOLDS-STRESS",
+          {
+              {"no_reynolds", reynolds_stress_stab_none},
+              {"yes_reynolds", reynolds_stress_stab},
+              {"reynolds_rhs", reynolds_stress_stab_only_rhs},
+          },
+          {.description = "Flag to (de)activate Reynolds-stress term -> residual-based VMM.",
+              .default_value = reynolds_stress_stab_none}),
 
-    fdyn_stab.specs.emplace_back(deprecated_selection<TauType>("DEFINITION_TAU", map,
-        {.description = "Definition of tau",
-            .default_value = tau_franca_barrenechea_valentin_frey_wall}));
-  }
 
-  // this parameter selects the characteristic element length for tau_Mu for all
-  // stabilization parameter definitions requiring such a length
-  fdyn_stab.specs.emplace_back(deprecated_selection<CharEleLengthU>("CHARELELENGTH_U",
-      {
-          {"streamlength", streamlength_u},
-          {"volume_equivalent_diameter", volume_equivalent_diameter_u},
-          {"root_of_volume", root_of_volume_u},
-      },
-      {.description = "Characteristic element length for tau_Mu",
-          .default_value = streamlength_u}));
 
-  // this parameter selects the characteristic element length for tau_Mp and tau_C for
-  // all stabilization parameter definitions requiring such a length
-  fdyn_stab.specs.emplace_back(deprecated_selection<CharEleLengthPC>("CHARELELENGTH_PC",
-      {
-          {"streamlength", streamlength_pc},
-          {"volume_equivalent_diameter", volume_equivalent_diameter_pc},
-          {"root_of_volume", root_of_volume_pc},
-      },
-      {.description = "Characteristic element length for tau_Mp/tau_C",
-          .default_value = volume_equivalent_diameter_pc}));
+      deprecated_selection<TauType>("DEFINITION_TAU",
+          {
+              {"Taylor_Hughes_Zarins", tau_taylor_hughes_zarins},
+              {"Taylor_Hughes_Zarins_wo_dt", tau_taylor_hughes_zarins_wo_dt},
+              {"Taylor_Hughes_Zarins_Whiting_Jansen", tau_taylor_hughes_zarins_whiting_jansen},
+              {"Taylor_Hughes_Zarins_Whiting_Jansen_wo_dt",
+                  tau_taylor_hughes_zarins_whiting_jansen_wo_dt},
+              {"Taylor_Hughes_Zarins_scaled", tau_taylor_hughes_zarins_scaled},
+              {"Taylor_Hughes_Zarins_scaled_wo_dt", tau_taylor_hughes_zarins_scaled_wo_dt},
+              {"Franca_Barrenechea_Valentin_Frey_Wall", tau_franca_barrenechea_valentin_frey_wall},
+              {"Franca_Barrenechea_Valentin_Frey_Wall_wo_dt",
+                  tau_franca_barrenechea_valentin_frey_wall_wo_dt},
+              {"Shakib_Hughes_Codina", tau_shakib_hughes_codina},
+              {"Shakib_Hughes_Codina_wo_dt", tau_shakib_hughes_codina_wo_dt},
+              {"Codina", tau_codina},
+              {"Codina_wo_dt", tau_codina_wo_dt},
+              {"Codina_convscaled", tau_codina_convscaled},
+              {"Franca_Madureira_Valentin_Badia_Codina",
+                  tau_franca_madureira_valentin_badia_codina},
+              {"Franca_Madureira_Valentin_Badia_Codina_wo_dt",
+                  tau_franca_madureira_valentin_badia_codina_wo_dt},
+              {"Hughes_Franca_Balestra_wo_dt", tau_hughes_franca_balestra_wo_dt},
+          },
+          {.description = "Definition of tau",
+              .default_value = tau_franca_barrenechea_valentin_frey_wall}),
 
-  // this parameter selects the location where tau is evaluated
 
-  std::vector<std::string> evaluation_tau_valid_input = {"element_center", "integration_point"};
-  fdyn_stab.specs.emplace_back(
-      deprecated_selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
-          {.description = "Location where tau is evaluated", .default_value = "element_center"}));
+      // this parameter selects the characteristic element length for tau_Mu for all
+      // stabilization parameter definitions requiring such a length
+      deprecated_selection<CharEleLengthU>("CHARELELENGTH_U",
+          {
+              {"streamlength", streamlength_u},
+              {"volume_equivalent_diameter", volume_equivalent_diameter_u},
+              {"root_of_volume", root_of_volume_u},
+          },
+          {.description = "Characteristic element length for tau_Mu",
+              .default_value = streamlength_u}),
 
-  // this parameter selects the location where the material law is evaluated
-  // (does not fit here very well, but parameter transfer is easier)
+      // this parameter selects the characteristic element length for tau_Mp and tau_C for
+      // all stabilization parameter definitions requiring such a length
+      deprecated_selection<CharEleLengthPC>("CHARELELENGTH_PC",
+          {
+              {"streamlength", streamlength_pc},
+              {"volume_equivalent_diameter", volume_equivalent_diameter_pc},
+              {"root_of_volume", root_of_volume_pc},
+          },
+          {.description = "Characteristic element length for tau_Mp/tau_C",
+              .default_value = volume_equivalent_diameter_pc}),
 
-  std::vector<std::string> evaluation_mat_valid_input = {"element_center", "integration_point"};
-  fdyn_stab.specs.emplace_back(
-      deprecated_selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
+      // this parameter selects the location where tau is evaluated
+      deprecated_selection<std::string>("EVALUATION_TAU", {"element_center", "integration_point"},
+          {.description = "Location where tau is evaluated", .default_value = "element_center"}),
+
+      // this parameter selects the location where the material law is evaluated
+      // (does not fit here very well, but parameter transfer is easier)
+      deprecated_selection<std::string>("EVALUATION_MAT", {"element_center", "integration_point"},
           {.description = "Location where material law is evaluated",
-              .default_value = "element_center"}));
+              .default_value = "element_center"}),
 
-  // these parameters active additional terms in loma continuity equation
-  // which might be identified as SUPG-/cross- and Reynolds-stress term
-  fdyn_stab.specs.emplace_back(parameter<bool>("LOMA_CONTI_SUPG",
-      {.description = "Flag to (de)activate SUPG stabilization in loma continuity equation.",
-          .default_value = false}));
+      // these parameters active additional terms in loma continuity equation
+      // which might be identified as SUPG-/cross- and Reynolds-stress term
+      parameter<bool>("LOMA_CONTI_SUPG",
+          {.description = "Flag to (de)activate SUPG stabilization in loma continuity equation.",
+              .default_value = false}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<CrossStress>("LOMA_CONTI_CROSS_STRESS",
-      {
-          {"no_cross", cross_stress_stab_none},
-          {"yes_cross", cross_stress_stab},
-          {"cross_rhs", cross_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate cross-stress term loma continuity equation-> "
-                      "residual-based VMM.",
-          .default_value = cross_stress_stab_none}));
+      deprecated_selection<CrossStress>("LOMA_CONTI_CROSS_STRESS",
+          {
+              {"no_cross", cross_stress_stab_none},
+              {"yes_cross", cross_stress_stab},
+              {"cross_rhs", cross_stress_stab_only_rhs},
+          },
+          {.description = "Flag to (de)activate cross-stress term loma continuity equation-> "
+                          "residual-based VMM.",
+              .default_value = cross_stress_stab_none}),
 
-  fdyn_stab.specs.emplace_back(deprecated_selection<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS",
-      {
-          {"no_reynolds", reynolds_stress_stab_none},
-          {"yes_reynolds", reynolds_stress_stab},
-          {"reynolds_rhs", reynolds_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate Reynolds-stress term loma continuity equation-> "
-                      "residual-based VMM.",
-          .default_value = reynolds_stress_stab_none}));
-
-  fdyn_stab.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fdyn_edge_based_stab{fdyn, "EDGE-BASED STABILIZATION"};
-
-  //! Flag to (de)activate edge-based (EOS) pressure stabilization
-  fdyn_edge_based_stab.specs.emplace_back(deprecated_selection<EosPres>("EOS_PRES",
-      {
-          {"none", EOS_PRES_none},
-          {"std_eos", EOS_PRES_std_eos},
-          {"xfem_gp", EOS_PRES_xfem_gp},
-      },
-      {.description =
-              "Flag to (de)activate pressure edge-based stabilization. Options: do not use "
-              "pressure edge-based stabilization, or, use pressure edge-based stabilization as "
-              "standard edge-based stabilization on the entire domain, or, use pressure edge-based "
-              "stabilization as xfem ghost-penalty stabilization just around cut elements",
-          .default_value = EOS_PRES_none}));
-
-  //! Flag to (de)activate edge-based (EOS) convective streamline stabilization
-  fdyn_edge_based_stab.specs.emplace_back(deprecated_selection<EosConvStream>("EOS_CONV_STREAM",
-      {
-          {"none", EOS_CONV_STREAM_none},
-          {"std_eos", EOS_CONV_STREAM_std_eos},
-          {"xfem_gp", EOS_CONV_STREAM_xfem_gp},
-      },
-      {.description =
-              "Flag to (de)activate convective streamline edge-based stabilization. Options: do "
-              "not use convective streamline edge-based stabilization, or, use convective "
-              "streamline edge-based stabilization as standard edge-based stabilization on the "
-              "entire domain, or, use convective streamline edge-based stabilization as xfem "
-              "ghost-penalty stabilization just around cut elements",
-          .default_value = EOS_CONV_STREAM_none}));
-
-  //! Flag to (de)activate edge-based (EOS) convective crosswind stabilization
-  fdyn_edge_based_stab.specs.emplace_back(deprecated_selection<EosConvCross>("EOS_CONV_CROSS",
-      {
-          {"none", EOS_CONV_CROSS_none},
-          {"std_eos", EOS_CONV_CROSS_std_eos},
-          {"xfem_gp", EOS_CONV_CROSS_xfem_gp},
-      },
-      {.description = "Flag to (de)activate convective crosswind edge-based stabilization. "
-                      "Options:do not use convective crosswind edge-based stabilization, or, use "
-                      "convective crosswind edge-based stabilization as standard edge-based "
-                      "stabilization on the entire domain, or, use convective crosswind edge-based "
-                      "stabilization as xfem ghost-penalty stabilization just around cut elements",
-          .default_value = EOS_CONV_CROSS_none}));
-
-  //! Flag to (de)activate edge-based (EOS) divergence stabilization
-  fdyn_edge_based_stab.specs.emplace_back(deprecated_selection<EosDiv>("EOS_DIV",
-      {
-          {"none", EOS_DIV_none},
-          {"vel_jump_std_eos", EOS_DIV_vel_jump_std_eos},
-          {"vel_jump_xfem_gp", EOS_DIV_vel_jump_xfem_gp},
-          {"div_jump_std_eos", EOS_DIV_div_jump_std_eos},
-          {"div_jump_xfem_gp", EOS_DIV_div_jump_xfem_gp},
-      },
-      {.description =
-              "Flag to (de)activate divergence edge-based stabilization. Options: do not use "
-              "divergence edge-based stabilization, or, divergence edge-based stabilization based "
-              "on velocity jump on the entire domain, or, divergence edge-based stabilization "
-              "based on divergence jump just around cut elements, or, divergence edge-based "
-              "stabilization based on velocity jump on the entire domain, or, divergence "
-              "edge-based stabilization based on divergence jump just around cut elements",
-          .default_value = EOS_DIV_none}));
-
-  //! special least-squares condition for pseudo 2D examples where pressure level is determined via
-  //! Krylov-projection
-  fdyn_edge_based_stab.specs.emplace_back(parameter<bool>(
-      "PRES_KRYLOV_2Dz", {.description = "residual based without second derivatives (i.e. only "
-                                         "consistent for tau->0, but faster)",
-                             .default_value = false}));
-
-  //! this parameter selects the definition of Edge-based stabilization parameter
-  fdyn_edge_based_stab.specs.emplace_back(deprecated_selection<EosTauType>("EOS_DEFINITION_TAU",
-      {
-          {"Burman_Fernandez_Hansbo", Inpar::FLUID::EOS_tau_burman_fernandez_hansbo},
-          {"Burman_Fernandez_Hansbo_wo_dt", Inpar::FLUID::EOS_tau_burman_fernandez_hansbo_wo_dt},
-          {"Braack_Burman_John_Lube", Inpar::FLUID::EOS_tau_braack_burman_john_lube},
-          {"Braack_Burman_John_Lube_wo_divjump",
-              Inpar::FLUID::EOS_tau_braack_burman_john_lube_wo_divjump},
-          {"Franca_Barrenechea_Valentin_Wall",
-              Inpar::FLUID::EOS_tau_franca_barrenechea_valentin_wall},
-          {"Burman_Fernandez", Inpar::FLUID::EOS_tau_burman_fernandez},
-          {"Burman_Hansbo_DAngelo_Zunino", Inpar::FLUID::EOS_tau_burman_hansbo_dangelo_zunino},
-          {"Burman_Hansbo_DAngelo_Zunino_wo_dt",
-              Inpar::FLUID::EOS_tau_burman_hansbo_dangelo_zunino_wo_dt},
-          {"Schott_Massing_Burman_DAngelo_Zunino",
-              Inpar::FLUID::EOS_tau_schott_massing_burman_dangelo_zunino},
-          {"Schott_Massing_Burman_DAngelo_Zunino_wo_dt",
-              Inpar::FLUID::EOS_tau_schott_massing_burman_dangelo_zunino_wo_dt},
-          {"Burman", Inpar::FLUID::EOS_tau_burman},
-          {"Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling",
-              Inpar::FLUID::EOS_tau_Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling},
-          {"tau_not_defined", Inpar::FLUID::EOS_tau_not_defined},
-      },
-      {.description = "Definition of stabilization parameter for edge-based stabilization",
-          .default_value = Inpar::FLUID::EOS_tau_burman_hansbo_dangelo_zunino}));
-
-  //! this parameter selects how the element length of Edge-based stabilization is defined
-  fdyn_edge_based_stab.specs.emplace_back(parameter<EosElementLength>("EOS_H_DEFINITION",
-      {.description =
-              "Definition of element length for edge-based stabilization. Options:take the maximal "
-              "(nsd-1)D diameter of faces that connect the internal face to its opposite faces, "
-              "or, take the maximal 1D distance along 1D edge to opposite surface for both parent "
-              "elements, or, take the maximal (nsd-1)D face diameter of all faces for both parent "
-              "elements, or, maximal nD diameter of the neighboring elements, or, maximal (n-1)D "
-              "diameter of the internal face/edge, or, take the maximal volume equivalent diameter "
-              "of adjacent elements",
-          .default_value = EOS_he_max_diameter_to_opp_surf}));
-
-  fdyn_edge_based_stab.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fdyn_porostab{fdyn, "POROUS-FLOW STABILIZATION"};
-
-  fdyn_porostab.specs.emplace_back(parameter<bool>("STAB_BIOT",
-      {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}));
-  fdyn_porostab.specs.emplace_back(parameter<double>("STAB_BIOT_SCALING",
-      {.description =
-              "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
-          .default_value = 1.0}));
-
-  // this parameter defines various stabilized methods
-  fdyn_porostab.specs.emplace_back(deprecated_selection<Inpar::FLUID::StabType>("STABTYPE",
-      {
-          {"no_stabilization", stabtype_nostab},
-          {"residual_based", stabtype_residualbased},
-          {"edge_based", stabtype_edgebased},
-      },
-      {.description = "Apply (un)stabilized fluid formulation. No stabilization is only possible "
-                      "for inf-sup stable elements. Use a residual-based stabilization or, more "
-                      "generally, a stabilization \nbased on the concept of the residual-based "
-                      "variational multiscale method...\nExpecting additional inputUse an "
-                      "edge-based stabilization, especially for XFEM",
-          .default_value = stabtype_residualbased}));
-
-  fdyn_porostab.specs.emplace_back(parameter<bool>(
-      "INCONSISTENT", {.description = "residual based without second derivatives (i.e. only "
-                                      "consistent for tau->0, but faster)",
-                          .default_value = false}));
-
-  fdyn_porostab.specs.emplace_back(parameter<bool>("Reconstruct_Sec_Der",
-      {.description = "residual computed with a reconstruction of the second derivatives via "
-                      "projection or superconvergent patch recovery",
-          .default_value = false}));
-
-  // the following parameters are necessary only if a residual based stabilized method is applied
-  fdyn_porostab.specs.emplace_back(deprecated_selection<SubscalesTD>("TDS",
-      {
-          {"quasistatic", subscales_quasistatic},
-          {"time_dependent", subscales_time_dependent},
-      },
-      {.description =
-              "Flag to allow time dependency of subscales for residual-based stabilization.",
-          .default_value = subscales_quasistatic}));
-
-  fdyn_porostab.specs.emplace_back(deprecated_selection<Transient>("TRANSIENT",
-      {
-          {"no_transient", inertia_stab_drop},
-          {"yes_transient", inertia_stab_keep},
-          {"transient_complete", inertia_stab_keep_complete},
-      },
-      {.description = "Specify how to treat the transient term.",
-          .default_value = inertia_stab_drop}));
-
-  fdyn_porostab.specs.emplace_back(parameter<bool>(
-      "PSPG", {.description = "Flag to (de)activate PSPG stabilization.", .default_value = true}));
-  fdyn_porostab.specs.emplace_back(parameter<bool>(
-      "SUPG", {.description = "Flag to (de)activate SUPG stabilization.", .default_value = true}));
-  fdyn_porostab.specs.emplace_back(parameter<bool>(
-      "GRAD_DIV", {.description = "Flag to (de)activate grad-div term.", .default_value = true}));
-
-  fdyn_porostab.specs.emplace_back(deprecated_selection<VStab>("VSTAB",
-      {
-          {"no_vstab", viscous_stab_none},
-          {"vstab_gls", viscous_stab_gls},
-          {"vstab_gls_rhs", viscous_stab_gls_only_rhs},
-          {"vstab_usfem", viscous_stab_usfem},
-          {"vstab_usfem_rhs", viscous_stab_usfem_only_rhs},
-      },
-      {.description = "Flag to (de)activate viscous term in residual-based stabilization.",
-          .default_value = viscous_stab_none}));
-
-  fdyn_porostab.specs.emplace_back(deprecated_selection<RStab>("RSTAB",
-      {
-          {"no_rstab", reactive_stab_none},
-          {"rstab_gls", reactive_stab_gls},
-          {"rstab_usfem", reactive_stab_usfem},
-      },
-      {.description = "Flag to (de)activate reactive term in residual-based stabilization.",
-          .default_value = reactive_stab_none}));
-
-  fdyn_porostab.specs.emplace_back(deprecated_selection<CrossStress>("CROSS-STRESS",
-      {
-          {"no_cross", cross_stress_stab_none},
-          {"yes_cross", cross_stress_stab},
-          {"cross_rhs", cross_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate cross-stress term -> residual-based VMM.",
-          .default_value = cross_stress_stab_none}));
-
-  fdyn_porostab.specs.emplace_back(deprecated_selection<ReynoldsStress>("REYNOLDS-STRESS",
-      {
-          {"no_reynolds", reynolds_stress_stab_none},
-          {"yes_reynolds", reynolds_stress_stab},
-          {"reynolds_rhs", reynolds_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate Reynolds-stress term -> residual-based VMM.",
-          .default_value = reynolds_stress_stab_none}));
-
-  // this parameter selects the tau definition applied
-  fdyn_porostab.specs.emplace_back(deprecated_selection<TauType>("DEFINITION_TAU",
-      {
-          {"Taylor_Hughes_Zarins", tau_taylor_hughes_zarins},
-          {"Taylor_Hughes_Zarins_wo_dt", tau_taylor_hughes_zarins_wo_dt},
-          {"Taylor_Hughes_Zarins_Whiting_Jansen", tau_taylor_hughes_zarins_whiting_jansen},
-          {"Taylor_Hughes_Zarins_Whiting_Jansen_wo_dt",
-              tau_taylor_hughes_zarins_whiting_jansen_wo_dt},
-          {"Taylor_Hughes_Zarins_scaled", tau_taylor_hughes_zarins_scaled},
-          {"Taylor_Hughes_Zarins_scaled_wo_dt", tau_taylor_hughes_zarins_scaled_wo_dt},
-          {"Franca_Barrenechea_Valentin_Frey_Wall", tau_franca_barrenechea_valentin_frey_wall},
-          {"Franca_Barrenechea_Valentin_Frey_Wall_wo_dt",
-              tau_franca_barrenechea_valentin_frey_wall_wo_dt},
-          {"Shakib_Hughes_Codina", tau_shakib_hughes_codina},
-          {"Shakib_Hughes_Codina_wo_dt", tau_shakib_hughes_codina_wo_dt},
-          {"Codina", tau_codina},
-          {"Codina_wo_dt", tau_codina_wo_dt},
-          {"Franca_Madureira_Valentin_Badia_Codina", tau_franca_madureira_valentin_badia_codina},
-          {"Franca_Madureira_Valentin_Badia_Codina_wo_dt",
-              tau_franca_madureira_valentin_badia_codina_wo_dt},
-      },
-      {.description = "Definition of tau_M and Tau_C",
-          .default_value = tau_franca_barrenechea_valentin_frey_wall}));
-
-  // this parameter selects the characteristic element length for tau_Mu for all
-  // stabilization parameter definitions requiring such a length
-  fdyn_porostab.specs.emplace_back(deprecated_selection<CharEleLengthU>("CHARELELENGTH_U",
-      {
-          {"streamlength", streamlength_u},
-          {"volume_equivalent_diameter", volume_equivalent_diameter_u},
-          {"root_of_volume", root_of_volume_u},
-      },
-      {.description = "Characteristic element length for tau_Mu",
-          .default_value = streamlength_u}));
-
-  // this parameter selects the characteristic element length for tau_Mp and tau_C for
-  // all stabilization parameter definitions requiring such a length
-  fdyn_porostab.specs.emplace_back(deprecated_selection<CharEleLengthPC>("CHARELELENGTH_PC",
-      {
-          {"streamlength", streamlength_pc},
-          {"volume_equivalent_diameter", volume_equivalent_diameter_pc},
-          {"root_of_volume", root_of_volume_pc},
-      },
-      {.description = "Characteristic element length for tau_Mp/tau_C",
-          .default_value = volume_equivalent_diameter_pc}));
-
-  // this parameter selects the location where tau is evaluated
-  evaluation_tau_valid_input = {"element_center", "integration_point"};
-  fdyn_porostab.specs.emplace_back(
-      deprecated_selection<std::string>("EVALUATION_TAU", evaluation_tau_valid_input,
-          {.description = "Location where tau is evaluated", .default_value = "element_center"}));
-
-  // this parameter selects the location where the material law is evaluated
-  // (does not fit here very well, but parameter transfer is easier)
-  evaluation_mat_valid_input = {"element_center", "integration_point"};
-  fdyn_porostab.specs.emplace_back(
-      deprecated_selection<std::string>("EVALUATION_MAT", evaluation_mat_valid_input,
-          {.description = "Location where material law is evaluated",
-              .default_value = "element_center"}));
-
-
-  // these parameters active additional terms in loma continuity equation
-  // which might be identified as SUPG-/cross- and Reynolds-stress term
-  fdyn_porostab.specs.emplace_back(parameter<bool>("LOMA_CONTI_SUPG",
-      {.description = "Flag to (de)activate SUPG stabilization in loma continuity equation.",
-          .default_value = false}));
-
-  fdyn_porostab.specs.emplace_back(deprecated_selection<CrossStress>("LOMA_CONTI_CROSS_STRESS",
-      {
-          {"no_cross", cross_stress_stab_none},
-          {"yes_cross", cross_stress_stab},
-          {"cross_rhs", cross_stress_stab_only_rhs},
-      },
-      {.description = "Flag to (de)activate cross-stress term loma continuity equation-> "
-                      "residual-based VMM.",
-          .default_value = cross_stress_stab_none}));
-
-  fdyn_porostab.specs.emplace_back(
       deprecated_selection<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS",
           {
               {"no_reynolds", reynolds_stress_stab_none},
@@ -801,541 +501,887 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           },
           {.description = "Flag to (de)activate Reynolds-stress term loma continuity equation-> "
                           "residual-based VMM.",
-              .default_value = reynolds_stress_stab_none}));
-
-  fdyn_porostab.move_into_collection(list);
+              .default_value = reynolds_stress_stab_none})});
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fdyn_turbu{fdyn, "TURBULENCE MODEL"};
+  list["FLUID DYNAMIC/EDGE-BASED STABILIZATION"] = all_of({
 
-  //----------------------------------------------------------------------
-  // modeling strategies
-  //----------------------------------------------------------------------
+      //! Flag to (de)activate edge-based (EOS) pressure stabilization
+      deprecated_selection<EosPres>("EOS_PRES",
+          {
+              {"none", EOS_PRES_none},
+              {"std_eos", EOS_PRES_std_eos},
+              {"xfem_gp", EOS_PRES_xfem_gp},
+          },
+          {.description =
+                  "Flag to (de)activate pressure edge-based stabilization. Options: do not use "
+                  "pressure edge-based stabilization, or, use pressure edge-based stabilization as "
+                  "standard edge-based stabilization on the entire domain, or, use pressure "
+                  "edge-based "
+                  "stabilization as xfem ghost-penalty stabilization just around cut elements",
+              .default_value = EOS_PRES_none}),
 
-  std::vector<std::string> turbulence_approach_valid_input = {"DNS_OR_RESVMM_LES", "CLASSICAL_LES"};
-  std::string turbulence_approach_doc_string =
-      "Try to solve flow as an underresolved DNS. Mind that your stabilisation already acts as a "
-      "kind of turbulence model! Perform a classical Large Eddy Simulation adding addititional "
-      "turbulent viscosity. This may be based on various physical models.)";
+      //! Flag to (de)activate edge-based (EOS) convective streamline stabilization
+      deprecated_selection<EosConvStream>("EOS_CONV_STREAM",
+          {
+              {"none", EOS_CONV_STREAM_none},
+              {"std_eos", EOS_CONV_STREAM_std_eos},
+              {"xfem_gp", EOS_CONV_STREAM_xfem_gp},
+          },
+          {.description =
+                  "Flag to (de)activate convective streamline edge-based stabilization. Options: "
+                  "do "
+                  "not use convective streamline edge-based stabilization, or, use convective "
+                  "streamline edge-based stabilization as standard edge-based stabilization on the "
+                  "entire domain, or, use convective streamline edge-based stabilization as xfem "
+                  "ghost-penalty stabilization just around cut elements",
+              .default_value = EOS_CONV_STREAM_none}),
 
-  fdyn_turbu.specs.emplace_back(
-      deprecated_selection<std::string>("TURBULENCE_APPROACH", turbulence_approach_valid_input,
-          {.description = turbulence_approach_doc_string, .default_value = "DNS_OR_RESVMM_LES"}));
+      //! Flag to (de)activate edge-based (EOS) convective crosswind stabilization
+      deprecated_selection<EosConvCross>("EOS_CONV_CROSS",
+          {
+              {"none", EOS_CONV_CROSS_none},
+              {"std_eos", EOS_CONV_CROSS_std_eos},
+              {"xfem_gp", EOS_CONV_CROSS_xfem_gp},
+          },
+          {.description =
+                  "Flag to (de)activate convective crosswind edge-based stabilization. "
+                  "Options:do not use convective crosswind edge-based stabilization, or, use "
+                  "convective crosswind edge-based stabilization as standard edge-based "
+                  "stabilization on the entire domain, or, use convective crosswind edge-based "
+                  "stabilization as xfem ghost-penalty stabilization just around cut elements",
+              .default_value = EOS_CONV_CROSS_none}),
 
-  std::vector<std::string> physical_model_valid_input = {"no_model", "Smagorinsky",
-      "Smagorinsky_with_van_Driest_damping", "Dynamic_Smagorinsky", "Multifractal_Subgrid_Scales",
-      "Vreman", "Dynamic_Vreman"};
-  std::string physical_model_doc_string =
-      "If classical LES is our turbulence approach, this is a contradiction and should cause a "
-      "FOUR_C_THROW. Classical constant coefficient Smagorinsky model. Be careful if you have a "
-      "wall bounded flow domain! Use an exponential damping function for the turbulent viscosity "
-      "close to the wall. This is only implemented for a channel geometry of height 2 in y "
-      "direction. The viscous lengthscale l_tau is required as additional input. The solution is "
-      "filtered and by comparison of the filtered velocity field with the real solution, the "
-      "Smagorinsky constant is estimated in each step --- mind that this procedure includes an "
-      "averaging in the xz plane, hence this implementation will only work for a channel flow. "
-      "Multifractal Subgrid-Scale Modeling based on the work of burton. Vremans constant model. "
-      "Dynamic Vreman model according to You and Moin (2007)";
-  fdyn_turbu.specs.emplace_back(
-      deprecated_selection<std::string>("PHYSICAL_MODEL", physical_model_valid_input,
-          {.description = physical_model_doc_string, .default_value = "no_model"}));
+      //! Flag to (de)activate edge-based (EOS) divergence stabilization
+      deprecated_selection<EosDiv>("EOS_DIV",
+          {
+              {"none", EOS_DIV_none},
+              {"vel_jump_std_eos", EOS_DIV_vel_jump_std_eos},
+              {"vel_jump_xfem_gp", EOS_DIV_vel_jump_xfem_gp},
+              {"div_jump_std_eos", EOS_DIV_div_jump_std_eos},
+              {"div_jump_xfem_gp", EOS_DIV_div_jump_xfem_gp},
+          },
+          {.description =
+                  "Flag to (de)activate divergence edge-based stabilization. Options: do not use "
+                  "divergence edge-based stabilization, or, divergence edge-based stabilization "
+                  "based "
+                  "on velocity jump on the entire domain, or, divergence edge-based stabilization "
+                  "based on divergence jump just around cut elements, or, divergence edge-based "
+                  "stabilization based on velocity jump on the entire domain, or, divergence "
+                  "edge-based stabilization based on divergence jump just around cut elements",
+              .default_value = EOS_DIV_none}),
 
-  fdyn_turbu.specs.emplace_back(deprecated_selection<Inpar::FLUID::FineSubgridVisc>("FSSUGRVISC",
-      {
-          {"No", no_fssgv},
-          {"Smagorinsky_all", smagorinsky_all},
-          {"Smagorinsky_small", smagorinsky_small},
-      },
-      {.description = "fine-scale subgrid viscosity", .default_value = no_fssgv}));
+      //! special least-squares condition for pseudo 2D examples where pressure level is determined
+      //! via
+      //! Krylov-projection
+      parameter<bool>(
+          "PRES_KRYLOV_2Dz", {.description = "residual based without second derivatives (i.e. only "
+                                             "consistent for tau->0, but faster)",
+                                 .default_value = false}),
 
-  //----------------------------------------------------------------------
-  // turbulence specific output and statistics
-  //----------------------------------------------------------------------
+      //! this parameter selects the definition of Edge-based stabilization parameter
+      deprecated_selection<EosTauType>("EOS_DEFINITION_TAU",
+          {
+              {"Burman_Fernandez_Hansbo", Inpar::FLUID::EOS_tau_burman_fernandez_hansbo},
+              {"Burman_Fernandez_Hansbo_wo_dt",
+                  Inpar::FLUID::EOS_tau_burman_fernandez_hansbo_wo_dt},
+              {"Braack_Burman_John_Lube", Inpar::FLUID::EOS_tau_braack_burman_john_lube},
+              {"Braack_Burman_John_Lube_wo_divjump",
+                  Inpar::FLUID::EOS_tau_braack_burman_john_lube_wo_divjump},
+              {"Franca_Barrenechea_Valentin_Wall",
+                  Inpar::FLUID::EOS_tau_franca_barrenechea_valentin_wall},
+              {"Burman_Fernandez", Inpar::FLUID::EOS_tau_burman_fernandez},
+              {"Burman_Hansbo_DAngelo_Zunino", Inpar::FLUID::EOS_tau_burman_hansbo_dangelo_zunino},
+              {"Burman_Hansbo_DAngelo_Zunino_wo_dt",
+                  Inpar::FLUID::EOS_tau_burman_hansbo_dangelo_zunino_wo_dt},
+              {"Schott_Massing_Burman_DAngelo_Zunino",
+                  Inpar::FLUID::EOS_tau_schott_massing_burman_dangelo_zunino},
+              {"Schott_Massing_Burman_DAngelo_Zunino_wo_dt",
+                  Inpar::FLUID::EOS_tau_schott_massing_burman_dangelo_zunino_wo_dt},
+              {"Burman", Inpar::FLUID::EOS_tau_burman},
+              {"Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling",
+                  Inpar::FLUID::EOS_tau_Taylor_Hughes_Zarins_Whiting_Jansen_Codina_scaling},
+              {"tau_not_defined", Inpar::FLUID::EOS_tau_not_defined},
+          },
+          {.description = "Definition of stabilization parameter for edge-based stabilization",
+              .default_value = Inpar::FLUID::EOS_tau_burman_hansbo_dangelo_zunino}),
 
-  fdyn_turbu.specs.emplace_back(parameter<int>(
-      "SAMPLING_START", {.description = "Time step after when sampling shall be started",
-                            .default_value = 10000000}));
-  fdyn_turbu.specs.emplace_back(parameter<int>("SAMPLING_STOP",
-      {.description = "Time step when sampling shall be stopped", .default_value = 1}));
-  fdyn_turbu.specs.emplace_back(parameter<int>("DUMPING_PERIOD",
-      {.description = "Period of time steps after which statistical data shall be dumped",
-          .default_value = 1}));
-  fdyn_turbu.specs.emplace_back(parameter<bool>(
-      "SUBGRID_DISSIPATION", {.description = "Flag to (de)activate estimation of subgrid-scale "
-                                             "dissipation (only for seclected flows).",
-                                 .default_value = false}));
-  fdyn_turbu.specs.emplace_back(parameter<bool>("OUTMEAN",
-      {.description = "Flag to (de)activate averaged paraview output", .default_value = false}));
-  fdyn_turbu.specs.emplace_back(parameter<bool>(
-      "TURBMODEL_LS", {.description = "Flag to (de)activate turbulence model in level-set equation",
-                          .default_value = true}));
+      //! this parameter selects how the element length of Edge-based stabilization is defined
+      parameter<EosElementLength>(
+          "EOS_H_DEFINITION", {.description = "Definition of element length for edge-based "
+                                              "stabilization. Options:take the maximal "
+                                              "(nsd-1)D diameter of faces that connect the "
+                                              "internal face to its opposite faces, "
+                                              "or, take the maximal 1D distance along 1D edge to "
+                                              "opposite surface for both parent "
+                                              "elements, or, take the maximal (nsd-1)D face "
+                                              "diameter of all faces for both parent "
+                                              "elements, or, maximal nD diameter of the "
+                                              "neighboring elements, or, maximal (n-1)D "
+                                              "diameter of the internal face/edge, or, take the "
+                                              "maximal volume equivalent diameter "
+                                              "of adjacent elements",
+                                  .default_value = EOS_he_max_diameter_to_opp_surf})});
 
-  //----------------------------------------------------------------------
-  // turbulent flow problem and general characteristics
-  //----------------------------------------------------------------------
+  /*----------------------------------------------------------------------*/
+  list["FLUID DYNAMIC/POROUS-FLOW STABILIZATION"] = all_of({
 
-  {
-    std::vector<std::string> canonical_flow_valid_input = {"no", "time_averaging",
-        "channel_flow_of_height_2", "lid_driven_cavity", "backward_facing_step", "square_cylinder",
-        "square_cylinder_nurbs", "rotating_circular_cylinder_nurbs",
-        "rotating_circular_cylinder_nurbs_scatra", "loma_channel_flow_of_height_2",
-        "loma_lid_driven_cavity", "loma_backward_facing_step", "combust_oracles",
-        "bubbly_channel_flow", "scatra_channel_flow_of_height_2",
-        "decaying_homogeneous_isotropic_turbulence", "forced_homogeneous_isotropic_turbulence",
-        "scatra_forced_homogeneous_isotropic_turbulence", "taylor_green_vortex", "periodic_hill",
-        "blood_fda_flow", "backward_facing_step2"};
+      parameter<bool>("STAB_BIOT",
+          {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}),
+      parameter<double>(
+          "STAB_BIOT_SCALING", {.description = "Scaling factor for stabilization parameter for "
+                                               "biot stabilization of porous flow.",
+                                   .default_value = 1.0}),
 
-    std::string canonical_flow_doc =
-        ""
-        "Sampling is different for different canonical flows - so specify what kind of flow you've "
-        "got \n\n"
-        "no: The flow is not further specified, so spatial averaging and hence the standard "
-        "sampling procedure is not possible\n"
-        "time_averaging: The flow is not further specified, but time averaging of velocity and "
-        "pressure field is performed\n"
-        "channel_flow_of_height_2: For this flow, all statistical data could be averaged in the "
-        "homogeneous planes - it is essentially a statistically one dimensional flow.\n"
-        "lid_driven_cavity: For this flow, all statistical data are evaluated on the center lines "
-        "of the xy-midplane, averaged only over time.\n"
-        "backward_facing_step: For this flow, statistical data are evaluated on various lines, "
-        "averaged over time and z.\n"
-        "square_cylinder: For this flow, statistical data are evaluated on various lines of the "
-        "xy-midplane, averaged only over time.\n"
-        "square_cylinder_nurbs: For this flow, statistical data are evaluated on various lines of "
-        "the xy-midplane, averaged over time and eventually in one home.direction.\n"
-        "rotating_circular_cylinder_nurbs: For this flow, statistical data is computed in "
-        "concentric surfaces and averaged. in time and in one home. direction\n"
-        "rotating_circular_cylinder_nurbs_scatra: For this flow with mass transport, statistical "
-        "data is computed in concentric surfaces and averaged. in time and in one home. direction\n"
-        "loma_channel_flow_of_height_2: For this low-Mach-number flow, all statistical data could "
-        "be averaged in the homogeneous planes - it is essentially a statistically one dimensional "
-        "flow.\n"
-        "loma_lid_driven_cavity: For this low-Mach-number flow, all statistical data are evaluated "
-        "on the center lines of the xy-midplane, averaged only over time.\n"
-        "loma_backward_facing_step: For this low-Mach-number flow, statistical data are evaluated "
-        "on various lines, averaged over time and z.\n"
-        "combust_oracles: ORACLES test rig for turbulent premixed combustion.\n"
-        "bubbly_channel_flow: Turbulent two-phase flow: bubbly channel flow, statistical data are "
-        "averaged in homogeneous planes and over time.\n"
-        "scatra_channel_flow_of_height_2: For this flow, all statistical data could be averaged in "
-        "the homogeneous planes - it is essentially a statistically one dimensional flow.\n"
-        "decaying_homogeneous_isotropic_turbulence: For this flow, all statistical data could be "
-        "averaged in the in all homogeneous directions  - it is essentially a statistically zero "
-        "dimensional flow.\n"
-        "forced_homogeneous_isotropic_turbulence: For this flow, all statistical data could be "
-        "averaged in the in all homogeneous directions  - it is essentially a statistically zero "
-        "dimensional flow.\n"
-        "scatra_forced_homogeneous_isotropic_turbulence: For this flow, all statistical data could "
-        "be averaged in the in all homogeneous directions  - it is essentially a statistically "
-        "zero dimensional flow.\n"
-        "taylor_green_vortex: For this flow, dissipation rate could be averaged in the in all "
-        "homogeneous directions  - it is essentially a statistically zero dimensional flow.\n"
-        "periodic_hill: For this flow, statistical data is evaluated on various lines, averaged "
-        "over time and z.\n"
-        "blood_fda_flow: For this flow, statistical data is evaluated on various planes.\n"
-        "backward_facing_step2: For this flow, statistical data is evaluated on various planes.\n";
+      // this parameter defines various stabilized methods
+      deprecated_selection<Inpar::FLUID::StabType>("STABTYPE",
+          {
+              {"no_stabilization", stabtype_nostab},
+              {"residual_based", stabtype_residualbased},
+              {"edge_based", stabtype_edgebased},
+          },
+          {.description =
+                  "Apply (un)stabilized fluid formulation. No stabilization is only possible "
+                  "for inf-sup stable elements. Use a residual-based stabilization or, more "
+                  "generally, a stabilization \nbased on the concept of the residual-based "
+                  "variational multiscale method...\nExpecting additional inputUse an "
+                  "edge-based stabilization, especially for XFEM",
+              .default_value = stabtype_residualbased}),
 
-    fdyn_turbu.specs.emplace_back(deprecated_selection<std::string>("CANONICAL_FLOW",
-        canonical_flow_valid_input, {.description = canonical_flow_doc, .default_value = "no"}));
-  }
+      parameter<bool>(
+          "INCONSISTENT", {.description = "residual based without second derivatives (i.e. only "
+                                          "consistent for tau->0, but faster)",
+                              .default_value = false}),
 
-  std::vector<std::string> homdir_valid_input = {
-      "not_specified", "x", "y", "z", "xy", "xz", "yz", "xyz"};
-  std::string homdir_doc =
-      "Specify the homogeneous direction(s) of a flow.\n"
-      "not_specified: no homogeneous directions available, averaging is restricted to time "
-      "averaging\n"
-      "x: average along x-direction\n"
-      "y: average along y-direction\n"
-      "z: average along z-direction\n"
-      "xy: Wall normal direction is z, average in x and y direction\n"
-      "xz: Wall normal direction is y, average in x and z direction\n"
-      "yz: Wall normal direction is x, average in y and z direction\n"
-      "xyz: Averaging in all directions\n";
-  fdyn_turbu.specs.emplace_back(deprecated_selection<std::string>(
-      "HOMDIR", homdir_valid_input, {.description = homdir_doc, .default_value = "not_specified"}));
+      parameter<bool>("Reconstruct_Sec_Der",
+          {.description = "residual computed with a reconstruction of the second derivatives via "
+                          "projection or superconvergent patch recovery",
+              .default_value = false}),
 
-  //---------------------------------------
-  // further problem-specific parameters
+      // the following parameters are necessary only if a residual based stabilized method is
+      // applied
+      deprecated_selection<SubscalesTD>("TDS",
+          {
+              {"quasistatic", subscales_quasistatic},
+              {"time_dependent", subscales_time_dependent},
+          },
+          {.description =
+                  "Flag to allow time dependency of subscales for residual-based stabilization.",
+              .default_value = subscales_quasistatic}),
 
-  // CHANNEL FLOW
-  //--------------
+      deprecated_selection<Transient>("TRANSIENT",
+          {
+              {"no_transient", inertia_stab_drop},
+              {"yes_transient", inertia_stab_keep},
+              {"transient_complete", inertia_stab_keep_complete},
+          },
+          {.description = "Specify how to treat the transient term.",
+              .default_value = inertia_stab_drop}),
 
-  fdyn_turbu.specs.emplace_back(parameter<double>(
-      "CHAN_AMPL_INIT_DIST", {.description = "Max. amplitude of the random disturbance in percent "
-                                             "of the initial value in mean flow direction.",
-                                 .default_value = 0.1}));
+      parameter<bool>("PSPG",
+          {.description = "Flag to (de)activate PSPG stabilization.", .default_value = true}),
+      parameter<bool>("SUPG",
+          {.description = "Flag to (de)activate SUPG stabilization.", .default_value = true}),
+      parameter<bool>("GRAD_DIV",
+          {.description = "Flag to (de)activate grad-div term.", .default_value = true}),
 
-  fdyn_turbu.specs.emplace_back(parameter<ForcingType>(
-      "FORCING_TYPE", {.description = "forcing strategy",
-                          .default_value = linear_compensation_from_intermediate_spectrum}));
+      deprecated_selection<VStab>("VSTAB",
+          {
+              {"no_vstab", viscous_stab_none},
+              {"vstab_gls", viscous_stab_gls},
+              {"vstab_gls_rhs", viscous_stab_gls_only_rhs},
+              {"vstab_usfem", viscous_stab_usfem},
+              {"vstab_usfem_rhs", viscous_stab_usfem_only_rhs},
+          },
+          {.description = "Flag to (de)activate viscous term in residual-based stabilization.",
+              .default_value = viscous_stab_none}),
 
-  fdyn_turbu.specs.emplace_back(parameter<int>("CHA_NUMSUBDIVISIONS",
-      {.description = "Number of homogeneous sampling planes in element", .default_value = 5}));
+      deprecated_selection<RStab>("RSTAB",
+          {
+              {"no_rstab", reactive_stab_none},
+              {"rstab_gls", reactive_stab_gls},
+              {"rstab_usfem", reactive_stab_usfem},
+          },
+          {.description = "Flag to (de)activate reactive term in residual-based stabilization.",
+              .default_value = reactive_stab_none}),
 
-  // HIT
-  //--------------
+      deprecated_selection<CrossStress>("CROSS-STRESS",
+          {
+              {"no_cross", cross_stress_stab_none},
+              {"yes_cross", cross_stress_stab},
+              {"cross_rhs", cross_stress_stab_only_rhs},
+          },
+          {.description = "Flag to (de)activate cross-stress term -> residual-based VMM.",
+              .default_value = cross_stress_stab_none}),
 
-  fdyn_turbu.specs.emplace_back(parameter<int>("FORCING_TIME_STEPS",
-      {.description = "Number of time steps during which forcing is applied", .default_value = 0}));
+      deprecated_selection<ReynoldsStress>("REYNOLDS-STRESS",
+          {
+              {"no_reynolds", reynolds_stress_stab_none},
+              {"yes_reynolds", reynolds_stress_stab},
+              {"reynolds_rhs", reynolds_stress_stab_only_rhs},
+          },
+          {.description = "Flag to (de)activate Reynolds-stress term -> residual-based VMM.",
+              .default_value = reynolds_stress_stab_none}),
 
-  fdyn_turbu.specs.emplace_back(parameter<double>(
-      "THRESHOLD_WAVENUMBER", {.description = "Forcing is only applied to wave numbers lower or "
-                                              "equal than the given threshold wave number.",
-                                  .default_value = 0.0}));
+      // this parameter selects the tau definition applied
+      deprecated_selection<TauType>("DEFINITION_TAU",
+          {
+              {"Taylor_Hughes_Zarins", tau_taylor_hughes_zarins},
+              {"Taylor_Hughes_Zarins_wo_dt", tau_taylor_hughes_zarins_wo_dt},
+              {"Taylor_Hughes_Zarins_Whiting_Jansen", tau_taylor_hughes_zarins_whiting_jansen},
+              {"Taylor_Hughes_Zarins_Whiting_Jansen_wo_dt",
+                  tau_taylor_hughes_zarins_whiting_jansen_wo_dt},
+              {"Taylor_Hughes_Zarins_scaled", tau_taylor_hughes_zarins_scaled},
+              {"Taylor_Hughes_Zarins_scaled_wo_dt", tau_taylor_hughes_zarins_scaled_wo_dt},
+              {"Franca_Barrenechea_Valentin_Frey_Wall", tau_franca_barrenechea_valentin_frey_wall},
+              {"Franca_Barrenechea_Valentin_Frey_Wall_wo_dt",
+                  tau_franca_barrenechea_valentin_frey_wall_wo_dt},
+              {"Shakib_Hughes_Codina", tau_shakib_hughes_codina},
+              {"Shakib_Hughes_Codina_wo_dt", tau_shakib_hughes_codina_wo_dt},
+              {"Codina", tau_codina},
+              {"Codina_wo_dt", tau_codina_wo_dt},
+              {"Franca_Madureira_Valentin_Badia_Codina",
+                  tau_franca_madureira_valentin_badia_codina},
+              {"Franca_Madureira_Valentin_Badia_Codina_wo_dt",
+                  tau_franca_madureira_valentin_badia_codina_wo_dt},
+          },
+          {.description = "Definition of tau_M and Tau_C",
+              .default_value = tau_franca_barrenechea_valentin_frey_wall}),
 
-  fdyn_turbu.specs.emplace_back(
-      parameter<double>("POWER_INPUT", {.description = "power of forcing", .default_value = 0.0}));
+      // this parameter selects the characteristic element length for tau_Mu for all
+      // stabilization parameter definitions requiring such a length
+      deprecated_selection<CharEleLengthU>("CHARELELENGTH_U",
+          {
+              {"streamlength", streamlength_u},
+              {"volume_equivalent_diameter", volume_equivalent_diameter_u},
+              {"root_of_volume", root_of_volume_u},
+          },
+          {.description = "Characteristic element length for tau_Mu",
+              .default_value = streamlength_u}),
 
-  std::vector<std::string> scalar_forcing_valid_input = {"no", "isotropic", "mean_scalar_gradient"};
-  std::string scalar_forcing_doc =
-      "no: Do not force the scalar field\n"
-      "isotropic: Force scalar field isotropically such as the fluid field.\n"
-      "mean_scalar_gradient: Force scalar field by imposed mean-scalar gradient.\n";
-  fdyn_turbu.specs.emplace_back(deprecated_selection<std::string>("SCALAR_FORCING",
-      scalar_forcing_valid_input, {.description = scalar_forcing_doc, .default_value = "no"}));
+      // this parameter selects the characteristic element length for tau_Mp and tau_C for
+      // all stabilization parameter definitions requiring such a length
+      deprecated_selection<CharEleLengthPC>("CHARELELENGTH_PC",
+          {
+              {"streamlength", streamlength_pc},
+              {"volume_equivalent_diameter", volume_equivalent_diameter_pc},
+              {"root_of_volume", root_of_volume_pc},
+          },
+          {.description = "Characteristic element length for tau_Mp/tau_C",
+              .default_value = volume_equivalent_diameter_pc}),
 
-  fdyn_turbu.specs.emplace_back(parameter<double>("MEAN_SCALAR_GRADIENT",
-      {.description = "Value of imposed mean-scalar gradient to force scalar field.",
-          .default_value = 0.0}));
+      // this parameter selects the location where tau is evaluated
+      deprecated_selection<std::string>("EVALUATION_TAU", {"element_center", "integration_point"},
+          {.description = "Location where tau is evaluated", .default_value = "element_center"}),
 
-  // filtering with xfem
-  //--------------
+      // this parameter selects the location where the material law is evaluated
+      // (does not fit here very well, but parameter transfer is easier)
+      deprecated_selection<std::string>("EVALUATION_MAT", {"element_center", "integration_point"},
+          {.description = "Location where material law is evaluated",
+              .default_value = "element_center"}),
 
-  fdyn_turbu.specs.emplace_back(parameter<bool>("EXCLUDE_XFEM",
-      {.description = "Flag to (de)activate XFEM dofs in calculation of fine-scale velocity.",
-          .default_value = false}));
 
-  fdyn_turbu.move_into_collection(list);
+      // these parameters active additional terms in loma continuity equation
+      // which might be identified as SUPG-/cross- and Reynolds-stress term
+      parameter<bool>("LOMA_CONTI_SUPG",
+          {.description = "Flag to (de)activate SUPG stabilization in loma continuity equation.",
+              .default_value = false}),
+
+      deprecated_selection<CrossStress>("LOMA_CONTI_CROSS_STRESS",
+          {
+              {"no_cross", cross_stress_stab_none},
+              {"yes_cross", cross_stress_stab},
+              {"cross_rhs", cross_stress_stab_only_rhs},
+          },
+          {.description = "Flag to (de)activate cross-stress term loma continuity equation-> "
+                          "residual-based VMM.",
+              .default_value = cross_stress_stab_none}),
+
+
+      deprecated_selection<ReynoldsStress>("LOMA_CONTI_REYNOLDS_STRESS",
+          {
+              {"no_reynolds", reynolds_stress_stab_none},
+              {"yes_reynolds", reynolds_stress_stab},
+              {"reynolds_rhs", reynolds_stress_stab_only_rhs},
+          },
+          {.description = "Flag to (de)activate Reynolds-stress term loma continuity equation-> "
+                          "residual-based VMM.",
+              .default_value = reynolds_stress_stab_none})});
+
+  /*----------------------------------------------------------------------*/
+  list["FLUID DYNAMIC/TURBULENCE MODEL"] = all_of({
+
+      //----------------------------------------------------------------------
+      // modeling strategies
+      //----------------------------------------------------------------------
+      deprecated_selection<std::string>("TURBULENCE_APPROACH",
+          {"DNS_OR_RESVMM_LES", "CLASSICAL_LES"},
+          {.description =
+                  "Try to solve flow as an underresolved DNS. Mind that your stabilisation "
+                  "already acts as a "
+                  "kind of turbulence model! Perform a classical Large Eddy Simulation adding "
+                  "addititional "
+                  "turbulent viscosity. This may be based on various physical models.)",
+              .default_value = "DNS_OR_RESVMM_LES"}),
+
+      deprecated_selection<std::string>("PHYSICAL_MODEL",
+          {"no_model", "Smagorinsky", "Smagorinsky_with_van_Driest_damping", "Dynamic_Smagorinsky",
+              "Multifractal_Subgrid_Scales", "Vreman", "Dynamic_Vreman"},
+          {.description =
+                  "If classical LES is our turbulence approach, this is a contradiction and should "
+                  "cause a "
+                  "FOUR_C_THROW. Classical constant coefficient Smagorinsky model. Be careful if "
+                  "you "
+                  "have a "
+                  "wall bounded flow domain! Use an exponential damping function for the turbulent "
+                  "viscosity "
+                  "close to the wall. This is only implemented for a channel geometry of height 2 "
+                  "in y "
+                  "direction. The viscous lengthscale l_tau is required as additional input. The "
+                  "solution is "
+                  "filtered and by comparison of the filtered velocity field with the real "
+                  "solution, "
+                  "the "
+                  "Smagorinsky constant is estimated in each step --- mind that this procedure "
+                  "includes an "
+                  "averaging in the xz plane, hence this implementation will only work for a "
+                  "channel "
+                  "flow. "
+                  "Multifractal Subgrid-Scale Modeling based on the work of burton. Vremans "
+                  "constant "
+                  "model. "
+                  "Dynamic Vreman model according to You and Moin (2007)",
+              .default_value = "no_model"}),
+
+      deprecated_selection<Inpar::FLUID::FineSubgridVisc>("FSSUGRVISC",
+          {
+              {"No", no_fssgv},
+              {"Smagorinsky_all", smagorinsky_all},
+              {"Smagorinsky_small", smagorinsky_small},
+          },
+          {.description = "fine-scale subgrid viscosity", .default_value = no_fssgv}),
+
+      //----------------------------------------------------------------------
+      // turbulence specific output and statistics
+      //----------------------------------------------------------------------
+      parameter<int>(
+          "SAMPLING_START", {.description = "Time step after when sampling shall be started",
+                                .default_value = 10000000}),
+      parameter<int>("SAMPLING_STOP",
+          {.description = "Time step when sampling shall be stopped", .default_value = 1}),
+      parameter<int>("DUMPING_PERIOD",
+          {.description = "Period of time steps after which statistical data shall be dumped",
+              .default_value = 1}),
+      parameter<bool>(
+          "SUBGRID_DISSIPATION", {.description = "Flag to (de)activate estimation of subgrid-scale "
+                                                 "dissipation (only for seclected flows).",
+                                     .default_value = false}),
+      parameter<bool>("OUTMEAN",
+          {.description = "Flag to (de)activate averaged paraview output", .default_value = false}),
+      parameter<bool>("TURBMODEL_LS",
+          {.description = "Flag to (de)activate turbulence model in level-set equation",
+              .default_value = true}),
+
+      //----------------------------------------------------------------------
+      // turbulent flow problem and general characteristics
+      //----------------------------------------------------------------------
+      deprecated_selection<std::string>("CANONICAL_FLOW",
+          {"no", "time_averaging", "channel_flow_of_height_2", "lid_driven_cavity",
+              "backward_facing_step", "square_cylinder", "square_cylinder_nurbs",
+              "rotating_circular_cylinder_nurbs", "rotating_circular_cylinder_nurbs_scatra",
+              "loma_channel_flow_of_height_2", "loma_lid_driven_cavity",
+              "loma_backward_facing_step", "combust_oracles", "bubbly_channel_flow",
+              "scatra_channel_flow_of_height_2", "decaying_homogeneous_isotropic_turbulence",
+              "forced_homogeneous_isotropic_turbulence",
+              "scatra_forced_homogeneous_isotropic_turbulence", "taylor_green_vortex",
+              "periodic_hill", "blood_fda_flow", "backward_facing_step2"},
+          {.description =
+                  ""
+                  "Sampling is different for different canonical flows - so specify what kind "
+                  "of "
+                  "flow you've "
+                  "got \n\n"
+                  "no: The flow is not further specified, so spatial averaging and hence the "
+                  "standard "
+                  "sampling procedure is not possible\n"
+                  "time_averaging: The flow is not further specified, but time averaging of "
+                  "velocity "
+                  "and "
+                  "pressure field is performed\n"
+                  "channel_flow_of_height_2: For this flow, all statistical data could be "
+                  "averaged "
+                  "in the "
+                  "homogeneous planes - it is essentially a statistically one dimensional "
+                  "flow.\n"
+                  "lid_driven_cavity: For this flow, all statistical data are evaluated on the "
+                  "center lines "
+                  "of the xy-midplane, averaged only over time.\n"
+                  "backward_facing_step: For this flow, statistical data are evaluated on "
+                  "various "
+                  "lines, "
+                  "averaged over time and z.\n"
+                  "square_cylinder: For this flow, statistical data are evaluated on various "
+                  "lines "
+                  "of the "
+                  "xy-midplane, averaged only over time.\n"
+                  "square_cylinder_nurbs: For this flow, statistical data are evaluated on "
+                  "various "
+                  "lines of "
+                  "the xy-midplane, averaged over time and eventually in one home.direction.\n"
+                  "rotating_circular_cylinder_nurbs: For this flow, statistical data is "
+                  "computed in "
+                  "concentric surfaces and averaged. in time and in one home. direction\n"
+                  "rotating_circular_cylinder_nurbs_scatra: For this flow with mass transport, "
+                  "statistical "
+                  "data is computed in concentric surfaces and averaged. in time and in one "
+                  "home. "
+                  "direction\n"
+                  "loma_channel_flow_of_height_2: For this low-Mach-number flow, all "
+                  "statistical "
+                  "data could "
+                  "be averaged in the homogeneous planes - it is essentially a statistically "
+                  "one "
+                  "dimensional "
+                  "flow.\n"
+                  "loma_lid_driven_cavity: For this low-Mach-number flow, all statistical data "
+                  "are "
+                  "evaluated "
+                  "on the center lines of the xy-midplane, averaged only over time.\n"
+                  "loma_backward_facing_step: For this low-Mach-number flow, statistical data "
+                  "are "
+                  "evaluated "
+                  "on various lines, averaged over time and z.\n"
+                  "combust_oracles: ORACLES test rig for turbulent premixed combustion.\n"
+                  "bubbly_channel_flow: Turbulent two-phase flow: bubbly channel flow, "
+                  "statistical "
+                  "data are "
+                  "averaged in homogeneous planes and over time.\n"
+                  "scatra_channel_flow_of_height_2: For this flow, all statistical data could "
+                  "be "
+                  "averaged in "
+                  "the homogeneous planes - it is essentially a statistically one dimensional "
+                  "flow.\n"
+                  "decaying_homogeneous_isotropic_turbulence: For this flow, all statistical "
+                  "data "
+                  "could be "
+                  "averaged in the in all homogeneous directions  - it is essentially a "
+                  "statistically zero "
+                  "dimensional flow.\n"
+                  "forced_homogeneous_isotropic_turbulence: For this flow, all statistical "
+                  "data "
+                  "could be "
+                  "averaged in the in all homogeneous directions  - it is essentially a "
+                  "statistically zero "
+                  "dimensional flow.\n"
+                  "scatra_forced_homogeneous_isotropic_turbulence: For this flow, all "
+                  "statistical "
+                  "data could "
+                  "be averaged in the in all homogeneous directions  - it is essentially a "
+                  "statistically "
+                  "zero dimensional flow.\n"
+                  "taylor_green_vortex: For this flow, dissipation rate could be averaged in "
+                  "the in "
+                  "all "
+                  "homogeneous directions  - it is essentially a statistically zero "
+                  "dimensional "
+                  "flow.\n"
+                  "periodic_hill: For this flow, statistical data is evaluated on various "
+                  "lines, "
+                  "averaged "
+                  "over time and z.\n"
+                  "blood_fda_flow: For this flow, statistical data is evaluated on various "
+                  "planes.\n"
+                  "backward_facing_step2: For this flow, statistical data is evaluated on "
+                  "various "
+                  "planes.\n",
+              .default_value = "no"}),
+
+      deprecated_selection<std::string>("HOMDIR",
+          {"not_specified", "x", "y", "z", "xy", "xz", "yz", "xyz"},
+          {.description = "Specify the homogeneous direction(s) of a flow.\n"
+                          "not_specified: no homogeneous directions available, averaging is "
+                          "restricted to time "
+                          "averaging\n"
+                          "x: average along x-direction\n"
+                          "y: average along y-direction\n"
+                          "z: average along z-direction\n"
+                          "xy: Wall normal direction is z, average in x and y direction\n"
+                          "xz: Wall normal direction is y, average in x and z direction\n"
+                          "yz: Wall normal direction is x, average in y and z direction\n"
+                          "xyz: Averaging in all directions\n",
+              .default_value = "not_specified"}),
+
+      //---------------------------------------
+      // further problem-specific parameters
+
+      // CHANNEL FLOW
+      //--------------
+      parameter<double>("CHAN_AMPL_INIT_DIST",
+          {.description = "Max. amplitude of the random disturbance in percent "
+                          "of the initial value in mean flow direction.",
+              .default_value = 0.1}),
+
+      parameter<ForcingType>(
+          "FORCING_TYPE", {.description = "forcing strategy",
+                              .default_value = linear_compensation_from_intermediate_spectrum}),
+
+      parameter<int>("CHA_NUMSUBDIVISIONS",
+          {.description = "Number of homogeneous sampling planes in element", .default_value = 5}),
+
+      // HIT
+      //--------------
+      parameter<int>("FORCING_TIME_STEPS",
+          {.description = "Number of time steps during which forcing is applied",
+              .default_value = 0}),
+
+      parameter<double>("THRESHOLD_WAVENUMBER",
+          {.description = "Forcing is only applied to wave numbers lower or "
+                          "equal than the given threshold wave number.",
+              .default_value = 0.0}),
+
+
+      parameter<double>("POWER_INPUT", {.description = "power of forcing", .default_value = 0.0}),
+
+      deprecated_selection<std::string>("SCALAR_FORCING",
+          {"no", "isotropic", "mean_scalar_gradient"},
+          {.description =
+                  "no: Do not force the scalar field\n"
+                  "isotropic: Force scalar field isotropically such as the fluid field.\n"
+                  "mean_scalar_gradient: Force scalar field by imposed mean-scalar gradient.\n",
+              .default_value = "no"}),
+
+      parameter<double>("MEAN_SCALAR_GRADIENT",
+          {.description = "Value of imposed mean-scalar gradient to force scalar field.",
+              .default_value = 0.0}),
+
+      // filtering with xfem
+      //--------------
+      parameter<bool>("EXCLUDE_XFEM",
+          {.description = "Flag to (de)activate XFEM dofs in calculation of fine-scale velocity.",
+              .default_value = false})});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for Smagorinsky model
-  Core::Utils::SectionSpecs fdyn_turbsgv{fdyn, "SUBGRID VISCOSITY"};
+  list["FLUID DYNAMIC/SUBGRID VISCOSITY"] = all_of({
 
-  fdyn_turbsgv.specs.emplace_back(parameter<double>("C_SMAGORINSKY",
-      {.description =
-              "Constant for the Smagorinsky model. Something between 0.1 to 0.24. Vreman constant "
-              "if the constant vreman model is applied (something between 0.07 and 0.01).",
-          .default_value = 0.0}));
-  fdyn_turbsgv.specs.emplace_back(parameter<double>("C_YOSHIZAWA",
-      {.description = "Constant for the compressible Smagorinsky model: isotropic part of "
-                      "subgrid-stress tensor. About 0.09 or 0.0066. Ci will not be squared!",
-          .default_value = -1.0}));
-  fdyn_turbsgv.specs.emplace_back(parameter<bool>("C_SMAGORINSKY_AVERAGED",
-      {.description = "Flag to (de)activate averaged Smagorinksy constant",
-          .default_value = false}));
-  fdyn_turbsgv.specs.emplace_back(parameter<bool>("C_INCLUDE_CI",
-      {.description = "Flag to (de)inclusion of Yoshizawa model", .default_value = false}));
-  // remark: following Moin et al. 1991, the extension of the dynamic Smagorinsky model to
-  // compressibel flow
-  //        also contains a model for the isotropic part of the subgrid-stress tensor according to
-  //        Yoshizawa 1989 although used in literature for turbulent variable-density flow at low
-  //        Mach number, this additional term seems to destabilize the simulation when the flow is
-  //        only weakly compressible therefore C_INCLUDE_CI allows to exclude this term if
-  //        C_SMAGORINSKY_AVERAGED == true
-  //           if C_INCLUDE_CI==true and C_YOSHIZAWA>=0.0 then the given value C_YOSHIZAWA is used
-  //           if C_INCLUDE_CI==true and C_YOSHIZAWA<0.0 then C_YOSHIZAWA is determined dynamically
-  //        else all values are taken from input
+      parameter<double>("C_SMAGORINSKY",
+          {.description =
+                  "Constant for the Smagorinsky model. Something between 0.1 to 0.24. Vreman "
+                  "constant "
+                  "if the constant vreman model is applied (something between 0.07 and 0.01).",
+              .default_value = 0.0}),
+      parameter<double>("C_YOSHIZAWA",
+          {.description = "Constant for the compressible Smagorinsky model: isotropic part of "
+                          "subgrid-stress tensor. About 0.09 or 0.0066. Ci will not be squared!",
+              .default_value = -1.0}),
+      parameter<bool>("C_SMAGORINSKY_AVERAGED",
+          {.description = "Flag to (de)activate averaged Smagorinksy constant",
+              .default_value = false}),
+      parameter<bool>("C_INCLUDE_CI",
+          {.description = "Flag to (de)inclusion of Yoshizawa model", .default_value = false}),
+      // remark: following Moin et al. 1991, the extension of the dynamic Smagorinsky model to
+      // compressibel flow
+      //        also contains a model for the isotropic part of the subgrid-stress tensor according
+      //        to Yoshizawa 1989 although used in literature for turbulent variable-density flow at
+      //        low Mach number, this additional term seems to destabilize the simulation when the
+      //        flow is only weakly compressible therefore C_INCLUDE_CI allows to exclude this term
+      //        if C_SMAGORINSKY_AVERAGED == true
+      //           if C_INCLUDE_CI==true and C_YOSHIZAWA>=0.0 then the given value C_YOSHIZAWA is
+      //           used if C_INCLUDE_CI==true and C_YOSHIZAWA<0.0 then C_YOSHIZAWA is determined
+      //           dynamically
+      //        else all values are taken from input
+      parameter<double>("CHANNEL_L_TAU",
+          {.description = "Used for normalisation of the wall normal distance in the Van \nDriest "
+                          "Damping function. May be taken from the output of \nthe "
+                          "apply_mesh_stretching.pl preprocessing script.",
+              .default_value = 0.0}),
 
-  fdyn_turbsgv.specs.emplace_back(parameter<double>("CHANNEL_L_TAU",
-      {.description = "Used for normalisation of the wall normal distance in the Van \nDriest "
-                      "Damping function. May be taken from the output of \nthe "
-                      "apply_mesh_stretching.pl preprocessing script.",
-          .default_value = 0.0}));
+      parameter<double>(
+          "C_TURBPRANDTL", {.description = "(Constant) turbulent Prandtl number for the "
+                                           "Smagorinsky model in scalar transport.",
+                               .default_value = 1.0}),
 
-  fdyn_turbsgv.specs.emplace_back(parameter<double>("C_TURBPRANDTL",
-      {.description =
-              "(Constant) turbulent Prandtl number for the Smagorinsky model in scalar transport.",
-          .default_value = 1.0}));
-
-  fdyn_turbsgv.specs.emplace_back(deprecated_selection<VremanFiMethod>("FILTER_WIDTH",
-      {
-          {"CubeRootVol", cuberootvol},
-          {"Direction_dependent", dir_dep},
-          {"Minimum_length", min_len},
-      },
-      {.description = "The Vreman model requires a filter width.", .default_value = cuberootvol}));
-
-  fdyn_turbsgv.move_into_collection(list);
+      deprecated_selection<VremanFiMethod>("FILTER_WIDTH",
+          {
+              {"CubeRootVol", cuberootvol},
+              {"Direction_dependent", dir_dep},
+              {"Minimum_length", min_len},
+          },
+          {.description = "The Vreman model requires a filter width.",
+              .default_value = cuberootvol})});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for Smagorinsky model
-  Core::Utils::SectionSpecs fdyn_wallmodel{fdyn, "WALL MODEL"};
+  list["FLUID DYNAMIC/WALL MODEL"] = all_of({
 
-  fdyn_wallmodel.specs.emplace_back(parameter<bool>(
-      "X_WALL", {.description = "Flag to switch on the xwall model", .default_value = false}));
-
-
-  std::vector<std::string> tauw_type_valid_input = {"constant", "between_steps"};
-  std::string tauw_type_doc =
-      "constant: Use the constant wall shear stress given in the input file for the whole "
-      "simulation.\n"
-      "between_steps: Calculate wall shear stress in between time steps.\n";
-  fdyn_wallmodel.specs.emplace_back(deprecated_selection<std::string>("Tauw_Type",
-      tauw_type_valid_input, {.description = tauw_type_doc, .default_value = "constant"}));
-
-  std::vector<std::string> tauw_calc_type_valid_input = {
-      "residual", "gradient", "gradient_to_residual"};
-  std::string tauw_calc_type_doc =
-      "residual: Residual (force) divided by area.\n"
-      "gradient: Gradient via shape functions and nodal values.\n"
-      "gradient_to_residual: First gradient, then residual.\n";
-  fdyn_wallmodel.specs.emplace_back(
-      deprecated_selection<std::string>("Tauw_Calc_Type", tauw_calc_type_valid_input,
-          {.description = tauw_calc_type_doc, .default_value = "residual"}));
+      parameter<bool>(
+          "X_WALL", {.description = "Flag to switch on the xwall model", .default_value = false}),
 
 
-  fdyn_wallmodel.specs.emplace_back(parameter<int>("Switch_Step",
-      {.description = "Switch from gradient to residual based tauw.", .default_value = -1}));
+      deprecated_selection<std::string>("Tauw_Type", {"constant", "between_steps"},
+          {.description = "constant: Use the constant wall shear stress given in the input file "
+                          "for the whole "
+                          "simulation.\n"
+                          "between_steps: Calculate wall shear stress in between time steps.\n",
+              .default_value = "constant"}),
 
-  std::vector<std::string> projection_valid_input = {
-      "No", "onlyl2projection", "l2projectionwithcontinuityconstraint"};
-  std::string projection_doc =
-      "Flag to switch projection of the enriched dofs after updating tauw, alternatively with or "
-      "without continuity constraint.";
-  fdyn_wallmodel.specs.emplace_back(deprecated_selection<std::string>("Projection",
-      projection_valid_input, {.description = projection_doc, .default_value = "No"}));
-
-  fdyn_wallmodel.specs.emplace_back(parameter<double>(
-      "C_Tauw", {.description = "Constant wall shear stress for Spalding's law, if applicable",
-                    .default_value = 1.0}));
-
-  fdyn_wallmodel.specs.emplace_back(parameter<double>(
-      "Min_Tauw", {.description = "Minimum wall shear stress preventing system to become singular",
-                      .default_value = 2.0e-9}));
-
-  fdyn_wallmodel.specs.emplace_back(parameter<double>(
-      "Inc_Tauw", {.description = "Increment of Tauw of full step, between 0.0 and 1.0",
-                      .default_value = 1.0}));
-
-  std::vector<std::string> blending_type_valid_input = {"none", "ramp_function"};
-  std::string blending_type_doc =
-      "Methods for blending the enrichment space.\n"
-      "none: No ramp function, does not converge!\n"
-      "ramp_function: Enrichment is multiplied with linear ramp function resulting in zero "
-      "enrichment at the interface.\n";
-  fdyn_wallmodel.specs.emplace_back(deprecated_selection<std::string>("Blending_Type",
-      blending_type_valid_input, {.description = blending_type_doc, .default_value = "none"}));
+      deprecated_selection<std::string>("Tauw_Calc_Type",
+          {"residual", "gradient", "gradient_to_residual"},
+          {.description = "residual: Residual (force) divided by area.\n"
+                          "gradient: Gradient via shape functions and nodal values.\n"
+                          "gradient_to_residual: First gradient, then residual.\n",
+              .default_value = "residual"}),
 
 
-  fdyn_wallmodel.specs.emplace_back(parameter<int>("GP_Wall_Normal",
-      {.description = "Gauss points in wall normal direction", .default_value = 3}));
-  fdyn_wallmodel.specs.emplace_back(parameter<int>("GP_Wall_Normal_Off_Wall",
-      {.description = "Gauss points in wall normal direction, off-wall elements",
-          .default_value = 3}));
-  fdyn_wallmodel.specs.emplace_back(parameter<int>("GP_Wall_Parallel",
-      {.description = "Gauss points in wall parallel direction", .default_value = 3}));
+      parameter<int>("Switch_Step",
+          {.description = "Switch from gradient to residual based tauw.", .default_value = -1}),
 
-  fdyn_wallmodel.specs.emplace_back(parameter<bool>("Treat_Tauw_on_Dirichlet_Inflow",
-      {.description = "Flag to treat residual on Dirichlet inflow nodes for calculation of wall "
-                      "shear stress",
-          .default_value = false}));
+      deprecated_selection<std::string>("Projection",
+          {"No", "onlyl2projection", "l2projectionwithcontinuityconstraint"},
+          {.description = "Flag to switch projection of the enriched dofs after updating tauw, "
+                          "alternatively with or "
+                          "without continuity constraint.",
+              .default_value = "No"}),
 
-  fdyn_wallmodel.specs.emplace_back(parameter<int>("PROJECTION_SOLVER",
-      {.description = "Set solver number for l2-projection.", .default_value = -1}));
+      parameter<double>(
+          "C_Tauw", {.description = "Constant wall shear stress for Spalding's law, if applicable",
+                        .default_value = 1.0}),
 
-  fdyn_wallmodel.move_into_collection(list);
+      parameter<double>("Min_Tauw",
+          {.description = "Minimum wall shear stress preventing system to become singular",
+              .default_value = 2.0e-9}),
+
+      parameter<double>(
+          "Inc_Tauw", {.description = "Increment of Tauw of full step, between 0.0 and 1.0",
+                          .default_value = 1.0}),
+
+      deprecated_selection<std::string>("Blending_Type", {"none", "ramp_function"},
+          {.description = "Methods for blending the enrichment space.\n"
+                          "none: No ramp function, does not converge!\n"
+                          "ramp_function: Enrichment is multiplied with linear ramp function "
+                          "resulting in zero "
+                          "enrichment at the interface.\n",
+              .default_value = "none"}),
+
+
+      parameter<int>("GP_Wall_Normal",
+          {.description = "Gauss points in wall normal direction", .default_value = 3}),
+      parameter<int>("GP_Wall_Normal_Off_Wall",
+          {.description = "Gauss points in wall normal direction, off-wall elements",
+              .default_value = 3}),
+      parameter<int>("GP_Wall_Parallel",
+          {.description = "Gauss points in wall parallel direction", .default_value = 3}),
+
+      parameter<bool>("Treat_Tauw_on_Dirichlet_Inflow",
+          {.description =
+                  "Flag to treat residual on Dirichlet inflow nodes for calculation of wall "
+                  "shear stress",
+              .default_value = false}),
+
+      parameter<int>("PROJECTION_SOLVER",
+          {.description = "Set solver number for l2-projection.", .default_value = -1})});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for multifractal subgrid-scales
-  Core::Utils::SectionSpecs fdyn_turbmfs{fdyn, "MULTIFRACTAL SUBGRID SCALES"};
+  list["FLUID DYNAMIC/MULTIFRACTAL SUBGRID SCALES"] = all_of({
 
-  fdyn_turbmfs.specs.emplace_back(parameter<double>("CSGS",
-      {.description = "Modelparameter of multifractal subgrid-scales.", .default_value = 0.0}));
+      parameter<double>("CSGS",
+          {.description = "Modelparameter of multifractal subgrid-scales.", .default_value = 0.0}),
 
-  std::vector<std::string> scale_separation_valid_input = {
-      "no_scale_sep", "box_filter", "algebraic_multigrid_operator"};
-  std::string scale_separation_doc =
-      "Specify the filter type for scale separation in LES.\n"
-      "no_scale_sep: no scale separation.\n"
-      "box_filter: classical box filter.\n"
-      "algebraic_multigrid_operator: scale separation by algebraic multigrid operator.\n";
-  fdyn_turbmfs.specs.emplace_back(
-      deprecated_selection<std::string>("SCALE_SEPARATION", scale_separation_valid_input,
-          {.description = scale_separation_doc, .default_value = "no_scale_sep"}));
+      deprecated_selection<std::string>("SCALE_SEPARATION",
+          {"no_scale_sep", "box_filter", "algebraic_multigrid_operator"},
+          {.description = "Specify the filter type for scale separation in LES.\n"
+                          "no_scale_sep: no scale separation.\n"
+                          "box_filter: classical box filter.\n"
+                          "algebraic_multigrid_operator: scale separation by algebraic multigrid "
+                          "operator.\n",
+              .default_value = "no_scale_sep"}),
 
 
-  fdyn_turbmfs.specs.emplace_back(parameter<int>("ML_SOLVER",
-      {.description =
-              "Set solver number for scale separation via level set transfer operators from "
-              "plain aggregation.",
-          .default_value = -1}));
+      parameter<int>("ML_SOLVER",
+          {.description =
+                  "Set solver number for scale separation via level set transfer operators from "
+                  "plain aggregation.",
+              .default_value = -1}),
 
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>(
-      "CALC_N", {.description = "Flag to (de)activate calculation of N from the Reynolds number.",
-                    .default_value = false}));
+      parameter<bool>("CALC_N",
+          {.description = "Flag to (de)activate calculation of N from the Reynolds number.",
+              .default_value = false}),
 
-  fdyn_turbmfs.specs.emplace_back(parameter<double>(
-      "N", {.description = "Set grid to viscous scale ratio.", .default_value = 1.0}));
+      parameter<double>(
+          "N", {.description = "Set grid to viscous scale ratio.", .default_value = 1.0}),
 
-  std::vector<std::string> ref_length_valid_input = {
-      "cube_edge", "sphere_diameter", "streamlength", "gradient_based", "metric_tensor"};
-  std::string ref_length_doc =
-      "Specify the reference length for Re-dependent N.\n"
-      "cube_edge: edge length of volume equivalent cube.\n"
-      "sphere_diameter: diameter of volume equivalent sphere.\n"
-      "streamlength: streamlength taken from stabilization.\n"
-      "gradient_based: gradient based length taken from stabilization.\n"
-      "metric_tensor: metric tensor taken from stabilization.\n";
-  fdyn_turbmfs.specs.emplace_back(deprecated_selection<std::string>("REF_LENGTH",
-      ref_length_valid_input, {.description = ref_length_doc, .default_value = "cube_edge"}));
-
-  std::vector<std::string> ref_velocity_valid_input = {"strainrate", "resolved", "fine_scale"};
-  std::string ref_velocity_doc =
-      "Specify the reference velocity for Re-dependent N.\n"
-      "strainrate: norm of strain rate.\n"
-      "resolved: resolved velocity.\n"
-      "fine_scale: fine-scale velocity.\n";
-  fdyn_turbmfs.specs.emplace_back(deprecated_selection<std::string>("REF_VELOCITY",
-      ref_velocity_valid_input, {.description = ref_velocity_doc, .default_value = "strainrate"}));
+      deprecated_selection<std::string>("REF_LENGTH",
+          {"cube_edge", "sphere_diameter", "streamlength", "gradient_based", "metric_tensor"},
+          {.description = "Specify the reference length for Re-dependent N.\n"
+                          "cube_edge: edge length of volume equivalent cube.\n"
+                          "sphere_diameter: diameter of volume equivalent sphere.\n"
+                          "streamlength: streamlength taken from stabilization.\n"
+                          "gradient_based: gradient based length taken from stabilization.\n"
+                          "metric_tensor: metric tensor taken from stabilization.\n",
+              .default_value = "cube_edge"}),
 
 
-  fdyn_turbmfs.specs.emplace_back(parameter<double>("C_NU",
-      {.description =
-              "Proportionality constant between Re and ratio viscous scale to element length.",
-          .default_value = 1.0}));
-
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>("NEAR_WALL_LIMIT",
-      {.description = "Flag to (de)activate near-wall limit.", .default_value = false}));
-
-  std::vector<std::string> evaluation_b_valid_input = {"element_center", "integration_point"};
-  std::string evaluation_b_doc =
-      "Location where B is evaluated\n"
-      "element_center: evaluate B at element center.\n"
-      "integration_point: evaluate B at integration point.\n";
-  fdyn_turbmfs.specs.emplace_back(
-      deprecated_selection<std::string>("EVALUATION_B", evaluation_b_valid_input,
-          {.description = evaluation_b_doc, .default_value = "element_center"}));
+      deprecated_selection<std::string>("REF_VELOCITY", {"strainrate", "resolved", "fine_scale"},
+          {.description = "Specify the reference velocity for Re-dependent N.\n"
+                          "strainrate: norm of strain rate.\n"
+                          "resolved: resolved velocity.\n"
+                          "fine_scale: fine-scale velocity.\n",
+              .default_value = "strainrate"}),
 
 
-  fdyn_turbmfs.specs.emplace_back(parameter<double>(
-      "BETA", {.description = "Cross- and Reynolds-stress terms only on right-hand-side.",
-                  .default_value = 0.0}));
+      parameter<double>("C_NU",
+          {.description =
+                  "Proportionality constant between Re and ratio viscous scale to element length.",
+              .default_value = 1.0}),
 
-  convform_valid_input = {"convective", "conservative"};
-  std::string convform_doc =
-      "form of convective term\n"
-      "convective: Use the convective form.\n"
-      "conservative: Use the conservative form.\n";
-  fdyn_turbmfs.specs.emplace_back(deprecated_selection<std::string>("CONVFORM",
-      convform_valid_input, {.description = convform_doc, .default_value = "convective"}));
+      parameter<bool>("NEAR_WALL_LIMIT",
+          {.description = "Flag to (de)activate near-wall limit.", .default_value = false}),
 
-  fdyn_turbmfs.specs.emplace_back(parameter<double>("CSGS_PHI",
-      {.description = "Modelparameter of multifractal subgrid-scales for scalar transport.",
-          .default_value = 0.0}));
 
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>("ADAPT_CSGS_PHI",
-      {.description = "Flag to (de)activate adaption of CsgsD to CsgsB.", .default_value = false}));
+      deprecated_selection<std::string>("EVALUATION_B", {"element_center", "integration_point"},
+          {.description = "Location where B is evaluated\n"
+                          "element_center: evaluate B at element center.\n"
+                          "integration_point: evaluate B at integration point.\n",
+              .default_value = "element_center"}),
 
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>("NEAR_WALL_LIMIT_CSGS_PHI",
-      {.description = "Flag to (de)activate near-wall limit for scalar field.",
-          .default_value = false}));
 
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>("CONSISTENT_FLUID_RESIDUAL",
-      {.description = "Flag to (de)activate the consistency term for residual-based stabilization.",
-          .default_value = false}));
+      parameter<double>(
+          "BETA", {.description = "Cross- and Reynolds-stress terms only on right-hand-side.",
+                      .default_value = 0.0}),
 
-  fdyn_turbmfs.specs.emplace_back(parameter<double>(
-      "C_DIFF", {.description = "Proportionality constant between Re*Pr and ratio dissipative "
-                                "scale to element length. Usually equal cnu.",
-                    .default_value = 1.0}));
 
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>("SET_FINE_SCALE_VEL",
-      {.description = "Flag to set fine-scale velocity for parallel nightly tests.",
-          .default_value = false}));
+      deprecated_selection<std::string>("CONVFORM", {"convective", "conservative"},
+          {.description = "form of convective term\n"
+                          "convective: Use the convective form.\n"
+                          "conservative: Use the conservative form.\n",
+              .default_value = "convective"}),
 
-  // activate cross- and Reynolds-stress terms in loma continuity equation
-  fdyn_turbmfs.specs.emplace_back(parameter<bool>("LOMA_CONTI",
-      {.description =
-              "Flag to (de)activate cross- and Reynolds-stress terms in loma continuity equation.",
-          .default_value = false}));
+      parameter<double>("CSGS_PHI",
+          {.description = "Modelparameter of multifractal subgrid-scales for scalar transport.",
+              .default_value = 0.0}),
 
-  fdyn_turbmfs.move_into_collection(list);
+      parameter<bool>(
+          "ADAPT_CSGS_PHI", {.description = "Flag to (de)activate adaption of CsgsD to CsgsB.",
+                                .default_value = false}),
+
+      parameter<bool>("NEAR_WALL_LIMIT_CSGS_PHI",
+          {.description = "Flag to (de)activate near-wall limit for scalar field.",
+              .default_value = false}),
+
+      parameter<bool>("CONSISTENT_FLUID_RESIDUAL",
+          {.description =
+                  "Flag to (de)activate the consistency term for residual-based stabilization.",
+              .default_value = false}),
+
+      parameter<double>(
+          "C_DIFF", {.description = "Proportionality constant between Re*Pr and ratio dissipative "
+                                    "scale to element length. Usually equal cnu.",
+                        .default_value = 1.0}),
+
+      parameter<bool>("SET_FINE_SCALE_VEL",
+          {.description = "Flag to set fine-scale velocity for parallel nightly tests.",
+              .default_value = false}),
+
+      // activate cross- and Reynolds-stress terms in loma continuity equation
+      parameter<bool>(
+          "LOMA_CONTI", {.description = "Flag to (de)activate cross- and Reynolds-stress terms in "
+                                        "loma continuity equation.",
+                            .default_value = false})});
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fdyn_turbinf{fdyn, "TURBULENT INFLOW"};
+  list["FLUID DYNAMIC/TURBULENT INFLOW"] = all_of({
 
-  fdyn_turbinf.specs.emplace_back(parameter<bool>("TURBULENTINFLOW",
-      {.description = "Flag to (de)activate potential separate turbulent inflow section",
-          .default_value = false}));
+      parameter<bool>("TURBULENTINFLOW",
+          {.description = "Flag to (de)activate potential separate turbulent inflow section",
+              .default_value = false}),
 
-  fdyn_turbinf.specs.emplace_back(deprecated_selection<InitialField>("INITIALINFLOWFIELD",
-      {
-          {"zero_field", initfield_zero_field},
-          {"field_by_function", initfield_field_by_function},
-          {"disturbed_field_from_function", initfield_disturbed_field_from_function},
-      },
-      {.description = "Initial field for inflow section", .default_value = initfield_zero_field}));
+      deprecated_selection<InitialField>("INITIALINFLOWFIELD",
+          {
+              {"zero_field", initfield_zero_field},
+              {"field_by_function", initfield_field_by_function},
+              {"disturbed_field_from_function", initfield_disturbed_field_from_function},
+          },
+          {.description = "Initial field for inflow section",
+              .default_value = initfield_zero_field}),
 
-  fdyn_turbinf.specs.emplace_back(parameter<int>(
-      "INFLOWFUNC", {.description = "Function number for initial flow field in inflow section",
-                        .default_value = -1}));
+      parameter<int>(
+          "INFLOWFUNC", {.description = "Function number for initial flow field in inflow section",
+                            .default_value = -1}),
 
-  fdyn_turbinf.specs.emplace_back(parameter<double>(
-      "INFLOW_INIT_DIST", {.description = "Max. amplitude of the random disturbance in percent of "
-                                          "the initial value in mean flow direction.",
-                              .default_value = 0.1}));
+      parameter<double>("INFLOW_INIT_DIST",
+          {.description = "Max. amplitude of the random disturbance in percent of "
+                          "the initial value in mean flow direction.",
+              .default_value = 0.1}),
 
-  fdyn_turbinf.specs.emplace_back(parameter<int>("NUMINFLOWSTEP",
-      {.description = "Total number of time steps for development of turbulent flow",
-          .default_value = 1}));
+      parameter<int>("NUMINFLOWSTEP",
+          {.description = "Total number of time steps for development of turbulent flow",
+              .default_value = 1}),
 
-  std::vector<std::string> canonical_inflow_valid_input = {"no", "time_averaging",
-      "channel_flow_of_height_2", "loma_channel_flow_of_height_2",
-      "scatra_channel_flow_of_height_2"};
-  std::string canonical_inflow_doc =
-      "Sampling is different for different canonical flows \n--- so specify what kind of flow "
-      "you've got\n"
-      "no: The flow is not further specified, so spatial averaging \nand hence the standard "
-      "sampling procedure is not possible.\n"
-      "time_averaging: The flow is not further specified, but time averaging of velocity and "
-      "pressure field is performed.\n"
-      "channel_flow_of_height_2: For this flow, all statistical data could be averaged in \nthe "
-      "homogeneous planes --- it is essentially a statistically one dimensional flow.\n"
-      "loma_channel_flow_of_height_2: For this low-Mach-number flow, all statistical data could be "
-      "averaged in \nthe homogeneous planes --- it is essentially a statistically one dimensional "
-      "flow.\n"
-      "scatra_channel_flow_of_height_2: For this flow, all statistical data could be averaged in "
-      "\nthe homogeneous planes --- it is essentially a statistically one dimensional flow.\n";
-  fdyn_turbinf.specs.emplace_back(deprecated_selection<std::string>("CANONICAL_INFLOW",
-      canonical_inflow_valid_input, {.description = canonical_inflow_doc, .default_value = "no"}));
+      deprecated_selection<std::string>("CANONICAL_INFLOW",
+          {"no", "time_averaging", "channel_flow_of_height_2", "loma_channel_flow_of_height_2",
+              "scatra_channel_flow_of_height_2"},
+          {.description =
+                  "Sampling is different for different canonical flows \n--- so specify what kind "
+                  "of "
+                  "flow "
+                  "you've got\n"
+                  "no: The flow is not further specified, so spatial averaging \nand hence the "
+                  "standard "
+                  "sampling procedure is not possible.\n"
+                  "time_averaging: The flow is not further specified, but time averaging of "
+                  "velocity "
+                  "and "
+                  "pressure field is performed.\n"
+                  "channel_flow_of_height_2: For this flow, all statistical data could be averaged "
+                  "in "
+                  "\nthe "
+                  "homogeneous planes --- it is essentially a statistically one dimensional flow.\n"
+                  "loma_channel_flow_of_height_2: For this low-Mach-number flow, all statistical "
+                  "data "
+                  "could be "
+                  "averaged in \nthe homogeneous planes --- it is essentially a statistically one "
+                  "dimensional "
+                  "flow.\n"
+                  "scatra_channel_flow_of_height_2: For this flow, all statistical data could be "
+                  "averaged in "
+                  "\nthe homogeneous planes --- it is essentially a statistically one dimensional "
+                  "flow.\n",
+              .default_value = "no"}),
 
 
-  fdyn_turbinf.specs.emplace_back(parameter<double>("INFLOW_CHA_SIDE",
-      {.description = "Most right side of inflow channel. Necessary to define sampling domain.",
-          .default_value = 0.0}));
+      parameter<double>("INFLOW_CHA_SIDE",
+          {.description = "Most right side of inflow channel. Necessary to define sampling domain.",
+              .default_value = 0.0}),
 
-  std::vector<std::string> inflow_homdir_valid_input = {
-      "not_specified", "x", "y", "z", "xy", "xz", "yz"};
-  std::string inflow_homdir_doc =
-      "Specify the homogeneous direction(s) of a flow\n"
-      "not_specified: no homogeneous directions available, averaging is restricted to time "
-      "averaging.\n"
-      "x: average along x-direction.\n"
-      "y: average along y-direction.\n"
-      "z: average along z-direction.\n"
-      "xy: Wall normal direction is z, average in x and y direction.\n"
-      "xz: Wall normal direction is y, average in x and z direction (standard case).\n"
-      "yz: Wall normal direction is x, average in y and z direction.\n";
-  fdyn_turbinf.specs.emplace_back(
-      deprecated_selection<std::string>("INFLOW_HOMDIR", inflow_homdir_valid_input,
-          {.description = inflow_homdir_doc, .default_value = "not_specified"}));
+      deprecated_selection<std::string>("INFLOW_HOMDIR",
+          {"not_specified", "x", "y", "z", "xy", "xz", "yz"},
+          {.description =
+                  "Specify the homogeneous direction(s) of a flow\n"
+                  "not_specified: no homogeneous directions available, averaging is restricted to "
+                  "time "
+                  "averaging.\n"
+                  "x: average along x-direction.\n"
+                  "y: average along y-direction.\n"
+                  "z: average along z-direction.\n"
+                  "xy: Wall normal direction is z, average in x and y direction.\n"
+                  "xz: Wall normal direction is y, average in x and z direction (standard case).\n"
+                  "yz: Wall normal direction is x, average in y and z direction.\n",
+              .default_value = "not_specified"}),
 
-  fdyn_turbinf.specs.emplace_back(parameter<int>(
-      "INFLOW_SAMPLING_START", {.description = "Time step after when sampling shall be started",
-                                   .default_value = 10000000}));
-  fdyn_turbinf.specs.emplace_back(parameter<int>("INFLOW_SAMPLING_STOP",
-      {.description = "Time step when sampling shall be stopped", .default_value = 1}));
-  fdyn_turbinf.specs.emplace_back(parameter<int>("INFLOW_DUMPING_PERIOD",
-      {.description = "Period of time steps after which statistical data shall be dumped",
-          .default_value = 1}));
-
-  fdyn_turbinf.move_into_collection(list);
+      parameter<int>(
+          "INFLOW_SAMPLING_START", {.description = "Time step after when sampling shall be started",
+                                       .default_value = 10000000}),
+      parameter<int>("INFLOW_SAMPLING_STOP",
+          {.description = "Time step when sampling shall be stopped", .default_value = 1}),
+      parameter<int>("INFLOW_DUMPING_PERIOD",
+          {.description = "Period of time steps after which statistical data shall be dumped",
+              .default_value = 1})});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for time adaptivity in fluid/ coupled problems
-  Core::Utils::SectionSpecs fdyn_timintada{fdyn, "TIMEADAPTIVITY"};
-  fdyn_timintada.specs.emplace_back(
+  list["FLUID DYNAMIC/TIMEADAPTIVITY"] = all_of({
+
       deprecated_selection<AdaptiveTimeStepEstimator>("ADAPTIVE_TIME_STEP_ESTIMATOR",
           {
               {"none", const_dt},
@@ -1343,18 +1389,18 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               {"only_print_cfl_number", only_print_cfl_number},
           },
           {.description = "Method used to determine adaptive time step size.",
-              .default_value = const_dt}));
+              .default_value = const_dt}),
 
-  fdyn_timintada.specs.emplace_back(parameter<double>(
-      "CFL_NUMBER", {.description = "CFL number for adaptive time step", .default_value = -1.0}));
-  fdyn_timintada.specs.emplace_back(parameter<int>("FREEZE_ADAPTIVE_DT_AT",
-      {.description = "keep time step constant after this step, otherwise turbulence statistics "
-                      "sampling is not consistent",
-          .default_value = 1000000}));
-  fdyn_timintada.specs.emplace_back(parameter<double>("ADAPTIVE_DT_INC",
-      {.description = "Increment of whole step for adaptive dt via CFL", .default_value = 0.8}));
-
-  fdyn_timintada.move_into_collection(list);
+      parameter<double>("CFL_NUMBER",
+          {.description = "CFL number for adaptive time step", .default_value = -1.0}),
+      parameter<int>("FREEZE_ADAPTIVE_DT_AT",
+          {.description =
+                  "keep time step constant after this step, otherwise turbulence statistics "
+                  "sampling is not consistent",
+              .default_value = 1000000}),
+      parameter<double>(
+          "ADAPTIVE_DT_INC", {.description = "Increment of whole step for adaptive dt via CFL",
+                                 .default_value = 0.8})});
 }
 
 
@@ -1364,43 +1410,38 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs lomacontrol{"LOMA CONTROL"};
+  list["LOMA CONTROL"] = all_of({
 
-  lomacontrol.specs.emplace_back(
-      parameter<bool>("MONOLITHIC", {.description = "monolithic solver", .default_value = false}));
-  lomacontrol.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of time steps", .default_value = 24}));
-  lomacontrol.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  lomacontrol.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  lomacontrol.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "Maximum number of outer iterations", .default_value = 10}));
-  lomacontrol.specs.emplace_back(parameter<int>("ITEMAX_BEFORE_SAMPLING",
-      {.description =
-              "Maximum number of outer iterations before sampling (for turbulent flows only)",
-          .default_value = 1}));
-  lomacontrol.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-6}));
-  lomacontrol.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  lomacontrol.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
+      parameter<bool>("MONOLITHIC", {.description = "monolithic solver", .default_value = false}),
+      parameter<int>("NUMSTEP", {.description = "Total number of time steps", .default_value = 24}),
 
-  std::vector<std::string> constthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
-  lomacontrol.specs.emplace_back(
-      deprecated_selection<std::string>("CONSTHERMPRESS", constthermpress_valid_input,
-          {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>(
+          "ITEMAX", {.description = "Maximum number of outer iterations", .default_value = 10}),
+      parameter<int>("ITEMAX_BEFORE_SAMPLING",
+          {.description =
+                  "Maximum number of outer iterations before sampling (for turbulent flows only)",
+              .default_value = 1}),
+      parameter<double>(
+          "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-6}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
 
-  lomacontrol.specs.emplace_back(parameter<bool>(
-      "SGS_MATERIAL_UPDATE", {.description = "update material by adding subgrid-scale scalar field",
-                                 .default_value = false}));
 
-  // number of linear solver used for LOMA solver
-  lomacontrol.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for LOMA problem", .default_value = -1}));
+      deprecated_selection<std::string>("CONSTHERMPRESS", {"No_energy", "No_mass", "Yes"},
+          {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}),
 
-  lomacontrol.move_into_collection(list);
+      parameter<bool>("SGS_MATERIAL_UPDATE",
+          {.description = "update material by adding subgrid-scale scalar field",
+              .default_value = false}),
+
+      // number of linear solver used for LOMA solver
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for LOMA problem", .default_value = -1})});
 }
 
 

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -20,113 +20,112 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs fpsidyn{"FPSI DYNAMIC"};
+  list["FPSI DYNAMIC"] = all_of({
 
-  fpsidyn.specs.emplace_back(parameter<FpsiCouplingType>("COUPALGO",
-      {.description = "Iteration Scheme over the fields", .default_value = fpsi_monolithic_plain}));
+      parameter<FpsiCouplingType>("COUPALGO", {.description = "Iteration Scheme over the fields",
+                                                  .default_value = fpsi_monolithic_plain}),
 
-  fpsidyn.specs.emplace_back(parameter<bool>("SHAPEDERIVATIVES",
-      {.description = "Include linearization with respect to mesh movement in Navier Stokes "
-                      "equation.\nSupported in monolithic FPSI for now.",
-          .default_value = false}));
+      parameter<bool>("SHAPEDERIVATIVES",
+          {.description = "Include linearization with respect to mesh movement in Navier Stokes "
+                          "equation.\nSupported in monolithic FPSI for now.",
+              .default_value = false}),
 
-  fpsidyn.specs.emplace_back(parameter<bool>("USESHAPEDERIVATIVES",
-      {.description = "Add linearization with respect to mesh movement in Navier Stokes equation "
-                      "to stiffness matrix.\nSupported in monolithic FPSI for now.",
-          .default_value = false}));
+      parameter<bool>("USESHAPEDERIVATIVES",
+          {.description =
+                  "Add linearization with respect to mesh movement in Navier Stokes equation "
+                  "to stiffness matrix.\nSupported in monolithic FPSI for now.",
+              .default_value = false}),
 
-  fpsidyn.specs.emplace_back(parameter<Inpar::FPSI::PartitionedCouplingMethod>(
-      "PARTITIONED", {.description = "Coupling strategies for partitioned FPSI solvers.",
-                         .default_value = RobinNeumann}));
+      parameter<Inpar::FPSI::PartitionedCouplingMethod>(
+          "PARTITIONED", {.description = "Coupling strategies for partitioned FPSI solvers.",
+                             .default_value = RobinNeumann}),
 
-  fpsidyn.specs.emplace_back(parameter<bool>("SECONDORDER",
-      {.description = "Second order coupling at the interface.", .default_value = false}));
+      parameter<bool>("SECONDORDER",
+          {.description = "Second order coupling at the interface.", .default_value = false}),
 
-  // Iterationparameters
-  fpsidyn.specs.emplace_back(parameter<std::string>("RESTOL",
-      {.description = "Tolerances for single fields in the residual norm for the Newton iteration. "
-                      "\nFor NORM_RESF != Abs_sys_split only the first value is used for all "
-                      "fields. \nOrder of fields: porofluidvelocity, porofluidpressure, "
-                      "porostructure, fluidvelocity, fluidpressure, ale",
-          .default_value = "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8"}));
+      // Iterationparameters
+      parameter<std::string>("RESTOL",
+          {.description =
+                  "Tolerances for single fields in the residual norm for the Newton iteration. "
+                  "\nFor NORM_RESF != Abs_sys_split only the first value is used for all "
+                  "fields. \nOrder of fields: porofluidvelocity, porofluidpressure, "
+                  "porostructure, fluidvelocity, fluidpressure, ale",
+              .default_value = "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8"}),
 
-  fpsidyn.specs.emplace_back(parameter<std::string>(
-      "INCTOL", {.description = "Tolerance in the increment norm for the Newton iteration. \nFor "
-                                "NORM_INC != \\*_split only the first value is used for all "
-                                "fields. \nOrder of fields: porofluidvelocity, porofluidpressure, "
-                                "porostructure, fluidvelocity, fluidpressure, ale",
-                    .default_value = "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8"}));
+      parameter<std::string>("INCTOL",
+          {.description = "Tolerance in the increment norm for the Newton iteration. \nFor "
+                          "NORM_INC != \\*_split only the first value is used for all "
+                          "fields. \nOrder of fields: porofluidvelocity, porofluidpressure, "
+                          "porostructure, fluidvelocity, fluidpressure, ale",
+              .default_value = "1e-8 1e-8 1e-8 1e-8 1e-8 1e-8"}),
 
-  fpsidyn.specs.emplace_back(deprecated_selection<Inpar::FPSI::ConvergenceNorm>("NORM_INC",
-      {
-          {"Abs", absoluteconvergencenorm},
-          {"Abs_sys_split", absoluteconvergencenorm_sys_split},
-          {"Rel_sys", relativconvergencenorm_sys},
-      },
-      {.description =
-              "Type of norm for primary variables convergence check.  \nAbs: absolute values, "
-              "Abs_sys_split: absolute values with correction of systemsize for every field "
-              "separate, Rel_sys: relative values with correction of systemsize.",
-          .default_value = absoluteconvergencenorm}));
+      deprecated_selection<Inpar::FPSI::ConvergenceNorm>("NORM_INC",
+          {
+              {"Abs", absoluteconvergencenorm},
+              {"Abs_sys_split", absoluteconvergencenorm_sys_split},
+              {"Rel_sys", relativconvergencenorm_sys},
+          },
+          {.description =
+                  "Type of norm for primary variables convergence check.  \nAbs: absolute values, "
+                  "Abs_sys_split: absolute values with correction of systemsize for every field "
+                  "separate, Rel_sys: relative values with correction of systemsize.",
+              .default_value = absoluteconvergencenorm}),
 
-  fpsidyn.specs.emplace_back(deprecated_selection<Inpar::FPSI::ConvergenceNorm>("NORM_RESF",
-      {
-          {"Abs", absoluteconvergencenorm},
-          {"Abs_sys_split", absoluteconvergencenorm_sys_split},
-          {"Rel_sys", relativconvergencenorm_sys},
-      },
-      {.description =
-              "Type of norm for primary variables convergence check. \nAbs: absolute values, "
-              "Abs_sys_split: absolute values with correction of systemsize for every field "
-              "separate, Rel_sys: relative values with correction of systemsize.",
-          .default_value = absoluteconvergencenorm}));
+      deprecated_selection<Inpar::FPSI::ConvergenceNorm>("NORM_RESF",
+          {
+              {"Abs", absoluteconvergencenorm},
+              {"Abs_sys_split", absoluteconvergencenorm_sys_split},
+              {"Rel_sys", relativconvergencenorm_sys},
+          },
+          {.description =
+                  "Type of norm for primary variables convergence check. \nAbs: absolute values, "
+                  "Abs_sys_split: absolute values with correction of systemsize for every field "
+                  "separate, Rel_sys: relative values with correction of systemsize.",
+              .default_value = absoluteconvergencenorm}),
 
-  fpsidyn.specs.emplace_back(deprecated_selection<Inpar::FPSI::BinaryOp>("NORMCOMBI_RESFINC",
-      {
-          {"And", bop_and},
-          {"Or", bop_or},
-      },
-      {.description = "binary operator to combine primary variables and residual force values",
-          .default_value = bop_and}));
+      deprecated_selection<Inpar::FPSI::BinaryOp>("NORMCOMBI_RESFINC",
+          {
+              {"And", bop_and},
+              {"Or", bop_or},
+          },
+          {.description = "binary operator to combine primary variables and residual force values",
+              .default_value = bop_and}),
 
-  fpsidyn.specs.emplace_back(
+
       parameter<bool>("LineSearch", {.description = "adapt increment in case of non-monotonic "
                                                     "residual convergence or residual oscillations",
-                                        .default_value = false}));
+                                        .default_value = false}),
 
-  fpsidyn.specs.emplace_back(parameter<bool>("FDCheck",
-      {.description = "perform FPSIFDCheck() finite difference check", .default_value = false}));
+      parameter<bool>("FDCheck",
+          {.description = "perform FPSIFDCheck() finite difference check", .default_value = false}),
 
-  // number of linear solver used for poroelasticity
-  fpsidyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for FPSI problems", .default_value = -1}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "minimal number of iterations over fields", .default_value = 1}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of Timesteps", .default_value = 200}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "Maximum number of iterations over fields", .default_value = 100}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "FDCheck_row", {.description = "print row value during fd_check", .default_value = 0}));
-  fpsidyn.specs.emplace_back(parameter<int>(
-      "FDCheck_column", {.description = "print column value during fd_check", .default_value = 0}));
+      // number of linear solver used for poroelasticity
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for FPSI problems", .default_value = -1}),
+      parameter<int>("ITEMIN",
+          {.description = "minimal number of iterations over fields", .default_value = 1}),
+      parameter<int>("NUMSTEP", {.description = "Total number of Timesteps", .default_value = 200}),
+      parameter<int>("ITEMAX",
+          {.description = "Maximum number of iterations over fields", .default_value = 100}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+      parameter<int>(
+          "FDCheck_row", {.description = "print row value during fd_check", .default_value = 0}),
+      parameter<int>("FDCheck_column",
+          {.description = "print column value during fd_check", .default_value = 0}),
 
-  fpsidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  fpsidyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  fpsidyn.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "Tolerance for iteration over fields", .default_value = 1e-6}));
-  fpsidyn.specs.emplace_back(parameter<double>(
-      "ALPHABJ", {.description = "Beavers-Joseph-Coefficient for Slip-Boundary-Condition at "
-                                 "Fluid-Porous-Interface (0.1-4)",
-                     .default_value = 1.0}));
 
-  fpsidyn.move_into_collection(list);
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<double>(
+          "CONVTOL", {.description = "Tolerance for iteration over fields", .default_value = 1e-6}),
+      parameter<double>(
+          "ALPHABJ", {.description = "Beavers-Joseph-Coefficient for Slip-Boundary-Condition at "
+                                     "Fluid-Porous-Interface (0.1-4)",
+                         .default_value = 1.0})});
 }
 
 

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -9,8 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -8,8 +8,7 @@
 #include "4C_inpar_fs3i.hpp"
 
 #include "4C_inpar_scatra.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -19,118 +19,114 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs fs3idyn{"FS3I DYNAMIC"};
+  list["FS3I DYNAMIC"] = all_of({
 
-  fs3idyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  fs3idyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of time steps", .default_value = 20}));
-  fs3idyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  fs3idyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  fs3idyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-  fs3idyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::SolverType>("SCATRA_SOLVERTYPE",
-      {
-          {"linear", Inpar::ScaTra::solvertype_linear_incremental},
-          {"nonlinear", Inpar::ScaTra::solvertype_nonlinear},
-      },
-      {.description = "type of scalar transport solver",
-          .default_value = Inpar::ScaTra::solvertype_nonlinear}));
-  fs3idyn.specs.emplace_back(parameter<bool>(
-      "INF_PERM", {.description = "Flag for infinite permeability", .default_value = true}));
-  std::vector<std::string> consthermpress_valid_input = {"No_energy", "No_mass", "Yes"};
-  fs3idyn.specs.emplace_back(
-      deprecated_selection<std::string>("CONSTHERMPRESS", consthermpress_valid_input,
-          {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<int>("NUMSTEP", {.description = "Total number of time steps", .default_value = 20}),
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+      deprecated_selection<Inpar::ScaTra::SolverType>("SCATRA_SOLVERTYPE",
+          {
+              {"linear", Inpar::ScaTra::solvertype_linear_incremental},
+              {"nonlinear", Inpar::ScaTra::solvertype_nonlinear},
+          },
+          {.description = "type of scalar transport solver",
+              .default_value = Inpar::ScaTra::solvertype_nonlinear}),
+      parameter<bool>(
+          "INF_PERM", {.description = "Flag for infinite permeability", .default_value = true}),
+      deprecated_selection<std::string>("CONSTHERMPRESS", {"No_energy", "No_mass", "Yes"},
+          {.description = "treatment of thermodynamic pressure in time", .default_value = "Yes"}),
 
-  // number of linear solver used for fs3i problems
-  fs3idyn.specs.emplace_back(parameter<int>("COUPLED_LINEAR_SOLVER",
-      {.description = "number of linear solver used for fs3i problem", .default_value = -1}));
-  fs3idyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER1",
-      {.description = "number of linear solver used for fluid problem", .default_value = -1}));
-  fs3idyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER2",
-      {.description = "number of linear solver used for structural problem", .default_value = -1}));
+      // number of linear solver used for fs3i problems
+      parameter<int>("COUPLED_LINEAR_SOLVER",
+          {.description = "number of linear solver used for fs3i problem", .default_value = -1}),
+      parameter<int>("LINEAR_SOLVER1",
+          {.description = "number of linear solver used for fluid problem", .default_value = -1}),
+      parameter<int>(
+          "LINEAR_SOLVER2", {.description = "number of linear solver used for structural problem",
+                                .default_value = -1}),
 
-  fs3idyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::ConvForm>("STRUCTSCAL_CONVFORM",
-      {
-          {"convective", Inpar::ScaTra::convform_convective},
-          {"conservative", Inpar::ScaTra::convform_conservative},
-      },
-      {.description = "form of convective term of structure scalar",
-          .default_value = Inpar::ScaTra::convform_conservative}));
+      deprecated_selection<Inpar::ScaTra::ConvForm>("STRUCTSCAL_CONVFORM",
+          {
+              {"convective", Inpar::ScaTra::convform_convective},
+              {"conservative", Inpar::ScaTra::convform_conservative},
+          },
+          {.description = "form of convective term of structure scalar",
+              .default_value = Inpar::ScaTra::convform_conservative}),
 
-  fs3idyn.specs.emplace_back(
+
       deprecated_selection<Inpar::ScaTra::InitialField>("STRUCTSCAL_INITIALFIELD",
           {
               {"zero_field", Inpar::ScaTra::initfield_zero_field},
               {"field_by_function", Inpar::ScaTra::initfield_field_by_function},
           },
           {.description = "Initial Field for structure scalar transport problem",
-              .default_value = Inpar::ScaTra::initfield_zero_field}));
+              .default_value = Inpar::ScaTra::initfield_zero_field}),
 
-  fs3idyn.specs.emplace_back(parameter<int>("STRUCTSCAL_INITFUNCNO",
-      {.description = "function number for structure scalar transport initial field",
-          .default_value = -1}));
+      parameter<int>("STRUCTSCAL_INITFUNCNO",
+          {.description = "function number for structure scalar transport initial field",
+              .default_value = -1}),
 
-  // Type of coupling strategy between structure and structure-scalar field
-  fs3idyn.specs.emplace_back(deprecated_selection<VolumeCoupling>("STRUCTSCAL_FIELDCOUPLING",
-      {
-          {"volume_matching", coupling_match},
-          {"volume_nonmatching", coupling_nonmatch},
-      },
-      {.description = "Type of coupling strategy between structure and structure-scalar field",
-          .default_value = coupling_match}));
+      // Type of coupling strategy between structure and structure-scalar field
+      deprecated_selection<VolumeCoupling>("STRUCTSCAL_FIELDCOUPLING",
+          {
+              {"volume_matching", coupling_match},
+              {"volume_nonmatching", coupling_nonmatch},
+          },
+          {.description = "Type of coupling strategy between structure and structure-scalar field",
+              .default_value = coupling_match}),
 
-  // Type of coupling strategy between fluid and fluid-scalar field
-  fs3idyn.specs.emplace_back(deprecated_selection<VolumeCoupling>("FLUIDSCAL_FIELDCOUPLING",
-      {
-          {"volume_matching", coupling_match},
-          {"volume_nonmatching", coupling_nonmatch},
-      },
-      {.description = "Type of coupling strategy between fluid and fluid-scalar field",
-          .default_value = coupling_match}));
+      // Type of coupling strategy between fluid and fluid-scalar field
+      deprecated_selection<VolumeCoupling>("FLUIDSCAL_FIELDCOUPLING",
+          {
+              {"volume_matching", coupling_match},
+              {"volume_nonmatching", coupling_nonmatch},
+          },
+          {.description = "Type of coupling strategy between fluid and fluid-scalar field",
+              .default_value = coupling_match}),
 
-  // type of scalar transport
-  fs3idyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::ImplType>("FLUIDSCAL_SCATRATYPE",
-      {
-          {"Undefined", Inpar::ScaTra::impltype_undefined},
-          {"ConvectionDiffusion", Inpar::ScaTra::impltype_std},
-          {"Loma", Inpar::ScaTra::impltype_loma},
-          {"Advanced_Reaction", Inpar::ScaTra::impltype_advreac},
-          {"Chemotaxis", Inpar::ScaTra::impltype_chemo},
-          {"Chemo_Reac", Inpar::ScaTra::impltype_chemoreac},
-      },
-      {.description = "Type of scalar transport problem",
-          .default_value = Inpar::ScaTra::impltype_std}));
+      // type of scalar transport
+      deprecated_selection<Inpar::ScaTra::ImplType>("FLUIDSCAL_SCATRATYPE",
+          {
+              {"Undefined", Inpar::ScaTra::impltype_undefined},
+              {"ConvectionDiffusion", Inpar::ScaTra::impltype_std},
+              {"Loma", Inpar::ScaTra::impltype_loma},
+              {"Advanced_Reaction", Inpar::ScaTra::impltype_advreac},
+              {"Chemotaxis", Inpar::ScaTra::impltype_chemo},
+              {"Chemo_Reac", Inpar::ScaTra::impltype_chemoreac},
+          },
+          {.description = "Type of scalar transport problem",
+              .default_value = Inpar::ScaTra::impltype_std}),
 
-  // Restart from FSI instead of FS3I
-  fs3idyn.specs.emplace_back(parameter<bool>(
-      "RESTART_FROM_PART_FSI", {.description = "restart from partitioned fsi problem (e.g. from "
-                                               "prestress calculations) instead of fs3i",
-                                   .default_value = false}));
+      // Restart from FSI instead of FS3I
+      parameter<bool>("RESTART_FROM_PART_FSI",
+          {.description = "restart from partitioned fsi problem (e.g. from "
+                          "prestress calculations) instead of fs3i",
+              .default_value = false}),
 
-  fs3idyn.move_into_collection(list);
+  });
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned FS3I */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs fs3idynpart{fs3idyn, "PARTITIONED"};
+  list["FS3I DYNAMIC/PARTITIONED"] = all_of({
 
-  // Coupling strategy for partitioned FS3I
-  fs3idynpart.specs.emplace_back(parameter<SolutionSchemeOverFields>("COUPALGO",
-      {.description = "Coupling strategies for FS3I solvers", .default_value = fs3i_IterStagg}));
+      // Coupling strategy for partitioned FS3I
+      parameter<SolutionSchemeOverFields>("COUPALGO",
+          {.description = "Coupling strategies for FS3I solvers", .default_value = fs3i_IterStagg}),
 
-  // convergence tolerance of outer iteration loop
-  fs3idynpart.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description = "tolerance for convergence check of outer iteration within partitioned FS3I",
-          .default_value = 1e-6}));
+      // convergence tolerance of outer iteration loop
+      parameter<double>("CONVTOL",
+          {.description =
+                  "tolerance for convergence check of outer iteration within partitioned FS3I",
+              .default_value = 1e-6}),
 
-  fs3idynpart.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "Maximum number of outer iterations", .default_value = 10}));
-
-  fs3idynpart.move_into_collection(list);
+      parameter<int>(
+          "ITEMAX", {.description = "Maximum number of outer iterations", .default_value = 10})});
 
   /*----------------------------------------------------------------------  */
   /* parameters for stabilization of the structure-scalar field             */

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -9,8 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -19,427 +19,427 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs fsidyn{"FSI DYNAMIC"};
+  list["FSI DYNAMIC"] = all_of({
 
-  std::map<std::string, FsiCoupling> map{
-      {"basic_sequ_stagg", fsi_basic_sequ_stagg},
-      {"iter_stagg_fixed_rel_param", fsi_iter_stagg_fixed_rel_param},
-      {"iter_stagg_AITKEN_rel_param", fsi_iter_stagg_AITKEN_rel_param},
-      {"iter_stagg_steep_desc", fsi_iter_stagg_steep_desc},
-      {"iter_stagg_NLCG", fsi_iter_stagg_NLCG},
-      {"iter_stagg_MFNK_FD", fsi_iter_stagg_MFNK_FD},
-      {"iter_stagg_MFNK_FSI", fsi_iter_stagg_MFNK_FSI},
-      {"iter_stagg_MPE", fsi_iter_stagg_MPE},
-      {"iter_stagg_RRE", fsi_iter_stagg_RRE},
-      {"iter_monolithicfluidsplit", fsi_iter_monolithicfluidsplit},
-      {"iter_monolithicstructuresplit", fsi_iter_monolithicstructuresplit},
-      {"iter_xfem_monolithic", fsi_iter_xfem_monolithic},
-      {"iter_mortar_monolithicstructuresplit", fsi_iter_mortar_monolithicstructuresplit},
-      {"iter_mortar_monolithicfluidsplit", fsi_iter_mortar_monolithicfluidsplit},
-      {"iter_fluidfluid_monolithicstructuresplit", fsi_iter_fluidfluid_monolithicstructuresplit},
-      {"iter_fluidfluid_monolithicfluidsplit", fsi_iter_fluidfluid_monolithicfluidsplit},
-      {"iter_fluidfluid_monolithicstructuresplit_nonox",
-          fsi_iter_fluidfluid_monolithicstructuresplit_nonox},
-      {"iter_fluidfluid_monolithicfluidsplit_nonox",
-          fsi_iter_fluidfluid_monolithicfluidsplit_nonox},
-      {"iter_sliding_monolithicfluidsplit", fsi_iter_sliding_monolithicfluidsplit},
-      {"iter_sliding_monolithicstructuresplit", fsi_iter_sliding_monolithicstructuresplit},
-      {"iter_mortar_monolithicfluidsplit_saddlepoint",
-          fsi_iter_mortar_monolithicfluidsplit_saddlepoint},
-  };
+      deprecated_selection<FsiCoupling>("COUPALGO",
+          {
+              {"basic_sequ_stagg", fsi_basic_sequ_stagg},
+              {"iter_stagg_fixed_rel_param", fsi_iter_stagg_fixed_rel_param},
+              {"iter_stagg_AITKEN_rel_param", fsi_iter_stagg_AITKEN_rel_param},
+              {"iter_stagg_steep_desc", fsi_iter_stagg_steep_desc},
+              {"iter_stagg_NLCG", fsi_iter_stagg_NLCG},
+              {"iter_stagg_MFNK_FD", fsi_iter_stagg_MFNK_FD},
+              {"iter_stagg_MFNK_FSI", fsi_iter_stagg_MFNK_FSI},
+              {"iter_stagg_MPE", fsi_iter_stagg_MPE},
+              {"iter_stagg_RRE", fsi_iter_stagg_RRE},
+              {"iter_monolithicfluidsplit", fsi_iter_monolithicfluidsplit},
+              {"iter_monolithicstructuresplit", fsi_iter_monolithicstructuresplit},
+              {"iter_xfem_monolithic", fsi_iter_xfem_monolithic},
+              {"iter_mortar_monolithicstructuresplit", fsi_iter_mortar_monolithicstructuresplit},
+              {"iter_mortar_monolithicfluidsplit", fsi_iter_mortar_monolithicfluidsplit},
+              {"iter_fluidfluid_monolithicstructuresplit",
+                  fsi_iter_fluidfluid_monolithicstructuresplit},
+              {"iter_fluidfluid_monolithicfluidsplit", fsi_iter_fluidfluid_monolithicfluidsplit},
+              {"iter_fluidfluid_monolithicstructuresplit_nonox",
+                  fsi_iter_fluidfluid_monolithicstructuresplit_nonox},
+              {"iter_fluidfluid_monolithicfluidsplit_nonox",
+                  fsi_iter_fluidfluid_monolithicfluidsplit_nonox},
+              {"iter_sliding_monolithicfluidsplit", fsi_iter_sliding_monolithicfluidsplit},
+              {"iter_sliding_monolithicstructuresplit", fsi_iter_sliding_monolithicstructuresplit},
+              {"iter_mortar_monolithicfluidsplit_saddlepoint",
+                  fsi_iter_mortar_monolithicfluidsplit_saddlepoint},
+          },
+          {.description = "Iteration Scheme over the fields",
+              .default_value = fsi_iter_stagg_AITKEN_rel_param}),
+
+      parameter<bool>("DEBUGOUTPUT",
+          {.description = "Output of unconverged interface values during FSI iteration. "
+                          "There will be a new control "
+                          "file for each time step. This might be helpful to understand "
+                          "the coupling iteration.",
+              .default_value = false}),
+      parameter<bool>("MATCHGRID_FLUIDALE",
+          {.description = "is matching grid (fluid-ale)", .default_value = true}),
+
+      parameter<bool>("MATCHGRID_STRUCTALE",
+          {.description = "is matching grid (structure-ale)", .default_value = true}),
+
+      parameter<bool>("MATCHALL",
+          {.description = "is matching grid (fluid-ale) and is full fluid-ale (without euler part)",
+              .default_value = true}),
+
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>("NUMSTEP", {.description = "Total number of Timesteps", .default_value = 200}),
+
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+
+      parameter<bool>("RESTART_FROM_PART_FSI",
+          {.description = "restart from partitioned fsi (e.g. from prestress "
+                          "calculations) instead of monolithic fsi",
+              .default_value = false}),
+
+      parameter<bool>("SECONDORDER",
+          {.description = "Second order displacement-velocity conversion at the interface.",
+              .default_value = false}),
+
+      deprecated_selection<Inpar::FSI::SlideALEProj>("SLIDEALEPROJ",
+          {
+              {"None", Inpar::FSI::ALEprojection_none},
+              {"Curr", Inpar::FSI::ALEprojection_curr},
+              {"Ref", Inpar::FSI::ALEprojection_ref},
+              {"RotZ", Inpar::FSI::ALEprojection_rot_z},
+              {"RotZSphere", Inpar::FSI::ALEprojection_rot_zsphere},
+          },
+          {.description = "Projection method to use for sliding FSI.",
+              .default_value = Inpar::FSI::ALEprojection_none}),
 
 
-  fsidyn.specs.emplace_back(deprecated_selection<FsiCoupling>("COUPALGO", map,
-      {.description = "Iteration Scheme over the fields",
-          .default_value = fsi_iter_stagg_AITKEN_rel_param}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
 
-  std::string debugoutput_doc =
-      "Output of unconverged interface values during FSI iteration. There will be a new control "
-      "file for each time step. This might be helpful to understand the coupling iteration.";
-  fsidyn.specs.emplace_back(
-      parameter<bool>("DEBUGOUTPUT", {.description = debugoutput_doc, .default_value = false}));
-  fsidyn.specs.emplace_back(parameter<bool>("MATCHGRID_FLUIDALE",
-      {.description = "is matching grid (fluid-ale)", .default_value = true}));
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
 
-  fsidyn.specs.emplace_back(parameter<bool>("MATCHGRID_STRUCTALE",
-      {.description = "is matching grid (structure-ale)", .default_value = true}));
-
-  fsidyn.specs.emplace_back(parameter<bool>("MATCHALL",
-      {.description = "is matching grid (fluid-ale) and is full fluid-ale (without euler part)",
-          .default_value = true}));
-
-  fsidyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  fsidyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of Timesteps", .default_value = 200}));
-
-  fsidyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-
-  fsidyn.specs.emplace_back(parameter<bool>(
-      "RESTART_FROM_PART_FSI", {.description = "restart from partitioned fsi (e.g. from prestress "
-                                               "calculations) instead of monolithic fsi",
-                                   .default_value = false}));
-
-  fsidyn.specs.emplace_back(parameter<bool>("SECONDORDER",
-      {.description = "Second order displacement-velocity conversion at the interface.",
-          .default_value = false}));
-
-  fsidyn.specs.emplace_back(deprecated_selection<Inpar::FSI::SlideALEProj>("SLIDEALEPROJ",
-      {
-          {"None", Inpar::FSI::ALEprojection_none},
-          {"Curr", Inpar::FSI::ALEprojection_curr},
-          {"Ref", Inpar::FSI::ALEprojection_ref},
-          {"RotZ", Inpar::FSI::ALEprojection_rot_z},
-          {"RotZSphere", Inpar::FSI::ALEprojection_rot_zsphere},
-      },
-      {.description = "Projection method to use for sliding FSI.",
-          .default_value = Inpar::FSI::ALEprojection_none}));
-
-  fsidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-
-  fsidyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-
-  fsidyn.specs.emplace_back(deprecated_selection<Inpar::FSI::Verbosity>("VERBOSITY",
-      {
-          {"full", Inpar::FSI::verbosity_full},
-          {"medium", Inpar::FSI::verbosity_medium},
-          {"low", Inpar::FSI::verbosity_low},
-          {"subproblem", Inpar::FSI::verbosity_subproblem},
-      },
-      {.description = "Verbosity of the FSI problem.",
-          .default_value = Inpar::FSI::verbosity_full}));
-
-  fsidyn.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      deprecated_selection<Inpar::FSI::Verbosity>("VERBOSITY",
+          {
+              {"full", Inpar::FSI::verbosity_full},
+              {"medium", Inpar::FSI::verbosity_medium},
+              {"low", Inpar::FSI::verbosity_low},
+              {"subproblem", Inpar::FSI::verbosity_subproblem},
+          },
+          {.description = "Verbosity of the FSI problem.",
+              .default_value = Inpar::FSI::
+                  verbosity_full})}); /*----------------------------------------------------------------------*/
   /* parameters for time step size adaptivity in fsi dynamics */
-  Core::Utils::SectionSpecs fsiadapt{fsidyn, "TIMEADAPTIVITY"};
+  list["FSI DYNAMIC/TIMEADAPTIVITY"] = all_of({
 
-  fsiadapt.specs.emplace_back(parameter<int>("ADAPTSTEPMAX",
-      {.description = "Maximum number of repetitions of one time step for adapting/reducing the "
-                      "time step size (>0)",
-          .default_value = 5}));
+      parameter<int>("ADAPTSTEPMAX",
+          {.description =
+                  "Maximum number of repetitions of one time step for adapting/reducing the "
+                  "time step size (>0)",
+              .default_value = 5}),
 
-  fsiadapt.specs.emplace_back(deprecated_selection<Inpar::FSI::FluidMethod>("AUXINTEGRATORFLUID",
-      {
-          {"None", Inpar::FSI::timada_fld_none},
-          {"ExplicitEuler", Inpar::FSI::timada_fld_expleuler},
-          {"AB2", Inpar::FSI::timada_fld_adamsbashforth2},
-      },
-      {.description = "Method for error estimation in the fluid field",
-          .default_value = Inpar::FSI::timada_fld_adamsbashforth2}));
+      deprecated_selection<Inpar::FSI::FluidMethod>("AUXINTEGRATORFLUID",
+          {
+              {"None", Inpar::FSI::timada_fld_none},
+              {"ExplicitEuler", Inpar::FSI::timada_fld_expleuler},
+              {"AB2", Inpar::FSI::timada_fld_adamsbashforth2},
+          },
+          {.description = "Method for error estimation in the fluid field",
+              .default_value = Inpar::FSI::timada_fld_adamsbashforth2}),
 
-  fsiadapt.specs.emplace_back(parameter<std::string>("AVERAGINGDT",
-      {.description = "Averaging of time step sizes in case of increasing time step "
-                      "size.\nParameters are ordered from most recent weight to the most historic "
-                      "one.\nNumber of parameters determines the number of previous time steps "
-                      "that are involved\nin the averaging procedure.",
-          .default_value = "0.3 0.7"}));
-
-
-  fsiadapt.specs.emplace_back(deprecated_selection<Inpar::FSI::DivContAct>("DIVERCONT",
-      {
-          {"stop", Inpar::FSI::divcont_stop},
-          {"continue", Inpar::FSI::divcont_continue},
-          {"halve_step", Inpar::FSI::divcont_halve_step},
-          {"revert_dt", Inpar::FSI::divcont_revert_dt},
-      },
-      {.description = "What to do if nonlinear solver does not converge?",
-          .default_value = Inpar::FSI::divcont_stop}));
-
-  fsiadapt.specs.emplace_back(parameter<double>("DTMAX",
-      {.description = "Limit maximally permitted time step size (>0)", .default_value = 0.1}));
-  fsiadapt.specs.emplace_back(parameter<double>("DTMIN",
-      {.description = "Limit minimally allowed time step size (>0)", .default_value = 1.0e-4}));
-
-  fsiadapt.specs.emplace_back(parameter<double>("LOCERRTOLFLUID",
-      {.description = "Tolerance for the norm of local velocity error", .default_value = 1.0e-3}));
+      parameter<std::string>("AVERAGINGDT",
+          {.description =
+                  "Averaging of time step sizes in case of increasing time step "
+                  "size.\nParameters are ordered from most recent weight to the most historic "
+                  "one.\nNumber of parameters determines the number of previous time steps "
+                  "that are involved\nin the averaging procedure.",
+              .default_value = "0.3 0.7"}),
 
 
-  fsiadapt.specs.emplace_back(parameter<int>("NUMINCREASESTEPS",
-      {.description = "Number of consecutive steps that want to increase time step size before\n"
-                      "actually increasing it. Set 0 to deactivate this feature.",
-          .default_value = 0}));
+      deprecated_selection<Inpar::FSI::DivContAct>("DIVERCONT",
+          {
+              {"stop", Inpar::FSI::divcont_stop},
+              {"continue", Inpar::FSI::divcont_continue},
+              {"halve_step", Inpar::FSI::divcont_halve_step},
+              {"revert_dt", Inpar::FSI::divcont_revert_dt},
+          },
+          {.description = "What to do if nonlinear solver does not converge?",
+              .default_value = Inpar::FSI::divcont_stop}),
 
-  fsiadapt.specs.emplace_back(parameter<double>(
-      "SAFETYFACTOR", {.description = "This is a safety factor to scale theoretical optimal step "
-                                      "size, \nshould be lower than 1 and must be larger than 0",
-                          .default_value = 0.9}));
+      parameter<double>("DTMAX",
+          {.description = "Limit maximally permitted time step size (>0)", .default_value = 0.1}),
+      parameter<double>("DTMIN",
+          {.description = "Limit minimally allowed time step size (>0)", .default_value = 1.0e-4}),
 
-  fsiadapt.specs.emplace_back(parameter<double>("SIZERATIOMAX",
-      {.description =
-              "Limit maximally permitted change of\ntime step size compared to previous size (>0).",
-          .default_value = 2.0}));
-  fsiadapt.specs.emplace_back(parameter<double>("SIZERATIOMIN",
-      {.description =
-              "Limit minimally permitted change of\ntime step size compared to previous size (>0).",
-          .default_value = 0.5}));
+      parameter<double>(
+          "LOCERRTOLFLUID", {.description = "Tolerance for the norm of local velocity error",
+                                .default_value = 1.0e-3}),
 
-  fsiadapt.specs.emplace_back(parameter<bool>("TIMEADAPTON",
-      {.description = "Activate or deactivate time step size adaptivity", .default_value = false}));
 
-  fsiadapt.move_into_collection(list);
+      parameter<int>("NUMINCREASESTEPS",
+          {.description =
+                  "Number of consecutive steps that want to increase time step size before\n"
+                  "actually increasing it. Set 0 to deactivate this feature.",
+              .default_value = 0}),
+
+      parameter<double>("SAFETYFACTOR",
+          {.description = "This is a safety factor to scale theoretical optimal step "
+                          "size, \nshould be lower than 1 and must be larger than 0",
+              .default_value = 0.9}),
+
+      parameter<double>("SIZERATIOMAX", {.description = "Limit maximally permitted change of\ntime "
+                                                        "step size compared to previous size (>0).",
+                                            .default_value = 2.0}),
+      parameter<double>("SIZERATIOMIN", {.description = "Limit minimally permitted change of\ntime "
+                                                        "step size compared to previous size (>0).",
+                                            .default_value = 0.5}),
+
+      parameter<bool>(
+          "TIMEADAPTON", {.description = "Activate or deactivate time step size adaptivity",
+                             .default_value = false})});
 
   /*--------------------------------------------------------------------------*/
 
   /*--------------------------------------------------------------------------*/
   /* parameters for monolithic FSI solvers */
-  Core::Utils::SectionSpecs fsimono{fsidyn, "MONOLITHIC SOLVER"};
+  list["FSI DYNAMIC/MONOLITHIC SOLVER"] = all_of({
 
-  fsimono.specs.emplace_back(parameter<double>("ADAPTIVEDIST",
-      {.description =
-              "Required distance for adaptive convergence check in Newton-type FSI.\n"
-              "This is the improvement we want to achieve in the linear extrapolation of the\n"
-              "adaptive convergence check. Set to zero to avoid the adaptive check altogether.",
-          .default_value = 0.0}));
+      parameter<double>("ADAPTIVEDIST",
+          {.description =
+                  "Required distance for adaptive convergence check in Newton-type FSI.\n"
+                  "This is the improvement we want to achieve in the linear extrapolation of the\n"
+                  "adaptive convergence check. Set to zero to avoid the adaptive check altogether.",
+              .default_value = 0.0}),
 
-  fsimono.specs.emplace_back(parameter<double>("BASETOL",
-      {.description =
-              "Basic tolerance for adaptive convergence check in monolithic FSI.\n"
-              "This tolerance will be used for the linear solve of the FSI block system.\n"
-              "The linear convergence test will always use the relative residual norm (AZ_r0).\n"
-              "Not to be confused with the Newton tolerance (CONVTOL) that applies\n"
-              "to the nonlinear convergence test using a absolute residual norm.",
-          .default_value = 1e-3}));
-  fsimono.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "Nonlinear tolerance for lung/constraint/fluid-fluid FSI",
-                     .default_value = 1e-6}));  // ToDo remove
+      parameter<double>("BASETOL",
+          {.description =
+                  "Basic tolerance for adaptive convergence check in monolithic FSI.\n"
+                  "This tolerance will be used for the linear solve of the FSI block system.\n"
+                  "The linear convergence test will always use the relative residual norm "
+                  "(AZ_r0).\n"
+                  "Not to be confused with the Newton tolerance (CONVTOL) that applies\n"
+                  "to the nonlinear convergence test using a absolute residual norm.",
+              .default_value = 1e-3}),
+      parameter<double>(
+          "CONVTOL", {.description = "Nonlinear tolerance for lung/constraint/fluid-fluid FSI",
+                         .default_value = 1e-6}),  // ToDo remove
 
-  fsimono.specs.emplace_back(parameter<bool>("ENERGYFILE",
-      {.description = "Write artificial interface energy due to temporal discretization to file",
-          .default_value = false}));
+      parameter<bool>("ENERGYFILE",
+          {.description =
+                  "Write artificial interface energy due to temporal discretization to file",
+              .default_value = false}),
 
-  fsimono.specs.emplace_back(parameter<bool>("FSIAMGANALYZE",
-      {.description = "run analysis on fsiamg multigrid scheme", .default_value = false}));
+      parameter<bool>("FSIAMGANALYZE",
+          {.description = "run analysis on fsiamg multigrid scheme", .default_value = false}),
 
-  fsimono.specs.emplace_back(parameter<bool>(
-      "INFNORMSCALING", {.description = "Scale Blocks with row infnorm?", .default_value = true}));
+      parameter<bool>("INFNORMSCALING",
+          {.description = "Scale Blocks with row infnorm?", .default_value = true}),
 
-  fsimono.specs.emplace_back(parameter<int>("ITEMAX",
-      {.description = "Maximum allowed number of nonlinear iterations", .default_value = 100}));
-  fsimono.specs.emplace_back(parameter<int>("KRYLOV_ITEMAX",
-      {.description = "Max Iterations for linear solver.", .default_value = 1000}));
-  fsimono.specs.emplace_back(parameter<int>(
-      "KRYLOV_SIZE", {.description = "Size of Krylov Subspace.", .default_value = 50}));
+      parameter<int>("ITEMAX",
+          {.description = "Maximum allowed number of nonlinear iterations", .default_value = 100}),
+      parameter<int>("KRYLOV_ITEMAX",
+          {.description = "Max Iterations for linear solver.", .default_value = 1000}),
+      parameter<int>(
+          "KRYLOV_SIZE", {.description = "Size of Krylov Subspace.", .default_value = 50}),
 
-  fsimono.specs.emplace_back(
+
       deprecated_selection<Inpar::FSI::LinearBlockSolver>("LINEARBLOCKSOLVER",
           {
               {"PreconditionedKrylov", Inpar::FSI::PreconditionedKrylov},
               {"LinalgSolver", Inpar::FSI::LinalgSolver},
           },
           {.description = "Linear block preconditioner for block system in monolithic FSI.",
-              .default_value = Inpar::FSI::PreconditionedKrylov}));
+              .default_value = Inpar::FSI::PreconditionedKrylov}),
 
-  fsimono.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "Number of SOLVER block describing the linear solver and preconditioner",
-          .default_value = -1}));
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "Number of SOLVER block describing the linear solver and preconditioner",
+              .default_value = -1}),
 
-  // Iteration parameters for convergence check of newton loop
-  // for implementations without NOX
-  fsimono.specs.emplace_back(deprecated_selection<Inpar::FSI::ConvNorm>("NORM_INC",
-      {
-          {"Abs", Inpar::FSI::convnorm_abs},
-          {"Rel", Inpar::FSI::convnorm_rel},
-          {"Mix", Inpar::FSI::convnorm_mix},
-      },
-      {.description = "type of norm for primary variables convergence check",
-          .default_value = Inpar::FSI::convnorm_rel}));
+      // Iteration parameters for convergence check of newton loop
+      // for implementations without NOX
+      deprecated_selection<Inpar::FSI::ConvNorm>("NORM_INC",
+          {
+              {"Abs", Inpar::FSI::convnorm_abs},
+              {"Rel", Inpar::FSI::convnorm_rel},
+              {"Mix", Inpar::FSI::convnorm_mix},
+          },
+          {.description = "type of norm for primary variables convergence check",
+              .default_value = Inpar::FSI::convnorm_rel}),
 
-  // for implementations without NOX
-  fsimono.specs.emplace_back(deprecated_selection<Inpar::FSI::ConvNorm>("NORM_RESF",
-      {
-          {"Abs", Inpar::FSI::convnorm_abs},
-          {"Rel", Inpar::FSI::convnorm_rel},
-          {"Mix", Inpar::FSI::convnorm_mix},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = Inpar::FSI::convnorm_rel}));
+      // for implementations without NOX
+      deprecated_selection<Inpar::FSI::ConvNorm>("NORM_RESF",
+          {
+              {"Abs", Inpar::FSI::convnorm_abs},
+              {"Rel", Inpar::FSI::convnorm_rel},
+              {"Mix", Inpar::FSI::convnorm_mix},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = Inpar::FSI::convnorm_rel}),
 
-  // for implementations without NOX
-  fsimono.specs.emplace_back(deprecated_selection<Inpar::FSI::BinaryOp>("NORMCOMBI_RESFINC",
-      {
-          {"And", Inpar::FSI::bop_and},
-      },
-      {.description = "binary operator to combine primary variables and residual force values",
-          .default_value = Inpar::FSI::bop_and}));
+      // for implementations without NOX
+      deprecated_selection<Inpar::FSI::BinaryOp>("NORMCOMBI_RESFINC",
+          {
+              {"And", Inpar::FSI::bop_and},
+          },
+          {.description = "binary operator to combine primary variables and residual force values",
+              .default_value = Inpar::FSI::bop_and}),
 
-  fsimono.specs.emplace_back(parameter<int>(
-      "PRECONDREUSE", {.description = "Number of iterations in one time step reusing the "
-                                      "preconditioner before rebuilding it",
-                          .default_value = 0}));
+      parameter<int>(
+          "PRECONDREUSE", {.description = "Number of iterations in one time step reusing the "
+                                          "preconditioner before rebuilding it",
+                              .default_value = 0}),
 
-  fsimono.specs.emplace_back(parameter<bool>("REBUILDPRECEVERYSTEP",
-      {.description = "Enforce rebuilding the preconditioner at the beginning of every time step",
-          .default_value = true}));
+      parameter<bool>("REBUILDPRECEVERYSTEP",
+          {.description =
+                  "Enforce rebuilding the preconditioner at the beginning of every time step",
+              .default_value = true}),
 
-  fsimono.specs.emplace_back(parameter<bool>("SHAPEDERIVATIVES",
-      {.description =
-              "Include linearization with respect to mesh movement in Navier Stokes equation.",
-          .default_value = false}));
+      parameter<bool>("SHAPEDERIVATIVES",
+          {.description =
+                  "Include linearization with respect to mesh movement in Navier Stokes equation.",
+              .default_value = false}),
 
-  fsimono.specs.emplace_back(parameter<bool>("SYMMETRICPRECOND",
-      {.description = "Symmetric block GS preconditioner or ordinary GS", .default_value = false}));
+      parameter<bool>(
+          "SYMMETRICPRECOND", {.description = "Symmetric block GS preconditioner or ordinary GS",
+                                  .default_value = false}),
 
-  // monolithic preconditioner parameter
+      // monolithic preconditioner parameter
+      parameter<std::string>("ALEPCOMEGA",
+          {.description = "Relaxation factor for Richardson iteration on ale block in MFSI block "
+                          "preconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1.0 1.0 1.0 1.0"}),
+      parameter<std::string>("ALEPCITER",
+          {.description = "Number of Richardson iterations on ale block in MFSI block "
+                          "preconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1 1 1 1"}),
+      parameter<std::string>("FLUIDPCOMEGA",
+          {.description = "Relaxation factor for Richardson iteration on fluid block in MFSI block "
+                          "preconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1.0 1.0 1.0 1.0"}),
+      parameter<std::string>("FLUIDPCITER",
+          {.description = "Number of Richardson iterations on fluid block in MFSI block "
+                          "preconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1 1 1 1"}),
+      parameter<std::string>("STRUCTPCOMEGA",
+          {.description = "Relaxation factor for Richardson iteration on structural block in MFSI "
+                          "block \npreconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1.0 1.0 1.0 1.0"}),
+      parameter<std::string>("STRUCTPCITER",
+          {.description = "Number of Richardson iterations on structural block in MFSI block "
+                          "preconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1 1 1 1"}),
 
-  fsimono.specs.emplace_back(parameter<std::string>("ALEPCOMEGA",
-      {.description = "Relaxation factor for Richardson iteration on ale block in MFSI block "
-                      "preconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1.0 1.0 1.0 1.0"}));
-  fsimono.specs.emplace_back(parameter<std::string>("ALEPCITER",
-      {.description = "Number of Richardson iterations on ale block in MFSI block "
-                      "preconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1 1 1 1"}));
-  fsimono.specs.emplace_back(parameter<std::string>("FLUIDPCOMEGA",
-      {.description = "Relaxation factor for Richardson iteration on fluid block in MFSI block "
-                      "preconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1.0 1.0 1.0 1.0"}));
-  fsimono.specs.emplace_back(parameter<std::string>("FLUIDPCITER",
-      {.description = "Number of Richardson iterations on fluid block in MFSI block "
-                      "preconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1 1 1 1"}));
-  fsimono.specs.emplace_back(parameter<std::string>("STRUCTPCOMEGA",
-      {.description = "Relaxation factor for Richardson iteration on structural block in MFSI "
-                      "block \npreconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1.0 1.0 1.0 1.0"}));
-  fsimono.specs.emplace_back(parameter<std::string>("STRUCTPCITER",
-      {.description = "Number of Richardson iterations on structural block in MFSI block "
-                      "preconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1 1 1 1"}));
+      parameter<std::string>("PCOMEGA",
+          {.description = "Relaxation factor for Richardson iteration on whole MFSI block "
+                          "preconditioner\nFSIAMG: each number belongs to a "
+                          "level\nPreconditiondKrylov: only first number is used for finest level",
+              .default_value = "1.0 1.0 1.0"}),
+      parameter<std::string>("PCITER",
+          {.description =
+                  "Number of Richardson iterations on whole MFSI block preconditioner\nFSIAMG: "
+                  "each number belongs to a level\nPreconditiondKrylov: only first number is "
+                  "used for finest level",
+              .default_value = "1 1 1"}),
 
-  fsimono.specs.emplace_back(parameter<std::string>("PCOMEGA",
-      {.description = "Relaxation factor for Richardson iteration on whole MFSI block "
-                      "preconditioner\nFSIAMG: each number belongs to a "
-                      "level\nPreconditiondKrylov: only first number is used for finest level",
-          .default_value = "1.0 1.0 1.0"}));
-  fsimono.specs.emplace_back(parameter<std::string>("PCITER",
-      {.description = "Number of Richardson iterations on whole MFSI block preconditioner\nFSIAMG: "
-                      "each number belongs to a level\nPreconditiondKrylov: only first number is "
-                      "used for finest level",
-          .default_value = "1 1 1"}));
+      parameter<std::string>(
+          "BLOCKSMOOTHER", {.description = "Type of block smoother, can be BGS or Schur",
+                               .default_value = "BGS BGS BGS"}),
 
-  fsimono.specs.emplace_back(parameter<std::string>(
-      "BLOCKSMOOTHER", {.description = "Type of block smoother, can be BGS or Schur",
-                           .default_value = "BGS BGS BGS"}));
+      parameter<std::string>(
+          "SCHUROMEGA", {.description = "Damping factor for Schur complement construction",
+                            .default_value = "0.001 0.01 0.1"}),
 
-  fsimono.specs.emplace_back(parameter<std::string>(
-      "SCHUROMEGA", {.description = "Damping factor for Schur complement construction",
-                        .default_value = "0.001 0.01 0.1"}));
-
-  // tolerances for convergence check of nonlinear solver in monolithic FSI
-  // structure displacements
-  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_RES_L2",
-      {.description = "Absolute tolerance for structure displacement residual in L2-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_RES_INF",
-      {.description = "Absolute tolerance for structure displacement residual in Inf-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_INC_L2",
-      {.description = "Absolute tolerance for structure displacement increment in L2-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_DIS_INC_INF",
-      {.description = "Absolute tolerance for structure displacement increment in Inf-norm",
-          .default_value = 1e-6}));
-  // interface tolerances
-  fsimono.specs.emplace_back(parameter<double>(
-      "TOL_FSI_RES_L2", {.description = "Absolute tolerance for interface residual in L2-norm",
-                            .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>(
-      "TOL_FSI_RES_INF", {.description = "Absolute tolerance for interface residual in Inf-norm",
-                             .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>(
-      "TOL_FSI_INC_L2", {.description = "Absolute tolerance for interface increment in L2-norm",
-                            .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>(
-      "TOL_FSI_INC_INF", {.description = "Absolute tolerance for interface increment in Inf-norm",
-                             .default_value = 1e-6}));
-  // fluid pressure
-  fsimono.specs.emplace_back(parameter<double>(
-      "TOL_PRE_RES_L2", {.description = "Absolute tolerance for fluid pressure residual in L2-norm",
-                            .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_PRE_RES_INF",
-      {.description = "Absolute tolerance for fluid pressure residual in Inf-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_PRE_INC_L2",
-      {.description = "Absolute tolerance for fluid pressure increment in L2-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_PRE_INC_INF",
-      {.description = "Absolute tolerance for fluid pressure increment in Inf-norm",
-          .default_value = 1e-6}));
-  // fluid velocities
-  fsimono.specs.emplace_back(parameter<double>(
-      "TOL_VEL_RES_L2", {.description = "Absolute tolerance for fluid velocity residual in L2-norm",
-                            .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_VEL_RES_INF",
-      {.description = "Absolute tolerance for fluid velocity residual in Inf-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_VEL_INC_L2",
-      {.description = "Absolute tolerance for fluid velocity increment in L2-norm",
-          .default_value = 1e-6}));
-  fsimono.specs.emplace_back(parameter<double>("TOL_VEL_INC_INF",
-      {.description = "Absolute tolerance for fluid velocity increment in Inf-norm",
-          .default_value = 1e-6}));
-
-  fsimono.move_into_collection(list);
+      // tolerances for convergence check of nonlinear solver in monolithic FSI
+      // structure displacements
+      parameter<double>("TOL_DIS_RES_L2",
+          {.description = "Absolute tolerance for structure displacement residual in L2-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_DIS_RES_INF",
+          {.description = "Absolute tolerance for structure displacement residual in Inf-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_DIS_INC_L2",
+          {.description = "Absolute tolerance for structure displacement increment in L2-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_DIS_INC_INF",
+          {.description = "Absolute tolerance for structure displacement increment in Inf-norm",
+              .default_value = 1e-6}),
+      // interface tolerances
+      parameter<double>(
+          "TOL_FSI_RES_L2", {.description = "Absolute tolerance for interface residual in L2-norm",
+                                .default_value = 1e-6}),
+      parameter<double>("TOL_FSI_RES_INF",
+          {.description = "Absolute tolerance for interface residual in Inf-norm",
+              .default_value = 1e-6}),
+      parameter<double>(
+          "TOL_FSI_INC_L2", {.description = "Absolute tolerance for interface increment in L2-norm",
+                                .default_value = 1e-6}),
+      parameter<double>("TOL_FSI_INC_INF",
+          {.description = "Absolute tolerance for interface increment in Inf-norm",
+              .default_value = 1e-6}),
+      // fluid pressure
+      parameter<double>("TOL_PRE_RES_L2",
+          {.description = "Absolute tolerance for fluid pressure residual in L2-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_PRE_RES_INF",
+          {.description = "Absolute tolerance for fluid pressure residual in Inf-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_PRE_INC_L2",
+          {.description = "Absolute tolerance for fluid pressure increment in L2-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_PRE_INC_INF",
+          {.description = "Absolute tolerance for fluid pressure increment in Inf-norm",
+              .default_value = 1e-6}),
+      // fluid velocities
+      parameter<double>("TOL_VEL_RES_L2",
+          {.description = "Absolute tolerance for fluid velocity residual in L2-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_VEL_RES_INF",
+          {.description = "Absolute tolerance for fluid velocity residual in Inf-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_VEL_INC_L2",
+          {.description = "Absolute tolerance for fluid velocity increment in L2-norm",
+              .default_value = 1e-6}),
+      parameter<double>("TOL_VEL_INC_INF",
+          {.description = "Absolute tolerance for fluid velocity increment in Inf-norm",
+              .default_value = 1e-6})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned FSI solvers */
-  Core::Utils::SectionSpecs fsipart{fsidyn, "PARTITIONED SOLVER"};
+  list["FSI DYNAMIC/PARTITIONED SOLVER"] = all_of({
 
-  fsipart.specs.emplace_back(parameter<double>("BASETOL",
-      {.description =
-              "Basic tolerance for adaptive convergence check in monolithic FSI.\n"
-              "This tolerance will be used for the linear solve of the FSI block system.\n"
-              "The linear convergence test will always use the relative residual norm (AZ_r0).\n"
-              "Not to be confused with the Newton tolerance (CONVTOL) that applies\n"
-              "to the nonlinear convergence test using a absolute residual norm.",
-          .default_value = 1e-3}));
+      parameter<double>("BASETOL",
+          {.description =
+                  "Basic tolerance for adaptive convergence check in monolithic FSI.\n"
+                  "This tolerance will be used for the linear solve of the FSI block system.\n"
+                  "The linear convergence test will always use the relative residual norm "
+                  "(AZ_r0).\n"
+                  "Not to be confused with the Newton tolerance (CONVTOL) that applies\n"
+                  "to the nonlinear convergence test using a absolute residual norm.",
+              .default_value = 1e-3}),
 
-  fsipart.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description = "Tolerance for iteration over fields in case of partitioned scheme",
-          .default_value = 1e-6}));
-
-  std::vector<std::string> coupmethod_valid_input = {"mortar", "conforming", "immersed"};
-  fsipart.specs.emplace_back(deprecated_selection<std::string>("COUPMETHOD", coupmethod_valid_input,
-      {.description = "Coupling Method mortar or conforming nodes at interface",
-          .default_value = "conforming"}));
-
-  fsipart.specs.emplace_back(deprecated_selection<Inpar::FSI::CoupVarPart>("COUPVARIABLE",
-      {
-          {"Displacement", Inpar::FSI::CoupVarPart::disp},
-          {"Force", Inpar::FSI::CoupVarPart::force},
-          {"Velocity", Inpar::FSI::CoupVarPart::vel},
-      },
-      {.description = "Coupling variable at the interface",
-          .default_value = Inpar::FSI::CoupVarPart::disp}));
-
-  fsipart.specs.emplace_back(parameter<bool>("DIVPROJECTION",
-      {.description = "Project velocity into divergence-free subspace for partitioned fsi",
-          .default_value = false}));
-
-  fsipart.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "Maximum number of iterations over fields", .default_value = 100}));
-
-  fsipart.specs.emplace_back(parameter<double>("MAXOMEGA",
-      {.description = "largest omega allowed for Aitken relaxation (0.0 means no constraint)",
-          .default_value = 0.0}));
-
-  fsipart.specs.emplace_back(parameter<double>(
-      "MINOMEGA", {.description = "smallest omega allowed for Aitken relaxation (default is -1.0)",
-                      .default_value = -1.0}));
+      parameter<double>("CONVTOL",
+          {.description = "Tolerance for iteration over fields in case of partitioned scheme",
+              .default_value = 1e-6}),
 
 
-  fsipart.specs.emplace_back(
+      deprecated_selection<std::string>("COUPMETHOD", {"mortar", "conforming", "immersed"},
+          {.description = "Coupling Method mortar or conforming nodes at interface",
+              .default_value = "conforming"}),
+
+      deprecated_selection<Inpar::FSI::CoupVarPart>("COUPVARIABLE",
+          {
+              {"Displacement", Inpar::FSI::CoupVarPart::disp},
+              {"Force", Inpar::FSI::CoupVarPart::force},
+              {"Velocity", Inpar::FSI::CoupVarPart::vel},
+          },
+          {.description = "Coupling variable at the interface",
+              .default_value = Inpar::FSI::CoupVarPart::disp}),
+
+      parameter<bool>("DIVPROJECTION",
+          {.description = "Project velocity into divergence-free subspace for partitioned fsi",
+              .default_value = false}),
+
+      parameter<int>("ITEMAX",
+          {.description = "Maximum number of iterations over fields", .default_value = 100}),
+
+      parameter<double>("MAXOMEGA",
+          {.description = "largest omega allowed for Aitken relaxation (0.0 means no constraint)",
+              .default_value = 0.0}),
+
+      parameter<double>("MINOMEGA",
+          {.description = "smallest omega allowed for Aitken relaxation (default is -1.0)",
+              .default_value = -1.0}),
+
+
+
       deprecated_selection<Inpar::FSI::PartitionedCouplingMethod>("PARTITIONED",
           {
               {"DirichletNeumann", Inpar::FSI::DirichletNeumann},
@@ -447,35 +447,30 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {"DirichletNeumannVolCoupl", Inpar::FSI::DirichletNeumannVolCoupl},
           },
           {.description = "Coupling strategies for partitioned FSI solvers.",
-              .default_value = Inpar::FSI::DirichletNeumann}));
+              .default_value = Inpar::FSI::DirichletNeumann}),
 
-  std::vector<std::string> predictor_valid_input = {
-      "d(n)", "d(n)+dt*(1.5*v(n)-0.5*v(n-1))", "d(n)+dt*v(n)", "d(n)+dt*v(n)+0.5*dt^2*a(n)"};
-  fsipart.specs.emplace_back(deprecated_selection<std::string>("PREDICTOR", predictor_valid_input,
-      {.description = "Predictor for interface displacements", .default_value = "d(n)"}));
+      deprecated_selection<std::string>("PREDICTOR",
+          {"d(n)", "d(n)+dt*(1.5*v(n)-0.5*v(n-1))", "d(n)+dt*v(n)", "d(n)+dt*v(n)+0.5*dt^2*a(n)"},
+          {.description = "Predictor for interface displacements", .default_value = "d(n)"}),
 
 
-  fsipart.specs.emplace_back(parameter<double>(
-      "RELAX", {.description = "fixed relaxation parameter for partitioned FSI solvers",
-                   .default_value = 1.0}));
-
-  fsipart.move_into_collection(list);
+      parameter<double>(
+          "RELAX", {.description = "fixed relaxation parameter for partitioned FSI solvers",
+                       .default_value = 1.0})});
 
   /* ----------------------------------------------------------------------- */
-  Core::Utils::SectionSpecs constrfsi{fsidyn, "CONSTRAINT"};
+  list["FSI DYNAMIC/CONSTRAINT"] = all_of({
 
-  constrfsi.specs.emplace_back(deprecated_selection<Inpar::FSI::PrecConstr>("PRECONDITIONER",
-      {
-          {"Simple", Inpar::FSI::Simple},
-          {"Simplec", Inpar::FSI::Simplec},
-      },
-      {.description = "preconditioner to use", .default_value = Inpar::FSI::Simple}));
-  constrfsi.specs.emplace_back(parameter<int>(
-      "SIMPLEITER", {.description = "Number of iterations for simple pc", .default_value = 2}));
-  constrfsi.specs.emplace_back(parameter<double>(
-      "ALPHA", {.description = "alpha parameter for simple pc", .default_value = 0.8}));
-
-  constrfsi.move_into_collection(list);
+      deprecated_selection<Inpar::FSI::PrecConstr>("PRECONDITIONER",
+          {
+              {"Simple", Inpar::FSI::Simple},
+              {"Simplec", Inpar::FSI::Simplec},
+          },
+          {.description = "preconditioner to use", .default_value = Inpar::FSI::Simple}),
+      parameter<int>(
+          "SIMPLEITER", {.description = "Number of iterations for simple pc", .default_value = 2}),
+      parameter<double>(
+          "ALPHA", {.description = "alpha parameter for simple pc", .default_value = 0.8})});
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_geometric_search.cpp
+++ b/src/inpar/4C_inpar_geometric_search.cpp
@@ -14,24 +14,24 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
-  Core::Utils::SectionSpecs boundingvolumestrategy{"BOUNDINGVOLUME STRATEGY"};
+  list["BOUNDINGVOLUME STRATEGY"] = all_of({
 
-  boundingvolumestrategy.specs.emplace_back(parameter<double>("BEAM_RADIUS_EXTENSION_FACTOR",
-      {.description = "Beams radius is multiplied with the factor and then the bounding volume "
-                      "only depending on the beam centerline is extended in all directions (+ and "
-                      "-) by that value.",
-          .default_value = 2.0}));
+      parameter<double>("BEAM_RADIUS_EXTENSION_FACTOR",
+          {.description =
+                  "Beams radius is multiplied with the factor and then the bounding volume "
+                  "only depending on the beam centerline is extended in all directions (+ and "
+                  "-) by that value.",
+              .default_value = 2.0}),
 
-  boundingvolumestrategy.specs.emplace_back(parameter<double>("SPHERE_RADIUS_EXTENSION_FACTOR",
-      {.description = "Bounding volume of the sphere is the sphere center extended by this factor "
-                      "times the sphere radius in all directions (+ and -).",
-          .default_value = 2.0}));
+      parameter<double>("SPHERE_RADIUS_EXTENSION_FACTOR",
+          {.description =
+                  "Bounding volume of the sphere is the sphere center extended by this factor "
+                  "times the sphere radius in all directions (+ and -).",
+              .default_value = 2.0}),
 
-  boundingvolumestrategy.specs.emplace_back(parameter<bool>("WRITE_GEOMETRIC_SEARCH_VISUALIZATION",
-      {.description = "If visualization output for the geometric search should be written",
-          .default_value = false}));
-
-  boundingvolumestrategy.move_into_collection(list);
+      parameter<bool>("WRITE_GEOMETRIC_SEARCH_VISUALIZATION",
+          {.description = "If visualization output for the geometric search should be written",
+              .default_value = false})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_geometric_search.cpp
+++ b/src/inpar/4C_inpar_geometric_search.cpp
@@ -7,8 +7,7 @@
 
 #include "4C_inpar_geometric_search.hpp"
 
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_geometry_pair.cpp
+++ b/src/inpar/4C_inpar_geometry_pair.cpp
@@ -15,33 +15,33 @@ FOUR_C_NAMESPACE_OPEN
 /**
  *
  */
-void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(Core::Utils::SectionSpecs& list)
+void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(std::vector<Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
 
   // Add the input parameters for line to 3D coupling.
 
   // Segmentation strategy.
-  list.specs.emplace_back(parameter<LineTo3DStrategy>(
+  list.push_back(parameter<LineTo3DStrategy>(
       "GEOMETRY_PAIR_STRATEGY", {.description = "Type of employed segmentation strategy",
                                     .default_value = LineTo3DStrategy::segmentation}));
 
   // Number of search points for segmentation.
-  list.specs.emplace_back(parameter<int>("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS",
+  list.push_back(parameter<int>("GEOMETRY_PAIR_SEGMENTATION_SEARCH_POINTS",
       {.description = "Number of search points for segmentation", .default_value = 6}));
 
   // What to do if not all Gauss points of a segment project valid
-  list.specs.emplace_back(parameter<NotAllGaussPointsProjectValidAction>(
+  list.push_back(parameter<NotAllGaussPointsProjectValidAction>(
       "GEOMETRY_PAIR_SEGMENTATION_NOT_ALL_GAUSS_POINTS_PROJECT_VALID_ACTION",
       {.description = "What to do if not all Gauss points of a segment project valid",
           .default_value = NotAllGaussPointsProjectValidAction::fail}));
 
   // Number of integration points on the line.
-  list.specs.emplace_back(parameter<int>("GAUSS_POINTS",
+  list.push_back(parameter<int>("GAUSS_POINTS",
       {.description = "Number of Gauss Points for the integral evaluations", .default_value = 6}));
 
   // Number of integration along the circumference in cross section coupling.
-  list.specs.emplace_back(parameter<int>("INTEGRATION_POINTS_CIRCUMFERENCE",
+  list.push_back(parameter<int>("INTEGRATION_POINTS_CIRCUMFERENCE",
       {.description = "Number of Integration points along the circumferential direction of the "
                       "beam. This is parameter is only used in beam to cylinder meshtying. No "
                       "gauss integration is used along the circumferential direction, equally "
@@ -52,12 +52,13 @@ void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to3_d(Core::Utils::SectionSp
 /**
  *
  */
-void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(Core::Utils::SectionSpecs& list)
+void Inpar::GEOMETRYPAIR::set_valid_parameters_line_to_surface(
+    std::vector<Core::IO::InputSpec>& list)
 {
   // Add the input parameters for line to surface coupling.
 
   // Add the surface normal option.
-  list.specs.emplace_back(Core::IO::InputSpecBuilders::parameter<GEOMETRYPAIR::SurfaceNormals>(
+  list.push_back(Core::IO::InputSpecBuilders::parameter<GEOMETRYPAIR::SurfaceNormals>(
       "GEOMETRY_PAIR_SURFACE_NORMALS",
       {.description = "How the surface normals are evaluated",
           .default_value = GEOMETRYPAIR::SurfaceNormals::standard}));

--- a/src/inpar/4C_inpar_geometry_pair.hpp
+++ b/src/inpar/4C_inpar_geometry_pair.hpp
@@ -69,7 +69,7 @@ namespace Inpar
      *
      * @param (out) Parameter list to add the line to 3D parameters to.
      */
-    void set_valid_parameters_line_to3_d(Core::Utils::SectionSpecs& list);
+    void set_valid_parameters_line_to3_d(std::vector<Core::IO::InputSpec>& list);
 
     /**
      * \brief Set valid input parameters for line to surface geometry pairs.
@@ -79,7 +79,7 @@ namespace Inpar
      *
      * @param (out) Parameter list to add the line to surface parameters to.
      */
-    void set_valid_parameters_line_to_surface(Core::Utils::SectionSpecs& list);
+    void set_valid_parameters_line_to_surface(std::vector<Core::IO::InputSpec>& list);
 
   }  // namespace GEOMETRYPAIR
 

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -19,97 +19,96 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs io{"IO"};
+  list["IO"] = all_of({
 
-  io.specs.emplace_back(
-      parameter<bool>("OUTPUT_GMSH", {.description = "", .default_value = false}));
-  io.specs.emplace_back(parameter<bool>("OUTPUT_ROT", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
-      parameter<bool>("OUTPUT_SPRING", {.description = "", .default_value = false}));
-  io.specs.emplace_back(parameter<bool>(
-      "OUTPUT_BIN", {.description = "Do you want to have binary output?", .default_value = true}));
+      parameter<bool>("OUTPUT_GMSH", {.description = "", .default_value = false}),
+      parameter<bool>("OUTPUT_ROT", {.description = "", .default_value = false}),
 
-  // Output every iteration (for debugging purposes)
-  io.specs.emplace_back(parameter<bool>("OUTPUT_EVERY_ITER",
-      {.description = "Do you desire structural displ. output every Newton iteration",
-          .default_value = false}));
-  io.specs.emplace_back(parameter<int>("OEI_FILE_COUNTER",
-      {.description = "Add an output name affix by introducing a additional number",
-          .default_value = 0}));
+      parameter<bool>("OUTPUT_SPRING", {.description = "", .default_value = false}),
+      parameter<bool>("OUTPUT_BIN",
+          {.description = "Do you want to have binary output?", .default_value = true}),
 
-  io.specs.emplace_back(parameter<bool>("ELEMENT_MAT_ID",
-      {.description = "Output of the material id of each element", .default_value = false}));
+      // Output every iteration (for debugging purposes)
+      parameter<bool>("OUTPUT_EVERY_ITER",
+          {.description = "Do you desire structural displ. output every Newton iteration",
+              .default_value = false}),
+      parameter<int>("OEI_FILE_COUNTER",
+          {.description = "Add an output name affix by introducing a additional number",
+              .default_value = 0}),
 
-  // Structural output
-  io.specs.emplace_back(parameter<bool>(
-      "STRUCT_ELE", {.description = "Output of element properties", .default_value = true}));
-  io.specs.emplace_back(parameter<bool>(
-      "STRUCT_DISP", {.description = "Output of displacements", .default_value = true}));
-  io.specs.emplace_back(deprecated_selection<Inpar::Solid::StressType>("STRUCT_STRESS",
-      {
-          {"No", Inpar::Solid::stress_none},
-          {"no", Inpar::Solid::stress_none},
-          {"NO", Inpar::Solid::stress_none},
-          {"Yes", Inpar::Solid::stress_2pk},
-          {"yes", Inpar::Solid::stress_2pk},
-          {"YES", Inpar::Solid::stress_2pk},
-          {"Cauchy", Inpar::Solid::stress_cauchy},
-          {"cauchy", Inpar::Solid::stress_cauchy},
-          {"2PK", Inpar::Solid::stress_2pk},
-          {"2pk", Inpar::Solid::stress_2pk},
-      },
-      {.description = "Output of stress", .default_value = Inpar::Solid::stress_none}));
-  // in case of a coupled problem (e.g. TSI) the additional stresses are
-  // (TSI: thermal stresses) are printed here
-  io.specs.emplace_back(deprecated_selection<Inpar::Solid::StressType>("STRUCT_COUPLING_STRESS",
-      {
-          {"No", Inpar::Solid::stress_none},
-          {"no", Inpar::Solid::stress_none},
-          {"NO", Inpar::Solid::stress_none},
-          {"Yes", Inpar::Solid::stress_2pk},
-          {"yes", Inpar::Solid::stress_2pk},
-          {"YES", Inpar::Solid::stress_2pk},
-          {"Cauchy", Inpar::Solid::stress_cauchy},
-          {"cauchy", Inpar::Solid::stress_cauchy},
-          {"2PK", Inpar::Solid::stress_2pk},
-          {"2pk", Inpar::Solid::stress_2pk},
-      },
-      {.description = "", .default_value = Inpar::Solid::stress_none}));
-  io.specs.emplace_back(deprecated_selection<Inpar::Solid::StrainType>("STRUCT_STRAIN",
-      {
-          {"No", Inpar::Solid::strain_none},
-          {"no", Inpar::Solid::strain_none},
-          {"NO", Inpar::Solid::strain_none},
-          {"Yes", Inpar::Solid::strain_gl},
-          {"yes", Inpar::Solid::strain_gl},
-          {"YES", Inpar::Solid::strain_gl},
-          {"EA", Inpar::Solid::strain_ea},
-          {"ea", Inpar::Solid::strain_ea},
-          {"GL", Inpar::Solid::strain_gl},
-          {"gl", Inpar::Solid::strain_gl},
-          {"LOG", Inpar::Solid::strain_log},
-          {"log", Inpar::Solid::strain_log},
-      },
-      {.description = "Output of strains", .default_value = Inpar::Solid::strain_none}));
-  io.specs.emplace_back(deprecated_selection<Inpar::Solid::StrainType>("STRUCT_PLASTIC_STRAIN",
-      {
-          {"No", Inpar::Solid::strain_none},
-          {"no", Inpar::Solid::strain_none},
-          {"NO", Inpar::Solid::strain_none},
-          {"Yes", Inpar::Solid::strain_gl},
-          {"yes", Inpar::Solid::strain_gl},
-          {"YES", Inpar::Solid::strain_gl},
-          {"EA", Inpar::Solid::strain_ea},
-          {"ea", Inpar::Solid::strain_ea},
-          {"GL", Inpar::Solid::strain_gl},
-          {"gl", Inpar::Solid::strain_gl},
-      },
-      {.description = "", .default_value = Inpar::Solid::strain_none}));
-  io.specs.emplace_back(
-      parameter<bool>("STRUCT_SURFACTANT", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
-      parameter<bool>("STRUCT_JACOBIAN_MATLAB", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
+      parameter<bool>("ELEMENT_MAT_ID",
+          {.description = "Output of the material id of each element", .default_value = false}),
+
+      // Structural output
+      parameter<bool>(
+          "STRUCT_ELE", {.description = "Output of element properties", .default_value = true}),
+      parameter<bool>(
+          "STRUCT_DISP", {.description = "Output of displacements", .default_value = true}),
+      deprecated_selection<Inpar::Solid::StressType>("STRUCT_STRESS",
+          {
+              {"No", Inpar::Solid::stress_none},
+              {"no", Inpar::Solid::stress_none},
+              {"NO", Inpar::Solid::stress_none},
+              {"Yes", Inpar::Solid::stress_2pk},
+              {"yes", Inpar::Solid::stress_2pk},
+              {"YES", Inpar::Solid::stress_2pk},
+              {"Cauchy", Inpar::Solid::stress_cauchy},
+              {"cauchy", Inpar::Solid::stress_cauchy},
+              {"2PK", Inpar::Solid::stress_2pk},
+              {"2pk", Inpar::Solid::stress_2pk},
+          },
+          {.description = "Output of stress", .default_value = Inpar::Solid::stress_none}),
+      // in case of a coupled problem (e.g. TSI) the additional stresses are
+      // (TSI: thermal stresses) are printed here
+      deprecated_selection<Inpar::Solid::StressType>("STRUCT_COUPLING_STRESS",
+          {
+              {"No", Inpar::Solid::stress_none},
+              {"no", Inpar::Solid::stress_none},
+              {"NO", Inpar::Solid::stress_none},
+              {"Yes", Inpar::Solid::stress_2pk},
+              {"yes", Inpar::Solid::stress_2pk},
+              {"YES", Inpar::Solid::stress_2pk},
+              {"Cauchy", Inpar::Solid::stress_cauchy},
+              {"cauchy", Inpar::Solid::stress_cauchy},
+              {"2PK", Inpar::Solid::stress_2pk},
+              {"2pk", Inpar::Solid::stress_2pk},
+          },
+          {.description = "", .default_value = Inpar::Solid::stress_none}),
+      deprecated_selection<Inpar::Solid::StrainType>("STRUCT_STRAIN",
+          {
+              {"No", Inpar::Solid::strain_none},
+              {"no", Inpar::Solid::strain_none},
+              {"NO", Inpar::Solid::strain_none},
+              {"Yes", Inpar::Solid::strain_gl},
+              {"yes", Inpar::Solid::strain_gl},
+              {"YES", Inpar::Solid::strain_gl},
+              {"EA", Inpar::Solid::strain_ea},
+              {"ea", Inpar::Solid::strain_ea},
+              {"GL", Inpar::Solid::strain_gl},
+              {"gl", Inpar::Solid::strain_gl},
+              {"LOG", Inpar::Solid::strain_log},
+              {"log", Inpar::Solid::strain_log},
+          },
+          {.description = "Output of strains", .default_value = Inpar::Solid::strain_none}),
+      deprecated_selection<Inpar::Solid::StrainType>("STRUCT_PLASTIC_STRAIN",
+          {
+              {"No", Inpar::Solid::strain_none},
+              {"no", Inpar::Solid::strain_none},
+              {"NO", Inpar::Solid::strain_none},
+              {"Yes", Inpar::Solid::strain_gl},
+              {"yes", Inpar::Solid::strain_gl},
+              {"YES", Inpar::Solid::strain_gl},
+              {"EA", Inpar::Solid::strain_ea},
+              {"ea", Inpar::Solid::strain_ea},
+              {"GL", Inpar::Solid::strain_gl},
+              {"gl", Inpar::Solid::strain_gl},
+          },
+          {.description = "", .default_value = Inpar::Solid::strain_none}),
+
+      parameter<bool>("STRUCT_SURFACTANT", {.description = "", .default_value = false}),
+
+      parameter<bool>("STRUCT_JACOBIAN_MATLAB", {.description = "", .default_value = false}),
+
       deprecated_selection<Inpar::Solid::ConditionNumber>("STRUCT_CONDITION_NUMBER",
           {
               {"gmres_estimate", Inpar::Solid::ConditionNumber::gmres_estimate},
@@ -120,106 +119,105 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
           },
           {.description = "Compute the condition number of the structural system matrix and write "
                           "it to a text file.",
-              .default_value = Inpar::Solid::ConditionNumber::none}));
-  io.specs.emplace_back(
-      parameter<bool>("FLUID_STRESS", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
-      parameter<bool>("FLUID_WALL_SHEAR_STRESS", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
-      parameter<bool>("FLUID_ELEDATA_EVERY_STEP", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
-      parameter<bool>("FLUID_NODEDATA_FIRST_STEP", {.description = "", .default_value = false}));
-  io.specs.emplace_back(
-      parameter<bool>("THERM_TEMPERATURE", {.description = "", .default_value = false}));
-  io.specs.emplace_back(deprecated_selection<Thermo::HeatFluxType>("THERM_HEATFLUX",
-      {
-          {"None", Thermo::heatflux_none},
-          {"No", Thermo::heatflux_none},
-          {"NO", Thermo::heatflux_none},
-          {"no", Thermo::heatflux_none},
-          {"Current", Thermo::heatflux_current},
-          {"Initial", Thermo::heatflux_initial},
-      },
-      {.description = "", .default_value = Thermo::heatflux_none}));
-  io.specs.emplace_back(deprecated_selection<Thermo::TempGradType>("THERM_TEMPGRAD",
-      {
-          {"None", Thermo::tempgrad_none},
-          {"No", Thermo::tempgrad_none},
-          {"NO", Thermo::tempgrad_none},
-          {"no", Thermo::tempgrad_none},
-          {"Current", Thermo::tempgrad_current},
-          {"Initial", Thermo::tempgrad_initial},
-      },
-      {.description = "", .default_value = Thermo::tempgrad_none}));
+              .default_value = Inpar::Solid::ConditionNumber::none}),
 
-  io.specs.emplace_back(parameter<int>(
-      "FILESTEPS", {.description = "Amount of timesteps written to a single result file",
-                       .default_value = 1000}));
-  io.specs.emplace_back(parameter<int>(
-      "STDOUTEVERY", {.description = "Print to screen every n step", .default_value = 1}));
+      parameter<bool>("FLUID_STRESS", {.description = "", .default_value = false}),
 
-  io.specs.emplace_back(parameter<bool>(
-      "WRITE_TO_SCREEN", {.description = "Write screen output", .default_value = true}));
-  io.specs.emplace_back(parameter<bool>(
-      "WRITE_TO_FILE", {.description = "Write the output into a file", .default_value = false}));
+      parameter<bool>("FLUID_WALL_SHEAR_STRESS", {.description = "", .default_value = false}),
 
-  io.specs.emplace_back(parameter<bool>("WRITE_INITIAL_STATE",
-      {.description = "Do you want to write output for initial state ?", .default_value = true}));
-  io.specs.emplace_back(parameter<bool>(
-      "WRITE_FINAL_STATE", {.description = "Enforce to write output/restart data at the final "
-                                           "state regardless of the other output/restart intervals",
-                               .default_value = false}));
+      parameter<bool>("FLUID_ELEDATA_EVERY_STEP", {.description = "", .default_value = false}),
 
-  io.specs.emplace_back(parameter<bool>("PREFIX_GROUP_ID",
-      {.description = "Put a <GroupID>: in front of every line", .default_value = false}));
-  io.specs.emplace_back(parameter<int>("LIMIT_OUTP_TO_PROC",
-      {.description = "Only the specified procs will write output", .default_value = -1}));
-  io.specs.emplace_back(deprecated_selection<FourC::Core::IO::Verbositylevel>("VERBOSITY",
-      {
-          {"minimal", FourC::Core::IO::minimal},
-          {"Minimal", FourC::Core::IO::minimal},
-          {"standard", FourC::Core::IO::standard},
-          {"Standard", FourC::Core::IO::standard},
-          {"verbose", FourC::Core::IO::verbose},
-          {"Verbose", FourC::Core::IO::verbose},
-          {"debug", FourC::Core::IO::debug},
-          {"Debug", FourC::Core::IO::debug},
-      },
-      {.description = "", .default_value = FourC::Core::IO::verbose}));
+      parameter<bool>("FLUID_NODEDATA_FIRST_STEP", {.description = "", .default_value = false}),
 
-  io.specs.emplace_back(parameter<double>("RESTARTWALLTIMEINTERVAL",
-      {.description =
-              "Enforce restart after this walltime interval (in seconds), smaller zero to disable",
-          .default_value = -1.0}));
-  io.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart every RESTARTEVERY steps", .default_value = -1}));
+      parameter<bool>("THERM_TEMPERATURE", {.description = "", .default_value = false}),
+      deprecated_selection<Thermo::HeatFluxType>("THERM_HEATFLUX",
+          {
+              {"None", Thermo::heatflux_none},
+              {"No", Thermo::heatflux_none},
+              {"NO", Thermo::heatflux_none},
+              {"no", Thermo::heatflux_none},
+              {"Current", Thermo::heatflux_current},
+              {"Initial", Thermo::heatflux_initial},
+          },
+          {.description = "", .default_value = Thermo::heatflux_none}),
+      deprecated_selection<Thermo::TempGradType>("THERM_TEMPGRAD",
+          {
+              {"None", Thermo::tempgrad_none},
+              {"No", Thermo::tempgrad_none},
+              {"NO", Thermo::tempgrad_none},
+              {"no", Thermo::tempgrad_none},
+              {"Current", Thermo::tempgrad_current},
+              {"Initial", Thermo::tempgrad_initial},
+          },
+          {.description = "", .default_value = Thermo::tempgrad_none}),
 
-  io.move_into_collection(list);
+      parameter<int>(
+          "FILESTEPS", {.description = "Amount of timesteps written to a single result file",
+                           .default_value = 1000}),
+      parameter<int>(
+          "STDOUTEVERY", {.description = "Print to screen every n step", .default_value = 1}),
 
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs io_every_iter{io, "EVERY ITERATION"};
+      parameter<bool>(
+          "WRITE_TO_SCREEN", {.description = "Write screen output", .default_value = true}),
+      parameter<bool>(
+          "WRITE_TO_FILE", {.description = "Write the output into a file", .default_value = false}),
 
-  // Output every iteration (for debugging purposes)
-  io_every_iter.specs.emplace_back(parameter<bool>("OUTPUT_EVERY_ITER",
-      {.description = "Do you wish output every Newton iteration?", .default_value = false}));
+      parameter<bool>(
+          "WRITE_INITIAL_STATE", {.description = "Do you want to write output for initial state ?",
+                                     .default_value = true}),
+      parameter<bool>("WRITE_FINAL_STATE",
+          {.description = "Enforce to write output/restart data at the final "
+                          "state regardless of the other output/restart intervals",
+              .default_value = false}),
 
-  io_every_iter.specs.emplace_back(parameter<int>("RUN_NUMBER",
-      {.description = "Create a new folder for different runs of the same simulation. "
-                      "If equal -1, no folder is created.",
-          .default_value = -1}));
+      parameter<bool>("PREFIX_GROUP_ID",
+          {.description = "Put a <GroupID>: in front of every line", .default_value = false}),
+      parameter<int>("LIMIT_OUTP_TO_PROC",
+          {.description = "Only the specified procs will write output", .default_value = -1}),
+      deprecated_selection<FourC::Core::IO::Verbositylevel>("VERBOSITY",
+          {
+              {"minimal", FourC::Core::IO::minimal},
+              {"Minimal", FourC::Core::IO::minimal},
+              {"standard", FourC::Core::IO::standard},
+              {"Standard", FourC::Core::IO::standard},
+              {"verbose", FourC::Core::IO::verbose},
+              {"Verbose", FourC::Core::IO::verbose},
+              {"debug", FourC::Core::IO::debug},
+              {"Debug", FourC::Core::IO::debug},
+          },
+          {.description = "", .default_value = FourC::Core::IO::verbose}),
 
-  io_every_iter.specs.emplace_back(parameter<int>("STEP_NP_NUMBER",
-      {.description = "Give the number of the step (i.e. step_{n+1}) for which you want to write "
-                      "the debug output. If a negative step number is provided, all steps will"
-                      "be written.",
-          .default_value = -1}));
+      parameter<double>(
+          "RESTARTWALLTIMEINTERVAL", {.description = "Enforce restart after this walltime interval "
+                                                     "(in seconds), smaller zero to disable",
+                                         .default_value = -1.0}),
+      parameter<int>("RESTARTEVERY",
+          {.description = "write restart every RESTARTEVERY steps",
+              .default_value =
+                  -1})}); /*----------------------------------------------------------------------*/
+  list["IO/EVERY ITERATION"] = all_of({
 
-  io_every_iter.specs.emplace_back(parameter<bool>("WRITE_OWNER_EACH_NEWTON_ITER",
-      {.description = "If yes, the ownership of elements and nodes are written each Newton step, "
-                      "instead of only once per time/load step.",
-          .default_value = false}));
+      // Output every iteration (for debugging purposes)
+      parameter<bool>("OUTPUT_EVERY_ITER",
+          {.description = "Do you wish output every Newton iteration?", .default_value = false}),
 
-  io_every_iter.move_into_collection(list);
+      parameter<int>("RUN_NUMBER",
+          {.description = "Create a new folder for different runs of the same simulation. "
+                          "If equal -1, no folder is created.",
+              .default_value = -1}),
+
+      parameter<int>("STEP_NP_NUMBER",
+          {.description =
+                  "Give the number of the step (i.e. step_{n+1}) for which you want to write "
+                  "the debug output. If a negative step number is provided, all steps will"
+                  "be written.",
+              .default_value = -1}),
+
+      parameter<bool>("WRITE_OWNER_EACH_NEWTON_ITER",
+          {.description =
+                  "If yes, the ownership of elements and nodes are written each Newton step, "
+                  "instead of only once per time/load step.",
+              .default_value = false})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -8,10 +8,9 @@
 #include "4C_inpar_io.hpp"
 
 #include "4C_inpar_structure.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_thermo_input.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -19,44 +19,38 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs levelsetcontrol{"LEVEL-SET CONTROL"};
+  list["LEVEL-SET CONTROL"] = all_of({
 
-  levelsetcontrol.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of time steps", .default_value = 24}));
-  levelsetcontrol.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  levelsetcontrol.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  levelsetcontrol.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  levelsetcontrol.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
+      parameter<int>("NUMSTEP", {.description = "Total number of time steps", .default_value = 24}),
 
-  levelsetcontrol.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+
+
       deprecated_selection<Inpar::ScaTra::CalcErrorLevelSet>("CALCERROR",
           {
               {"No", Inpar::ScaTra::calcerror_no_ls},
               {"InitialField", Inpar::ScaTra::calcerror_initial_field},
           },
           {.description = "compute error compared to analytical solution",
-              .default_value = Inpar::ScaTra::calcerror_no_ls}));
+              .default_value = Inpar::ScaTra::calcerror_no_ls}),
 
-  levelsetcontrol.specs.emplace_back(parameter<bool>("EXTRACT_INTERFACE_VEL",
-      {.description = "replace computed velocity at nodes of given distance of interface by "
-                      "approximated interface velocity",
-          .default_value = false}));
-  levelsetcontrol.specs.emplace_back(parameter<int>("NUM_CONVEL_LAYERS",
-      {.description =
-              "number of layers around the interface which keep their computed convective velocity",
-          .default_value = -1}));
+      parameter<bool>("EXTRACT_INTERFACE_VEL",
+          {.description = "replace computed velocity at nodes of given distance of interface by "
+                          "approximated interface velocity",
+              .default_value = false}),
+      parameter<int>("NUM_CONVEL_LAYERS",
+          {.description = "number of layers around the interface which keep their computed "
+                          "convective velocity",
+              .default_value =
+                  -1})}); /*----------------------------------------------------------------------*/
+  list["LEVEL-SET CONTROL/REINITIALIZATION"] = all_of({
 
-  levelsetcontrol.move_into_collection(list);
-
-
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs ls_reinit{levelsetcontrol, "REINITIALIZATION"};
-
-  ls_reinit.specs.emplace_back(
       deprecated_selection<Inpar::ScaTra::ReInitialAction>("REINITIALIZATION",
           {
               {"None", Inpar::ScaTra::reinitaction_none},
@@ -65,70 +59,70 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
               {"EllipticEq", Inpar::ScaTra::reinitaction_ellipticeq},
           },
           {.description = "Type of reinitialization strategy for level set function",
-              .default_value = Inpar::ScaTra::reinitaction_none}));
+              .default_value = Inpar::ScaTra::reinitaction_none}),
 
-  ls_reinit.specs.emplace_back(parameter<bool>("REINIT_INITIAL",
-      {.description = "Has level set field to be reinitialized before first time step?",
-          .default_value = false}));
-  ls_reinit.specs.emplace_back(parameter<int>(
-      "REINITINTERVAL", {.description = "reinitialization interval", .default_value = 1}));
+      parameter<bool>("REINIT_INITIAL",
+          {.description = "Has level set field to be reinitialized before first time step?",
+              .default_value = false}),
+      parameter<int>(
+          "REINITINTERVAL", {.description = "reinitialization interval", .default_value = 1}),
 
-  // parameters for signed distance reinitialization
-  ls_reinit.specs.emplace_back(parameter<bool>("REINITBAND",
-      {.description = "reinitialization only within a band around the interface, or entire domain?",
-          .default_value = false}));
-  ls_reinit.specs.emplace_back(parameter<double>(
-      "REINITBANDWIDTH", {.description = "level-set value defining band width for reinitialization",
-                             .default_value = 1.0}));
+      // parameters for signed distance reinitialization
+      parameter<bool>("REINITBAND",
+          {.description =
+                  "reinitialization only within a band around the interface, or entire domain?",
+              .default_value = false}),
+      parameter<double>("REINITBANDWIDTH",
+          {.description = "level-set value defining band width for reinitialization",
+              .default_value = 1.0}),
 
-  // parameters for reinitialization equation
-  ls_reinit.specs.emplace_back(parameter<int>("NUMSTEPSREINIT",
-      {.description = "(maximal) number of pseudo-time steps", .default_value = 1}));
-  ls_reinit.specs.emplace_back(parameter<double>(
-      "TIMESTEPREINIT", {.description = "pseudo-time step length (usually a * characteristic "
-                                        "element length of discretization with a>0)",
-                            .default_value = 1.0}));
-  ls_reinit.specs.emplace_back(parameter<double>(
-      "THETAREINIT", {.description = "theta for time discretization of reinitialization equation",
-                         .default_value = 1.0}));
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::StabType>("STABTYPEREINIT",
-      {
-          {"no_stabilization", Inpar::ScaTra::stabtype_no_stabilization},
-          {"SUPG", Inpar::ScaTra::stabtype_SUPG},
-          {"GLS", Inpar::ScaTra::stabtype_GLS},
-          {"USFEM", Inpar::ScaTra::stabtype_USFEM},
-      },
-      {.description = "Type of stabilization (if any). No stabilization is only reasonable for "
-                      "low-Peclet-number.",
-          .default_value = Inpar::ScaTra::stabtype_SUPG}));
-  // this parameter selects the tau definition applied
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::TauType>("DEFINITION_TAU_REINIT",
-      {
-          {"Taylor_Hughes_Zarins", Inpar::ScaTra::tau_taylor_hughes_zarins},
-          {"Taylor_Hughes_Zarins_wo_dt", Inpar::ScaTra::tau_taylor_hughes_zarins_wo_dt},
-          {"Franca_Valentin", Inpar::ScaTra::tau_franca_valentin},
-          {"Franca_Valentin_wo_dt", Inpar::ScaTra::tau_franca_valentin_wo_dt},
-          {"Shakib_Hughes_Codina", Inpar::ScaTra::tau_shakib_hughes_codina},
-          {"Shakib_Hughes_Codina_wo_dt", Inpar::ScaTra::tau_shakib_hughes_codina_wo_dt},
-          {"Codina", Inpar::ScaTra::tau_codina},
-          {"Codina_wo_dt", Inpar::ScaTra::tau_codina_wo_dt},
-          {"Exact_1D", Inpar::ScaTra::tau_exact_1d},
-          {"Zero", Inpar::ScaTra::tau_zero},
-      },
-      {.description = "Definition of tau",
-          .default_value = Inpar::ScaTra::tau_taylor_hughes_zarins}));
-  // this parameter governs whether all-scale subgrid diffusivity is included
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::ArtDiff>("ARTDIFFREINIT",
-      {
-          {"no", Inpar::ScaTra::artdiff_none},
-          {"isotropic", Inpar::ScaTra::artdiff_isotropic},
-          {"crosswind", Inpar::ScaTra::artdiff_crosswind},
-      },
-      {.description = "potential incorporation of all-scale subgrid diffusivity (a.k.a. "
-                      "discontinuity-capturing) term",
-          .default_value = Inpar::ScaTra::artdiff_none}));
-  // this parameter selects the all-scale subgrid-diffusivity definition applied
-  ls_reinit.specs.emplace_back(
+      // parameters for reinitialization equation
+      parameter<int>("NUMSTEPSREINIT",
+          {.description = "(maximal) number of pseudo-time steps", .default_value = 1}),
+      parameter<double>(
+          "TIMESTEPREINIT", {.description = "pseudo-time step length (usually a * characteristic "
+                                            "element length of discretization with a>0)",
+                                .default_value = 1.0}),
+      parameter<double>("THETAREINIT",
+          {.description = "theta for time discretization of reinitialization equation",
+              .default_value = 1.0}),
+      deprecated_selection<Inpar::ScaTra::StabType>("STABTYPEREINIT",
+          {
+              {"no_stabilization", Inpar::ScaTra::stabtype_no_stabilization},
+              {"SUPG", Inpar::ScaTra::stabtype_SUPG},
+              {"GLS", Inpar::ScaTra::stabtype_GLS},
+              {"USFEM", Inpar::ScaTra::stabtype_USFEM},
+          },
+          {.description = "Type of stabilization (if any). No stabilization is only reasonable for "
+                          "low-Peclet-number.",
+              .default_value = Inpar::ScaTra::stabtype_SUPG}),
+      // this parameter selects the tau definition applied
+      deprecated_selection<Inpar::ScaTra::TauType>("DEFINITION_TAU_REINIT",
+          {
+              {"Taylor_Hughes_Zarins", Inpar::ScaTra::tau_taylor_hughes_zarins},
+              {"Taylor_Hughes_Zarins_wo_dt", Inpar::ScaTra::tau_taylor_hughes_zarins_wo_dt},
+              {"Franca_Valentin", Inpar::ScaTra::tau_franca_valentin},
+              {"Franca_Valentin_wo_dt", Inpar::ScaTra::tau_franca_valentin_wo_dt},
+              {"Shakib_Hughes_Codina", Inpar::ScaTra::tau_shakib_hughes_codina},
+              {"Shakib_Hughes_Codina_wo_dt", Inpar::ScaTra::tau_shakib_hughes_codina_wo_dt},
+              {"Codina", Inpar::ScaTra::tau_codina},
+              {"Codina_wo_dt", Inpar::ScaTra::tau_codina_wo_dt},
+              {"Exact_1D", Inpar::ScaTra::tau_exact_1d},
+              {"Zero", Inpar::ScaTra::tau_zero},
+          },
+          {.description = "Definition of tau",
+              .default_value = Inpar::ScaTra::tau_taylor_hughes_zarins}),
+      // this parameter governs whether all-scale subgrid diffusivity is included
+      deprecated_selection<Inpar::ScaTra::ArtDiff>("ARTDIFFREINIT",
+          {
+              {"no", Inpar::ScaTra::artdiff_none},
+              {"isotropic", Inpar::ScaTra::artdiff_isotropic},
+              {"crosswind", Inpar::ScaTra::artdiff_crosswind},
+          },
+          {.description = "potential incorporation of all-scale subgrid diffusivity (a.k.a. "
+                          "discontinuity-capturing) term",
+              .default_value = Inpar::ScaTra::artdiff_none}),
+      // this parameter selects the all-scale subgrid-diffusivity definition applied
       deprecated_selection<Inpar::ScaTra::AssgdType>("DEFINITION_ARTDIFFREINIT",
           {
               {"artificial_linear", Inpar::ScaTra::assgd_artificial},
@@ -142,9 +136,9 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
               {"Codina_nonlinear", Inpar::ScaTra::assgd_codina},
           },
           {.description = "Definition of (all-scale) subgrid diffusivity",
-              .default_value = Inpar::ScaTra::assgd_artificial}));
+              .default_value = Inpar::ScaTra::assgd_artificial}),
 
-  ls_reinit.specs.emplace_back(
+
       deprecated_selection<Inpar::ScaTra::SmoothedSignType>("SMOOTHED_SIGN_TYPE",
           {
               {"NonSmoothed", Inpar::ScaTra::signtype_nonsmoothed},
@@ -153,77 +147,77 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
               {"PengEtAl1999", Inpar::ScaTra::signtype_PengEtAl1999},
           },
           {.description = "sign function for reinitialization equation",
-              .default_value = Inpar::ScaTra::signtype_SussmanSmerekaOsher1994}));
-  ls_reinit.specs.emplace_back(
+              .default_value = Inpar::ScaTra::signtype_SussmanSmerekaOsher1994}),
+
       deprecated_selection<Inpar::ScaTra::CharEleLengthReinit>("CHARELELENGTHREINIT",
           {
               {"root_of_volume", Inpar::ScaTra::root_of_volume_reinit},
               {"streamlength", Inpar::ScaTra::streamlength_reinit},
           },
           {.description = "characteristic element length for sign function",
-              .default_value = Inpar::ScaTra::root_of_volume_reinit}));
-  ls_reinit.specs.emplace_back(parameter<double>("INTERFACE_THICKNESS",
-      {.description = "factor for interface thickness (multiplied by element length)",
-          .default_value = 1.0}));
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::VelReinit>("VELREINIT",
-      {
-          {"integration_point_based", Inpar::ScaTra::vel_reinit_integration_point_based},
-          {"node_based", Inpar::ScaTra::vel_reinit_node_based},
-      },
-      {.description = "evaluate velocity at integration point or compute node-based velocity",
-          .default_value = Inpar::ScaTra::vel_reinit_integration_point_based}));
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::LinReinit>("LINEARIZATIONREINIT",
-      {
-          {"newton", Inpar::ScaTra::newton},
-          {"fixed_point", Inpar::ScaTra::fixed_point},
-      },
-      {.description =
-              "linearization scheme for nonlinear convective term of reinitialization equation",
-          .default_value = Inpar::ScaTra::newton}));
-  ls_reinit.specs.emplace_back(parameter<bool>(
-      "CORRECTOR_STEP", {.description = "correction of interface position via volume constraint "
-                                        "according to Sussman & Fatemi",
-                            .default_value = true}));
-  ls_reinit.specs.emplace_back(parameter<double>(
-      "CONVTOL_REINIT", {.description = "tolerance for convergence check according to Sussman et "
-                                        "al. 1994 (turned off negative)",
-                            .default_value = -1.0}));
+              .default_value = Inpar::ScaTra::root_of_volume_reinit}),
+      parameter<double>("INTERFACE_THICKNESS",
+          {.description = "factor for interface thickness (multiplied by element length)",
+              .default_value = 1.0}),
+      deprecated_selection<Inpar::ScaTra::VelReinit>("VELREINIT",
+          {
+              {"integration_point_based", Inpar::ScaTra::vel_reinit_integration_point_based},
+              {"node_based", Inpar::ScaTra::vel_reinit_node_based},
+          },
+          {.description = "evaluate velocity at integration point or compute node-based velocity",
+              .default_value = Inpar::ScaTra::vel_reinit_integration_point_based}),
+      deprecated_selection<Inpar::ScaTra::LinReinit>("LINEARIZATIONREINIT",
+          {
+              {"newton", Inpar::ScaTra::newton},
+              {"fixed_point", Inpar::ScaTra::fixed_point},
+          },
+          {.description =
+                  "linearization scheme for nonlinear convective term of reinitialization equation",
+              .default_value = Inpar::ScaTra::newton}),
+      parameter<bool>("CORRECTOR_STEP",
+          {.description = "correction of interface position via volume constraint "
+                          "according to Sussman & Fatemi",
+              .default_value = true}),
+      parameter<double>("CONVTOL_REINIT",
+          {.description = "tolerance for convergence check according to Sussman et "
+                          "al. 1994 (turned off negative)",
+              .default_value = -1.0}),
 
-  ls_reinit.specs.emplace_back(parameter<bool>("REINITVOLCORRECTION",
-      {.description = "volume correction after reinitialization", .default_value = false}));
+      parameter<bool>("REINITVOLCORRECTION",
+          {.description = "volume correction after reinitialization", .default_value = false}),
 
-  ls_reinit.specs.emplace_back(parameter<double>("PENALTY_PARA",
-      {.description = "penalty parameter for elliptic reinitialization", .default_value = -1.0}));
+      parameter<double>(
+          "PENALTY_PARA", {.description = "penalty parameter for elliptic reinitialization",
+                              .default_value = -1.0}),
 
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::LSDim>("DIMENSION",
-      {
-          {"3D", Inpar::ScaTra::ls_3D},
-          {"2Dx", Inpar::ScaTra::ls_2Dx},
-          {"2Dy", Inpar::ScaTra::ls_2Dy},
-          {"2Dz", Inpar::ScaTra::ls_2Dz},
-      },
-      {.description =
-              "number of space dimensions for handling of quasi-2D problems with 3D elements",
-          .default_value = Inpar::ScaTra::ls_3D}));
+      deprecated_selection<Inpar::ScaTra::LSDim>("DIMENSION",
+          {
+              {"3D", Inpar::ScaTra::ls_3D},
+              {"2Dx", Inpar::ScaTra::ls_2Dx},
+              {"2Dy", Inpar::ScaTra::ls_2Dy},
+              {"2Dz", Inpar::ScaTra::ls_2Dz},
+          },
+          {.description =
+                  "number of space dimensions for handling of quasi-2D problems with 3D elements",
+              .default_value = Inpar::ScaTra::ls_3D}),
 
-  ls_reinit.specs.emplace_back(parameter<bool>(
-      "PROJECTION", {.description = "use L2-projection for grad phi and related quantities",
-                        .default_value = true}));
-  ls_reinit.specs.emplace_back(parameter<double>("PROJECTION_DIFF",
-      {.description = "use diffusive term for L2-projection", .default_value = 0.0}));
-  ls_reinit.specs.emplace_back(parameter<bool>("LUMPING",
-      {.description = "use lumped mass matrix for L2-projection", .default_value = false}));
+      parameter<bool>(
+          "PROJECTION", {.description = "use L2-projection for grad phi and related quantities",
+                            .default_value = true}),
+      parameter<double>("PROJECTION_DIFF",
+          {.description = "use diffusive term for L2-projection", .default_value = 0.0}),
+      parameter<bool>("LUMPING",
+          {.description = "use lumped mass matrix for L2-projection", .default_value = false}),
 
-  ls_reinit.specs.emplace_back(deprecated_selection<Inpar::ScaTra::DiffFunc>("DIFF_FUNC",
-      {
-          {"hyperbolic", Inpar::ScaTra::hyperbolic},
-          {"hyperbolic_smoothed_positive", Inpar::ScaTra::hyperbolic_smoothed_positive},
-          {"hyperbolic_clipped_05", Inpar::ScaTra::hyperbolic_clipped_05},
-          {"hyperbolic_clipped_1", Inpar::ScaTra::hyperbolic_clipped_1},
-      },
-      {.description = "function for diffusivity", .default_value = Inpar::ScaTra::hyperbolic}));
-
-  ls_reinit.move_into_collection(list);
+      deprecated_selection<Inpar::ScaTra::DiffFunc>("DIFF_FUNC",
+          {
+              {"hyperbolic", Inpar::ScaTra::hyperbolic},
+              {"hyperbolic_smoothed_positive", Inpar::ScaTra::hyperbolic_smoothed_positive},
+              {"hyperbolic_clipped_05", Inpar::ScaTra::hyperbolic_clipped_05},
+              {"hyperbolic_clipped_1", Inpar::ScaTra::hyperbolic_clipped_1},
+          },
+          {.description = "function for diffusivity",
+              .default_value = Inpar::ScaTra::hyperbolic})});
 }
 
 

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -9,8 +9,7 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_inpar_scatra.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -9,8 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -21,34 +21,34 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for mortar coupling */
-  Core::Utils::SectionSpecs mortar{"MORTAR COUPLING"};
+  list["MORTAR COUPLING"] = all_of({
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::ShapeFcn>("LM_SHAPEFCN",
-      {
-          {"Dual", shape_dual},
-          {"dual", shape_dual},
-          {"Standard", shape_standard},
-          {"standard", shape_standard},
-          {"std", shape_standard},
-          {"PetrovGalerkin", shape_petrovgalerkin},
-          {"petrovgalerkin", shape_petrovgalerkin},
-          {"pg", shape_petrovgalerkin},
-      },
-      {.description = "Type of employed set of shape functions", .default_value = shape_dual}));
+      deprecated_selection<Inpar::Mortar::ShapeFcn>("LM_SHAPEFCN",
+          {
+              {"Dual", shape_dual},
+              {"dual", shape_dual},
+              {"Standard", shape_standard},
+              {"standard", shape_standard},
+              {"std", shape_standard},
+              {"PetrovGalerkin", shape_petrovgalerkin},
+              {"petrovgalerkin", shape_petrovgalerkin},
+              {"pg", shape_petrovgalerkin},
+          },
+          {.description = "Type of employed set of shape functions", .default_value = shape_dual}),
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::SearchAlgorithm>("SEARCH_ALGORITHM",
-      {
-          {"BruteForce", search_bfele},
-          {"bruteforce", search_bfele},
-          {"BruteForceEleBased", search_bfele},
-          {"bruteforceelebased", search_bfele},
-          {"BinaryTree", search_binarytree},
-          {"Binarytree", search_binarytree},
-          {"binarytree", search_binarytree},
-      },
-      {.description = "Type of contact search", .default_value = search_binarytree}));
+      deprecated_selection<Inpar::Mortar::SearchAlgorithm>("SEARCH_ALGORITHM",
+          {
+              {"BruteForce", search_bfele},
+              {"bruteforce", search_bfele},
+              {"BruteForceEleBased", search_bfele},
+              {"bruteforceelebased", search_bfele},
+              {"BinaryTree", search_binarytree},
+              {"Binarytree", search_binarytree},
+              {"binarytree", search_binarytree},
+          },
+          {.description = "Type of contact search", .default_value = search_binarytree}),
 
-  mortar.specs.emplace_back(
+
       deprecated_selection<Inpar::Mortar::BinaryTreeUpdateType>("BINARYTREE_UPDATETYPE",
           {
               {"BottomUp", binarytree_bottom_up},
@@ -56,35 +56,35 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           },
           {.description =
                   "Type of binary tree update, which is either a bottom up or a top down approach.",
-              .default_value = binarytree_bottom_up}));
+              .default_value = binarytree_bottom_up}),
 
-  mortar.specs.emplace_back(parameter<double>(
-      "SEARCH_PARAM", {.description = "Radius / Bounding volume inflation for contact search",
-                          .default_value = 0.3}));
+      parameter<double>(
+          "SEARCH_PARAM", {.description = "Radius / Bounding volume inflation for contact search",
+                              .default_value = 0.3}),
 
-  mortar.specs.emplace_back(parameter<bool>("SEARCH_USE_AUX_POS",
-      {.description = "If chosen auxiliary position is used for computing dops",
-          .default_value = true}));
+      parameter<bool>("SEARCH_USE_AUX_POS",
+          {.description = "If chosen auxiliary position is used for computing dops",
+              .default_value = true}),
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::LagMultQuad>("LM_QUAD",
-      {
-          {"undefined", lagmult_undefined},
-          {"quad", lagmult_quad},
-          {"quadratic", lagmult_quad},
-          {"pwlin", lagmult_pwlin},
-          {"piecewiselinear", lagmult_pwlin},
-          {"lin", lagmult_lin},
-          {"linear", lagmult_lin},
-          {"const", lagmult_const},
-      },
-      {.description = "Type of LM interpolation for quadratic FE",
-          .default_value = lagmult_undefined}));
+      deprecated_selection<Inpar::Mortar::LagMultQuad>("LM_QUAD",
+          {
+              {"undefined", lagmult_undefined},
+              {"quad", lagmult_quad},
+              {"quadratic", lagmult_quad},
+              {"pwlin", lagmult_pwlin},
+              {"piecewiselinear", lagmult_pwlin},
+              {"lin", lagmult_lin},
+              {"linear", lagmult_lin},
+              {"const", lagmult_const},
+          },
+          {.description = "Type of LM interpolation for quadratic FE",
+              .default_value = lagmult_undefined}),
 
-  mortar.specs.emplace_back(parameter<bool>("CROSSPOINTS",
-      {.description = "If chosen, multipliers are removed from crosspoints / edge nodes",
-          .default_value = false}));
+      parameter<bool>("CROSSPOINTS",
+          {.description = "If chosen, multipliers are removed from crosspoints / edge nodes",
+              .default_value = false}),
 
-  mortar.specs.emplace_back(
+
       deprecated_selection<Inpar::Mortar::ConsistentDualType>("LM_DUAL_CONSISTENT",
           {
               {"none", consistent_none},
@@ -93,123 +93,122 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           },
           {.description = "For which elements should the dual basis be calculated on EXACTLY the "
                           "same GPs as the contact terms",
-              .default_value = consistent_boundary}));
+              .default_value = consistent_boundary}),
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::MeshRelocation>("MESH_RELOCATION",
-      {
-          {"Initial", relocation_initial},
-          {"Every_Timestep", relocation_timestep},
-          {"None", relocation_none},
-      },
-      {.description = "Type of mesh relocation", .default_value = relocation_initial}));
+      deprecated_selection<Inpar::Mortar::MeshRelocation>("MESH_RELOCATION",
+          {
+              {"Initial", relocation_initial},
+              {"Every_Timestep", relocation_timestep},
+              {"None", relocation_none},
+          },
+          {.description = "Type of mesh relocation", .default_value = relocation_initial}),
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::AlgorithmType>("ALGORITHM",
-      {
-          {"mortar", algorithm_mortar},
-          {"Mortar", algorithm_mortar},
-          {"nts", algorithm_nts},
-          {"NTS", algorithm_nts},
-          {"gpts", algorithm_gpts},
-          {"GPTS", algorithm_gpts},
-          {"lts", algorithm_lts},
-          {"LTS", algorithm_lts},
-          {"ltl", algorithm_ltl},
-          {"LTL", algorithm_ltl},
-          {"stl", algorithm_stl},
-          {"STL", algorithm_stl},
-      },
-      {.description = "Type of meshtying/contact algorithm", .default_value = algorithm_mortar}));
+      deprecated_selection<Inpar::Mortar::AlgorithmType>("ALGORITHM",
+          {
+              {"mortar", algorithm_mortar},
+              {"Mortar", algorithm_mortar},
+              {"nts", algorithm_nts},
+              {"NTS", algorithm_nts},
+              {"gpts", algorithm_gpts},
+              {"GPTS", algorithm_gpts},
+              {"lts", algorithm_lts},
+              {"LTS", algorithm_lts},
+              {"ltl", algorithm_ltl},
+              {"LTL", algorithm_ltl},
+              {"stl", algorithm_stl},
+              {"STL", algorithm_stl},
+          },
+          {.description = "Type of meshtying/contact algorithm",
+              .default_value = algorithm_mortar}),
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::IntType>("INTTYPE",
-      {
-          {"Segments", inttype_segments},
-          {"segments", inttype_segments},
-          {"Elements", inttype_elements},
-          {"elements", inttype_elements},
-          {"Elements_BS", inttype_elements_BS},
-          {"elements_BS", inttype_elements_BS},
-      },
-      {.description = "Type of numerical integration scheme", .default_value = inttype_segments}));
+      deprecated_selection<Inpar::Mortar::IntType>("INTTYPE",
+          {
+              {"Segments", inttype_segments},
+              {"segments", inttype_segments},
+              {"Elements", inttype_elements},
+              {"elements", inttype_elements},
+              {"Elements_BS", inttype_elements_BS},
+              {"elements_BS", inttype_elements_BS},
+          },
+          {.description = "Type of numerical integration scheme",
+              .default_value = inttype_segments}),
 
-  mortar.specs.emplace_back(parameter<int>("NUMGP_PER_DIM",
-      {.description = "Number of employed integration points per dimension", .default_value = 0}));
+      parameter<int>(
+          "NUMGP_PER_DIM", {.description = "Number of employed integration points per dimension",
+                               .default_value = 0}),
 
-  mortar.specs.emplace_back(deprecated_selection<Inpar::Mortar::Triangulation>("TRIANGULATION",
-      {
-          {"Delaunay", triangulation_delaunay},
-          {"delaunay", triangulation_delaunay},
-          {"Center", triangulation_center},
-          {"center", triangulation_center},
-      },
-      {.description = "Type of triangulation for segment-based integration",
-          .default_value = triangulation_delaunay}));
+      deprecated_selection<Inpar::Mortar::Triangulation>("TRIANGULATION",
+          {
+              {"Delaunay", triangulation_delaunay},
+              {"delaunay", triangulation_delaunay},
+              {"Center", triangulation_center},
+              {"center", triangulation_center},
+          },
+          {.description = "Type of triangulation for segment-based integration",
+              .default_value = triangulation_delaunay}),
 
-  mortar.specs.emplace_back(parameter<bool>("RESTART_WITH_MESHTYING",
-      {.description =
-              "Must be chosen if a non-meshtying simulation is to be restarted with meshtying",
-          .default_value = false}));
+      parameter<bool>("RESTART_WITH_MESHTYING",
+          {.description =
+                  "Must be chosen if a non-meshtying simulation is to be restarted with meshtying",
+              .default_value = false}),
 
-  mortar.specs.emplace_back(parameter<bool>("OUTPUT_INTERFACES",
-      {.description = "Write output for each mortar interface separately.\nThis is an additional "
-                      "feature, purely to enhance visualization. Currently, this is limited to "
-                      "solid meshtying and contact w/o friction.",
-          .default_value = false}));
-
-  mortar.move_into_collection(list);
-
-  /*--------------------------------------------------------------------*/
+      parameter<bool>("OUTPUT_INTERFACES",
+          {.description =
+                  "Write output for each mortar interface separately.\nThis is an additional "
+                  "feature, purely to enhance visualization. Currently, this is limited to "
+                  "solid meshtying and contact w/o friction.",
+              .default_value =
+                  false})}); /*--------------------------------------------------------------------*/
   // parameters for parallel redistribution of mortar interfaces
-  Core::Utils::SectionSpecs parallelRedist{mortar, "PARALLEL REDISTRIBUTION"};
+  list["MORTAR COUPLING/PARALLEL REDISTRIBUTION"] = all_of({
 
-  parallelRedist.specs.emplace_back(parameter<bool>("EXPLOIT_PROXIMITY",
-      {.description =
-              "Exploit information on geometric proximity to split slave interface into close and "
-              "non-close parts and redistribute them independently. [Contact only]",
-          .default_value = true}));
+      parameter<bool>("EXPLOIT_PROXIMITY",
+          {.description = "Exploit information on geometric proximity to split slave interface "
+                          "into close and "
+                          "non-close parts and redistribute them independently. [Contact only]",
+              .default_value = true}),
 
-  parallelRedist.specs.emplace_back(deprecated_selection<ExtendGhosting>("GHOSTING_STRATEGY",
-      {
-          {"redundant_all", ExtendGhosting::redundant_all},
-          {"redundant_master", ExtendGhosting::redundant_master},
-          {"round_robin", ExtendGhosting::roundrobin},
-          {"binning", ExtendGhosting::binning},
-      },
-      {.description = "Type of interface ghosting and ghosting extension algorithm",
-          .default_value = ExtendGhosting::redundant_master}));
+      deprecated_selection<ExtendGhosting>("GHOSTING_STRATEGY",
+          {
+              {"redundant_all", ExtendGhosting::redundant_all},
+              {"redundant_master", ExtendGhosting::redundant_master},
+              {"round_robin", ExtendGhosting::roundrobin},
+              {"binning", ExtendGhosting::binning},
+          },
+          {.description = "Type of interface ghosting and ghosting extension algorithm",
+              .default_value = ExtendGhosting::redundant_master}),
 
-  parallelRedist.specs.emplace_back(parameter<double>("IMBALANCE_TOL",
-      {.description = "Max. relative imbalance of subdomain size after redistribution",
-          .default_value = 1.1}));
+      parameter<double>("IMBALANCE_TOL",
+          {.description = "Max. relative imbalance of subdomain size after redistribution",
+              .default_value = 1.1}),
 
-  parallelRedist.specs.emplace_back(parameter<double>(
-      "MAX_BALANCE_EVAL_TIME", {.description = "Max-to-min ratio of contact evaluation time per "
-                                               "processor to trigger parallel redistribution",
-                                   .default_value = 2.0}));
+      parameter<double>("MAX_BALANCE_EVAL_TIME",
+          {.description = "Max-to-min ratio of contact evaluation time per "
+                          "processor to trigger parallel redistribution",
+              .default_value = 2.0}),
 
-  parallelRedist.specs.emplace_back(parameter<double>(
-      "MAX_BALANCE_SLAVE_ELES", {.description = "Max-to-min ratio of mortar slave elements per "
-                                                "processor to trigger parallel redistribution",
-                                    .default_value = 0.5}));
+      parameter<double>(
+          "MAX_BALANCE_SLAVE_ELES", {.description = "Max-to-min ratio of mortar slave elements per "
+                                                    "processor to trigger parallel redistribution",
+                                        .default_value = 0.5}),
 
-  parallelRedist.specs.emplace_back(parameter<int>("MIN_ELEPROC",
-      {.description = "Minimum no. of elements per processor for parallel redistribution",
-          .default_value = 0}));
+      parameter<int>("MIN_ELEPROC",
+          {.description = "Minimum no. of elements per processor for parallel redistribution",
+              .default_value = 0}),
 
-  parallelRedist.specs.emplace_back(deprecated_selection<ParallelRedist>("PARALLEL_REDIST",
-      {
-          {"None", ParallelRedist::redist_none},
-          {"Static", ParallelRedist::redist_static},
-          {"Dynamic", ParallelRedist::redist_dynamic},
-      },
-      {.description = "Type of redistribution algorithm",
-          .default_value = ParallelRedist::redist_static}));
+      deprecated_selection<ParallelRedist>("PARALLEL_REDIST",
+          {
+              {"None", ParallelRedist::redist_none},
+              {"Static", ParallelRedist::redist_static},
+              {"Dynamic", ParallelRedist::redist_dynamic},
+          },
+          {.description = "Type of redistribution algorithm",
+              .default_value = ParallelRedist::redist_static}),
 
-  parallelRedist.specs.emplace_back(parameter<bool>(
-      "PRINT_DISTRIBUTION", {.description = "Print details of the parallel distribution, i.e. "
-                                            "number of nodes/elements for each rank.",
-                                .default_value = true}));
-
-  parallelRedist.move_into_collection(list);
+      parameter<bool>(
+          "PRINT_DISTRIBUTION", {.description = "Print details of the parallel distribution, i.e. "
+                                                "number of nodes/elements for each rank.",
+                                    .default_value = true})});
 }
 
 void Inpar::Mortar::set_valid_conditions(

--- a/src/inpar/4C_inpar_mpc_rve.cpp
+++ b/src/inpar/4C_inpar_mpc_rve.cpp
@@ -18,24 +18,22 @@ FOUR_C_NAMESPACE_OPEN
 void Inpar::RveMpc::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
-  Core::Utils::SectionSpecs mpc{"MULTI POINT CONSTRAINTS"};
+  list["MULTI POINT CONSTRAINTS"] = all_of({
 
-  mpc.specs.emplace_back(
       parameter<Inpar::RveMpc::RveReferenceDeformationDefinition>("RVE_REFERENCE_POINTS",
           {.description = "Method of definition of the reference points of an RVE",
-              .default_value = automatic}));
+              .default_value = automatic}),
 
-  mpc.specs.emplace_back(deprecated_selection<Inpar::RveMpc::EnforcementStrategy>("ENFORCEMENT",
-      {
-          {"penalty_method", penalty},
-          {"lagrange_multiplier_method", lagrangeMultiplier},
-      },
-      {.description = "Method to enforce the multi point constraint", .default_value = penalty}));
+      deprecated_selection<Inpar::RveMpc::EnforcementStrategy>("ENFORCEMENT",
+          {
+              {"penalty_method", penalty},
+              {"lagrange_multiplier_method", lagrangeMultiplier},
+          },
+          {.description = "Method to enforce the multi point constraint",
+              .default_value = penalty}),
 
-  mpc.specs.emplace_back(parameter<double>(
-      "PENALTY_PARAM", {.description = "Value of the penalty parameter", .default_value = 1e5}));
-
-  mpc.move_into_collection(list);
+      parameter<double>("PENALTY_PARAM",
+          {.description = "Value of the penalty parameter", .default_value = 1e5})});
 }
 
 // set mpc specific conditions

--- a/src/inpar/4C_inpar_mpc_rve.cpp
+++ b/src/inpar/4C_inpar_mpc_rve.cpp
@@ -11,8 +11,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 // set the mpc specific parameters
 void Inpar::RveMpc::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -24,210 +24,205 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
   /*-------------------------------------------------------------------------*
    | general control parameters for particle simulations                     |
    *-------------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs particledyn{"PARTICLE DYNAMIC"};
+  list["PARTICLE DYNAMIC"] = all_of({
 
-  // type of particle time integration
-  particledyn.specs.emplace_back(deprecated_selection<DynamicType>("DYNAMICTYPE",
-      {
-          {"SemiImplicitEuler", Inpar::PARTICLE::dyna_semiimpliciteuler},
-          {"VelocityVerlet", Inpar::PARTICLE::dyna_velocityverlet},
-      },
-      {.description = "type of particle time integration",
-          .default_value = Inpar::PARTICLE::dyna_velocityverlet}));
+      // type of particle time integration
+      deprecated_selection<DynamicType>("DYNAMICTYPE",
+          {
+              {"SemiImplicitEuler", Inpar::PARTICLE::dyna_semiimpliciteuler},
+              {"VelocityVerlet", Inpar::PARTICLE::dyna_velocityverlet},
+          },
+          {.description = "type of particle time integration",
+              .default_value = Inpar::PARTICLE::dyna_velocityverlet}),
 
-  // type of particle interaction
-  particledyn.specs.emplace_back(deprecated_selection<InteractionType>("INTERACTION",
-      {
-          {"None", Inpar::PARTICLE::interaction_none},
-          {"SPH", Inpar::PARTICLE::interaction_sph},
-          {"DEM", Inpar::PARTICLE::interaction_dem},
-      },
-      {.description = "type of particle interaction",
-          .default_value = Inpar::PARTICLE::interaction_none}));
+      // type of particle interaction
+      deprecated_selection<InteractionType>("INTERACTION",
+          {
+              {"None", Inpar::PARTICLE::interaction_none},
+              {"SPH", Inpar::PARTICLE::interaction_sph},
+              {"DEM", Inpar::PARTICLE::interaction_dem},
+          },
+          {.description = "type of particle interaction",
+              .default_value = Inpar::PARTICLE::interaction_none}),
 
-  // output type
-  particledyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "write particle runtime output every RESULTSEVERY steps",
-                          .default_value = 1}));
-  particledyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
+      // output type
+      parameter<int>(
+          "RESULTSEVERY", {.description = "write particle runtime output every RESULTSEVERY steps",
+                              .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
 
-  // write ghosted particles
-  particledyn.specs.emplace_back(parameter<bool>("WRITE_GHOSTED_PARTICLES",
-      {.description = "write ghosted particles (debug feature)", .default_value = false}));
+      // write ghosted particles
+      parameter<bool>("WRITE_GHOSTED_PARTICLES",
+          {.description = "write ghosted particles (debug feature)", .default_value = false}),
 
-  // time loop control
-  particledyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.01}));
-  particledyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "maximum number of steps", .default_value = 100}));
-  particledyn.specs.emplace_back(
-      parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 1.0}));
+      // time loop control
+      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.01}),
 
-  // gravity acceleration control
-  particledyn.specs.emplace_back(parameter<std::string>("GRAVITY_ACCELERATION",
-      {.description = "acceleration due to gravity", .default_value = "0.0 0.0 0.0"}));
-  particledyn.specs.emplace_back(parameter<int>("GRAVITY_RAMP_FUNCT",
-      {.description = "number of function governing gravity ramp", .default_value = -1}));
+      parameter<int>("NUMSTEP", {.description = "maximum number of steps", .default_value = 100}),
 
-  // viscous damping factor
-  particledyn.specs.emplace_back(parameter<double>("VISCOUS_DAMPING",
-      {.description = "apply viscous damping force to determine static equilibrium solutions",
-          .default_value = -1.0}));
+      parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 1.0}),
 
-  // transfer particles to new bins every time step
-  particledyn.specs.emplace_back(parameter<bool>("TRANSFER_EVERY",
-      {.description = "transfer particles to new bins every time step", .default_value = false}));
+      // gravity acceleration control
+      parameter<std::string>("GRAVITY_ACCELERATION",
+          {.description = "acceleration due to gravity", .default_value = "0.0 0.0 0.0"}),
+      parameter<int>("GRAVITY_RAMP_FUNCT",
+          {.description = "number of function governing gravity ramp", .default_value = -1}),
 
-  // considered particle phases with dynamic load balance weighting factor
-  particledyn.specs.emplace_back(parameter<std::string>("PHASE_TO_DYNLOADBALFAC",
-      {.description = "considered particle phases with dynamic load balance weighting factor",
-          .default_value = "none"}));
+      // viscous damping factor
+      parameter<double>("VISCOUS_DAMPING",
+          {.description = "apply viscous damping force to determine static equilibrium solutions",
+              .default_value = -1.0}),
 
-  // relate particle phase to material id
-  particledyn.specs.emplace_back(parameter<std::string>("PHASE_TO_MATERIAL_ID",
-      {.description = "relate particle phase to material id", .default_value = "none"}));
+      // transfer particles to new bins every time step
+      parameter<bool>(
+          "TRANSFER_EVERY", {.description = "transfer particles to new bins every time step",
+                                .default_value = false}),
 
-  // amplitude of noise added to initial position for each spatial direction
-  particledyn.specs.emplace_back(parameter<std::string>("INITIAL_POSITION_AMPLITUDE",
-      {.description = "amplitude of noise added to initial position for each spatial direction",
-          .default_value = "0.0 0.0 0.0"}));
+      // considered particle phases with dynamic load balance weighting factor
+      parameter<std::string>("PHASE_TO_DYNLOADBALFAC",
+          {.description = "considered particle phases with dynamic load balance weighting factor",
+              .default_value = "none"}),
 
-  // type of particle wall source
-  particledyn.specs.emplace_back(deprecated_selection<ParticleWallSource>("PARTICLE_WALL_SOURCE",
-      {
-          {"NoParticleWall", Inpar::PARTICLE::NoParticleWall},
-          {"DiscretCondition", Inpar::PARTICLE::DiscretCondition},
-          {"BoundingBox", Inpar::PARTICLE::BoundingBox},
-      },
-      {.description = "type of particle wall source",
-          .default_value = Inpar::PARTICLE::NoParticleWall}));
+      // relate particle phase to material id
+      parameter<std::string>("PHASE_TO_MATERIAL_ID",
+          {.description = "relate particle phase to material id", .default_value = "none"}),
 
-  // material id for particle wall from bounding box source
-  particledyn.specs.emplace_back(parameter<int>(
-      "PARTICLE_WALL_MAT", {.description = "material id for particle wall from bounding box source",
-                               .default_value = -1}));
+      // amplitude of noise added to initial position for each spatial direction
+      parameter<std::string>("INITIAL_POSITION_AMPLITUDE",
+          {.description = "amplitude of noise added to initial position for each spatial direction",
+              .default_value = "0.0 0.0 0.0"}),
 
-  // flags defining considered states of particle wall
-  particledyn.specs.emplace_back(parameter<bool>("PARTICLE_WALL_MOVING",
-      {.description = "consider a moving particle wall", .default_value = false}));
-  particledyn.specs.emplace_back(parameter<bool>("PARTICLE_WALL_LOADED",
-      {.description = "consider loading on particle wall", .default_value = false}));
+      // type of particle wall source
+      deprecated_selection<ParticleWallSource>("PARTICLE_WALL_SOURCE",
+          {
+              {"NoParticleWall", Inpar::PARTICLE::NoParticleWall},
+              {"DiscretCondition", Inpar::PARTICLE::DiscretCondition},
+              {"BoundingBox", Inpar::PARTICLE::BoundingBox},
+          },
+          {.description = "type of particle wall source",
+              .default_value = Inpar::PARTICLE::NoParticleWall}),
 
-  // consider rigid body motion
-  particledyn.specs.emplace_back(parameter<bool>(
-      "RIGID_BODY_MOTION", {.description = "consider rigid body motion", .default_value = false}));
+      // material id for particle wall from bounding box source
+      parameter<int>("PARTICLE_WALL_MAT",
+          {.description = "material id for particle wall from bounding box source",
+              .default_value = -1}),
 
-  particledyn.specs.emplace_back(parameter<double>("RIGID_BODY_PHASECHANGE_RADIUS",
-      {.description = "search radius for neighboring rigid bodies in case of phase change",
-          .default_value = -1.0}));
+      // flags defining considered states of particle wall
+      parameter<bool>("PARTICLE_WALL_MOVING",
+          {.description = "consider a moving particle wall", .default_value = false}),
+      parameter<bool>("PARTICLE_WALL_LOADED",
+          {.description = "consider loading on particle wall", .default_value = false}),
 
-  particledyn.move_into_collection(list);
+      // consider rigid body motion
+      parameter<bool>("RIGID_BODY_MOTION",
+          {.description = "consider rigid body motion", .default_value = false}),
 
-  /*-------------------------------------------------------------------------*
-   | control parameters for initial/boundary conditions                      |
-   *-------------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs particledynconditions{particledyn, "INITIAL AND BOUNDARY CONDITIONS"};
+      parameter<double>("RIGID_BODY_PHASECHANGE_RADIUS",
+          {.description = "search radius for neighboring rigid bodies in case of phase change",
+              .default_value =
+                  -1.0})}); /*-------------------------------------------------------------------------*
+                            | control parameters for initial/boundary conditions |
+                            *-------------------------------------------------------------------------*/
+  list["PARTICLE DYNAMIC/INITIAL AND BOUNDARY CONDITIONS"] = all_of({
 
-  // initial temperature field of particle phase given by function
-  particledynconditions.specs.emplace_back(parameter<std::string>("INITIAL_TEMP_FIELD",
-      {.description =
-              "Refer to the function ID describing the initial temperature field of particle phase",
-          .default_value = "none"}));
+      // initial temperature field of particle phase given by function
+      parameter<std::string>(
+          "INITIAL_TEMP_FIELD", {.description = "Refer to the function ID describing the initial "
+                                                "temperature field of particle phase",
+                                    .default_value = "none"}),
 
-  // initial velocity field of particle phase given by function
-  particledynconditions.specs.emplace_back(parameter<std::string>("INITIAL_VELOCITY_FIELD",
-      {.description =
-              "Refer to the function ID describing the initial velocity field of particle phase",
-          .default_value = "none"}));
+      // initial velocity field of particle phase given by function
+      parameter<std::string>(
+          "INITIAL_VELOCITY_FIELD", {.description = "Refer to the function ID describing the "
+                                                    "initial velocity field of particle phase",
+                                        .default_value = "none"}),
 
-  // initial angular velocity field of particle phase given by function
-  particledynconditions.specs.emplace_back(parameter<std::string>("INITIAL_ANGULAR_VELOCITY_FIELD",
-      {.description = "Refer to the function ID describing the initial angular velocity field of "
-                      "rigid body  phase/DEM particle",
-          .default_value = "none"}));
+      // initial angular velocity field of particle phase given by function
+      parameter<std::string>("INITIAL_ANGULAR_VELOCITY_FIELD",
+          {.description =
+                  "Refer to the function ID describing the initial angular velocity field of "
+                  "rigid body  phase/DEM particle",
+              .default_value = "none"}),
 
 
-  // initial acceleration field of particle phase given by function
-  particledynconditions.specs.emplace_back(parameter<std::string>(
-      "INITIAL_ACCELERATION_FIELD", {.description = "Refer to the function ID describing the "
-                                                    "initial acceleration field of particle phase",
-                                        .default_value = "none"}));
+      // initial acceleration field of particle phase given by function
+      parameter<std::string>("INITIAL_ACCELERATION_FIELD",
+          {.description = "Refer to the function ID describing the "
+                          "initial acceleration field of particle phase",
+              .default_value = "none"}),
 
-  // initial angular acceleration field of particle phase given by function
-  particledynconditions.specs.emplace_back(
+      // initial angular acceleration field of particle phase given by function
       parameter<std::string>("INITIAL_ANGULAR_ACCELERATION_FIELD",
           {.description = "Refer to the function ID describing the initial angular acceleration "
                           "field of rigid body  phase/DEM particle",
-              .default_value = "none"}));
+              .default_value = "none"}),
 
 
-  // dirichlet boundary condition of particle phase given by function
-  particledynconditions.specs.emplace_back(parameter<std::string>("DIRICHLET_BOUNDARY_CONDITION",
-      {.description = "Refer to the function ID describing the dirichlet boundary condition of "
-                      "particle phase",
-          .default_value = "none"}));
+      // dirichlet boundary condition of particle phase given by function
+      parameter<std::string>("DIRICHLET_BOUNDARY_CONDITION",
+          {.description = "Refer to the function ID describing the dirichlet boundary condition of "
+                          "particle phase",
+              .default_value = "none"}),
 
-  // temperature boundary condition of particle phase given by function
-  particledynconditions.specs.emplace_back(parameter<std::string>("TEMPERATURE_BOUNDARY_CONDITION",
-      {.description = "Refer to the function ID describing the temperature boundary condition of "
-                      "particle phase",
-          .default_value = "none"}));
-
-  particledynconditions.move_into_collection(list);
+      // temperature boundary condition of particle phase given by function
+      parameter<std::string>("TEMPERATURE_BOUNDARY_CONDITION",
+          {.description =
+                  "Refer to the function ID describing the temperature boundary condition of "
+                  "particle phase",
+              .default_value = "none"})});
 
   /*-------------------------------------------------------------------------*
    | smoothed particle hydrodynamics (SPH) specific control parameters       |
    *-------------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs particledynsph{particledyn, "SPH"};
+  list["PARTICLE DYNAMIC/SPH"] = all_of({
 
-  // write particle-wall interaction output
-  particledynsph.specs.emplace_back(parameter<bool>("WRITE_PARTICLE_WALL_INTERACTION",
-      {.description = "write particle-wall interaction output", .default_value = false}));
+      // write particle-wall interaction output
+      parameter<bool>("WRITE_PARTICLE_WALL_INTERACTION",
+          {.description = "write particle-wall interaction output", .default_value = false}),
 
-  // type of smoothed particle hydrodynamics kernel
-  particledynsph.specs.emplace_back(deprecated_selection<KernelType>("KERNEL",
-      {
-          {"CubicSpline", Inpar::PARTICLE::CubicSpline},
-          {"QuinticSpline", Inpar::PARTICLE::QuinticSpline},
-      },
-      {.description = "type of smoothed particle hydrodynamics kernel",
-          .default_value = Inpar::PARTICLE::CubicSpline}));
+      // type of smoothed particle hydrodynamics kernel
+      deprecated_selection<KernelType>("KERNEL",
+          {
+              {"CubicSpline", Inpar::PARTICLE::CubicSpline},
+              {"QuinticSpline", Inpar::PARTICLE::QuinticSpline},
+          },
+          {.description = "type of smoothed particle hydrodynamics kernel",
+              .default_value = Inpar::PARTICLE::CubicSpline}),
 
-  // kernel space dimension number
-  particledynsph.specs.emplace_back(deprecated_selection<KernelSpaceDimension>("KERNEL_SPACE_DIM",
-      {
-          {"Kernel1D", Inpar::PARTICLE::Kernel1D},
-          {"Kernel2D", Inpar::PARTICLE::Kernel2D},
-          {"Kernel3D", Inpar::PARTICLE::Kernel3D},
-      },
-      {.description = "kernel space dimension number",
-          .default_value = Inpar::PARTICLE::Kernel3D}));
+      // kernel space dimension number
+      deprecated_selection<KernelSpaceDimension>("KERNEL_SPACE_DIM",
+          {
+              {"Kernel1D", Inpar::PARTICLE::Kernel1D},
+              {"Kernel2D", Inpar::PARTICLE::Kernel2D},
+              {"Kernel3D", Inpar::PARTICLE::Kernel3D},
+          },
+          {.description = "kernel space dimension number",
+              .default_value = Inpar::PARTICLE::Kernel3D}),
 
-  particledynsph.specs.emplace_back(parameter<double>("INITIALPARTICLESPACING",
-      {.description = "initial spacing of particles", .default_value = 0.0}));
+      parameter<double>("INITIALPARTICLESPACING",
+          {.description = "initial spacing of particles", .default_value = 0.0}),
 
-  // type of smoothed particle hydrodynamics equation of state
-  particledynsph.specs.emplace_back(deprecated_selection<EquationOfStateType>("EQUATIONOFSTATE",
-      {
-          {"GenTait", Inpar::PARTICLE::GenTait},
-          {"IdealGas", Inpar::PARTICLE::IdealGas},
-      },
-      {.description = "type of smoothed particle hydrodynamics equation of state",
-          .default_value = Inpar::PARTICLE::GenTait}));
+      // type of smoothed particle hydrodynamics equation of state
+      deprecated_selection<EquationOfStateType>("EQUATIONOFSTATE",
+          {
+              {"GenTait", Inpar::PARTICLE::GenTait},
+              {"IdealGas", Inpar::PARTICLE::IdealGas},
+          },
+          {.description = "type of smoothed particle hydrodynamics equation of state",
+              .default_value = Inpar::PARTICLE::GenTait}),
 
-  // type of smoothed particle hydrodynamics momentum formulation
-  particledynsph.specs.emplace_back(
+      // type of smoothed particle hydrodynamics momentum formulation
       deprecated_selection<MomentumFormulationType>("MOMENTUMFORMULATION",
           {
               {"AdamiMomentumFormulation", Inpar::PARTICLE::AdamiMomentumFormulation},
               {"MonaghanMomentumFormulation", Inpar::PARTICLE::MonaghanMomentumFormulation},
           },
           {.description = "type of smoothed particle hydrodynamics momentum formulation",
-              .default_value = Inpar::PARTICLE::AdamiMomentumFormulation}));
+              .default_value = Inpar::PARTICLE::AdamiMomentumFormulation}),
 
-  // type of density evaluation scheme
-  particledynsph.specs.emplace_back(
+      // type of density evaluation scheme
       deprecated_selection<DensityEvaluationScheme>("DENSITYEVALUATION",
           {
               {"DensitySummation", Inpar::PARTICLE::DensitySummation},
@@ -235,10 +230,9 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
               {"DensityPredictCorrect", Inpar::PARTICLE::DensityPredictCorrect},
           },
           {.description = "type of density evaluation scheme",
-              .default_value = Inpar::PARTICLE::DensitySummation}));
+              .default_value = Inpar::PARTICLE::DensitySummation}),
 
-  // type of density correction scheme
-  particledynsph.specs.emplace_back(
+      // type of density correction scheme
       deprecated_selection<DensityCorrectionScheme>("DENSITYCORRECTION",
           {
               {"NoCorrection", Inpar::PARTICLE::NoCorrection},
@@ -247,39 +241,36 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
               {"RandlesCorrection", Inpar::PARTICLE::RandlesCorrection},
           },
           {.description = "type of density correction scheme",
-              .default_value = Inpar::PARTICLE::NoCorrection}));
+              .default_value = Inpar::PARTICLE::NoCorrection}),
 
-  // type of boundary particle formulation
-  particledynsph.specs.emplace_back(
+      // type of boundary particle formulation
       deprecated_selection<BoundaryParticleFormulationType>("BOUNDARYPARTICLEFORMULATION",
           {
               {"NoBoundaryFormulation", Inpar::PARTICLE::NoBoundaryFormulation},
               {"AdamiBoundaryFormulation", Inpar::PARTICLE::AdamiBoundaryFormulation},
           },
           {.description = "type of boundary particle formulation",
-              .default_value = Inpar::PARTICLE::NoBoundaryFormulation}));
+              .default_value = Inpar::PARTICLE::NoBoundaryFormulation}),
 
-  // type of boundary particle interaction
-  particledynsph.specs.emplace_back(
+      // type of boundary particle interaction
       deprecated_selection<BoundaryParticleInteraction>("BOUNDARYPARTICLEINTERACTION",
           {
               {"NoSlipBoundaryParticle", Inpar::PARTICLE::NoSlipBoundaryParticle},
               {"FreeSlipBoundaryParticle", Inpar::PARTICLE::FreeSlipBoundaryParticle},
           },
           {.description = "type of boundary particle interaction",
-              .default_value = Inpar::PARTICLE::NoSlipBoundaryParticle}));
+              .default_value = Inpar::PARTICLE::NoSlipBoundaryParticle}),
 
-  // type of wall formulation
-  particledynsph.specs.emplace_back(deprecated_selection<WallFormulationType>("WALLFORMULATION",
-      {
-          {"NoWallFormulation", Inpar::PARTICLE::NoWallFormulation},
-          {"VirtualParticleWallFormulation", Inpar::PARTICLE::VirtualParticleWallFormulation},
-      },
-      {.description = "type of wall formulation",
-          .default_value = Inpar::PARTICLE::NoWallFormulation}));
+      // type of wall formulation
+      deprecated_selection<WallFormulationType>("WALLFORMULATION",
+          {
+              {"NoWallFormulation", Inpar::PARTICLE::NoWallFormulation},
+              {"VirtualParticleWallFormulation", Inpar::PARTICLE::VirtualParticleWallFormulation},
+          },
+          {.description = "type of wall formulation",
+              .default_value = Inpar::PARTICLE::NoWallFormulation}),
 
-  // type of transport velocity formulation
-  particledynsph.specs.emplace_back(
+      // type of transport velocity formulation
       deprecated_selection<TransportVelocityFormulation>("TRANSPORTVELOCITYFORMULATION",
           {
               {"NoTransportVelocity", Inpar::PARTICLE::NoTransportVelocity},
@@ -287,270 +278,267 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
               {"GeneralizedTransportVelocity", Inpar::PARTICLE::GeneralizedTransportVelocity},
           },
           {.description = "type of transport velocity formulation",
-              .default_value = Inpar::PARTICLE::NoTransportVelocity}));
+              .default_value = Inpar::PARTICLE::NoTransportVelocity}),
 
-  // type of temperature evaluation scheme
-  particledynsph.specs.emplace_back(
+      // type of temperature evaluation scheme
       deprecated_selection<TemperatureEvaluationScheme>("TEMPERATUREEVALUATION",
           {
               {"NoTemperatureEvaluation", Inpar::PARTICLE::NoTemperatureEvaluation},
               {"TemperatureIntegration", Inpar::PARTICLE::TemperatureIntegration},
           },
           {.description = "type of temperature evaluation scheme",
-              .default_value = Inpar::PARTICLE::NoTemperatureEvaluation}));
+              .default_value = Inpar::PARTICLE::NoTemperatureEvaluation}),
 
-  particledynsph.specs.emplace_back(parameter<bool>("TEMPERATUREGRADIENT",
-      {.description = "evaluate temperature gradient", .default_value = false}));
+      parameter<bool>("TEMPERATUREGRADIENT",
+          {.description = "evaluate temperature gradient", .default_value = false}),
 
-  // type of heat source
-  particledynsph.specs.emplace_back(deprecated_selection<HeatSourceType>("HEATSOURCETYPE",
-      {
-          {"NoHeatSource", Inpar::PARTICLE::NoHeatSource},
-          {"VolumeHeatSource", Inpar::PARTICLE::VolumeHeatSource},
-          {"SurfaceHeatSource", Inpar::PARTICLE::SurfaceHeatSource},
-      },
-      {.description = "type of heat source", .default_value = Inpar::PARTICLE::NoHeatSource}));
+      // type of heat source
+      deprecated_selection<HeatSourceType>("HEATSOURCETYPE",
+          {
+              {"NoHeatSource", Inpar::PARTICLE::NoHeatSource},
+              {"VolumeHeatSource", Inpar::PARTICLE::VolumeHeatSource},
+              {"SurfaceHeatSource", Inpar::PARTICLE::SurfaceHeatSource},
+          },
+          {.description = "type of heat source", .default_value = Inpar::PARTICLE::NoHeatSource}),
 
-  particledynsph.specs.emplace_back(parameter<int>("HEATSOURCE_FUNCT",
-      {.description = "number of function governing heat source", .default_value = -1}));
+      parameter<int>("HEATSOURCE_FUNCT",
+          {.description = "number of function governing heat source", .default_value = -1}),
 
-  particledynsph.specs.emplace_back(parameter<std::string>("HEATSOURCE_DIRECTION",
-      {.description = "direction of surface heat source", .default_value = "0.0 0.0 0.0"}));
+      parameter<std::string>("HEATSOURCE_DIRECTION",
+          {.description = "direction of surface heat source", .default_value = "0.0 0.0 0.0"}),
 
-  // evaporation induced heat loss
-  particledynsph.specs.emplace_back(parameter<bool>("VAPOR_HEATLOSS",
-      {.description = "evaluate evaporation induced heat loss", .default_value = false}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_LATENTHEAT",
-      {.description = "latent heat in heat loss formula", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_ENTHALPY_REFTEMP",
-      {.description = "enthalpy reference temperature in heat loss formula",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_PFAC",
-      {.description = "pressure factor in heat loss formula", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_HEATLOSS_TFAC",
-      {.description = "temperature factor in heat loss formula", .default_value = 0.0}));
+      // evaporation induced heat loss
+      parameter<bool>("VAPOR_HEATLOSS",
+          {.description = "evaluate evaporation induced heat loss", .default_value = false}),
+      parameter<double>("VAPOR_HEATLOSS_LATENTHEAT",
+          {.description = "latent heat in heat loss formula", .default_value = 0.0}),
+      parameter<double>("VAPOR_HEATLOSS_ENTHALPY_REFTEMP",
+          {.description = "enthalpy reference temperature in heat loss formula",
+              .default_value = 0.0}),
+      parameter<double>("VAPOR_HEATLOSS_PFAC",
+          {.description = "pressure factor in heat loss formula", .default_value = 0.0}),
+      parameter<double>("VAPOR_HEATLOSS_TFAC",
+          {.description = "temperature factor in heat loss formula", .default_value = 0.0}),
 
-  // evaporation induced recoil pressure
-  particledynsph.specs.emplace_back(parameter<bool>("VAPOR_RECOIL",
-      {.description = "evaluate evaporation induced recoil pressure", .default_value = false}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_RECOIL_BOILINGTEMPERATURE",
-      {.description = "boiling temperature in recoil pressure formula", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_RECOIL_PFAC",
-      {.description = "pressure factor in recoil pressure formula", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("VAPOR_RECOIL_TFAC",
-      {.description = "temperature factor in recoil pressure formula", .default_value = 0.0}));
+      // evaporation induced recoil pressure
+      parameter<bool>("VAPOR_RECOIL",
+          {.description = "evaluate evaporation induced recoil pressure", .default_value = false}),
+      parameter<double>("VAPOR_RECOIL_BOILINGTEMPERATURE",
+          {.description = "boiling temperature in recoil pressure formula", .default_value = 0.0}),
+      parameter<double>("VAPOR_RECOIL_PFAC",
+          {.description = "pressure factor in recoil pressure formula", .default_value = 0.0}),
+      parameter<double>("VAPOR_RECOIL_TFAC",
+          {.description = "temperature factor in recoil pressure formula", .default_value = 0.0}),
 
-  // type of surface tension formulation
-  particledynsph.specs.emplace_back(
+      // type of surface tension formulation
       deprecated_selection<SurfaceTensionFormulation>("SURFACETENSIONFORMULATION",
           {
               {"NoSurfaceTension", Inpar::PARTICLE::NoSurfaceTension},
               {"ContinuumSurfaceForce", Inpar::PARTICLE::ContinuumSurfaceForce},
           },
           {.description = "type of surface tension formulation",
-              .default_value = Inpar::PARTICLE::NoSurfaceTension}));
+              .default_value = Inpar::PARTICLE::NoSurfaceTension}),
 
-  particledynsph.specs.emplace_back(parameter<int>("SURFACETENSION_RAMP_FUNCT",
-      {.description = "number of function governing surface tension ramp", .default_value = -1}));
+      parameter<int>("SURFACETENSION_RAMP_FUNCT",
+          {.description = "number of function governing surface tension ramp",
+              .default_value = -1}),
 
-  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONCOEFFICIENT",
-      {.description = "constant part of surface tension coefficient", .default_value = -1.0}));
-  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONMINIMUM",
-      {.description = "minimum surface tension coefficient in case of temperature dependence",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONTEMPFAC",
-      {.description = "factor of dependence of surface tension coefficient on temperature",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("SURFACETENSIONREFTEMP",
-      {.description = "reference temperature for surface tension coefficient",
-          .default_value = 0.0}));
+      parameter<double>("SURFACETENSIONCOEFFICIENT",
+          {.description = "constant part of surface tension coefficient", .default_value = -1.0}),
+      parameter<double>("SURFACETENSIONMINIMUM",
+          {.description = "minimum surface tension coefficient in case of temperature dependence",
+              .default_value = 0.0}),
+      parameter<double>("SURFACETENSIONTEMPFAC",
+          {.description = "factor of dependence of surface tension coefficient on temperature",
+              .default_value = 0.0}),
+      parameter<double>("SURFACETENSIONREFTEMP",
+          {.description = "reference temperature for surface tension coefficient",
+              .default_value = 0.0}),
 
-  // wetting
-  particledynsph.specs.emplace_back(parameter<double>(
-      "STATICCONTACTANGLE", {.description = "static contact angle in degree with wetting effects",
-                                .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRIPLEPOINTNORMAL_CORR_CF_LOW",
-      {.description = "triple point normal correction wall color field low",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRIPLEPOINTNORMAL_CORR_CF_UP",
-      {.description = "triple point normal correction wall color field up", .default_value = 0.0}));
+      // wetting
+      parameter<double>("STATICCONTACTANGLE",
+          {.description = "static contact angle in degree with wetting effects",
+              .default_value = 0.0}),
+      parameter<double>("TRIPLEPOINTNORMAL_CORR_CF_LOW",
+          {.description = "triple point normal correction wall color field low",
+              .default_value = 0.0}),
+      parameter<double>("TRIPLEPOINTNORMAL_CORR_CF_UP",
+          {.description = "triple point normal correction wall color field up",
+              .default_value = 0.0}),
 
-  // interface viscosity
-  particledynsph.specs.emplace_back(parameter<bool>("INTERFACE_VISCOSITY",
-      {.description = "evaluate interface viscosity", .default_value = false}));
-  particledynsph.specs.emplace_back(parameter<double>("INTERFACE_VISCOSITY_LIQUIDGAS",
-      {.description = "artificial viscosity on liquid-gas interface", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("INTERFACE_VISCOSITY_SOLIDLIQUID",
-      {.description = "artificial viscosity on solid-liquid interface", .default_value = 0.0}));
+      // interface viscosity
+      parameter<bool>("INTERFACE_VISCOSITY",
+          {.description = "evaluate interface viscosity", .default_value = false}),
+      parameter<double>("INTERFACE_VISCOSITY_LIQUIDGAS",
+          {.description = "artificial viscosity on liquid-gas interface", .default_value = 0.0}),
+      parameter<double>("INTERFACE_VISCOSITY_SOLIDLIQUID",
+          {.description = "artificial viscosity on solid-liquid interface", .default_value = 0.0}),
 
-  // barrier force
-  particledynsph.specs.emplace_back(parameter<bool>(
-      "BARRIER_FORCE", {.description = "evaluate barrier force", .default_value = false}));
-  particledynsph.specs.emplace_back(parameter<double>(
-      "BARRIER_FORCE_DISTANCE", {.description = "barrier force distance", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_TEMPSCALE",
-      {.description = "barrier force temperature scaling", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_STIFF_HEAVY",
-      {.description = "barrier force stiffness of heavy phase", .default_value = -1.0}));
-  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_DAMP_HEAVY",
-      {.description = "barrier force damping parameter of heavy phase", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_STIFF_GAS",
-      {.description = "barrier force stiffness of gas phase", .default_value = -1.0}));
-  particledynsph.specs.emplace_back(parameter<double>("BARRIER_FORCE_DAMP_GAS",
-      {.description = "barrier force damping parameter of gas phase", .default_value = 0.0}));
+      // barrier force
+      parameter<bool>(
+          "BARRIER_FORCE", {.description = "evaluate barrier force", .default_value = false}),
+      parameter<double>("BARRIER_FORCE_DISTANCE",
+          {.description = "barrier force distance", .default_value = 0.0}),
+      parameter<double>("BARRIER_FORCE_TEMPSCALE",
+          {.description = "barrier force temperature scaling", .default_value = 0.0}),
+      parameter<double>("BARRIER_FORCE_STIFF_HEAVY",
+          {.description = "barrier force stiffness of heavy phase", .default_value = -1.0}),
+      parameter<double>("BARRIER_FORCE_DAMP_HEAVY",
+          {.description = "barrier force damping parameter of heavy phase", .default_value = 0.0}),
+      parameter<double>("BARRIER_FORCE_STIFF_GAS",
+          {.description = "barrier force stiffness of gas phase", .default_value = -1.0}),
+      parameter<double>("BARRIER_FORCE_DAMP_GAS",
+          {.description = "barrier force damping parameter of gas phase", .default_value = 0.0}),
 
-  // linear transition in surface tension evaluation
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_REF_TEMPERATURE",
-      {.description = "transition reference temperature", .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_SURFACETENSION",
-      {.description = "transition temperature difference for surface tension evaluation",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_MARANGONI",
-      {.description = "transition temperature difference for marangoni evaluation",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_CURVATURE",
-      {.description = "transition temperature difference for curvature evaluation",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_WETTING",
-      {.description = "transition temperature difference for wetting evaluation",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_INTVISC",
-      {.description = "transition temperature difference for interface viscosity evaluation",
-          .default_value = 0.0}));
-  particledynsph.specs.emplace_back(parameter<double>("TRANS_DT_BARRIER",
-      {.description = "transition temperature difference for barrier force evaluation",
-          .default_value = 0.0}));
+      // linear transition in surface tension evaluation
+      parameter<double>("TRANS_REF_TEMPERATURE",
+          {.description = "transition reference temperature", .default_value = 0.0}),
+      parameter<double>("TRANS_DT_SURFACETENSION",
+          {.description = "transition temperature difference for surface tension evaluation",
+              .default_value = 0.0}),
+      parameter<double>("TRANS_DT_MARANGONI",
+          {.description = "transition temperature difference for marangoni evaluation",
+              .default_value = 0.0}),
+      parameter<double>("TRANS_DT_CURVATURE",
+          {.description = "transition temperature difference for curvature evaluation",
+              .default_value = 0.0}),
+      parameter<double>("TRANS_DT_WETTING",
+          {.description = "transition temperature difference for wetting evaluation",
+              .default_value = 0.0}),
+      parameter<double>("TRANS_DT_INTVISC",
+          {.description = "transition temperature difference for interface viscosity evaluation",
+              .default_value = 0.0}),
+      parameter<double>("TRANS_DT_BARRIER",
+          {.description = "transition temperature difference for barrier force evaluation",
+              .default_value = 0.0}),
 
-  // type of dirichlet open boundary
-  particledynsph.specs.emplace_back(
+      // type of dirichlet open boundary
       deprecated_selection<DirichletOpenBoundaryType>("DIRICHLETBOUNDARYTYPE",
           {
               {"NoDirichletOpenBoundary", Inpar::PARTICLE::NoDirichletOpenBoundary},
               {"DirichletNormalToPlane", Inpar::PARTICLE::DirichletNormalToPlane},
           },
           {.description = "type of dirichlet open boundary",
-              .default_value = Inpar::PARTICLE::NoDirichletOpenBoundary}));
+              .default_value = Inpar::PARTICLE::NoDirichletOpenBoundary}),
 
-  particledynsph.specs.emplace_back(parameter<int>("DIRICHLET_FUNCT",
-      {.description = "number of function governing velocity condition on dirichlet open boundary",
-          .default_value = -1}));
+      parameter<int>("DIRICHLET_FUNCT",
+          {.description =
+                  "number of function governing velocity condition on dirichlet open boundary",
+              .default_value = -1}),
 
-  particledynsph.specs.emplace_back(parameter<std::string>("DIRICHLET_OUTWARD_NORMAL",
-      {.description = "direction of outward normal on dirichlet open boundary",
-          .default_value = "0.0 0.0 0.0"}));
-  particledynsph.specs.emplace_back(parameter<std::string>("DIRICHLET_PLANE_POINT",
-      {.description = "point on dirichlet open boundary plane", .default_value = "0.0 0.0 0.0"}));
+      parameter<std::string>("DIRICHLET_OUTWARD_NORMAL",
+          {.description = "direction of outward normal on dirichlet open boundary",
+              .default_value = "0.0 0.0 0.0"}),
+      parameter<std::string>(
+          "DIRICHLET_PLANE_POINT", {.description = "point on dirichlet open boundary plane",
+                                       .default_value = "0.0 0.0 0.0"}),
 
-  // type of neumann open boundary
-  particledynsph.specs.emplace_back(
+      // type of neumann open boundary
       deprecated_selection<NeumannOpenBoundaryType>("NEUMANNBOUNDARYTYPE",
           {
               {"NoNeumannOpenBoundary", Inpar::PARTICLE::NoNeumannOpenBoundary},
               {"NeumannNormalToPlane", Inpar::PARTICLE::NeumannNormalToPlane},
           },
           {.description = "type of neumann open boundary",
-              .default_value = Inpar::PARTICLE::NoNeumannOpenBoundary}));
+              .default_value = Inpar::PARTICLE::NoNeumannOpenBoundary}),
 
-  particledynsph.specs.emplace_back(parameter<int>("NEUMANN_FUNCT",
-      {.description = "number of function governing pressure condition on neumann open boundary",
-          .default_value = -1}));
+      parameter<int>("NEUMANN_FUNCT",
+          {.description =
+                  "number of function governing pressure condition on neumann open boundary",
+              .default_value = -1}),
 
-  particledynsph.specs.emplace_back(parameter<std::string>("NEUMANN_OUTWARD_NORMAL",
-      {.description = "direction of outward normal on neumann open boundary",
-          .default_value = "0.0 0.0 0.0"}));
-  particledynsph.specs.emplace_back(parameter<std::string>("NEUMANN_PLANE_POINT",
-      {.description = "point on neumann open boundary plane", .default_value = "0.0 0.0 0.0"}));
+      parameter<std::string>("NEUMANN_OUTWARD_NORMAL",
+          {.description = "direction of outward normal on neumann open boundary",
+              .default_value = "0.0 0.0 0.0"}),
+      parameter<std::string>("NEUMANN_PLANE_POINT",
+          {.description = "point on neumann open boundary plane", .default_value = "0.0 0.0 0.0"}),
 
-  // type of phase change
-  particledynsph.specs.emplace_back(deprecated_selection<PhaseChangeType>("PHASECHANGETYPE",
-      {
-          {"NoPhaseChange", Inpar::PARTICLE::NoPhaseChange},
-          {"OneWayScalarBelowToAbovePhaseChange",
-              Inpar::PARTICLE::OneWayScalarBelowToAbovePhaseChange},
-          {"OneWayScalarAboveToBelowPhaseChange",
-              Inpar::PARTICLE::OneWayScalarAboveToBelowPhaseChange},
-          {"TwoWayScalarPhaseChange", Inpar::PARTICLE::TwoWayScalarPhaseChange},
-      },
-      {.description = "type of phase change", .default_value = Inpar::PARTICLE::NoPhaseChange}));
+      // type of phase change
+      deprecated_selection<PhaseChangeType>("PHASECHANGETYPE",
+          {
+              {"NoPhaseChange", Inpar::PARTICLE::NoPhaseChange},
+              {"OneWayScalarBelowToAbovePhaseChange",
+                  Inpar::PARTICLE::OneWayScalarBelowToAbovePhaseChange},
+              {"OneWayScalarAboveToBelowPhaseChange",
+                  Inpar::PARTICLE::OneWayScalarAboveToBelowPhaseChange},
+              {"TwoWayScalarPhaseChange", Inpar::PARTICLE::TwoWayScalarPhaseChange},
+          },
+          {.description = "type of phase change", .default_value = Inpar::PARTICLE::NoPhaseChange}),
 
-  // definition of phase change
-  particledynsph.specs.emplace_back(parameter<std::string>("PHASECHANGEDEFINITION",
-      {.description = "phase change definition", .default_value = "none"}));
+      // definition of phase change
+      parameter<std::string>("PHASECHANGEDEFINITION",
+          {.description = "phase change definition", .default_value = "none"}),
 
-  // type of rigid particle contact
-  particledynsph.specs.emplace_back(
+      // type of rigid particle contact
       deprecated_selection<RigidParticleContactType>("RIGIDPARTICLECONTACTTYPE",
           {
               {"NoRigidParticleContact", Inpar::PARTICLE::NoRigidParticleContact},
               {"ElasticRigidParticleContact", Inpar::PARTICLE::ElasticRigidParticleContact},
           },
           {.description = "type of rigid particle contact",
-              .default_value = Inpar::PARTICLE::NoRigidParticleContact}));
+              .default_value = Inpar::PARTICLE::NoRigidParticleContact}),
 
-  particledynsph.specs.emplace_back(parameter<double>("RIGIDPARTICLECONTACTSTIFF",
-      {.description = "rigid particle contact stiffness", .default_value = -1.0}));
-  particledynsph.specs.emplace_back(parameter<double>("RIGIDPARTICLECONTACTDAMP",
-      {.description = "rigid particle contact damping parameter", .default_value = 0.0}));
-
-  particledynsph.move_into_collection(list);
+      parameter<double>("RIGIDPARTICLECONTACTSTIFF",
+          {.description = "rigid particle contact stiffness", .default_value = -1.0}),
+      parameter<double>("RIGIDPARTICLECONTACTDAMP",
+          {.description = "rigid particle contact damping parameter", .default_value = 0.0})});
 
   /*-------------------------------------------------------------------------*
    | discrete element method (DEM) specific control parameters               |
    *-------------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs particledyndem{particledyn, "DEM"};
+  list["PARTICLE DYNAMIC/DEM"] = all_of({
 
-  // write particle energy output
-  particledyndem.specs.emplace_back(parameter<bool>("WRITE_PARTICLE_ENERGY",
-      {.description = "write particle energy output", .default_value = false}));
+      // write particle energy output
+      parameter<bool>("WRITE_PARTICLE_ENERGY",
+          {.description = "write particle energy output", .default_value = false}),
 
-  // write particle-wall interaction output
-  particledyndem.specs.emplace_back(parameter<bool>("WRITE_PARTICLE_WALL_INTERACTION",
-      {.description = "write particle-wall interaction output", .default_value = false}));
+      // write particle-wall interaction output
+      parameter<bool>("WRITE_PARTICLE_WALL_INTERACTION",
+          {.description = "write particle-wall interaction output", .default_value = false}),
 
-  // type of normal contact law
-  particledyndem.specs.emplace_back(deprecated_selection<NormalContact>("NORMALCONTACTLAW",
-      {
-          {"NormalLinearSpring", Inpar::PARTICLE::NormalLinSpring},
-          {"NormalLinearSpringDamp", Inpar::PARTICLE::NormalLinSpringDamp},
-          {"NormalHertz", Inpar::PARTICLE::NormalHertz},
-          {"NormalLeeHerrmann", Inpar::PARTICLE::NormalLeeHerrmann},
-          {"NormalKuwabaraKono", Inpar::PARTICLE::NormalKuwabaraKono},
-          {"NormalTsuji", Inpar::PARTICLE::NormalTsuji},
-      },
-      {.description = "normal contact law for particles",
-          .default_value = Inpar::PARTICLE::NormalLinSpring}));
+      // type of normal contact law
+      deprecated_selection<NormalContact>("NORMALCONTACTLAW",
+          {
+              {"NormalLinearSpring", Inpar::PARTICLE::NormalLinSpring},
+              {"NormalLinearSpringDamp", Inpar::PARTICLE::NormalLinSpringDamp},
+              {"NormalHertz", Inpar::PARTICLE::NormalHertz},
+              {"NormalLeeHerrmann", Inpar::PARTICLE::NormalLeeHerrmann},
+              {"NormalKuwabaraKono", Inpar::PARTICLE::NormalKuwabaraKono},
+              {"NormalTsuji", Inpar::PARTICLE::NormalTsuji},
+          },
+          {.description = "normal contact law for particles",
+              .default_value = Inpar::PARTICLE::NormalLinSpring}),
 
-  // type of tangential contact law
-  particledyndem.specs.emplace_back(deprecated_selection<TangentialContact>("TANGENTIALCONTACTLAW",
-      {
-          {"NoTangentialContact", Inpar::PARTICLE::NoTangentialContact},
-          {"TangentialLinSpringDamp", Inpar::PARTICLE::TangentialLinSpringDamp},
-      },
-      {.description = "tangential contact law for particles",
-          .default_value = Inpar::PARTICLE::NoTangentialContact}));
+      // type of tangential contact law
+      deprecated_selection<TangentialContact>("TANGENTIALCONTACTLAW",
+          {
+              {"NoTangentialContact", Inpar::PARTICLE::NoTangentialContact},
+              {"TangentialLinSpringDamp", Inpar::PARTICLE::TangentialLinSpringDamp},
+          },
+          {.description = "tangential contact law for particles",
+              .default_value = Inpar::PARTICLE::NoTangentialContact}),
 
-  // type of rolling contact law
-  particledyndem.specs.emplace_back(deprecated_selection<RollingContact>("ROLLINGCONTACTLAW",
-      {
-          {"NoRollingContact", Inpar::PARTICLE::NoRollingContact},
-          {"RollingViscous", Inpar::PARTICLE::RollingViscous},
-          {"RollingCoulomb", Inpar::PARTICLE::RollingCoulomb},
-      },
-      {.description = "rolling contact law for particles",
-          .default_value = Inpar::PARTICLE::NoRollingContact}));
+      // type of rolling contact law
+      deprecated_selection<RollingContact>("ROLLINGCONTACTLAW",
+          {
+              {"NoRollingContact", Inpar::PARTICLE::NoRollingContact},
+              {"RollingViscous", Inpar::PARTICLE::RollingViscous},
+              {"RollingCoulomb", Inpar::PARTICLE::RollingCoulomb},
+          },
+          {.description = "rolling contact law for particles",
+              .default_value = Inpar::PARTICLE::NoRollingContact}),
 
-  // type of normal adhesion law
-  particledyndem.specs.emplace_back(deprecated_selection<AdhesionLaw>("ADHESIONLAW",
-      {
-          {"NoAdhesion", Inpar::PARTICLE::NoAdhesion},
-          {"AdhesionVdWDMT", Inpar::PARTICLE::AdhesionVdWDMT},
-          {"AdhesionRegDMT", Inpar::PARTICLE::AdhesionRegDMT},
-      },
-      {.description = "type of adhesion law for particles",
-          .default_value = Inpar::PARTICLE::NoAdhesion}));
+      // type of normal adhesion law
+      deprecated_selection<AdhesionLaw>("ADHESIONLAW",
+          {
+              {"NoAdhesion", Inpar::PARTICLE::NoAdhesion},
+              {"AdhesionVdWDMT", Inpar::PARTICLE::AdhesionVdWDMT},
+              {"AdhesionRegDMT", Inpar::PARTICLE::AdhesionRegDMT},
+          },
+          {.description = "type of adhesion law for particles",
+              .default_value = Inpar::PARTICLE::NoAdhesion}),
 
-  // type of (random) surface energy distribution
-  particledyndem.specs.emplace_back(
+      // type of (random) surface energy distribution
       deprecated_selection<SurfaceEnergyDistribution>("ADHESION_SURFACE_ENERGY_DISTRIBUTION",
           {
               {"ConstantSurfaceEnergy", Inpar::PARTICLE::ConstantSurfaceEnergy},
@@ -559,85 +547,84 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
                   Inpar::PARTICLE::LogNormalSurfaceEnergyDistribution},
           },
           {.description = "type of (random) surface energy distribution",
-              .default_value = Inpar::PARTICLE::ConstantSurfaceEnergy}));
+              .default_value = Inpar::PARTICLE::ConstantSurfaceEnergy}),
 
-  particledyndem.specs.emplace_back(parameter<double>(
-      "MIN_RADIUS", {.description = "minimum allowed particle radius", .default_value = 0.0}));
-  particledyndem.specs.emplace_back(parameter<double>(
-      "MAX_RADIUS", {.description = "maximum allowed particle radius", .default_value = 0.0}));
-  particledyndem.specs.emplace_back(parameter<double>("MAX_VELOCITY",
-      {.description = "maximum expected particle velocity", .default_value = -1.0}));
+      parameter<double>(
+          "MIN_RADIUS", {.description = "minimum allowed particle radius", .default_value = 0.0}),
+      parameter<double>(
+          "MAX_RADIUS", {.description = "maximum allowed particle radius", .default_value = 0.0}),
+      parameter<double>("MAX_VELOCITY",
+          {.description = "maximum expected particle velocity", .default_value = -1.0}),
 
-  // type of initial particle radius assignment
-  particledyndem.specs.emplace_back(deprecated_selection<InitialRadiusAssignment>("INITIAL_RADIUS",
-      {
-          {"RadiusFromParticleMaterial", Inpar::PARTICLE::RadiusFromParticleMaterial},
-          {"RadiusFromParticleInput", Inpar::PARTICLE::RadiusFromParticleInput},
-          {"NormalRadiusDistribution", Inpar::PARTICLE::NormalRadiusDistribution},
-          {"LogNormalRadiusDistribution", Inpar::PARTICLE::LogNormalRadiusDistribution},
-      },
-      {.description = "type of initial particle radius assignment",
-          .default_value = Inpar::PARTICLE::RadiusFromParticleMaterial}));
+      // type of initial particle radius assignment
+      deprecated_selection<InitialRadiusAssignment>("INITIAL_RADIUS",
+          {
+              {"RadiusFromParticleMaterial", Inpar::PARTICLE::RadiusFromParticleMaterial},
+              {"RadiusFromParticleInput", Inpar::PARTICLE::RadiusFromParticleInput},
+              {"NormalRadiusDistribution", Inpar::PARTICLE::NormalRadiusDistribution},
+              {"LogNormalRadiusDistribution", Inpar::PARTICLE::LogNormalRadiusDistribution},
+          },
+          {.description = "type of initial particle radius assignment",
+              .default_value = Inpar::PARTICLE::RadiusFromParticleMaterial}),
 
-  particledyndem.specs.emplace_back(parameter<double>("RADIUSDISTRIBUTION_SIGMA",
-      {.description = "sigma of random particle radius distribution", .default_value = -1.0}));
+      parameter<double>("RADIUSDISTRIBUTION_SIGMA",
+          {.description = "sigma of random particle radius distribution", .default_value = -1.0}),
 
-  particledyndem.specs.emplace_back(parameter<double>("REL_PENETRATION",
-      {.description = "maximum allowed relative penetration", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>(
-      "NORMAL_STIFF", {.description = "normal contact stiffness", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>(
-      "NORMAL_DAMP", {.description = "normal contact damping parameter", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>(
-      "COEFF_RESTITUTION", {.description = "coefficient of restitution", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>(
-      "DAMP_REG_FAC", {.description = "linearly regularized damping normal force in the interval "
-                                      "$|g| < (\\text{DAMP_REG_FAC} \\cdot r_{\\min})$",
-                          .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<bool>("TENSION_CUTOFF",
-      {.description = "evaluate tension cutoff of normal contact force", .default_value = true}));
+      parameter<double>("REL_PENETRATION",
+          {.description = "maximum allowed relative penetration", .default_value = -1.0}),
+      parameter<double>(
+          "NORMAL_STIFF", {.description = "normal contact stiffness", .default_value = -1.0}),
+      parameter<double>("NORMAL_DAMP",
+          {.description = "normal contact damping parameter", .default_value = -1.0}),
+      parameter<double>("COEFF_RESTITUTION",
+          {.description = "coefficient of restitution", .default_value = -1.0}),
+      parameter<double>("DAMP_REG_FAC",
+          {.description = "linearly regularized damping normal force in the interval "
+                          "$|g| < (\\text{DAMP_REG_FAC} \\cdot r_{\\min})$",
+              .default_value = -1.0}),
+      parameter<bool>(
+          "TENSION_CUTOFF", {.description = "evaluate tension cutoff of normal contact force",
+                                .default_value = true}),
 
-  particledyndem.specs.emplace_back(
-      parameter<double>("POISSON_RATIO", {.description = "poisson ratio", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>(
-      "YOUNG_MODULUS", {.description = "young's modulus", .default_value = -1.0}));
 
-  particledyndem.specs.emplace_back(parameter<double>("FRICT_COEFF_TANG",
-      {.description = "friction coefficient for tangential contact", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>("FRICT_COEFF_ROLL",
-      {.description = "friction coefficient for rolling contact", .default_value = -1.0}));
+      parameter<double>("POISSON_RATIO", {.description = "poisson ratio", .default_value = -1.0}),
+      parameter<double>("YOUNG_MODULUS", {.description = "young's modulus", .default_value = -1.0}),
 
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_DISTANCE",
-      {.description = "adhesion distance between interacting surfaces", .default_value = -1.0}));
+      parameter<double>("FRICT_COEFF_TANG",
+          {.description = "friction coefficient for tangential contact", .default_value = -1.0}),
+      parameter<double>("FRICT_COEFF_ROLL",
+          {.description = "friction coefficient for rolling contact", .default_value = -1.0}),
 
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_MAX_CONTACT_PRESSURE",
-      {.description = "adhesion maximum contact pressure", .default_value = 0.0}));
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_MAX_CONTACT_FORCE",
-      {.description = "adhesion maximum contact force", .default_value = 0.0}));
-  particledyndem.specs.emplace_back(parameter<bool>("ADHESION_USE_MAX_CONTACT_FORCE",
-      {.description = "use maximum contact force instead of maximum contact pressure",
-          .default_value = false}));
+      parameter<double>("ADHESION_DISTANCE",
+          {.description = "adhesion distance between interacting surfaces", .default_value = -1.0}),
 
-  particledyndem.specs.emplace_back(parameter<bool>("ADHESION_VDW_CURVE_SHIFT",
-      {.description = "shifts van-der-Waals-curve to g = 0", .default_value = false}));
+      parameter<double>("ADHESION_MAX_CONTACT_PRESSURE",
+          {.description = "adhesion maximum contact pressure", .default_value = 0.0}),
+      parameter<double>("ADHESION_MAX_CONTACT_FORCE",
+          {.description = "adhesion maximum contact force", .default_value = 0.0}),
+      parameter<bool>("ADHESION_USE_MAX_CONTACT_FORCE",
+          {.description = "use maximum contact force instead of maximum contact pressure",
+              .default_value = false}),
 
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_HAMAKER",
-      {.description = "hamaker constant of van-der-Waals interaction", .default_value = -1.0}));
+      parameter<bool>("ADHESION_VDW_CURVE_SHIFT",
+          {.description = "shifts van-der-Waals-curve to g = 0", .default_value = false}),
 
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_SURFACE_ENERGY",
-      {.description = "adhesion surface energy for the calculation of the pull-out force",
-          .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_SURFACE_ENERGY_DISTRIBUTION_VAR",
-      {.description = "variance of adhesion surface energy distribution", .default_value = -1.0}));
-  particledyndem.specs.emplace_back(
+      parameter<double>("ADHESION_HAMAKER",
+          {.description = "hamaker constant of van-der-Waals interaction", .default_value = -1.0}),
+
+      parameter<double>("ADHESION_SURFACE_ENERGY",
+          {.description = "adhesion surface energy for the calculation of the pull-out force",
+              .default_value = -1.0}),
+      parameter<double>("ADHESION_SURFACE_ENERGY_DISTRIBUTION_VAR",
+          {.description = "variance of adhesion surface energy distribution",
+              .default_value = -1.0}),
+
       parameter<double>("ADHESION_SURFACE_ENERGY_DISTRIBUTION_CUTOFF_FACTOR",
           {.description = "adhesion surface energy distribution limited by multiple of variance",
-              .default_value = -1.0}));
-  particledyndem.specs.emplace_back(parameter<double>("ADHESION_SURFACE_ENERGY_FACTOR",
-      {.description = "factor to calculate minimum adhesion surface energy",
-          .default_value = 1.0}));
-
-  particledyndem.move_into_collection(list);
+              .default_value = -1.0}),
+      parameter<double>("ADHESION_SURFACE_ENERGY_FACTOR",
+          {.description = "factor to calculate minimum adhesion surface energy",
+              .default_value = 1.0})});
 }
 
 /*---------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -9,8 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 /*---------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -19,61 +19,60 @@ void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs pasidyn{"PASI DYNAMIC"};
+  list["PASI DYNAMIC"] = all_of({
 
-  // time loop control
-  pasidyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  pasidyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-  pasidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}));
-  pasidyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of Timesteps", .default_value = 100}));
-  pasidyn.specs.emplace_back(
-      parameter<double>("MAXTIME", {.description = "Total simulation time", .default_value = 1.0}));
+      // time loop control
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
 
-  // type of partitioned coupling
-  pasidyn.specs.emplace_back(parameter<PartitionedCouplingType>("COUPLING",
-      {.description = "partitioned coupling strategies for particle structure interaction",
-          .default_value = partitioned_onewaycoup}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.01}),
+      parameter<int>("NUMSTEP", {.description = "Total number of Timesteps", .default_value = 100}),
 
-  // partitioned iteration dependent parameters
-  pasidyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of partitioned iterations over fields",
-                    .default_value = 10}));
+      parameter<double>("MAXTIME", {.description = "Total simulation time", .default_value = 1.0}),
 
-  pasidyn.specs.emplace_back(parameter<double>(
-      "CONVTOLSCALEDDISP", {.description = "tolerance of dof and dt scaled interface displacement "
-                                           "increments in partitioned iterations",
-                               .default_value = -1.0}));
+      // type of partitioned coupling
+      parameter<PartitionedCouplingType>("COUPLING",
+          {.description = "partitioned coupling strategies for particle structure interaction",
+              .default_value = partitioned_onewaycoup}),
 
-  pasidyn.specs.emplace_back(parameter<double>("CONVTOLRELATIVEDISP",
-      {.description =
-              "tolerance of relative interface displacement increments in partitioned iterations",
-          .default_value = -1.0}));
+      // partitioned iteration dependent parameters
+      parameter<int>(
+          "ITEMAX", {.description = "maximum number of partitioned iterations over fields",
+                        .default_value = 10}),
 
-  pasidyn.specs.emplace_back(parameter<double>("CONVTOLSCALEDFORCE",
-      {.description =
-              "tolerance of dof and dt scaled interface force increments in partitioned iterations",
-          .default_value = -1.0}));
+      parameter<double>("CONVTOLSCALEDDISP",
+          {.description = "tolerance of dof and dt scaled interface displacement "
+                          "increments in partitioned iterations",
+              .default_value = -1.0}),
 
-  pasidyn.specs.emplace_back(parameter<double>("CONVTOLRELATIVEFORCE",
-      {.description = "tolerance of relative interface force increments in partitioned iterations",
-          .default_value = -1.0}));
+      parameter<double>(
+          "CONVTOLRELATIVEDISP", {.description = "tolerance of relative interface displacement "
+                                                 "increments in partitioned iterations",
+                                     .default_value = -1.0}),
 
-  pasidyn.specs.emplace_back(parameter<bool>("IGNORE_CONV_CHECK",
-      {.description = "ignore convergence check and proceed simulation", .default_value = false}));
+      parameter<double>(
+          "CONVTOLSCALEDFORCE", {.description = "tolerance of dof and dt scaled interface force "
+                                                "increments in partitioned iterations",
+                                    .default_value = -1.0}),
 
-  // parameters for relaxation
-  pasidyn.specs.emplace_back(parameter<double>(
-      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
-  pasidyn.specs.emplace_back(parameter<double>("MAXOMEGA",
-      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
-  pasidyn.specs.emplace_back(parameter<double>("MINOMEGA",
-      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
+      parameter<double>("CONVTOLRELATIVEFORCE",
+          {.description =
+                  "tolerance of relative interface force increments in partitioned iterations",
+              .default_value = -1.0}),
 
-  pasidyn.move_into_collection(list);
+      parameter<bool>(
+          "IGNORE_CONV_CHECK", {.description = "ignore convergence check and proceed simulation",
+                                   .default_value = false}),
+
+      // parameters for relaxation
+      parameter<double>(
+          "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}),
+      parameter<double>("MAXOMEGA",
+          {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}),
+      parameter<double>("MINOMEGA",
+          {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -7,8 +7,7 @@
 
 #include "4C_inpar_pasi.hpp"
 
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 /*---------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -9,8 +9,7 @@
 
 #include "4C_inpar_structure.hpp"
 #include "4C_inpar_tsi.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -22,72 +22,72 @@ void Inpar::Plasticity::set_valid_parameters(std::map<std::string, Core::IO::Inp
 
   /*----------------------------------------------------------------------*/
   /* parameters for semi-smooth Newton plasticity algorithm */
-  Core::Utils::SectionSpecs iplast{"SEMI-SMOOTH PLASTICITY"};
+  list["SEMI-SMOOTH PLASTICITY"] = all_of({
 
-  iplast.specs.emplace_back(parameter<double>("SEMI_SMOOTH_CPL",
-      {.description = "Weighting factor cpl for semi-smooth PDASS", .default_value = 1.0}));
-  iplast.specs.emplace_back(parameter<double>("STABILIZATION_S",
-      {.description = "Stabilization factor s for semi-smooth PDASS", .default_value = 1.0}));
+      parameter<double>("SEMI_SMOOTH_CPL",
+          {.description = "Weighting factor cpl for semi-smooth PDASS", .default_value = 1.0}),
+      parameter<double>("STABILIZATION_S",
+          {.description = "Stabilization factor s for semi-smooth PDASS", .default_value = 1.0}),
 
-  // solver convergence test parameters for semi-smooth plasticity formulation
-  iplast.specs.emplace_back(deprecated_selection<Inpar::Solid::BinaryOp>(
-      "NORMCOMBI_RESFPLASTCONSTR",
-      {
-          {"And", Inpar::Solid::bop_and},
-          {"Or", Inpar::Solid::bop_or},
-      },
-      {.description = "binary operator to combine plasticity constraints and residual force values",
-          .default_value = Inpar::Solid::bop_and}));
+      // solver convergence test parameters for semi-smooth plasticity formulation
+      deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_RESFPLASTCONSTR",
+          {
+              {"And", Inpar::Solid::bop_and},
+              {"Or", Inpar::Solid::bop_or},
+          },
+          {.description =
+                  "binary operator to combine plasticity constraints and residual force values",
+              .default_value = Inpar::Solid::bop_and}),
 
-  iplast.specs.emplace_back(deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPPLASTINCR",
-      {
-          {"And", Inpar::Solid::bop_and},
-          {"Or", Inpar::Solid::bop_or},
-      },
-      {.description = "binary operator to combine displacement increments and plastic flow (Delta "
-                      "Lp) increment values",
-          .default_value = Inpar::Solid::bop_and}));
+      deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_DISPPLASTINCR",
+          {
+              {"And", Inpar::Solid::bop_and},
+              {"Or", Inpar::Solid::bop_or},
+          },
+          {.description =
+                  "binary operator to combine displacement increments and plastic flow (Delta "
+                  "Lp) increment values",
+              .default_value = Inpar::Solid::bop_and}),
 
-  iplast.specs.emplace_back(parameter<double>("TOLPLASTCONSTR",
-      {.description = "tolerance in the plastic constraint norm for the newton iteration",
-          .default_value = 1.0E-8}));
-  iplast.specs.emplace_back(parameter<double>("TOLDELTALP",
-      {.description = "tolerance in the plastic flow (Delta Lp) norm for the Newton iteration",
-          .default_value = 1.0E-8}));
+      parameter<double>("TOLPLASTCONSTR",
+          {.description = "tolerance in the plastic constraint norm for the newton iteration",
+              .default_value = 1.0E-8}),
+      parameter<double>("TOLDELTALP",
+          {.description = "tolerance in the plastic flow (Delta Lp) norm for the Newton iteration",
+              .default_value = 1.0E-8}),
 
-  iplast.specs.emplace_back(deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_EASRES",
-      {
-          {"And", Inpar::Solid::bop_and},
-          {"Or", Inpar::Solid::bop_or},
-      },
-      {.description = "binary operator to combine EAS-residual and residual force values",
-          .default_value = Inpar::Solid::bop_and}));
+      deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_EASRES",
+          {
+              {"And", Inpar::Solid::bop_and},
+              {"Or", Inpar::Solid::bop_or},
+          },
+          {.description = "binary operator to combine EAS-residual and residual force values",
+              .default_value = Inpar::Solid::bop_and}),
 
-  iplast.specs.emplace_back(deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_EASINCR",
-      {
-          {"And", Inpar::Solid::bop_and},
-          {"Or", Inpar::Solid::bop_or},
-      },
-      {.description = "binary operator to combine displacement increments and EAS increment values",
-          .default_value = Inpar::Solid::bop_and}));
+      deprecated_selection<Inpar::Solid::BinaryOp>("NORMCOMBI_EASINCR",
+          {
+              {"And", Inpar::Solid::bop_and},
+              {"Or", Inpar::Solid::bop_or},
+          },
+          {.description =
+                  "binary operator to combine displacement increments and EAS increment values",
+              .default_value = Inpar::Solid::bop_and}),
 
-  iplast.specs.emplace_back(parameter<double>(
-      "TOLEASRES", {.description = "tolerance in the EAS residual norm for the newton iteration",
-                       .default_value = 1.0E-8}));
-  iplast.specs.emplace_back(parameter<double>(
-      "TOLEASINCR", {.description = "tolerance in the EAS increment norm for the Newton iteration",
-                        .default_value = 1.0E-8}));
+      parameter<double>("TOLEASRES",
+          {.description = "tolerance in the EAS residual norm for the newton iteration",
+              .default_value = 1.0E-8}),
+      parameter<double>("TOLEASINCR",
+          {.description = "tolerance in the EAS increment norm for the Newton iteration",
+              .default_value = 1.0E-8}),
 
-  iplast.specs.emplace_back(deprecated_selection<Inpar::TSI::DissipationMode>("DISSIPATION_MODE",
-      {
-          {"pl_multiplier", Inpar::TSI::pl_multiplier},
-          {"pl_flow", Inpar::TSI::pl_flow},
-          {"Taylor_Quinney", Inpar::TSI::Taylor_Quinney},
-      },
-      {.description = "method to calculate the plastic dissipation",
-          .default_value = Inpar::TSI::pl_multiplier}));
-
-  iplast.move_into_collection(list);
+      deprecated_selection<Inpar::TSI::DissipationMode>("DISSIPATION_MODE",
+          {
+              {"pl_multiplier", Inpar::TSI::pl_multiplier},
+              {"pl_flow", Inpar::TSI::pl_flow},
+              {"Taylor_Quinney", Inpar::TSI::Taylor_Quinney},
+          },
+          {.description = "method to calculate the plastic dissipation",
+              .default_value = Inpar::TSI::pl_multiplier})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -8,9 +8,8 @@
 #include "4C_inpar_poroelast.hpp"
 
 #include "4C_inpar_fluid.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -19,10 +19,9 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs poroelastdyn{"POROELASTICITY DYNAMIC"};
+  list["POROELASTICITY DYNAMIC"] = all_of({
 
-  // Coupling strategy for (monolithic) porous media solvers
-  poroelastdyn.specs.emplace_back(
+      // Coupling strategy for (monolithic) porous media solvers
       deprecated_selection<Inpar::PoroElast::SolutionSchemeOverFields>("COUPALGO",
           {
               {"poro_partitioned", Partitioned},
@@ -33,20 +32,19 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
               {"poro_monolithicmeshtying", Monolithic_meshtying},
           },
           {.description = "Coupling strategies for poroelasticity solvers",
-              .default_value = Monolithic}));
+              .default_value = Monolithic}),
 
-  // physical type of poro fluid flow (incompressible, varying density, loma, Boussinesq
-  // approximation)
-  poroelastdyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE",
-      {
-          {"Poro", Inpar::FLUID::poro},
-          {"Poro_P1", Inpar::FLUID::poro_p1},
-      },
-      {.description = "Physical Type of Porofluid", .default_value = Inpar::FLUID::poro}));
+      // physical type of poro fluid flow (incompressible, varying density, loma, Boussinesq
+      // approximation)
+      deprecated_selection<Inpar::FLUID::PhysicalType>("PHYSICAL_TYPE",
+          {
+              {"Poro", Inpar::FLUID::poro},
+              {"Poro_P1", Inpar::FLUID::poro_p1},
+          },
+          {.description = "Physical Type of Porofluid", .default_value = Inpar::FLUID::poro}),
 
-  // physical type of poro fluid flow (incompressible, varying density, loma, Boussinesq
-  // approximation)
-  poroelastdyn.specs.emplace_back(
+      // physical type of poro fluid flow (incompressible, varying density, loma, Boussinesq
+      // approximation)
       deprecated_selection<Inpar::PoroElast::TransientEquationsOfPoroFluid>("TRANSIENT_TERMS",
           {
               {"none", transient_none},
@@ -55,87 +53,88 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
               {"all", transient_all},
           },
           {.description = "which equation includes transient terms",
-              .default_value = transient_all}));
+              .default_value = transient_all}),
 
-  // Output type
-  poroelastdyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
+      // Output type
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
 
-  // Time loop control
-  poroelastdyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  poroelastdyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
-  poroelastdyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  poroelastdyn.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "minimal number of iterations over fields", .default_value = 1}));
-  poroelastdyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
+      // Time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  // Iterationparameters
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLRES_DISP", {.description = "tolerance in the residual norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLINC_DISP", {.description = "tolerance in the increment norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLRES_PORO", {.description = "tolerance in the residual norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLINC_PORO", {.description = "tolerance in the increment norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLRES_VEL", {.description = "tolerance in the residual norm for the Newton iteration",
-                        .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLINC_VEL", {.description = "tolerance in the increment norm for the Newton iteration",
-                        .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLRES_PRES", {.description = "tolerance in the residual norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLINC_PRES", {.description = "tolerance in the increment norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroelastdyn.specs.emplace_back(parameter<double>(
-      "TOLRES_NCOUP", {.description = "tolerance in the residual norm for the Newton iteration",
-                          .default_value = 1e-8}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<int>("ITEMIN",
+          {.description = "minimal number of iterations over fields", .default_value = 1}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
 
-  poroelastdyn.specs.emplace_back(deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_INC",
-      {
-          {"AbsGlobal", convnorm_abs_global},
-          {"AbsSingleFields", convnorm_abs_singlefields},
-      },
-      {.description = "type of norm for primary variables convergence check",
-          .default_value = convnorm_abs_singlefields}));
+      // Iterationparameters
+      parameter<double>("TOLRES_GLOBAL",
+          {.description = "tolerance in the residual norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>("TOLINC_GLOBAL",
+          {.description = "tolerance in the increment norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_DISP", {.description = "tolerance in the residual norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_DISP", {.description = "tolerance in the increment norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_PORO", {.description = "tolerance in the residual norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_PORO", {.description = "tolerance in the increment norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_VEL", {.description = "tolerance in the residual norm for the Newton iteration",
+                            .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_VEL", {.description = "tolerance in the increment norm for the Newton iteration",
+                            .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_PRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_PRES", {.description = "tolerance in the increment norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_NCOUP", {.description = "tolerance in the residual norm for the Newton iteration",
+                              .default_value = 1e-8}),
 
-  poroelastdyn.specs.emplace_back(deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_RESF",
-      {
-          {"AbsGlobal", convnorm_abs_global},
-          {"AbsSingleFields", convnorm_abs_singlefields},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = convnorm_abs_singlefields}));
+      deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_INC",
+          {
+              {"AbsGlobal", convnorm_abs_global},
+              {"AbsSingleFields", convnorm_abs_singlefields},
+          },
+          {.description = "type of norm for primary variables convergence check",
+              .default_value = convnorm_abs_singlefields}),
 
-  poroelastdyn.specs.emplace_back(
+      deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_RESF",
+          {
+              {"AbsGlobal", convnorm_abs_global},
+              {"AbsSingleFields", convnorm_abs_singlefields},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = convnorm_abs_singlefields}),
+
+
       deprecated_selection<Inpar::PoroElast::BinaryOp>("NORMCOMBI_RESFINC",
           {
               {"And", bop_and},
               {"Or", bop_or},
           },
           {.description = "binary operator to combine primary variables and residual force values",
-              .default_value = bop_and}));
+              .default_value = bop_and}),
 
-  poroelastdyn.specs.emplace_back(
+
       deprecated_selection<Inpar::PoroElast::VectorNorm>("VECTORNORM_RESF",
           {
               {"L1", norm_l1},
@@ -144,9 +143,9 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
               {"Rms", norm_rms},
               {"Inf", norm_inf},
           },
-          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}));
+          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}),
 
-  poroelastdyn.specs.emplace_back(
+
       deprecated_selection<Inpar::PoroElast::VectorNorm>("VECTORNORM_INC",
           {
               {"L1", norm_l1},
@@ -155,37 +154,35 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
               {"Rms", norm_rms},
               {"Inf", norm_inf},
           },
-          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}));
+          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}),
 
-  poroelastdyn.specs.emplace_back(parameter<bool>("SECONDORDER",
-      {.description = "Second order coupling at the interface.", .default_value = true}));
+      parameter<bool>("SECONDORDER",
+          {.description = "Second order coupling at the interface.", .default_value = true}),
 
-  poroelastdyn.specs.emplace_back(parameter<bool>("CONTIPARTINT",
-      {.description = "Partial integration of porosity gradient in continuity equation",
-          .default_value = false}));
+      parameter<bool>("CONTIPARTINT",
+          {.description = "Partial integration of porosity gradient in continuity equation",
+              .default_value = false}),
 
-  poroelastdyn.specs.emplace_back(parameter<bool>("CONTACT_NO_PENETRATION",
-      {.description =
-              "No-Penetration Condition on active contact surface in case of poro contact problem!",
-          .default_value = false}));
+      parameter<bool>(
+          "CONTACT_NO_PENETRATION", {.description = "No-Penetration Condition on active contact "
+                                                    "surface in case of poro contact problem!",
+                                        .default_value = false}),
 
-  poroelastdyn.specs.emplace_back(
-      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
-  poroelastdyn.specs.emplace_back(parameter<bool>(
-      "CONVECTIVE_TERM", {.description = "convective term ", .default_value = false}));
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}),
 
-  // number of linear solver used for poroelasticity
-  poroelastdyn.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for poroelasticity problems",
-                           .default_value = -1}));
+      parameter<bool>(
+          "CONVECTIVE_TERM", {.description = "convective term ", .default_value = false}),
 
-  // flag for equilibration of global system of equations
-  poroelastdyn.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
-                           .default_value = Core::LinAlg::EquilibrationMethod::none}));
+      // number of linear solver used for poroelasticity
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for poroelasticity problems",
+              .default_value = -1}),
 
-  poroelastdyn.move_into_collection(list);
+      // flag for equilibration of global system of equations
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
+                               .default_value = Core::LinAlg::EquilibrationMethod::none})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -9,8 +9,7 @@
 
 #include "4C_inpar_poroelast.hpp"
 #include "4C_inpar_scatra.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -20,83 +20,84 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs poroscatradyn{"POROSCATRA CONTROL"};
+  list["POROSCATRA CONTROL"] = all_of({
 
-  // Output type
-  poroscatradyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
-  // Time loop control
-  poroscatradyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  poroscatradyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
-  poroscatradyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
-  poroscatradyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  poroscatradyn.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "minimal number of iterations over fields", .default_value = 1}));
+      // Output type
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
+      // Time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  // Iterationparameters
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLRES_DISP", {.description = "tolerance in the residual norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLINC_DISP", {.description = "tolerance in the increment norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLRES_VEL", {.description = "tolerance in the residual norm for the Newton iteration",
-                        .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLINC_VEL", {.description = "tolerance in the increment norm for the Newton iteration",
-                        .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLRES_PRES", {.description = "tolerance in the residual norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLINC_PRES", {.description = "tolerance in the increment norm for the Newton iteration",
-                         .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLRES_SCALAR", {.description = "tolerance in the residual norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poroscatradyn.specs.emplace_back(parameter<double>(
-      "TOLINC_SCALAR", {.description = "tolerance in the increment norm for the Newton iteration",
-                           .default_value = 1e-8}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<int>("ITEMIN",
+          {.description = "minimal number of iterations over fields", .default_value = 1}),
 
-  poroscatradyn.specs.emplace_back(deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_INC",
-      {
-          {"AbsGlobal", Inpar::PoroElast::convnorm_abs_global},
-          {"AbsSingleFields", Inpar::PoroElast::convnorm_abs_singlefields},
-      },
-      {.description = "type of norm for primary variables convergence check",
-          .default_value = Inpar::PoroElast::convnorm_abs_singlefields}));
+      // Iterationparameters
+      parameter<double>("TOLRES_GLOBAL",
+          {.description = "tolerance in the residual norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>("TOLINC_GLOBAL",
+          {.description = "tolerance in the increment norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_DISP", {.description = "tolerance in the residual norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_DISP", {.description = "tolerance in the increment norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_VEL", {.description = "tolerance in the residual norm for the Newton iteration",
+                            .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_VEL", {.description = "tolerance in the increment norm for the Newton iteration",
+                            .default_value = 1e-8}),
+      parameter<double>(
+          "TOLRES_PRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>(
+          "TOLINC_PRES", {.description = "tolerance in the increment norm for the Newton iteration",
+                             .default_value = 1e-8}),
+      parameter<double>("TOLRES_SCALAR",
+          {.description = "tolerance in the residual norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>("TOLINC_SCALAR",
+          {.description = "tolerance in the increment norm for the Newton iteration",
+              .default_value = 1e-8}),
 
-  poroscatradyn.specs.emplace_back(deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_RESF",
-      {
-          {"AbsGlobal", Inpar::PoroElast::convnorm_abs_global},
-          {"AbsSingleFields", Inpar::PoroElast::convnorm_abs_singlefields},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = Inpar::PoroElast::convnorm_abs_singlefields}));
+      deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_INC",
+          {
+              {"AbsGlobal", Inpar::PoroElast::convnorm_abs_global},
+              {"AbsSingleFields", Inpar::PoroElast::convnorm_abs_singlefields},
+          },
+          {.description = "type of norm for primary variables convergence check",
+              .default_value = Inpar::PoroElast::convnorm_abs_singlefields}),
 
-  poroscatradyn.specs.emplace_back(
+      deprecated_selection<Inpar::PoroElast::ConvNorm>("NORM_RESF",
+          {
+              {"AbsGlobal", Inpar::PoroElast::convnorm_abs_global},
+              {"AbsSingleFields", Inpar::PoroElast::convnorm_abs_singlefields},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = Inpar::PoroElast::convnorm_abs_singlefields}),
+
+
       deprecated_selection<Inpar::PoroElast::BinaryOp>("NORMCOMBI_RESFINC",
           {
               {"And", Inpar::PoroElast::bop_and},
               {"Or", Inpar::PoroElast::bop_or},
           },
           {.description = "binary operator to combine primary variables and residual force values",
-              .default_value = Inpar::PoroElast::bop_and}));
+              .default_value = Inpar::PoroElast::bop_and}),
 
-  poroscatradyn.specs.emplace_back(
+
       deprecated_selection<Inpar::PoroElast::VectorNorm>("VECTORNORM_RESF",
           {
               {"L1", Inpar::PoroElast::norm_l1},
@@ -106,9 +107,9 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
               {"Inf", Inpar::PoroElast::norm_inf},
           },
           {.description = "type of norm to be applied to residuals",
-              .default_value = Inpar::PoroElast::norm_l2}));
+              .default_value = Inpar::PoroElast::norm_l2}),
 
-  poroscatradyn.specs.emplace_back(
+
       deprecated_selection<Inpar::PoroElast::VectorNorm>("VECTORNORM_INC",
           {
               {"L1", Inpar::PoroElast::norm_l1},
@@ -118,28 +119,26 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
               {"Inf", Inpar::PoroElast::norm_inf},
           },
           {.description = "type of norm to be applied to residuals",
-              .default_value = Inpar::PoroElast::norm_l2}));
+              .default_value = Inpar::PoroElast::norm_l2}),
 
-  // number of linear solver used for poroelasticity
-  poroscatradyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for monolithic poroscatra problems",
-          .default_value = -1}));
+      // number of linear solver used for poroelasticity
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for monolithic poroscatra problems",
+              .default_value = -1}),
 
-  // Coupling strategy for poroscatra solvers
-  poroscatradyn.specs.emplace_back(deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
-      {
-          {"monolithic", Monolithic},
-          {"scatra_to_solid", Part_ScatraToPoro},
-          {"solid_to_scatra", Part_PoroToScatra},
-          {"two_way", Part_TwoWay},
-      },
-      {.description = "Coupling strategies for poroscatra solvers",
-          .default_value = Part_PoroToScatra}));
+      // Coupling strategy for poroscatra solvers
+      deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
+          {
+              {"monolithic", Monolithic},
+              {"scatra_to_solid", Part_ScatraToPoro},
+              {"solid_to_scatra", Part_PoroToScatra},
+              {"two_way", Part_TwoWay},
+          },
+          {.description = "Coupling strategies for poroscatra solvers",
+              .default_value = Part_PoroToScatra}),
 
-  poroscatradyn.specs.emplace_back(
-      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
-  poroscatradyn.move_into_collection(list);
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_problemtype.cpp
+++ b/src/inpar/4C_inpar_problemtype.cpp
@@ -8,9 +8,8 @@
 #include "4C_inpar_problemtype.hpp"
 
 #include "4C_fem_general_shape_function_type.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_utils_exceptions.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_problemtype.cpp
+++ b/src/inpar/4C_inpar_problemtype.cpp
@@ -21,22 +21,19 @@ void Inpar::PROBLEMTYPE::set_valid_parameters(std::map<std::string, Core::IO::In
   using namespace Core::IO::InputSpecBuilders;
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs type{"PROBLEM TYPE"};
+  list["PROBLEM TYPE"] = all_of({
 
-  type.specs.emplace_back(
       deprecated_selection<Core::ProblemType>("PROBLEMTYPE", string_to_problem_type_map(),
-          {.description = "Type of the problem", .default_value = Core::ProblemType::fsi}));
+          {.description = "Type of the problem", .default_value = Core::ProblemType::fsi}),
 
-  type.specs.emplace_back(deprecated_selection<Core::FE::ShapeFunctionType>("SHAPEFCT",
-      Core::FE::string_to_shape_function_type_map(),
-      {.description = "Defines the function spaces for the spatial approximation",
-          .default_value = Core::FE::ShapeFunctionType::polynomial}));
+      deprecated_selection<Core::FE::ShapeFunctionType>("SHAPEFCT",
+          Core::FE::string_to_shape_function_type_map(),
+          {.description = "Defines the function spaces for the spatial approximation",
+              .default_value = Core::FE::ShapeFunctionType::polynomial}),
 
-  type.specs.emplace_back(parameter<int>("RESTART", {.description = "", .default_value = 0}));
-  type.specs.emplace_back(parameter<int>("RANDSEED",
-      {.description = "Set the random seed. If < 0 use current time.", .default_value = -1}));
-
-  type.move_into_collection(list);
+      parameter<int>("RESTART", {.description = "", .default_value = 0}),
+      parameter<int>("RANDSEED",
+          {.description = "Set the random seed. If < 0 use current time.", .default_value = -1})});
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_rebalance.cpp
+++ b/src/inpar/4C_inpar_rebalance.cpp
@@ -7,9 +7,8 @@
 
 #include "4C_inpar_rebalance.hpp"
 
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_rebalance.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::Rebalance::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_rebalance.cpp
+++ b/src/inpar/4C_inpar_rebalance.cpp
@@ -17,26 +17,25 @@ void Inpar::Rebalance::set_valid_parameters(std::map<std::string, Core::IO::Inpu
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs meshpartitioning{"MESH PARTITIONING"};
+  list["MESH PARTITIONING"] = all_of({
 
-  meshpartitioning.specs.emplace_back(parameter<Core::Rebalance::RebalanceType>(
-      "METHOD", {.description = "Type of rebalance/partition algorithm to be used for decomposing "
-                                "the entire mesh into subdomains for parallel computing.",
-                    .default_value = Core::Rebalance::RebalanceType::hypergraph}));
+      parameter<Core::Rebalance::RebalanceType>("METHOD",
+          {.description = "Type of rebalance/partition algorithm to be used for decomposing "
+                          "the entire mesh into subdomains for parallel computing.",
+              .default_value = Core::Rebalance::RebalanceType::hypergraph}),
 
-  meshpartitioning.specs.emplace_back(parameter<double>("IMBALANCE_TOL",
-      {.description = "Tolerance for relative imbalance of subdomain sizes for graph partitioning "
-                      "of unstructured meshes read from input files.",
-          .default_value = 1.1}));
+      parameter<double>("IMBALANCE_TOL",
+          {.description =
+                  "Tolerance for relative imbalance of subdomain sizes for graph partitioning "
+                  "of unstructured meshes read from input files.",
+              .default_value = 1.1}),
 
-  meshpartitioning.specs.emplace_back(parameter<int>("MIN_ELE_PER_PROC",
-      {.description =
-              "This parameter defines the minimum number of elements to be assigned to any "
-              "MPI rank during redistribution. Use 0 to not interfere with the minimal size "
-              "of a subdomain.",
-          .default_value = 0}));
-
-  meshpartitioning.move_into_collection(list);
+      parameter<int>("MIN_ELE_PER_PROC",
+          {.description =
+                  "This parameter defines the minimum number of elements to be assigned to any "
+                  "MPI rank during redistribution. Use 0 to not interfere with the minimal size "
+                  "of a subdomain.",
+              .default_value = 0})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -21,88 +21,89 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs s2icoupling{"SCALAR TRANSPORT DYNAMIC/S2I COUPLING"};
+  list["SCALAR TRANSPORT DYNAMIC/S2I COUPLING"] = all_of({
 
-  // type of mortar meshtying
-  s2icoupling.specs.emplace_back(deprecated_selection<CouplingType>("COUPLINGTYPE",
-      {
-          {"Undefined", coupling_undefined},
-          {"MatchingNodes", coupling_matching_nodes},
-          {"StandardMortar", coupling_mortar_standard},
-          {"SaddlePointMortar_Petrov", coupling_mortar_saddlepoint_petrov},
-          {"SaddlePointMortar_Bubnov", coupling_mortar_saddlepoint_bubnov},
-          {"CondensedMortar_Petrov", coupling_mortar_condensed_petrov},
-          {"CondensedMortar_Bubnov", coupling_mortar_condensed_bubnov},
-          {"StandardNodeToSegment", coupling_nts_standard},
-      },
-      {.description = "type of mortar meshtying", .default_value = coupling_undefined}));
+      // type of mortar meshtying
+      deprecated_selection<CouplingType>("COUPLINGTYPE",
+          {
+              {"Undefined", coupling_undefined},
+              {"MatchingNodes", coupling_matching_nodes},
+              {"StandardMortar", coupling_mortar_standard},
+              {"SaddlePointMortar_Petrov", coupling_mortar_saddlepoint_petrov},
+              {"SaddlePointMortar_Bubnov", coupling_mortar_saddlepoint_bubnov},
+              {"CondensedMortar_Petrov", coupling_mortar_condensed_petrov},
+              {"CondensedMortar_Bubnov", coupling_mortar_condensed_bubnov},
+              {"StandardNodeToSegment", coupling_nts_standard},
+          },
+          {.description = "type of mortar meshtying", .default_value = coupling_undefined}),
 
-  // flag for interface side underlying Lagrange multiplier definition
-  s2icoupling.specs.emplace_back(deprecated_selection<InterfaceSides>("LMSIDE",
-      {
-          {"slave", side_slave},
-          {"master", side_master},
-      },
-      {.description = "flag for interface side underlying Lagrange multiplier definition",
-          .default_value = side_slave}));
+      // flag for interface side underlying Lagrange multiplier definition
+      deprecated_selection<InterfaceSides>("LMSIDE",
+          {
+              {"slave", side_slave},
+              {"master", side_master},
+          },
+          {.description = "flag for interface side underlying Lagrange multiplier definition",
+              .default_value = side_slave}),
 
-  // flag for evaluation of interface linearizations and residuals on slave side only
-  s2icoupling.specs.emplace_back(parameter<bool>("SLAVEONLY",
-      {.description =
-              "flag for evaluation of interface linearizations and residuals on slave side only",
-          .default_value = false}));
+      // flag for evaluation of interface linearizations and residuals on slave side only
+      parameter<bool>(
+          "SLAVEONLY", {.description = "flag for evaluation of interface linearizations and "
+                                       "residuals on slave side only",
+                           .default_value = false}),
 
-  // node-to-segment projection tolerance
-  s2icoupling.specs.emplace_back(parameter<double>(
-      "NTSPROJTOL", {.description = "node-to-segment projection tolerance", .default_value = 0.0}));
+      // node-to-segment projection tolerance
+      parameter<double>("NTSPROJTOL",
+          {.description = "node-to-segment projection tolerance", .default_value = 0.0}),
 
-  // flag for evaluation of scatra-scatra interface coupling involving interface layer growth
-  s2icoupling.specs.emplace_back(deprecated_selection<GrowthEvaluation>("INTLAYERGROWTH_EVALUATION",
-      {
-          {"none", growth_evaluation_none},
-          {"monolithic", growth_evaluation_monolithic},
-          {"semi-implicit", growth_evaluation_semi_implicit},
-      },
-      {.description = "flag for evaluation of scatra-scatra interface coupling involving interface "
-                      "layer growth",
-          .default_value = growth_evaluation_none}));
+      // flag for evaluation of scatra-scatra interface coupling involving interface layer growth
+      deprecated_selection<GrowthEvaluation>("INTLAYERGROWTH_EVALUATION",
+          {
+              {"none", growth_evaluation_none},
+              {"monolithic", growth_evaluation_monolithic},
+              {"semi-implicit", growth_evaluation_semi_implicit},
+          },
+          {.description =
+                  "flag for evaluation of scatra-scatra interface coupling involving interface "
+                  "layer growth",
+              .default_value = growth_evaluation_none}),
 
-  // local Newton-Raphson convergence tolerance for scatra-scatra interface coupling involving
-  // interface layer growth
-  s2icoupling.specs.emplace_back(parameter<double>("INTLAYERGROWTH_CONVTOL",
-      {.description = "local Newton-Raphson convergence tolerance for scatra-scatra interface "
-                      "coupling involving interface layer growth",
-          .default_value = 1.e-12}));
+      // local Newton-Raphson convergence tolerance for scatra-scatra interface coupling involving
+      // interface layer growth
+      parameter<double>("INTLAYERGROWTH_CONVTOL",
+          {.description = "local Newton-Raphson convergence tolerance for scatra-scatra interface "
+                          "coupling involving interface layer growth",
+              .default_value = 1.e-12}),
 
-  // maximum number of local Newton-Raphson iterations for scatra-scatra interface coupling
-  // involving interface layer growth
-  s2icoupling.specs.emplace_back(parameter<int>("INTLAYERGROWTH_ITEMAX",
-      {.description = "maximum number of local Newton-Raphson iterations for scatra-scatra "
-                      "interface coupling involving interface layer growth",
-          .default_value = 5}));
+      // maximum number of local Newton-Raphson iterations for scatra-scatra interface coupling
+      // involving interface layer growth
+      parameter<int>("INTLAYERGROWTH_ITEMAX",
+          {.description = "maximum number of local Newton-Raphson iterations for scatra-scatra "
+                          "interface coupling involving interface layer growth",
+              .default_value = 5}),
 
-  // ID of linear solver for monolithic scatra-scatra interface coupling involving interface layer
-  // growth
-  s2icoupling.specs.emplace_back(parameter<int>("INTLAYERGROWTH_LINEAR_SOLVER",
-      {.description = "ID of linear solver for monolithic scatra-scatra interface coupling "
-                      "involving interface layer growth",
-          .default_value = -1}));
-  // modified time step size for scatra-scatra interface coupling involving interface layer growth
-  s2icoupling.specs.emplace_back(parameter<double>("INTLAYERGROWTH_TIMESTEP",
-      {.description = "modified time step size for scatra-scatra interface coupling involving "
-                      "interface layer growth",
-          .default_value = -1.}));
+      // ID of linear solver for monolithic scatra-scatra interface coupling involving interface
+      // layer
+      // growth
+      parameter<int>("INTLAYERGROWTH_LINEAR_SOLVER",
+          {.description = "ID of linear solver for monolithic scatra-scatra interface coupling "
+                          "involving interface layer growth",
+              .default_value = -1}),
+      // modified time step size for scatra-scatra interface coupling involving interface layer
+      // growth
+      parameter<double>("INTLAYERGROWTH_TIMESTEP",
+          {.description = "modified time step size for scatra-scatra interface coupling involving "
+                          "interface layer growth",
+              .default_value = -1.}),
 
-  s2icoupling.specs.emplace_back(parameter<bool>("MESHTYING_CONDITIONS_INDEPENDENT_SETUP",
-      {.description = "mesh tying for different conditions should be setup independently",
-          .default_value = false}));
+      parameter<bool>("MESHTYING_CONDITIONS_INDEPENDENT_SETUP",
+          {.description = "mesh tying for different conditions should be setup independently",
+              .default_value = false}),
 
-  s2icoupling.specs.emplace_back(parameter<bool>(
-      "OUTPUT_INTERFACE_FLUX", {.description = "evaluate integral of coupling flux on slave side "
-                                               "for each s2i condition and write it to csv file",
-                                   .default_value = false}));
-
-  s2icoupling.move_into_collection(list);
+      parameter<bool>("OUTPUT_INTERFACE_FLUX",
+          {.description = "evaluate integral of coupling flux on slave side "
+                          "for each s2i condition and write it to csv file",
+              .default_value = false})});
 }
 
 

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -9,8 +9,6 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 /*------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -28,23 +28,24 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs scatradyn{"SCALAR TRANSPORT DYNAMIC"};
+  list["SCALAR TRANSPORT DYNAMIC"] = all_of({
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::SolverType>("SOLVERTYPE",
-      {
-          {"linear_full", solvertype_linear_full},
-          {"linear_incremental", solvertype_linear_incremental},
-          {"nonlinear", solvertype_nonlinear},
-          {"nonlinear_multiscale_macrotomicro", solvertype_nonlinear_multiscale_macrotomicro},
-          {"nonlinear_multiscale_macrotomicro_aitken",
-              solvertype_nonlinear_multiscale_macrotomicro_aitken},
-          {"nonlinear_multiscale_macrotomicro_aitken_dofsplit",
-              solvertype_nonlinear_multiscale_macrotomicro_aitken_dofsplit},
-          {"nonlinear_multiscale_microtomacro", solvertype_nonlinear_multiscale_microtomacro},
-      },
-      {.description = "type of scalar transport solver", .default_value = solvertype_linear_full}));
+      deprecated_selection<Inpar::ScaTra::SolverType>("SOLVERTYPE",
+          {
+              {"linear_full", solvertype_linear_full},
+              {"linear_incremental", solvertype_linear_incremental},
+              {"nonlinear", solvertype_nonlinear},
+              {"nonlinear_multiscale_macrotomicro", solvertype_nonlinear_multiscale_macrotomicro},
+              {"nonlinear_multiscale_macrotomicro_aitken",
+                  solvertype_nonlinear_multiscale_macrotomicro_aitken},
+              {"nonlinear_multiscale_macrotomicro_aitken_dofsplit",
+                  solvertype_nonlinear_multiscale_macrotomicro_aitken_dofsplit},
+              {"nonlinear_multiscale_microtomacro", solvertype_nonlinear_multiscale_microtomacro},
+          },
+          {.description = "type of scalar transport solver",
+              .default_value = solvertype_linear_full}),
 
-  scatradyn.specs.emplace_back(
+
       deprecated_selection<Inpar::ScaTra::TimeIntegrationScheme>("TIMEINTEGR",
           {
               {"Stationary", timeint_stationary},
@@ -52,121 +53,120 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               {"BDF2", timeint_bdf2},
               {"Gen_Alpha", timeint_gen_alpha},
           },
-          {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}));
+          {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}),
 
-  scatradyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  scatradyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of time steps", .default_value = 20}));
-  scatradyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  scatradyn.specs.emplace_back(parameter<double>(
-      "THETA", {.description = "One-step-theta time integration factor", .default_value = 0.5}));
-  scatradyn.specs.emplace_back(parameter<double>("ALPHA_M",
-      {.description = "Generalized-alpha time integration factor", .default_value = 0.5}));
-  scatradyn.specs.emplace_back(parameter<double>("ALPHA_F",
-      {.description = "Generalized-alpha time integration factor", .default_value = 0.5}));
-  scatradyn.specs.emplace_back(parameter<double>(
-      "GAMMA", {.description = "Generalized-alpha time integration factor", .default_value = 0.5}));
-  scatradyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  scatradyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
-  scatradyn.specs.emplace_back(parameter<int>(
-      "MATID", {.description = "Material ID for automatic mesh generation", .default_value = -1}));
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>("NUMSTEP", {.description = "Total number of time steps", .default_value = 20}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::VelocityField>("VELOCITYFIELD",
-      {
-          {"zero", velocity_zero},
-          {"function", velocity_function},
-          {"Navier_Stokes", velocity_Navier_Stokes},
-      },
-      {.description = "type of velocity field used for scalar transport problems",
-          .default_value = velocity_zero}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<double>(
+          "THETA", {.description = "One-step-theta time integration factor", .default_value = 0.5}),
+      parameter<double>("ALPHA_M",
+          {.description = "Generalized-alpha time integration factor", .default_value = 0.5}),
+      parameter<double>("ALPHA_F",
+          {.description = "Generalized-alpha time integration factor", .default_value = 0.5}),
+      parameter<double>("GAMMA",
+          {.description = "Generalized-alpha time integration factor", .default_value = 0.5}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
+      parameter<int>("MATID",
+          {.description = "Material ID for automatic mesh generation", .default_value = -1}),
 
-  scatradyn.specs.emplace_back(parameter<int>("VELFUNCNO",
-      {.description = "function number for scalar transport velocity field", .default_value = -1}));
+      deprecated_selection<Inpar::ScaTra::VelocityField>("VELOCITYFIELD",
+          {
+              {"zero", velocity_zero},
+              {"function", velocity_function},
+              {"Navier_Stokes", velocity_Navier_Stokes},
+          },
+          {.description = "type of velocity field used for scalar transport problems",
+              .default_value = velocity_zero}),
 
-  {
-    std::map<std::string, Inpar::ScaTra::InitialField> map{
-        {"zero_field", initfield_zero_field},
-        {"field_by_function", initfield_field_by_function},
-        {"field_by_condition", initfield_field_by_condition},
-        {"disturbed_field_by_function", initfield_disturbed_field_by_function},
-        {"1D_DISCONTPV", initfield_discontprogvar_1D},
-        {"FLAME_VORTEX_INTERACTION", initfield_flame_vortex_interaction},
-        {"RAYTAYMIXFRAC", initfield_raytaymixfrac},
-        {"L_shaped_domain", initfield_Lshapeddomain},
-        {"facing_flame_fronts", initfield_facing_flame_fronts},
-        {"oracles_flame", initfield_oracles_flame},
-        {"high_forced_hit", initialfield_forced_hit_high_Sc},
-        {"low_forced_hit", initialfield_forced_hit_low_Sc},
-        {"algebraic_field_dependence", initialfield_algebraic_field_dependence},
-    };
+      parameter<int>(
+          "VELFUNCNO", {.description = "function number for scalar transport velocity field",
+                           .default_value = -1}),
 
-    scatradyn.specs.emplace_back(
-        deprecated_selection<Inpar::ScaTra::InitialField>("INITIALFIELD", map,
-            {.description = "Initial Field for transport problem",
-                .default_value = initfield_zero_field}));
-  }
 
-  scatradyn.specs.emplace_back(parameter<int>("INITFUNCNO",
-      {.description = "function number for scalar transport initial field", .default_value = -1}));
 
-  scatradyn.specs.emplace_back(parameter<bool>(
-      "SPHERICALCOORDS", {.description = "use of spherical coordinates", .default_value = false}));
+      deprecated_selection<Inpar::ScaTra::InitialField>("INITIALFIELD",
+          {
+              {"zero_field", initfield_zero_field},
+              {"field_by_function", initfield_field_by_function},
+              {"field_by_condition", initfield_field_by_condition},
+              {"disturbed_field_by_function", initfield_disturbed_field_by_function},
+              {"1D_DISCONTPV", initfield_discontprogvar_1D},
+              {"FLAME_VORTEX_INTERACTION", initfield_flame_vortex_interaction},
+              {"RAYTAYMIXFRAC", initfield_raytaymixfrac},
+              {"L_shaped_domain", initfield_Lshapeddomain},
+              {"facing_flame_fronts", initfield_facing_flame_fronts},
+              {"oracles_flame", initfield_oracles_flame},
+              {"high_forced_hit", initialfield_forced_hit_high_Sc},
+              {"low_forced_hit", initialfield_forced_hit_low_Sc},
+              {"algebraic_field_dependence", initialfield_algebraic_field_dependence},
+          },
+          {.description = "Initial Field for transport problem",
+              .default_value = initfield_zero_field}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::CalcError>("CALCERROR",
-      {
-          {"No", calcerror_no},
-          {"Kwok_Wu", calcerror_Kwok_Wu},
-          {"ConcentricCylinders", calcerror_cylinder},
-          {"Electroneutrality", calcerror_electroneutrality},
-          {"error_by_function", calcerror_byfunction},
-          {"error_by_condition", calcerror_bycondition},
-          {"SphereDiffusion", calcerror_spherediffusion},
-          {"AnalyticSeries", calcerror_AnalyticSeries},
-      },
-      {.description = "compute error compared to analytical solution",
-          .default_value = calcerror_no}));
+      parameter<int>(
+          "INITFUNCNO", {.description = "function number for scalar transport initial field",
+                            .default_value = -1}),
 
-  scatradyn.specs.emplace_back(parameter<int>(
-      "CALCERRORNO", {.description = "function number for scalar transport error computation",
-                         .default_value = -1}));
+      parameter<bool>("SPHERICALCOORDS",
+          {.description = "use of spherical coordinates", .default_value = false}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::FluxType>("CALCFLUX_DOMAIN",
-      {
-          {"No", flux_none},
-          {"total", flux_total},
-          {"diffusive", flux_diffusive},
-      },
-      {.description = "output of diffusive/total flux vectors inside domain",
-          .default_value = flux_none}));
+      deprecated_selection<Inpar::ScaTra::CalcError>("CALCERROR",
+          {
+              {"No", calcerror_no},
+              {"Kwok_Wu", calcerror_Kwok_Wu},
+              {"ConcentricCylinders", calcerror_cylinder},
+              {"Electroneutrality", calcerror_electroneutrality},
+              {"error_by_function", calcerror_byfunction},
+              {"error_by_condition", calcerror_bycondition},
+              {"SphereDiffusion", calcerror_spherediffusion},
+              {"AnalyticSeries", calcerror_AnalyticSeries},
+          },
+          {.description = "compute error compared to analytical solution",
+              .default_value = calcerror_no}),
 
-  scatradyn.specs.emplace_back(parameter<bool>("CALCFLUX_DOMAIN_LUMPED",
-      {.description = "perform approximate domain flux calculation involving matrix lumping",
-          .default_value = true}));
+      parameter<int>(
+          "CALCERRORNO", {.description = "function number for scalar transport error computation",
+                             .default_value = -1}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::FluxType>("CALCFLUX_BOUNDARY",
-      {
-          {"No", flux_none},
-          {"total", flux_total},
-          {"diffusive", flux_diffusive},
-          {"convective", flux_convective},
-      },
-      {.description = "output of convective/diffusive/total flux vectors on boundary",
-          .default_value = flux_none}));
+      deprecated_selection<Inpar::ScaTra::FluxType>("CALCFLUX_DOMAIN",
+          {
+              {"No", flux_none},
+              {"total", flux_total},
+              {"diffusive", flux_diffusive},
+          },
+          {.description = "output of diffusive/total flux vectors inside domain",
+              .default_value = flux_none}),
 
-  scatradyn.specs.emplace_back(parameter<bool>("CALCFLUX_BOUNDARY_LUMPED",
-      {.description = "perform approximate boundary flux calculation involving matrix lumping",
-          .default_value = true}));
+      parameter<bool>("CALCFLUX_DOMAIN_LUMPED",
+          {.description = "perform approximate domain flux calculation involving matrix lumping",
+              .default_value = true}),
 
-  scatradyn.specs.emplace_back(parameter<std::string>(
-      "WRITEFLUX_IDS", {.description = "Write diffusive/total flux vector fields for these scalar "
-                                       "fields only (starting with 1)",
-                           .default_value = "-1"}));
+      deprecated_selection<Inpar::ScaTra::FluxType>("CALCFLUX_BOUNDARY",
+          {
+              {"No", flux_none},
+              {"total", flux_total},
+              {"diffusive", flux_diffusive},
+              {"convective", flux_convective},
+          },
+          {.description = "output of convective/diffusive/total flux vectors on boundary",
+              .default_value = flux_none}),
 
-  scatradyn.specs.emplace_back(
+      parameter<bool>("CALCFLUX_BOUNDARY_LUMPED",
+          {.description = "perform approximate boundary flux calculation involving matrix lumping",
+              .default_value = true}),
+
+      parameter<std::string>("WRITEFLUX_IDS",
+          {.description = "Write diffusive/total flux vector fields for these scalar "
+                          "fields only (starting with 1)",
+              .default_value = "-1"}),
+
+
       deprecated_selection<Inpar::ScaTra::OutputScalarType>("OUTPUTSCALARS",
           {
               {"none", outputscalars_none},
@@ -175,108 +175,110 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               {"entire_domain_and_by_condition", outputscalars_entiredomain_condition},
           },
           {.description = "Output of total and mean values for transported scalars",
-              .default_value = outputscalars_none}));
-  scatradyn.specs.emplace_back(parameter<bool>("OUTPUTSCALARSMEANGRAD",
-      {.description = "Output of mean gradient of scalars", .default_value = false}));
-  scatradyn.specs.emplace_back(parameter<bool>("OUTINTEGRREAC",
-      {.description = "Output of integral reaction values", .default_value = false}));
-  scatradyn.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
-      {.description = "Do you want to write Gmsh postprocessing files?", .default_value = false}));
+              .default_value = outputscalars_none}),
+      parameter<bool>("OUTPUTSCALARSMEANGRAD",
+          {.description = "Output of mean gradient of scalars", .default_value = false}),
+      parameter<bool>("OUTINTEGRREAC",
+          {.description = "Output of integral reaction values", .default_value = false}),
+      parameter<bool>(
+          "OUTPUT_GMSH", {.description = "Do you want to write Gmsh postprocessing files?",
+                             .default_value = false}),
 
-  scatradyn.specs.emplace_back(parameter<bool>("MATLAB_STATE_OUTPUT",
-      {.description = "Do you want to write the state solution to Matlab file?",
-          .default_value = false}));
+      parameter<bool>("MATLAB_STATE_OUTPUT",
+          {.description = "Do you want to write the state solution to Matlab file?",
+              .default_value = false}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::ConvForm>("CONVFORM",
-      {
-          {"convective", convform_convective},
-          {"conservative", convform_conservative},
-      },
-      {.description = "form of convective term", .default_value = convform_convective}));
+      deprecated_selection<Inpar::ScaTra::ConvForm>("CONVFORM",
+          {
+              {"convective", convform_convective},
+              {"conservative", convform_conservative},
+          },
+          {.description = "form of convective term", .default_value = convform_convective}),
 
-  scatradyn.specs.emplace_back(parameter<bool>(
-      "NEUMANNINFLOW", {.description = "Flag to (de)activate potential Neumann inflow term(s)",
-                           .default_value = false}));
+      parameter<bool>(
+          "NEUMANNINFLOW", {.description = "Flag to (de)activate potential Neumann inflow term(s)",
+                               .default_value = false}),
 
-  scatradyn.specs.emplace_back(parameter<bool>("CONV_HEAT_TRANS",
-      {.description = "Flag to (de)activate potential convective heat transfer boundary conditions",
-          .default_value = false}));
+      parameter<bool>("CONV_HEAT_TRANS",
+          {.description =
+                  "Flag to (de)activate potential convective heat transfer boundary conditions",
+              .default_value = false}),
 
-  scatradyn.specs.emplace_back(parameter<bool>(
-      "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
-                         .default_value = false}));
+      parameter<bool>(
+          "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
+                             .default_value = false}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::FSSUGRDIFF>("FSSUGRDIFF",
-      {
-          {"No", fssugrdiff_no},
-          {"artificial", fssugrdiff_artificial},
-          {"Smagorinsky_all", fssugrdiff_smagorinsky_all},
-          {"Smagorinsky_small", fssugrdiff_smagorinsky_small},
-      },
-      {.description = "fine-scale subgrid diffusivity", .default_value = fssugrdiff_no}));
+      deprecated_selection<Inpar::ScaTra::FSSUGRDIFF>("FSSUGRDIFF",
+          {
+              {"No", fssugrdiff_no},
+              {"artificial", fssugrdiff_artificial},
+              {"Smagorinsky_all", fssugrdiff_smagorinsky_all},
+              {"Smagorinsky_small", fssugrdiff_smagorinsky_small},
+          },
+          {.description = "fine-scale subgrid diffusivity", .default_value = fssugrdiff_no}),
 
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::FLUID::MeshTying>("MESHTYING",
-      {
-          {"no", Inpar::FLUID::no_meshtying},
-          {"Condensed_Smat", Inpar::FLUID::condensed_smat},
-          {"Condensed_Bmat", Inpar::FLUID::condensed_bmat},
-          {"Condensed_Bmat_merged", Inpar::FLUID::condensed_bmat_merged},
-      },
-      {.description = "Flag to (de)activate mesh tying algorithm",
-          .default_value = Inpar::FLUID::no_meshtying}));
+      deprecated_selection<Inpar::FLUID::MeshTying>("MESHTYING",
+          {
+              {"no", Inpar::FLUID::no_meshtying},
+              {"Condensed_Smat", Inpar::FLUID::condensed_smat},
+              {"Condensed_Bmat", Inpar::FLUID::condensed_bmat},
+              {"Condensed_Bmat_merged", Inpar::FLUID::condensed_bmat_merged},
+          },
+          {.description = "Flag to (de)activate mesh tying algorithm",
+              .default_value = Inpar::FLUID::no_meshtying}),
 
-  // Type of coupling strategy between the two fields
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::FieldCoupling>("FIELDCOUPLING",
-      {
-          {"matching", coupling_match},
-          {"volmortar", coupling_volmortar},
-      },
-      {.description = "Type of coupling strategy between fields",
-          .default_value = coupling_match}));
+      // Type of coupling strategy between the two fields
+      deprecated_selection<Inpar::ScaTra::FieldCoupling>("FIELDCOUPLING",
+          {
+              {"matching", coupling_match},
+              {"volmortar", coupling_volmortar},
+          },
+          {.description = "Type of coupling strategy between fields",
+              .default_value = coupling_match}),
 
-  // linear solver id used for scalar transport/elch problems
-  scatradyn.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for scalar transport/elch...",
-                           .default_value = -1}));
-  // linear solver id used for l2 projection problems (e.g. gradient projections)
-  scatradyn.specs.emplace_back(parameter<int>("L2_PROJ_LINEAR_SOLVER",
-      {.description = "number of linear solver used for l2-projection sub-problems",
-          .default_value = -1}));
+      // linear solver id used for scalar transport/elch problems
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for scalar transport/elch...",
+              .default_value = -1}),
+      // linear solver id used for l2 projection problems (e.g. gradient projections)
+      parameter<int>("L2_PROJ_LINEAR_SOLVER",
+          {.description = "number of linear solver used for l2-projection sub-problems",
+              .default_value = -1}),
 
-  // flag for equilibration of global system of equations
-  scatradyn.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
-                           .default_value = Core::LinAlg::EquilibrationMethod::none}));
+      // flag for equilibration of global system of equations
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
+                               .default_value = Core::LinAlg::EquilibrationMethod::none}),
 
-  // type of global system matrix in global system of equations
-  scatradyn.specs.emplace_back(parameter<Core::LinAlg::MatrixType>(
-      "MATRIXTYPE", {.description = "type of global system matrix in global system of equations",
-                        .default_value = Core::LinAlg::MatrixType::sparse}));
+      // type of global system matrix in global system of equations
+      parameter<Core::LinAlg::MatrixType>("MATRIXTYPE",
+          {.description = "type of global system matrix in global system of equations",
+              .default_value = Core::LinAlg::MatrixType::sparse}),
 
-  // flag for natural convection effects
-  scatradyn.specs.emplace_back(parameter<bool>("NATURAL_CONVECTION",
-      {.description = "Include natural convection effects", .default_value = false}));
+      // flag for natural convection effects
+      parameter<bool>("NATURAL_CONVECTION",
+          {.description = "Include natural convection effects", .default_value = false}),
 
-  // parameters for finite difference check
-  scatradyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::FdCheck>("FDCHECK",
-      {
-          {"none", fdcheck_none},
-          {"global", fdcheck_global},
-          {"global_extended", fdcheck_global_extended},
-          {"local", fdcheck_local},
-      },
-      {.description = "flag for finite difference check: none, local, or global",
-          .default_value = fdcheck_none}));
-  scatradyn.specs.emplace_back(parameter<double>(
-      "FDCHECKEPS", {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
-                                    "seems to work very well, whereas smaller values don't)",
-                        .default_value = 1.e-6}));
-  scatradyn.specs.emplace_back(parameter<double>("FDCHECKTOL",
-      {.description = "relative tolerance for finite difference check", .default_value = 1.e-6}));
+      // parameters for finite difference check
+      deprecated_selection<Inpar::ScaTra::FdCheck>("FDCHECK",
+          {
+              {"none", fdcheck_none},
+              {"global", fdcheck_global},
+              {"global_extended", fdcheck_global_extended},
+              {"local", fdcheck_local},
+          },
+          {.description = "flag for finite difference check: none, local, or global",
+              .default_value = fdcheck_none}),
+      parameter<double>("FDCHECKEPS",
+          {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
+                          "seems to work very well, whereas smaller values don't)",
+              .default_value = 1.e-6}),
+      parameter<double>(
+          "FDCHECKTOL", {.description = "relative tolerance for finite difference check",
+                            .default_value = 1.e-6}),
 
-  // parameter for optional computation of domain and boundary integrals, i.e., of surface areas and
-  // volumes associated with specified nodesets
-  scatradyn.specs.emplace_back(
+      // parameter for optional computation of domain and boundary integrals, i.e., of surface areas
+      // and volumes associated with specified nodesets
       deprecated_selection<Inpar::ScaTra::ComputeIntegrals>("COMPUTEINTEGRALS",
           {
               {"none", computeintegrals_none},
@@ -284,135 +286,131 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               {"repeated", computeintegrals_repeated},
           },
           {.description = "flag for optional computation of domain integrals",
-              .default_value = computeintegrals_none}));
+              .default_value = computeintegrals_none}),
 
-  // parameter for using p-adpativity and semi-implicit evaluation of the reaction term (at the
-  // moment only used for HDG and cardiac monodomain problems)
-  scatradyn.specs.emplace_back(parameter<bool>(
-      "PADAPTIVITY", {.description = "Flag to (de)activate p-adativity", .default_value = false}));
-  scatradyn.specs.emplace_back(parameter<double>("PADAPTERRORTOL",
-      {.description = "The error tolerance to calculate the variation of the elemental degree",
-          .default_value = 1e-6}));
-  scatradyn.specs.emplace_back(parameter<double>("PADAPTERRORBASE",
-      {.description = "The error tolerance base to calculate the variation of the elemental degree",
-          .default_value = 1.66}));
-  scatradyn.specs.emplace_back(parameter<int>("PADAPTDEGREEMAX",
-      {.description = "The max. degree of the shape functions", .default_value = 4}));
-  scatradyn.specs.emplace_back(parameter<bool>("SEMIIMPLICIT",
-      {.description = "Flag to (de)activate semi-implicit calculation of the reaction term",
-          .default_value = false}));
+      // parameter for using p-adpativity and semi-implicit evaluation of the reaction term (at the
+      // moment only used for HDG and cardiac monodomain problems)
+      parameter<bool>("PADAPTIVITY",
+          {.description = "Flag to (de)activate p-adativity", .default_value = false}),
+      parameter<double>("PADAPTERRORTOL",
+          {.description = "The error tolerance to calculate the variation of the elemental degree",
+              .default_value = 1e-6}),
+      parameter<double>("PADAPTERRORBASE",
+          {.description =
+                  "The error tolerance base to calculate the variation of the elemental degree",
+              .default_value = 1.66}),
+      parameter<int>("PADAPTDEGREEMAX",
+          {.description = "The max. degree of the shape functions", .default_value = 4}),
+      parameter<bool>("SEMIIMPLICIT",
+          {.description = "Flag to (de)activate semi-implicit calculation of the reaction term",
+              .default_value = false}),
 
-  // flag for output of performance statistics associated with linear solver into *.csv file
-  scatradyn.specs.emplace_back(parameter<bool>(
-      "OUTPUTLINSOLVERSTATS", {.description = "flag for output of performance statistics "
-                                              "associated with linear solver into csv file",
-                                  .default_value = false}));
+      // flag for output of performance statistics associated with linear solver into *.csv file
+      parameter<bool>(
+          "OUTPUTLINSOLVERSTATS", {.description = "flag for output of performance statistics "
+                                                  "associated with linear solver into csv file",
+                                      .default_value = false}),
 
-  // flag for output of performance statistics associated with nonlinear solver into *.csv file
-  scatradyn.specs.emplace_back(parameter<bool>(
-      "OUTPUTNONLINSOLVERSTATS", {.description = "flag for output of performance statistics "
-                                                 "associated with nonlinear solver into csv file",
-                                     .default_value = false}));
+      // flag for output of performance statistics associated with nonlinear solver into *.csv file
+      parameter<bool>("OUTPUTNONLINSOLVERSTATS",
+          {.description = "flag for output of performance statistics "
+                          "associated with nonlinear solver into csv file",
+              .default_value = false}),
 
-  // flag for point-based null space calculation
-  scatradyn.specs.emplace_back(parameter<bool>("NULLSPACE_POINTBASED",
-      {.description = "flag for point-based null space calculation", .default_value = false}));
+      // flag for point-based null space calculation
+      parameter<bool>("NULLSPACE_POINTBASED",
+          {.description = "flag for point-based null space calculation", .default_value = false}),
 
-  // flag for adaptive time stepping
-  scatradyn.specs.emplace_back(parameter<bool>("ADAPTIVE_TIMESTEPPING",
-      {.description = "flag for adaptive time stepping", .default_value = false}));
+      // flag for adaptive time stepping
+      parameter<bool>("ADAPTIVE_TIMESTEPPING",
+          {.description = "flag for adaptive time stepping",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
+  list["SCALAR TRANSPORT DYNAMIC/NONLINEAR"] = all_of({
 
-  scatradyn.move_into_collection(list);
+      parameter<int>(
+          "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}),
+      parameter<double>(
+          "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-6}),
+      parameter<int>("ITEMAX_OUTER",
+          {.description = "Maximum number of outer iterations in partitioned coupling "
+                          "schemes (natural convection, multi-scale simulations etc.)",
+              .default_value = 10}),
+      parameter<double>("CONVTOL_OUTER",
+          {.description =
+                  "Convergence check tolerance for outer loop in partitioned coupling schemes "
+                  "(natural convection, multi-scale simulations etc.)",
+              .default_value = 1e-6}),
+      parameter<bool>("EXPLPREDICT",
+          {.description = "do an explicit predictor step before starting nonlinear iteration",
+              .default_value = false}),
+      parameter<double>("ABSTOLRES", {.description = "Absolute tolerance for deciding if residual "
+                                                     "of nonlinear problem is already zero",
+                                         .default_value = 1e-14}),
 
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs scatra_nonlin{scatradyn, "NONLINEAR"};
-
-  scatra_nonlin.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}));
-  scatra_nonlin.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-6}));
-  scatra_nonlin.specs.emplace_back(parameter<int>(
-      "ITEMAX_OUTER", {.description = "Maximum number of outer iterations in partitioned coupling "
-                                      "schemes (natural convection, multi-scale simulations etc.)",
-                          .default_value = 10}));
-  scatra_nonlin.specs.emplace_back(parameter<double>("CONVTOL_OUTER",
-      {.description = "Convergence check tolerance for outer loop in partitioned coupling schemes "
-                      "(natural convection, multi-scale simulations etc.)",
-          .default_value = 1e-6}));
-  scatra_nonlin.specs.emplace_back(parameter<bool>("EXPLPREDICT",
-      {.description = "do an explicit predictor step before starting nonlinear iteration",
-          .default_value = false}));
-  scatra_nonlin.specs.emplace_back(parameter<double>("ABSTOLRES",
-      {.description =
-              "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
-          .default_value = 1e-14}));
-
-  // convergence criteria adaptivity
-  scatra_nonlin.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  scatra_nonlin.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
-
-  scatra_nonlin.move_into_collection(list);
+      // convergence criteria adaptivity
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1})});
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs scatradyn_stab{scatradyn, "STABILIZATION"};
+  list["SCALAR TRANSPORT DYNAMIC/STABILIZATION"] = all_of({
 
-  // this parameter governs type of stabilization
-  scatradyn_stab.specs.emplace_back(deprecated_selection<Inpar::ScaTra::StabType>("STABTYPE",
-      {
-          {"no_stabilization", stabtype_no_stabilization},
-          {"SUPG", stabtype_SUPG},
-          {"GLS", stabtype_GLS},
-          {"USFEM", stabtype_USFEM},
-          {"centered", stabtype_hdg_centered},
-          {"upwind", stabtype_hdg_upwind},
-      },
-      {.description = "Type of stabilization (if any). No stabilization is only reasonable for "
-                      "low-Peclet-number.",
-          .default_value = stabtype_SUPG}));
+      // this parameter governs type of stabilization
+      deprecated_selection<Inpar::ScaTra::StabType>("STABTYPE",
+          {
+              {"no_stabilization", stabtype_no_stabilization},
+              {"SUPG", stabtype_SUPG},
+              {"GLS", stabtype_GLS},
+              {"USFEM", stabtype_USFEM},
+              {"centered", stabtype_hdg_centered},
+              {"upwind", stabtype_hdg_upwind},
+          },
+          {.description = "Type of stabilization (if any). No stabilization is only reasonable for "
+                          "low-Peclet-number.",
+              .default_value = stabtype_SUPG}),
 
-  // this parameter governs whether subgrid-scale velocity is included
-  scatradyn_stab.specs.emplace_back(parameter<bool>(
-      "SUGRVEL", {.description = "potential incorporation of subgrid-scale velocity",
-                     .default_value = false}));
+      // this parameter governs whether subgrid-scale velocity is included
+      parameter<bool>(
+          "SUGRVEL", {.description = "potential incorporation of subgrid-scale velocity",
+                         .default_value = false}),
 
-  // this parameter governs whether all-scale subgrid diffusivity is included
-  scatradyn_stab.specs.emplace_back(parameter<bool>(
-      "ASSUGRDIFF", {.description = "potential incorporation of all-scale subgrid diffusivity "
-                                    "(a.k.a. discontinuity-capturing) term",
-                        .default_value = false}));
+      // this parameter governs whether all-scale subgrid diffusivity is included
+      parameter<bool>(
+          "ASSUGRDIFF", {.description = "potential incorporation of all-scale subgrid diffusivity "
+                                        "(a.k.a. discontinuity-capturing) term",
+                            .default_value = false}),
 
-  // this parameter selects the tau definition applied
-  scatradyn_stab.specs.emplace_back(deprecated_selection<Inpar::ScaTra::TauType>("DEFINITION_TAU",
-      {
-          {"Taylor_Hughes_Zarins", tau_taylor_hughes_zarins},
-          {"Taylor_Hughes_Zarins_wo_dt", tau_taylor_hughes_zarins_wo_dt},
-          {"Franca_Valentin", tau_franca_valentin},
-          {"Franca_Valentin_wo_dt", tau_franca_valentin_wo_dt},
-          {"Shakib_Hughes_Codina", tau_shakib_hughes_codina},
-          {"Shakib_Hughes_Codina_wo_dt", tau_shakib_hughes_codina_wo_dt},
-          {"Codina", tau_codina},
-          {"Codina_wo_dt", tau_codina_wo_dt},
-          {"Franca_Madureira_Valentin", tau_franca_madureira_valentin},
-          {"Franca_Madureira_Valentin_wo_dt", tau_franca_madureira_valentin_wo_dt},
-          {"Exact_1D", tau_exact_1d},
-          {"Zero", tau_zero},
-          {"Numerical_Value", tau_numerical_value},
-      },
-      {.description = "Definition of tau", .default_value = tau_franca_valentin}));
+      // this parameter selects the tau definition applied
+      deprecated_selection<Inpar::ScaTra::TauType>("DEFINITION_TAU",
+          {
+              {"Taylor_Hughes_Zarins", tau_taylor_hughes_zarins},
+              {"Taylor_Hughes_Zarins_wo_dt", tau_taylor_hughes_zarins_wo_dt},
+              {"Franca_Valentin", tau_franca_valentin},
+              {"Franca_Valentin_wo_dt", tau_franca_valentin_wo_dt},
+              {"Shakib_Hughes_Codina", tau_shakib_hughes_codina},
+              {"Shakib_Hughes_Codina_wo_dt", tau_shakib_hughes_codina_wo_dt},
+              {"Codina", tau_codina},
+              {"Codina_wo_dt", tau_codina_wo_dt},
+              {"Franca_Madureira_Valentin", tau_franca_madureira_valentin},
+              {"Franca_Madureira_Valentin_wo_dt", tau_franca_madureira_valentin_wo_dt},
+              {"Exact_1D", tau_exact_1d},
+              {"Zero", tau_zero},
+              {"Numerical_Value", tau_numerical_value},
+          },
+          {.description = "Definition of tau", .default_value = tau_franca_valentin}),
 
-  // this parameter selects the characteristic element length for tau for all
-  // stabilization parameter definitions requiring such a length
-  scatradyn_stab.specs.emplace_back(parameter<Inpar::ScaTra::CharEleLength>("CHARELELENGTH",
-      {.description = "Characteristic element length for tau", .default_value = streamlength}));
+      // this parameter selects the characteristic element length for tau for all
+      // stabilization parameter definitions requiring such a length
+      parameter<Inpar::ScaTra::CharEleLength>("CHARELELENGTH",
+          {.description = "Characteristic element length for tau", .default_value = streamlength}),
 
-  // this parameter selects the all-scale subgrid-diffusivity definition applied
-  scatradyn_stab.specs.emplace_back(
+      // this parameter selects the all-scale subgrid-diffusivity definition applied
       deprecated_selection<Inpar::ScaTra::AssgdType>("DEFINITION_ASSGD",
           {
               {"artificial_linear", assgd_artificial},
@@ -426,46 +424,44 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               {"Codina_nonlinear", assgd_codina},
           },
           {.description = "Definition of (all-scale) subgrid diffusivity",
-              .default_value = assgd_artificial}));
+              .default_value = assgd_artificial}),
 
-  // this parameter selects the location where tau is evaluated
-  scatradyn_stab.specs.emplace_back(deprecated_selection<Inpar::ScaTra::EvalTau>("EVALUATION_TAU",
-      {
-          {"element_center", evaltau_element_center},
-          {"integration_point", evaltau_integration_point},
-      },
-      {.description = "Location where tau is evaluated", .default_value = evaltau_element_center}));
+      // this parameter selects the location where tau is evaluated
+      deprecated_selection<Inpar::ScaTra::EvalTau>("EVALUATION_TAU",
+          {
+              {"element_center", evaltau_element_center},
+              {"integration_point", evaltau_integration_point},
+          },
+          {.description = "Location where tau is evaluated",
+              .default_value = evaltau_element_center}),
 
-  // this parameter selects the location where the material law is evaluated
-  // (does not fit here very well, but parameter transfer is easier)
-  scatradyn_stab.specs.emplace_back(deprecated_selection<Inpar::ScaTra::EvalMat>("EVALUATION_MAT",
-      {
-          {"element_center", evalmat_element_center},
-          {"integration_point", evalmat_integration_point},
-      },
-      {.description = "Location where material law is evaluated",
-          .default_value = evalmat_element_center}));
+      // this parameter selects the location where the material law is evaluated
+      // (does not fit here very well, but parameter transfer is easier)
+      deprecated_selection<Inpar::ScaTra::EvalMat>("EVALUATION_MAT",
+          {
+              {"element_center", evalmat_element_center},
+              {"integration_point", evalmat_integration_point},
+          },
+          {.description = "Location where material law is evaluated",
+              .default_value = evalmat_element_center}),
 
-  // this parameter selects methods for improving consistency of stabilization terms
-  scatradyn_stab.specs.emplace_back(deprecated_selection<Inpar::ScaTra::Consistency>("CONSISTENCY",
-      {
-          {"no", consistency_no},
-          {"L2_projection_lumped", consistency_l2_projection_lumped},
-      },
-      {.description = "improvement of consistency for stabilization",
-          .default_value = consistency_no}));
+      // this parameter selects methods for improving consistency of stabilization terms
+      deprecated_selection<Inpar::ScaTra::Consistency>("CONSISTENCY",
+          {
+              {"no", consistency_no},
+              {"L2_projection_lumped", consistency_l2_projection_lumped},
+          },
+          {.description = "improvement of consistency for stabilization",
+              .default_value = consistency_no}),
 
-  // this parameter defines the numerical value, if stabilization with numerical values is used
-  scatradyn_stab.specs.emplace_back(parameter<double>("TAU_VALUE",
-      {.description = "Numerical value for tau for stabilization", .default_value = 0.0}));
-
-  scatradyn_stab.move_into_collection(list);
+      // this parameter defines the numerical value, if stabilization with numerical values is used
+      parameter<double>("TAU_VALUE",
+          {.description = "Numerical value for tau for stabilization", .default_value = 0.0})});
 
   // ----------------------------------------------------------------------
   // artery mesh tying
-  Core::Utils::SectionSpecs scatradyn_art{scatradyn, "ARTERY COUPLING"};
+  list["SCALAR TRANSPORT DYNAMIC/ARTERY COUPLING"] = all_of({
 
-  scatradyn_art.specs.emplace_back(
       deprecated_selection<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
           "ARTERY_COUPLING_METHOD",
           {
@@ -477,54 +473,50 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           },
           {.description = "Coupling method for artery coupling.",
               .default_value =
-                  Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::none}));
+                  Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::none}),
 
-  // penalty parameter
-  scatradyn_art.specs.emplace_back(parameter<double>("PENALTY",
-      {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}));
+      // penalty parameter
+      parameter<double>("PENALTY",
+          {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}),
 
-  // coupled artery dofs for mesh tying
-  scatradyn_art.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_ARTSCATRA",
-      {.description = "coupled artery dofs for mesh tying", .default_value = "-1.0"}));
+      // coupled artery dofs for mesh tying
+      parameter<std::string>("COUPLEDDOFS_ARTSCATRA",
+          {.description = "coupled artery dofs for mesh tying", .default_value = "-1.0"}),
 
-  // coupled porofluid dofs for mesh tying
-  scatradyn_art.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_SCATRA",
-      {.description = "coupled porofluid dofs for mesh tying", .default_value = "-1.0"}));
+      // coupled porofluid dofs for mesh tying
+      parameter<std::string>("COUPLEDDOFS_SCATRA",
+          {.description = "coupled porofluid dofs for mesh tying", .default_value = "-1.0"}),
 
-  // functions for coupling (arteryscatra part)
-  scatradyn_art.specs.emplace_back(parameter<std::string>("REACFUNCT_ART",
-      {.description = "functions for coupling (arteryscatra part)", .default_value = "-1"}));
+      // functions for coupling (arteryscatra part)
+      parameter<std::string>("REACFUNCT_ART",
+          {.description = "functions for coupling (arteryscatra part)", .default_value = "-1"}),
 
-  // scale for coupling (arteryscatra part)
-  scatradyn_art.specs.emplace_back(parameter<std::string>("SCALEREAC_ART",
-      {.description = "scale for coupling (arteryscatra part)", .default_value = "0"}));
+      // scale for coupling (arteryscatra part)
+      parameter<std::string>("SCALEREAC_ART",
+          {.description = "scale for coupling (arteryscatra part)", .default_value = "0"}),
 
-  // functions for coupling (scatra part)
-  scatradyn_art.specs.emplace_back(parameter<std::string>("REACFUNCT_CONT",
-      {.description = "functions for coupling (scatra part)", .default_value = "-1"}));
+      // functions for coupling (scatra part)
+      parameter<std::string>("REACFUNCT_CONT",
+          {.description = "functions for coupling (scatra part)", .default_value = "-1"}),
 
-  // scale for coupling (scatra part)
-  scatradyn_art.specs.emplace_back(parameter<std::string>(
-      "SCALEREAC_CONT", {.description = "scale for coupling (scatra part)", .default_value = "0"}));
-
-  scatradyn_art.move_into_collection(list);
+      // scale for coupling (scatra part)
+      parameter<std::string>("SCALEREAC_CONT",
+          {.description = "scale for coupling (scatra part)", .default_value = "0"})});
 
   // ----------------------------------------------------------------------
-  Core::Utils::SectionSpecs scatradyn_external_force{scatradyn, "EXTERNAL FORCE"};
+  list["SCALAR TRANSPORT DYNAMIC/EXTERNAL FORCE"] = all_of({
 
-  // Flag for external force
-  scatradyn_external_force.specs.emplace_back(parameter<bool>("EXTERNAL_FORCE",
-      {.description = "Flag to activate external force", .default_value = false}));
+      // Flag for external force
+      parameter<bool>("EXTERNAL_FORCE",
+          {.description = "Flag to activate external force", .default_value = false}),
 
-  // Function ID for external force
-  scatradyn_external_force.specs.emplace_back(parameter<int>(
-      "FORCE_FUNCTION_ID", {.description = "Function ID for external force", .default_value = -1}));
+      // Function ID for external force
+      parameter<int>("FORCE_FUNCTION_ID",
+          {.description = "Function ID for external force", .default_value = -1}),
 
-  // Function ID for mobility of the scalar
-  scatradyn_external_force.specs.emplace_back(parameter<int>("INTRINSIC_MOBILITY_FUNCTION_ID",
-      {.description = "Function ID for intrinsic mobility", .default_value = -1}));
-
-  scatradyn_external_force.move_into_collection(list);
+      // Function ID for mobility of the scalar
+      parameter<int>("INTRINSIC_MOBILITY_FUNCTION_ID",
+          {.description = "Function ID for intrinsic mobility", .default_value = -1})});
 }
 
 

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -16,7 +16,6 @@
 #include "4C_linalg_sparseoperator.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
-#include "4C_utils_parameter_list.hpp"
 
 #include <utility>
 #include <vector>

--- a/src/inpar/4C_inpar_searchtree.cpp
+++ b/src/inpar/4C_inpar_searchtree.cpp
@@ -7,8 +7,7 @@
 
 #include "4C_inpar_searchtree.hpp"
 
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_searchtree.cpp
+++ b/src/inpar/4C_inpar_searchtree.cpp
@@ -18,18 +18,16 @@ void Inpar::Geo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs search_tree{"SEARCH TREE"};
+  list["SEARCH TREE"] = all_of({
 
-  search_tree.specs.emplace_back(deprecated_selection<Inpar::Geo::TreeType>("TREE_TYPE",
-      {
-          {"notree", Inpar::Geo::Notree},
-          {"octree3d", Inpar::Geo::Octree3D},
-          {"quadtree3d", Inpar::Geo::Quadtree3D},
-          {"quadtree2d", Inpar::Geo::Quadtree2D},
-      },
-      {.description = "set tree type", .default_value = Inpar::Geo::Notree}));
-
-  search_tree.move_into_collection(list);
+      deprecated_selection<Inpar::Geo::TreeType>("TREE_TYPE",
+          {
+              {"notree", Inpar::Geo::Notree},
+              {"octree3d", Inpar::Geo::Octree3D},
+              {"quadtree3d", Inpar::Geo::Quadtree3D},
+              {"quadtree2d", Inpar::Geo::Quadtree2D},
+          },
+          {.description = "set tree type", .default_value = Inpar::Geo::Notree})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -19,136 +19,116 @@ namespace Inpar::SOLVER
   void set_valid_solver_parameters(Core::IO::InputSpec& spec)
   {
     using namespace Core::IO::InputSpecBuilders;
-    Core::Utils::SectionSpecs list{"dummy"};
-    // Solver options
-    {
-      list.specs.emplace_back(deprecated_selection<Core::LinearSolver::SolverType>("SOLVER",
-          {
-              {"UMFPACK", Core::LinearSolver::SolverType::umfpack},
-              {"Superlu", Core::LinearSolver::SolverType::superlu},
-              {"Belos", Core::LinearSolver::SolverType::belos},
-              {"undefined", Core::LinearSolver::SolverType::undefined},
-          },
-          {.description = "The solver to attack the system of linear equations arising of FE "
-                          "approach with.",
-              .default_value = Core::LinearSolver::SolverType::undefined}));
-    }
+    spec = Core::IO::InputSpecBuilders::all_of({
+        // Solver options
+        deprecated_selection<Core::LinearSolver::SolverType>("SOLVER",
+            {
+                {"UMFPACK", Core::LinearSolver::SolverType::umfpack},
+                {"Superlu", Core::LinearSolver::SolverType::superlu},
+                {"Belos", Core::LinearSolver::SolverType::belos},
+                {"undefined", Core::LinearSolver::SolverType::undefined},
+            },
+            {.description = "The solver to attack the system of linear equations arising of FE "
+                            "approach with.",
+                .default_value = Core::LinearSolver::SolverType::undefined}),
 
-    // Iterative solver options
-    {
-      list.specs.emplace_back(
-          deprecated_selection<Core::LinearSolver::IterativeSolverType>("AZSOLVE",
-              {
-                  {"CG", Core::LinearSolver::IterativeSolverType::cg},
-                  {"GMRES", Core::LinearSolver::IterativeSolverType::gmres},
-                  {"BiCGSTAB", Core::LinearSolver::IterativeSolverType::bicgstab},
-              },
-              {.description = "Type of linear solver algorithm to use.",
-                  .default_value = Core::LinearSolver::IterativeSolverType::gmres}));
-    }
+        // Iterative solver options
+        deprecated_selection<Core::LinearSolver::IterativeSolverType>("AZSOLVE",
+            {
+                {"CG", Core::LinearSolver::IterativeSolverType::cg},
+                {"GMRES", Core::LinearSolver::IterativeSolverType::gmres},
+                {"BiCGSTAB", Core::LinearSolver::IterativeSolverType::bicgstab},
+            },
+            {.description = "Type of linear solver algorithm to use.",
+                .default_value = Core::LinearSolver::IterativeSolverType::gmres}),
 
-    // Preconditioner options
-    {
-      list.specs.emplace_back(deprecated_selection<Core::LinearSolver::PreconditionerType>("AZPREC",
-          {
-              {"ILU", Core::LinearSolver::PreconditionerType::ilu},
-              {"MueLu", Core::LinearSolver::PreconditionerType::multigrid_muelu},
-              {"AMGnxn", Core::LinearSolver::PreconditionerType::multigrid_nxn},
-              {"Teko", Core::LinearSolver::PreconditionerType::block_teko},
-          },
-          {.description = "Type of internal preconditioner to use.\nNote! this preconditioner will "
-                          "only be used if the input operator\nsupports the Epetra_RowMatrix "
-                          "interface and the client does not pass\nin an external preconditioner!",
-              .default_value = Core::LinearSolver::PreconditionerType::ilu}));
-    }
+        // Preconditioner options
+        deprecated_selection<Core::LinearSolver::PreconditionerType>("AZPREC",
+            {
+                {"ILU", Core::LinearSolver::PreconditionerType::ilu},
+                {"MueLu", Core::LinearSolver::PreconditionerType::multigrid_muelu},
+                {"AMGnxn", Core::LinearSolver::PreconditionerType::multigrid_nxn},
+                {"Teko", Core::LinearSolver::PreconditionerType::block_teko},
+            },
+            {.description =
+                    "Type of internal preconditioner to use.\nNote! this preconditioner will "
+                    "only be used if the input operator\nsupports the Epetra_RowMatrix "
+                    "interface and the client does not pass\nin an external preconditioner!",
+                .default_value = Core::LinearSolver::PreconditionerType::ilu}),
 
-    // Ifpack options
-    {
-      list.specs.emplace_back(parameter<int>("IFPACKOVERLAP",
-          {.description = "The amount of overlap used for the ifpack \"ilu\" preconditioner.",
-              .default_value = 0}));
+        // Ifpack options
+        parameter<int>("IFPACKOVERLAP",
+            {.description = "The amount of overlap used for the ifpack \"ilu\" preconditioner.",
+                .default_value = 0}),
 
-      list.specs.emplace_back(parameter<int>("IFPACKGFILL",
-          {.description = "The amount of fill allowed for an internal \"ilu\" preconditioner.",
-              .default_value = 0}));
+        parameter<int>("IFPACKGFILL",
+            {.description = "The amount of fill allowed for an internal \"ilu\" preconditioner.",
+                .default_value = 0}),
 
-      std::vector<std::string> ifpack_combine_valid_input = {"Add", "Insert", "Zero"};
-      list.specs.emplace_back(
-          deprecated_selection<std::string>("IFPACKCOMBINE", ifpack_combine_valid_input,
-              {.description = "Combine mode for Ifpack Additive Schwarz", .default_value = "Add"}));
-    }
 
-    // Iterative solver options
-    {
-      list.specs.emplace_back(parameter<int>(
-          "AZITER", {.description = "The maximum number of iterations the underlying iterative "
-                                    "solver is allowed to perform",
-                        .default_value = 1000}));
+        deprecated_selection<std::string>("IFPACKCOMBINE", {"Add", "Insert", "Zero"},
+            {.description = "Combine mode for Ifpack Additive Schwarz", .default_value = "Add"}),
 
-      list.specs.emplace_back(parameter<double>("AZTOL",
-          {.description =
-                  "The level the residual norms must reach to decide about successful convergence",
-              .default_value = 1e-8}));
+        // Iterative solver options
+        parameter<int>(
+            "AZITER", {.description = "The maximum number of iterations the underlying iterative "
+                                      "solver is allowed to perform",
+                          .default_value = 1000}),
 
-      list.specs.emplace_back(deprecated_selection<Belos::ScaleType>("AZCONV",
-          {
-              {"AZ_r0", Belos::ScaleType::NormOfInitRes},
-              {"AZ_noscaled", Belos::ScaleType::None},
-          },
-          {.description = "The implicit residual norm scaling type to use for terminating the "
-                          "iterative solver.",
-              .default_value = Belos::ScaleType::NormOfInitRes}));
+        parameter<double>("AZTOL", {.description = "The level the residual norms must reach to "
+                                                   "decide about successful convergence",
+                                       .default_value = 1e-8}),
 
-      list.specs.emplace_back(parameter<int>(
-          "AZOUTPUT", {.description = "The number of iterations between each output of the "
-                                      "solver's progress is written to "
-                                      "screen",
-                          .default_value = 0}));
+        deprecated_selection<Belos::ScaleType>("AZCONV",
+            {
+                {"AZ_r0", Belos::ScaleType::NormOfInitRes},
+                {"AZ_noscaled", Belos::ScaleType::None},
+            },
+            {.description = "The implicit residual norm scaling type to use for terminating the "
+                            "iterative solver.",
+                .default_value = Belos::ScaleType::NormOfInitRes}),
 
-      list.specs.emplace_back(parameter<int>("AZREUSE",
-          {.description = "The number specifying how often to recompute some preconditioners",
-              .default_value = 0}));
+        parameter<int>(
+            "AZOUTPUT", {.description = "The number of iterations between each output of the "
+                                        "solver's progress is written to "
+                                        "screen",
+                            .default_value = 0}),
 
-      list.specs.emplace_back(parameter<int>(
-          "AZSUB", {.description = "The maximum size of the Krylov subspace used with \"GMRES\" "
-                                   "before\n a restart is performed.",
-                       .default_value = 50}));
+        parameter<int>("AZREUSE",
+            {.description = "The number specifying how often to recompute some preconditioners",
+                .default_value = 0}),
 
-      list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "SOLVER_XML_FILE", {.description = "xml file defining any iterative solver"}));
-    }
+        parameter<int>(
+            "AZSUB", {.description = "The maximum size of the Krylov subspace used with \"GMRES\" "
+                                     "before\n a restart is performed.",
+                         .default_value = 50}),
 
-    // MueLu options
-    {
-      list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "MUELU_XML_FILE", {.description = "xml file defining any MueLu preconditioner"}));
-    }
 
-    // Teko options
-    {
-      list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "TEKO_XML_FILE", {.description = "xml file defining any Teko preconditioner"}));
-    }
+        parameter<std::optional<std::filesystem::path>>(
+            "SOLVER_XML_FILE", {.description = "xml file defining any iterative solver"}),
 
-    // user-given name of solver block (just for beauty)
-    list.specs.emplace_back(parameter<std::string>("NAME",
-        {.description = "User specified name for solver block", .default_value = "No_name"}));
 
-    // Parameters for AMGnxn Preconditioner
-    {
-      list.specs.emplace_back(parameter<std::string>(
-          "AMGNXN_TYPE", {.description = "Name of the pre-built preconditioner to be used. If set "
-                                         "to\"XML\" the preconditioner is defined using a xml file",
-                             .default_value = "AMG(BGS)"}));
-      list.specs.emplace_back(
-          Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
-              "AMGNXN_XML_FILE", {.description = "xml file defining the AMGnxn preconditioner"}));
-    }
+        // MueLu options
+        Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
+            "MUELU_XML_FILE", {.description = "xml file defining any MueLu preconditioner"}),
 
-    spec = Core::IO::InputSpecBuilders::all_of(std::move(list.specs));
+        // Teko options
+        Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
+            "TEKO_XML_FILE", {.description = "xml file defining any Teko preconditioner"}),
+
+        // user-given name of solver block (just for beauty)
+        parameter<std::string>("NAME",
+            {.description = "User specified name for solver block", .default_value = "No_name"}),
+
+        // Parameters for AMGnxn Preconditioner
+        parameter<std::string>("AMGNXN_TYPE",
+            {.description = "Name of the pre-built preconditioner to be used. If set "
+                            "to\"XML\" the preconditioner is defined using a xml file",
+                .default_value = "AMG(BGS)"}),
+
+        Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>(
+            "AMGNXN_XML_FILE", {.description = "xml file defining the AMGnxn preconditioner"}),
+    });
   }
 
 

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -7,8 +7,8 @@
 
 #include "4C_inpar_solver.hpp"
 
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_linear_solver_method.hpp"
-#include "4C_utils_parameter_list.hpp"
 
 #include <BelosTypes.hpp>
 

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -7,9 +7,8 @@
 
 #include "4C_inpar_solver_nonlin.hpp"
 
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_solver_nonlin_nox_enum_lists.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -22,408 +22,342 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
   /*----------------------------------------------------------------------*
    * parameters for NOX - non-linear solution
    *----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs snox{"STRUCT NOX"};
+  list["STRUCT NOX"] = all_of({
 
-  {
-    std::vector<std::string> nonlinear_solver_valid_input = {"Line Search Based",
-        "Pseudo Transient", "Trust Region Based", "Inexact Trust Region Based", "Tensor Based",
-        "Single Step"};
-
-    snox.specs.emplace_back(
-        deprecated_selection<std::string>("Nonlinear Solver", nonlinear_solver_valid_input,
-            {.description = "Choose a nonlinear solver method.",
-                .default_value = "Line Search Based"}));
-  }
-  snox.move_into_collection(list);
+      deprecated_selection<std::string>("Nonlinear Solver",
+          {"Line Search Based", "Pseudo Transient", "Trust Region Based",
+              "Inexact Trust Region Based", "Tensor Based", "Single Step"},
+          {.description = "Choose a nonlinear solver method.",
+              .default_value = "Line Search Based"})});
 
   // sub-list direction
-  Core::Utils::SectionSpecs direction{snox, "Direction"};
+  list["STRUCT NOX/Direction"] = all_of({
 
-  {
-    std::vector<std::string> newton_method_valid_input = {
-        "Newton", "Steepest Descent", "NonlinearCG", "Broyden", "User Defined"};
-    direction.specs.emplace_back(
-        deprecated_selection<std::string>("Method", newton_method_valid_input,
-            {.description = "Choose a direction method for the nonlinear solver.",
-                .default_value = "Newton"}));
+      deprecated_selection<std::string>("Method",
+          {"Newton", "Steepest Descent", "NonlinearCG", "Broyden", "User Defined"},
+          {.description = "Choose a direction method for the nonlinear solver.",
+              .default_value = "Newton"}),
 
-    std::vector<std::string> user_defined_method_valid_input = {"Newton", "Modified Newton"};
-    direction.specs.emplace_back(
-        deprecated_selection<std::string>("User Defined Method", user_defined_method_valid_input,
-            {.description = "Choose a user-defined direction method.",
-                .default_value = "Modified Newton"}));
-  }
-  direction.move_into_collection(list);
+
+      deprecated_selection<std::string>("User Defined Method", {"Newton", "Modified Newton"},
+          {.description = "Choose a user-defined direction method.",
+              .default_value = "Modified Newton"})});
 
   // sub-sub-list "Newton"
-  Core::Utils::SectionSpecs newton{direction, "Newton"};
+  list["STRUCT NOX/Direction/Newton"] = all_of({
 
-  {
-    std::vector<std::string> forcing_term_valid_input = {"Constant", "Type 1", "Type 2"};
-    newton.specs.emplace_back(deprecated_selection<std::string>("Forcing Term Method",
-        forcing_term_valid_input, {.description = "", .default_value = "Constant"}));
+      deprecated_selection<std::string>("Forcing Term Method", {"Constant", "Type 1", "Type 2"},
+          {.description = "", .default_value = "Constant"}),
 
-    newton.specs.emplace_back(parameter<double>("Forcing Term Initial Tolerance",
-        {.description = "initial linear solver tolerance", .default_value = 0.1}));
-    newton.specs.emplace_back(parameter<double>(
-        "Forcing Term Minimum Tolerance", {.description = "", .default_value = 1.0e-6}));
-    newton.specs.emplace_back(parameter<double>(
-        "Forcing Term Maximum Tolerance", {.description = "", .default_value = 0.01}));
-    newton.specs.emplace_back(parameter<double>(
-        "Forcing Term Alpha", {.description = "used only by \"Type 2\"", .default_value = 1.5}));
-    newton.specs.emplace_back(parameter<double>(
-        "Forcing Term Gamma", {.description = "used only by \"Type 2\"", .default_value = 0.9}));
-    newton.specs.emplace_back(parameter<bool>("Rescue Bad Newton Solve",
-        {.description = "If set to true, we will use the computed direction even if the linear "
-                        "solve does not achieve the tolerance specified by the forcing term",
-            .default_value = true}));
-  }
-  newton.move_into_collection(list);
+      parameter<double>("Forcing Term Initial Tolerance",
+          {.description = "initial linear solver tolerance", .default_value = 0.1}),
+      parameter<double>(
+          "Forcing Term Minimum Tolerance", {.description = "", .default_value = 1.0e-6}),
+      parameter<double>(
+          "Forcing Term Maximum Tolerance", {.description = "", .default_value = 0.01}),
+      parameter<double>(
+          "Forcing Term Alpha", {.description = "used only by \"Type 2\"", .default_value = 1.5}),
+      parameter<double>(
+          "Forcing Term Gamma", {.description = "used only by \"Type 2\"", .default_value = 0.9}),
+      parameter<bool>("Rescue Bad Newton Solve",
+          {.description = "If set to true, we will use the computed direction even if the linear "
+                          "solve does not achieve the tolerance specified by the forcing term",
+              .default_value = true})});
 
   // sub-sub-list "Steepest Descent"
-  Core::Utils::SectionSpecs steepestdescent{direction, "Steepest Descent"};
+  list["STRUCT NOX/Direction/Steepest Descent"] = all_of({
 
-  {
-    std::vector<std::string> scaling_type_valid_input = {
-        "2-Norm", "Quadratic Model Min", "F 2-Norm", "None"};
-    steepestdescent.specs.emplace_back(deprecated_selection<std::string>(
-        "Scaling Type", scaling_type_valid_input, {.description = "", .default_value = "None"}));
-  }
-  steepestdescent.move_into_collection(list);
+      deprecated_selection<std::string>("Scaling Type",
+          {"2-Norm", "Quadratic Model Min", "F 2-Norm", "None"},
+          {.description = "", .default_value = "None"})});
 
   // sub-list "Pseudo Transient"
-  Core::Utils::SectionSpecs ptc{snox, "Pseudo Transient"};
+  list["STRUCT NOX/Pseudo Transient"] = all_of({
 
-  {
-    ptc.specs.emplace_back(parameter<double>(
-        "deltaInit", {.description = "Initial time step size. If its negative, the initial time "
-                                     "step is calculated automatically.",
-                         .default_value = -1.0}));
-    ptc.specs.emplace_back(parameter<double>("deltaMax",
-        {.description =
-                "Maximum time step size. If the new step size is greater than this value, the "
-                "transient terms will be eliminated from the Newton iteration resulting in a full "
-                "Newton solve.",
-            .default_value = std::numeric_limits<double>::max()}));
-    ptc.specs.emplace_back(parameter<double>(
-        "deltaMin", {.description = "Minimum step size.", .default_value = 1.0e-5}));
-    ptc.specs.emplace_back(parameter<int>("Max Number of PTC Iterations",
-        {.description = "", .default_value = std::numeric_limits<int>::max()}));
-    ptc.specs.emplace_back(
-        parameter<double>("SER_alpha", {.description = "Exponent of SET.", .default_value = 1.0}));
-    ptc.specs.emplace_back(parameter<double>(
-        "ScalingFactor", {.description = "Scaling Factor for ptc matrix.", .default_value = 1.0}));
+      parameter<double>(
+          "deltaInit", {.description = "Initial time step size. If its negative, the initial time "
+                                       "step is calculated automatically.",
+                           .default_value = -1.0}),
+      parameter<double>("deltaMax",
+          {.description =
+                  "Maximum time step size. If the new step size is greater than this value, the "
+                  "transient terms will be eliminated from the Newton iteration resulting in a "
+                  "full "
+                  "Newton solve.",
+              .default_value = std::numeric_limits<double>::max()}),
+      parameter<double>("deltaMin", {.description = "Minimum step size.", .default_value = 1.0e-5}),
+      parameter<int>("Max Number of PTC Iterations",
+          {.description = "", .default_value = std::numeric_limits<int>::max()}),
 
-    std::vector<std::string> time_step_control_valid_input = {"SER",
-        "Switched Evolution Relaxation", "TTE", "Temporal Truncation Error", "MRR",
-        "Model Reduction Ratio"};
-    ptc.specs.emplace_back(deprecated_selection<std::string>("Time Step Control",
-        time_step_control_valid_input, {.description = "", .default_value = "SER"}));
+      parameter<double>("SER_alpha", {.description = "Exponent of SET.", .default_value = 1.0}),
+      parameter<double>(
+          "ScalingFactor", {.description = "Scaling Factor for ptc matrix.", .default_value = 1.0}),
 
-    std::vector<std::string> tsc_norm_type_valid_input = {"Two Norm", "One Norm", "Max Norm"};
-    ptc.specs.emplace_back(
-        deprecated_selection<std::string>("Norm Type for TSC", tsc_norm_type_valid_input,
-            {.description = "Norm Type for the time step control", .default_value = "Max Norm"}));
+      deprecated_selection<std::string>("Time Step Control",
+          {"SER", "Switched Evolution Relaxation", "TTE", "Temporal Truncation Error", "MRR",
+              "Model Reduction Ratio"},
+          {.description = "", .default_value = "SER"}),
 
-    std::vector<std::string> scaling_op_valid_input = {
-        "Identity", "CFL Diagonal", "Lumped Mass", "Element based"};
-    ptc.specs.emplace_back(deprecated_selection<std::string>("Scaling Type", scaling_op_valid_input,
-        {.description = "Type of the scaling matrix for the PTC method.",
-            .default_value = "Identity"}));
 
-    std::vector<std::string> build_scale_op_valid_input = {"every iter", "every timestep"};
-    ptc.specs.emplace_back(
-        deprecated_selection<std::string>("Build scaling operator", build_scale_op_valid_input,
-            {.description = "Build scaling operator in every iteration or timestep",
-                .default_value = "every timestep"}));
-  }
-  ptc.move_into_collection(list);
+      deprecated_selection<std::string>("Norm Type for TSC", {"Two Norm", "One Norm", "Max Norm"},
+          {.description = "Norm Type for the time step control", .default_value = "Max Norm"}),
+
+      deprecated_selection<std::string>("Scaling Type",
+          {"Identity", "CFL Diagonal", "Lumped Mass", "Element based"},
+          {.description = "Type of the scaling matrix for the PTC method.",
+              .default_value = "Identity"}),
+
+
+      deprecated_selection<std::string>("Build scaling operator", {"every iter", "every timestep"},
+          {.description = "Build scaling operator in every iteration or timestep",
+              .default_value = "every timestep"})});
 
   // sub-list "Line Search"
-  Core::Utils::SectionSpecs linesearch{snox, "Line Search"};
+  list["STRUCT NOX/Line Search"] = all_of({
 
-  {
-    std::vector<std::string> method_valid_input = {
-        "Full Step", "Backtrack", "Polynomial", "More'-Thuente", "User Defined"};
-    linesearch.specs.emplace_back(deprecated_selection<std::string>(
-        "Method", method_valid_input, {.description = "", .default_value = "Full Step"}));
+      deprecated_selection<std::string>("Method",
+          {"Full Step", "Backtrack", "Polynomial", "More'-Thuente", "User Defined"},
+          {.description = "", .default_value = "Full Step"}),
 
 
-    linesearch.specs.emplace_back(
-        deprecated_selection<::NOX::StatusTest::CheckType>("Inner Status Test Check Type",
-            {
-                {"Complete", ::NOX::StatusTest::Complete},
-                {"Minimal", ::NOX::StatusTest::Minimal},
-                {"None", ::NOX::StatusTest::None},
-            },
-            {.description = "Specify the check type for the inner status tests.",
-                .default_value = ::NOX::StatusTest::Minimal}));
-  }
-  linesearch.move_into_collection(list);
+
+      deprecated_selection<::NOX::StatusTest::CheckType>("Inner Status Test Check Type",
+          {
+              {"Complete", ::NOX::StatusTest::Complete},
+              {"Minimal", ::NOX::StatusTest::Minimal},
+              {"None", ::NOX::StatusTest::None},
+          },
+          {.description = "Specify the check type for the inner status tests.",
+              .default_value = ::NOX::StatusTest::Minimal})});
 
   // sub-sub-list "Full Step"
-  Core::Utils::SectionSpecs fullstep{linesearch, "Full Step"};
+  list["STRUCT NOX/Line Search/Full Step"] = all_of({
 
-  {
-    fullstep.specs.emplace_back(parameter<double>(
-        "Full Step", {.description = "length of a full step", .default_value = 1.0}));
-  }
-  fullstep.move_into_collection(list);
+      parameter<double>(
+          "Full Step", {.description = "length of a full step", .default_value = 1.0})});
 
   // sub-sub-list "Backtrack"
-  Core::Utils::SectionSpecs backtrack{linesearch, "Backtrack"};
+  list["STRUCT NOX/Line Search/Backtrack"] = all_of({
 
-  {
-    backtrack.specs.emplace_back(parameter<double>(
-        "Default Step", {.description = "starting step length", .default_value = 1.0}));
-    backtrack.specs.emplace_back(parameter<double>("Minimum Step",
-        {.description = "minimum acceptable step length", .default_value = 1.0e-12}));
-    backtrack.specs.emplace_back(parameter<double>("Recovery Step",
-        {.description =
-                "step to take when the line search fails (defaults to value for \"Default Step\")",
-            .default_value = 1.0}));
-    backtrack.specs.emplace_back(parameter<int>(
-        "Max Iters", {.description = "maximum number of iterations", .default_value = 50}));
-    backtrack.specs.emplace_back(parameter<double>(
-        "Reduction Factor", {.description = "A multiplier between zero and one that reduces the "
-                                            "step size between line search iterations",
-                                .default_value = 0.5}));
-    backtrack.specs.emplace_back(parameter<bool>("Allow Exceptions",
-        {.description = "Set to true, if exceptions during the force evaluation and backtracking "
-                        "routine should be allowed.",
-            .default_value = false}));
-  }
-  backtrack.move_into_collection(list);
+      parameter<double>(
+          "Default Step", {.description = "starting step length", .default_value = 1.0}),
+      parameter<double>("Minimum Step",
+          {.description = "minimum acceptable step length", .default_value = 1.0e-12}),
+      parameter<double>("Recovery Step", {.description = "step to take when the line search fails "
+                                                         "(defaults to value for \"Default Step\")",
+                                             .default_value = 1.0}),
+      parameter<int>(
+          "Max Iters", {.description = "maximum number of iterations", .default_value = 50}),
+      parameter<double>(
+          "Reduction Factor", {.description = "A multiplier between zero and one that reduces the "
+                                              "step size between line search iterations",
+                                  .default_value = 0.5}),
+      parameter<bool>("Allow Exceptions",
+          {.description = "Set to true, if exceptions during the force evaluation and backtracking "
+                          "routine should be allowed.",
+              .default_value = false})});
 
   // sub-sub-list "Polynomial"
-  Core::Utils::SectionSpecs polynomial{linesearch, "Polynomial"};
+  list["STRUCT NOX/Line Search/Polynomial"] = all_of({
 
-  {
-    polynomial.specs.emplace_back(parameter<double>(
-        "Default Step", {.description = "Starting step length", .default_value = 1.0}));
-    polynomial.specs.emplace_back(parameter<int>(
-        "Max Iters", {.description = "Maximum number of line search iterations. The search "
-                                     "fails if the number of iterations exceeds this value",
-                         .default_value = 100}));
-    polynomial.specs.emplace_back(parameter<double>(
-        "Minimum Step", {.description = "Minimum acceptable step length. The search fails if the "
-                                        "computed $\\lambda_k$ is less than this value",
-                            .default_value = 1.0e-12}));
+      parameter<double>(
+          "Default Step", {.description = "Starting step length", .default_value = 1.0}),
+      parameter<int>(
+          "Max Iters", {.description = "Maximum number of line search iterations. The search "
+                                       "fails if the number of iterations exceeds this value",
+                           .default_value = 100}),
+      parameter<double>(
+          "Minimum Step", {.description = "Minimum acceptable step length. The search fails if the "
+                                          "computed $\\lambda_k$ is less than this value",
+                              .default_value = 1.0e-12}),
 
-    std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
-    polynomial.specs.emplace_back(
-        deprecated_selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
-            {.description = "Determines the step size to take when the line search fails",
-                .default_value = "Constant"}));
 
-    polynomial.specs.emplace_back(parameter<double>(
-        "Recovery Step", {.description = "The value of the step to take when the line search "
-                                         "fails. Only used if the \"Recovery "
-                                         "Step Type\" is set to \"Constant\"",
-                             .default_value = 1.0}));
+      deprecated_selection<std::string>("Recovery Step Type", {"Constant", "Last Computed Step"},
+          {.description = "Determines the step size to take when the line search fails",
+              .default_value = "Constant"}),
 
-    std::vector<std::string> interpolation_type_valid_input = {"Quadratic", "Quadratic3", "Cubic"};
-    polynomial.specs.emplace_back(deprecated_selection<std::string>("Interpolation Type",
-        interpolation_type_valid_input,
-        {.description = "Type of interpolation that should be used", .default_value = "Cubic"}));
+      parameter<double>(
+          "Recovery Step", {.description = "The value of the step to take when the line search "
+                                           "fails. Only used if the \"Recovery "
+                                           "Step Type\" is set to \"Constant\"",
+                               .default_value = 1.0}),
 
-    polynomial.specs.emplace_back(parameter<double>("Min Bounds Factor",
-        {.description = "Choice for $\\gamma_{\\min}$, i.e., the factor that limits the minimum "
-                        "size of the new step based on the previous step",
-            .default_value = 0.1}));
-    polynomial.specs.emplace_back(parameter<double>("Max Bounds Factor",
-        {.description = "Choice for $\\gamma_{\\max}$, i.e., the factor that limits the maximum "
-                        "size of the new step based on the previous step",
-            .default_value = 0.5}));
 
-    std::vector<std::string> sufficient_decrease_condition_valid_input = {
-        "Armijo-Goldstein", "Ared/Pred", "None"};
-    polynomial.specs.emplace_back(deprecated_selection<std::string>("Sufficient Decrease Condition",
-        sufficient_decrease_condition_valid_input,
-        {.description = "Choice to use for the sufficient decrease condition",
-            .default_value = "Armijo-Goldstein"}));
+      deprecated_selection<std::string>("Interpolation Type", {"Quadratic", "Quadratic3", "Cubic"},
+          {.description = "Type of interpolation that should be used", .default_value = "Cubic"}),
 
-    polynomial.specs.emplace_back(parameter<double>(
-        "Alpha Factor", {.description = "Parameter choice for sufficient decrease condition",
-                            .default_value = 1.0e-4}));
-    polynomial.specs.emplace_back(parameter<bool>("Force Interpolation",
-        {.description = "Set to true if at least one interpolation step should be used. The "
-                        "default is false which means that the line search will stop if the "
-                        "default step length satisfies the convergence criteria",
-            .default_value = false}));
-    polynomial.specs.emplace_back(parameter<bool>("Use Counters",
-        {.description = "Set to true if we should use counters and then output the result to the "
-                        "parameter list as described in Output Parameters",
-            .default_value = true}));
-    polynomial.specs.emplace_back(parameter<int>("Maximum Iteration for Increase",
-        {.description =
-                "Maximum index of the nonlinear iteration for which we allow a relative increase",
-            .default_value = 0}));
-    polynomial.specs.emplace_back(parameter<double>(
-        "Allowed Relative Increase", {.description = "", .default_value = 100.0}));
-  }
-  polynomial.move_into_collection(list);
+      parameter<double>("Min Bounds Factor",
+          {.description = "Choice for $\\gamma_{\\min}$, i.e., the factor that limits the minimum "
+                          "size of the new step based on the previous step",
+              .default_value = 0.1}),
+      parameter<double>("Max Bounds Factor",
+          {.description = "Choice for $\\gamma_{\\max}$, i.e., the factor that limits the maximum "
+                          "size of the new step based on the previous step",
+              .default_value = 0.5}),
+
+      deprecated_selection<std::string>("Sufficient Decrease Condition",
+          {"Armijo-Goldstein", "Ared/Pred", "None"},
+          {.description = "Choice to use for the sufficient decrease condition",
+              .default_value = "Armijo-Goldstein"}),
+
+      parameter<double>(
+          "Alpha Factor", {.description = "Parameter choice for sufficient decrease condition",
+                              .default_value = 1.0e-4}),
+      parameter<bool>("Force Interpolation",
+          {.description = "Set to true if at least one interpolation step should be used. The "
+                          "default is false which means that the line search will stop if the "
+                          "default step length satisfies the convergence criteria",
+              .default_value = false}),
+      parameter<bool>("Use Counters",
+          {.description = "Set to true if we should use counters and then output the result to the "
+                          "parameter list as described in Output Parameters",
+              .default_value = true}),
+      parameter<int>("Maximum Iteration for Increase",
+          {.description =
+                  "Maximum index of the nonlinear iteration for which we allow a relative increase",
+              .default_value = 0}),
+
+      parameter<double>("Allowed Relative Increase", {.description = "", .default_value = 100.0})});
 
   // sub-sub-list "More'-Thuente"
-  Core::Utils::SectionSpecs morethuente{linesearch, "More'-Thuente"};
+  list["STRUCT NOX/Line Search/More'-Thuente"] = all_of({
 
-  {
-    morethuente.specs.emplace_back(parameter<double>("Sufficient Decrease",
-        {.description = "The ftol in the sufficient decrease condition", .default_value = 1.0e-4}));
-    morethuente.specs.emplace_back(parameter<double>("Curvature Condition",
-        {.description = "The gtol in the curvature condition", .default_value = 0.9999}));
-    morethuente.specs.emplace_back(parameter<double>("Interval Width",
-        {.description =
-                "The maximum width of the interval containing the minimum of the modified function",
-            .default_value = 1.0e-15}));
-    morethuente.specs.emplace_back(parameter<double>(
-        "Maximum Step", {.description = "maximum allowable step length", .default_value = 1.0e6}));
-    morethuente.specs.emplace_back(parameter<double>("Minimum Step",
-        {.description = "minimum allowable step length", .default_value = 1.0e-12}));
-    morethuente.specs.emplace_back(parameter<int>("Max Iters",
-        {.description = "maximum number of right-hand-side and corresponding Jacobian evaluations",
-            .default_value = 20}));
-    morethuente.specs.emplace_back(parameter<double>(
-        "Default Step", {.description = "starting step length", .default_value = 1.0}));
+      parameter<double>(
+          "Sufficient Decrease", {.description = "The ftol in the sufficient decrease condition",
+                                     .default_value = 1.0e-4}),
+      parameter<double>("Curvature Condition",
+          {.description = "The gtol in the curvature condition", .default_value = 0.9999}),
+      parameter<double>(
+          "Interval Width", {.description = "The maximum width of the interval containing the "
+                                            "minimum of the modified function",
+                                .default_value = 1.0e-15}),
+      parameter<double>(
+          "Maximum Step", {.description = "maximum allowable step length", .default_value = 1.0e6}),
+      parameter<double>("Minimum Step",
+          {.description = "minimum allowable step length", .default_value = 1.0e-12}),
+      parameter<int>("Max Iters",
+          {.description =
+                  "maximum number of right-hand-side and corresponding Jacobian evaluations",
+              .default_value = 20}),
+      parameter<double>(
+          "Default Step", {.description = "starting step length", .default_value = 1.0}),
 
-    std::vector<std::string> recovery_step_type_valid_input = {"Constant", "Last Computed Step"};
-    morethuente.specs.emplace_back(
-        deprecated_selection<std::string>("Recovery Step Type", recovery_step_type_valid_input,
-            {.description = "Determines the step size to take when the line search fails",
-                .default_value = "Constant"}));
 
-    morethuente.specs.emplace_back(parameter<double>(
-        "Recovery Step", {.description = "The value of the step to take when the line search "
-                                         "fails. Only used if the \"Recovery "
-                                         "Step Type\" is set to \"Constant\"",
-                             .default_value = 1.0}));
+      deprecated_selection<std::string>("Recovery Step Type", {"Constant", "Last Computed Step"},
+          {.description = "Determines the step size to take when the line search fails",
+              .default_value = "Constant"}),
 
-    std::vector<std::string> sufficient_decrease_condition_valid_input = {
-        "Armijo-Goldstein", "Ared/Pred", "None"};
-    morethuente.specs.emplace_back(deprecated_selection<std::string>(
-        "Sufficient Decrease Condition", sufficient_decrease_condition_valid_input,
-        {.description = "Choice to use for the sufficient decrease condition",
-            .default_value = "Armijo-Goldstein"}));
+      parameter<double>(
+          "Recovery Step", {.description = "The value of the step to take when the line search "
+                                           "fails. Only used if the \"Recovery "
+                                           "Step Type\" is set to \"Constant\"",
+                               .default_value = 1.0}),
 
-    morethuente.specs.emplace_back(parameter<bool>("Optimize Slope Calculation",
-        {.description = "Boolean value. If set to true the value of $s^T J^T F$ is estimated using "
-                        "a directional derivative in a call to "
-                        "::NOX::LineSearch::Common::computeSlopeWithOutJac. If false the slope "
-                        "computation is computed with the ::NOX::LineSearch::Common::computeSlope "
-                        "method. Setting this to true eliminates having to compute the Jacobian at "
-                        "each inner iteration of the More'-Thuente line search",
-            .default_value = false}));
-  }
-  morethuente.move_into_collection(list);
+      deprecated_selection<std::string>("Sufficient Decrease Condition",
+          {"Armijo-Goldstein", "Ared/Pred", "None"},
+          {.description = "Choice to use for the sufficient decrease condition",
+              .default_value = "Armijo-Goldstein"}),
+
+      parameter<bool>("Optimize Slope Calculation",
+          {.description =
+                  "Boolean value. If set to true the value of $s^T J^T F$ is estimated using "
+                  "a directional derivative in a call to "
+                  "::NOX::LineSearch::Common::computeSlopeWithOutJac. If false the slope "
+                  "computation is computed with the ::NOX::LineSearch::Common::computeSlope "
+                  "method. Setting this to true eliminates having to compute the Jacobian at "
+                  "each inner iteration of the More'-Thuente line search",
+              .default_value = false})});
 
   // sub-list "Trust Region"
-  Core::Utils::SectionSpecs trustregion{snox, "Trust Region"};
+  list["STRUCT NOX/Trust Region"] = all_of({
 
-  {
-    trustregion.specs.emplace_back(parameter<double>("Minimum Trust Region Radius",
-        {.description = "Minimum allowable trust region radius", .default_value = 1.0e-6}));
-    trustregion.specs.emplace_back(parameter<double>("Maximum Trust Region Radius",
-        {.description = "Maximum allowable trust region radius", .default_value = 1.0e+9}));
-    trustregion.specs.emplace_back(parameter<double>("Minimum Improvement Ratio",
-        {.description = "Minimum improvement ratio to accept the step", .default_value = 1.0e-4}));
-    trustregion.specs.emplace_back(parameter<double>("Contraction Trigger Ratio",
-        {.description =
-                "If the improvement ratio is less than this value, then the trust region is "
-                "contracted by "
-                "the amount specified by the \"Contraction Factor\". Must be larger than \"Minimum "
-                "Improvement Ratio\"",
-            .default_value = 0.1}));
-    trustregion.specs.emplace_back(
-        parameter<double>("Contraction Factor", {.description = "", .default_value = 0.25}));
-    trustregion.specs.emplace_back(parameter<double>("Expansion Trigger Ratio",
-        {.description = "If the improvement ratio is greater than this value, then the trust "
-                        "region is contracted "
-                        "by the amount specified by the \"Expansion Factor\"",
-            .default_value = 0.75}));
-    trustregion.specs.emplace_back(
-        parameter<double>("Expansion Factor", {.description = "", .default_value = 4.0}));
-    trustregion.specs.emplace_back(
-        parameter<double>("Recovery Step", {.description = "", .default_value = 1.0}));
-  }
-  trustregion.move_into_collection(list);
+      parameter<double>("Minimum Trust Region Radius",
+          {.description = "Minimum allowable trust region radius", .default_value = 1.0e-6}),
+      parameter<double>("Maximum Trust Region Radius",
+          {.description = "Maximum allowable trust region radius", .default_value = 1.0e+9}),
+      parameter<double>("Minimum Improvement Ratio",
+          {.description = "Minimum improvement ratio to accept the step", .default_value = 1.0e-4}),
+      parameter<double>("Contraction Trigger Ratio",
+          {.description =
+                  "If the improvement ratio is less than this value, then the trust region is "
+                  "contracted by "
+                  "the amount specified by the \"Contraction Factor\". Must be larger than "
+                  "\"Minimum "
+                  "Improvement Ratio\"",
+              .default_value = 0.1}),
+
+      parameter<double>("Contraction Factor", {.description = "", .default_value = 0.25}),
+      parameter<double>("Expansion Trigger Ratio",
+          {.description = "If the improvement ratio is greater than this value, then the trust "
+                          "region is contracted "
+                          "by the amount specified by the \"Expansion Factor\"",
+              .default_value = 0.75}),
+
+      parameter<double>("Expansion Factor", {.description = "", .default_value = 4.0}),
+
+      parameter<double>("Recovery Step", {.description = "", .default_value = 1.0})});
 
   // sub-list "Printing"
-  Core::Utils::SectionSpecs printing{snox, "Printing"};
+  list["STRUCT NOX/Printing"] = all_of({
 
-  {
-    printing.specs.emplace_back(
-        parameter<bool>("Error", {.description = "", .default_value = false}));
-    printing.specs.emplace_back(
-        parameter<bool>("Warning", {.description = "", .default_value = true}));
-    printing.specs.emplace_back(
-        parameter<bool>("Outer Iteration", {.description = "", .default_value = true}));
-    printing.specs.emplace_back(
-        parameter<bool>("Inner Iteration", {.description = "", .default_value = true}));
-    printing.specs.emplace_back(
-        parameter<bool>("Parameters", {.description = "", .default_value = false}));
-    printing.specs.emplace_back(
-        parameter<bool>("Details", {.description = "", .default_value = false}));
-    printing.specs.emplace_back(
-        parameter<bool>("Outer Iteration StatusTest", {.description = "", .default_value = true}));
-    printing.specs.emplace_back(
-        parameter<bool>("Linear Solver Details", {.description = "", .default_value = false}));
-    printing.specs.emplace_back(
-        parameter<bool>("Test Details", {.description = "", .default_value = false}));
-    printing.specs.emplace_back(
-        parameter<bool>("Debug", {.description = "", .default_value = false}));
-  }
-  printing.move_into_collection(list);
+      parameter<bool>("Error", {.description = "", .default_value = false}),
+
+      parameter<bool>("Warning", {.description = "", .default_value = true}),
+
+      parameter<bool>("Outer Iteration", {.description = "", .default_value = true}),
+
+      parameter<bool>("Inner Iteration", {.description = "", .default_value = true}),
+
+      parameter<bool>("Parameters", {.description = "", .default_value = false}),
+
+      parameter<bool>("Details", {.description = "", .default_value = false}),
+
+      parameter<bool>("Outer Iteration StatusTest", {.description = "", .default_value = true}),
+
+      parameter<bool>("Linear Solver Details", {.description = "", .default_value = false}),
+
+      parameter<bool>("Test Details", {.description = "", .default_value = false}),
+
+      parameter<bool>("Debug", {.description = "", .default_value = false})});
 
   // sub-list "Status Test"
-  Core::Utils::SectionSpecs statusTest{snox, "Status Test"};
+  list["STRUCT NOX/Status Test"] = all_of({
 
-  {
-    statusTest.specs.emplace_back(
-        Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>("XML File",
-            {.description = "Filename of XML file with configuration of nox status test"}));
-  }
-  statusTest.move_into_collection(list);
+      Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>("XML File",
+          {.description = "Filename of XML file with configuration of nox status test"})});
 
   // sub-list "Solver Options"
-  Core::Utils::SectionSpecs solverOptions{snox, "Solver Options"};
+  list["STRUCT NOX/Solver Options"] = all_of({
 
-  {
-    solverOptions.specs.emplace_back(
-        deprecated_selection<NOX::Nln::MeritFunction::MeritFctName>("Merit Function",
-            {
-                {"Sum of Squares", NOX::Nln::MeritFunction::mrtfct_sum_of_squares},
-            },
-            {.description = "", .default_value = NOX::Nln::MeritFunction::mrtfct_sum_of_squares}));
+      deprecated_selection<NOX::Nln::MeritFunction::MeritFctName>("Merit Function",
+          {
+              {"Sum of Squares", NOX::Nln::MeritFunction::mrtfct_sum_of_squares},
+          },
+          {.description = "", .default_value = NOX::Nln::MeritFunction::mrtfct_sum_of_squares}),
 
-    std::vector<std::string> status_test_check_type_valid_input = {"Complete", "Minimal", "None"};
-    solverOptions.specs.emplace_back(deprecated_selection<std::string>("Status Test Check Type",
-        status_test_check_type_valid_input, {.description = "", .default_value = "Complete"}));
-  }
-  solverOptions.move_into_collection(list);
+      deprecated_selection<std::string>("Status Test Check Type", {"Complete", "Minimal", "None"},
+          {.description = "", .default_value = "Complete"})});
 
   // sub-sub-sub-list "Linear Solver"
-  Core::Utils::SectionSpecs linearSolver{newton, "Linear Solver"};
+  list["STRUCT NOX/Direction/Newton/Linear Solver"] = all_of({
 
-  {
-    // convergence criteria adaptivity
-    linearSolver.specs.emplace_back(parameter<bool>("Adaptive Control",
-        {.description =
-                "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-            .default_value = false}));
-    linearSolver.specs.emplace_back(parameter<double>("Adaptive Control Objective",
-        {.description = "The linear solver shall be this much better than the current nonlinear "
-                        "residual in the nonlinear convergence limit",
-            .default_value = 0.1}));
-    linearSolver.specs.emplace_back(parameter<bool>("Zero Initial Guess",
-        {.description = "Zero out the delta X vector if requested.", .default_value = true}));
-    linearSolver.specs.emplace_back(parameter<bool>("Computing Scaling Manually",
-        {.description =
-                "Allows the manually scaling of your linear system (not supported at the moment).",
-            .default_value = false}));
-    linearSolver.specs.emplace_back(parameter<bool>("Output Solver Details",
-        {.description = "Switch the linear solver output on and off.", .default_value = true}));
-  }
-  linearSolver.move_into_collection(list);
+      // convergence criteria adaptivity
+      parameter<bool>("Adaptive Control",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("Adaptive Control Objective",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
+      parameter<bool>("Zero Initial Guess",
+          {.description = "Zero out the delta X vector if requested.", .default_value = true}),
+      parameter<bool>("Computing Scaling Manually",
+          {.description = "Allows the manually scaling of your linear system (not supported at the "
+                          "moment).",
+              .default_value = false}),
+      parameter<bool>("Output Solver Details",
+          {.description = "Switch the linear solver output on and off.", .default_value = true})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -13,8 +13,6 @@
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_sparseoperator.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -22,173 +22,173 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs ssidyn{"SSI CONTROL"};
+  list["SSI CONTROL"] = all_of({
 
-  // Output type
-  ssidyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0.0}));
-  ssidyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
-  // Time loop control
-  ssidyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  ssidyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  ssidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
-  ssidyn.specs.emplace_back(parameter<bool>("DIFFTIMESTEPSIZE",
-      {.description = "use different step size for scatra and solid", .default_value = false}));
-  ssidyn.specs.emplace_back(parameter<double>(
-      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0.0}));
-  ssidyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
-  ssidyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  ssidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",
-      {.description = "read scatra result from restart files (use option 'restartfromfile' during "
-                      "execution of 4C)",
-          .default_value = false}));
-  ssidyn.specs.emplace_back(parameter<std::string>(
-      "SCATRA_FILENAME", {.description = "Control-file name for reading scatra results in SSI",
-                             .default_value = "nil"}));
+      // Output type
+      parameter<double>(
+          "RESTARTEVERYTIME", {.description = "write restart possibility every RESTARTEVERY steps",
+                                  .default_value = 0.0}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
+      // Time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  // Type of coupling strategy between the two fields
-  ssidyn.specs.emplace_back(deprecated_selection<FieldCoupling>("FIELDCOUPLING",
-      {
-          {"volume_matching", FieldCoupling::volume_match},
-          {"volume_nonmatching", FieldCoupling::volume_nonmatch},
-          {"boundary_nonmatching", FieldCoupling::boundary_nonmatch},
-          {"volumeboundary_matching", FieldCoupling::volumeboundary_match},
-      },
-      {.description = "Type of coupling strategy between fields",
-          .default_value = FieldCoupling::volume_match}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}),
+      parameter<bool>("DIFFTIMESTEPSIZE",
+          {.description = "use different step size for scatra and solid", .default_value = false}),
+      parameter<double>("RESULTSEVERYTIME",
+          {.description = "increment for writing solution", .default_value = 0.0}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<bool>("SCATRA_FROM_RESTART_FILE",
+          {.description =
+                  "read scatra result from restart files (use option 'restartfromfile' during "
+                  "execution of 4C)",
+              .default_value = false}),
+      parameter<std::string>(
+          "SCATRA_FILENAME", {.description = "Control-file name for reading scatra results in SSI",
+                                 .default_value = "nil"}),
 
-  // Coupling strategy for SSI solvers
-  ssidyn.specs.emplace_back(parameter<SolutionSchemeOverFields>(
-      "COUPALGO", {.description = "Coupling strategies for SSI solvers",
-                      .default_value = SolutionSchemeOverFields::ssi_IterStagg}));
+      // Type of coupling strategy between the two fields
+      deprecated_selection<FieldCoupling>("FIELDCOUPLING",
+          {
+              {"volume_matching", FieldCoupling::volume_match},
+              {"volume_nonmatching", FieldCoupling::volume_nonmatch},
+              {"boundary_nonmatching", FieldCoupling::boundary_nonmatch},
+              {"volumeboundary_matching", FieldCoupling::volumeboundary_match},
+          },
+          {.description = "Type of coupling strategy between fields",
+              .default_value = FieldCoupling::volume_match}),
 
-  // type of scalar transport time integration
-  ssidyn.specs.emplace_back(deprecated_selection<ScaTraTimIntType>("SCATRATIMINTTYPE",
-      {
-          {"Standard", ScaTraTimIntType::standard},
-          {"Cardiac_Monodomain", ScaTraTimIntType::cardiac_monodomain},
-          {"Elch", ScaTraTimIntType::elch},
-      },
-      {.description = "scalar transport time integration type is needed to instantiate correct "
-                      "scalar transport time integration scheme for ssi problems",
-          .default_value = ScaTraTimIntType::standard}));
+      // Coupling strategy for SSI solvers
+      parameter<SolutionSchemeOverFields>(
+          "COUPALGO", {.description = "Coupling strategies for SSI solvers",
+                          .default_value = SolutionSchemeOverFields::ssi_IterStagg}),
 
-  // Restart from Structure problem instead of SSI
-  ssidyn.specs.emplace_back(parameter<bool>("RESTART_FROM_STRUCTURE",
-      {.description =
-              "restart from structure problem (e.g. from prestress calculations) instead of ssi",
-          .default_value = false}));
+      // type of scalar transport time integration
+      deprecated_selection<ScaTraTimIntType>("SCATRATIMINTTYPE",
+          {
+              {"Standard", ScaTraTimIntType::standard},
+              {"Cardiac_Monodomain", ScaTraTimIntType::cardiac_monodomain},
+              {"Elch", ScaTraTimIntType::elch},
+          },
+          {.description = "scalar transport time integration type is needed to instantiate correct "
+                          "scalar transport time integration scheme for ssi problems",
+              .default_value = ScaTraTimIntType::standard}),
 
-  // Adaptive time stepping
-  ssidyn.specs.emplace_back(parameter<bool>("ADAPTIVE_TIMESTEPPING",
-      {.description = "flag for adaptive time stepping", .default_value = false}));
+      // Restart from Structure problem instead of SSI
+      parameter<bool>(
+          "RESTART_FROM_STRUCTURE", {.description = "restart from structure problem (e.g. from "
+                                                    "prestress calculations) instead of ssi",
+                                        .default_value = false}),
 
-  // do redistribution by binning of solid mechanics discretization (scatra dis is cloned from solid
-  // dis for volume_matching and volumeboundary_matching)
-  ssidyn.specs.emplace_back(parameter<bool>("REDISTRIBUTE_SOLID",
-      {.description = "redistribution by binning of solid mechanics discretization",
-          .default_value = false}));
+      // Adaptive time stepping
+      parameter<bool>("ADAPTIVE_TIMESTEPPING",
+          {.description = "flag for adaptive time stepping", .default_value = false}),
 
-  ssidyn.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      // do redistribution by binning of solid mechanics discretization (scatra dis is cloned from
+      // solid
+      // dis for volume_matching and volumeboundary_matching)
+      parameter<bool>("REDISTRIBUTE_SOLID",
+          {.description = "redistribution by binning of solid mechanics discretization",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
   /* parameters for partitioned SSI */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs ssidynpart{ssidyn, "PARTITIONED"};
+  list["SSI CONTROL/PARTITIONED"] = all_of({
 
-  // Solver parameter for relaxation of iterative staggered partitioned SSI
-  ssidynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
-      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
-  ssidynpart.specs.emplace_back(parameter<double>("MINOMEGA",
-      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
-  ssidynpart.specs.emplace_back(parameter<double>(
-      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
+      // Solver parameter for relaxation of iterative staggered partitioned SSI
+      parameter<double>("MAXOMEGA",
+          {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}),
+      parameter<double>("MINOMEGA",
+          {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}),
+      parameter<double>(
+          "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}),
 
-  // convergence tolerance of outer iteration loop
-  ssidynpart.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description = "tolerance for convergence check of outer iteration within partitioned SSI",
-          .default_value = 1e-6}));
-
-  ssidynpart.move_into_collection(list);
+      // convergence tolerance of outer iteration loop
+      parameter<double>("CONVTOL",
+          {.description =
+                  "tolerance for convergence check of outer iteration within partitioned SSI",
+              .default_value = 1e-6})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for monolithic SSI */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs ssidynmono{ssidyn, "MONOLITHIC"};
+  list["SSI CONTROL/MONOLITHIC"] = all_of({
 
-  // convergence tolerances of Newton-Raphson iteration loop
-  ssidynmono.specs.emplace_back(parameter<double>(
-      "ABSTOLRES", {.description = "absolute tolerance for deciding if global residual of "
-                                   "nonlinear problem is already zero",
-                       .default_value = 1.e-14}));
-  ssidynmono.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description =
-              "tolerance for convergence check of Newton-Raphson iteration within monolithic SSI",
-          .default_value = 1.e-6}));
+      // convergence tolerances of Newton-Raphson iteration loop
+      parameter<double>(
+          "ABSTOLRES", {.description = "absolute tolerance for deciding if global residual of "
+                                       "nonlinear problem is already zero",
+                           .default_value = 1.e-14}),
+      parameter<double>("CONVTOL", {.description = "tolerance for convergence check of "
+                                                   "Newton-Raphson iteration within monolithic SSI",
+                                       .default_value = 1.e-6}),
 
-  // ID of linear solver for global system of equations
-  ssidynmono.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "ID of linear solver for global system of equations", .default_value = -1}));
+      // ID of linear solver for global system of equations
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "ID of linear solver for global system of equations",
+                               .default_value = -1}),
 
-  // type of global system matrix in global system of equations
-  ssidynmono.specs.emplace_back(deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-      {
-          {"undefined", Core::LinAlg::MatrixType::undefined},
-          {"block", Core::LinAlg::MatrixType::block_field},
-          {"sparse", Core::LinAlg::MatrixType::sparse},
-      },
-      {.description = "type of global system matrix in global system of equations",
-          .default_value = Core::LinAlg::MatrixType::undefined}));
+      // type of global system matrix in global system of equations
+      deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
+          {
+              {"undefined", Core::LinAlg::MatrixType::undefined},
+              {"block", Core::LinAlg::MatrixType::block_field},
+              {"sparse", Core::LinAlg::MatrixType::sparse},
+          },
+          {.description = "type of global system matrix in global system of equations",
+              .default_value = Core::LinAlg::MatrixType::undefined}),
 
-  ssidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
-                           .default_value = Core::LinAlg::EquilibrationMethod::none}));
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
+                               .default_value = Core::LinAlg::EquilibrationMethod::none}),
 
-  ssidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION_STRUCTURE", {.description = "flag for equilibration of structural equations",
-                                     .default_value = Core::LinAlg::EquilibrationMethod::none}));
+      parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_STRUCTURE",
+          {.description = "flag for equilibration of structural equations",
+              .default_value = Core::LinAlg::EquilibrationMethod::none}),
 
-  ssidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION_SCATRA", {.description = "flag for equilibration of scatra equations",
-                                  .default_value = Core::LinAlg::EquilibrationMethod::none}));
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION_SCATRA", {.description = "flag for equilibration of scatra equations",
+                                      .default_value = Core::LinAlg::EquilibrationMethod::none}),
 
-  ssidynmono.specs.emplace_back(parameter<bool>("PRINT_MAT_RHS_MAP_MATLAB",
-      {.description = "print system matrix, rhs vector, and full map to matlab readable file after "
-                      "solution of time step",
-          .default_value = false}));
+      parameter<bool>("PRINT_MAT_RHS_MAP_MATLAB",
+          {.description =
+                  "print system matrix, rhs vector, and full map to matlab readable file after "
+                  "solution of time step",
+              .default_value = false}),
 
-  ssidynmono.specs.emplace_back(parameter<double>("RELAX_LIN_SOLVER_TOLERANCE",
-      {.description = "relax the tolerance of the linear solver in case it is an iterative solver "
-                      "by scaling the convergence tolerance with factor RELAX_LIN_SOLVER_TOLERANCE",
-          .default_value = 1.0}));
+      parameter<double>("RELAX_LIN_SOLVER_TOLERANCE",
+          {.description =
+                  "relax the tolerance of the linear solver in case it is an iterative solver "
+                  "by scaling the convergence tolerance with factor RELAX_LIN_SOLVER_TOLERANCE",
+              .default_value = 1.0}),
 
-  ssidynmono.specs.emplace_back(parameter<int>(
-      "RELAX_LIN_SOLVER_STEP", {.description = "relax the tolerance of the linear solver within "
-                                               "the first RELAX_LIN_SOLVER_STEP steps",
-                                   .default_value = -1}));
-
-  ssidynmono.move_into_collection(list);
+      parameter<int>("RELAX_LIN_SOLVER_STEP",
+          {.description = "relax the tolerance of the linear solver within "
+                          "the first RELAX_LIN_SOLVER_STEP steps",
+              .default_value = -1})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for SSI with manifold */
   /*----------------------------------------------------------------------*/
 
-  Core::Utils::SectionSpecs ssidynmanifold{ssidyn, "MANIFOLD"};
+  list["SSI CONTROL/MANIFOLD"] = all_of({
 
-  ssidynmanifold.specs.emplace_back(parameter<bool>(
-      "ADD_MANIFOLD", {.description = "activate additional manifold?", .default_value = false}));
+      parameter<bool>(
+          "ADD_MANIFOLD", {.description = "activate additional manifold?", .default_value = false}),
 
-  ssidynmanifold.specs.emplace_back(parameter<bool>("MESHTYING_MANIFOLD",
-      {.description = "activate meshtying between all manifold fields in case they intersect?",
-          .default_value = false}));
+      parameter<bool>("MESHTYING_MANIFOLD",
+          {.description = "activate meshtying between all manifold fields in case they intersect?",
+              .default_value = false}),
 
-  ssidynmanifold.specs.emplace_back(
+
       deprecated_selection<Inpar::ScaTra::InitialField>("INITIALFIELD",
           {
               {"zero_field", Inpar::ScaTra::initfield_zero_field},
@@ -196,30 +196,27 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {"field_by_condition", Inpar::ScaTra::initfield_field_by_condition},
           },
           {.description = "Initial field for scalar transport on manifold",
-              .default_value = Inpar::ScaTra::initfield_zero_field}));
+              .default_value = Inpar::ScaTra::initfield_zero_field}),
 
-  ssidynmanifold.specs.emplace_back(parameter<int>("INITFUNCNO",
-      {.description = "function number for scalar transport on manifold initial field",
-          .default_value = -1}));
-  ssidynmanifold.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "linear solver for scalar transport on manifold", .default_value = -1}));
+      parameter<int>("INITFUNCNO",
+          {.description = "function number for scalar transport on manifold initial field",
+              .default_value = -1}),
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "linear solver for scalar transport on manifold", .default_value = -1}),
 
-  ssidynmanifold.specs.emplace_back(parameter<bool>(
-      "OUTPUT_INFLOW", {.description = "write output of inflow of scatra manifold - scatra "
-                                       "coupling into scatra manifold to csv file",
-                           .default_value = false}));
-
-  ssidynmanifold.move_into_collection(list);
+      parameter<bool>(
+          "OUTPUT_INFLOW", {.description = "write output of inflow of scatra manifold - scatra "
+                                           "coupling into scatra manifold to csv file",
+                               .default_value = false})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for SSI with elch */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs ssidynelch{ssidyn, "ELCH"};
-  ssidynelch.specs.emplace_back(parameter<bool>(
-      "INITPOTCALC", {.description = "Automatically calculate initial field for electric potential",
-                         .default_value = false}));
+  list["SSI CONTROL/ELCH"] = all_of({
 
-  ssidynelch.move_into_collection(list);
+      parameter<bool>("INITPOTCALC",
+          {.description = "Automatically calculate initial field for electric potential",
+              .default_value = false})});
 }
 
 /*--------------------------------------------------------------------

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -13,8 +13,6 @@
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
 #include "4C_linalg_sparseoperator.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -22,108 +22,107 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs sstidyn{"SSTI CONTROL"};
+  list["SSTI CONTROL"] = all_of({
 
-  sstidyn.specs.emplace_back(parameter<double>("RESTARTEVERYTIME",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 0.0}));
-  sstidyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
-  sstidyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
+      parameter<double>(
+          "RESTARTEVERYTIME", {.description = "write restart possibility every RESTARTEVERY steps",
+                                  .default_value = 0.0}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
 
-  sstidyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  sstidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
-  sstidyn.specs.emplace_back(parameter<double>(
-      "RESULTSEVERYTIME", {.description = "increment for writing solution", .default_value = 0.0}));
-  sstidyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
-  sstidyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  sstidyn.specs.emplace_back(parameter<bool>("SCATRA_FROM_RESTART_FILE",
-      {.description = "read scatra result from restart files (use option 'restartfromfile' during "
-                      "execution of 4C)",
-          .default_value = false}));
-  sstidyn.specs.emplace_back(parameter<std::string>(
-      "SCATRA_FILENAME", {.description = "Control-file name for reading scatra results in SSTI",
-                             .default_value = "nil"}));
-  sstidyn.specs.emplace_back(deprecated_selection<SolutionScheme>("COUPALGO",
-      {
-          {"ssti_Monolithic", SolutionScheme::monolithic},
-      },
-      {.description = "Coupling strategies for SSTI solvers",
-          .default_value = SolutionScheme::monolithic}));
-  sstidyn.specs.emplace_back(deprecated_selection<ScaTraTimIntType>("SCATRATIMINTTYPE",
-      {
-          {"Elch", ScaTraTimIntType::elch},
-      },
-      {.description = "scalar transport time integration type is needed to instantiate correct "
-                      "scalar transport time integration scheme for ssi problems",
-          .default_value = ScaTraTimIntType::elch}));
-  sstidyn.specs.emplace_back(parameter<bool>("ADAPTIVE_TIMESTEPPING",
-      {.description = "flag for adaptive time stepping", .default_value = false}));
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  sstidyn.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}),
+      parameter<double>("RESULTSEVERYTIME",
+          {.description = "increment for writing solution", .default_value = 0.0}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<bool>("SCATRA_FROM_RESTART_FILE",
+          {.description =
+                  "read scatra result from restart files (use option 'restartfromfile' during "
+                  "execution of 4C)",
+              .default_value = false}),
+      parameter<std::string>(
+          "SCATRA_FILENAME", {.description = "Control-file name for reading scatra results in SSTI",
+                                 .default_value = "nil"}),
+      deprecated_selection<SolutionScheme>("COUPALGO",
+          {
+              {"ssti_Monolithic", SolutionScheme::monolithic},
+          },
+          {.description = "Coupling strategies for SSTI solvers",
+              .default_value = SolutionScheme::monolithic}),
+      deprecated_selection<ScaTraTimIntType>("SCATRATIMINTTYPE",
+          {
+              {"Elch", ScaTraTimIntType::elch},
+          },
+          {.description = "scalar transport time integration type is needed to instantiate correct "
+                          "scalar transport time integration scheme for ssi problems",
+              .default_value = ScaTraTimIntType::elch}),
+      parameter<bool>("ADAPTIVE_TIMESTEPPING",
+          {.description = "flag for adaptive time stepping",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
   /* parameters for monolithic SSTI                                       */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs sstidynmono{sstidyn, "MONOLITHIC"};
-  sstidynmono.specs.emplace_back(parameter<double>(
-      "ABSTOLRES", {.description = "absolute tolerance for deciding if global residual of "
-                                   "nonlinear problem is already zero",
-                       .default_value = 1.0e-14}));
-  sstidynmono.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description =
-              "tolerance for convergence check of Newton-Raphson iteration within monolithic SSI",
-          .default_value = 1.0e-6}));
-  sstidynmono.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "ID of linear solver for global system of equations", .default_value = -1}));
-  sstidynmono.specs.emplace_back(deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-      {
-          {"undefined", Core::LinAlg::MatrixType::undefined},
-          {"block", Core::LinAlg::MatrixType::block_field},
-          {"sparse", Core::LinAlg::MatrixType::sparse},
-      },
-      {.description = "type of global system matrix in global system of equations",
-          .default_value = Core::LinAlg::MatrixType::undefined}));
-  sstidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
-                           .default_value = Core::LinAlg::EquilibrationMethod::none}));
-  sstidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION_STRUCTURE", {.description = "flag for equilibration of structural equations",
-                                     .default_value = Core::LinAlg::EquilibrationMethod::none}));
-  sstidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION_SCATRA", {.description = "flag for equilibration of scatra equations",
-                                  .default_value = Core::LinAlg::EquilibrationMethod::none}));
-  sstidynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION_THERMO", {.description = "flag for equilibration of scatra equations",
-                                  .default_value = Core::LinAlg::EquilibrationMethod::none}));
-  sstidynmono.specs.emplace_back(parameter<bool>("EQUILIBRATION_INIT_SCATRA",
-      {.description =
-              "use equilibration method of ScaTra to equilibrate initial calculation of potential",
-          .default_value = false}));
+  list["SSTI CONTROL/MONOLITHIC"] = all_of({
 
-  sstidynmono.move_into_collection(list);
+      parameter<double>(
+          "ABSTOLRES", {.description = "absolute tolerance for deciding if global residual of "
+                                       "nonlinear problem is already zero",
+                           .default_value = 1.0e-14}),
+      parameter<double>("CONVTOL", {.description = "tolerance for convergence check of "
+                                                   "Newton-Raphson iteration within monolithic SSI",
+                                       .default_value = 1.0e-6}),
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "ID of linear solver for global system of equations",
+                               .default_value = -1}),
+      deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
+          {
+              {"undefined", Core::LinAlg::MatrixType::undefined},
+              {"block", Core::LinAlg::MatrixType::block_field},
+              {"sparse", Core::LinAlg::MatrixType::sparse},
+          },
+          {.description = "type of global system matrix in global system of equations",
+              .default_value = Core::LinAlg::MatrixType::undefined}),
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
+                               .default_value = Core::LinAlg::EquilibrationMethod::none}),
+      parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION_STRUCTURE",
+          {.description = "flag for equilibration of structural equations",
+              .default_value = Core::LinAlg::EquilibrationMethod::none}),
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION_SCATRA", {.description = "flag for equilibration of scatra equations",
+                                      .default_value = Core::LinAlg::EquilibrationMethod::none}),
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION_THERMO", {.description = "flag for equilibration of scatra equations",
+                                      .default_value = Core::LinAlg::EquilibrationMethod::none}),
+      parameter<bool>("EQUILIBRATION_INIT_SCATRA",
+          {.description = "use equilibration method of ScaTra to equilibrate initial calculation "
+                          "of potential",
+              .default_value = false})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for thermo                                                */
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs thermodyn{sstidyn, "THERMO"};
-  thermodyn.specs.emplace_back(parameter<int>("INITTHERMOFUNCT",
-      {.description = "initial function for thermo field", .default_value = -1}));
-  thermodyn.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "linear solver for thermo field", .default_value = -1}));
-  thermodyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::InitialField>("INITIALFIELD",
-      {
-          {"field_by_function", Inpar::ScaTra::InitialField::initfield_field_by_function},
-          {"field_by_condition", Inpar::ScaTra::InitialField::initfield_field_by_condition},
-      },
-      {.description = "defines, how to set the initial field",
-          .default_value = Inpar::ScaTra::InitialField::initfield_field_by_function}));
+  list["SSTI CONTROL/THERMO"] = all_of({
 
-  thermodyn.move_into_collection(list);
+      parameter<int>("INITTHERMOFUNCT",
+          {.description = "initial function for thermo field", .default_value = -1}),
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "linear solver for thermo field", .default_value = -1}),
+      deprecated_selection<Inpar::ScaTra::InitialField>("INITIALFIELD",
+          {
+              {"field_by_function", Inpar::ScaTra::InitialField::initfield_field_by_function},
+              {"field_by_condition", Inpar::ScaTra::InitialField::initfield_field_by_condition},
+          },
+          {.description = "defines, how to set the initial field",
+              .default_value = Inpar::ScaTra::InitialField::initfield_field_by_function})});
 }
 
 

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -9,9 +9,8 @@
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_inpar_scatra.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_sparseoperator.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 /*------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -22,97 +22,90 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs stidyn{"STI DYNAMIC"};
+  list["STI DYNAMIC"] = all_of({
 
-  // type of scalar transport time integration
-  stidyn.specs.emplace_back(deprecated_selection<ScaTraTimIntType>("SCATRATIMINTTYPE",
-      {
-          {"Standard", ScaTraTimIntType::standard},
-          {"Elch", ScaTraTimIntType::elch},
-      },
-      {.description =
-              "scalar transport time integration type is needed to instantiate correct scalar "
-              "transport time integration scheme for scatra-thermo interaction problems",
-          .default_value = ScaTraTimIntType::standard}));
+      // type of scalar transport time integration
+      deprecated_selection<ScaTraTimIntType>("SCATRATIMINTTYPE",
+          {
+              {"Standard", ScaTraTimIntType::standard},
+              {"Elch", ScaTraTimIntType::elch},
+          },
+          {.description =
+                  "scalar transport time integration type is needed to instantiate correct scalar "
+                  "transport time integration scheme for scatra-thermo interaction problems",
+              .default_value = ScaTraTimIntType::standard}),
 
-  // type of coupling between scatra and thermo fields
-  stidyn.specs.emplace_back(deprecated_selection<CouplingType>("COUPLINGTYPE",
-      {
-          {"Undefined", CouplingType::undefined},
-          {"Monolithic", CouplingType::monolithic},
-          {"OneWay_ScatraToThermo", CouplingType::oneway_scatratothermo},
-          {"OneWay_ThermoToScatra", CouplingType::oneway_thermotoscatra},
-          {"TwoWay_ScatraToThermo", CouplingType::twoway_scatratothermo},
-          {"TwoWay_ScatraToThermo_Aitken", CouplingType::twoway_scatratothermo_aitken},
-          {"TwoWay_ScatraToThermo_Aitken_Dofsplit",
-              CouplingType::twoway_scatratothermo_aitken_dofsplit},
-          {"TwoWay_ThermoToScatra", CouplingType::twoway_thermotoscatra},
-          {"TwoWay_ThermoToScatra_Aitken", CouplingType::twoway_thermotoscatra_aitken},
-      },
-      {.description = "type of coupling between scatra and thermo fields",
-          .default_value = CouplingType::undefined}));
+      // type of coupling between scatra and thermo fields
+      deprecated_selection<CouplingType>("COUPLINGTYPE",
+          {
+              {"Undefined", CouplingType::undefined},
+              {"Monolithic", CouplingType::monolithic},
+              {"OneWay_ScatraToThermo", CouplingType::oneway_scatratothermo},
+              {"OneWay_ThermoToScatra", CouplingType::oneway_thermotoscatra},
+              {"TwoWay_ScatraToThermo", CouplingType::twoway_scatratothermo},
+              {"TwoWay_ScatraToThermo_Aitken", CouplingType::twoway_scatratothermo_aitken},
+              {"TwoWay_ScatraToThermo_Aitken_Dofsplit",
+                  CouplingType::twoway_scatratothermo_aitken_dofsplit},
+              {"TwoWay_ThermoToScatra", CouplingType::twoway_thermotoscatra},
+              {"TwoWay_ThermoToScatra_Aitken", CouplingType::twoway_thermotoscatra_aitken},
+          },
+          {.description = "type of coupling between scatra and thermo fields",
+              .default_value = CouplingType::undefined}),
 
-  // specification of initial temperature field
-  stidyn.specs.emplace_back(deprecated_selection<Inpar::ScaTra::InitialField>("THERMO_INITIALFIELD",
-      {
-          {"zero_field", Inpar::ScaTra::initfield_zero_field},
-          {"field_by_function", Inpar::ScaTra::initfield_field_by_function},
-          {"field_by_condition", Inpar::ScaTra::initfield_field_by_condition},
-      },
-      {.description = "initial temperature field for scatra-thermo interaction problems",
-          .default_value = Inpar::ScaTra::initfield_zero_field}));
+      // specification of initial temperature field
+      deprecated_selection<Inpar::ScaTra::InitialField>("THERMO_INITIALFIELD",
+          {
+              {"zero_field", Inpar::ScaTra::initfield_zero_field},
+              {"field_by_function", Inpar::ScaTra::initfield_field_by_function},
+              {"field_by_condition", Inpar::ScaTra::initfield_field_by_condition},
+          },
+          {.description = "initial temperature field for scatra-thermo interaction problems",
+              .default_value = Inpar::ScaTra::initfield_zero_field}),
 
-  // function number for initial temperature field
-  stidyn.specs.emplace_back(parameter<int>(
-      "THERMO_INITFUNCNO", {.description = "function number for initial temperature field for "
-                                           "scatra-thermo interaction problems",
-                               .default_value = -1}));
+      // function number for initial temperature field
+      parameter<int>(
+          "THERMO_INITFUNCNO", {.description = "function number for initial temperature field for "
+                                               "scatra-thermo interaction problems",
+                                   .default_value = -1}),
 
-  // ID of linear solver for temperature field
-  stidyn.specs.emplace_back(parameter<int>("THERMO_LINEAR_SOLVER",
-      {.description = "ID of linear solver for temperature field", .default_value = -1}));
+      // ID of linear solver for temperature field
+      parameter<int>("THERMO_LINEAR_SOLVER",
+          {.description = "ID of linear solver for temperature field", .default_value = -1}),
 
-  // flag for double condensation of linear equations associated with temperature field
-  stidyn.specs.emplace_back(parameter<bool>("THERMO_CONDENSATION",
-      {.description =
-              "flag for double condensation of linear equations associated with temperature field",
-          .default_value = false}));
-
-  stidyn.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      // flag for double condensation of linear equations associated with temperature field
+      parameter<bool>("THERMO_CONDENSATION",
+          {.description = "flag for double condensation of linear equations associated with "
+                          "temperature field",
+              .default_value =
+                  false})}); /*----------------------------------------------------------------------*/
   // valid parameters for monolithic scatra-thermo interaction
-  Core::Utils::SectionSpecs stidyn_monolithic{stidyn, "MONOLITHIC"};
+  list["STI DYNAMIC/MONOLITHIC"] = all_of({
 
-  // ID of linear solver for global system of equations
-  stidyn_monolithic.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "ID of linear solver for global system of equations", .default_value = -1}));
+      // ID of linear solver for global system of equations
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "ID of linear solver for global system of equations",
+                               .default_value = -1}),
 
-  // type of global system matrix in global system of equations
-  stidyn_monolithic.specs.emplace_back(deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
-      {
-          {"block", Core::LinAlg::MatrixType::block_condition},
-          {"sparse", Core::LinAlg::MatrixType::sparse},
-      },
-      {.description = "type of global system matrix in global system of equations",
-          .default_value = Core::LinAlg::MatrixType::block_condition}));
-
-  stidyn_monolithic.move_into_collection(list);
+      // type of global system matrix in global system of equations
+      deprecated_selection<Core::LinAlg::MatrixType>("MATRIXTYPE",
+          {
+              {"block", Core::LinAlg::MatrixType::block_condition},
+              {"sparse", Core::LinAlg::MatrixType::sparse},
+          },
+          {.description = "type of global system matrix in global system of equations",
+              .default_value = Core::LinAlg::MatrixType::block_condition})});
 
   /*----------------------------------------------------------------------*/
   // valid parameters for partitioned scatra-thermo interaction
-  Core::Utils::SectionSpecs stidyn_partitioned{stidyn, "PARTITIONED"};
+  list["STI DYNAMIC/PARTITIONED"] = all_of({
 
-  // relaxation parameter
-  stidyn_partitioned.specs.emplace_back(
-      parameter<double>("OMEGA", {.description = "relaxation parameter", .default_value = 1.}));
+      // relaxation parameter
+      parameter<double>("OMEGA", {.description = "relaxation parameter", .default_value = 1.}),
 
-  // maximum value of Aitken relaxation parameter
-  stidyn_partitioned.specs.emplace_back(parameter<double>("OMEGAMAX",
-      {.description = "maximum value of Aitken relaxation parameter (0.0 = no constraint)",
-          .default_value = 0.}));
-
-  stidyn_partitioned.move_into_collection(list);
+      // maximum value of Aitken relaxation parameter
+      parameter<double>("OMEGAMAX",
+          {.description = "maximum value of Aitken relaxation parameter (0.0 = no constraint)",
+              .default_value = 0.})});
 }
 
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -12,8 +12,6 @@
 #include "4C_io_geometry_type.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_utils_enum.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Inpar

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -68,520 +68,522 @@ namespace Inpar
       using Teuchos::tuple;
       using namespace Core::IO::InputSpecBuilders;
 
-      Core::Utils::SectionSpecs sdyn{"STRUCTURAL DYNAMIC"};
+      list["STRUCTURAL DYNAMIC"] = all_of({
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::IntegrationStrategy>("INT_STRATEGY",
-          {
-              {"Old", int_old},
-              {"Standard", int_standard},
-          },
-          {.description = "global type of the used integration strategy",
-              .default_value = int_old}));
+          deprecated_selection<Solid::IntegrationStrategy>("INT_STRATEGY",
+              {
+                  {"Old", int_old},
+                  {"Standard", int_standard},
+              },
+              {.description = "global type of the used integration strategy",
+                  .default_value = int_old}),
 
-      sdyn.specs.emplace_back(parameter<bool>("TIME_ADAPTIVITY",
-          {.description = "Enable adaptive time integration", .default_value = false}));
+          parameter<bool>("TIME_ADAPTIVITY",
+              {.description = "Enable adaptive time integration", .default_value = false}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::DynamicType>("DYNAMICTYPE",
-          {
-              {"Statics", DynamicType::Statics},
-              {"GenAlpha", DynamicType::GenAlpha},
-              {"GenAlphaLieGroup", DynamicType::GenAlphaLieGroup},
-              {"OneStepTheta", DynamicType::OneStepTheta},
-              {"ExplicitEuler", DynamicType::ExplEuler},
-              {"CentrDiff", DynamicType::CentrDiff},
-              {"AdamsBashforth2", DynamicType::AdamsBashforth2},
-              {"AdamsBashforth4", DynamicType::AdamsBashforth4},
-          },
-          {.description = "type of the specific dynamic time integration scheme",
-              .default_value = DynamicType::GenAlpha}));
+          deprecated_selection<Solid::DynamicType>("DYNAMICTYPE",
+              {
+                  {"Statics", DynamicType::Statics},
+                  {"GenAlpha", DynamicType::GenAlpha},
+                  {"GenAlphaLieGroup", DynamicType::GenAlphaLieGroup},
+                  {"OneStepTheta", DynamicType::OneStepTheta},
+                  {"ExplicitEuler", DynamicType::ExplEuler},
+                  {"CentrDiff", DynamicType::CentrDiff},
+                  {"AdamsBashforth2", DynamicType::AdamsBashforth2},
+                  {"AdamsBashforth4", DynamicType::AdamsBashforth4},
+              },
+              {.description = "type of the specific dynamic time integration scheme",
+                  .default_value = DynamicType::GenAlpha}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Inpar::Solid::PreStress>("PRESTRESS",
-          {
-              {"none", Inpar::Solid::PreStress::none},
-              {"None", Inpar::Solid::PreStress::none},
-              {"NONE", Inpar::Solid::PreStress::none},
-              {"mulf", Inpar::Solid::PreStress::mulf},
-              {"Mulf", Inpar::Solid::PreStress::mulf},
-              {"MULF", Inpar::Solid::PreStress::mulf},
-              {"Material_Iterative", Inpar::Solid::PreStress::material_iterative},
-              {"MATERIAL_ITERATIVE", Inpar::Solid::PreStress::material_iterative},
-              {"material_iterative", Inpar::Solid::PreStress::material_iterative},
-          },
-          {.description = "prestressing takes values none mulf material_iterative",
-              .default_value = Inpar::Solid::PreStress::none}));
+          deprecated_selection<Inpar::Solid::PreStress>("PRESTRESS",
+              {
+                  {"none", Inpar::Solid::PreStress::none},
+                  {"None", Inpar::Solid::PreStress::none},
+                  {"NONE", Inpar::Solid::PreStress::none},
+                  {"mulf", Inpar::Solid::PreStress::mulf},
+                  {"Mulf", Inpar::Solid::PreStress::mulf},
+                  {"MULF", Inpar::Solid::PreStress::mulf},
+                  {"Material_Iterative", Inpar::Solid::PreStress::material_iterative},
+                  {"MATERIAL_ITERATIVE", Inpar::Solid::PreStress::material_iterative},
+                  {"material_iterative", Inpar::Solid::PreStress::material_iterative},
+              },
+              {.description = "prestressing takes values none mulf material_iterative",
+                  .default_value = Inpar::Solid::PreStress::none}),
 
-      sdyn.specs.emplace_back(parameter<double>("PRESTRESSTIME",
-          {.description = "time to switch from pre to post stressing", .default_value = 0.0}));
+          parameter<double>("PRESTRESSTIME",
+              {.description = "time to switch from pre to post stressing", .default_value = 0.0}),
 
-      sdyn.specs.emplace_back(parameter<double>("PRESTRESSTOLDISP",
-          {.description = "tolerance in the displacement norm during prestressing",
-              .default_value = 1e-9}));
-      sdyn.specs.emplace_back(parameter<int>("PRESTRESSMINLOADSTEPS",
-          {.description = "Minimum number of load steps during prestressing", .default_value = 0}));
+          parameter<double>("PRESTRESSTOLDISP",
+              {.description = "tolerance in the displacement norm during prestressing",
+                  .default_value = 1e-9}),
+          parameter<int>("PRESTRESSMINLOADSTEPS",
+              {.description = "Minimum number of load steps during prestressing",
+                  .default_value = 0}),
 
-      // Output type
-      sdyn.specs.emplace_back(parameter<int>("RESULTSEVERY",
-          {.description = "save displacements and contact forces every RESULTSEVERY steps",
-              .default_value = 1}));
-      sdyn.specs.emplace_back(parameter<int>("RESEVERYERGY",
-          {.description = "write system energies every requested step", .default_value = 0}));
-      sdyn.specs.emplace_back(parameter<int>(
-          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
-                              .default_value = 1}));
-      sdyn.specs.emplace_back(parameter<bool>("CALC_ACC_ON_RESTART",
-          {.description = "Compute the initial state for a restart dynamics analysis",
-              .default_value = false}));
-      sdyn.specs.emplace_back(parameter<int>("OUTPUT_STEP_OFFSET",
-          {.description = "An offset added to the current step to shift the steps to be written.",
-              .default_value = 0}));
+          // Output type
+          parameter<int>("RESULTSEVERY",
+              {.description = "save displacements and contact forces every RESULTSEVERY steps",
+                  .default_value = 1}),
+          parameter<int>("RESEVERYERGY",
+              {.description = "write system energies every requested step", .default_value = 0}),
+          parameter<int>(
+              "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                                  .default_value = 1}),
+          parameter<bool>("CALC_ACC_ON_RESTART",
+              {.description = "Compute the initial state for a restart dynamics analysis",
+                  .default_value = false}),
+          parameter<int>("OUTPUT_STEP_OFFSET",
+              {.description =
+                      "An offset added to the current step to shift the steps to be written.",
+                  .default_value = 0}),
 
-      // Time loop control
-      sdyn.specs.emplace_back(
-          parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.05}));
-      sdyn.specs.emplace_back(parameter<int>(
-          "NUMSTEP", {.description = "maximum number of steps", .default_value = 200}));
-      sdyn.specs.emplace_back(
-          parameter<double>("TIMEINIT", {.description = "initial time", .default_value = 0.0}));
-      sdyn.specs.emplace_back(
-          parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 5.0}));
+          // Time loop control
+          parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.05}),
+          parameter<int>(
+              "NUMSTEP", {.description = "maximum number of steps", .default_value = 200}),
 
-      // Damping
-      sdyn.specs.emplace_back(deprecated_selection<Solid::DampKind>("DAMPING",
-          {
-              {"None", damp_none},
-              {"Rayleigh", damp_rayleigh},
-              {"Material", damp_material},
-          },
-          {.description = "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M "
-                          "+ K_DAMP x K, (2) Material based and calculated in elements",
-              .default_value = damp_none}));
-      sdyn.specs.emplace_back(
-          parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}));
-      sdyn.specs.emplace_back(
-          parameter<double>("K_DAMP", {.description = "", .default_value = -1.0}));
+          parameter<double>("TIMEINIT", {.description = "initial time", .default_value = 0.0}),
 
-      sdyn.specs.emplace_back(parameter<double>(
-          "TOLDISP", {.description = "tolerance in the displacement norm for the newton iteration",
-                         .default_value = 1.0E-10}));
-      sdyn.specs.emplace_back(deprecated_selection<Solid::ConvNorm>("NORM_DISP",
-          {
-              {"Abs", convnorm_abs},
-              {"Rel", convnorm_rel},
-              {"Mix", convnorm_mix},
-          },
-          {.description = "type of norm for displacement convergence check",
-              .default_value = convnorm_abs}));
+          parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 5.0}),
 
-      sdyn.specs.emplace_back(parameter<double>(
-          "TOLRES", {.description = "tolerance in the residual norm for the newton iteration",
-                        .default_value = 1.0E-08}));
-      sdyn.specs.emplace_back(deprecated_selection<Solid::ConvNorm>("NORM_RESF",
-          {
-              {"Abs", convnorm_abs},
-              {"Rel", convnorm_rel},
-              {"Mix", convnorm_mix},
-          },
-          {.description = "type of norm for residual convergence check",
-              .default_value = convnorm_abs}));
+          // Damping
+          deprecated_selection<Solid::DampKind>("DAMPING",
+              {
+                  {"None", damp_none},
+                  {"Rayleigh", damp_rayleigh},
+                  {"Material", damp_material},
+              },
+              {.description =
+                      "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M "
+                      "+ K_DAMP x K, (2) Material based and calculated in elements",
+                  .default_value = damp_none}),
 
-      sdyn.specs.emplace_back(parameter<double>(
-          "TOLPRE", {.description = "tolerance in pressure norm for the newton iteration",
-                        .default_value = 1.0E-08}));
-      sdyn.specs.emplace_back(deprecated_selection<Solid::ConvNorm>("NORM_PRES",
-          {
-              {"Abs", convnorm_abs},
-          },
-          {.description = "type of norm for pressure convergence check",
-              .default_value = convnorm_abs}));
+          parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}),
 
-      sdyn.specs.emplace_back(parameter<double>("TOLINCO",
-          {.description = "tolerance in the incompressible residual norm for the newton iteration",
-              .default_value = 1.0E-08}));
-      sdyn.specs.emplace_back(deprecated_selection<Solid::ConvNorm>("NORM_INCO",
-          {
-              {"Abs", convnorm_abs},
-          },
-          {.description = "type of norm for incompressible residual convergence check",
-              .default_value = convnorm_abs}));
+          parameter<double>("K_DAMP", {.description = "", .default_value = -1.0}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::BinaryOp>("NORMCOMBI_DISPPRES",
-          {
-              {"And", bop_and},
-              {"Or", bop_or},
-          },
-          {.description = "binary operator to combine pressure and displacement values",
-              .default_value = bop_and}));
+          parameter<double>("TOLDISP",
+              {.description = "tolerance in the displacement norm for the newton iteration",
+                  .default_value = 1.0E-10}),
+          deprecated_selection<Solid::ConvNorm>("NORM_DISP",
+              {
+                  {"Abs", convnorm_abs},
+                  {"Rel", convnorm_rel},
+                  {"Mix", convnorm_mix},
+              },
+              {.description = "type of norm for displacement convergence check",
+                  .default_value = convnorm_abs}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::BinaryOp>("NORMCOMBI_RESFINCO",
-          {
-              {"And", bop_and},
-              {"Or", bop_or},
-          },
-          {.description = "binary operator to combine force and incompressible residual",
-              .default_value = bop_and}));
+          parameter<double>(
+              "TOLRES", {.description = "tolerance in the residual norm for the newton iteration",
+                            .default_value = 1.0E-08}),
+          deprecated_selection<Solid::ConvNorm>("NORM_RESF",
+              {
+                  {"Abs", convnorm_abs},
+                  {"Rel", convnorm_rel},
+                  {"Mix", convnorm_mix},
+              },
+              {.description = "type of norm for residual convergence check",
+                  .default_value = convnorm_abs}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::BinaryOp>("NORMCOMBI_RESFDISP",
-          {
-              {"And", bop_and},
-              {"Or", bop_or},
-          },
-          {.description = "binary operator to combine displacement and residual force values",
-              .default_value = bop_and}));
+          parameter<double>(
+              "TOLPRE", {.description = "tolerance in pressure norm for the newton iteration",
+                            .default_value = 1.0E-08}),
+          deprecated_selection<Solid::ConvNorm>("NORM_PRES",
+              {
+                  {"Abs", convnorm_abs},
+              },
+              {.description = "type of norm for pressure convergence check",
+                  .default_value = convnorm_abs}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::StcScale>("STC_SCALING",
-          {
-              {"Inactive", stc_inactive},
-              {"Symmetric", stc_currsym},
-              {"Right", stc_curr},
-          },
-          {.description = "Scaled director conditioning for thin shell structures",
-              .default_value = stc_inactive}));
+          parameter<double>("TOLINCO",
+              {.description =
+                      "tolerance in the incompressible residual norm for the newton iteration",
+                  .default_value = 1.0E-08}),
+          deprecated_selection<Solid::ConvNorm>("NORM_INCO",
+              {
+                  {"Abs", convnorm_abs},
+              },
+              {.description = "type of norm for incompressible residual convergence check",
+                  .default_value = convnorm_abs}),
 
-      sdyn.specs.emplace_back(parameter<int>("STC_LAYER",
-          {.description = "number of STC layers for multilayer case", .default_value = 1}));
+          deprecated_selection<Solid::BinaryOp>("NORMCOMBI_DISPPRES",
+              {
+                  {"And", bop_and},
+                  {"Or", bop_or},
+              },
+              {.description = "binary operator to combine pressure and displacement values",
+                  .default_value = bop_and}),
 
-      sdyn.specs.emplace_back(parameter<double>(
-          "PTCDT", {.description = "pseudo time step for pseudo transient continuation (PTC) "
-                                   "stabilized Newton procedure",
-                       .default_value = 0.1}));
+          deprecated_selection<Solid::BinaryOp>("NORMCOMBI_RESFINCO",
+              {
+                  {"And", bop_and},
+                  {"Or", bop_or},
+              },
+              {.description = "binary operator to combine force and incompressible residual",
+                  .default_value = bop_and}),
 
-      sdyn.specs.emplace_back(parameter<double>("TOLCONSTR",
-          {.description = "tolerance in the constr error norm for the newton iteration",
-              .default_value = 1.0E-08}));
+          deprecated_selection<Solid::BinaryOp>("NORMCOMBI_RESFDISP",
+              {
+                  {"And", bop_and},
+                  {"Or", bop_or},
+              },
+              {.description = "binary operator to combine displacement and residual force values",
+                  .default_value = bop_and}),
 
-      sdyn.specs.emplace_back(parameter<double>("TOLCONSTRINCR",
-          {.description = "tolerance in the constr lm incr norm for the newton iteration",
-              .default_value = 1.0E-08}));
+          deprecated_selection<Solid::StcScale>("STC_SCALING",
+              {
+                  {"Inactive", stc_inactive},
+                  {"Symmetric", stc_currsym},
+                  {"Right", stc_curr},
+              },
+              {.description = "Scaled director conditioning for thin shell structures",
+                  .default_value = stc_inactive}),
 
-      sdyn.specs.emplace_back(parameter<int>(
-          "MAXITER", {.description = "maximum number of iterations allowed for Newton-Raphson "
-                                     "iteration before failure",
-                         .default_value = 50}));
-      sdyn.specs.emplace_back(parameter<int>("MINITER",
-          {.description = "minimum number of iterations to be done within Newton-Raphson loop",
-              .default_value = 0}));
-      sdyn.specs.emplace_back(deprecated_selection<Solid::VectorNorm>("ITERNORM",
-          {
-              {"L1", norm_l1},
-              {"L2", norm_l2},
-              {"Rms", norm_rms},
-              {"Inf", norm_inf},
-          },
-          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}));
+          parameter<int>("STC_LAYER",
+              {.description = "number of STC layers for multilayer case", .default_value = 1}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::DivContAct>("DIVERCONT",
-          {
-              {"stop", divcont_stop},
-              {"continue", divcont_continue},
-              {"repeat_step", divcont_repeat_step},
-              {"halve_step", divcont_halve_step},
-              {"adapt_step", divcont_adapt_step},
-              {"rand_adapt_step", divcont_rand_adapt_step},
-              {"rand_adapt_step_ele_err", divcont_rand_adapt_step_ele_err},
-              {"repeat_simulation", divcont_repeat_simulation},
-              {"adapt_penaltycontact", divcont_adapt_penaltycontact},
-              {"adapt_3D0Dptc_ele_err", divcont_adapt_3D0Dptc_ele_err},
-          },
-          {.description = "What to do with time integration when Newton-Raphson iteration failed",
-              .default_value = divcont_stop}));
+          parameter<double>(
+              "PTCDT", {.description = "pseudo time step for pseudo transient continuation (PTC) "
+                                       "stabilized Newton procedure",
+                           .default_value = 0.1}),
 
-      sdyn.specs.emplace_back(parameter<int>("MAXDIVCONREFINEMENTLEVEL",
-          {.description = "number of times timestep is halved in case nonlinear solver diverges",
-              .default_value = 10}));
+          parameter<double>("TOLCONSTR",
+              {.description = "tolerance in the constr error norm for the newton iteration",
+                  .default_value = 1.0E-08}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::NonlinSolTech>("NLNSOL",
-          {
-              {"vague", soltech_vague},
-              {"fullnewton", soltech_newtonfull},
-              {"modnewton", soltech_newtonmod},
-              {"lsnewton", soltech_newtonls},
-              {"ptc", soltech_ptc},
-              {"newtonlinuzawa", soltech_newtonuzawalin},
-              {"augmentedlagrange", soltech_newtonuzawanonlin},
-              {"NoxNewtonLineSearch", soltech_noxnewtonlinesearch},
-              {"noxgeneral", soltech_noxgeneral},
-              {"noxnln", soltech_nox_nln},
-              {"singlestep", soltech_singlestep},
-          },
-          {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}));
+          parameter<double>("TOLCONSTRINCR",
+              {.description = "tolerance in the constr lm incr norm for the newton iteration",
+                  .default_value = 1.0E-08}),
 
-      sdyn.specs.emplace_back(parameter<int>("LSMAXITER",
-          {.description = "maximum number of line search steps", .default_value = 30}));
-      sdyn.specs.emplace_back(parameter<double>(
-          "ALPHA_LS", {.description = "step reduction factor alpha in (Newton) line search scheme",
-                          .default_value = 0.5}));
-      sdyn.specs.emplace_back(parameter<double>(
-          "SIGMA_LS", {.description = "sufficient descent factor in (Newton) line search scheme",
-                          .default_value = 1.e-4}));
+          parameter<int>(
+              "MAXITER", {.description = "maximum number of iterations allowed for Newton-Raphson "
+                                         "iteration before failure",
+                             .default_value = 50}),
+          parameter<int>("MINITER",
+              {.description = "minimum number of iterations to be done within Newton-Raphson loop",
+                  .default_value = 0}),
+          deprecated_selection<Solid::VectorNorm>("ITERNORM",
+              {
+                  {"L1", norm_l1},
+                  {"L2", norm_l2},
+                  {"Rms", norm_rms},
+                  {"Inf", norm_inf},
+              },
+              {.description = "type of norm to be applied to residuals", .default_value = norm_l2}),
 
-      std::vector<std::string> material_tangent_valid_input = {"analytical", "finitedifferences"};
-      sdyn.specs.emplace_back(
-          deprecated_selection<std::string>("MATERIALTANGENT", material_tangent_valid_input,
+          deprecated_selection<Solid::DivContAct>("DIVERCONT",
+              {
+                  {"stop", divcont_stop},
+                  {"continue", divcont_continue},
+                  {"repeat_step", divcont_repeat_step},
+                  {"halve_step", divcont_halve_step},
+                  {"adapt_step", divcont_adapt_step},
+                  {"rand_adapt_step", divcont_rand_adapt_step},
+                  {"rand_adapt_step_ele_err", divcont_rand_adapt_step_ele_err},
+                  {"repeat_simulation", divcont_repeat_simulation},
+                  {"adapt_penaltycontact", divcont_adapt_penaltycontact},
+                  {"adapt_3D0Dptc_ele_err", divcont_adapt_3D0Dptc_ele_err},
+              },
+              {.description =
+                      "What to do with time integration when Newton-Raphson iteration failed",
+                  .default_value = divcont_stop}),
+
+          parameter<int>("MAXDIVCONREFINEMENTLEVEL",
+              {.description =
+                      "number of times timestep is halved in case nonlinear solver diverges",
+                  .default_value = 10}),
+
+          deprecated_selection<Solid::NonlinSolTech>("NLNSOL",
+              {
+                  {"vague", soltech_vague},
+                  {"fullnewton", soltech_newtonfull},
+                  {"modnewton", soltech_newtonmod},
+                  {"lsnewton", soltech_newtonls},
+                  {"ptc", soltech_ptc},
+                  {"newtonlinuzawa", soltech_newtonuzawalin},
+                  {"augmentedlagrange", soltech_newtonuzawanonlin},
+                  {"NoxNewtonLineSearch", soltech_noxnewtonlinesearch},
+                  {"noxgeneral", soltech_noxgeneral},
+                  {"noxnln", soltech_nox_nln},
+                  {"singlestep", soltech_singlestep},
+              },
+              {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}),
+
+          parameter<int>("LSMAXITER",
+              {.description = "maximum number of line search steps", .default_value = 30}),
+          parameter<double>("ALPHA_LS",
+              {.description = "step reduction factor alpha in (Newton) line search scheme",
+                  .default_value = 0.5}),
+          parameter<double>("SIGMA_LS",
+              {.description = "sufficient descent factor in (Newton) line search scheme",
+                  .default_value = 1.e-4}),
+
+          deprecated_selection<std::string>("MATERIALTANGENT", {"analytical", "finitedifferences"},
               {.description = "way of evaluating the constitutive matrix",
-                  .default_value = "analytical"}));
+                  .default_value = "analytical"}),
 
 
-      sdyn.specs.emplace_back(parameter<bool>(
-          "LOADLIN", {.description = "Use linearization of external follower load in Newton",
-                         .default_value = false}));
+          parameter<bool>(
+              "LOADLIN", {.description = "Use linearization of external follower load in Newton",
+                             .default_value = false}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Inpar::Solid::MassLin>("MASSLIN",
-          {
-              {"none", Inpar::Solid::MassLin::ml_none},
-              {"rotations", Inpar::Solid::MassLin::ml_rotations},
-          },
-          {.description = "Application of nonlinear inertia terms",
-              .default_value = Inpar::Solid::MassLin::ml_none}));
+          deprecated_selection<Inpar::Solid::MassLin>("MASSLIN",
+              {
+                  {"none", Inpar::Solid::MassLin::ml_none},
+                  {"rotations", Inpar::Solid::MassLin::ml_rotations},
+              },
+              {.description = "Application of nonlinear inertia terms",
+                  .default_value = Inpar::Solid::MassLin::ml_none}),
 
-      sdyn.specs.emplace_back(parameter<bool>(
-          "NEGLECTINERTIA", {.description = "Neglect inertia", .default_value = false}));
+          parameter<bool>(
+              "NEGLECTINERTIA", {.description = "Neglect inertia", .default_value = false}),
 
-      // Since predictor "none" would be misleading, the usage of no predictor is called vague.
-      sdyn.specs.emplace_back(deprecated_selection<Solid::PredEnum>("PREDICT",
-          {
-              {"Vague", pred_vague},
-              {"ConstDis", pred_constdis},
-              {"ConstVel", pred_constvel},
-              {"ConstAcc", pred_constacc},
-              {"ConstDisVelAcc", pred_constdisvelacc},
-              {"TangDis", pred_tangdis},
-              {"TangDisConstFext", pred_tangdis_constfext},
-              {"ConstDisPres", pred_constdispres},
-              {"ConstDisVelAccPres", pred_constdisvelaccpres},
-          },
-          {.description = "Type of predictor", .default_value = pred_constdis}));
+          // Since predictor "none" would be misleading, the usage of no predictor is called vague.
+          deprecated_selection<Solid::PredEnum>("PREDICT",
+              {
+                  {"Vague", pred_vague},
+                  {"ConstDis", pred_constdis},
+                  {"ConstVel", pred_constvel},
+                  {"ConstAcc", pred_constacc},
+                  {"ConstDisVelAcc", pred_constdisvelacc},
+                  {"TangDis", pred_tangdis},
+                  {"TangDisConstFext", pred_tangdis_constfext},
+                  {"ConstDisPres", pred_constdispres},
+                  {"ConstDisVelAccPres", pred_constdisvelaccpres},
+              },
+              {.description = "Type of predictor", .default_value = pred_constdis}),
 
-      // Uzawa iteration for constraint systems
-      sdyn.specs.emplace_back(parameter<double>("UZAWAPARAM",
-          {.description = "Parameter for Uzawa algorithm dealing with lagrange multipliers",
-              .default_value = 1.0}));
-      sdyn.specs.emplace_back(parameter<double>(
-          "UZAWATOL", {.description = "Tolerance for iterative solve with Uzawa algorithm",
-                          .default_value = 1.0E-8}));
-      sdyn.specs.emplace_back(parameter<int>(
-          "UZAWAMAXITER", {.description = "maximum number of iterations allowed for uzawa "
-                                          "algorithm before failure going to next newton step",
-                              .default_value = 50}));
-      sdyn.specs.emplace_back(deprecated_selection<Solid::ConSolveAlgo>("UZAWAALGO",
-          {
-              {"uzawa", consolve_uzawa},
-              {"simple", consolve_simple},
-              {"direct", consolve_direct},
-          },
-          {.description = "", .default_value = consolve_direct}));
+          // Uzawa iteration for constraint systems
+          parameter<double>("UZAWAPARAM",
+              {.description = "Parameter for Uzawa algorithm dealing with lagrange multipliers",
+                  .default_value = 1.0}),
+          parameter<double>(
+              "UZAWATOL", {.description = "Tolerance for iterative solve with Uzawa algorithm",
+                              .default_value = 1.0E-8}),
+          parameter<int>(
+              "UZAWAMAXITER", {.description = "maximum number of iterations allowed for uzawa "
+                                              "algorithm before failure going to next newton step",
+                                  .default_value = 50}),
+          deprecated_selection<Solid::ConSolveAlgo>("UZAWAALGO",
+              {
+                  {"uzawa", consolve_uzawa},
+                  {"simple", consolve_simple},
+                  {"direct", consolve_direct},
+              },
+              {.description = "", .default_value = consolve_direct}),
 
-      // convergence criteria adaptivity
-      sdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
-          {.description =
-                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-              .default_value = false}));
-      sdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-          {.description = "The linear solver shall be this much better than the current nonlinear "
-                          "residual in the nonlinear convergence limit",
-              .default_value = 0.1}));
+          // convergence criteria adaptivity
+          parameter<bool>("ADAPTCONV", {.description = "Switch on adaptive control of linear "
+                                                       "solver tolerance for nonlinear solution",
+                                           .default_value = false}),
+          parameter<double>("ADAPTCONV_BETTER",
+              {.description =
+                      "The linear solver shall be this much better than the current nonlinear "
+                      "residual in the nonlinear convergence limit",
+                  .default_value = 0.1}),
 
-      sdyn.specs.emplace_back(parameter<bool>(
-          "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
-                          .default_value = false}));
+          parameter<bool>(
+              "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
+                              .default_value = false}),
 
-      sdyn.specs.emplace_back(parameter<bool>("MODIFIEDEXPLEULER",
-          {.description = "Use the modified explicit Euler time integration scheme",
-              .default_value = true}));
+          parameter<bool>("MODIFIEDEXPLEULER",
+              {.description = "Use the modified explicit Euler time integration scheme",
+                  .default_value = true}),
 
-      // linear solver id used for structural problems
-      sdyn.specs.emplace_back(parameter<int>(
-          "LINEAR_SOLVER", {.description = "number of linear solver used for structural problems",
-                               .default_value = -1}));
+          // linear solver id used for structural problems
+          parameter<int>("LINEAR_SOLVER",
+              {.description = "number of linear solver used for structural problems",
+                  .default_value = -1}),
 
-      // where the geometry comes from
-      sdyn.specs.emplace_back(deprecated_selection<Core::IO::GeometryType>("GEOMETRY",
-          {
-              {"full", Core::IO::geometry_full},
-              {"box", Core::IO::geometry_box},
-              {"file", Core::IO::geometry_file},
-          },
-          {.description = "How the geometry is specified",
-              .default_value = Core::IO::geometry_full}));
+          // where the geometry comes from
+          deprecated_selection<Core::IO::GeometryType>("GEOMETRY",
+              {
+                  {"full", Core::IO::geometry_full},
+                  {"box", Core::IO::geometry_box},
+                  {"file", Core::IO::geometry_file},
+              },
+              {.description = "How the geometry is specified",
+                  .default_value = Core::IO::geometry_full}),
 
-      sdyn.specs.emplace_back(deprecated_selection<Solid::MidAverageEnum>("MIDTIME_ENERGY_TYPE",
-          {
-              {"vague", midavg_vague},
-              {"imrLike", midavg_imrlike},
-              {"trLike", midavg_trlike},
-          },
-          {.description = "Specify the mid-averaging type for the structural energy contributions",
-              .default_value = midavg_vague}));
+          deprecated_selection<Solid::MidAverageEnum>("MIDTIME_ENERGY_TYPE",
+              {
+                  {"vague", midavg_vague},
+                  {"imrLike", midavg_imrlike},
+                  {"trLike", midavg_trlike},
+              },
+              {.description =
+                      "Specify the mid-averaging type for the structural energy contributions",
+                  .default_value = midavg_vague}),
 
-      // Initial displacement
-      sdyn.specs.emplace_back(deprecated_selection<Solid::InitialDisp>("INITIALDISP",
-          {
-              {"zero_displacement", initdisp_zero_disp},
-              {"displacement_by_function", initdisp_disp_by_function},
-          },
-          {.description = "Initial displacement for structure problem",
-              .default_value = initdisp_zero_disp}));
+          // Initial displacement
+          deprecated_selection<Solid::InitialDisp>("INITIALDISP",
+              {
+                  {"zero_displacement", initdisp_zero_disp},
+                  {"displacement_by_function", initdisp_disp_by_function},
+              },
+              {.description = "Initial displacement for structure problem",
+                  .default_value = initdisp_zero_disp}),
 
-      // Function to evaluate initial displacement
-      sdyn.specs.emplace_back(parameter<int>("STARTFUNCNO",
-          {.description = "Function for Initial displacement", .default_value = -1}));
-
-      sdyn.move_into_collection(list);
-
-      /*--------------------------------------------------------------------*/
+          // Function to evaluate initial displacement
+          parameter<int>("STARTFUNCNO",
+              {.description = "Function for Initial displacement",
+                  .default_value =
+                      -1})}); /*--------------------------------------------------------------------*/
       /* parameters for time step size adaptivity in structural dynamics */
-      Core::Utils::SectionSpecs tap{sdyn, "TIMEADAPTIVITY"};
-      tap.specs.emplace_back(deprecated_selection<Inpar::Solid::TimAdaKind>("KIND",
-          {
-              {"None", Inpar::Solid::timada_kind_none},
-              {"ZienkiewiczXie", Inpar::Solid::timada_kind_zienxie},
-              {"JointExplicit", Inpar::Solid::timada_kind_joint_explicit},
-              {"AdamsBashforth2", Inpar::Solid::timada_kind_ab2},
-              {"ExplicitEuler", Inpar::Solid::timada_kind_expleuler},
-              {"CentralDifference", Inpar::Solid::timada_kind_centraldiff},
-          },
-          {.description = "Method for time step size adaptivity",
-              .default_value = Inpar::Solid::timada_kind_none}));
+      list["STRUCTURAL DYNAMIC/TIMEADAPTIVITY"] = all_of({
 
-      tap.specs.emplace_back(parameter<double>(
-          "OUTSYSPERIOD", {.description = "Write system vectors (displacements, velocities, etc) "
-                                          "every given period of time",
-                              .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("OUTSTRPERIOD",
-          {.description = "Write stress/strain every given period of time", .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("OUTENEPERIOD",
-          {.description = "Write energy every given period of time", .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("OUTRESTPERIOD",
-          {.description = "Write restart data every given period of time", .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<int>("OUTSIZEEVERY",
-          {.description = "Write step size every given time step", .default_value = 0}));
+          deprecated_selection<Inpar::Solid::TimAdaKind>("KIND",
+              {
+                  {"None", Inpar::Solid::timada_kind_none},
+                  {"ZienkiewiczXie", Inpar::Solid::timada_kind_zienxie},
+                  {"JointExplicit", Inpar::Solid::timada_kind_joint_explicit},
+                  {"AdamsBashforth2", Inpar::Solid::timada_kind_ab2},
+                  {"ExplicitEuler", Inpar::Solid::timada_kind_expleuler},
+                  {"CentralDifference", Inpar::Solid::timada_kind_centraldiff},
+              },
+              {.description = "Method for time step size adaptivity",
+                  .default_value = Inpar::Solid::timada_kind_none}),
 
-      tap.specs.emplace_back(parameter<double>("STEPSIZEMAX",
-          {.description = "Limit maximally permitted time step size (>0)", .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("STEPSIZEMIN",
-          {.description = "Limit minimally allowed time step size (>0)", .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("SIZERATIOMAX",
-          {.description = "Limit maximally permitted change of time step size compared to previous "
-                          "size, important for multi-step schemes (>0)",
-              .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("SIZERATIOMIN",
-          {.description = "Limit minimally permitted change of time step size compared to previous "
-                          "size, important for multi-step schemes (>0)",
-              .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<double>("SIZERATIOSCALE",
-          {.description = "This is a safety factor to scale theoretical optimal step size, should "
-                          "be lower than 1 and must be larger than 0",
-              .default_value = 0.9}));
+          parameter<double>("OUTSYSPERIOD",
+              {.description = "Write system vectors (displacements, velocities, etc) "
+                              "every given period of time",
+                  .default_value = 0.0}),
+          parameter<double>(
+              "OUTSTRPERIOD", {.description = "Write stress/strain every given period of time",
+                                  .default_value = 0.0}),
+          parameter<double>("OUTENEPERIOD",
+              {.description = "Write energy every given period of time", .default_value = 0.0}),
+          parameter<double>(
+              "OUTRESTPERIOD", {.description = "Write restart data every given period of time",
+                                   .default_value = 0.0}),
+          parameter<int>("OUTSIZEEVERY",
+              {.description = "Write step size every given time step", .default_value = 0}),
 
-      tap.specs.emplace_back(deprecated_selection<Inpar::Solid::VectorNorm>("LOCERRNORM",
-          {
-              {"Vague", Inpar::Solid::norm_vague},
-              {"L1", Inpar::Solid::norm_l1},
-              {"L2", Inpar::Solid::norm_l2},
-              {"Rms", Inpar::Solid::norm_rms},
-              {"Inf", Inpar::Solid::norm_inf},
-          },
-          {.description = "Vector norm to treat error vector with",
-              .default_value = Inpar::Solid::norm_vague}));
+          parameter<double>(
+              "STEPSIZEMAX", {.description = "Limit maximally permitted time step size (>0)",
+                                 .default_value = 0.0}),
+          parameter<double>("STEPSIZEMIN",
+              {.description = "Limit minimally allowed time step size (>0)", .default_value = 0.0}),
+          parameter<double>("SIZERATIOMAX",
+              {.description =
+                      "Limit maximally permitted change of time step size compared to previous "
+                      "size, important for multi-step schemes (>0)",
+                  .default_value = 0.0}),
+          parameter<double>("SIZERATIOMIN",
+              {.description =
+                      "Limit minimally permitted change of time step size compared to previous "
+                      "size, important for multi-step schemes (>0)",
+                  .default_value = 0.0}),
+          parameter<double>("SIZERATIOSCALE",
+              {.description =
+                      "This is a safety factor to scale theoretical optimal step size, should "
+                      "be lower than 1 and must be larger than 0",
+                  .default_value = 0.9}),
 
-      tap.specs.emplace_back(parameter<double>(
-          "LOCERRTOL", {.description = "Target local error tolerance (>0)", .default_value = 0.0}));
-      tap.specs.emplace_back(parameter<int>("ADAPTSTEPMAX",
-          {.description = "Limit maximally allowed step size reduction attempts (>0)",
-              .default_value = 0}));
-      tap.move_into_collection(list);
+          deprecated_selection<Inpar::Solid::VectorNorm>("LOCERRNORM",
+              {
+                  {"Vague", Inpar::Solid::norm_vague},
+                  {"L1", Inpar::Solid::norm_l1},
+                  {"L2", Inpar::Solid::norm_l2},
+                  {"Rms", Inpar::Solid::norm_rms},
+                  {"Inf", Inpar::Solid::norm_inf},
+              },
+              {.description = "Vector norm to treat error vector with",
+                  .default_value = Inpar::Solid::norm_vague}),
+
+          parameter<double>("LOCERRTOL",
+              {.description = "Target local error tolerance (>0)", .default_value = 0.0}),
+          parameter<int>("ADAPTSTEPMAX",
+              {.description = "Limit maximally allowed step size reduction attempts (>0)",
+                  .default_value = 0})});
 
       /// valid parameters for JOINT EXPLICIT
 
-      Core::Utils::SectionSpecs jep{tap, "JOINT EXPLICIT"};
+      list["STRUCTURAL DYNAMIC/TIMEADAPTIVITY/JOINT EXPLICIT"] = all_of({
 
-      jep.specs.emplace_back(parameter<int>(
-          "LINEAR_SOLVER", {.description = "number of linear solver used for auxiliary integrator",
-                               .default_value = -1}));
+          parameter<int>("LINEAR_SOLVER",
+              {.description = "number of linear solver used for auxiliary integrator",
+                  .default_value = -1}),
 
-      jep.specs.emplace_back(deprecated_selection<Inpar::Solid::IntegrationStrategy>("INT_STRATEGY",
-          {
-              {"Standard", int_standard},
-          },
-          {.description = "global type of the used integration strategy",
-              .default_value = int_standard}));
+          deprecated_selection<Inpar::Solid::IntegrationStrategy>("INT_STRATEGY",
+              {
+                  {"Standard", int_standard},
+              },
+              {.description = "global type of the used integration strategy",
+                  .default_value = int_standard}),
 
-      jep.specs.emplace_back(deprecated_selection<Inpar::Solid::DynamicType>("DYNAMICTYPE",
-          {
-              {"ExplicitEuler", DynamicType::ExplEuler},
-              {"CentrDiff", DynamicType::CentrDiff},
-              {"AdamsBashforth2", DynamicType::AdamsBashforth2},
-              {"AdamsBashforth4", DynamicType::AdamsBashforth4},
-          },
-          {.description = "type of the specific auxiliary dynamic time integration scheme",
-              .default_value = DynamicType::CentrDiff}));
+          deprecated_selection<Inpar::Solid::DynamicType>("DYNAMICTYPE",
+              {
+                  {"ExplicitEuler", DynamicType::ExplEuler},
+                  {"CentrDiff", DynamicType::CentrDiff},
+                  {"AdamsBashforth2", DynamicType::AdamsBashforth2},
+                  {"AdamsBashforth4", DynamicType::AdamsBashforth4},
+              },
+              {.description = "type of the specific auxiliary dynamic time integration scheme",
+                  .default_value = DynamicType::CentrDiff}),
 
-      jep.specs.emplace_back(parameter<bool>(
-          "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
-                          .default_value = false}));
+          parameter<bool>(
+              "LUMPMASS", {.description = "Lump the mass matrix for explicit time integration",
+                              .default_value = false}),
 
-      jep.specs.emplace_back(deprecated_selection<Inpar::Solid::DampKind>("DAMPING",
-          {
-              {"None", damp_none},
-              {"Rayleigh", damp_rayleigh},
-              {"Material", damp_material},
-          },
-          {.description = "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M "
-                          "+ K_DAMP x K, (2) Material based and calculated in elements",
-              .default_value = damp_none}));
+          deprecated_selection<Inpar::Solid::DampKind>("DAMPING",
+              {
+                  {"None", damp_none},
+                  {"Rayleigh", damp_rayleigh},
+                  {"Material", damp_material},
+              },
+              {.description =
+                      "type of damping: (1) Rayleigh damping matrix and use it from M_DAMP x M "
+                      "+ K_DAMP x K, (2) Material based and calculated in elements",
+                  .default_value = damp_none}),
 
-      jep.specs.emplace_back(
-          parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}));
-      jep.specs.emplace_back(
-          parameter<double>("K_DAMP", {.description = "", .default_value = -1.0}));
 
-      jep.move_into_collection(list);
+          parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}),
+
+          parameter<double>("K_DAMP", {.description = "", .default_value = -1.0})});
 
       /*----------------------------------------------------------------------*/
       /* parameters for generalised-alpha structural integrator */
-      Core::Utils::SectionSpecs genalpha{sdyn, "GENALPHA"};
+      list["STRUCTURAL DYNAMIC/GENALPHA"] = all_of({
 
-      genalpha.specs.emplace_back(deprecated_selection<Solid::MidAverageEnum>("GENAVG",
-          {
-              {"Vague", midavg_vague},
-              {"ImrLike", midavg_imrlike},
-              {"TrLike", midavg_trlike},
-          },
-          {.description = "mid-average type of internal forces", .default_value = midavg_trlike}));
-      genalpha.specs.emplace_back(parameter<double>(
-          "BETA", {.description = "Generalised-alpha factor in (0,1/2]", .default_value = -1.0}));
-      genalpha.specs.emplace_back(parameter<double>(
-          "GAMMA", {.description = "Generalised-alpha factor in (0,1]", .default_value = -1.0}));
-      genalpha.specs.emplace_back(parameter<double>(
-          "ALPHA_M", {.description = "Generalised-alpha factor in [0,1)", .default_value = -1.0}));
-      genalpha.specs.emplace_back(parameter<double>(
-          "ALPHA_F", {.description = "Generalised-alpha factor in [0,1)", .default_value = -1.0}));
-      genalpha.specs.emplace_back(parameter<double>("RHO_INF",
-          {.description =
-                  "Spectral radius for generalised-alpha time integration, valid range is [0,1]",
-              .default_value = 1.0}));
-
-      genalpha.move_into_collection(list);
+          deprecated_selection<Solid::MidAverageEnum>("GENAVG",
+              {
+                  {"Vague", midavg_vague},
+                  {"ImrLike", midavg_imrlike},
+                  {"TrLike", midavg_trlike},
+              },
+              {.description = "mid-average type of internal forces",
+                  .default_value = midavg_trlike}),
+          parameter<double>("BETA",
+              {.description = "Generalised-alpha factor in (0,1/2]", .default_value = -1.0}),
+          parameter<double>(
+              "GAMMA", {.description = "Generalised-alpha factor in (0,1]", .default_value = -1.0}),
+          parameter<double>("ALPHA_M",
+              {.description = "Generalised-alpha factor in [0,1)", .default_value = -1.0}),
+          parameter<double>("ALPHA_F",
+              {.description = "Generalised-alpha factor in [0,1)", .default_value = -1.0}),
+          parameter<double>("RHO_INF", {.description = "Spectral radius for generalised-alpha time "
+                                                       "integration, valid range is [0,1]",
+                                           .default_value = 1.0})});
 
       /*----------------------------------------------------------------------*/
       /* parameters for one-step-theta structural integrator */
-      Core::Utils::SectionSpecs onesteptheta{sdyn, "ONESTEPTHETA"};
+      list["STRUCTURAL DYNAMIC/ONESTEPTHETA"] = all_of({
 
-      onesteptheta.specs.emplace_back(parameter<double>(
-          "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5}));
-
-      onesteptheta.move_into_collection(list);
+          parameter<double>(
+              "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5})});
 
       /*----------------------------------------------------------------------*/
       /* parameters for error evaluation */
-      Core::Utils::SectionSpecs errorevaluator{sdyn, "ERROR EVALUATION"};
-      errorevaluator.specs.emplace_back(parameter<bool>("EVALUATE_ERROR_ANALYTICAL_REFERENCE",
-          {.description =
-                  "Calculate error with respect to analytical solution defined by a function",
-              .default_value = false}));
-      errorevaluator.specs.emplace_back(parameter<int>("ANALYTICAL_DISPLACEMENT_FUNCTION",
-          {.description = "function ID of the analytical solution", .default_value = -1}));
+      list["STRUCTURAL DYNAMIC/ERROR EVALUATION"] = all_of({
 
-      errorevaluator.move_into_collection(list);
+          parameter<bool>("EVALUATE_ERROR_ANALYTICAL_REFERENCE",
+              {.description =
+                      "Calculate error with respect to analytical solution defined by a function",
+                  .default_value = false}),
+          parameter<int>("ANALYTICAL_DISPLACEMENT_FUNCTION",
+              {.description = "function ID of the analytical solution", .default_value = -1})});
     }
 
 

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -19,209 +19,204 @@ void Inpar::TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs tsidyn{"TSI DYNAMIC"};
+  list["TSI DYNAMIC"] = all_of({
 
-  // coupling strategy for (partitioned and monolithic) TSI solvers
-  tsidyn.specs.emplace_back(deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
-      {
-          {"tsi_oneway", OneWay},
-          {"tsi_sequstagg", SequStagg},
-          {"tsi_iterstagg", IterStagg},
-          {"tsi_iterstagg_aitken", IterStaggAitken},
-          {"tsi_iterstagg_aitkenirons", IterStaggAitkenIrons},
-          {"tsi_iterstagg_fixedrelax", IterStaggFixedRel},
-          {"tsi_monolithic", Monolithic},
-      },
-      {.description = "Coupling strategies for TSI solvers", .default_value = Monolithic}));
+      // coupling strategy for (partitioned and monolithic) TSI solvers
+      deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
+          {
+              {"tsi_oneway", OneWay},
+              {"tsi_sequstagg", SequStagg},
+              {"tsi_iterstagg", IterStagg},
+              {"tsi_iterstagg_aitken", IterStaggAitken},
+              {"tsi_iterstagg_aitkenirons", IterStaggAitkenIrons},
+              {"tsi_iterstagg_fixedrelax", IterStaggFixedRel},
+              {"tsi_monolithic", Monolithic},
+          },
+          {.description = "Coupling strategies for TSI solvers", .default_value = Monolithic}),
 
-  tsidyn.specs.emplace_back(
-      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
-  // output type
-  tsidyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}),
 
-  // time loop control
-  tsidyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  tsidyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  tsidyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
-  tsidyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  tsidyn.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "minimal number of iterations over fields", .default_value = 1}));
-  tsidyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
+      // output type
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
 
-  tsidyn.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_INC",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for convergence check of primary variables in TSI",
-          .default_value = convnorm_abs}));
+      // time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  tsidyn.move_into_collection(list);
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<int>("ITEMIN",
+          {.description = "minimal number of iterations over fields", .default_value = 1}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+
+      deprecated_selection<ConvNorm>("NORM_INC",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for convergence check of primary variables in TSI",
+              .default_value = convnorm_abs})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for monolithic TSI */
-  Core::Utils::SectionSpecs tsidynmono{tsidyn, "MONOLITHIC"};
+  list["TSI DYNAMIC/MONOLITHIC"] = all_of({
 
-  // convergence tolerance of tsi residual
-  tsidynmono.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "tolerance for convergence check of TSI", .default_value = 1e-6}));
-  // Iterationparameters
-  tsidynmono.specs.emplace_back(parameter<double>("TOLINC",
-      {.description = "tolerance for convergence check of TSI-increment in monolithic TSI",
-          .default_value = 1.0e-6}));
+      // convergence tolerance of tsi residual
+      parameter<double>("CONVTOL",
+          {.description = "tolerance for convergence check of TSI", .default_value = 1e-6}),
+      // Iterationparameters
+      parameter<double>("TOLINC",
+          {.description = "tolerance for convergence check of TSI-increment in monolithic TSI",
+              .default_value = 1.0e-6}),
 
-  tsidynmono.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_RESF",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = convnorm_abs}));
+      deprecated_selection<ConvNorm>("NORM_RESF",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = convnorm_abs}),
 
-  tsidynmono.specs.emplace_back(deprecated_selection<BinaryOp>("NORMCOMBI_RESFINC",
-      {
-          {"And", bop_and},
-          {"Or", bop_or},
-          {"Coupl_Or_Single", bop_coupl_or_single},
-          {"Coupl_And_Single", bop_coupl_and_single},
-          {"And_Single", bop_and_single},
-          {"Or_Single", bop_or_single},
-      },
-      {.description = "binary operator to combine primary variables and residual force values",
-          .default_value = bop_coupl_and_single}));
+      deprecated_selection<BinaryOp>("NORMCOMBI_RESFINC",
+          {
+              {"And", bop_and},
+              {"Or", bop_or},
+              {"Coupl_Or_Single", bop_coupl_or_single},
+              {"Coupl_And_Single", bop_coupl_and_single},
+              {"And_Single", bop_and_single},
+              {"Or_Single", bop_or_single},
+          },
+          {.description = "binary operator to combine primary variables and residual force values",
+              .default_value = bop_coupl_and_single}),
 
-  tsidynmono.specs.emplace_back(deprecated_selection<VectorNorm>("ITERNORM",
-      {
-          {"L1", norm_l1},
-          {"L1_Scaled", norm_l1_scaled},
-          {"L2", norm_l2},
-          {"Rms", norm_rms},
-          {"Inf", norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals", .default_value = norm_rms}));
+      deprecated_selection<VectorNorm>("ITERNORM",
+          {
+              {"L1", norm_l1},
+              {"L1_Scaled", norm_l1_scaled},
+              {"L2", norm_l2},
+              {"Rms", norm_rms},
+              {"Inf", norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals", .default_value = norm_rms}),
 
-  tsidynmono.specs.emplace_back(deprecated_selection<NlnSolTech>("NLNSOL",
-      {
-          {"fullnewton", soltech_newtonfull},
-          {"ptc", soltech_ptc},
-      },
-      {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}));
+      deprecated_selection<NlnSolTech>("NLNSOL",
+          {
+              {"fullnewton", soltech_newtonfull},
+              {"ptc", soltech_ptc},
+          },
+          {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}),
 
-  tsidynmono.specs.emplace_back(
+
       parameter<double>("PTCDT", {.description = "pseudo time step for pseudo-transient "
                                                  "continuation (PTC) stabilised Newton procedure",
-                                     .default_value = 0.1}));
+                                     .default_value = 0.1}),
 
-  // number of linear solver used for monolithic TSI
-  tsidynmono.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for monolithic TSI problems",
-                           .default_value = -1}));
+      // number of linear solver used for monolithic TSI
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for monolithic TSI problems",
+              .default_value = -1}),
 
-  // convergence criteria adaptivity of monolithic TSI solver
-  tsidynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  tsidynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
+      // convergence criteria adaptivity of monolithic TSI solver
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
 
-  tsidynmono.specs.emplace_back(parameter<bool>("INFNORMSCALING",
-      {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}));
+      parameter<bool>("INFNORMSCALING",
+          {.description = "Scale blocks of matrix with row infnorm?", .default_value = true}),
 
-  // merge TSI block matrix to enable use of direct solver in monolithic TSI
-  // default: "No", i.e. use block matrix
-  tsidynmono.specs.emplace_back(parameter<bool>(
-      "MERGE_TSI_BLOCK_MATRIX", {.description = "Merge TSI block matrix", .default_value = false}));
+      // merge TSI block matrix to enable use of direct solver in monolithic TSI
+      // default: "No", i.e. use block matrix
+      parameter<bool>("MERGE_TSI_BLOCK_MATRIX",
+          {.description = "Merge TSI block matrix", .default_value = false}),
 
-  // in case of monolithic TSI nodal values (displacements, temperatures and
-  // reaction forces) at fix points of the body can be calculated
-  // default: "No", i.e. nothing is calculated
-  tsidynmono.specs.emplace_back(parameter<bool>("CALC_NECKING_TSI_VALUES",
-      {.description = "Calculate nodal values for evaluation and validation of necking",
-          .default_value = false}));
+      // in case of monolithic TSI nodal values (displacements, temperatures and
+      // reaction forces) at fix points of the body can be calculated
+      // default: "No", i.e. nothing is calculated
+      parameter<bool>("CALC_NECKING_TSI_VALUES",
+          {.description = "Calculate nodal values for evaluation and validation of necking",
+              .default_value = false}),
 
-  tsidynmono.specs.emplace_back(deprecated_selection<LineSearch>("TSI_LINE_SEARCH",
-      {
-          {"none", LS_none},
-          {"structure", LS_structure},
-          {"thermo", LS_thermo},
-          {"and", LS_and},
-          {"or", LS_or},
-      },
-      {.description = "line-search strategy", .default_value = LS_none}));
-
-  tsidynmono.move_into_collection(list);
+      deprecated_selection<LineSearch>("TSI_LINE_SEARCH",
+          {
+              {"none", LS_none},
+              {"structure", LS_structure},
+              {"thermo", LS_thermo},
+              {"and", LS_and},
+              {"or", LS_or},
+          },
+          {.description = "line-search strategy", .default_value = LS_none})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned TSI */
 
-  Core::Utils::SectionSpecs tsidynpart{tsidyn, "PARTITIONED"};
+  list["TSI DYNAMIC/PARTITIONED"] = all_of({
 
-  std::vector<std::string> couplvariable_valid_input = {"Displacement", "Temperature"};
-  tsidynpart.specs.emplace_back(
-      deprecated_selection<std::string>("COUPVARIABLE", couplvariable_valid_input,
-          {.description = "Coupling variable", .default_value = "Displacement"}));
+      deprecated_selection<std::string>("COUPVARIABLE", {"Displacement", "Temperature"},
+          {.description = "Coupling variable", .default_value = "Displacement"}),
 
 
-  // Solver parameter for relaxation of iterative staggered partitioned TSI
-  tsidynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
-      {.description = "largest omega allowed for Aitken relaxation (0.0 means no constraint)",
-          .default_value = 0.0}));
-  tsidynpart.specs.emplace_back(parameter<double>(
-      "FIXEDOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
+      // Solver parameter for relaxation of iterative staggered partitioned TSI
+      parameter<double>("MAXOMEGA",
+          {.description = "largest omega allowed for Aitken relaxation (0.0 means no constraint)",
+              .default_value = 0.0}),
+      parameter<double>(
+          "FIXEDOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}),
 
-  // convergence tolerance of outer iteration loop
-  tsidynpart.specs.emplace_back(parameter<double>("CONVTOL",
-      {.description = "tolerance for convergence check of outer iteraiton within partitioned TSI",
-          .default_value = 1e-6}));
-
-  tsidynpart.move_into_collection(list);
+      // convergence tolerance of outer iteration loop
+      parameter<double>("CONVTOL",
+          {.description =
+                  "tolerance for convergence check of outer iteraiton within partitioned TSI",
+              .default_value = 1e-6}),
+  });
 
   /*----------------------------------------------------------------------*/
   /* parameters for tsi contact */
-  Core::Utils::SectionSpecs tsic{"TSI CONTACT"};
+  list["TSI CONTACT"] =
+      all_of({parameter<double>("HEATTRANSSLAVE",
+                  {.description = "Heat transfer parameter for slave side in thermal contact",
+                      .default_value = 0.0}),
+          parameter<double>("HEATTRANSMASTER",
+              {.description = "Heat transfer parameter for master side in thermal contact",
+                  .default_value = 0.0}),
+          parameter<double>("TEMP_DAMAGE",
+              {.description =
+                      "damage temperature at contact interface: friction coefficient zero there",
+                  .default_value = 1.0e12}),
 
-  tsic.specs.emplace_back(parameter<double>(
-      "HEATTRANSSLAVE", {.description = "Heat transfer parameter for slave side in thermal contact",
-                            .default_value = 0.0}));
-  tsic.specs.emplace_back(parameter<double>("HEATTRANSMASTER",
-      {.description = "Heat transfer parameter for master side in thermal contact",
-          .default_value = 0.0}));
-  tsic.specs.emplace_back(parameter<double>("TEMP_DAMAGE",
-      {.description = "damage temperature at contact interface: friction coefficient zero there",
-          .default_value = 1.0e12}));
-  tsic.specs.emplace_back(
-      parameter<double>("TEMP_REF", {.description = "reference temperature at contact interface: "
-                                                    "friction coefficient equals the given value",
-                                        .default_value = 0.0}));
+          parameter<double>(
+              "TEMP_REF", {.description = "reference temperature at contact interface: "
+                                          "friction coefficient equals the given value",
+                              .default_value = 0.0}),
 
-  tsic.specs.emplace_back(parameter<double>(
-      "NITSCHE_THETA_TSI", {.description = "+1: symmetric, 0: non-symmetric, -1: skew-symmetric",
-                               .default_value = 0.0}));
+          parameter<double>("NITSCHE_THETA_TSI",
+              {.description = "+1: symmetric, 0: non-symmetric, -1: skew-symmetric",
+                  .default_value = 0.0}),
 
-  tsic.specs.emplace_back(parameter<CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING_TSI",
-      {.description = "how to weight consistency terms in Nitsche contact formulation",
-          .default_value = CONTACT::NitscheWeighting::harmonic}));
+          parameter<CONTACT::NitscheWeighting>("NITSCHE_WEIGHTING_TSI",
+              {.description = "how to weight consistency terms in Nitsche contact formulation",
+                  .default_value = CONTACT::NitscheWeighting::harmonic}),
 
-  tsic.specs.emplace_back(parameter<bool>("NITSCHE_PENALTY_ADAPTIVE_TSI",
-      {.description = "adapt penalty parameter after each converged time step",
-          .default_value = true}));
+          parameter<bool>("NITSCHE_PENALTY_ADAPTIVE_TSI",
+              {.description = "adapt penalty parameter after each converged time step",
+                  .default_value = true}),
 
-  tsic.specs.emplace_back(parameter<double>("PENALTYPARAM_THERMO",
-      {.description = "Penalty parameter for Nitsche solution strategy", .default_value = 0.0}));
-
-  tsic.move_into_collection(list);
+          parameter<double>("PENALTYPARAM_THERMO",
+              {.description = "Penalty parameter for Nitsche solution strategy",
+                  .default_value = 0.0})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_tsi.cpp
+++ b/src/inpar/4C_inpar_tsi.cpp
@@ -8,8 +8,7 @@
 #include "4C_inpar_tsi.hpp"
 
 #include "4C_contact_input.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_validparameters.cpp
+++ b/src/inpar/4C_inpar_validparameters.cpp
@@ -58,13 +58,13 @@
 #include "4C_inpar_wear.hpp"
 #include "4C_inpar_xfem.hpp"
 #include "4C_io_input_file_utils.hpp"
+#include "4C_io_input_spec_builders.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_lubrication_input.hpp"
 #include "4C_porofluid_pressure_based_elast_input.hpp"
 #include "4C_porofluid_pressure_based_elast_scatra_input.hpp"
 #include "4C_porofluid_pressure_based_input.hpp"
 #include "4C_thermo_input.hpp"
-#include "4C_utils_parameter_list.hpp"
 
 #include <Teuchos_any.hpp>
 #include <Teuchos_Array.hpp>

--- a/src/inpar/4C_inpar_validparameters.cpp
+++ b/src/inpar/4C_inpar_validparameters.cpp
@@ -92,65 +92,54 @@ std::map<std::string, Core::IO::InputSpec> Input::valid_parameters()
   using namespace Core::IO::InputSpecBuilders;
   std::map<std::string, Core::IO::InputSpec> list;
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs discret{"DISCRETISATION"};
+  list["DISCRETISATION"] = all_of({
 
-  discret.specs.emplace_back(parameter<int>(
-      "NUMFLUIDDIS", {.description = "Number of meshes in fluid field", .default_value = 1}));
-  discret.specs.emplace_back(parameter<int>(
-      "NUMSTRUCDIS", {.description = "Number of meshes in structural field", .default_value = 1}));
-  discret.specs.emplace_back(parameter<int>(
-      "NUMALEDIS", {.description = "Number of meshes in ale field", .default_value = 1}));
-  discret.specs.emplace_back(parameter<int>("NUMARTNETDIS",
-      {.description = "Number of meshes in arterial network field", .default_value = 1}));
-  discret.specs.emplace_back(parameter<int>(
-      "NUMTHERMDIS", {.description = "Number of meshes in thermal field", .default_value = 1}));
-  discret.specs.emplace_back(parameter<int>("NUMAIRWAYSDIS",
-      {.description = "Number of meshes in reduced dimensional airways network field",
-          .default_value = 1}));
+      parameter<int>(
+          "NUMFLUIDDIS", {.description = "Number of meshes in fluid field", .default_value = 1}),
+      parameter<int>("NUMSTRUCDIS",
+          {.description = "Number of meshes in structural field", .default_value = 1}),
+      parameter<int>(
+          "NUMALEDIS", {.description = "Number of meshes in ale field", .default_value = 1}),
+      parameter<int>("NUMARTNETDIS",
+          {.description = "Number of meshes in arterial network field", .default_value = 1}),
+      parameter<int>(
+          "NUMTHERMDIS", {.description = "Number of meshes in thermal field", .default_value = 1}),
+      parameter<int>("NUMAIRWAYSDIS",
+          {.description = "Number of meshes in reduced dimensional airways network field",
+              .default_value =
+                  1})}); /*----------------------------------------------------------------------*/
+  list["PROBLEM SIZE"] = all_of({
 
-  discret.move_into_collection(list);
+      parameter<int>("DIM", {.description = "2d or 3d problem", .default_value = 3}),
 
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs size{"PROBLEM SIZE"};
+      // deactivate all the following (unused) parameters one day
+      // they are nice as general info in the input file but should not
+      // read into a parameter list. Misuse is possible
+      parameter<int>("ELEMENTS", {.description = "Total number of elements", .default_value = 0}),
 
-  size.specs.emplace_back(
-      parameter<int>("DIM", {.description = "2d or 3d problem", .default_value = 3}));
+      parameter<int>("NODES", {.description = "Total number of nodes", .default_value = 0}),
 
-  // deactivate all the following (unused) parameters one day
-  // they are nice as general info in the input file but should not
-  // read into a parameter list. Misuse is possible
-  size.specs.emplace_back(
-      parameter<int>("ELEMENTS", {.description = "Total number of elements", .default_value = 0}));
-  size.specs.emplace_back(
-      parameter<int>("NODES", {.description = "Total number of nodes", .default_value = 0}));
-  size.specs.emplace_back(
-      parameter<int>("NPATCHES", {.description = "number of nurbs patches", .default_value = 0}));
-  size.specs.emplace_back(
-      parameter<int>("MATERIALS", {.description = "number of materials", .default_value = 0}));
-  size.specs.emplace_back(parameter<int>(
-      "NUMDF", {.description = "maximum number of degrees of freedom", .default_value = 3}));
+      parameter<int>("NPATCHES", {.description = "number of nurbs patches", .default_value = 0}),
 
-  size.move_into_collection(list);
-
+      parameter<int>("MATERIALS", {.description = "number of materials", .default_value = 0}),
+      parameter<int>(
+          "NUMDF", {.description = "maximum number of degrees of freedom", .default_value = 3})});
   Inpar::PROBLEMTYPE::set_valid_parameters(list);
 
   /*----------------------------------------------------------------------*/
 
-  Core::Utils::SectionSpecs nurbs_param{"NURBS"};
+  list["NURBS"] = all_of({
 
-  nurbs_param.specs.emplace_back(parameter<bool>(
-      "DO_LS_DBC_PROJECTION", {.description = "Determines if a projection is needed for least "
-                                              "square Dirichlet boundary conditions.",
-                                  .default_value = false}));
+      parameter<bool>(
+          "DO_LS_DBC_PROJECTION", {.description = "Determines if a projection is needed for least "
+                                                  "square Dirichlet boundary conditions.",
+                                      .default_value = false}),
 
-  nurbs_param.specs.emplace_back(parameter<int>("SOLVER_LS_DBC_PROJECTION",
-      {.description = "Number of linear solver for the projection of least squares "
-                      "Dirichlet boundary conditions for NURBS discretizations",
-          .default_value = -1}));
-
-  nurbs_param.move_into_collection(list);
-
-  /*----------------------------------------------------------------------*/
+      parameter<int>("SOLVER_LS_DBC_PROJECTION",
+          {.description = "Number of linear solver for the projection of least squares "
+                          "Dirichlet boundary conditions for NURBS discretizations",
+              .default_value =
+                  -1})}); /*----------------------------------------------------------------------*/
   /* Finally call the problem-specific SetValidParameter functions        */
   /*----------------------------------------------------------------------*/
 

--- a/src/inpar/4C_inpar_volmortar.cpp
+++ b/src/inpar/4C_inpar_volmortar.cpp
@@ -8,8 +8,7 @@
 #include "4C_inpar_volmortar.hpp"
 
 #include "4C_coupling_volmortar.hpp"
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_volmortar.cpp
+++ b/src/inpar/4C_inpar_volmortar.cpp
@@ -20,19 +20,19 @@ void Inpar::VolMortar::set_valid_parameters(std::map<std::string, Core::IO::Inpu
   using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for volmortar */
-  Core::Utils::SectionSpecs volmortar{"VOLMORTAR COUPLING"};
+  list["VOLMORTAR COUPLING"] = all_of({
 
-  volmortar.specs.emplace_back(deprecated_selection<Coupling::VolMortar::IntType>("INTTYPE",
-      {
-          {"Elements", Coupling::VolMortar::inttype_elements},
-          {"elements", Coupling::VolMortar::inttype_elements},
-          {"Segments", Coupling::VolMortar::inttype_segments},
-          {"segments", Coupling::VolMortar::inttype_segments},
-      },
-      {.description = "Type of numerical integration scheme",
-          .default_value = Coupling::VolMortar::inttype_elements}));
+      deprecated_selection<Coupling::VolMortar::IntType>("INTTYPE",
+          {
+              {"Elements", Coupling::VolMortar::inttype_elements},
+              {"elements", Coupling::VolMortar::inttype_elements},
+              {"Segments", Coupling::VolMortar::inttype_segments},
+              {"segments", Coupling::VolMortar::inttype_segments},
+          },
+          {.description = "Type of numerical integration scheme",
+              .default_value = Coupling::VolMortar::inttype_elements}),
 
-  volmortar.specs.emplace_back(
+
       deprecated_selection<Coupling::VolMortar::CouplingType>("COUPLINGTYPE",
           {
               {"Volmortar", Coupling::VolMortar::couplingtype_volmortar},
@@ -41,52 +41,50 @@ void Inpar::VolMortar::set_valid_parameters(std::map<std::string, Core::IO::Inpu
               {"consint", Coupling::VolMortar::couplingtype_coninter},
           },
           {.description = "Type of coupling",
-              .default_value = Coupling::VolMortar::couplingtype_volmortar}));
+              .default_value = Coupling::VolMortar::couplingtype_volmortar}),
 
-  volmortar.specs.emplace_back(deprecated_selection<Coupling::VolMortar::Shapefcn>("SHAPEFCN",
-      {
-          {"Dual", Coupling::VolMortar::shape_dual},
-          {"dual", Coupling::VolMortar::shape_dual},
-          {"Standard", Coupling::VolMortar::shape_std},
-          {"standard", Coupling::VolMortar::shape_std},
-          {"std", Coupling::VolMortar::shape_std},
-      },
-      {.description = "Type of employed set of shape functions",
-          .default_value = Coupling::VolMortar::shape_dual}));
+      deprecated_selection<Coupling::VolMortar::Shapefcn>("SHAPEFCN",
+          {
+              {"Dual", Coupling::VolMortar::shape_dual},
+              {"dual", Coupling::VolMortar::shape_dual},
+              {"Standard", Coupling::VolMortar::shape_std},
+              {"standard", Coupling::VolMortar::shape_std},
+              {"std", Coupling::VolMortar::shape_std},
+          },
+          {.description = "Type of employed set of shape functions",
+              .default_value = Coupling::VolMortar::shape_dual}),
 
-  volmortar.specs.emplace_back(deprecated_selection<Coupling::VolMortar::CutType>("CUTTYPE",
-      {
-          {"dd", Coupling::VolMortar::cuttype_directdivergence},
-          {"directdivergence", Coupling::VolMortar::cuttype_directdivergence},
-          {"DirectDivergence", Coupling::VolMortar::cuttype_directdivergence},
-          {"tessellation", Coupling::VolMortar::cuttype_tessellation},
-          {"t", Coupling::VolMortar::cuttype_tessellation},
-          {"Tessellation", Coupling::VolMortar::cuttype_tessellation},
-      },
-      {.description = "Type of cut procedure/ integration point calculation",
-          .default_value = Coupling::VolMortar::cuttype_directdivergence}));
+      deprecated_selection<Coupling::VolMortar::CutType>("CUTTYPE",
+          {
+              {"dd", Coupling::VolMortar::cuttype_directdivergence},
+              {"directdivergence", Coupling::VolMortar::cuttype_directdivergence},
+              {"DirectDivergence", Coupling::VolMortar::cuttype_directdivergence},
+              {"tessellation", Coupling::VolMortar::cuttype_tessellation},
+              {"t", Coupling::VolMortar::cuttype_tessellation},
+              {"Tessellation", Coupling::VolMortar::cuttype_tessellation},
+          },
+          {.description = "Type of cut procedure/ integration point calculation",
+              .default_value = Coupling::VolMortar::cuttype_directdivergence}),
 
-  volmortar.specs.emplace_back(deprecated_selection<Coupling::VolMortar::DualQuad>("DUALQUAD",
-      {
-          {"nm", Coupling::VolMortar::dualquad_no_mod},
-          {"nomod", Coupling::VolMortar::dualquad_no_mod},
-          {"lm", Coupling::VolMortar::dualquad_lin_mod},
-          {"lin_mod", Coupling::VolMortar::dualquad_lin_mod},
-          {"qm", Coupling::VolMortar::dualquad_quad_mod},
-          {"quad_mod", Coupling::VolMortar::dualquad_quad_mod},
-      },
-      {.description = "Type of dual shape function for weighting function for quadr. problems",
-          .default_value = Coupling::VolMortar::dualquad_no_mod}));
+      deprecated_selection<Coupling::VolMortar::DualQuad>("DUALQUAD",
+          {
+              {"nm", Coupling::VolMortar::dualquad_no_mod},
+              {"nomod", Coupling::VolMortar::dualquad_no_mod},
+              {"lm", Coupling::VolMortar::dualquad_lin_mod},
+              {"lin_mod", Coupling::VolMortar::dualquad_lin_mod},
+              {"qm", Coupling::VolMortar::dualquad_quad_mod},
+              {"quad_mod", Coupling::VolMortar::dualquad_quad_mod},
+          },
+          {.description = "Type of dual shape function for weighting function for quadr. problems",
+              .default_value = Coupling::VolMortar::dualquad_no_mod}),
 
-  volmortar.specs.emplace_back(parameter<bool>(
-      "MESH_INIT", {.description = "If chosen, mesh initialization procedure is performed",
-                       .default_value = false}));
+      parameter<bool>(
+          "MESH_INIT", {.description = "If chosen, mesh initialization procedure is performed",
+                           .default_value = false}),
 
-  volmortar.specs.emplace_back(parameter<bool>("KEEP_EXTENDEDGHOSTING",
-      {.description = "If chosen, extended ghosting is kept for simulation",
-          .default_value = true}));
-
-  volmortar.move_into_collection(list);
+      parameter<bool>("KEEP_EXTENDEDGHOSTING",
+          {.description = "If chosen, extended ghosting is kept for simulation",
+              .default_value = true})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -19,88 +19,86 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using namespace Core::IO::InputSpecBuilders;
 
   /* parameters for wear */
-  Core::Utils::SectionSpecs wear{"WEAR"};
+  list["WEAR"] = all_of({
 
-  wear.specs.emplace_back(deprecated_selection<WearLaw>("WEARLAW",
-      {
-          {"None", wear_none},
-          {"none", wear_none},
-          {"Archard", wear_archard},
-          {"archard", wear_archard},
-      },
-      {.description = "Type of wear law", .default_value = wear_none}));
+      deprecated_selection<WearLaw>("WEARLAW",
+          {
+              {"None", wear_none},
+              {"none", wear_none},
+              {"Archard", wear_archard},
+              {"archard", wear_archard},
+          },
+          {.description = "Type of wear law", .default_value = wear_none}),
 
-  wear.specs.emplace_back(
-      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}));
 
-  wear.specs.emplace_back(deprecated_selection<WearShape>("WEAR_SHAPEFCN",
-      {
-          {"Dual", wear_shape_dual},
-          {"dual", wear_shape_dual},
-          {"Standard", wear_shape_standard},
-          {"standard", wear_shape_standard},
-          {"std", wear_shape_standard},
-      },
-      {.description = "Type of employed set of shape functions for wear",
-          .default_value = wear_shape_standard}));
+      parameter<bool>("MATCHINGGRID", {.description = "is matching grid", .default_value = true}),
 
-  wear.specs.emplace_back(parameter<double>(
-      "WEARCOEFF", {.description = "Wear coefficient for slave surface", .default_value = 0.0}));
-  wear.specs.emplace_back(parameter<double>("WEARCOEFF_MASTER",
-      {.description = "Wear coefficient for master surface", .default_value = 0.0}));
-  wear.specs.emplace_back(parameter<double>(
-      "WEAR_TIMERATIO", {.description = "Time step ratio between wear and spatial time scale",
-                            .default_value = 1.0}));
-  wear.specs.emplace_back(parameter<double>(
-      "SSSLIP", {.description = "Fixed slip for steady state wear", .default_value = 1.0}));
+      deprecated_selection<WearShape>("WEAR_SHAPEFCN",
+          {
+              {"Dual", wear_shape_dual},
+              {"dual", wear_shape_dual},
+              {"Standard", wear_shape_standard},
+              {"standard", wear_shape_standard},
+              {"std", wear_shape_standard},
+          },
+          {.description = "Type of employed set of shape functions for wear",
+              .default_value = wear_shape_standard}),
 
-  wear.specs.emplace_back(parameter<bool>(
-      "SSWEAR", {.description = "flag for steady state wear", .default_value = false}));
+      parameter<double>(
+          "WEARCOEFF", {.description = "Wear coefficient for slave surface", .default_value = 0.0}),
+      parameter<double>("WEARCOEFF_MASTER",
+          {.description = "Wear coefficient for master surface", .default_value = 0.0}),
+      parameter<double>(
+          "WEAR_TIMERATIO", {.description = "Time step ratio between wear and spatial time scale",
+                                .default_value = 1.0}),
+      parameter<double>(
+          "SSSLIP", {.description = "Fixed slip for steady state wear", .default_value = 1.0}),
 
-  wear.specs.emplace_back(deprecated_selection<WearSide>("WEAR_SIDE",
-      {
-          {"s", wear_slave},
-          {"slave", wear_slave},
-          {"Slave", wear_slave},
-          {"both", wear_both},
-          {"slave_master", wear_both},
-          {"sm", wear_both},
-      },
-      {.description = "Definition of wear side", .default_value = wear_slave}));
+      parameter<bool>(
+          "SSWEAR", {.description = "flag for steady state wear", .default_value = false}),
 
-  wear.specs.emplace_back(deprecated_selection<WearType>("WEARTYPE",
-      {
-          {"intstate", wear_intstate},
-          {"is", wear_intstate},
-          {"internal_state", wear_intstate},
-          {"primvar", wear_primvar},
-          {"pv", wear_primvar},
-          {"primary_variable", wear_primvar},
-      },
-      {.description = "Definition of wear algorithm", .default_value = wear_intstate}));
+      deprecated_selection<WearSide>("WEAR_SIDE",
+          {
+              {"s", wear_slave},
+              {"slave", wear_slave},
+              {"Slave", wear_slave},
+              {"both", wear_both},
+              {"slave_master", wear_both},
+              {"sm", wear_both},
+          },
+          {.description = "Definition of wear side", .default_value = wear_slave}),
 
-  wear.specs.emplace_back(deprecated_selection<WearTimInt>("WEARTIMINT",
-      {
-          {"explicit", wear_expl},
-          {"e", wear_expl},
-          {"expl", wear_expl},
-          {"implicit", wear_impl},
-          {"i", wear_impl},
-          {"impl", wear_impl},
-      },
-      {.description = "Definition of wear time integration", .default_value = wear_expl}));
+      deprecated_selection<WearType>("WEARTYPE",
+          {
+              {"intstate", wear_intstate},
+              {"is", wear_intstate},
+              {"internal_state", wear_intstate},
+              {"primvar", wear_primvar},
+              {"pv", wear_primvar},
+              {"primary_variable", wear_primvar},
+          },
+          {.description = "Definition of wear algorithm", .default_value = wear_intstate}),
 
-  wear.specs.emplace_back(deprecated_selection<WearTimeScale>("WEAR_TIMESCALE",
-      {
-          {"equal", wear_time_equal},
-          {"e", wear_time_equal},
-          {"different", wear_time_different},
-          {"d", wear_time_different},
-      },
-      {.description = "Definition wear time scale compares to std. time scale",
-          .default_value = wear_time_equal}));
+      deprecated_selection<WearTimInt>("WEARTIMINT",
+          {
+              {"explicit", wear_expl},
+              {"e", wear_expl},
+              {"expl", wear_expl},
+              {"implicit", wear_impl},
+              {"i", wear_impl},
+              {"impl", wear_impl},
+          },
+          {.description = "Definition of wear time integration", .default_value = wear_expl}),
 
-  wear.move_into_collection(list);
+      deprecated_selection<WearTimeScale>("WEAR_TIMESCALE",
+          {
+              {"equal", wear_time_equal},
+              {"e", wear_time_equal},
+              {"different", wear_time_different},
+              {"d", wear_time_different},
+          },
+          {.description = "Definition wear time scale compares to std. time scale",
+              .default_value = wear_time_equal})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -7,8 +7,7 @@
 
 #include "4C_inpar_wear.hpp"
 
-#include "4C_utils_parameter_list.hpp"
-
+#include "4C_io_input_spec_builders.hpp"
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -21,37 +21,37 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs xfem_general{"XFEM GENERAL"};
+  list["XFEM GENERAL"] = all_of({
 
-  // OUTPUT options
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_DEBUG_OUT",
-      {.description = "Do you want to write extended Gmsh output for each timestep?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_DEBUG_OUT_SCREEN",
-      {.description = "Do you want to be informed, if Gmsh output is written?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_SOL_OUT",
-      {.description = "Do you want to write extended Gmsh output for each timestep?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_TIMINT_OUT",
-      {.description = "Do you want to write extended Gmsh output for each timestep?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_EOS_OUT",
-      {.description = "Do you want to write extended Gmsh output for each timestep?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_DISCRET_OUT",
-      {.description = "Do you want to write extended Gmsh output for each timestep?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("GMSH_CUT_OUT",
-      {.description = "Do you want to write extended Gmsh output for each timestep?",
-          .default_value = false}));
-  xfem_general.specs.emplace_back(parameter<bool>("PRINT_OUTPUT",
-      {.description = "Is the output of the cut process desired?", .default_value = false}));
+      // OUTPUT options
+      parameter<bool>("GMSH_DEBUG_OUT",
+          {.description = "Do you want to write extended Gmsh output for each timestep?",
+              .default_value = false}),
+      parameter<bool>("GMSH_DEBUG_OUT_SCREEN",
+          {.description = "Do you want to be informed, if Gmsh output is written?",
+              .default_value = false}),
+      parameter<bool>("GMSH_SOL_OUT",
+          {.description = "Do you want to write extended Gmsh output for each timestep?",
+              .default_value = false}),
+      parameter<bool>("GMSH_TIMINT_OUT",
+          {.description = "Do you want to write extended Gmsh output for each timestep?",
+              .default_value = false}),
+      parameter<bool>("GMSH_EOS_OUT",
+          {.description = "Do you want to write extended Gmsh output for each timestep?",
+              .default_value = false}),
+      parameter<bool>("GMSH_DISCRET_OUT",
+          {.description = "Do you want to write extended Gmsh output for each timestep?",
+              .default_value = false}),
+      parameter<bool>("GMSH_CUT_OUT",
+          {.description = "Do you want to write extended Gmsh output for each timestep?",
+              .default_value = false}),
+      parameter<bool>("PRINT_OUTPUT",
+          {.description = "Is the output of the cut process desired?", .default_value = false}),
 
-  xfem_general.specs.emplace_back(parameter<int>("MAX_NUM_DOFSETS",
-      {.description = "Maximum number of volumecells in the XFEM element", .default_value = 3}));
+      parameter<int>("MAX_NUM_DOFSETS",
+          {.description = "Maximum number of volumecells in the XFEM element", .default_value = 3}),
 
-  xfem_general.specs.emplace_back(
+
       deprecated_selection<Cut::NodalDofSetStrategy>("NODAL_DOFSET_STRATEGY",
           {
               {"OneDofset_PerNodeAndPosition", Cut::NDS_Strategy_OneDofset_PerNodeAndPosition},
@@ -60,19 +60,19 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {"full", Cut::NDS_Strategy_full},
           },
           {.description = "Strategy used for the nodal dofset management per node",
-              .default_value = Cut::NDS_Strategy_full}));
+              .default_value = Cut::NDS_Strategy_full}),
 
-  // Integration options
-  xfem_general.specs.emplace_back(deprecated_selection<Cut::VCellGaussPts>("VOLUME_GAUSS_POINTS_BY",
-      {
-          {"Tessellation", Cut::VCellGaussPts_Tessellation},
-          {"MomentFitting", Cut::VCellGaussPts_MomentFitting},
-          {"DirectDivergence", Cut::VCellGaussPts_DirectDivergence},
-      },
-      {.description = "Method for finding Gauss Points for the cut volumes",
-          .default_value = Cut::VCellGaussPts_Tessellation}));
+      // Integration options
+      deprecated_selection<Cut::VCellGaussPts>("VOLUME_GAUSS_POINTS_BY",
+          {
+              {"Tessellation", Cut::VCellGaussPts_Tessellation},
+              {"MomentFitting", Cut::VCellGaussPts_MomentFitting},
+              {"DirectDivergence", Cut::VCellGaussPts_DirectDivergence},
+          },
+          {.description = "Method for finding Gauss Points for the cut volumes",
+              .default_value = Cut::VCellGaussPts_Tessellation}),
 
-  xfem_general.specs.emplace_back(
+
       deprecated_selection<Cut::BCellGaussPts>("BOUNDARY_GAUSS_POINTS_BY",
           {
               {"Tessellation", Cut::BCellGaussPts_Tessellation},
@@ -80,33 +80,26 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {"DirectDivergence", Cut::BCellGaussPts_DirectDivergence},
           },
           {.description = "Method for finding Gauss Points for the boundary cells",
-              .default_value = Cut::BCellGaussPts_Tessellation}));
+              .default_value = Cut::
+                  BCellGaussPts_Tessellation})}); /*----------------------------------------------------------------------*/
+  list["XFLUID DYNAMIC/GENERAL"] = all_of({
 
-  xfem_general.move_into_collection(list);
+      // Do we use more than one fluid discretization?
+      parameter<bool>(
+          "XFLUIDFLUID", {.description = "Use an embedded fluid patch.", .default_value = false}),
 
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs xfluid_dyn{"XFLUID DYNAMIC"};
+      // How many monolithic steps we keep the fluidfluid-boundary fixed
+      parameter<int>("RELAXING_ALE_EVERY",
+          {.description = "Relaxing Ale after how many monolithic steps", .default_value = 1}),
 
-  /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs xfluid_general{xfluid_dyn, "GENERAL"};
+      parameter<bool>("RELAXING_ALE",
+          {.description = "switch on/off for relaxing Ale in monolithic fluid-fluid-fsi",
+              .default_value = true}),
 
-  // Do we use more than one fluid discretization?
-  xfluid_general.specs.emplace_back(parameter<bool>(
-      "XFLUIDFLUID", {.description = "Use an embedded fluid patch.", .default_value = false}));
+      parameter<double>("XFLUIDFLUID_SEARCHRADIUS",
+          {.description = "Radius of the search tree", .default_value = 1.0}),
 
-  // How many monolithic steps we keep the fluidfluid-boundary fixed
-  xfluid_general.specs.emplace_back(parameter<int>("RELAXING_ALE_EVERY",
-      {.description = "Relaxing Ale after how many monolithic steps", .default_value = 1}));
-
-  xfluid_general.specs.emplace_back(parameter<bool>("RELAXING_ALE",
-      {.description = "switch on/off for relaxing Ale in monolithic fluid-fluid-fsi",
-          .default_value = true}));
-
-  xfluid_general.specs.emplace_back(parameter<double>("XFLUIDFLUID_SEARCHRADIUS",
-      {.description = "Radius of the search tree", .default_value = 1.0}));
-
-  // xfluidfluid-fsi-monolithic approach
-  xfluid_general.specs.emplace_back(
+      // xfluidfluid-fsi-monolithic approach
       deprecated_selection<MonolithicXffsiApproach>("MONOLITHIC_XFFSI_APPROACH",
           {
               {"xffsi_full_newton", Inpar::XFEM::XFFSI_Full_Newton},
@@ -114,109 +107,107 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {"xffsi_fixedALE_partitioned", Inpar::XFEM::XFFSI_FixedALE_Partitioned},
           },
           {.description = "The monolithic approach for xfluidfluid-fsi",
-              .default_value = Inpar::XFEM::XFFSI_FixedALE_Partitioned}));
+              .default_value = Inpar::XFEM::XFFSI_FixedALE_Partitioned}),
 
-  // xfluidfluid time integration approach
-  xfluid_general.specs.emplace_back(deprecated_selection<XFluidFluidTimeInt>("XFLUIDFLUID_TIMEINT",
-      {
-          {"Xff_TimeInt_FullProj", Inpar::XFEM::Xff_TimeInt_FullProj},
-          {"Xff_TimeInt_ProjIfMoved", Inpar::XFEM::Xff_TimeInt_ProjIfMoved},
-          {"Xff_TimeInt_KeepGhostValues", Inpar::XFEM::Xff_TimeInt_KeepGhostValues},
-          {"Xff_TimeInt_IncompProj", Inpar::XFEM::Xff_TimeInt_IncompProj},
-      },
-      {.description = "The xfluidfluid-timeintegration approach",
-          .default_value = Inpar::XFEM::Xff_TimeInt_FullProj}));
+      // xfluidfluid time integration approach
+      deprecated_selection<XFluidFluidTimeInt>("XFLUIDFLUID_TIMEINT",
+          {
+              {"Xff_TimeInt_FullProj", Inpar::XFEM::Xff_TimeInt_FullProj},
+              {"Xff_TimeInt_ProjIfMoved", Inpar::XFEM::Xff_TimeInt_ProjIfMoved},
+              {"Xff_TimeInt_KeepGhostValues", Inpar::XFEM::Xff_TimeInt_KeepGhostValues},
+              {"Xff_TimeInt_IncompProj", Inpar::XFEM::Xff_TimeInt_IncompProj},
+          },
+          {.description = "The xfluidfluid-timeintegration approach",
+              .default_value = Inpar::XFEM::Xff_TimeInt_FullProj}),
 
-  xfluid_general.specs.emplace_back(deprecated_selection<XFluidTimeIntScheme>("XFLUID_TIMEINT",
-      {
-          {"STD=COPY_and_GHOST=COPY/GP",
-              Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_AND_GHOST_by_Copy_or_GP},
-          {"STD=COPY/SL_and_GHOST=COPY/GP",
-              Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_SL_AND_GHOST_by_Copy_or_GP},
-          {"STD=SL(boundary-zone)_and_GHOST=GP",
-              Inpar::XFEM::Xf_TimeIntScheme_STD_by_SL_cut_zone_AND_GHOST_by_GP},
-          {"STD=COPY/PROJ_and_GHOST=COPY/PROJ/GP",
-              Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_Proj_AND_GHOST_by_Proj_or_Copy_or_GP},
-      },
-      {.description = "The xfluid time integration approach",
-          .default_value =
-              Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_SL_AND_GHOST_by_Copy_or_GP}));
+      deprecated_selection<XFluidTimeIntScheme>("XFLUID_TIMEINT",
+          {
+              {"STD=COPY_and_GHOST=COPY/GP",
+                  Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_AND_GHOST_by_Copy_or_GP},
+              {"STD=COPY/SL_and_GHOST=COPY/GP",
+                  Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_SL_AND_GHOST_by_Copy_or_GP},
+              {"STD=SL(boundary-zone)_and_GHOST=GP",
+                  Inpar::XFEM::Xf_TimeIntScheme_STD_by_SL_cut_zone_AND_GHOST_by_GP},
+              {"STD=COPY/PROJ_and_GHOST=COPY/PROJ/GP",
+                  Inpar::XFEM::
+                      Xf_TimeIntScheme_STD_by_Copy_or_Proj_AND_GHOST_by_Proj_or_Copy_or_GP},
+          },
+          {.description = "The xfluid time integration approach",
+              .default_value =
+                  Inpar::XFEM::Xf_TimeIntScheme_STD_by_Copy_or_SL_AND_GHOST_by_Copy_or_GP}),
 
-  xfluid_general.specs.emplace_back(parameter<bool>(
-      "ALE_XFluid", {.description = "XFluid is Ale Fluid?", .default_value = false}));
+      parameter<bool>(
+          "ALE_XFluid", {.description = "XFluid is Ale Fluid?", .default_value = false}),
 
-  // for new OST-implementation: which interface terms to be evaluated for previous time step
-  xfluid_general.specs.emplace_back(
+      // for new OST-implementation: which interface terms to be evaluated for previous time step
       deprecated_selection<InterfaceTermsPreviousState>("INTERFACE_TERMS_PREVIOUS_STATE",
           {
               {"PreviousState_only_consistency", Inpar::XFEM::PreviousState_only_consistency},
               {"PreviousState_full", Inpar::XFEM::PreviousState_full},
           },
           {.description = "how to treat interface terms from previous time step (new OST)",
-              .default_value = Inpar::XFEM::PreviousState_only_consistency}));
+              .default_value = Inpar::XFEM::PreviousState_only_consistency}),
 
-  xfluid_general.specs.emplace_back(parameter<bool>("XFLUID_TIMEINT_CHECK_INTERFACETIPS",
-      {.description = "Xfluid TimeIntegration Special Check if node has changed the side!",
-          .default_value = true}));
+      parameter<bool>("XFLUID_TIMEINT_CHECK_INTERFACETIPS",
+          {.description = "Xfluid TimeIntegration Special Check if node has changed the side!",
+              .default_value = true}),
 
-  xfluid_general.specs.emplace_back(parameter<bool>("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE",
-      {.description = "Xfluid TimeIntegration Special Check if node is sliding on surface!",
-          .default_value = true}));
-
-  xfluid_general.move_into_collection(list);
+      parameter<bool>("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE",
+          {.description = "Xfluid TimeIntegration Special Check if node is sliding on surface!",
+              .default_value = true})});
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs xfluid_stab{xfluid_dyn, "STABILIZATION"};
+  list["XFLUID DYNAMIC/STABILIZATION"] = all_of({
 
-  // Boundary-Coupling options
-  xfluid_stab.specs.emplace_back(deprecated_selection<CouplingMethod>("COUPLING_METHOD",
-      {
-          {"Hybrid_LM_Cauchy_stress", Inpar::XFEM::Hybrid_LM_Cauchy_stress},
-          {"Hybrid_LM_viscous_stress", Inpar::XFEM::Hybrid_LM_viscous_stress},
-          {"Nitsche", Inpar::XFEM::Nitsche},
-      },
-      {.description =
-              "method how to enforce embedded boundary/coupling conditions at the interface",
-          .default_value = Inpar::XFEM::Nitsche}));
+      // Boundary-Coupling options
+      deprecated_selection<CouplingMethod>("COUPLING_METHOD",
+          {
+              {"Hybrid_LM_Cauchy_stress", Inpar::XFEM::Hybrid_LM_Cauchy_stress},
+              {"Hybrid_LM_viscous_stress", Inpar::XFEM::Hybrid_LM_viscous_stress},
+              {"Nitsche", Inpar::XFEM::Nitsche},
+          },
+          {.description =
+                  "method how to enforce embedded boundary/coupling conditions at the interface",
+              .default_value = Inpar::XFEM::Nitsche}),
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<HybridLmL2Proj>("HYBRID_LM_L2_PROJ",
-      {
-          {"full_ele_proj", Inpar::XFEM::Hybrid_LM_L2_Proj_full},
-          {"part_ele_proj", Inpar::XFEM::Hybrid_LM_L2_Proj_part},
-      },
-      {.description =
-              "perform the L2 projection between stress fields on whole element or on fluid part?",
-          .default_value = Inpar::XFEM::Hybrid_LM_L2_Proj_part}));
+      deprecated_selection<HybridLmL2Proj>("HYBRID_LM_L2_PROJ",
+          {
+              {"full_ele_proj", Inpar::XFEM::Hybrid_LM_L2_Proj_full},
+              {"part_ele_proj", Inpar::XFEM::Hybrid_LM_L2_Proj_part},
+          },
+          {.description = "perform the L2 projection between stress fields on whole element or on "
+                          "fluid part?",
+              .default_value = Inpar::XFEM::Hybrid_LM_L2_Proj_part}),
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<AdjointScaling>("VISC_ADJOINT_SYMMETRY",
-      {
-          {"yes", Inpar::XFEM::adj_sym},
-          {"no", Inpar::XFEM::adj_skew},
-          {"sym", Inpar::XFEM::adj_sym},
-          {"skew", Inpar::XFEM::adj_skew},
-          {"none", Inpar::XFEM::adj_none},
-      },
-      {.description = "viscous and adjoint viscous interface terms with matching sign?",
-          .default_value = Inpar::XFEM::adj_sym}));
+      deprecated_selection<AdjointScaling>("VISC_ADJOINT_SYMMETRY",
+          {
+              {"yes", Inpar::XFEM::adj_sym},
+              {"no", Inpar::XFEM::adj_skew},
+              {"sym", Inpar::XFEM::adj_sym},
+              {"skew", Inpar::XFEM::adj_skew},
+              {"none", Inpar::XFEM::adj_none},
+          },
+          {.description = "viscous and adjoint viscous interface terms with matching sign?",
+              .default_value = Inpar::XFEM::adj_sym}),
 
-  // viscous and convective Nitsche/MSH stabilization parameter
-  xfluid_stab.specs.emplace_back(parameter<double>(
-      "NIT_STAB_FAC", {.description = " ( stabilization parameter for Nitsche's penalty term",
-                          .default_value = 35.0}));
-  xfluid_stab.specs.emplace_back(parameter<double>("NIT_STAB_FAC_TANG",
-      {.description = " ( stabilization parameter for Nitsche's penalty tangential term",
-          .default_value = 35.0}));
+      // viscous and convective Nitsche/MSH stabilization parameter
+      parameter<double>(
+          "NIT_STAB_FAC", {.description = " ( stabilization parameter for Nitsche's penalty term",
+                              .default_value = 35.0}),
+      parameter<double>("NIT_STAB_FAC_TANG",
+          {.description = " ( stabilization parameter for Nitsche's penalty tangential term",
+              .default_value = 35.0}),
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<ViscStabTraceEstimate>(
-      "VISC_STAB_TRACE_ESTIMATE",
-      {
-          {"CT_div_by_hk", Inpar::XFEM::ViscStab_TraceEstimate_CT_div_by_hk},
-          {"eigenvalue", Inpar::XFEM::ViscStab_TraceEstimate_eigenvalue},
-      },
-      {.description = "how to estimate the scaling from the trace inequality in Nitsche's method",
-          .default_value = Inpar::XFEM::ViscStab_TraceEstimate_CT_div_by_hk}));
+      deprecated_selection<ViscStabTraceEstimate>("VISC_STAB_TRACE_ESTIMATE",
+          {
+              {"CT_div_by_hk", Inpar::XFEM::ViscStab_TraceEstimate_CT_div_by_hk},
+              {"eigenvalue", Inpar::XFEM::ViscStab_TraceEstimate_eigenvalue},
+          },
+          {.description =
+                  "how to estimate the scaling from the trace inequality in Nitsche's method",
+              .default_value = Inpar::XFEM::ViscStab_TraceEstimate_CT_div_by_hk}),
 
-  xfluid_stab.specs.emplace_back(
+
       deprecated_selection<TraceEstimateEigenvalueUpdate>("UPDATE_EIGENVALUE_TRACE_ESTIMATE",
           {
               {"every_iter", Inpar::XFEM::Eigenvalue_update_every_iter},
@@ -224,50 +215,49 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {"once", Inpar::XFEM::Eigenvalue_update_once},
           },
           {.description = "how often should the local eigenvalue problem be updated",
-              .default_value = Inpar::XFEM::Eigenvalue_update_every_iter}));
+              .default_value = Inpar::XFEM::Eigenvalue_update_every_iter}),
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<ViscStabHk>("VISC_STAB_HK",
-      {
-          {"vol_equivalent", Inpar::XFEM::ViscStab_hk_vol_equivalent},
-          {"cut_vol_div_by_cut_surf", Inpar::XFEM::ViscStab_hk_cut_vol_div_by_cut_surf},
-          {"ele_vol_div_by_cut_surf", Inpar::XFEM::ViscStab_hk_ele_vol_div_by_cut_surf},
-          {"ele_vol_div_by_ele_surf", Inpar::XFEM::ViscStab_hk_ele_vol_div_by_ele_surf},
-          {"ele_vol_div_by_max_ele_surf", Inpar::XFEM::ViscStab_hk_ele_vol_div_by_max_ele_surf},
-      },
-      {.description = "how to define the characteristic element length in cut elements",
-          .default_value = Inpar::XFEM::ViscStab_hk_ele_vol_div_by_max_ele_surf}));
+      deprecated_selection<ViscStabHk>("VISC_STAB_HK",
+          {
+              {"vol_equivalent", Inpar::XFEM::ViscStab_hk_vol_equivalent},
+              {"cut_vol_div_by_cut_surf", Inpar::XFEM::ViscStab_hk_cut_vol_div_by_cut_surf},
+              {"ele_vol_div_by_cut_surf", Inpar::XFEM::ViscStab_hk_ele_vol_div_by_cut_surf},
+              {"ele_vol_div_by_ele_surf", Inpar::XFEM::ViscStab_hk_ele_vol_div_by_ele_surf},
+              {"ele_vol_div_by_max_ele_surf", Inpar::XFEM::ViscStab_hk_ele_vol_div_by_max_ele_surf},
+          },
+          {.description = "how to define the characteristic element length in cut elements",
+              .default_value = Inpar::XFEM::ViscStab_hk_ele_vol_div_by_max_ele_surf}),
 
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<ConvStabScaling>("CONV_STAB_SCALING",
-      {
-          {"inflow", Inpar::XFEM::ConvStabScaling_inflow},
-          {"abs_inflow", Inpar::XFEM::ConvStabScaling_abs_inflow},
-          {"none", Inpar::XFEM::ConvStabScaling_none},
-      },
-      {.description = "scaling factor for viscous interface stabilization (Nitsche, MSH)",
-          .default_value = Inpar::XFEM::ConvStabScaling_none}));
+      deprecated_selection<ConvStabScaling>("CONV_STAB_SCALING",
+          {
+              {"inflow", Inpar::XFEM::ConvStabScaling_inflow},
+              {"abs_inflow", Inpar::XFEM::ConvStabScaling_abs_inflow},
+              {"none", Inpar::XFEM::ConvStabScaling_none},
+          },
+          {.description = "scaling factor for viscous interface stabilization (Nitsche, MSH)",
+              .default_value = Inpar::XFEM::ConvStabScaling_none}),
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<XffConvStabScaling>("XFF_CONV_STAB_SCALING",
-      {
-          {"inflow", Inpar::XFEM::XFF_ConvStabScaling_upwinding},
-          {"averaged", Inpar::XFEM::XFF_ConvStabScaling_only_averaged},
-          {"none", Inpar::XFEM::XFF_ConvStabScaling_none},
-      },
-      {.description =
-              "scaling factor for convective interface stabilization of fluid-fluid Coupling",
-          .default_value = Inpar::XFEM::XFF_ConvStabScaling_none}));
+      deprecated_selection<XffConvStabScaling>("XFF_CONV_STAB_SCALING",
+          {
+              {"inflow", Inpar::XFEM::XFF_ConvStabScaling_upwinding},
+              {"averaged", Inpar::XFEM::XFF_ConvStabScaling_only_averaged},
+              {"none", Inpar::XFEM::XFF_ConvStabScaling_none},
+          },
+          {.description =
+                  "scaling factor for convective interface stabilization of fluid-fluid Coupling",
+              .default_value = Inpar::XFEM::XFF_ConvStabScaling_none}),
 
-  xfluid_stab.specs.emplace_back(deprecated_selection<MassConservationCombination>(
-      "MASS_CONSERVATION_COMBO",
-      {
-          {"max", Inpar::XFEM::MassConservationCombination_max},
-          {"sum", Inpar::XFEM::MassConservationCombination_sum},
-      },
-      {.description =
-              "choose the maximum from viscous and convective contributions or just sum both up",
-          .default_value = Inpar::XFEM::MassConservationCombination_max}));
+      deprecated_selection<MassConservationCombination>("MASS_CONSERVATION_COMBO",
+          {
+              {"max", Inpar::XFEM::MassConservationCombination_max},
+              {"sum", Inpar::XFEM::MassConservationCombination_sum},
+          },
+          {.description = "choose the maximum from viscous and convective contributions or just "
+                          "sum both up",
+              .default_value = Inpar::XFEM::MassConservationCombination_max}),
 
-  xfluid_stab.specs.emplace_back(
+
       deprecated_selection<MassConservationScaling>("MASS_CONSERVATION_SCALING",
           {
               {"full", Inpar::XFEM::MassConservationScaling_full},
@@ -275,117 +265,117 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           },
           {.description = "apply additional scaling of penalty term to enforce mass conservation "
                           "for convection-dominated flow",
-              .default_value = Inpar::XFEM::MassConservationScaling_only_visc}));
+              .default_value = Inpar::XFEM::MassConservationScaling_only_visc}),
 
-  xfluid_stab.specs.emplace_back(parameter<bool>(
-      "GHOST_PENALTY_STAB", {.description = "switch on/off ghost penalty interface stabilization",
-                                .default_value = false}));
+      parameter<bool>("GHOST_PENALTY_STAB",
+          {.description = "switch on/off ghost penalty interface stabilization",
+              .default_value = false}),
 
-  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_TRANSIENT_STAB",
-      {.description = "switch on/off ghost penalty transient interface stabilization",
-          .default_value = false}));
+      parameter<bool>("GHOST_PENALTY_TRANSIENT_STAB",
+          {.description = "switch on/off ghost penalty transient interface stabilization",
+              .default_value = false}),
 
-  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_2nd_STAB",
-      {.description =
-              "switch on/off ghost penalty interface stabilization for 2nd order derivatives",
-          .default_value = false}));
-  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_2nd_STAB_NORMAL",
-      {.description = "switch between ghost penalty interface stabilization for 2nd order "
-                      "derivatives in normal or all spatial directions",
-          .default_value = false}));
-
-
-  xfluid_stab.specs.emplace_back(parameter<double>("GHOST_PENALTY_FAC",
-      {.description = "define stabilization parameter ghost penalty interface stabilization",
-          .default_value = 0.1}));
-
-  xfluid_stab.specs.emplace_back(parameter<double>("GHOST_PENALTY_TRANSIENT_FAC",
-      {.description =
-              "define stabilization parameter ghost penalty transient interface stabilization",
-          .default_value = 0.001}));
-
-  xfluid_stab.specs.emplace_back(parameter<double>(
-      "GHOST_PENALTY_2nd_FAC", {.description = "define stabilization parameter ghost penalty 2nd "
-                                               "order viscous interface stabilization",
-                                   .default_value = 0.05}));
-  xfluid_stab.specs.emplace_back(parameter<double>("GHOST_PENALTY_PRESSURE_2nd_FAC",
-      {.description = "define stabilization parameter ghost penalty 2nd order pressure interface "
-                      "stabilization",
-          .default_value = 0.05}));
+      parameter<bool>("GHOST_PENALTY_2nd_STAB",
+          {.description =
+                  "switch on/off ghost penalty interface stabilization for 2nd order derivatives",
+              .default_value = false}),
+      parameter<bool>("GHOST_PENALTY_2nd_STAB_NORMAL",
+          {.description = "switch between ghost penalty interface stabilization for 2nd order "
+                          "derivatives in normal or all spatial directions",
+              .default_value = false}),
 
 
-  xfluid_stab.specs.emplace_back(parameter<bool>("XFF_EOS_PRES_EMB_LAYER",
-      {.description = "switch on/off edge-based pressure stabilization on interface-contributing "
-                      "elements of the embedded fluid",
-          .default_value = false}));
+      parameter<double>("GHOST_PENALTY_FAC",
+          {.description = "define stabilization parameter ghost penalty interface stabilization",
+              .default_value = 0.1}),
 
-  xfluid_stab.specs.emplace_back(parameter<bool>(
-      "IS_PSEUDO_2D", {.description = "modify viscous interface stabilization due to the vanishing "
-                                      "polynomial in third dimension when using strong Dirichlet "
-                                      "conditions to block polynomials in one spatial dimension",
-                          .default_value = false}));
+      parameter<double>("GHOST_PENALTY_TRANSIENT_FAC",
+          {.description =
+                  "define stabilization parameter ghost penalty transient interface stabilization",
+              .default_value = 0.001}),
 
-  xfluid_stab.specs.emplace_back(parameter<bool>("GHOST_PENALTY_ADD_INNER_FACES",
-      {.description = "Apply ghost penalty stabilization also for inner faces if this is possible "
-                      "due to the dofsets",
-          .default_value = false}));
+      parameter<double>("GHOST_PENALTY_2nd_FAC",
+          {.description = "define stabilization parameter ghost penalty 2nd "
+                          "order viscous interface stabilization",
+              .default_value = 0.05}),
+      parameter<double>("GHOST_PENALTY_PRESSURE_2nd_FAC",
+          {.description =
+                  "define stabilization parameter ghost penalty 2nd order pressure interface "
+                  "stabilization",
+              .default_value = 0.05}),
 
-  xfluid_stab.move_into_collection(list);
+
+      parameter<bool>("XFF_EOS_PRES_EMB_LAYER",
+          {.description =
+                  "switch on/off edge-based pressure stabilization on interface-contributing "
+                  "elements of the embedded fluid",
+              .default_value = false}),
+
+      parameter<bool>("IS_PSEUDO_2D",
+          {.description = "modify viscous interface stabilization due to the vanishing "
+                          "polynomial in third dimension when using strong Dirichlet "
+                          "conditions to block polynomials in one spatial dimension",
+              .default_value = false}),
+
+      parameter<bool>("GHOST_PENALTY_ADD_INNER_FACES",
+          {.description =
+                  "Apply ghost penalty stabilization also for inner faces if this is possible "
+                  "due to the dofsets",
+              .default_value = false})});
 
   /*----------------------------------------------------------------------*/
-  Core::Utils::SectionSpecs xfsi_monolithic{xfluid_dyn, "XFPSI MONOLITHIC"};
+  list["XFLUID DYNAMIC/XFPSI MONOLITHIC"] = all_of({
 
-  xfsi_monolithic.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "How many iterations are performed minimal", .default_value = 1}));
-  xfsi_monolithic.specs.emplace_back(parameter<int>("ITEMAX_OUTER",
-      {.description = "How many outer iterations are performed maximal", .default_value = 5}));
-  xfsi_monolithic.specs.emplace_back(parameter<bool>("ND_NEWTON_DAMPING",
-      {.description = "Activate Newton damping based on residual and increment",
-          .default_value = false}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_DISP_ITERINC",
-      {.description =
-              "Maximal displacement increment to apply full newton --> otherwise damp newton",
-          .default_value = -1.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_VEL_ITERINC",
-      {.description =
-              "Maximal fluid velocity increment to apply full newton --> otherwise damp newton",
-          .default_value = -1.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_PRES_ITERINC",
-      {.description =
-              "Maximal fluid pressure increment to apply full newton --> otherwise damp newton",
-          .default_value = -1.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_PVEL_ITERINC",
-      {.description =
-              "Maximal porofluid velocity increment to apply full newton --> otherwise damp newton",
-          .default_value = -1.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("ND_MAX_PPRES_ITERINC",
-      {.description =
-              "Maximal porofluid pressure increment to apply full newton --> otherwise damp newton",
-          .default_value = -1.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>(
-      "CUT_EVALUATE_MINTOL", {.description = "Minimal value of the maximal structural displacement "
-                                             "for which the CUT is evaluate in this iteration!",
-                                 .default_value = 0.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<bool>(
-      "EXTRAPOLATE_TO_ZERO", {.description = "the extrapolation of the fluid stress in the contact "
-                                             "zone is relaxed to zero after a certain distance",
-                                 .default_value = false}));
-  xfsi_monolithic.specs.emplace_back(parameter<int>("CUT_EVALUATE_MINITER",
-      {.description =
-              "Minimal number of nonlinear iterations, before the CUT is potentially not evaluated",
-          .default_value = 0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("POROCONTACTFPSI_HFRACTION",
-      {.description = "factor of element size, when transition between FPSI and PSCI is started!",
-          .default_value = 1.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<double>("POROCONTACTFPSI_FULLPCFRACTION",
-      {.description = "ration of gap/(POROCONTACTFPSI_HFRACTION*h) when full PSCI is started!",
-          .default_value = 0.0}));
-  xfsi_monolithic.specs.emplace_back(parameter<bool>(
-      "USE_PORO_PRESSURE", {.description = "the extrapolation of the fluid stress in the contact "
-                                           "zone is relaxed to zero after a certtain distance",
-                               .default_value = true}));
-
-  xfsi_monolithic.move_into_collection(list);
+      parameter<int>("ITEMIN",
+          {.description = "How many iterations are performed minimal", .default_value = 1}),
+      parameter<int>("ITEMAX_OUTER",
+          {.description = "How many outer iterations are performed maximal", .default_value = 5}),
+      parameter<bool>("ND_NEWTON_DAMPING",
+          {.description = "Activate Newton damping based on residual and increment",
+              .default_value = false}),
+      parameter<double>("ND_MAX_DISP_ITERINC",
+          {.description =
+                  "Maximal displacement increment to apply full newton --> otherwise damp newton",
+              .default_value = -1.0}),
+      parameter<double>("ND_MAX_VEL_ITERINC",
+          {.description =
+                  "Maximal fluid velocity increment to apply full newton --> otherwise damp newton",
+              .default_value = -1.0}),
+      parameter<double>("ND_MAX_PRES_ITERINC",
+          {.description =
+                  "Maximal fluid pressure increment to apply full newton --> otherwise damp newton",
+              .default_value = -1.0}),
+      parameter<double>(
+          "ND_MAX_PVEL_ITERINC", {.description = "Maximal porofluid velocity increment to apply "
+                                                 "full newton --> otherwise damp newton",
+                                     .default_value = -1.0}),
+      parameter<double>(
+          "ND_MAX_PPRES_ITERINC", {.description = "Maximal porofluid pressure increment to apply "
+                                                  "full newton --> otherwise damp newton",
+                                      .default_value = -1.0}),
+      parameter<double>("CUT_EVALUATE_MINTOL",
+          {.description = "Minimal value of the maximal structural displacement "
+                          "for which the CUT is evaluate in this iteration!",
+              .default_value = 0.0}),
+      parameter<bool>("EXTRAPOLATE_TO_ZERO",
+          {.description = "the extrapolation of the fluid stress in the contact "
+                          "zone is relaxed to zero after a certain distance",
+              .default_value = false}),
+      parameter<int>(
+          "CUT_EVALUATE_MINITER", {.description = "Minimal number of nonlinear iterations, before "
+                                                  "the CUT is potentially not evaluated",
+                                      .default_value = 0}),
+      parameter<double>("POROCONTACTFPSI_HFRACTION",
+          {.description =
+                  "factor of element size, when transition between FPSI and PSCI is started!",
+              .default_value = 1.0}),
+      parameter<double>("POROCONTACTFPSI_FULLPCFRACTION",
+          {.description = "ration of gap/(POROCONTACTFPSI_HFRACTION*h) when full PSCI is started!",
+              .default_value = 0.0}),
+      parameter<bool>("USE_PORO_PRESSURE",
+          {.description = "the extrapolation of the fluid stress in the contact "
+                          "zone is relaxed to zero after a certtain distance",
+              .default_value = true})});
 }
 
 

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -10,8 +10,6 @@
 #include "4C_cut_enum.hpp"
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
-#include "4C_utils_parameter_list.hpp"
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/lubrication/src/4C_lubrication_input.cpp
+++ b/src/lubrication/src/4C_lubrication_input.cpp
@@ -17,32 +17,32 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs lubricationdyn("LUBRICATION DYNAMIC");
+  list["LUBRICATION DYNAMIC"] = all_of({
 
-  lubricationdyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  lubricationdyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of time steps", .default_value = 20}));
-  lubricationdyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  lubricationdyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  lubricationdyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>("NUMSTEP", {.description = "Total number of time steps", .default_value = 20}),
+
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
 
 
-  lubricationdyn.specs.emplace_back(deprecated_selection<Lubrication::CalcError>("CALCERROR",
-      {
-          {"No", calcerror_no},
-          {"error_by_function", calcerror_byfunction},
-      },
-      {.description = "compute error compared to analytical solution",
-          .default_value = calcerror_no}));
+      deprecated_selection<Lubrication::CalcError>("CALCERROR",
+          {
+              {"No", calcerror_no},
+              {"error_by_function", calcerror_byfunction},
+          },
+          {.description = "compute error compared to analytical solution",
+              .default_value = calcerror_no}),
 
-  lubricationdyn.specs.emplace_back(parameter<int>("CALCERRORNO",
-      {.description = "function number for lubrication error computation", .default_value = -1}));
+      parameter<int>(
+          "CALCERRORNO", {.description = "function number for lubrication error computation",
+                             .default_value = -1}),
 
-  lubricationdyn.specs.emplace_back(
+
       deprecated_selection<Lubrication::VelocityField>("VELOCITYFIELD",
           {
               {"zero", velocity_zero},
@@ -50,118 +50,116 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {"EHL", velocity_EHL},
           },
           {.description = "type of velocity field used for lubrication problems",
-              .default_value = velocity_zero}));
+              .default_value = velocity_zero}),
 
-  lubricationdyn.specs.emplace_back(parameter<int>("VELFUNCNO",
-      {.description = "function number for lubrication velocity field", .default_value = -1}));
+      parameter<int>("VELFUNCNO",
+          {.description = "function number for lubrication velocity field", .default_value = -1}),
 
-  lubricationdyn.specs.emplace_back(deprecated_selection<Lubrication::HeightField>("HEIGHTFEILD",
-      {
-          {"zero", height_zero},
-          {"function", height_function},
-          {"EHL", height_EHL},
-      },
-      {.description = "type of height field used for lubrication problems",
-          .default_value = height_zero}));
+      deprecated_selection<Lubrication::HeightField>("HEIGHTFEILD",
+          {
+              {"zero", height_zero},
+              {"function", height_function},
+              {"EHL", height_EHL},
+          },
+          {.description = "type of height field used for lubrication problems",
+              .default_value = height_zero}),
 
-  lubricationdyn.specs.emplace_back(parameter<int>("HFUNCNO",
-      {.description = "function number for lubrication height field", .default_value = -1}));
+      parameter<int>("HFUNCNO",
+          {.description = "function number for lubrication height field", .default_value = -1}),
 
-  lubricationdyn.specs.emplace_back(parameter<bool>("OUTMEAN",
-      {.description = "Output of mean values for scalars and density", .default_value = false}));
+      parameter<bool>("OUTMEAN",
+          {.description = "Output of mean values for scalars and density", .default_value = false}),
 
-  lubricationdyn.specs.emplace_back(parameter<bool>("OUTPUT_GMSH",
-      {.description = "Do you want to write Gmsh postprocessing files?", .default_value = false}));
+      parameter<bool>(
+          "OUTPUT_GMSH", {.description = "Do you want to write Gmsh postprocessing files?",
+                             .default_value = false}),
 
-  lubricationdyn.specs.emplace_back(parameter<bool>("MATLAB_STATE_OUTPUT",
-      {.description = "Do you want to write the state solution to Matlab file?",
-          .default_value = false}));
+      parameter<bool>("MATLAB_STATE_OUTPUT",
+          {.description = "Do you want to write the state solution to Matlab file?",
+              .default_value = false}),
 
-  /// linear solver id used for lubrication problems
-  lubricationdyn.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for the Lubrication problem",
-                           .default_value = -1}));
+      /// linear solver id used for lubrication problems
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for the Lubrication problem",
+              .default_value = -1}),
 
-  lubricationdyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}));
-  lubricationdyn.specs.emplace_back(parameter<double>("ABSTOLRES",
-      {.description =
-              "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
-          .default_value = 1e-14}));
-  lubricationdyn.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-13}));
+      parameter<int>(
+          "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}),
+      parameter<double>("ABSTOLRES", {.description = "Absolute tolerance for deciding if residual "
+                                                     "of nonlinear problem is already zero",
+                                         .default_value = 1e-14}),
+      parameter<double>(
+          "CONVTOL", {.description = "Tolerance for convergence check", .default_value = 1e-13}),
 
-  // convergence criteria adaptivity
-  lubricationdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  lubricationdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
+      // convergence criteria adaptivity
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
 
-  lubricationdyn.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_PRE",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for temperature convergence check",
-          .default_value = convnorm_abs}));
+      deprecated_selection<ConvNorm>("NORM_PRE",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for temperature convergence check",
+              .default_value = convnorm_abs}),
 
-  lubricationdyn.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_RESF",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = convnorm_abs}));
+      deprecated_selection<ConvNorm>("NORM_RESF",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = convnorm_abs}),
 
-  lubricationdyn.specs.emplace_back(deprecated_selection<VectorNorm>("ITERNORM",
-      {
-          {"L1", norm_l1},
-          {"L2", norm_l2},
-          {"Rms", norm_rms},
-          {"Inf", norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals", .default_value = norm_l2}));
+      deprecated_selection<VectorNorm>("ITERNORM",
+          {
+              {"L1", norm_l1},
+              {"L2", norm_l2},
+              {"Rms", norm_rms},
+              {"Inf", norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}),
 
-  /// Iterationparameters
-  lubricationdyn.specs.emplace_back(parameter<double>(
-      "TOLPRE", {.description = "tolerance in the temperature norm of the Newton iteration",
-                    .default_value = 1.0E-06}));
+      /// Iterationparameters
+      parameter<double>(
+          "TOLPRE", {.description = "tolerance in the temperature norm of the Newton iteration",
+                        .default_value = 1.0E-06}),
 
-  lubricationdyn.specs.emplace_back(parameter<double>(
-      "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
-                    .default_value = 1.0E-06}));
+      parameter<double>(
+          "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                        .default_value = 1.0E-06}),
 
-  lubricationdyn.specs.emplace_back(parameter<double>("PENALTY_CAVITATION",
-      {.description = "penalty parameter for regularized cavitation", .default_value = 0.}));
+      parameter<double>("PENALTY_CAVITATION",
+          {.description = "penalty parameter for regularized cavitation", .default_value = 0.}),
 
-  lubricationdyn.specs.emplace_back(parameter<double>(
-      "GAP_OFFSET", {.description = "Additional offset to the fluid gap", .default_value = 0.}));
+      parameter<double>(
+          "GAP_OFFSET", {.description = "Additional offset to the fluid gap", .default_value = 0.}),
 
-  lubricationdyn.specs.emplace_back(parameter<double>("ROUGHNESS_STD_DEVIATION",
-      {.description = "standard deviation of surface roughness", .default_value = 0.}));
+      parameter<double>("ROUGHNESS_STD_DEVIATION",
+          {.description = "standard deviation of surface roughness", .default_value = 0.}),
 
-  /// use modified reynolds equ.
-  lubricationdyn.specs.emplace_back(parameter<bool>("MODIFIED_REYNOLDS_EQU",
-      {.description = "the lubrication problem will use the modified reynolds equ. in order to "
-                      "consider surface roughness",
-          .default_value = false}));
+      /// use modified reynolds equ.
+      parameter<bool>("MODIFIED_REYNOLDS_EQU",
+          {.description = "the lubrication problem will use the modified reynolds equ. in order to "
+                          "consider surface roughness",
+              .default_value = false}),
 
-  /// Flag for considering the Squeeze term in Reynolds Equation
-  lubricationdyn.specs.emplace_back(parameter<bool>("ADD_SQUEEZE_TERM",
-      {.description = "the squeeze term will also be considered in the Reynolds Equation",
-          .default_value = false}));
+      /// Flag for considering the Squeeze term in Reynolds Equation
+      parameter<bool>("ADD_SQUEEZE_TERM",
+          {.description = "the squeeze term will also be considered in the Reynolds Equation",
+              .default_value = false}),
 
-  /// Flag for considering the pure Reynolds Equation
-  lubricationdyn.specs.emplace_back(parameter<bool>(
-      "PURE_LUB", {.description = "the problem is pure lubrication", .default_value = false}));
-
-  lubricationdyn.move_into_collection(list);
+      /// Flag for considering the pure Reynolds Equation
+      parameter<bool>(
+          "PURE_LUB", {.description = "the problem is pure lubrication", .default_value = false})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
@@ -17,194 +17,193 @@ void POROFLUIDMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::I
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs porofluidmultiphasedyn{"POROFLUIDMULTIPHASE DYNAMIC"};
+  list["POROFLUIDMULTIPHASE DYNAMIC"] = all_of({
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "Total number of time steps", .default_value = 20}));
-  porofluidmultiphasedyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>(
-      "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}));
+      parameter<double>(
+          "MAXTIME", {.description = "Total simulation time", .default_value = 1000.0}),
+      parameter<int>("NUMSTEP", {.description = "Total number of time steps", .default_value = 20}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
-      "THETA", {.description = "One-step-theta time integration factor", .default_value = 0.5}));
+      parameter<double>("TIMESTEP", {.description = "Time increment dt", .default_value = 0.1}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "Increment for writing solution", .default_value = 1}),
+      parameter<int>(
+          "RESTARTEVERY", {.description = "Increment for writing restart", .default_value = 1}),
 
-  porofluidmultiphasedyn.specs.emplace_back(
+      parameter<double>(
+          "THETA", {.description = "One-step-theta time integration factor", .default_value = 0.5}),
+
+
       deprecated_selection<TimeIntegrationScheme>("TIMEINTEGR",
           {
               {"One_Step_Theta", timeint_one_step_theta},
           },
-          {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}));
+          {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}),
 
-  porofluidmultiphasedyn.specs.emplace_back(deprecated_selection<CalcError>("CALCERROR",
-      {
-          {"No", calcerror_no},
-          {"error_by_function", calcerror_byfunction},
-      },
-      {.description = "compute error compared to analytical solution",
-          .default_value = calcerror_no}));
+      deprecated_selection<CalcError>("CALCERROR",
+          {
+              {"No", calcerror_no},
+              {"error_by_function", calcerror_byfunction},
+          },
+          {.description = "compute error compared to analytical solution",
+              .default_value = calcerror_no}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>(
-      "CALCERRORNO", {.description = "function number for porofluidmultiphase error computation",
-                         .default_value = -1}));
+      parameter<int>("CALCERRORNO",
+          {.description = "function number for porofluidmultiphase error computation",
+              .default_value = -1}),
 
-  // linear solver id used for porofluidmultiphase problems
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for the porofluidmultiphase problem",
-          .default_value = -1}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("ABSTOLRES",
-      {.description =
-              "Absolute tolerance for deciding if residual of nonlinear problem is already zero",
-          .default_value = 1e-14}));
+      // linear solver id used for porofluidmultiphase problems
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for the porofluidmultiphase problem",
+              .default_value = -1}),
+      parameter<int>(
+          "ITEMAX", {.description = "max. number of nonlin. iterations", .default_value = 10}),
+      parameter<double>("ABSTOLRES", {.description = "Absolute tolerance for deciding if residual "
+                                                     "of nonlinear problem is already zero",
+                                         .default_value = 1e-14}),
 
-  // convergence criteria adaptivity
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
+      // convergence criteria adaptivity
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
 
-  // parameters for finite difference check
-  porofluidmultiphasedyn.specs.emplace_back(deprecated_selection<FdCheck>("FDCHECK",
-      {
-          {"none", fdcheck_none},
-          {"global", fdcheck_global},
-      },
-      {.description = "flag for finite difference check: none, local, or global",
-          .default_value = fdcheck_none}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
-      "FDCHECKEPS", {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
-                                    "seems to work very well, whereas smaller values don't)",
-                        .default_value = 1.e-6}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("FDCHECKTOL",
-      {.description = "relative tolerance for finite difference check", .default_value = 1.e-6}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>(
-      "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
-                         .default_value = true}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("OUTPUT_SATANDPRESS",
-      {.description = "Flag if output of saturations and pressures should be calculated",
-          .default_value = true}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>(
-      "OUTPUT_SOLIDPRESS", {.description = "Flag if output of solid pressure should be calculated",
-                               .default_value = true}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("OUTPUT_POROSITY",
-      {.description = "Flag if output of porosity should be calculated", .default_value = true}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("OUTPUT_PHASE_VELOCITIES",
-      {.description = "Flag if output of phase velocities should be calculated",
-          .default_value = true}));
+      // parameters for finite difference check
+      deprecated_selection<FdCheck>("FDCHECK",
+          {
+              {"none", fdcheck_none},
+              {"global", fdcheck_global},
+          },
+          {.description = "flag for finite difference check: none, local, or global",
+              .default_value = fdcheck_none}),
+      parameter<double>("FDCHECKEPS",
+          {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
+                          "seems to work very well, whereas smaller values don't)",
+              .default_value = 1.e-6}),
+      parameter<double>(
+          "FDCHECKTOL", {.description = "relative tolerance for finite difference check",
+                            .default_value = 1.e-6}),
+      parameter<bool>(
+          "SKIPINITDER", {.description = "Flag to skip computation of initial time derivative",
+                             .default_value = true}),
+      parameter<bool>("OUTPUT_SATANDPRESS",
+          {.description = "Flag if output of saturations and pressures should be calculated",
+              .default_value = true}),
+      parameter<bool>("OUTPUT_SOLIDPRESS",
+          {.description = "Flag if output of solid pressure should be calculated",
+              .default_value = true}),
+      parameter<bool>(
+          "OUTPUT_POROSITY", {.description = "Flag if output of porosity should be calculated",
+                                 .default_value = true}),
+      parameter<bool>("OUTPUT_PHASE_VELOCITIES",
+          {.description = "Flag if output of phase velocities should be calculated",
+              .default_value = true}),
 
-  // Biot stabilization
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("STAB_BIOT",
-      {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("STAB_BIOT_SCALING",
-      {.description =
-              "Scaling factor for stabilization parameter for biot stabilization of porous flow.",
-          .default_value = 1.0}));
+      // Biot stabilization
+      parameter<bool>("STAB_BIOT",
+          {.description = "Flag to (de)activate BIOT stabilization.", .default_value = false}),
+      parameter<double>(
+          "STAB_BIOT_SCALING", {.description = "Scaling factor for stabilization parameter for "
+                                               "biot stabilization of porous flow.",
+                                   .default_value = 1.0}),
 
-  porofluidmultiphasedyn.specs.emplace_back(deprecated_selection<VectorNorm>("VECTORNORM_RESF",
-      {
-          {"L1", POROFLUIDMULTIPHASE::norm_l1},
-          {"L1_Scaled", POROFLUIDMULTIPHASE::norm_l1_scaled},
-          {"L2", POROFLUIDMULTIPHASE::norm_l2},
-          {"Rms", POROFLUIDMULTIPHASE::norm_rms},
-          {"Inf", POROFLUIDMULTIPHASE::norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals",
-          .default_value = POROFLUIDMULTIPHASE::norm_l2}));
+      deprecated_selection<VectorNorm>("VECTORNORM_RESF",
+          {
+              {"L1", POROFLUIDMULTIPHASE::norm_l1},
+              {"L1_Scaled", POROFLUIDMULTIPHASE::norm_l1_scaled},
+              {"L2", POROFLUIDMULTIPHASE::norm_l2},
+              {"Rms", POROFLUIDMULTIPHASE::norm_rms},
+              {"Inf", POROFLUIDMULTIPHASE::norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals",
+              .default_value = POROFLUIDMULTIPHASE::norm_l2}),
 
-  porofluidmultiphasedyn.specs.emplace_back(deprecated_selection<VectorNorm>("VECTORNORM_INC",
-      {
-          {"L1", POROFLUIDMULTIPHASE::norm_l1},
-          {"L1_Scaled", POROFLUIDMULTIPHASE::norm_l1_scaled},
-          {"L2", POROFLUIDMULTIPHASE::norm_l2},
-          {"Rms", POROFLUIDMULTIPHASE::norm_rms},
-          {"Inf", POROFLUIDMULTIPHASE::norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals",
-          .default_value = POROFLUIDMULTIPHASE::norm_l2}));
+      deprecated_selection<VectorNorm>("VECTORNORM_INC",
+          {
+              {"L1", POROFLUIDMULTIPHASE::norm_l1},
+              {"L1_Scaled", POROFLUIDMULTIPHASE::norm_l1_scaled},
+              {"L2", POROFLUIDMULTIPHASE::norm_l2},
+              {"Rms", POROFLUIDMULTIPHASE::norm_rms},
+              {"Inf", POROFLUIDMULTIPHASE::norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals",
+              .default_value = POROFLUIDMULTIPHASE::norm_l2}),
 
-  // Iterationparameters
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
-      "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
-                    .default_value = 1e-6}));
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>(
-      "TOLINC", {.description = "tolerance in the increment norm for the Newton iteration",
-                    .default_value = 1e-6}));
+      // Iterationparameters
+      parameter<double>(
+          "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                        .default_value = 1e-6}),
+      parameter<double>(
+          "TOLINC", {.description = "tolerance in the increment norm for the Newton iteration",
+                        .default_value = 1e-6}),
 
-  porofluidmultiphasedyn.specs.emplace_back(deprecated_selection<InitialField>("INITIALFIELD",
-      {
-          {"zero_field", initfield_zero_field},
-          {"field_by_function", initfield_field_by_function},
-          {"field_by_condition", initfield_field_by_condition},
-      },
-      {.description = "Initial Field for transport problem",
-          .default_value = initfield_zero_field}));
+      deprecated_selection<InitialField>("INITIALFIELD",
+          {
+              {"zero_field", initfield_zero_field},
+              {"field_by_function", initfield_field_by_function},
+              {"field_by_condition", initfield_field_by_condition},
+          },
+          {.description = "Initial Field for transport problem",
+              .default_value = initfield_zero_field}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>("INITFUNCNO",
-      {.description = "function number for scalar transport initial field", .default_value = -1}));
+      parameter<int>(
+          "INITFUNCNO", {.description = "function number for scalar transport initial field",
+                            .default_value = -1}),
 
-  porofluidmultiphasedyn.specs.emplace_back(deprecated_selection<DivContAct>("DIVERCONT",
-      {
-          {"stop", divcont_stop},
-          {"continue", divcont_continue},
-      },
-      {.description = "What to do with time integration when Newton-Raphson iteration failed",
-          .default_value = divcont_stop}));
+      deprecated_selection<DivContAct>("DIVERCONT",
+          {
+              {"stop", divcont_stop},
+              {"continue", divcont_continue},
+          },
+          {.description = "What to do with time integration when Newton-Raphson iteration failed",
+              .default_value = divcont_stop}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<int>("FLUX_PROJ_SOLVER",
-      {.description = "Number of linear solver used for L2 projection", .default_value = -1}));
+      parameter<int>("FLUX_PROJ_SOLVER",
+          {.description = "Number of linear solver used for L2 projection", .default_value = -1}),
 
-  porofluidmultiphasedyn.specs.emplace_back(
+
       deprecated_selection<FluxReconstructionMethod>("FLUX_PROJ_METHOD",
           {
               {"none", gradreco_none},
               {"L2_projection", gradreco_l2},
           },
           {.description = "Flag to (de)activate flux reconstruction.",
-              .default_value = gradreco_none}));
+              .default_value = gradreco_none}),
 
-  // functions used for domain integrals
-  porofluidmultiphasedyn.specs.emplace_back(parameter<std::string>("DOMAININT_FUNCT",
-      {.description = "functions used for domain integrals", .default_value = "-1.0"}));
+      // functions used for domain integrals
+      parameter<std::string>("DOMAININT_FUNCT",
+          {.description = "functions used for domain integrals", .default_value = "-1.0"}),
 
-  // coupling with 1D artery network active
-  porofluidmultiphasedyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
-      {.description = "Coupling with 1D blood vessels.", .default_value = false}));
+      // coupling with 1D artery network active
+      parameter<bool>("ARTERY_COUPLING",
+          {.description = "Coupling with 1D blood vessels.", .default_value = false}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<double>("STARTING_DBC_TIME_END",
-      {.description = "End time for the starting Dirichlet BC.", .default_value = -1.0}));
+      parameter<double>("STARTING_DBC_TIME_END",
+          {.description = "End time for the starting Dirichlet BC.", .default_value = -1.0}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<std::string>("STARTING_DBC_ONOFF",
-      {.description = "Switching the starting Dirichlet BC on or off.", .default_value = "0"}));
+      parameter<std::string>("STARTING_DBC_ONOFF",
+          {.description = "Switching the starting Dirichlet BC on or off.", .default_value = "0"}),
 
-  porofluidmultiphasedyn.specs.emplace_back(parameter<std::string>("STARTING_DBC_FUNCT",
-      {.description = "Function prescribing the starting Dirichlet BC.", .default_value = "0"}));
-
-  porofluidmultiphasedyn.move_into_collection(list);
-
-  // ----------------------------------------------------------------------
+      parameter<std::string>("STARTING_DBC_FUNCT",
+          {.description = "Function prescribing the starting Dirichlet BC.",
+              .default_value =
+                  "0"})});  // ----------------------------------------------------------------------
   // artery mesh tying
-  Core::Utils::SectionSpecs porofluidmultiphasemshtdyn{porofluidmultiphasedyn, "ARTERY COUPLING"};
+  list["POROFLUIDMULTIPHASE DYNAMIC/ARTERY COUPLING"] = all_of({
 
-  // maximum number of segments per artery element for 1D-3D artery coupling
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<int>("MAXNUMSEGPERARTELE",
-      {.description = "maximum number of segments per artery element for 1D-3D artery coupling",
-          .default_value = 5}));
+      // maximum number of segments per artery element for 1D-3D artery coupling
+      parameter<int>("MAXNUMSEGPERARTELE",
+          {.description = "maximum number of segments per artery element for 1D-3D artery coupling",
+              .default_value = 5}),
 
-  // penalty parameter
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<double>("PENALTY",
-      {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}));
+      // penalty parameter
+      parameter<double>("PENALTY",
+          {.description = "Penalty parameter for line-based coupling", .default_value = 1000.0}),
 
-  porofluidmultiphasemshtdyn.specs.emplace_back(
+
       deprecated_selection<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
           "ARTERY_COUPLING_METHOD",
           {
@@ -216,81 +215,85 @@ void POROFLUIDMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::I
           },
           {.description = "Coupling method for artery coupling.",
               .default_value =
-                  Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::none}));
+                  Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::none}),
 
-  // coupled artery dofs for mesh tying
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_ART",
-      {.description = "coupled artery dofs for mesh tying", .default_value = "-1.0"}));
+      // coupled artery dofs for mesh tying
+      parameter<std::string>("COUPLEDDOFS_ART",
+          {.description = "coupled artery dofs for mesh tying", .default_value = "-1.0"}),
 
-  // coupled porofluid dofs for mesh tying
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("COUPLEDDOFS_PORO",
-      {.description = "coupled porofluid dofs for mesh tying", .default_value = "-1.0"}));
+      // coupled porofluid dofs for mesh tying
+      parameter<std::string>("COUPLEDDOFS_PORO",
+          {.description = "coupled porofluid dofs for mesh tying", .default_value = "-1.0"}),
 
-  // functions for coupling (artery part)
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("REACFUNCT_ART",
-      {.description = "functions for coupling (artery part)", .default_value = "-1"}));
+      // functions for coupling (artery part)
+      parameter<std::string>("REACFUNCT_ART",
+          {.description = "functions for coupling (artery part)", .default_value = "-1"}),
 
-  // scale for coupling (artery part)
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>(
-      "SCALEREAC_ART", {.description = "scale for coupling (artery part)", .default_value = "0"}));
+      // scale for coupling (artery part)
+      parameter<std::string>("SCALEREAC_ART",
+          {.description = "scale for coupling (artery part)", .default_value = "0"}),
 
-  // functions for coupling (porofluid part)
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("REACFUNCT_CONT",
-      {.description = "functions for coupling (porofluid part)", .default_value = "-1"}));
+      // functions for coupling (porofluid part)
+      parameter<std::string>("REACFUNCT_CONT",
+          {.description = "functions for coupling (porofluid part)", .default_value = "-1"}),
 
-  // scale for coupling (porofluid part)
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<std::string>("SCALEREAC_CONT",
-      {.description = "scale for coupling (porofluid part)", .default_value = "0"}));
+      // scale for coupling (porofluid part)
+      parameter<std::string>("SCALEREAC_CONT",
+          {.description = "scale for coupling (porofluid part)", .default_value = "0"}),
 
-  // Flag if artery elements are evaluated in reference or current configuration
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("EVALUATE_IN_REF_CONFIG",
-      {.description = "Flag if artery elements are evaluated in reference or current configuration",
-          .default_value = true}));
+      // Flag if artery elements are evaluated in reference or current configuration
+      parameter<bool>("EVALUATE_IN_REF_CONFIG",
+          {.description =
+                  "Flag if artery elements are evaluated in reference or current configuration",
+              .default_value = true}),
 
-  // Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of embedded artery
-  // elements
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("LATERAL_SURFACE_COUPLING",
-      {.description = "Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of "
-                      "embedded artery elements",
-          .default_value = false}));
+      // Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of embedded artery
+      // elements
+      parameter<bool>("LATERAL_SURFACE_COUPLING",
+          {.description =
+                  "Flag if 1D-3D coupling should be evaluated on lateral (cylinder) surface of "
+                  "embedded artery elements",
+              .default_value = false}),
 
 
-  // Number of integration patches per 1D element in axial direction for lateral surface coupling
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<int>("NUMPATCH_AXI",
-      {.description = "Number of integration patches per 1D element in axial direction for "
-                      "lateral surface coupling",
-          .default_value = 1}));
+      // Number of integration patches per 1D element in axial direction for lateral surface
+      // coupling
+      parameter<int>("NUMPATCH_AXI",
+          {.description = "Number of integration patches per 1D element in axial direction for "
+                          "lateral surface coupling",
+              .default_value = 1}),
 
-  // Number of integration patches per 1D element in radial direction for lateral surface coupling
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<int>("NUMPATCH_RAD",
-      {.description = "Number of integration patches per 1D element in radial direction for "
-                      "lateral surface coupling",
-          .default_value = 1}));
+      // Number of integration patches per 1D element in radial direction for lateral surface
+      // coupling
+      parameter<int>("NUMPATCH_RAD",
+          {.description = "Number of integration patches per 1D element in radial direction for "
+                          "lateral surface coupling",
+              .default_value = 1}),
 
-  // Flag if blood vessel volume fraction should be output
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("OUTPUT_BLOODVESSELVOLFRAC",
-      {.description = "Flag if output of blood vessel volume fraction should be calculated",
-          .default_value = false}));
+      // Flag if blood vessel volume fraction should be output
+      parameter<bool>("OUTPUT_BLOODVESSELVOLFRAC",
+          {.description = "Flag if output of blood vessel volume fraction should be calculated",
+              .default_value = false}),
 
-  // Flag if summary of coupling-pairs should be printed
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("PRINT_OUT_SUMMARY_PAIRS",
-      {.description = "Flag if summary of coupling-pairs should be printed",
-          .default_value = false}));
+      // Flag if summary of coupling-pairs should be printed
+      parameter<bool>("PRINT_OUT_SUMMARY_PAIRS",
+          {.description = "Flag if summary of coupling-pairs should be printed",
+              .default_value = false}),
 
-  // Flag if free-hanging elements (after blood vessel collapse) should be deleted
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<bool>("DELETE_FREE_HANGING_ELES",
-      {.description =
-              "Flag if free-hanging elements (after blood vessel collapse) should be deleted",
-          .default_value = false}));
+      // Flag if free-hanging elements (after blood vessel collapse) should be deleted
+      parameter<bool>("DELETE_FREE_HANGING_ELES",
+          {.description =
+                  "Flag if free-hanging elements (after blood vessel collapse) should be deleted",
+              .default_value = false}),
 
-  // components whose size is smaller than this fraction of the total network size are also deleted
-  porofluidmultiphasemshtdyn.specs.emplace_back(parameter<double>("DELETE_SMALL_FREE_HANGING_COMPS",
-      {.description = "Small connected components whose size is smaller than this fraction of the "
-                      "overall network size are additionally deleted (a valid choice of this "
-                      "parameter should lie between 0 and 1)",
-          .default_value = -1.0}));
-
-  porofluidmultiphasemshtdyn.move_into_collection(list);
+      // components whose size is smaller than this fraction of the total network size are also
+      // deleted
+      parameter<double>("DELETE_SMALL_FREE_HANGING_COMPS",
+          {.description =
+                  "Small connected components whose size is smaller than this fraction of the "
+                  "overall network size are additionally deleted (a valid choice of this "
+                  "parameter should lie between 0 and 1)",
+              .default_value = -1.0})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
@@ -21,137 +21,132 @@ void POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::InputS
 
   // ----------------------------------------------------------------------
   // (1) general control parameters
-  Core::Utils::SectionSpecs poromultiphasedyn{"POROMULTIPHASE DYNAMIC"};
+  list["POROMULTIPHASE DYNAMIC"] = all_of({
 
-  // Output type
-  poromultiphasedyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
-  // Time loop control
-  poromultiphasedyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  poromultiphasedyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  poromultiphasedyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}));
-  poromultiphasedyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
-  poromultiphasedyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
+      // Output type
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
+      // Time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  // here the computation of the structure can be skipped, this is helpful if only fluid-scatra
-  // coupling should be calculated
-  poromultiphasedyn.specs.emplace_back(parameter<bool>("SOLVE_STRUCTURE",
-      {.description = "Flag to skip computation of structural field", .default_value = true}));
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = -1.0}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+
+      // here the computation of the structure can be skipped, this is helpful if only fluid-scatra
+      // coupling should be calculated
+      parameter<bool>("SOLVE_STRUCTURE",
+          {.description = "Flag to skip computation of structural field", .default_value = true}),
 
 
-  // Coupling strategy for solvers
-  poromultiphasedyn.specs.emplace_back(deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
-      {
-          {"twoway_partitioned", solscheme_twoway_partitioned},
-          {"twoway_monolithic", solscheme_twoway_monolithic},
-      },
-      {.description = "Coupling strategies for poro multiphase solvers",
-          .default_value = solscheme_twoway_partitioned}));
+      // Coupling strategy for solvers
+      deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
+          {
+              {"twoway_partitioned", solscheme_twoway_partitioned},
+              {"twoway_monolithic", solscheme_twoway_monolithic},
+          },
+          {.description = "Coupling strategies for poro multiphase solvers",
+              .default_value = solscheme_twoway_partitioned}),
 
-  // coupling with 1D artery network active
-  poromultiphasedyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
-      {.description = "Coupling with 1D blood vessels.", .default_value = false}));
-
-  poromultiphasedyn.move_into_collection(list);
-
-  // ----------------------------------------------------------------------
+      // coupling with 1D artery network active
+      parameter<bool>("ARTERY_COUPLING",
+          {.description = "Coupling with 1D blood vessels.",
+              .default_value =
+                  false})});  // ----------------------------------------------------------------------
   // (2) monolithic parameters
-  Core::Utils::SectionSpecs poromultiphasedynmono{poromultiphasedyn, "MONOLITHIC"};
+  list["POROMULTIPHASE DYNAMIC/MONOLITHIC"] = all_of({
 
-  // convergence tolerances for monolithic coupling
-  poromultiphasedynmono.specs.emplace_back(parameter<double>(
-      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poromultiphasedynmono.specs.emplace_back(parameter<double>(
-      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
-                           .default_value = 1e-8}));
+      // convergence tolerances for monolithic coupling
+      parameter<double>("TOLRES_GLOBAL",
+          {.description = "tolerance in the residual norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>("TOLINC_GLOBAL",
+          {.description = "tolerance in the increment norm for the Newton iteration",
+              .default_value = 1e-8}),
 
-  // number of linear solver used for poroelasticity
-  poromultiphasedynmono.specs.emplace_back(parameter<int>(
-      "LINEAR_SOLVER", {.description = "number of linear solver used for poroelasticity problems",
-                           .default_value = -1}));
+      // number of linear solver used for poroelasticity
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for poroelasticity problems",
+              .default_value = -1}),
 
-  // parameters for finite difference check
-  poromultiphasedynmono.specs.emplace_back(deprecated_selection<FdCheck>("FDCHECK",
-      {
-          {"none", fdcheck_none},
-          {"global", fdcheck_global},
-      },
-      {.description = "flag for finite difference check: none or global",
-          .default_value = fdcheck_none}));
+      // parameters for finite difference check
+      deprecated_selection<FdCheck>("FDCHECK",
+          {
+              {"none", fdcheck_none},
+              {"global", fdcheck_global},
+          },
+          {.description = "flag for finite difference check: none or global",
+              .default_value = fdcheck_none}),
 
-  poromultiphasedynmono.specs.emplace_back(deprecated_selection<VectorNorm>("VECTORNORM_RESF",
-      {
-          {"L1", POROMULTIPHASE::norm_l1},
-          {"L1_Scaled", POROMULTIPHASE::norm_l1_scaled},
-          {"L2", POROMULTIPHASE::norm_l2},
-          {"Rms", POROMULTIPHASE::norm_rms},
-          {"Inf", POROMULTIPHASE::norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals",
-          .default_value = POROMULTIPHASE::norm_l2}));
+      deprecated_selection<VectorNorm>("VECTORNORM_RESF",
+          {
+              {"L1", POROMULTIPHASE::norm_l1},
+              {"L1_Scaled", POROMULTIPHASE::norm_l1_scaled},
+              {"L2", POROMULTIPHASE::norm_l2},
+              {"Rms", POROMULTIPHASE::norm_rms},
+              {"Inf", POROMULTIPHASE::norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals",
+              .default_value = POROMULTIPHASE::norm_l2}),
 
-  poromultiphasedynmono.specs.emplace_back(deprecated_selection<VectorNorm>("VECTORNORM_INC",
-      {
-          {"L1", POROMULTIPHASE::norm_l1},
-          {"L1_Scaled", POROMULTIPHASE::norm_l1_scaled},
-          {"L2", POROMULTIPHASE::norm_l2},
-          {"Rms", POROMULTIPHASE::norm_rms},
-          {"Inf", POROMULTIPHASE::norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals",
-          .default_value = POROMULTIPHASE::norm_l2}));
+      deprecated_selection<VectorNorm>("VECTORNORM_INC",
+          {
+              {"L1", POROMULTIPHASE::norm_l1},
+              {"L1_Scaled", POROMULTIPHASE::norm_l1_scaled},
+              {"L2", POROMULTIPHASE::norm_l2},
+              {"Rms", POROMULTIPHASE::norm_rms},
+              {"Inf", POROMULTIPHASE::norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals",
+              .default_value = POROMULTIPHASE::norm_l2}),
 
-  // flag for equilibration of global system of equations
-  poromultiphasedynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
-                           .default_value = Core::LinAlg::EquilibrationMethod::none}));
+      // flag for equilibration of global system of equations
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
+                               .default_value = Core::LinAlg::EquilibrationMethod::none}),
 
-  // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
-  poromultiphasedynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  poromultiphasedynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.001}));
-
-  poromultiphasedynmono.move_into_collection(list);
+      // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.001})});
 
   // ----------------------------------------------------------------------
   // (3) partitioned parameters
-  Core::Utils::SectionSpecs poromultiphasedynpart{poromultiphasedyn, "PARTITIONED"};
+  list["POROMULTIPHASE DYNAMIC/PARTITIONED"] = all_of({
 
-  // convergence tolerance of outer iteration loop
-  poromultiphasedynpart.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
-                     .default_value = 1e-6}));
+      // convergence tolerance of outer iteration loop
+      parameter<double>(
+          "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
+                         .default_value = 1e-6}),
 
-  // flag for relaxation of partitioned scheme
-  poromultiphasedynpart.specs.emplace_back(deprecated_selection<RelaxationMethods>("RELAXATION",
-      {
-          {"none", relaxation_none},
-          {"Constant", relaxation_constant},
-          {"Aitken", relaxation_aitken},
-      },
-      {.description = "flag for relaxation of partitioned scheme",
-          .default_value = relaxation_none}));
+      // flag for relaxation of partitioned scheme
+      deprecated_selection<RelaxationMethods>("RELAXATION",
+          {
+              {"none", relaxation_none},
+              {"Constant", relaxation_constant},
+              {"Aitken", relaxation_aitken},
+          },
+          {.description = "flag for relaxation of partitioned scheme",
+              .default_value = relaxation_none}),
 
-  // parameters for relaxation of partitioned coupling
-  poromultiphasedynpart.specs.emplace_back(parameter<double>(
-      "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}));
-  poromultiphasedynpart.specs.emplace_back(parameter<double>("MINOMEGA",
-      {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}));
-  poromultiphasedynpart.specs.emplace_back(parameter<double>("MAXOMEGA",
-      {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0}));
-
-  poromultiphasedynpart.move_into_collection(list);
+      // parameters for relaxation of partitioned coupling
+      parameter<double>(
+          "STARTOMEGA", {.description = "fixed relaxation parameter", .default_value = 1.0}),
+      parameter<double>("MINOMEGA",
+          {.description = "smallest omega allowed for Aitken relaxation", .default_value = 0.1}),
+      parameter<double>("MAXOMEGA",
+          {.description = "largest omega allowed for Aitken relaxation", .default_value = 10.0})});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
@@ -22,27 +22,27 @@ void PoroMultiPhaseScaTra::set_valid_parameters(std::map<std::string, Core::IO::
 
   // ----------------------------------------------------------------------
   // (1) general control parameters
-  Core::Utils::SectionSpecs poromultiphasescatradyn{"POROMULTIPHASESCATRA DYNAMIC"};
+  list["POROMULTIPHASESCATRA DYNAMIC"] = all_of({
 
-  // Output type
-  poromultiphasescatradyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
-  // Time loop control
-  poromultiphasescatradyn.specs.emplace_back(parameter<int>(
-      "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}));
-  poromultiphasescatradyn.specs.emplace_back(parameter<double>(
-      "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}));
-  poromultiphasescatradyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}));
-  poromultiphasescatradyn.specs.emplace_back(parameter<int>(
-      "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}));
-  poromultiphasescatradyn.specs.emplace_back(parameter<int>(
-      "ITEMAX", {.description = "maximum number of iterations over fields", .default_value = 10}));
-  poromultiphasescatradyn.specs.emplace_back(parameter<int>(
-      "ITEMIN", {.description = "minimal number of iterations over fields", .default_value = 1}));
+      // Output type
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
+      // Time loop control
+      parameter<int>(
+          "NUMSTEP", {.description = "maximum number of Timesteps", .default_value = 200}),
+      parameter<double>(
+          "MAXTIME", {.description = "total simulation time", .default_value = 1000.0}),
 
-  // Coupling strategy for poroscatra solvers
-  poromultiphasescatradyn.specs.emplace_back(
+      parameter<double>("TIMESTEP", {.description = "time step size dt", .default_value = 0.05}),
+      parameter<int>(
+          "RESULTSEVERY", {.description = "increment for writing solution", .default_value = 1}),
+      parameter<int>("ITEMAX",
+          {.description = "maximum number of iterations over fields", .default_value = 10}),
+      parameter<int>("ITEMIN",
+          {.description = "minimal number of iterations over fields", .default_value = 1}),
+
+      // Coupling strategy for poroscatra solvers
       deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
           {
               {"twoway_partitioned_nested", solscheme_twoway_partitioned_nested},
@@ -50,99 +50,92 @@ void PoroMultiPhaseScaTra::set_valid_parameters(std::map<std::string, Core::IO::
               {"twoway_monolithic", solscheme_twoway_monolithic},
           },
           {.description = "Coupling strategies for poroscatra solvers",
-              .default_value = solscheme_twoway_partitioned_nested}));
+              .default_value = solscheme_twoway_partitioned_nested}),
 
-  // coupling with 1D artery network active
-  poromultiphasescatradyn.specs.emplace_back(parameter<bool>("ARTERY_COUPLING",
-      {.description = "Coupling with 1D blood vessels.", .default_value = false}));
+      // coupling with 1D artery network active
+      parameter<bool>("ARTERY_COUPLING",
+          {.description = "Coupling with 1D blood vessels.", .default_value = false}),
 
-  // no convergence of coupling scheme
-  poromultiphasescatradyn.specs.emplace_back(deprecated_selection<DivContAct>("DIVERCONT",
-      {
-          {"stop", divcont_stop},
-          {"continue", divcont_continue},
-      },
-      {.description =
-              "What to do with time integration when Poromultiphase-Scatra iteration failed",
-          .default_value = divcont_stop}));
-
-  poromultiphasescatradyn.move_into_collection(list);
-
-  // ----------------------------------------------------------------------
+      // no convergence of coupling scheme
+      deprecated_selection<DivContAct>("DIVERCONT",
+          {
+              {"stop", divcont_stop},
+              {"continue", divcont_continue},
+          },
+          {.description =
+                  "What to do with time integration when Poromultiphase-Scatra iteration failed",
+              .default_value =
+                  divcont_stop})});  // ----------------------------------------------------------------------
   // (2) monolithic parameters
-  Core::Utils::SectionSpecs poromultiphasescatradynmono{poromultiphasescatradyn, "MONOLITHIC"};
+  list["POROMULTIPHASESCATRA DYNAMIC/MONOLITHIC"] = all_of({
 
-  poromultiphasescatradynmono.specs.emplace_back(deprecated_selection<VectorNorm>("VECTORNORM_RESF",
-      {
-          {"L1", PoroMultiPhaseScaTra::norm_l1},
-          {"L1_Scaled", PoroMultiPhaseScaTra::norm_l1_scaled},
-          {"L2", PoroMultiPhaseScaTra::norm_l2},
-          {"Rms", PoroMultiPhaseScaTra::norm_rms},
-          {"Inf", PoroMultiPhaseScaTra::norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals",
-          .default_value = PoroMultiPhaseScaTra::norm_l2}));
+      deprecated_selection<VectorNorm>("VECTORNORM_RESF",
+          {
+              {"L1", PoroMultiPhaseScaTra::norm_l1},
+              {"L1_Scaled", PoroMultiPhaseScaTra::norm_l1_scaled},
+              {"L2", PoroMultiPhaseScaTra::norm_l2},
+              {"Rms", PoroMultiPhaseScaTra::norm_rms},
+              {"Inf", PoroMultiPhaseScaTra::norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals",
+              .default_value = PoroMultiPhaseScaTra::norm_l2}),
 
-  poromultiphasescatradynmono.specs.emplace_back(deprecated_selection<VectorNorm>("VECTORNORM_INC",
-      {
-          {"L1", PoroMultiPhaseScaTra::norm_l1},
-          {"L1_Scaled", PoroMultiPhaseScaTra::norm_l1_scaled},
-          {"L2", PoroMultiPhaseScaTra::norm_l2},
-          {"Rms", PoroMultiPhaseScaTra::norm_rms},
-          {"Inf", PoroMultiPhaseScaTra::norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals",
-          .default_value = PoroMultiPhaseScaTra::norm_l2}));
+      deprecated_selection<VectorNorm>("VECTORNORM_INC",
+          {
+              {"L1", PoroMultiPhaseScaTra::norm_l1},
+              {"L1_Scaled", PoroMultiPhaseScaTra::norm_l1_scaled},
+              {"L2", PoroMultiPhaseScaTra::norm_l2},
+              {"Rms", PoroMultiPhaseScaTra::norm_rms},
+              {"Inf", PoroMultiPhaseScaTra::norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals",
+              .default_value = PoroMultiPhaseScaTra::norm_l2}),
 
-  // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
-  poromultiphasescatradynmono.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  poromultiphasescatradynmono.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.001}));
+      // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.001}),
 
-  // Iterationparameters
-  poromultiphasescatradynmono.specs.emplace_back(parameter<double>(
-      "TOLRES_GLOBAL", {.description = "tolerance in the residual norm for the Newton iteration",
-                           .default_value = 1e-8}));
-  poromultiphasescatradynmono.specs.emplace_back(parameter<double>(
-      "TOLINC_GLOBAL", {.description = "tolerance in the increment norm for the Newton iteration",
-                           .default_value = 1e-8}));
+      // Iterationparameters
+      parameter<double>("TOLRES_GLOBAL",
+          {.description = "tolerance in the residual norm for the Newton iteration",
+              .default_value = 1e-8}),
+      parameter<double>("TOLINC_GLOBAL",
+          {.description = "tolerance in the increment norm for the Newton iteration",
+              .default_value = 1e-8}),
 
-  // number of linear solver used for poroelasticity
-  poromultiphasescatradynmono.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for monolithic poroscatra problems",
-          .default_value = -1}));
+      // number of linear solver used for poroelasticity
+      parameter<int>("LINEAR_SOLVER",
+          {.description = "number of linear solver used for monolithic poroscatra problems",
+              .default_value = -1}),
 
-  // parameters for finite difference check
-  poromultiphasescatradynmono.specs.emplace_back(deprecated_selection<FdCheck>("FDCHECK",
-      {
-          {"none", fdcheck_none},
-          {"global", fdcheck_global},
-      },
-      {.description = "flag for finite difference check: none or global",
-          .default_value = fdcheck_none}));
+      // parameters for finite difference check
+      deprecated_selection<FdCheck>("FDCHECK",
+          {
+              {"none", fdcheck_none},
+              {"global", fdcheck_global},
+          },
+          {.description = "flag for finite difference check: none or global",
+              .default_value = fdcheck_none}),
 
-  // flag for equilibration of global system of equations
-  poromultiphasescatradynmono.specs.emplace_back(parameter<Core::LinAlg::EquilibrationMethod>(
-      "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
-                           .default_value = Core::LinAlg::EquilibrationMethod::none}));
-
-  poromultiphasescatradynmono.move_into_collection(list);
+      // flag for equilibration of global system of equations
+      parameter<Core::LinAlg::EquilibrationMethod>(
+          "EQUILIBRATION", {.description = "flag for equilibration of global system of equations",
+                               .default_value = Core::LinAlg::EquilibrationMethod::none})});
 
   // ----------------------------------------------------------------------
   // (3) partitioned parameters
-  Core::Utils::SectionSpecs poromultiphasescatradynpart{poromultiphasescatradyn, "PARTITIONED"};
+  list["POROMULTIPHASESCATRA DYNAMIC/PARTITIONED"] = all_of({
 
-  // convergence tolerance of outer iteration loop
-  poromultiphasescatradynpart.specs.emplace_back(parameter<double>(
-      "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
-                     .default_value = 1e-6}));
-
-  poromultiphasescatradynpart.move_into_collection(list);
+      // convergence tolerance of outer iteration loop
+      parameter<double>(
+          "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
+                         .default_value = 1e-6})});
 }
 
 void PoroMultiPhaseScaTra::set_valid_conditions(

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -19,245 +19,236 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
   using Teuchos::tuple;
   using namespace Core::IO::InputSpecBuilders;
 
-  Core::Utils::SectionSpecs tdyn{"THERMAL DYNAMIC"};
+  list["THERMAL DYNAMIC"] = all_of({
 
-  tdyn.specs.emplace_back(parameter<Thermo::DynamicType>(
-      "DYNAMICTYPE", {.description = "type of time integration control",
-                         .default_value = Thermo::DynamicType::OneStepTheta}));
+      parameter<Thermo::DynamicType>(
+          "DYNAMICTYPE", {.description = "type of time integration control",
+                             .default_value = Thermo::DynamicType::OneStepTheta}),
 
-  // output type
-  tdyn.specs.emplace_back(parameter<int>("RESULTSEVERY",
-      {.description = "save temperature and other global quantities every RESULTSEVERY steps",
-          .default_value = 1}));
+      // output type
+      parameter<int>("RESULTSEVERY",
+          {.description = "save temperature and other global quantities every RESULTSEVERY steps",
+              .default_value = 1}),
 
-  tdyn.specs.emplace_back(parameter<int>("RESTARTEVERY",
-      {.description = "write restart possibility every RESTARTEVERY steps", .default_value = 1}));
+      parameter<int>(
+          "RESTARTEVERY", {.description = "write restart possibility every RESTARTEVERY steps",
+                              .default_value = 1}),
 
 
-  tdyn.specs.emplace_back(deprecated_selection<InitialField>("INITIALFIELD",
-      {
-          {"zero_field", initfield_zero_field},
-          {"field_by_function", initfield_field_by_function},
-          {"field_by_condition", initfield_field_by_condition},
-      },
-      {.description = "Initial Field for thermal problem", .default_value = initfield_zero_field}));
+      deprecated_selection<InitialField>("INITIALFIELD",
+          {
+              {"zero_field", initfield_zero_field},
+              {"field_by_function", initfield_field_by_function},
+              {"field_by_condition", initfield_field_by_condition},
+          },
+          {.description = "Initial Field for thermal problem",
+              .default_value = initfield_zero_field}),
 
-  tdyn.specs.emplace_back(parameter<int>("INITFUNCNO",
-      {.description = "function number for thermal initial field", .default_value = -1}));
+      parameter<int>("INITFUNCNO",
+          {.description = "function number for thermal initial field", .default_value = -1}),
 
-  // Time loop control
-  tdyn.specs.emplace_back(
-      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.05}));
-  tdyn.specs.emplace_back(
-      parameter<int>("NUMSTEP", {.description = "maximum number of steps", .default_value = 200}));
-  tdyn.specs.emplace_back(
-      parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 5.0}));
+      // Time loop control
+      parameter<double>("TIMESTEP", {.description = "time step size", .default_value = 0.05}),
 
-  // Iterationparameters
-  tdyn.specs.emplace_back(parameter<double>(
-      "TOLTEMP", {.description = "tolerance in the temperature norm of the Newton iteration",
-                     .default_value = 1.0E-10}));
+      parameter<int>("NUMSTEP", {.description = "maximum number of steps", .default_value = 200}),
 
-  tdyn.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_TEMP",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for temperature convergence check",
-          .default_value = convnorm_abs}));
+      parameter<double>("MAXTIME", {.description = "maximum time", .default_value = 5.0}),
 
-  tdyn.specs.emplace_back(parameter<double>(
-      "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
-                    .default_value = 1.0E-08}));
+      // Iterationparameters
+      parameter<double>(
+          "TOLTEMP", {.description = "tolerance in the temperature norm of the Newton iteration",
+                         .default_value = 1.0E-10}),
 
-  tdyn.specs.emplace_back(deprecated_selection<ConvNorm>("NORM_RESF",
-      {
-          {"Abs", convnorm_abs},
-          {"Rel", convnorm_rel},
-          {"Mix", convnorm_mix},
-      },
-      {.description = "type of norm for residual convergence check",
-          .default_value = convnorm_abs}));
+      deprecated_selection<ConvNorm>("NORM_TEMP",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for temperature convergence check",
+              .default_value = convnorm_abs}),
 
-  tdyn.specs.emplace_back(deprecated_selection<BinaryOp>("NORMCOMBI_RESFTEMP",
-      {
-          {"And", bop_and},
-          {"Or", bop_or},
-      },
-      {.description = "binary operator to combine temperature and residual force values",
-          .default_value = bop_and}));
+      parameter<double>(
+          "TOLRES", {.description = "tolerance in the residual norm for the Newton iteration",
+                        .default_value = 1.0E-08}),
 
-  tdyn.specs.emplace_back(parameter<int>("MAXITER",
-      {.description =
-              "maximum number of iterations allowed for Newton-Raphson iteration before failure",
-          .default_value = 50}));
+      deprecated_selection<ConvNorm>("NORM_RESF",
+          {
+              {"Abs", convnorm_abs},
+              {"Rel", convnorm_rel},
+              {"Mix", convnorm_mix},
+          },
+          {.description = "type of norm for residual convergence check",
+              .default_value = convnorm_abs}),
 
-  tdyn.specs.emplace_back(parameter<int>("MINITER",
-      {.description = "minimum number of iterations to be done within Newton-Raphson loop",
-          .default_value = 0}));
+      deprecated_selection<BinaryOp>("NORMCOMBI_RESFTEMP",
+          {
+              {"And", bop_and},
+              {"Or", bop_or},
+          },
+          {.description = "binary operator to combine temperature and residual force values",
+              .default_value = bop_and}),
 
-  tdyn.specs.emplace_back(deprecated_selection<VectorNorm>("ITERNORM",
-      {
-          {"L1", norm_l1},
-          {"L2", norm_l2},
-          {"Rms", norm_rms},
-          {"Inf", norm_inf},
-      },
-      {.description = "type of norm to be applied to residuals", .default_value = norm_l2}));
+      parameter<int>("MAXITER", {.description = "maximum number of iterations allowed for "
+                                                "Newton-Raphson iteration before failure",
+                                    .default_value = 50}),
 
-  tdyn.specs.emplace_back(deprecated_selection<DivContAct>("DIVERCONT",
-      {
-          {"stop", divcont_stop},
-          {"continue", divcont_continue},
-          {"halve_step", divcont_halve_step},
-          {"repeat_step", divcont_repeat_step},
-          {"repeat_simulation", divcont_repeat_simulation},
-      },
-      {.description = "What to do with time integration when Newton-Raphson iteration failed",
-          .default_value = divcont_stop}));
+      parameter<int>("MINITER",
+          {.description = "minimum number of iterations to be done within Newton-Raphson loop",
+              .default_value = 0}),
 
-  tdyn.specs.emplace_back(parameter<int>("MAXDIVCONREFINEMENTLEVEL",
-      {.description = "number of times timestep is halved in case nonlinear solver diverges",
-          .default_value = 10}));
+      deprecated_selection<VectorNorm>("ITERNORM",
+          {
+              {"L1", norm_l1},
+              {"L2", norm_l2},
+              {"Rms", norm_rms},
+              {"Inf", norm_inf},
+          },
+          {.description = "type of norm to be applied to residuals", .default_value = norm_l2}),
 
-  tdyn.specs.emplace_back(deprecated_selection<NonlinSolTech>("NLNSOL",
-      {
-          {"vague", soltech_vague},
-          {"fullnewton", soltech_newtonfull},
-      },
-      {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}));
+      deprecated_selection<DivContAct>("DIVERCONT",
+          {
+              {"stop", divcont_stop},
+              {"continue", divcont_continue},
+              {"halve_step", divcont_halve_step},
+              {"repeat_step", divcont_repeat_step},
+              {"repeat_simulation", divcont_repeat_simulation},
+          },
+          {.description = "What to do with time integration when Newton-Raphson iteration failed",
+              .default_value = divcont_stop}),
 
-  tdyn.specs.emplace_back(deprecated_selection<PredEnum>("PREDICT",
-      {
-          {"Vague", pred_vague},
-          {"ConstTemp", pred_consttemp},
-          {"ConstTempRate", pred_consttemprate},
-          {"TangTemp", pred_tangtemp},
-      },
-      {.description = "Predictor of iterative solution techniques",
-          .default_value = pred_consttemp}));
+      parameter<int>("MAXDIVCONREFINEMENTLEVEL",
+          {.description = "number of times timestep is halved in case nonlinear solver diverges",
+              .default_value = 10}),
 
-  // convergence criteria solver adaptivity
-  tdyn.specs.emplace_back(parameter<bool>("ADAPTCONV",
-      {.description =
-              "Switch on adaptive control of linear solver tolerance for nonlinear solution",
-          .default_value = false}));
-  tdyn.specs.emplace_back(parameter<double>("ADAPTCONV_BETTER",
-      {.description = "The linear solver shall be this much better than the current nonlinear "
-                      "residual in the nonlinear convergence limit",
-          .default_value = 0.1}));
+      deprecated_selection<NonlinSolTech>("NLNSOL",
+          {
+              {"vague", soltech_vague},
+              {"fullnewton", soltech_newtonfull},
+          },
+          {.description = "Nonlinear solution technique", .default_value = soltech_newtonfull}),
 
-  tdyn.specs.emplace_back(parameter<bool>(
-      "LUMPCAPA", {.description = "Lump the capacity matrix for explicit time integration",
-                      .default_value = false}));
+      deprecated_selection<PredEnum>("PREDICT",
+          {
+              {"Vague", pred_vague},
+              {"ConstTemp", pred_consttemp},
+              {"ConstTempRate", pred_consttemprate},
+              {"TangTemp", pred_tangtemp},
+          },
+          {.description = "Predictor of iterative solution techniques",
+              .default_value = pred_consttemp}),
 
-  // number of linear solver used for thermal problems
-  tdyn.specs.emplace_back(parameter<int>("LINEAR_SOLVER",
-      {.description = "number of linear solver used for thermal problems", .default_value = -1}));
+      // convergence criteria solver adaptivity
+      parameter<bool>("ADAPTCONV",
+          {.description =
+                  "Switch on adaptive control of linear solver tolerance for nonlinear solution",
+              .default_value = false}),
+      parameter<double>("ADAPTCONV_BETTER",
+          {.description = "The linear solver shall be this much better than the current nonlinear "
+                          "residual in the nonlinear convergence limit",
+              .default_value = 0.1}),
 
-  // where the geometry comes from
-  tdyn.specs.emplace_back(deprecated_selection<Core::IO::GeometryType>("GEOMETRY",
-      {
-          {"full", Core::IO::geometry_full},
-          {"box", Core::IO::geometry_box},
-          {"file", Core::IO::geometry_file},
-      },
-      {.description = "How the geometry is specified", .default_value = Core::IO::geometry_full}));
+      parameter<bool>(
+          "LUMPCAPA", {.description = "Lump the capacity matrix for explicit time integration",
+                          .default_value = false}),
 
-  tdyn.specs.emplace_back(deprecated_selection<CalcError>("CALCERROR",
-      {
-          {"No", no_error_calculation},
-          {"byfunct", calcerror_byfunct},
-      },
-      {.description = "compute error compared to analytical solution",
-          .default_value = no_error_calculation}));
-  tdyn.specs.emplace_back(parameter<int>(
-      "CALCERRORFUNCNO", {.description = "Function for Error Calculation", .default_value = -1}));
+      // number of linear solver used for thermal problems
+      parameter<int>(
+          "LINEAR_SOLVER", {.description = "number of linear solver used for thermal problems",
+                               .default_value = -1}),
 
-  tdyn.move_into_collection(list);
+      // where the geometry comes from
+      deprecated_selection<Core::IO::GeometryType>("GEOMETRY",
+          {
+              {"full", Core::IO::geometry_full},
+              {"box", Core::IO::geometry_box},
+              {"file", Core::IO::geometry_file},
+          },
+          {.description = "How the geometry is specified",
+              .default_value = Core::IO::geometry_full}),
 
-  /*----------------------------------------------------------------------*/
+      deprecated_selection<CalcError>("CALCERROR",
+          {
+              {"No", no_error_calculation},
+              {"byfunct", calcerror_byfunct},
+          },
+          {.description = "compute error compared to analytical solution",
+              .default_value = no_error_calculation}),
+      parameter<int>("CALCERRORFUNCNO",
+          {.description = "Function for Error Calculation",
+              .default_value =
+                  -1})}); /*----------------------------------------------------------------------*/
   /* parameters for generalised-alpha thermal integrator */
-  Core::Utils::SectionSpecs tgenalpha{tdyn, "GENALPHA"};
+  list["THERMAL DYNAMIC/GENALPHA"] = all_of({
 
-  tgenalpha.specs.emplace_back(deprecated_selection<MidAverageEnum>("GENAVG",
-      {
-          {"Vague", midavg_vague},
-          {"ImrLike", midavg_imrlike},
-          {"TrLike", midavg_trlike},
-      },
-      {.description = "mid-average type of internal forces", .default_value = midavg_trlike}));
+      deprecated_selection<MidAverageEnum>("GENAVG",
+          {
+              {"Vague", midavg_vague},
+              {"ImrLike", midavg_imrlike},
+              {"TrLike", midavg_trlike},
+          },
+          {.description = "mid-average type of internal forces", .default_value = midavg_trlike}),
 
-  // default values correspond to midpoint-rule
-  tgenalpha.specs.emplace_back(parameter<double>(
-      "GAMMA", {.description = "Generalised-alpha factor in (0,1]", .default_value = 0.5}));
-  tgenalpha.specs.emplace_back(parameter<double>(
-      "ALPHA_M", {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}));
-  tgenalpha.specs.emplace_back(parameter<double>(
-      "ALPHA_F", {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}));
-  tgenalpha.specs.emplace_back(parameter<double>(
-      "RHO_INF", {.description = "Generalised-alpha factor in [0,1]", .default_value = -1.0}));
-
-  tgenalpha.move_into_collection(list);
+      // default values correspond to midpoint-rule
+      parameter<double>(
+          "GAMMA", {.description = "Generalised-alpha factor in (0,1]", .default_value = 0.5}),
+      parameter<double>(
+          "ALPHA_M", {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}),
+      parameter<double>(
+          "ALPHA_F", {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}),
+      parameter<double>(
+          "RHO_INF", {.description = "Generalised-alpha factor in [0,1]", .default_value = -1.0})});
 
   /*----------------------------------------------------------------------*/
   /* parameters for one-step-theta thermal integrator */
-  Core::Utils::SectionSpecs tonesteptheta{tdyn, "ONESTEPTHETA"};
+  list["THERMAL DYNAMIC/ONESTEPTHETA"] = all_of({
 
-  tonesteptheta.specs.emplace_back(parameter<double>(
-      "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5}));
-
-  tonesteptheta.move_into_collection(list);
+      parameter<double>(
+          "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5})});
 
   // vtk runtime output
   {
-    Core::Utils::SectionSpecs sublist_vtk_output{tdyn, "RUNTIME VTK OUTPUT"};
+    list["THERMAL DYNAMIC/RUNTIME VTK OUTPUT"] = all_of({
 
-    // whether to write output for thermo
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "OUTPUT_THERMO", {.description = "write thermo output", .default_value = false}));
+        // whether to write output for thermo
+        parameter<bool>(
+            "OUTPUT_THERMO", {.description = "write thermo output", .default_value = false}),
 
-    // whether to write temperature state
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "TEMPERATURE", {.description = "write temperature output", .default_value = false}));
+        // whether to write temperature state
+        parameter<bool>(
+            "TEMPERATURE", {.description = "write temperature output", .default_value = false}),
 
-    // whether to write heatflux state
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "HEATFLUX", {.description = "write heatflux output", .default_value = false}));
+        // whether to write heatflux state
+        parameter<bool>(
+            "HEATFLUX", {.description = "write heatflux output", .default_value = false}),
 
-    // whether to write temperature gradient state
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "TEMPGRAD", {.description = "write temperature gradient output", .default_value = false}));
+        // whether to write temperature gradient state
+        parameter<bool>("TEMPGRAD",
+            {.description = "write temperature gradient output", .default_value = false}),
 
-    // whether to write element owner
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}));
+        // whether to write element owner
+        parameter<bool>(
+            "ELEMENT_OWNER", {.description = "write element owner", .default_value = false}),
 
-    // whether to write element GIDs
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "ELEMENT_GID", {.description = "write 4C internal element GIDs", .default_value = false}));
+        // whether to write element GIDs
+        parameter<bool>("ELEMENT_GID",
+            {.description = "write 4C internal element GIDs", .default_value = false}),
 
-    // whether to write node GIDs
-    sublist_vtk_output.specs.emplace_back(parameter<bool>(
-        "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false}));
-
-    sublist_vtk_output.move_into_collection(list);
+        // whether to write node GIDs
+        parameter<bool>(
+            "NODE_GID", {.description = "write 4C internal node GIDs", .default_value = false})});
   }
 
   // csv runtime output
   {
-    Core::Utils::SectionSpecs sublist_csv_output{tdyn, "RUNTIME CSV OUTPUT"};
+    list["THERMAL DYNAMIC/RUNTIME CSV OUTPUT"] = all_of({
 
-    // whether to write csv output for thermo
-    sublist_csv_output.specs.emplace_back(parameter<bool>(
-        "OUTPUT_THERMO", {.description = "write thermo output", .default_value = false}));
+        // whether to write csv output for thermo
+        parameter<bool>(
+            "OUTPUT_THERMO", {.description = "write thermo output", .default_value = false}),
 
-    // whether to write energy state
-    sublist_csv_output.specs.emplace_back(
-        parameter<bool>("ENERGY", {.description = "write energy output", .default_value = false}));
-
-    sublist_csv_output.move_into_collection(list);
+        // whether to write energy state
+        parameter<bool>("ENERGY", {.description = "write energy output", .default_value = false})});
   }
 }
 


### PR DESCRIPTION
Removes the calls of input helper `Core::Utils::SectionSpecs`. See https://github.com/4C-multiphysics/4C/issues/463