### PR TITLE
Fix d node topology

### DIFF
--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -19,6 +19,7 @@
 #include "4C_io_value_parser.hpp"
 #include "4C_io_yaml.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
+#include "4C_utils_exceptions.hpp"
 #include "4C_utils_string.hpp"
 
 #include <Teuchos_ParameterList.hpp>
@@ -345,6 +346,11 @@ void Core::IO::read_design(InputFile& input, const std::string& name,
     if (nname == "NODE")  // plain old reading of the design nodes from the input file
     {
       stream >> nodeid >> dname >> dobj;
+
+      FOUR_C_ASSERT_ALWAYS(name == dname || (name == "DSURF" && dname == "DSURFACE") ||
+                               (name == "DVOL" && dname == "DVOLUME"),
+          "Wrong design node name: {}. Expected {}.", dname, name);
+
       topology[dobj - 1].insert(nodeid - 1);
     }
     else  // fancy specification of the design nodes by specifying min or max of the domain


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

After doing some roundtrip tests (convert all .dat files from 4C to .yaml -> read in all 4C.yaml files with fourcipp -> dump all files again -> run all simulations with 4C) the following problem emerged

Similar to #581. One was able to enter anything into a design section, i.e.,

```
---------------------------------------------------------DLINE-NODE TOPOLOGY
NODE  1 4C_is_cool 1
---------------------------------------------------------DSURF-NODE TOPOLOGY
NODE  1 THIS_IS_THE_BEST_SIMULATION_ON_EARTH 1
```

This PR checks if the actual keyword in each line is identical to the current section (see first commit). The second commit fixes `DSURF` -> `DSURFACE` and the third commit fixes `DVOL` -> `DVOLUME`

@sebproell this could be improved in the future by not asserting this check but using the parser identical to #581 

ping @gilrrei this should solve our observed problem

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

#581 
