### PR TITLE
Resolve one header-in-header include

### DIFF
--- a/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
@@ -10,6 +10,7 @@
 #include "4C_contact_friction_node.hpp"
 #include "4C_contact_interface.hpp"
 #include "4C_contact_lagrange_strategy_tsi.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_sparsematrix.hpp"

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_constraint_penalty.hpp"
 
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"

--- a/src/contact/4C_contact_interface.cpp
+++ b/src/contact/4C_contact_interface.cpp
@@ -19,6 +19,7 @@
 #include "4C_contact_nitsche_utils.hpp"
 #include "4C_contact_node.hpp"
 #include "4C_contact_selfcontact_binarytree_unbiased.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_graph.hpp"

--- a/src/contact/4C_contact_interface_assemble.cpp
+++ b/src/contact/4C_contact_interface_assemble.cpp
@@ -9,6 +9,7 @@
 #include "4C_contact_friction_node.hpp"
 #include "4C_contact_interface.hpp"
 #include "4C_coupling_adapter.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -16,6 +16,7 @@
 #include "4C_contact_interface.hpp"
 #include "4C_contact_paramsinterface.hpp"
 #include "4C_contact_utils.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"

--- a/src/contact/4C_contact_lagrange_strategy_poro.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_poro.cpp
@@ -13,6 +13,7 @@
 #include "4C_contact_interface.hpp"
 #include "4C_coupling_adapter.hpp"
 #include "4C_coupling_adapter_converter.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"

--- a/src/contact/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_tsi.cpp
@@ -14,6 +14,7 @@
 #include "4C_contact_tsi_interface.hpp"
 #include "4C_coupling_adapter.hpp"
 #include "4C_coupling_adapter_converter.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_sparsematrix.hpp"

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -14,6 +14,7 @@
 #include "4C_contact_interface.hpp"
 #include "4C_contact_lagrange_strategy.hpp"
 #include "4C_contact_wear_interface.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_wear.hpp"
 #include "4C_io.hpp"

--- a/src/contact/4C_contact_manager.cpp
+++ b/src/contact/4C_contact_manager.cpp
@@ -26,6 +26,7 @@
 #include "4C_contact_utils.hpp"
 #include "4C_contact_utils_parallel.hpp"
 #include "4C_contact_wear_interface.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_mortar.hpp"
 #include "4C_inpar_wear.hpp"

--- a/src/contact/4C_contact_meshtying_manager.cpp
+++ b/src/contact/4C_contact_meshtying_manager.cpp
@@ -12,6 +12,7 @@
 #include "4C_contact_meshtying_lagrange_strategy.hpp"
 #include "4C_contact_meshtying_penalty_strategy.hpp"
 #include "4C_contact_meshtying_poro_lagrange_strategy.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_mortar.hpp"
 #include "4C_io.hpp"

--- a/src/contact/4C_contact_nitsche_strategy_ssi.cpp
+++ b/src/contact/4C_contact_nitsche_strategy_ssi.cpp
@@ -8,6 +8,7 @@
 #include "4C_contact_nitsche_strategy_ssi.hpp"
 
 #include "4C_contact_interface.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"

--- a/src/contact/4C_contact_penalty_strategy.cpp
+++ b/src/contact/4C_contact_penalty_strategy.cpp
@@ -14,6 +14,7 @@
 #include "4C_contact_interface.hpp"
 #include "4C_contact_node.hpp"
 #include "4C_contact_paramsinterface.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_structure.hpp"
 #include "4C_linalg_sparsematrix.hpp"

--- a/src/contact/4C_contact_tsi_interface.cpp
+++ b/src/contact/4C_contact_tsi_interface.cpp
@@ -13,6 +13,7 @@
 #include "4C_contact_friction_node.hpp"
 #include "4C_contact_interface.hpp"
 #include "4C_contact_node.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_inpar_mortar.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"

--- a/src/contact/4C_contact_wear_interface.cpp
+++ b/src/contact/4C_contact_wear_interface.cpp
@@ -12,6 +12,7 @@
 #include "4C_contact_friction_node.hpp"
 #include "4C_contact_interface.hpp"
 #include "4C_contact_node.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_inpar_mortar.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"

--- a/src/contact/4C_contact_wear_interface_tools.cpp
+++ b/src/contact/4C_contact_wear_interface_tools.cpp
@@ -11,6 +11,7 @@
 #include "4C_contact_integrator.hpp"
 #include "4C_contact_selfcontact_binarytree.hpp"
 #include "4C_contact_wear_interface.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_io_control.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_mortar_defines.hpp"

--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_exporter.hpp"
 #include "4C_comm_mpi_utils.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_io_pstream.hpp"

--- a/src/core/comm/src/4C_comm_utils_factory.hpp
+++ b/src/core/comm/src/4C_comm_utils_factory.hpp
@@ -10,12 +10,19 @@
 
 #include "4C_config.hpp"
 
-#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 #include "4C_utils_shared_ptr_from_ref.hpp"
 
 
 
+namespace FourC::Core::Nodes
+{
+  class Node;
+}
+namespace FourC::Core::Elements
+{
+  class Element;
+}
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::Communication

--- a/src/core/fem/src/condition/4C_fem_condition_utils.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_utils.cpp
@@ -8,6 +8,7 @@
 #include "4C_fem_condition_utils.hpp"
 
 #include "4C_fem_condition_selector.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"

--- a/src/core/io/src/4C_io_elementreader.cpp
+++ b/src/core/io/src/4C_io_elementreader.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_comm_utils_factory.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_element_definition.hpp"
 #include "4C_io_input_file.hpp"

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -8,6 +8,7 @@
 #include "4C_coupling_adapter.hpp"
 
 #include "4C_fem_condition_utils.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_fem_geometric_search_matchingoctree.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"

--- a/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.hpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_transfer_turb_inflow.hpp
@@ -17,6 +17,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace Core::Conditions
+{
+  class Condition;
+}
+
 namespace Core::FE
 {
   class Discretization;

--- a/src/mat/4C_mat_micromaterial_evaluate.cpp
+++ b/src/mat/4C_mat_micromaterial_evaluate.cpp
@@ -9,6 +9,7 @@
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_comm_utils.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_densematrix_svd.hpp"
 #include "4C_mat_micromaterial.hpp"

--- a/src/particle_engine/4C_particle_engine.cpp
+++ b/src/particle_engine/4C_particle_engine.cpp
@@ -11,6 +11,7 @@
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_comm_utils_factory.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_particle.hpp"

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -14,6 +14,7 @@
 #include "4C_contact_meshtying_contact_bridge.hpp"
 #include "4C_contact_meshtying_poro_lagrange_strategy.hpp"
 #include "4C_contact_nitsche_strategy_poro.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_assemblestrategy.hpp"
 #include "4C_fem_general_elements_paramsminimal.hpp"
 #include "4C_fluid_ele_action.hpp"

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.hpp"
 
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.cpp
@@ -8,6 +8,7 @@
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.hpp"
 
 #include "4C_fem_condition_selector.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp"

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.hpp"
 
+#include "4C_fem_discretization.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp"

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_comm_utils_factory.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 #include "4C_fluid_ele_nullspace.hpp"
 #include "4C_io_input_spec_builders.hpp"

--- a/src/shell7p/4C_shell7p_utils.cpp
+++ b/src/shell7p/4C_shell7p_utils.cpp
@@ -8,6 +8,7 @@
 #include "4C_shell7p_utils.hpp"
 
 #include "4C_comm_exporter.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
 #include "4C_shell7p_ele.hpp"

--- a/src/structure/4C_structure_timint_ab2.cpp
+++ b/src/structure/4C_structure_timint_ab2.cpp
@@ -8,6 +8,7 @@
 #include "4C_structure_timint_ab2.hpp"
 
 #include "4C_contact_meshtying_contact_bridge.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linear_solver_method_linalg.hpp"

--- a/src/structure/4C_structure_timint_centrdiff.cpp
+++ b/src/structure/4C_structure_timint_centrdiff.cpp
@@ -8,6 +8,7 @@
 #include "4C_structure_timint_centrdiff.hpp"
 
 #include "4C_contact_meshtying_contact_bridge.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linear_solver_method_linalg.hpp"

--- a/src/structure/4C_structure_timint_expl.cpp
+++ b/src/structure/4C_structure_timint_expl.cpp
@@ -12,6 +12,7 @@
 #include "4C_constraint_springdashpot_manager.hpp"
 #include "4C_contact_input.hpp"
 #include "4C_contact_meshtying_contact_bridge.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_mortar_manager_base.hpp"
 #include "4C_mortar_strategy_base.hpp"

--- a/src/structure/4C_structure_timint_expleuler.cpp
+++ b/src/structure/4C_structure_timint_expleuler.cpp
@@ -8,6 +8,7 @@
 #include "4C_structure_timint_expleuler.hpp"
 
 #include "4C_contact_meshtying_contact_bridge.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_io.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linear_solver_method_linalg.hpp"

--- a/src/structure_new/src/output/4C_structure_new_gauss_point_data_output_manager.hpp
+++ b/src/structure_new/src/output/4C_structure_new_gauss_point_data_output_manager.hpp
@@ -26,6 +26,15 @@ namespace Discret
   class Exporter;
 }
 
+namespace Core::LinAlg
+{
+  template <typename T>
+  class MultiVector;
+
+  template <typename T>
+  class Vector;
+}  // namespace Core::LinAlg
+
 namespace Solid
 {
   namespace ModelEvaluator

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_exporter.hpp"
 #include "4C_comm_mpi_utils.hpp"
 #include "4C_coupling_adapter.hpp"
+#include "4C_fem_discretization.hpp"
 
 #include <Epetra_Export.h>
 


### PR DESCRIPTION
Remove an include from `4C_comm_utils_factory.hpp`. This does not help compile time all that much, but it is still correct.