### PR TITLE
Allow multiple beam contact pairs for element pair

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_conditions.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_conditions.cpp
@@ -273,8 +273,8 @@ void BeamInteraction::BeamInteractionConditions::clear()
 /**
  *
  */
-std::shared_ptr<BeamInteraction::BeamContactPair>
-BeamInteraction::BeamInteractionConditions::create_contact_pair(
+void BeamInteraction::BeamInteractionConditions::create_contact_pairs(
+    std::vector<std::shared_ptr<BeamInteraction::BeamContactPair>>& created_pairs,
     const std::vector<Core::Elements::Element const*>& ele_ptrs)
 {
   std::shared_ptr<BeamInteraction::BeamContactPair> new_pair;
@@ -283,12 +283,9 @@ BeamInteraction::BeamInteractionConditions::create_contact_pair(
     for (auto& condition : map_pair.second)
     {
       new_pair = condition->create_contact_pair(ele_ptrs);
-      if (new_pair != nullptr) return new_pair;
+      if (new_pair != nullptr) created_pairs.push_back(new_pair);
     }
   }
-
-  // Default return value, i.e. the pair was not found in any of the conditions.
-  return nullptr;
 }
 
 /**

--- a/src/beaminteraction/src/4C_beaminteraction_conditions.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_conditions.hpp
@@ -198,13 +198,14 @@ namespace BeamInteraction
     /**
      * \brief Create the correct pair for the given element pointers.
      *
-     * We assume, that each beam interaction pair can only be in one beam interaction condition.
+     * We assume, that each beam interaction condition can only have one interaction pair.
      * This function checks which interaction condition contains both elements of this pair and
      * creates the correct pair.
      *
      * @param ele_ptrs (in) Pointer to the two elements contained in the pair.
      */
-    std::shared_ptr<BeamInteraction::BeamContactPair> create_contact_pair(
+    void create_contact_pairs(
+        std::vector<std::shared_ptr<BeamInteraction::BeamContactPair>>& created_pairs,
         const std::vector<Core::Elements::Element const*>& ele_ptrs);
 
     /**

--- a/src/beaminteraction/src/4C_beaminteraction_contact_pair.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_contact_pair.cpp
@@ -65,10 +65,13 @@ void BeamInteraction::BeamContactPair::setup()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::shared_ptr<BeamInteraction::BeamContactPair> BeamInteraction::BeamContactPair::create(
+std::vector<std::shared_ptr<BeamInteraction::BeamContactPair>>
+BeamInteraction::BeamContactPair::create(
     std::vector<Core::Elements::Element const*> const& ele_ptrs,
     BeamInteraction::BeamInteractionConditions& beam_interaction_conditions_ptr)
 {
+  std::vector<std::shared_ptr<BeamInteraction::BeamContactPair>> created_pairs;
+
   // Check the type of the second element.
   const bool other_is_beam =
       dynamic_cast<Discret::Elements::Beam3Base const*>(ele_ptrs[1]) != nullptr;
@@ -81,7 +84,7 @@ std::shared_ptr<BeamInteraction::BeamContactPair> BeamInteraction::BeamContactPa
   if (other_is_beam or other_is_solid)
   {
     // Beam-to-beam and beam-to-solid pairs are exclusively created by conditions.
-    return beam_interaction_conditions_ptr.create_contact_pair(ele_ptrs);
+    beam_interaction_conditions_ptr.create_contact_pairs(created_pairs, ele_ptrs);
   }
   else if (other_is_sphere)
   {
@@ -103,19 +106,27 @@ std::shared_ptr<BeamInteraction::BeamContactPair> BeamInteraction::BeamContactPa
         {
           case 2:
           {
-            return std::make_shared<BeamInteraction::BeamToSphereContactPair<2, 1>>();
+            created_pairs.push_back(
+                std::make_shared<BeamInteraction::BeamToSphereContactPair<2, 1>>());
+            break;
           }
           case 3:
           {
-            return std::make_shared<BeamInteraction::BeamToSphereContactPair<3, 1>>();
+            created_pairs.push_back(
+                std::make_shared<BeamInteraction::BeamToSphereContactPair<3, 1>>());
+            break;
           }
           case 4:
           {
-            return std::make_shared<BeamInteraction::BeamToSphereContactPair<4, 1>>();
+            created_pairs.push_back(
+                std::make_shared<BeamInteraction::BeamToSphereContactPair<4, 1>>());
+            break;
           }
           case 5:
           {
-            return std::make_shared<BeamInteraction::BeamToSphereContactPair<5, 1>>();
+            created_pairs.push_back(
+                std::make_shared<BeamInteraction::BeamToSphereContactPair<5, 1>>());
+            break;
           }
           default:
           {
@@ -135,7 +146,9 @@ std::shared_ptr<BeamInteraction::BeamContactPair> BeamInteraction::BeamContactPa
         {
           case 2:
           {
-            return std::make_shared<BeamInteraction::BeamToSphereContactPair<2, 2>>();
+            created_pairs.push_back(
+                std::make_shared<BeamInteraction::BeamToSphereContactPair<2, 2>>());
+            break;
           }
           default:
           {
@@ -164,7 +177,7 @@ std::shared_ptr<BeamInteraction::BeamContactPair> BeamInteraction::BeamContactPa
   {
     FOUR_C_THROW("Unknown type of second element in creation of beam contact pair.");
   }
-  return nullptr;
+  return created_pairs;
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/beaminteraction/src/4C_beaminteraction_contact_pair.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_contact_pair.hpp
@@ -95,8 +95,9 @@ namespace BeamInteraction
         Core::LinAlg::SerialDenseMatrix* stiffmat12, Core::LinAlg::SerialDenseMatrix* stiffmat21,
         Core::LinAlg::SerialDenseMatrix* stiffmat22) = 0;
 
-    //! return appropriate internal implementation class (acts as a simple factory)
-    static std::shared_ptr<BeamContactPair> create(
+    //! return appropriate internal implementation class (acts as a simple factory), also works if a
+    //! single pair of elements results in multiple beam contact pairs
+    static std::vector<std::shared_ptr<BeamContactPair>> create(
         std::vector<Core::Elements::Element const*> const& ele_ptrs,
         BeamInteraction::BeamInteractionConditions& beam_interaction_conditions_ptr);
 

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.cpp
@@ -999,16 +999,16 @@ void BeamInteraction::SUBMODELEVALUATOR::BeamContact::create_beam_contact_elemen
       ele_ptrs[1] = *secondeleiter;
 
       // construct, init and setup contact pairs
-      std::shared_ptr<BeamInteraction::BeamContactPair> newbeaminteractionpair =
+      std::vector<std::shared_ptr<BeamInteraction::BeamContactPair>> newbeaminteractionpairs =
           BeamInteraction::BeamContactPair::create(ele_ptrs, *beam_interaction_conditions_ptr_);
 
-      if (newbeaminteractionpair != nullptr)
+      for (auto& pair : newbeaminteractionpairs)
       {
-        newbeaminteractionpair->init(beam_contact_params_ptr_, ele_ptrs);
-        newbeaminteractionpair->setup();
+        pair->init(beam_contact_params_ptr_, ele_ptrs);
+        pair->setup();
 
         // add to list of current contact pairs
-        contact_elepairs_.push_back(newbeaminteractionpair);
+        contact_elepairs_.push_back(pair);
       }
     }
   }


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Up until now we could only create a single beam interaction pair for a single pairing of structural elements. This causes issues, if one wants to combine different coupling methods, e.g., line-to-surface and line-to-line contact interactions for beam-to-solid contact. This PR allows for multiple beam interaction conditions to create a beam contact pair for a single pairing of structural elements.

Note: A single beam interaction condition, e.g., beam-to-surface, beam-to-volume, ..., can still only create a single beam contact pair, as the underlying formulations don't not make sense otherwise.