### PR TITLE
[LinAlg] Remove unused matrix split method

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -312,36 +312,6 @@ std::shared_ptr<Core::LinAlg::Graph> Core::LinAlg::enrich_matrix_graph(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-bool Core::LinAlg::split_matrix2x2(std::shared_ptr<Epetra_CrsMatrix> A,
-    std::shared_ptr<BlockSparseMatrix<DefaultBlockMatrixStrategy>>& Ablock,
-    std::shared_ptr<Core::LinAlg::Map>& A11rowmap, std::shared_ptr<Core::LinAlg::Map>& A22rowmap)
-{
-  if (A == nullptr) FOUR_C_THROW("A==null on entry");
-
-  if (A11rowmap == nullptr && A22rowmap != nullptr)
-    A11rowmap = Core::LinAlg::split_map(Map(A->RowMap()), *A22rowmap);
-  else if (A11rowmap != nullptr && A22rowmap == nullptr)
-    A22rowmap = Core::LinAlg::split_map(Map(A->RowMap()), *A11rowmap);
-  else if (A11rowmap == nullptr && A22rowmap == nullptr)
-    FOUR_C_THROW("Both A11rowmap and A22rowmap == null on entry");
-
-  std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps(2);
-  maps[0] = std::make_shared<Core::LinAlg::Map>(*A11rowmap);
-  maps[1] = std::make_shared<Core::LinAlg::Map>(*A22rowmap);
-  Core::LinAlg::MultiMapExtractor extractor(Map(A->RowMap()), maps);
-
-  // create SparseMatrix view to input matrix A
-  SparseMatrix a(A, DataAccess::View);
-
-  // split matrix into pieces, where main diagonal blocks are square
-  Ablock = Core::LinAlg::split_matrix<DefaultBlockMatrixStrategy>(a, extractor, extractor);
-  Ablock->complete();
-
-  return true;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 bool Core::LinAlg::split_matrix2x2(std::shared_ptr<Core::LinAlg::SparseMatrix> A,
     std::shared_ptr<Core::LinAlg::Map>& A11rowmap, std::shared_ptr<Core::LinAlg::Map>& A22rowmap,
     std::shared_ptr<Core::LinAlg::Map>& A11domainmap,

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.hpp
@@ -117,26 +117,6 @@ namespace Core::LinAlg
   std::shared_ptr<Core::LinAlg::Graph> enrich_matrix_graph(const SparseMatrix& A, int power);
 
   /*!
-   \brief split a matrix into a 2x2 block system where the rowmap of one of the blocks is given
-          and return a block matrix
-
-   Splits a given matrix into a 2x2 block system where the rowmap of one of the blocks is given
-   on input. Blocks A11 and A22 are assumed to be square.
-   All values on entry have to be nullptr except the given rowmap and matrix A.
-   Note that either A11rowmap or A22rowmap or both have to be nonzero. In case
-   both rowmaps are supplied they have to be an exact and nonoverlapping split of A->RowMap().
-   Matrix blocks are fill_complete() on exit.
-
-   \param A         : Matrix A on input
-   \param Ablock    : Blockmatrix version of A to be calculated
-   \param A11rowmap : rowmap of A11 or null
-   \param A22rowmap : rowmap of A22 or null
-   */
-  bool split_matrix2x2(std::shared_ptr<Epetra_CrsMatrix> A,
-      std::shared_ptr<BlockSparseMatrix<DefaultBlockMatrixStrategy>>& Ablock,
-      std::shared_ptr<Core::LinAlg::Map>& A11rowmap, std::shared_ptr<Core::LinAlg::Map>& A22rowmap);
-
-  /*!
    \brief split a matrix into a 2x2 block system
 
    Splits a given matrix into a 2x2 block system. All values on entry have to be


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title states. Found this while cleaning up my branches ... let's see if it goes through.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
