### PR TITLE
Add Google Benchmark for micro-benchmark tests

### DIFF
--- a/cmake/functions/four_c_auto_define_benchmark_tests.cmake
+++ b/cmake/functions/four_c_auto_define_benchmark_tests.cmake
@@ -1,0 +1,116 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+function(_set_up_benchmark_test_target _module_under_test _target)
+  message(VERBOSE "Setting up benchmark test target ${_target}")
+
+  add_executable(
+    ${_target}
+    ${PROJECT_SOURCE_DIR}/tests/benchmark_tests/4C_benchmark_tests_main.cpp ${_parsed_SOURCE}
+    )
+
+  # Store benchmark test executables directly inside the tests/ directory
+  set_target_properties(${_target} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/tests)
+
+  # Do not try to build benchmark tests as unity files.
+  set_target_properties(${_target} PROPERTIES UNITY_BUILD OFF)
+
+  # All libraries are linked as PRIVATE since a benchmark test executable cannot be used as a dependency itself.
+
+  # Common dependencies for benchmark tests
+  target_link_libraries(${_target} PRIVATE four_c_private_compile_interface)
+
+  target_link_libraries(${_target} PRIVATE ${_module_under_test}_unit_test_deps)
+
+  target_link_libraries(${_target} PRIVATE benchmark::benchmark)
+
+  add_test(NAME ${_target} COMMAND $<TARGET_FILE:${_target}> --benchmark_dry_run)
+  set_tests_properties(${_target} PROPERTIES TIMEOUT ${UNITTEST_TIMEOUT})
+  set_tests_properties(${_target} PROPERTIES PROCESSORS 1)
+  set_tests_properties(${_target} PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")
+
+  add_dependencies(benchmarktests ${_target})
+endfunction()
+
+##
+# Pickup all the source files in the current directory and add them to a benchmark test target.
+# Recursively add all subdirectories that contain CMakeLists.txt files. A module under test
+# may be supplied via MODULE. If no module name is supplied, the name of the parent module is used.
+##
+function(four_c_auto_define_benchmark_tests)
+  if(NOT FOUR_C_WITH_GOOGLE_BENCHMARK)
+    return()
+  endif()
+
+  set(options "")
+  set(oneValueArgs MODULE)
+  set(multiValueArgs "")
+  cmake_parse_arguments(
+    _parsed
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+    )
+  if(DEFINED _parsed_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "There are unparsed arguments: ${_parsed_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(_parsed_MODULE)
+    set(_module_under_test ${_parsed_MODULE})
+  else()
+    if("${FOUR_C_CURRENTLY_DEFINED_PARENT_MODULE}" STREQUAL "")
+      message(
+        FATAL_ERROR
+          "No parent module is set. Either give the module this test belongs to or call this functions inside a module."
+        )
+    endif()
+
+    set(_module_under_test "${FOUR_C_CURRENTLY_DEFINED_PARENT_MODULE}")
+  endif()
+
+  if(NOT TARGET "${_module_under_test}_objs")
+    message(
+      FATAL_ERROR
+        "Tried to add tests for a module named '${_module_under_test}' which is not a known module name."
+      )
+  endif()
+
+  set(_test_name_base "benchmarktests_${_module_under_test}")
+
+  file(GLOB_RECURSE _sources CONFIGURE_DEPENDS *.cpp)
+
+  # Treat every source file separately: determine test requirements and add to or create new test target.
+  foreach(_source ${_sources})
+    set(_current_test_name ${_test_name_base})
+
+    if(NOT TARGET ${_current_test_name})
+      _set_up_benchmark_test_target(${_module_under_test} ${_current_test_name})
+    endif()
+
+    target_sources(${_current_test_name} PRIVATE ${_source})
+  endforeach()
+
+  # Recursively add all subdirectories that contain CMakeLists.txt files.
+  # N.B. We need to directly glob for CMakeLists.txt files here to ensure
+  # the glob reruns when a new CMakeLists.txt is added.
+  file(
+    GLOB children
+    RELATIVE ${CMAKE_CURRENT_LIST_DIR}
+    CONFIGURE_DEPENDS ${CMAKE_CURRENT_LIST_DIR}/*/CMakeLists.txt
+    )
+  foreach(child ${children})
+    get_filename_component(_subdir ${child} DIRECTORY)
+    add_subdirectory(${_subdir})
+  endforeach()
+
+  # Simulate a "return" by setting a variable at the call site
+  set(AUTO_DEFINED_TEST_NAME
+      ${_test_name_base}
+      PARENT_SCOPE
+      )
+endfunction()

--- a/cmake/setup_tests.cmake
+++ b/cmake/setup_tests.cmake
@@ -31,7 +31,8 @@ if(FOUR_C_WITH_GOOGLETEST)
 
   if(TARGET gtest)
     message(
-      FATAL_ERROR "A target <gtest> has already been included by a TPL." "This is not supported."
+      FATAL_ERROR "A target <gtest> has already been included by another library."
+                  "This is not supported."
       )
   endif()
 
@@ -48,6 +49,37 @@ if(FOUR_C_WITH_GOOGLETEST)
 
 else()
   message(STATUS "Unit tests with GoogleTest: disabled")
+endif()
+
+# Fetch Google Benchmark and setup benchmark tests if option is enabled
+four_c_process_global_option(
+  FOUR_C_WITH_GOOGLE_BENCHMARK "Use Google Benchmark for micro benchmark tests" OFF
+  )
+if(FOUR_C_WITH_GOOGLE_BENCHMARK)
+  # Define a convenience target for all benchmark tests and add it to 'full'
+  # All benchmark test executables should add themselves as a dependency to 'benchmarktests'
+  # disable tests from google benchmark
+  set(BENCHMARK_ENABLE_TESTING OFF)
+  add_custom_target(benchmarktests)
+  add_dependencies(full benchmarktests)
+
+  if(TARGET benchmark_main)
+    message(
+      FATAL_ERROR "A target <benchmark_main> has already been included by another library."
+                  "This is not supported."
+      )
+  endif()
+
+  include(FetchContent)
+  fetchcontent_declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG afa23b7699c17f1e26c88cbf95257b20d78d6247 # v1.9.2
+    )
+  fetchcontent_makeavailable(googlebenchmark)
+
+else()
+  message(STATUS "Benchmark tests with Google Benchmark: disabled")
 endif()
 
 # setup test for installation

--- a/src/core/linalg/benchmark_tests/4C_linalg_tensor_benchmark.cpp
+++ b/src/core/linalg/benchmark_tests/4C_linalg_tensor_benchmark.cpp
@@ -1,0 +1,85 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_linalg_tensor.hpp"
+
+#include <benchmark/benchmark.h>
+
+FOUR_C_NAMESPACE_OPEN
+template <std::size_t... size>
+Core::LinAlg::Tensor<double, size...> get_random_tensor()
+{
+  Core::LinAlg::Tensor<double, size...> tensor;
+  std::generate(tensor.container().begin(), tensor.container().end(),
+      []() { return static_cast<double>(std::rand()) / RAND_MAX; });
+  return tensor;
+}
+
+template <std::size_t size>
+static void matrix_matrix_product(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = A * B;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_matrix_product<2>);
+BENCHMARK(matrix_matrix_product<3>);
+BENCHMARK(matrix_matrix_product<4>);
+
+
+template <std::size_t size>
+static void matrix_matrix_t_product(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = A * Core::LinAlg::transpose(B);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_matrix_t_product<2>);
+BENCHMARK(matrix_matrix_t_product<3>);
+BENCHMARK(matrix_matrix_t_product<4>);
+
+
+template <std::size_t size>
+static void matrix_vector_product(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size> b = get_random_tensor<size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size> result = A * b;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_vector_product<2>);
+BENCHMARK(matrix_vector_product<3>);
+BENCHMARK(matrix_vector_product<4>);
+
+
+template <std::size_t size>
+static void scaled_matrix_matrix_product(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = 3.0 * A * B;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(scaled_matrix_matrix_product<2>);
+BENCHMARK(scaled_matrix_matrix_product<3>);
+BENCHMARK(scaled_matrix_matrix_product<4>);
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/benchmark_tests/CMakeLists.txt
+++ b/src/core/linalg/benchmark_tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+four_c_auto_define_benchmark_tests()

--- a/src/core/linalg/src/dense/4C_linalg_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor.hpp
@@ -689,6 +689,7 @@ namespace Core::LinAlg
     }
 
     template <typename TensorLeft, typename TensorRight>
+      requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight>)
     constexpr auto operator*(const TensorLeft& A, const TensorRight& B)
     {
       return dot(A, B);

--- a/tests/benchmark_tests/4C_benchmark_tests_main.cpp
+++ b/tests/benchmark_tests/4C_benchmark_tests_main.cpp
@@ -1,0 +1,33 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_config.hpp"
+
+#include "4C_utils_singleton_owner.hpp"
+
+#include <benchmark/benchmark.h>
+#include <Kokkos_Core.hpp>
+#include <mpi.h>
+
+int main(int argc, char** argv)
+{
+  using namespace FourC;
+
+  MPI_Init(&argc, &argv);
+  struct CleanUpMPI
+  {
+    ~CleanUpMPI() { MPI_Finalize(); }
+  } cleanup;
+  // Kokkos should be initialized right after MPI.
+  Kokkos::ScopeGuard kokkos_guard{};
+
+  Core::Utils::SingletonOwnerRegistry::ScopeGuard guard;
+
+  benchmark::Initialize(&argc, argv);
+  benchmark::RunSpecifiedBenchmarks();
+  benchmark::Shutdown();
+}


### PR DESCRIPTION
This provides infrastructure for micro-benchmarking tests. Useful for profiling or comparing different implementations. Setup is very similar to Google Test.

I added a few benchmark tests for the tensors added in #583.

Closes #611 