### PR TITLE
Add post setup call to StructPoro material

### DIFF
--- a/src/mat/4C_mat_structporo.cpp
+++ b/src/mat/4C_mat_structporo.cpp
@@ -210,6 +210,12 @@ void Mat::StructPoro::unpack(Core::Communication::UnpackBuffer& buffer)
   is_initialized_ = true;
 }
 
+void Mat::StructPoro::post_setup(Teuchos::ParameterList& params, const int eleGID)
+{
+  // Forward post_setup call to actual solid material
+  mat_->post_setup(params, eleGID);
+}
+
 void Mat::StructPoro::compute_porosity(const double& refporosity, const double& press,
     const double& J, const int& gp, double& porosity, double* dphi_dp, double* dphi_dJ,
     double* dphi_dJdp, double* dphi_dJJ, double* dphi_dpp, double* dphi_dphiref, bool save)

--- a/src/mat/4C_mat_structporo.hpp
+++ b/src/mat/4C_mat_structporo.hpp
@@ -327,6 +327,8 @@ namespace Mat
       mat_->setup(numgp, container);
     }
 
+    void post_setup(Teuchos::ParameterList& params, const int eleGID) override;
+
     void update() override { mat_->update(); }
 
     void reset_step() override { mat_->reset_step(); }


### PR DESCRIPTION

## Description and Context
This PR add the `post_setup` call to the material `StructPoro`. This enables usage of materials that rely on this call (e.g. `mixture`) as the solid material within the poroelastic framework.

## Related Issues and Pull Requests
none
