### PR TITLE
Fix bug in --to-yaml

### DIFF
--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -352,7 +352,8 @@ int main(int argc, char* argv[])
       std::filesystem::path outputfile_name;
       if (argc == 3)
       {
-        outputfile_name = inputfile_name.replace_extension("4C.yaml");
+        outputfile_name = inputfile_name;
+        outputfile_name.replace_extension("4C.yaml");
         if (std::filesystem::exists(outputfile_name))
         {
           printf("You did not provide an output file name.\n");


### PR DESCRIPTION
## Description and Context
While starting with the conversion of `ssti` files I realized that using the `--to-yaml` option with only the current input file (.dat) was not working as the `replace_extension` call did also replace the file extension of the input file that is not yet available, thus reading of the dat file and subsequent conversion to 4C.yaml did not work.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
