### PR TITLE
Rewrite a loop that triggers a compiler warning with UBSAN

### DIFF
--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -174,17 +174,17 @@ namespace Core::Binstrategy::Utils
     // ---- pack data for sending -----
     std::map<int, std::vector<char>> sdata;
     std::vector<int> targetprocs(numproc, 0);
-    std::map<int, std::vector<std::pair<int, std::vector<int>>>>::const_iterator p;
-    for (p = toranktosendbinids.begin(); p != toranktosendbinids.end(); ++p)
+
+    for (const auto& [rank, bin_list] : toranktosendbinids)
     {
-      std::vector<std::pair<int, std::vector<int>>>::const_iterator iter;
-      for (iter = p->second.begin(); iter != p->second.end(); ++iter)
+      Core::Communication::PackBuffer data;
+      for (const auto& bin : bin_list)
       {
-        Core::Communication::PackBuffer data;
-        add_to_pack(data, *iter);
-        sdata[p->first].insert(sdata[p->first].end(), data().begin(), data().end());
+        add_to_pack(data, bin);
       }
-      targetprocs[p->first] = 1;
+      auto& buffer = sdata[rank];
+      buffer.insert(buffer.end(), data().begin(), data().end());
+      targetprocs[rank] = 1;
     }
 
     // ---- send ----


### PR DESCRIPTION
I am trying to add the undefined behavior sanitizer (UBSAN) to our nightly sanitizer run. Locally, I run into a compiler warning for one loop. Rewriting it in a cleaner way removes the warning. 