### PR TITLE
Fix bug in structure micro-micro

### DIFF
--- a/src/mat/4C_mat_micromaterial.cpp
+++ b/src/mat/4C_mat_micromaterial.cpp
@@ -50,12 +50,6 @@ Core::Communication::ParObject* Mat::MicroMaterialType::create(
   return micro;
 }
 
-
-/*----------------------------------------------------------------------*/
-/*----------------------------------------------------------------------*/
-Mat::MicroMaterial::MicroMaterial() : params_(nullptr) {}
-
-
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 Mat::MicroMaterial::MicroMaterial(Mat::PAR::MicroMaterial* params) : params_(params) {}

--- a/src/mat/4C_mat_micromaterial.hpp
+++ b/src/mat/4C_mat_micromaterial.hpp
@@ -75,7 +75,7 @@ namespace Mat
   {
    public:
     /// construct empty material object
-    MicroMaterial();
+    MicroMaterial() = default;
 
     /// construct the material object given material parameters
     explicit MicroMaterial(Mat::PAR::MicroMaterial* params);
@@ -154,6 +154,16 @@ namespace Mat
 
     double density() const override;
 
+    /*!
+     * @brief Initialize the density based on the micromaterial
+     *
+     * @note Since we can assign only one material per element, all Gauss points have the same
+     * density -> arbitrarily ask the micromaterial at gp=0
+     *
+     * @param[in] gp Gauss point id
+     */
+    void initialize_density(int gp);
+
     /// Calculate stresses and strains on the micro-scale
     void prepare_output();
 
@@ -190,10 +200,10 @@ namespace Mat
    private:
     std::map<int, std::shared_ptr<MicroMaterialGP>> matgp_;
 
-    double density_;
+    double density_{0.0};
 
     /// my material parameters
-    Mat::PAR::MicroMaterial* params_;
+    Mat::PAR::MicroMaterial* params_{nullptr};
   };
 
 }  // namespace Mat

--- a/src/mat/4C_mat_micromaterial_evaluate.cpp
+++ b/src/mat/4C_mat_micromaterial_evaluate.cpp
@@ -137,15 +137,7 @@ void Mat::MicroMaterial::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
   if (matgp_.find(gp) == matgp_.end())
   {
     matgp_[gp] = std::make_shared<MicroMaterialGP>(gp, eleGID, eleowner, microdisnum, V0);
-
-    /// save density of this micromaterial
-    /// -> since we can assign only one material per element, all Gauss points have
-    /// the same density -> arbitrarily ask micromaterialgp at gp=0
-    if (gp == 0)
-    {
-      std::shared_ptr<MicroMaterialGP> actmicromatgp = matgp_[gp];
-      density_ = actmicromatgp->density();
-    }
+    initialize_density(gp);
   }
 
   std::shared_ptr<MicroMaterialGP> actmicromatgp = matgp_[gp];
@@ -245,6 +237,14 @@ void Mat::MicroMaterial::prepare_output()
   }
 }
 
+void Mat::MicroMaterial::initialize_density(const int gp)
+{
+  if (gp == 0)
+  {
+    density_ = matgp_[gp]->density();
+  }
+}
+
 // output for all procs
 void Mat::MicroMaterial::output_step_state()
 {
@@ -323,6 +323,7 @@ void Mat::MicroMaterial::read_restart(const int gp, const int eleID, const bool 
   if (matgp_.find(gp) == matgp_.end())
   {
     matgp_[gp] = std::make_shared<MicroMaterialGP>(gp, eleID, eleowner, microdisnum, V0);
+    initialize_density(gp);
   }
 
   std::shared_ptr<MicroMaterialGP> actmicromatgp = matgp_[gp];
@@ -337,6 +338,7 @@ void Mat::MicroMaterial::read_restart(
   if (matgp_.find(gp) == matgp_.end())
   {
     matgp_[gp] = std::make_shared<MicroMaterialGP>(gp, eleID, eleowner, microdisnum, V0);
+    initialize_density(gp);
   }
 
   std::shared_ptr<MicroMaterialGP> actmicromatgp = matgp_[gp];

--- a/src/mat/4C_mat_micromaterialgp_static.cpp
+++ b/src/mat/4C_mat_micromaterialgp_static.cpp
@@ -8,7 +8,6 @@
 #include "4C_mat_micromaterialgp_static.hpp"
 
 #include "4C_fem_discretization.hpp"
-#include "4C_fem_general_elementtype.hpp"
 #include "4C_global_data.hpp"
 #include "4C_inpar_structure.hpp"
 #include "4C_io.hpp"

--- a/src/structure/4C_structure_dyn_nln_drt.cpp
+++ b/src/structure/4C_structure_dyn_nln_drt.cpp
@@ -124,11 +124,11 @@ void dyn_nlnstructural_drt()
   {
     structadapter->read_restart(restart);
   }
-  // write output at beginning of calc
+  // post_setup tasks for the structural adapter
   else
   {
-    // post_setup tasks for the structural adapter
     structadapter->post_setup();
+    // write output at beginning of calc
     if (write_initial_state)
     {
       constexpr bool force_prepare = true;

--- a/tests/input_files/sohex8_multiscale_macro.dat
+++ b/tests/input_files/sohex8_multiscale_macro.dat
@@ -26,7 +26,7 @@ DIM                             3
 MATERIALS                       1
 NUMDF                           6
 -----------------------------------------------------------------PROBLEM TYPE
-PROBLEMTYPE                      Structure
+PROBLEMTYPE                     Structure
 RESTART                         0
 //!RESTART                      1
 --------------------------------------------------------------DISCRETISATION
@@ -44,9 +44,9 @@ WRITE_INITIAL_STATE             No
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 INT_STRATEGY                    Standard
 LINEAR_SOLVER                   1
-DYNAMICTYPE                      GenAlpha
-RESULTSEVERY                     1
-RESTARTEVERY                     1
+DYNAMICTYPE                     GenAlpha
+RESULTSEVERY                    1
+RESTARTEVERY                    1
 NLNSOL                          fullnewton
 TIMESTEP                        0.5
 NUMSTEP                         3


### PR DESCRIPTION
## Description and Context
The density was not properly initialized in solid micro-macro simulations. In addition, for restart simulations also, no value was set, resulting in garbage values for the density, letting restart simulations fail.

This should be fixed now. I also tested it on an asan and a debug configuration on my workstation without failure.

Thanks also to @georghammerl and @sebproell for support during nasty debugging.

## Related Issues and Pull Requests
Closes #635 
