### PR TITLE
Correct license identifier

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,4 +11,4 @@ identifiers:
     value: 'https://www.4c-multiphysics.org'
 repository-code: 'https://github.com/4C-multiphysics/4C'
 url: 'https://www.4c-multiphysics.org'
-license: LGPL-3.0
+license: LGPL-3.0-or-later


### PR DESCRIPTION
The correct SPDX identifier of our chosen license includes the "-or-later".

## Interested parties
@4C-multiphysics/maintainer 