### PR TITLE
Throw if iterative linear solver does not converge

### DIFF
--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -286,6 +286,8 @@ Teuchos::ParameterList translate_four_c_to_belos(const Teuchos::ParameterList& i
   beloslist.set("reuse", inparams.get<int>("AZREUSE"));
   beloslist.set("ncall", 0);
 
+  beloslist.set("THROW_IF_UNCONVERGED", inparams.get<bool>("THROW_IF_UNCONVERGED"));
+
   // try to get an xml file if possible
   auto xmlfile = inparams.get<std::optional<std::filesystem::path>>("SOLVER_XML_FILE");
   if (xmlfile)

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -103,6 +103,14 @@ namespace Inpar::SOLVER
                                      "before\n a restart is performed.",
                          .default_value = 50}),
 
+        parameter<bool>("THROW_IF_UNCONVERGED",
+            {.description =
+                    "If set to true, the iterative linear solver "
+                    "will throw an exception if it does not "
+                    "converge. To only issue a warning without stopping the simulation, set "
+                    "this parameter to false.",
+                .default_value = true}),
+
 
         parameter<std::optional<std::filesystem::path>>(
             "SOLVER_XML_FILE", {.description = "xml file defining any iterative solver"}),

--- a/tests/input_files/consinter3D_tsi_hex8_tet4.dat
+++ b/tests/input_files/consinter3D_tsi_hex8_tet4.dat
@@ -105,6 +105,7 @@ AZREUSE                         0
 AZSOLVE                         GMRES
 AZSUB                           300
 AZTOL                           1e-10
+THROW_IF_UNCONVERGED            No
 AZPREC                          Teko
 TEKO_XML_FILE                   xml/block_preconditioner/thermo_solid.xml
 -------------------------------------------------------------------MATERIALS

--- a/tests/input_files/f2_channel_EOS_quad4_1000x10_quad_inflow_h_diam_to_opp.dat
+++ b/tests/input_files/f2_channel_EOS_quad4_1000x10_quad_inflow_h_diam_to_opp.dat
@@ -76,6 +76,7 @@ AZPREC                          MueLu
 MUELU_XML_FILE                  xml/multigrid/fluid_template.xml
 AZTOL                           1.0E-8
 AZCONV                          AZ_r0
+THROW_IF_UNCONVERGED            No
 ---------------------------------------------------------MATERIALS
 MAT       1 MAT_fluid  DYNVISCOSITY 1.0 DENSITY 1.0 GAMMA 1.0
 MAT       2 MAT_Struct_StVenantKirchhoff  YOUNG 1.0 NUE 0.0 DENS 1.0

--- a/tests/input_files/f2_channel_EOS_quad4_200x10_cubic_inflow.dat
+++ b/tests/input_files/f2_channel_EOS_quad4_200x10_cubic_inflow.dat
@@ -76,6 +76,7 @@ AZPREC                          MueLu
 MUELU_XML_FILE                  xml/multigrid/fluid_template.xml
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
+THROW_IF_UNCONVERGED            No
 ---------------------------------------------------------MATERIALS
 MAT       1 MAT_fluid  DYNVISCOSITY 1.0 DENSITY 1.0 GAMMA 1.0
 MAT       2 MAT_Struct_StVenantKirchhoff  YOUNG 1.0 NUE 0.0 DENS 1.0

--- a/tests/input_files/f2_drivencavity32x32_Re1000_stat.dat
+++ b/tests/input_files/f2_drivencavity32x32_Re1000_stat.dat
@@ -71,7 +71,7 @@ AZTOL                           1.0E-7
 AZITER                          1000
 AZSUB                           25
 IFPACKOVERLAP                   0
-//AZCONV                        AZ_r0
+THROW_IF_UNCONVERGED            No
 ----------------------------------------------DESIGN POINT DIRICH CONDITIONS
 // DOBJECT FLAG FLAG FLAG FLAG FLAG FLAG VAL VAL VAL VAL VAL VAL CURVE CURVE CURVE CURVE CURVE CURVE
 E 1 NUMDOF 3 ONOFF 1 1 0 VAL 0.0 0.0 0.0 FUNCT 0 0 0

--- a/tests/input_files/f3_beltrami_tet10_hdg.dat
+++ b/tests/input_files/f3_beltrami_tet10_hdg.dat
@@ -49,6 +49,7 @@ AZTOL                           1.0E-3
 AZITER                          200
 AZSUB                           100
 AZOUTPUT                        1
+THROW_IF_UNCONVERGED            No
 -------------------------------------DESIGN SURF DIRICH CONDITIONS
 // beltramiboundary
 E 1 NUMDOF 4 ONOFF 1 1 1 0 VAL 1.0 1.0 1.0 1.0 FUNCT 1 1 1 2

--- a/tests/input_files/f3_cha_8x8x8_recongradl2.dat
+++ b/tests/input_files/f3_cha_8x8x8_recongradl2.dat
@@ -73,6 +73,7 @@ MUELU_XML_FILE                  xml/multigrid/fluid_template.xml
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZREUSE                         5
+THROW_IF_UNCONVERGED            No
 -----------------------------------------------------------SOLVER 2
 NAME                            Fluid_Solver
 SOLVER                          Belos
@@ -81,6 +82,7 @@ AZPREC                          ILU
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZREUSE                         5
+THROW_IF_UNCONVERGED            No
 ----------------------------------------------------------MATERIALS
 MAT 1   MAT_fluid   DYNVISCOSITY 0.5 DENSITY 1.0
 -------------------------------------------------------------FUNCT1

--- a/tests/input_files/f3_cha_8x8x8_recongradspr.dat
+++ b/tests/input_files/f3_cha_8x8x8_recongradspr.dat
@@ -73,6 +73,7 @@ MUELU_XML_FILE                  xml/multigrid/fluid_template.xml
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZREUSE                         5
+THROW_IF_UNCONVERGED            No
 -----------------------------------------------------------SOLVER 2
 NAME                            Fluid_Solver
 SOLVER                          Belos
@@ -82,6 +83,7 @@ MUELU_XML_FILE                  xml/multigrid/fluid_template.xml
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZREUSE                         5
+THROW_IF_UNCONVERGED            No
 ----------------------------------------------------------MATERIALS
 MAT 1   MAT_fluid   DYNVISCOSITY 0.5 DENSITY 1.0
 -------------------------------------------------------------FUNCT1

--- a/tests/input_files/f3_decaying_hit_8x8x8.dat
+++ b/tests/input_files/f3_decaying_hit_8x8x8.dat
@@ -94,6 +94,7 @@ AZPREC                          ILU
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZITER                          10
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_fluid DYNVISCOSITY 0.0007431 DENSITY 1.0
 --------------------------------------------------------CLONING MATERIAL MAP

--- a/tests/input_files/f3_decaying_hit_eb.dat
+++ b/tests/input_files/f3_decaying_hit_eb.dat
@@ -96,6 +96,7 @@ MUELU_XML_FILE                  xml/multigrid/fluid_template.xml
 AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZITER                          100
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_fluid DYNVISCOSITY 0.0007431 DENSITY 1.0
 ----------------------------------------------------------RESULT DESCRIPTION

--- a/tests/input_files/f3_impl_channel_pressuregrad.dat
+++ b/tests/input_files/f3_impl_channel_pressuregrad.dat
@@ -63,6 +63,7 @@ AZTOL                           1.0E-4
 AZCONV                          AZ_r0
 AZREUSE                         5
 AZOUTPUT                        10
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_fluid DYNVISCOSITY 0.5 DENSITY 10.0 GAMMA 1.0
 ----------------------------------------------------------------------FUNCT1

--- a/tests/input_files/f3_periodic_hill_w_forcing_24x12x12.dat
+++ b/tests/input_files/f3_periodic_hill_w_forcing_24x12x12.dat
@@ -79,18 +79,19 @@ CHAN_AMPL_INIT_DIST             0.1
 ------------------------------------FLUID DYNAMIC/WALL MODEL
 X_WALL                          No
 ------------------------------------------------------SOLVER 1
-NAME              Fluid_Solver
-SOLVER            Belos
-AZOUTPUT          0
-AZSOLVE           GMRES
-AZPREC            ILU
-AZREUSE           8
-IFPACKGFILL       0
-AZTOL             1.0E-20
-AZCONV            AZ_r0
-AZITER            1000
-AZSUB             40
-IFPACKOVERLAP     0
+NAME                            Fluid_Solver
+SOLVER                          Belos
+AZOUTPUT                        0
+AZSOLVE                         GMRES
+AZPREC                          ILU
+AZREUSE                         8
+IFPACKGFILL                     0
+AZTOL                           1.0E-20
+AZCONV                          AZ_r0
+AZITER                          1000
+AZSUB                           40
+IFPACKOVERLAP                   0
+THROW_IF_UNCONVERGED            No
 ----------------------------------------------------------MATERIALS
 MAT 1   MAT_fluid   DYNVISCOSITY 0.0000182 DENSITY 0.000001225
 -------------------------------------------------------------FUNCT1

--- a/tests/input_files/f3_womersley.dat
+++ b/tests/input_files/f3_womersley.dat
@@ -96,6 +96,7 @@ AZTOL                           1.0E-12
 AZCONV                          AZ_r0
 AZREUSE                         10
 AZOUTPUT                        0
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_fluid DYNVISCOSITY 0.004 DENSITY 0.001 GAMMA 1.0
 MAT 2 MAT_ElastHyper NUMMAT 1 MATIDS 5 DENS 0.001

--- a/tests/input_files/fsi_dc_mono_mtrss_ada_ab2_none.dat
+++ b/tests/input_files/fsi_dc_mono_mtrss_ada_ab2_none.dat
@@ -100,6 +100,7 @@ SOLVER_XML_FILE                 xml/linear_solver/iterative_gmres_template.xml
 AZPREC                          Teko
 TEKO_XML_FILE                   xml/block_preconditioner/fluid_solid_ale.xml
 AZREUSE                         10
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_fluid DYNVISCOSITY 0.01 DENSITY 1.0
 MAT 2 MAT_ElastHyper NUMMAT 1 MATIDS 3 DENS 500

--- a/tests/input_files/scatra_forced_hit_iso_8x8x8_dsm.dat
+++ b/tests/input_files/scatra_forced_hit_iso_8x8x8_dsm.dat
@@ -127,6 +127,7 @@ AZCONV                          AZ_r0
 AZREUSE                         0
 AZOUTPUT                        10
 AZITER                          20
+THROW_IF_UNCONVERGED            No
 --------------------------------------------------------------------SOLVER 2
 SOLVER                          Belos
 AZSOLVE                         GMRES
@@ -137,6 +138,7 @@ AZCONV                          AZ_r0
 AZREUSE                         5
 AZOUTPUT                        10
 AZITER                          20
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_fluid DYNVISCOSITY 0.0001 DENSITY 1.0
 MAT 2 MAT_scatra DIFFUSIVITY 0.0001 REACOEFF 0.0

--- a/tests/input_files/sti_mono_2D_quad4_elch_s2i_butlervolmerpeltier_diabatic_AMG_vectorbased.dat
+++ b/tests/input_files/sti_mono_2D_quad4_elch_s2i_butlervolmerpeltier_diabatic_AMG_vectorbased.dat
@@ -49,6 +49,7 @@ SOLVER                          Belos
 AZPREC                          MueLu
 MUELU_XML_FILE                  xml/multigrid/sti_template.xml
 AZSUB                           100
+THROW_IF_UNCONVERGED            No
 -----------------------------------------------------------SOLVER 2
 SOLVER                          UMFPACK
 ----------------------------------------------------------MATERIALS

--- a/tests/input_files/volmortar3D_tsi_hex8_tet4.dat
+++ b/tests/input_files/volmortar3D_tsi_hex8_tet4.dat
@@ -102,6 +102,7 @@ AZPREC                          Teko
 TEKO_XML_FILE                   xml/block_preconditioner/thermo_solid.xml
 AZTOL                           1e-10
 AZREUSE                         10
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_Struct_ThermoStVenantK YOUNGNUM 1 YOUNG 2.1e05 NUE 0.3 DENS 7.85e-06 THEXPANS 1.1e-03 CAPA 6.445 CONDUCT 1031.2 INITTEMP 0.0
 MAT 2 MAT_Fourier CONDUCT_PARA_NUM 1 CAPA 6.445 CONDUCT 1031.2

--- a/tests/input_files/xfluid_stat_sliver_cut_instat.dat
+++ b/tests/input_files/xfluid_stat_sliver_cut_instat.dat
@@ -89,7 +89,8 @@ AZPREC                          ILU
 AZREUSE                         4
 AZSOLVE                         GMRES
 AZSUB                           40
-AZTOL                           1e-012
+AZTOL                           1e-12
+THROW_IF_UNCONVERGED            No
 -------------------------------------------------------------------MATERIALS
 // MAT_fluid
 MAT 1 MAT_fluid DYNVISCOSITY 0.1 DENSITY 1.0 GAMMA 1.0

--- a/tests/input_files/xfluid_taylor_couette_NavSlip_eps1.0_25x25_krylov_levelset_altgeogeneration.dat
+++ b/tests/input_files/xfluid_taylor_couette_NavSlip_eps1.0_25x25_krylov_levelset_altgeogeneration.dat
@@ -166,6 +166,7 @@ AZPREC                          ILU
 AZREUSE                         1
 AZTOL                           1.0E-5
 AZCONV                          AZ_r0
+THROW_IF_UNCONVERGED            No
 IFPACKOVERLAP                   3
 IFPACKGFILL                     3
 --------------------------------------------------------------------SOLVER 2

--- a/tests/input_files/xfluid_taylor_couette_NavSlip_ri0.19_ro0.49_epsi1.0_epso1e-5_ti-2.5_to0.5_8x8_levelset_hex27.dat
+++ b/tests/input_files/xfluid_taylor_couette_NavSlip_ri0.19_ro0.49_epsi1.0_epso1e-5_ti-2.5_to0.5_8x8_levelset_hex27.dat
@@ -95,6 +95,7 @@ AZPREC                          ILU
 AZREUSE                         1
 AZTOL                           1.0E-5
 AZCONV                          AZ_r0
+THROW_IF_UNCONVERGED            No
 IFPACKOVERLAP                   3
 IFPACKGFILL                     3
 --------------------------------------------------------------------SOLVER 2
@@ -106,6 +107,7 @@ AZPREC                          ILU
 AZREUSE                         1
 AZTOL                           1.0E-5
 AZCONV                          AZ_r0
+THROW_IF_UNCONVERGED            No
 IFPACKOVERLAP                   3
 IFPACKGFILL                     3
 --------------------------------------------------------------------SOLVER 3


### PR DESCRIPTION
## Description and Context

Failed convergence of iterative linear solvers has lead to trouble in the past --- either in solver development or on applications, where "bad" Newton increments are likely to disturb/destroy the convergence of the outer Newton solver. This PR finally throws, if the iterative solver did not converge in the maximum number of iterations.

## Additional Information

If necessary for the pipeline to pass or if desired by the community, I can add an input option to issue a warning instead. In order to be on the safe side, the new default behavior will be to throw.

UPDATE: I have added the option `THROW_IF_UNCONVERGED`, so that the user can overwrite default behavior and only gets a warning instead of an error.