### PR TITLE
Improve ArborX interface

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.hpp
@@ -238,7 +238,8 @@ namespace BeamInteraction
        * - elements sharing nodes don't interact
        */
       void select_eles_to_be_considered_for_contact_evaluation(
-          Core::Elements::Element* currele, std::set<Core::Elements::Element*>& neighbors) const;
+          const Core::Elements::Element* currele,
+          std::set<Core::Elements::Element*>& neighbors) const;
 
       /// create instances of class BeamContactPair that will be evaluated
       //  to get force and stiffness contributions from beam interactions

--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_access_traits.hpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_access_traits.hpp
@@ -55,7 +55,10 @@ namespace ArborX
     static KOKKOS_FUNCTION auto get(
         const BoundingVolumeVectorPlaceholder<PrimitivesTag>& placeholder, size_type i)
     {
-      return placeholder.bounding_volumes_[i].second.bounding_volume_;
+      // We are interested in the gid of the primitive, not the id in the bounding volume vector,
+      // thus we attach the gid here.
+      return ArborX::PairValueIndex{placeholder.bounding_volumes_[i].second.bounding_volume_,
+          placeholder.bounding_volumes_[i].first};
     }
 
     static KOKKOS_FUNCTION auto get(

--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_bvh.hpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_bvh.hpp
@@ -20,6 +20,16 @@ namespace Core::GeometricSearch
 {
   struct BoundingVolume;
 
+  /*! \brief Structure to hold a pair found during a collision search
+   */
+  struct CollisionSearchResult
+  {
+    //! Global ID of the predicate
+    int gid_predicate;
+    //! Global ID of the primitive
+    int gid_primitive;
+  };
+
   /*! \brief Finds all primitives meeting the predicates and record results in {indices, offsets}.
    *
    * (From ArborX documentation)
@@ -35,10 +45,9 @@ namespace Core::GeometricSearch
    * @param predicates Bounding volumes to intersect with
    * @param comm Communicator object of the discretization
    * @param verbosity Enabling printout of the geometric search information
-   * @return {indices, offsets} stores indices of the objects that satisfy the predicates and
-   *          offsets stores the locations in the indices view that start a predicate
+   * @return pairs Vector of the found interaction pairs
    */
-  std::pair<std::vector<int>, std::vector<int>> collision_search(
+  std::vector<CollisionSearchResult> collision_search(
       const std::vector<std::pair<int, BoundingVolume>>& primitives,
       const std::vector<std::pair<int, BoundingVolume>>& predicates, MPI_Comm comm,
       const Core::IO::Verbositylevel verbosity);

--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_distributed_tree.hpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_distributed_tree.hpp
@@ -22,8 +22,8 @@ namespace Core::GeometricSearch
 {
   struct BoundingVolume;
 
-  /*! \brief Structure to hold the resulting global/local ID pairings that are found during a global
-   * collision search
+  /*! \brief Structure to hold a resulting global/local ID pair found during a global collision
+   * search
    */
   struct GlobalCollisionSearchResult
   {
@@ -31,8 +31,6 @@ namespace Core::GeometricSearch
     int lid_predicate;
     //! Global ID of the predicate
     int gid_predicate;
-    //! Local ID of the primitives (on the primitives rank)
-    int lid_primitive;
     //! Global ID of the primitives
     int gid_primitive;
     //! Processor ID owning the primitive

--- a/src/core/fem/src/geometric_search/4C_fem_geometric_search_utils.hpp
+++ b/src/core/fem/src/geometric_search/4C_fem_geometric_search_utils.hpp
@@ -33,26 +33,6 @@ namespace Core::GeometricSearch
    */
   void print_geometric_search_details(MPI_Comm comm, const GeometricSearchInfo info);
 
-  /*! \brief Returns interaction pair indices based on the search output of ArborX
-   *
-   * @tparam T Data container for stored indice and offset array
-   * @param indices Stores the indices of the objects that satisfy predicates
-   * @param offset Stores the locations in indices that start a predicate
-   * @return Interaction pair indices , i.e., {i_predicate, i_primitive} where i_predicate is
-   * satisfied by i_primitive. The indices correspond to the primitive and predicate vectors, NOT
-   * element GIDs.
-   */
-  template <typename T>
-  std::vector<std::pair<int, int>> get_pairs(const T& indices, const T& offset)
-  {
-    std::vector<std::pair<int, int>> pairs;
-    for (size_t i_offset = 0; i_offset < offset.size() - 1; i_offset++)
-      for (int j = offset[i_offset]; j < offset[i_offset + 1]; j++)
-        pairs.emplace_back(std::pair{i_offset, indices[j]});
-
-    return pairs;
-  }
-
   /*! \brief Get the polyhedron representation of a k-DOP
    *
    * @param boundingVolume Bounding volume enclosing the respective element (as k-DOP)

--- a/src/core/fem/tests/geometric_search/4C_fem_geometric_search_distributed_test.np3.cpp
+++ b/src/core/fem/tests/geometric_search/4C_fem_geometric_search_distributed_test.np3.cpp
@@ -87,8 +87,7 @@ namespace
         {
           const auto& reference_pair = reference_map.at({pair.gid_predicate, pair.gid_primitive});
           EXPECT_EQ(pair.lid_predicate, std::get<0>(reference_pair));
-          EXPECT_EQ(pair.lid_primitive, std::get<1>(reference_pair));
-          EXPECT_EQ(pair.pid_primitive, std::get<2>(reference_pair));
+          EXPECT_EQ(pair.pid_primitive, std::get<1>(reference_pair));
         }
         else
         {
@@ -100,38 +99,38 @@ namespace
 
     if (my_rank_ == 0)
     {
-      std::map<std::pair<int, int>, std::array<int, 4>> reference_pairs{
-          {{3, 0}, {0, 0, 0}},   //
-          {{3, 1}, {0, 1, 0}},   //
-          {{3, 6}, {0, 0, 1}},   //
-          {{3, 9}, {0, 0, 2}},   //
-          {{3, 10}, {0, 1, 2}},  //
-          {{4, 0}, {1, 0, 0}},   //
-          {{4, 1}, {1, 1, 0}},   //
-          {{4, 6}, {1, 0, 1}},   //
-          {{4, 9}, {1, 0, 2}},   //
-          {{4, 10}, {1, 1, 2}},  //
-          {{5, 2}, {2, 2, 0}},   //
-          {{5, 7}, {2, 1, 1}}    //
+      std::map<std::pair<int, int>, std::array<int, 2>> reference_pairs{
+          {{3, 0}, {0, 0}},   //
+          {{3, 1}, {0, 0}},   //
+          {{3, 6}, {0, 1}},   //
+          {{3, 9}, {0, 2}},   //
+          {{3, 10}, {0, 2}},  //
+          {{4, 0}, {1, 0}},   //
+          {{4, 1}, {1, 0}},   //
+          {{4, 6}, {1, 1}},   //
+          {{4, 9}, {1, 2}},   //
+          {{4, 10}, {1, 2}},  //
+          {{5, 2}, {2, 0}},   //
+          {{5, 7}, {2, 1}}    //
       };
       compare_results(pairs, reference_pairs);
     }
     else if (my_rank_ == 1)
     {
-      std::map<std::pair<int, int>, std::array<int, 4>> reference_pairs{
-          {{8, 0}, {0, 0, 0}},   //
-          {{8, 1}, {0, 1, 0}},   //
-          {{8, 6}, {0, 0, 1}},   //
-          {{8, 9}, {0, 0, 2}},   //
-          {{8, 10}, {0, 1, 2}},  //
+      std::map<std::pair<int, int>, std::array<int, 2>> reference_pairs{
+          {{8, 0}, {0, 0}},   //
+          {{8, 1}, {0, 0}},   //
+          {{8, 6}, {0, 1}},   //
+          {{8, 9}, {0, 2}},   //
+          {{8, 10}, {0, 2}},  //
       };
       compare_results(pairs, reference_pairs);
     }
     else if (my_rank_ == 2)
     {
-      std::map<std::pair<int, int>, std::array<int, 4>> reference_pairs{
-          {{11, 2}, {0, 2, 0}},  //
-          {{11, 7}, {0, 1, 1}}   //
+      std::map<std::pair<int, int>, std::array<int, 2>> reference_pairs{
+          {{11, 2}, {0, 0}},  //
+          {{11, 7}, {0, 1}}   //
       };
       compare_results(pairs, reference_pairs);
     }
@@ -165,13 +164,11 @@ namespace
 
       EXPECT_EQ(pairs[0].lid_predicate, 0);
       EXPECT_EQ(pairs[0].gid_predicate, 3);
-      EXPECT_EQ(pairs[0].lid_primitive, 1);
       EXPECT_EQ(pairs[0].gid_primitive, 1);
       EXPECT_EQ(pairs[0].pid_primitive, 0);
 
       EXPECT_EQ(pairs[1].lid_predicate, 0);
       EXPECT_EQ(pairs[1].gid_predicate, 3);
-      EXPECT_EQ(pairs[1].lid_primitive, 0);
       EXPECT_EQ(pairs[1].gid_primitive, 0);
       EXPECT_EQ(pairs[1].pid_primitive, 0);
     }

--- a/src/core/fem/tests/geometric_search/4C_fem_geometric_search_test.cpp
+++ b/src/core/fem/tests/geometric_search/4C_fem_geometric_search_test.cpp
@@ -51,14 +51,12 @@ namespace
     EXPECT_EQ(primitives_.size(), 2);
     EXPECT_EQ(predicates_.size(), 1);
 
-    const auto& [indices, offsets] =
+    const auto pairs =
         Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
 
-    const auto pairs = Core::GeometricSearch::get_pairs(indices, offsets);
-
     EXPECT_EQ(pairs.size(), 1);
-    EXPECT_EQ(pairs[0].first, 0);
-    EXPECT_EQ(pairs[0].second, 0);
+    EXPECT_EQ(pairs[0].gid_primitive, 0);
+    EXPECT_EQ(pairs[0].gid_predicate, 2);
   }
 
   /**
@@ -76,10 +74,8 @@ namespace
     EXPECT_EQ(primitives_.size(), 0);
     EXPECT_EQ(predicates_.size(), 3);
 
-    const auto& [indices, offsets] =
+    const auto& pairs =
         Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
-
-    const auto pairs = Core::GeometricSearch::get_pairs(indices, offsets);
 
     EXPECT_EQ(pairs.size(), 0);
   }
@@ -99,10 +95,8 @@ namespace
     EXPECT_EQ(primitives_.size(), 3);
     EXPECT_EQ(predicates_.size(), 0);
 
-    const auto& [indices, offsets] =
+    const auto& pairs =
         Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
-
-    const auto pairs = Core::GeometricSearch::get_pairs(indices, offsets);
 
     EXPECT_EQ(pairs.size(), 0);
   }
@@ -115,10 +109,8 @@ namespace
     EXPECT_EQ(primitives_.size(), 0);
     EXPECT_EQ(predicates_.size(), 0);
 
-    const auto& [indices, offsets] =
+    const auto pairs =
         Core::GeometricSearch::collision_search(primitives_, predicates_, comm_, verbosity_);
-
-    const auto pairs = Core::GeometricSearch::get_pairs(indices, offsets);
 
     EXPECT_EQ(pairs.size(), 0);
   }

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -416,8 +416,7 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_monolithic_nod
   }
 
   // 5. Fill the graph with the geometric close entries
-  for (const auto& [predicate_lid, predicate_gid, primitive_lid, primitive_gid, primitive_proc] :
-      result)
+  for (const auto& [predicate_lid, predicate_gid, primitive_gid, primitive_proc] : result)
   {
     int predicate_lid_discretization = dis.element_row_map()->LID(predicate_gid);
     if (predicate_lid_discretization < 0)


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

This PR cleans up how we return results from the local and global collision search powered by ArborX. We how return a vector of `CollisionSearchResult` in the local search, that contains all the relevant information need (similar to how we already did it in the global search).

Furthermore, the internal way we perform the search and query the BVH was improved, so it should now be possible to simply split up the collision search functions into the creation of a BVH (which can be stored as a wrapped object) and a query part, enabling multiple different queries of a BVH.

@maxfirmbach @mayrmt 