### PR TITLE
Unify input of discretizations

### DIFF
--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -20,8 +20,10 @@ void Core::FE::DiscretizationCreatorBase::initial_checks(
     const Core::FE::Discretization& sourcedis, const Core::FE::Discretization& targetdis) const
 {
   // are the source and target discretizations ready?
-  if (!sourcedis.filled()) FOUR_C_THROW("The source discretization is not filled!");
-  if (!targetdis.filled()) FOUR_C_THROW("The target discretization is not filled!");
+  if (!sourcedis.filled())
+    FOUR_C_THROW("The source discretization '{}' is not filled!", sourcedis.name());
+  if (!targetdis.filled())
+    FOUR_C_THROW("The target discretization '{}' is not filled!", targetdis.name());
 
   // is the target discretization really empty?
   if (targetdis.num_global_elements() or targetdis.num_global_nodes())

--- a/src/core/io/src/4C_io_meshreader.hpp
+++ b/src/core/io/src/4C_io_meshreader.hpp
@@ -103,13 +103,10 @@ namespace Core::IO
      *
      * \param dis            [in] This discretization will be passed on
      * \param input          [in] The input file.
-     * \param sectionname    [in] This will be passed on element/domain readers only (not used for
-     *                            file reader)
-     * \param geometrysource [in] selects which reader will be created
+     * \param sectionname    [in] The section name in the input file.
      */
-    void add_advanced_reader(std::shared_ptr<Core::FE::Discretization> dis,
-        Core::IO::InputFile& input, const std::string& sectionname,
-        const Core::IO::GeometryType geometrysource);
+    void add_advanced_reader(
+        std::shared_ptr<Core::FE::Discretization> dis, const std::string& sectionname);
 
     /// do the actual reading
     /*!
@@ -194,6 +191,11 @@ namespace Core::IO
 
     /// Additional parameters for reading meshes.
     MeshReaderParameters parameters_;
+
+    /// The discretizations to be filled. The key is an identifier for the sections in the input.
+    /// Multiple discretizations might be filled from the same section.
+    std::vector<std::pair<std::string, std::shared_ptr<Core::FE::Discretization>>>
+        target_discretizations_;
   };
 }  // namespace Core::IO
 


### PR DESCRIPTION
This PR simplifies a massive function for global input of discretizations. As a side effect, this should enable the use of the three ways to read a discretization, from `ELEMENTS`, `DOMAIN` or `GEOMETRY` sections, for _all_ fields.
