### PR TITLE
Some cleanup of the ssi module

### DIFF
--- a/src/ssi/4C_ssi_base.hpp
+++ b/src/ssi/4C_ssi_base.hpp
@@ -15,6 +15,8 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_ssi_str_model_evaluator_base.hpp"
 
+#include <utility>
+
 FOUR_C_NAMESPACE_OPEN
 
 // forward declarations
@@ -73,7 +75,7 @@ namespace SSI
 
     //! return counter for Newton-Raphson iterations (monolithic algorithm) or outer coupling
     //! iterations (partitioned algorithm)
-    int iteration_count() const { return iter_; }
+    [[nodiscard]] int iteration_count() const { return iter_; }
 
     //! reset the counter for Newton-Raphson iterations (monolithic algorithm) or outer coupling
     //! iterations (partitioned algorithm)
@@ -106,7 +108,7 @@ namespace SSI
     */
     virtual void init(MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams,
         const Teuchos::ParameterList& scatraparams, const Teuchos::ParameterList& structparams,
-        const std::string& struct_disname, const std::string& scatra_disname, bool isAle) = 0;
+        const std::string& struct_disname, const std::string& scatra_disname, bool is_ale) = 0;
 
     /*! \brief Setup all class internal objects and members
 
@@ -132,19 +134,19 @@ namespace SSI
      * @brief Perform all necessary tasks after setting up the object.
      * Currently, this only calls the post_setup routine of the structure field.
      */
-    void post_setup();
+    void post_setup() const;
 
     //! returns true if setup() was called and is still valid
-    bool is_setup() const { return issetup_; };
+    [[nodiscard]] bool is_setup() const { return issetup_; }
 
     /*!
      * @brief checks whether simulation is restarted or not
      *
      * @return  flag indicating if simulation is restarted
      */
-    bool is_restart() const;
+    [[nodiscard]] bool is_restart() const;
 
-    [[nodiscard]] bool is_s2_i_kinetics_with_pseudo_contact() const
+    [[nodiscard]] bool is_s2i_kinetics_with_pseudo_contact() const
     {
       return is_s2i_kinetic_with_pseudo_contact_;
     }
@@ -165,7 +167,7 @@ namespace SSI
 
     */
     virtual void init_discretizations(MPI_Comm comm, const std::string& struct_disname,
-        const std::string& scatra_disname, const bool redistribute_struct_dis);
+        const std::string& scatra_disname, bool redistribute_struct_dis);
 
     /// setup
     virtual void setup_system();
@@ -180,34 +182,36 @@ namespace SSI
     void read_restart(int restart) override;
 
     //! access to structural field
-    const std::shared_ptr<Adapter::SSIStructureWrapper>& structure_field() const
+    [[nodiscard]] std::shared_ptr<Adapter::SSIStructureWrapper> structure_field() const
     {
       return structure_;
     }
 
     /// pointer to the underlying structure problem base algorithm
-    std::shared_ptr<Adapter::StructureBaseAlgorithmNew> structure_base_algorithm() const
+    [[nodiscard]] std::shared_ptr<Adapter::StructureBaseAlgorithmNew> structure_base_algorithm()
+        const
     {
       return struct_adapterbase_ptr_;
     }
 
     //! access the scalar transport base algorithm
-    const std::shared_ptr<Adapter::ScaTraBaseAlgorithm>& scatra_base_algorithm() const
+    [[nodiscard]] std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra_base_algorithm() const
     {
       return scatra_base_algorithm_;
     }
 
     //! access the scalar transport base algorithm on manifolds
-    const std::shared_ptr<Adapter::ScaTraBaseAlgorithm>& scatra_manifold_base_algorithm() const
+    [[nodiscard]] std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra_manifold_base_algorithm()
+        const
     {
       return scatra_manifold_base_algorithm_;
     }
 
     //! access the scalar transport field
-    std::shared_ptr<ScaTra::ScaTraTimIntImpl> scatra_field() const;
+    [[nodiscard]] std::shared_ptr<ScaTra::ScaTraTimIntImpl> scatra_field() const;
 
     //! access the scalar transport field on manifolds
-    std::shared_ptr<ScaTra::ScaTraTimIntImpl> scatra_manifold() const;
+    [[nodiscard]] std::shared_ptr<ScaTra::ScaTraTimIntImpl> scatra_manifold() const;
 
     /// set structure solution on other fields
     void set_struct_solution(std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
@@ -231,50 +235,50 @@ namespace SSI
     void evaluate_and_set_temperature_field();
 
     //! get bool indicating if we have at least one ssi interface meshtying condition
-    bool ssi_interface_meshtying() const { return ssiinterfacemeshtying_; }
+    [[nodiscard]] bool ssi_interface_meshtying() const { return ssi_interface_meshtying_; }
 
     //! return the scatra-scatra interface meshtying strategy
-    std::shared_ptr<const ScaTra::MeshtyingStrategyS2I> meshtying_strategy_s2_i() const
+    [[nodiscard]] std::shared_ptr<const ScaTra::MeshtyingStrategyS2I> meshtying_strategy_s2i() const
     {
       return meshtying_strategy_s2i_;
     }
 
     //! returns whether calculation of the initial potential field is performed
-    bool do_calculate_initial_potential_field() const;
+    [[nodiscard]] bool do_calculate_initial_potential_field() const;
 
     //! returns if the scalar transport time integration is of type electrochemistry
-    bool is_elch_scatra_tim_int_type() const;
+    [[nodiscard]] bool is_elch_scatra_time_int_type() const;
 
     //! solve additional scatra field on manifolds
-    bool is_scatra_manifold() const { return is_scatra_manifold_; }
+    [[nodiscard]] bool is_scatra_manifold() const { return is_scatra_manifold_; }
 
     //! activate mesh tying between overlapping manifold fields
-    bool is_scatra_manifold_meshtying() const { return is_manifold_meshtying_; }
+    [[nodiscard]] bool is_scatra_manifold_meshtying() const { return is_manifold_meshtying_; }
 
     //! Redistribute nodes and elements on processors
     void redistribute(RedistributionType redistribution_type);
 
     //! get bool indicating if we have at least one ssi interface contact condition
-    bool ssi_interface_contact() const { return ssiinterfacecontact_; }
+    [[nodiscard]] bool ssi_interface_contact() const { return ssi_interface_contact_; }
 
     //! set up a pointer to the contact strategy of the structural field and store it
     void setup_contact_strategy();
 
     //! SSI structure meshtying object containing coupling adapters, converters and maps
-    std::shared_ptr<SSI::Utils::SSIMeshTying> ssi_structure_mesh_tying() const
+    [[nodiscard]] std::shared_ptr<Utils::SSIMeshTying> ssi_structure_mesh_tying() const
     {
       return ssi_structure_meshtying_;
     }
 
     //! return contact nitsche strategy for ssi problems
-    std::shared_ptr<CONTACT::NitscheStrategySsi> nitsche_strategy_ssi() const
+    [[nodiscard]] std::shared_ptr<CONTACT::NitscheStrategySsi> nitsche_strategy_ssi() const
     {
       return contact_strategy_nitsche_;
     }
 
    protected:
     //! get bool indicating if old structural time integration is used
-    bool use_old_structure_time_int() const { return use_old_structure_; }
+    [[nodiscard]] bool use_old_structure_time_int() const { return use_old_structure_; }
 
     //! check if \ref setup() was called
     void check_is_setup() const
@@ -304,7 +308,7 @@ namespace SSI
     void set_modelevaluator_base_ssi(
         std::shared_ptr<Solid::ModelEvaluator::Generic> modelevaluator_ssi_base)
     {
-      modelevaluator_ssi_base_ = modelevaluator_ssi_base;
+      modelevaluator_ssi_base_ = std::move(modelevaluator_ssi_base);
     }
 
     //! set flag true after setup or false if setup became invalid
@@ -317,10 +321,10 @@ namespace SSI
     virtual void setup_model_evaluator();
 
     //! macro-micro scatra problem?
-    bool macro_scale() const { return macro_scale_; }
+    [[nodiscard]] bool macro_scale() const { return macro_scale_; }
 
     //! different time step size between scatra field and structure field
-    bool diff_time_step_size() const { return diff_time_step_size_; }
+    [[nodiscard]] bool diff_time_step_size() const { return diff_time_step_size_; }
 
     //! store contact nitsche strategy for ssi problems
     std::shared_ptr<CONTACT::NitscheStrategySsi> contact_strategy_nitsche_;
@@ -344,11 +348,11 @@ namespace SSI
      * @param[in] structparams      parameter list containing the STRUCTURAL DYNAMIC parameters
      * @param[in] struct_disname    name of structure discretization
      * @param[in] scatra_disname    name of scalar transport discretization
-     * @param[in] isAle             flag indicating if ALE is activated
+     * @param[in] is_ale            flag indicating if ALE is activated
      */
     void init_time_integrators(const Teuchos::ParameterList& globaltimeparams,
         const Teuchos::ParameterList& scatraparams, const Teuchos::ParameterList& structparams,
-        const std::string& struct_disname, const std::string& scatra_disname, const bool isAle);
+        const std::string& struct_disname, const std::string& scatra_disname, bool is_ale);
 
     /*!
      * @brief check whether pseudo contact is activated for at least one of the s2i kinetics
@@ -356,7 +360,7 @@ namespace SSI
      *
      * @param[in] struct_disname  name of structure discretization
      */
-    [[nodiscard]] bool check_s2_i_kinetics_condition_for_pseudo_contact(
+    [[nodiscard]] bool check_s2i_kinetics_condition_for_pseudo_contact(
         const std::string& struct_disname) const;
 
     //! check whether scatra-structure interaction flags are set correctly
@@ -370,7 +374,7 @@ namespace SSI
     void check_ssi_interface_conditions(const std::string& struct_disname) const;
 
     //! returns true if init(..) was called and is still valid
-    bool is_init() const { return isinit_; }
+    [[nodiscard]] bool is_init() const { return isinit_; }
 
     /// set structure mesh displacement on scatra field
     void set_mesh_disp(std::shared_ptr<const Core::LinAlg::Vector<double>> disp);
@@ -419,16 +423,16 @@ namespace SSI
     std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra_manifold_base_algorithm_;
 
     //! SSI structure mesh tying object containing coupling adapters, converters and maps
-    std::shared_ptr<SSI::Utils::SSIMeshTying> ssi_structure_meshtying_;
+    std::shared_ptr<Utils::SSIMeshTying> ssi_structure_meshtying_;
 
     /// helper class for applying SSI couplings
     std::shared_ptr<SSICouplingBase> ssicoupling_;
 
     //! bool indicating if we have at least one ssi interface contact condition
-    const bool ssiinterfacecontact_;
+    const bool ssi_interface_contact_;
 
     //! bool indicating if we have at least one ssi interface meshtying condition
-    const bool ssiinterfacemeshtying_;
+    const bool ssi_interface_meshtying_;
 
     /// ptr to underlying structure
     std::shared_ptr<Adapter::SSIStructureWrapper> structure_;

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -68,7 +68,7 @@ void SSI::SSICouplingMatchingVolume::init(const int ndim,
       FOUR_C_THROW("unexpected dof sets in structure field");
   }
 
-  if (ssi_base->is_s2_i_kinetics_with_pseudo_contact())
+  if (ssi_base->is_s2i_kinetics_with_pseudo_contact())
   {
     const int numDofsPerNodeStresses = 6;
     std::shared_ptr<Core::DOFSets::DofSetInterface> dofsetstresses =

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -835,7 +835,7 @@ SSI::ManifoldMeshTyingStrategyBase::ManifoldMeshTyingStrategyBase(
   if (is_manifold_meshtying_)
   {
     ssi_meshtying_ = std::make_shared<SSI::Utils::SSIMeshTying>(
-        "SSISurfaceManifold", scatra_manifold_dis, false, false);
+        "SSISurfaceManifold", *scatra_manifold_dis, false, false);
 
     if (ssi_meshtying_->mesh_tying_handlers().empty())
     {

--- a/src/ssi/4C_ssi_monolithic.hpp
+++ b/src/ssi/4C_ssi_monolithic.hpp
@@ -107,7 +107,7 @@ namespace SSI
      * @note in case an equilibration method (scaling of rows and columns) is defined this is also
      * performed within this call
      */
-    void solve_linear_system();
+    void solve_linear_system() const;
 
     //! this object holds all maps relevant to monolithic scalar transport - structure interaction
     std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps() const { return ssi_maps_; }
@@ -125,28 +125,28 @@ namespace SSI
     class ConvCheckStrategyStd;
 
     //! apply the contact contributions to matrices and residuals of the sub problems
-    void apply_contact_to_sub_problems();
+    void apply_contact_to_sub_problems() const;
 
     //! apply the Dirichlet boundary conditions to the ssi system, i.e. matrices and residuals
-    void apply_dbc_to_system();
+    void apply_dbc_to_system() const;
 
     //! apply mesh tying between manifold domains on matrices and residuals
-    void apply_manifold_meshtying();
+    void apply_manifold_meshtying() const;
 
     //! perform mesh tying on matrices and residuals as obtained from sub problems
-    void apply_meshtying_to_sub_problems();
+    void apply_meshtying_to_sub_problems() const;
 
     //! assemble global system of equations
-    void assemble_mat_and_rhs();
+    void assemble_mat_and_rhs() const;
 
     //! assemble linearization of scatra residuals to system matrix
-    void assemble_mat_scatra();
+    void assemble_mat_scatra() const;
 
     //! assemble linearization of scatra on manifold residuals to system matrix
-    void assemble_mat_scatra_manifold();
+    void assemble_mat_scatra_manifold() const;
 
     //! assemble linearization of structural residuals to system matrix
-    void assemble_mat_structure();
+    void assemble_mat_structure() const;
 
     //! build null spaces associated with blocks of global system matrix
     void build_null_spaces() const;
@@ -160,26 +160,26 @@ namespace SSI
     void calc_initial_time_derivative();
 
     //! call complete on the sub problem matrices
-    void complete_subproblem_matrices();
+    void complete_subproblem_matrices() const;
 
     //! distribute solution to all other fields
     //! \param restore_velocity   restore velocity when structure_field()->set_state() is called
     void distribute_solution_all_fields(bool restore_velocity = false);
 
     //! evaluate all off-diagonal matrix contributions
-    void evaluate_off_diag_contributions();
+    void evaluate_off_diag_contributions() const;
 
     //! Evaluate ScaTra including copy to corresponding ssi matrix
-    void evaluate_scatra();
+    void evaluate_scatra() const;
 
     //! Evaluate ScaTra on manifold incl. coupling with scatra
-    void evaluate_scatra_manifold();
+    void evaluate_scatra_manifold() const;
 
     //! get matrix and right-hand-side for all subproblems incl. coupling
     void evaluate_subproblems();
 
     //! build and return vector of equilibration methods for each block of system matrix
-    std::vector<Core::LinAlg::EquilibrationMethod> get_block_equilibration();
+    std::vector<Core::LinAlg::EquilibrationMethod> get_block_equilibration() const;
 
     /*!
      * @note This is only necessary in the first iteration of the simulation, since only there the
@@ -201,13 +201,13 @@ namespace SSI
     void prepare_output();
 
     //! print system matrix, rhs, and map of system matrix to file
-    void print_system_matrix_rhs_to_mat_lab_format();
+    void print_system_matrix_rhs_to_mat_lab_format() const;
 
     //! print time step size, time, and number of time step
-    void print_time_step_info();
+    void print_time_step_info() const;
 
     //! set scatra manifold solution on scatra field
-    void set_scatra_manifold_solution(const Core::LinAlg::Vector<double>& phi);
+    void set_scatra_manifold_solution(const Core::LinAlg::Vector<double>& phi) const;
 
     //! evaluate time step using Newton-Raphson iteration
     void newton_loop();
@@ -215,10 +215,10 @@ namespace SSI
     void update() override;
 
     //! update ScaTra state within Newton iteration
-    void update_iter_scatra();
+    void update_iter_scatra() const;
 
     //! update structure state within Newton iteration
-    void update_iter_structure();
+    void update_iter_structure() const;
 
     //! Dirichlet boundary condition handler
     std::shared_ptr<SSI::DBCHandlerBase> dbc_handler_;

--- a/src/ssi/4C_ssi_partitioned.cpp
+++ b/src/ssi/4C_ssi_partitioned.cpp
@@ -8,7 +8,6 @@
 #include "4C_ssi_partitioned.hpp"
 
 #include "4C_adapter_scatra_base_algorithm.hpp"
-#include "4C_adapter_str_ssiwrapper.hpp"
 #include "4C_adapter_str_structure_new.hpp"
 #include "4C_contact_nitsche_strategy_ssi.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
@@ -77,7 +76,7 @@ void SSI::SSIPart::setup_model_evaluator()
           Core::Utils::shared_ptr_from_ref(*this));
   structure_base_algorithm()->register_model_evaluator("Partitioned Coupling Model", ssi_model_ptr);
 
-  if (is_s2_i_kinetics_with_pseudo_contact()) set_modelevaluator_base_ssi(ssi_model_ptr);
+  if (is_s2i_kinetics_with_pseudo_contact()) set_modelevaluator_base_ssi(ssi_model_ptr);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_partitioned_1wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_1wc.cpp
@@ -166,9 +166,9 @@ void SSI::SSIPart1WCSolidToScatra::prepare_time_step(bool printheader)
 
   if (structure_field()->step() % diffsteps == 0)
   {
-    if (is_s2_i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
+    if (is_s2i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
     set_struct_solution(structure_field()->dispn(), structure_field()->veln(),
-        is_s2_i_kinetics_with_pseudo_contact());
+        is_s2i_kinetics_with_pseudo_contact());
     scatra_field()->prepare_time_step();
   }
 }
@@ -237,9 +237,9 @@ void SSI::SSIPart1WCSolidToScatra::timeloop()
                        // itself.
     if (structure_field()->step() % diffsteps == 0)
     {
-      if (is_s2_i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
+      if (is_s2i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
       set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
-          is_s2_i_kinetics_with_pseudo_contact());
+          is_s2i_kinetics_with_pseudo_contact());
       do_scatra_step();  // It has its own time and timestep variables, and it increments them by
                          // itself.
     }

--- a/src/ssi/4C_ssi_partitioned_2wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_2wc.cpp
@@ -142,11 +142,11 @@ void SSI::SSIPart2WC::do_struct_step()
   // Newton-Raphson iteration
   structure_field()->solve();
 
-  if (is_s2_i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
+  if (is_s2i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
 
   //  set mesh displacement and velocity fields
   return set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
-      is_s2_i_kinetics_with_pseudo_contact());
+      is_s2i_kinetics_with_pseudo_contact());
 }
 
 /*----------------------------------------------------------------------*
@@ -503,7 +503,7 @@ void SSI::SSIPart2WCSolidToScatraRelax::outer_loop()
     // begin nonlinear solver / outer iteration ***************************
 
     // set relaxed mesh displacements and velocity field
-    set_struct_solution(dispnp, velnp, is_s2_i_kinetics_with_pseudo_contact());
+    set_struct_solution(dispnp, velnp, is_s2i_kinetics_with_pseudo_contact());
 
     // solve scalar transport equation
     do_scatra_step();

--- a/src/ssi/4C_ssi_utils.hpp
+++ b/src/ssi/4C_ssi_utils.hpp
@@ -15,8 +15,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <set>
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Coupling::Adapter
@@ -59,18 +57,18 @@ namespace SSI
     //! check for a consistent input file definition of the SSIInterfaceContact condition
     void check_consistency_of_ssi_interface_contact_condition(
         const std::vector<Core::Conditions::Condition*>& conditionsToBeTested,
-        std::shared_ptr<Core::FE::Discretization>& structdis);
+        const Core::FE::Discretization& structdis);
 
     /// Function for checking that the different time steps are a
     /// multiplicative of each other
     int check_time_stepping(double dt1, double dt2);
 
     //! clone scatra specific parameters for solver of manifold. Add manifold specific parameters
-    Teuchos::ParameterList clone_sca_tra_manifold_params(const Teuchos::ParameterList& scatraparams,
+    Teuchos::ParameterList clone_scatra_manifold_params(const Teuchos::ParameterList& scatraparams,
         const Teuchos::ParameterList& sublist_manifold_params);
 
     //! modify scatra parameters for ssi specific values
-    Teuchos::ParameterList modify_sca_tra_params(const Teuchos::ParameterList& scatraparams);
+    Teuchos::ParameterList modify_scatra_params(const Teuchos::ParameterList& scatraparams);
 
 
     /*---------------------------------------------------------------------------------*
@@ -82,14 +80,13 @@ namespace SSI
       /*!
        * @brief constructor
        *
-       * @param[in] ssi_maps            pointer to the ssi maps object containing all relevant maps
+       * @param[in] ssi_maps            ssi maps object containing all relevant maps
        * @param[in] ssi_matrixtype      the ssi matrix type
        * @param[in] scatra_matrixtype   the scalar transport matrix type
        * @param[in] is_scatra_manifold  flag indicating if a scatra manifold is used
        */
-      SSIMatrices(std::shared_ptr<const SSI::Utils::SSIMaps> ssi_maps,
-          Core::LinAlg::MatrixType ssi_matrixtype, Core::LinAlg::MatrixType scatra_matrixtype,
-          bool is_scatra_manifold);
+      SSIMatrices(const SSIMaps& ssi_maps, Core::LinAlg::MatrixType ssi_matrixtype,
+          Core::LinAlg::MatrixType scatra_matrixtype, bool is_scatra_manifold);
 
       void complete_scatra_manifold_scatra_matrix();
 
@@ -105,33 +102,48 @@ namespace SSI
       void complete_structure_scatra_matrix();
 
       //! method that clears all ssi matrices
-      void clear_matrices();
+      void clear_matrices() const;
 
       //! return the system matrix
-      std::shared_ptr<Core::LinAlg::SparseOperator> system_matrix() { return system_matrix_; }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> system_matrix() const
+      {
+        return system_matrix_;
+      }
 
       //! return sub blocks of system matrix
       //@{
-      std::shared_ptr<Core::LinAlg::SparseOperator> scatra_matrix() { return scatra_matrix_; }
-      std::shared_ptr<Core::LinAlg::SparseOperator> scatra_manifold_structure_matrix()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> scatra_matrix() const
+      {
+        return scatra_matrix_;
+      }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> scatra_manifold_structure_matrix()
+          const
       {
         return scatramanifold_structure_matrix_;
       }
-      std::shared_ptr<Core::LinAlg::SparseOperator> scatra_structure_matrix()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> scatra_structure_matrix() const
       {
         return scatra_structure_matrix_;
       }
-      std::shared_ptr<Core::LinAlg::SparseOperator> structure_scatra_matrix()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> structure_scatra_matrix() const
       {
         return structure_scatra_matrix_;
       }
-      std::shared_ptr<Core::LinAlg::SparseMatrix> structure_matrix() { return structure_matrix_; }
-      std::shared_ptr<Core::LinAlg::SparseOperator> manifold_matrix() { return manifold_matrix_; }
-      std::shared_ptr<Core::LinAlg::SparseOperator> scatra_scatra_manifold_matrix()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseMatrix> structure_matrix() const
+      {
+        return structure_matrix_;
+      }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> manifold_matrix() const
+      {
+        return manifold_matrix_;
+      }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> scatra_scatra_manifold_matrix()
+          const
       {
         return scatra_scatramanifold_matrix_;
       }
-      std::shared_ptr<Core::LinAlg::SparseOperator> scatra_manifold_scatra_matrix()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::SparseOperator> scatra_manifold_scatra_matrix()
+          const
       {
         return scatramanifold_scatra_matrix_;
       }
@@ -163,14 +175,14 @@ namespace SSI
        *
        * @param[in] ssi_maps            pointer to the ssi maps object containing all relevant maps
        */
-      void initialize_main_diag_matrices(const SSI::Utils::SSIMaps& ssi_maps);
+      void initialize_main_diag_matrices(const SSIMaps& ssi_maps);
 
       /*!
        * @brief initialize the scatra-structure interaction off-diagonal matrices
        *
        * @param[in] ssi_maps            pointer to the ssi maps object containing all relevant maps
        */
-      void initialize_off_diag_matrices(const SSI::Utils::SSIMaps& ssi_maps);
+      void initialize_off_diag_matrices(const SSIMaps& ssi_maps);
 
       /*!
        * @brief initialize the system matrix
@@ -179,7 +191,7 @@ namespace SSI
        * @param[in] ssi_matrixtype   the ssi matrix type
        */
       void initialize_system_matrix(
-          const SSI::Utils::SSIMaps& ssi_maps, Core::LinAlg::MatrixType ssi_matrixtype);
+          const SSIMaps& ssi_maps, Core::LinAlg::MatrixType ssi_matrixtype);
 
       //! flag indicating if we have a scatra manifold
       const bool is_scatra_manifold_;
@@ -220,34 +232,42 @@ namespace SSI
       /*!
        * @brief constructor
        *
-       * @param[in] ssi_maps  pointer to the ssi maps object containing all relevant maps
+       * @param[in] ssi_maps            ssi maps object containing all relevant maps
        * @param[in] is_scatra_manifold  flag indicating if a scatra manifold is used
        */
-      explicit SSIVectors(
-          std::shared_ptr<const SSI::Utils::SSIMaps> ssi_maps, bool is_scatra_manifold);
+      explicit SSIVectors(const SSIMaps& ssi_maps, bool is_scatra_manifold);
 
       //! clear the increment vector
-      void clear_increment();
+      void clear_increment() const;
 
       //! clear all residual vectors
-      void clear_residuals();
+      void clear_residuals() const;
 
       //! global increment vector for Newton-Raphson iteration
-      std::shared_ptr<Core::LinAlg::Vector<double>> increment() { return increment_; }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::Vector<double>> increment() const
+      {
+        return increment_;
+      }
 
       //! residual vector on right-hand side of global system of equations
-      std::shared_ptr<Core::LinAlg::Vector<double>> residual() { return residual_; }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::Vector<double>> residual() const
+      {
+        return residual_;
+      }
 
       //! residual vector on right-hand side of scalar transport system
-      std::shared_ptr<Core::LinAlg::Vector<double>> scatra_residual() { return scatra_residual_; }
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::Vector<double>> scatra_residual() const
+      {
+        return scatra_residual_;
+      }
 
       //! residual vector on right-hand side of structure system
-      std::shared_ptr<Core::LinAlg::Vector<double>> structure_residual()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::Vector<double>> structure_residual() const
       {
         return structure_residual_;
       }
 
-      std::shared_ptr<Core::LinAlg::Vector<double>> manifold_residual()
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::Vector<double>> manifold_residual() const
       {
         return manifold_residual_;
       }
@@ -278,31 +298,34 @@ namespace SSI
     {
      public:
       //! constructor
-      explicit SSIMaps(const SSI::SsiMono& ssi_mono_algorithm);
+      explicit SSIMaps(const SsiMono& ssi_mono_algorithm);
 
       //! get vector containing positions within system matrix for specific subproblem
-      std::vector<int> get_block_positions(Subproblem subproblem) const;
+      [[nodiscard]] std::vector<int> get_block_positions(Subproblem subproblem) const;
 
       //! get position within global dof map for specific sub problem
       static int get_problem_position(Subproblem subproblem);
 
       //! the multi map extractor of the scalar transport field
-      std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra() const;
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra() const;
 
       //! the multi map extractor of the scalar transport on manifold field
-      std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra_manifold() const;
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor>
+      block_map_scatra_manifold() const;
 
       //! the multi map extractor of the structure field
-      std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_structure() const;
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_structure()
+          const;
 
       //! map extractor associated with blocks of global system matrix
-      std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_system_matrix() const
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_system_matrix()
+          const
       {
         return block_map_system_matrix_;
       }
 
       //! all dofs of the SSI algorithm
-      std::shared_ptr<const Core::LinAlg::Map> map_system_matrix() const
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> map_system_matrix() const
       {
         return map_system_matrix_;
       }
@@ -311,19 +334,19 @@ namespace SSI
        * @brief global map extractor
        * @note only access with GetProblemPosition method
        */
-      std::shared_ptr<const Core::LinAlg::MultiMapExtractor> maps_sub_problems() const
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> maps_sub_problems() const
       {
         return maps_sub_problems_;
       }
 
       //! the scalar transport dof row map
-      std::shared_ptr<const Core::LinAlg::Map> scatra_dof_row_map() const;
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> scatra_dof_row_map() const;
 
       //! the scalar transport on manifolds dof row map
-      std::shared_ptr<const Core::LinAlg::Map> scatra_manifold_dof_row_map() const;
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> scatra_manifold_dof_row_map() const;
 
       //! the structure dof row map
-      std::shared_ptr<const Core::LinAlg::Map> structure_dof_row_map() const;
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> structure_dof_row_map() const;
 
      private:
       //! create and check the block maps of all sub problems
@@ -364,25 +387,26 @@ namespace SSI
           std::shared_ptr<Coupling::Adapter::Coupling> slave_slave_transformation);
 
       //! coupling adapter between master and slave coupling
-      std::shared_ptr<Coupling::Adapter::Coupling> slave_master_coupling() const
+      [[nodiscard]] std::shared_ptr<Coupling::Adapter::Coupling> slave_master_coupling() const
       {
         return slave_master_coupling_;
       }
 
       //! map extractor for coupling adapter: 0: interior, 1: slave, 2: master
-      std::shared_ptr<Core::LinAlg::MultiMapExtractor> slave_master_extractor() const
+      [[nodiscard]] std::shared_ptr<Core::LinAlg::MultiMapExtractor> slave_master_extractor() const
       {
         return slave_master_extractor_;
       }
 
       //! converter to convert slave dofs to master side
-      std::shared_ptr<Coupling::Adapter::CouplingSlaveConverter> slave_side_converter() const
+      [[nodiscard]] std::shared_ptr<Coupling::Adapter::CouplingSlaveConverter>
+      slave_side_converter() const
       {
         return slave_side_converter_;
       }
 
       //! coupling adapter between new slave nodes and slave nodes from input file
-      std::shared_ptr<Coupling::Adapter::Coupling> slave_slave_transformation() const
+      [[nodiscard]] std::shared_ptr<Coupling::Adapter::Coupling> slave_slave_transformation() const
       {
         return slave_slave_transformation_;
       }
@@ -405,7 +429,7 @@ namespace SSI
     {
      public:
       explicit SSIMeshTying(const std::string& conditionname_coupling,
-          std::shared_ptr<Core::FE::Discretization> dis, bool build_slave_slave_transformation,
+          const Core::FE::Discretization& dis, bool build_slave_slave_transformation,
           bool check_over_constrained);
 
       //! check if one dof has slave side conditions and Dirichlet conditions
@@ -413,22 +437,25 @@ namespace SSI
           std::shared_ptr<const Core::LinAlg::Map> struct_dbc_map) const;
 
       //! all master side dofs
-      std::shared_ptr<const Core::LinAlg::Map> full_master_side_map() const
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> full_master_side_map() const
       {
         return full_master_side_map_;
       }
 
       //! all slave side dofs
-      std::shared_ptr<const Core::LinAlg::Map> full_slave_side_map() const
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> full_slave_side_map() const
       {
         return full_slave_side_map_;
       }
 
       //! all interior dofs
-      std::shared_ptr<const Core::LinAlg::Map> interior_map() const { return interior_map_; }
+      [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> interior_map() const
+      {
+        return interior_map_;
+      }
 
       //! vector of all mesh tying handlers
-      std::vector<std::shared_ptr<SSIMeshTyingHandler>> mesh_tying_handlers() const
+      [[nodiscard]] std::vector<std::shared_ptr<SSIMeshTyingHandler>> mesh_tying_handlers() const
       {
         return meshtying_handlers_;
       }
@@ -442,7 +469,7 @@ namespace SSI
       //!                                 (value)
       //! \param check_over_constrained   [in] check if two DBCs are set on two dofs at the same
       //! position
-      void define_master_slave_pairing(std::shared_ptr<Core::FE::Discretization> dis,
+      void define_master_slave_pairing(const Core::FE::Discretization& dis,
           const std::vector<std::vector<int>>& grouped_matching_nodes,
           std::vector<int>& master_gids, std::map<int, int>& slave_master_pair,
           bool check_over_constrained) const;
@@ -451,7 +478,7 @@ namespace SSI
       //! \param dis                 [in] discretization
       //! \param name_meshtying_condition   [in] name of meshtying condition
       //! \param coupling_pairs         [out] vector of pairs of matching nodes
-      void find_matching_node_pairs(Core::FE::Discretization& dis,
+      void find_matching_node_pairs(const Core::FE::Discretization& dis,
           const std::string& name_meshtying_condition,
           std::vector<std::pair<int, int>>& coupling_pairs) const;
 
@@ -460,7 +487,7 @@ namespace SSI
       //! \param name_meshtying_condition          [in] name of meshtying condition
       //! \param inodegidvec_slave                 [in] new slave nodes on this proc
       //! \param all_coupled_original_slave_gids   [out] old slave nodes that match new slave nodes
-      void find_slave_slave_transformation_nodes(Core::FE::Discretization& dis,
+      void find_slave_slave_transformation_nodes(const Core::FE::Discretization& dis,
           const std::string& name_meshtying_condition, const std::vector<int>& inodegidvec_slave,
           std::vector<int>& all_coupled_original_slave_gids) const;
 
@@ -486,7 +513,7 @@ namespace SSI
       //! \param gid             [in] gid to be checked
       //! \param matching_nodes  [in] grouped node gids
       //! \return                index in matching_nodes (outer vector) where gid is, otherwise -1
-      int has_gid(int gid, const std::vector<std::vector<int>>& matching_nodes) const;
+      [[nodiscard]] int has_gid(int gid, const std::vector<std::vector<int>>& matching_nodes) const;
 
       //! Check if subset of matching_nodes has this gid.
       //! \param gid             [in] gid to be checked
@@ -495,7 +522,7 @@ namespace SSI
       //! \param matching_nodes  [in] grouped node gids
       //! \return                index in matching_nodes (outer vector) between start and end where
       //!                        gid is, otherwise -1
-      int has_gid_partial(
+      [[nodiscard]] int has_gid_partial(
           int gid, int start, int end, const std::vector<std::vector<int>>& matching_nodes) const;
 
       //! Construct mesh tying handlers based on conditions with name conditionname_coupling
@@ -503,7 +530,7 @@ namespace SSI
       //! \param name_meshtying_condition    [in] name of meshtying condition
       //! \param build_slave_slave_transformation [in] is a map required that defines the
       //! transformation from slave nodes at the input and matched slave nodes
-      void setup_mesh_tying_handlers(std::shared_ptr<Core::FE::Discretization> dis,
+      void setup_mesh_tying_handlers(const Core::FE::Discretization& dis,
           const std::string& name_meshtying_condition, bool build_slave_slave_transformation,
           bool check_over_constrained);
 

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -85,7 +85,7 @@ void SSTI::SSTIAlgorithm::init(MPI_Comm comm, const Teuchos::ParameterList& ssti
 
   // create and initialize scatra problem and thermo problem
   scatra_ = std::make_shared<Adapter::ScaTraBaseAlgorithm>(sstitimeparams,
-      SSI::Utils::modify_sca_tra_params(scatraparams),
+      SSI::Utils::modify_scatra_params(scatraparams),
       problem->solver_params(scatraparams.get<int>("LINEAR_SOLVER")), "scatra", true);
   scatra_->init();
   scatra_->scatra_field()->set_number_of_dof_set_displacement(1);
@@ -210,7 +210,7 @@ void SSTI::SSTIAlgorithm::setup()
 
     // setup everything for SSTI structure meshtying
     ssti_structure_meshtying_ = std::make_shared<SSI::Utils::SSIMeshTying>(
-        "SSTIInterfaceMeshtying", structure_->discretization(), true, true);
+        "SSTIInterfaceMeshtying", *structure_->discretization(), true, true);
   }
 
   issetup_ = true;


### PR DESCRIPTION
## Description and Context
I'll do some cleanup of the ssi module, where this is the first part to keep the PR reviewable. Some of the main things I did:
  - remove unnecessary header inclusions
    - improve readability of variable names
    - remove unnecessary references to authors
    - clang tidy suggestions:
      - add const's
      - add nodiscard's
      - designated initalization
      - remove redundant qualifiers to improve formatting and thereby readability

