### PR TITLE
Merge porofluidmulti namespaces

### DIFF
--- a/src/adapter/4C_adapter_porofluid_pressure_based.hpp
+++ b/src/adapter/4C_adapter_porofluid_pressure_based.hpp
@@ -26,7 +26,7 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   class TimIntImpl;
 }

--- a/src/adapter/4C_adapter_porofluid_pressure_based_wrapper.hpp
+++ b/src/adapter/4C_adapter_porofluid_pressure_based_wrapper.hpp
@@ -22,7 +22,7 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   class TimIntImpl;
 }

--- a/src/global_legacy_module/4C_global_legacy_module.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module.cpp
@@ -289,7 +289,7 @@ namespace
     Discret::Utils::add_valid_combust_functions(function_manager);
     Discret::Utils::add_valid_xfluid_functions(function_manager);
     add_valid_library_functions(function_manager);
-    PoroMultiPhaseScaTra::add_valid_poro_functions(function_manager);
+    PoroPressureBased::add_valid_poro_functions(function_manager);
     ScaTra::add_valid_scatra_functions(function_manager);
   }
 

--- a/src/inpar/4C_inpar_validconditions.cpp
+++ b/src/inpar/4C_inpar_validconditions.cpp
@@ -846,7 +846,7 @@ std::vector<Core::Conditions::ConditionDefinition> Input::valid_conditions()
   Inpar::RveMpc::set_valid_conditions(condlist);
   Inpar::BeamInteraction::set_valid_conditions(condlist);
   EHL::set_valid_conditions(condlist);
-  PoroMultiPhaseScaTra::set_valid_conditions(condlist);
+  PoroPressureBased::set_valid_conditions_porofluid_elast_scatra(condlist);
 
   // finally some conditions that do not have their own files yet are problem-specific
   set_miscellaneous_conditions(condlist);

--- a/src/inpar/4C_inpar_validparameters.cpp
+++ b/src/inpar/4C_inpar_validparameters.cpp
@@ -202,7 +202,7 @@ std::map<std::string, Core::IO::InputSpec> Input::valid_parameters()
   Inpar::PoroElast::set_valid_parameters(specs);
   Inpar::PoroScaTra::set_valid_parameters(specs);
   PoroPressureBased::set_valid_parameters_porofluid(specs);
-  PoroMultiPhaseScaTra::set_valid_parameters(specs);
+  PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(specs);
   PoroPressureBased::set_valid_parameters_porofluid_elast(specs);
   EHL::set_valid_parameters(specs);
   Inpar::SSI::set_valid_parameters(specs);

--- a/src/inpar/4C_inpar_validparameters.cpp
+++ b/src/inpar/4C_inpar_validparameters.cpp
@@ -201,9 +201,9 @@ std::map<std::string, Core::IO::InputSpec> Input::valid_parameters()
   Inpar::FS3I::set_valid_parameters(specs);
   Inpar::PoroElast::set_valid_parameters(specs);
   Inpar::PoroScaTra::set_valid_parameters(specs);
-  POROMULTIPHASE::set_valid_parameters(specs);
+  PoroPressureBased::set_valid_parameters_porofluid(specs);
   PoroMultiPhaseScaTra::set_valid_parameters(specs);
-  POROFLUIDMULTIPHASE::set_valid_parameters(specs);
+  PoroPressureBased::set_valid_parameters_porofluid_elast(specs);
   EHL::set_valid_parameters(specs);
   Inpar::SSI::set_valid_parameters(specs);
   Inpar::SSTI::set_valid_parameters(specs);

--- a/src/mat/4C_mat_fluidporo_multiphase.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase.cpp
@@ -311,7 +311,7 @@ void Mat::FluidPoroMultiPhase::evaluate_gen_pressure(
   {
     // get the single phase material
     const Mat::FluidPoroSinglePhase& singlephasemat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_multi_material(*this, iphase);
+        PoroPressureBased::ElementUtils::get_single_phase_mat_from_multi_material(*this, iphase);
 
     // evaluate generalized pressure (i.e. some kind of linear combination of the true pressures)
     genpressure[iphase] = singlephasemat.evaluate_gen_pressure(iphase, phinp);
@@ -336,8 +336,7 @@ void Mat::FluidPoroMultiPhase::evaluate_saturation(std::vector<double>& saturati
     {
       // get the single phase material
       const Mat::FluidPoroSinglePhase& singlephasemat =
-          POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_multi_material(
-              *this, iphase);
+          PoroPressureBased::ElementUtils::get_single_phase_mat_from_multi_material(*this, iphase);
 
       saturation[iphase] = singlephasemat.evaluate_saturation(iphase, phinp, pressure);
       // the saturation of the last phase is 1.0- (sum of all saturations)

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
@@ -38,7 +38,7 @@ void porofluidmultiphase_dyn(int restart)
   // access the problem
   Global::Problem* problem = Global::Problem::instance();
 
-  // print problem type and logo
+  // print problem type
   if (Core::Communication::my_mpi_rank(comm) == 0)
   {
     std::cout << "###################################################" << std::endl;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
@@ -41,7 +41,6 @@ void porofluidmultiphase_dyn(int restart)
   // print problem type and logo
   if (Core::Communication::my_mpi_rank(comm) == 0)
   {
-    PoroPressureBased::print_logo();
     std::cout << "###################################################" << std::endl;
     std::cout << "# YOUR PROBLEM TYPE: " << Global::Problem::instance()->problem_name()
               << std::endl;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
@@ -86,7 +86,7 @@ void porofluidmultiphase_dyn(int restart)
       case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::ntp:
       {
         actdis->fill_complete();
-        nearbyelepairs = POROFLUIDMULTIPHASE::Utils::extended_ghosting_artery_discretization(
+        nearbyelepairs = POROFLUIDMULTIPHASE::extended_ghosting_artery_discretization(
             *actdis, arterydis, evaluate_on_lateral_surface, arterycoupl);
         break;
       }
@@ -123,7 +123,7 @@ void porofluidmultiphase_dyn(int restart)
       Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::TimeIntegrationScheme>(porodyn, "TIMEINTEGR");
 
   // build poro fluid time integrator
-  std::shared_ptr<Adapter::PoroFluidMultiphase> algo = POROFLUIDMULTIPHASE::Utils::create_algorithm(
+  std::shared_ptr<Adapter::PoroFluidMultiphase> algo = POROFLUIDMULTIPHASE::create_algorithm(
       timintscheme, actdis, linsolvernumber, porodyn, porodyn, output);
 
   // initialize
@@ -140,7 +140,7 @@ void porofluidmultiphase_dyn(int restart)
   // assign poro material for evaluation of porosity
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  POROFLUIDMULTIPHASE::Utils::setup_material(comm, struct_disname, fluid_disname);
+  POROFLUIDMULTIPHASE::setup_material(comm, struct_disname, fluid_disname);
 
   // 4.- Run of the actual problem.
   algo->time_loop();

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_dyn.cpp
@@ -41,7 +41,7 @@ void porofluidmultiphase_dyn(int restart)
   // print problem type and logo
   if (Core::Communication::my_mpi_rank(comm) == 0)
   {
-    POROFLUIDMULTIPHASE::print_logo();
+    PoroPressureBased::print_logo();
     std::cout << "###################################################" << std::endl;
     std::cout << "# YOUR PROBLEM TYPE: " << Global::Problem::instance()->problem_name()
               << std::endl;
@@ -86,7 +86,7 @@ void porofluidmultiphase_dyn(int restart)
       case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::ntp:
       {
         actdis->fill_complete();
-        nearbyelepairs = POROFLUIDMULTIPHASE::extended_ghosting_artery_discretization(
+        nearbyelepairs = PoroPressureBased::extended_ghosting_artery_discretization(
             *actdis, arterydis, evaluate_on_lateral_surface, arterycoupl);
         break;
       }
@@ -120,10 +120,10 @@ void porofluidmultiphase_dyn(int restart)
   // time-integration (or stationary) scheme
   // -------------------------------------------------------------------
   auto timintscheme =
-      Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::TimeIntegrationScheme>(porodyn, "TIMEINTEGR");
+      Teuchos::getIntegralValue<PoroPressureBased::TimeIntegrationScheme>(porodyn, "TIMEINTEGR");
 
   // build poro fluid time integrator
-  std::shared_ptr<Adapter::PoroFluidMultiphase> algo = POROFLUIDMULTIPHASE::create_algorithm(
+  std::shared_ptr<Adapter::PoroFluidMultiphase> algo = PoroPressureBased::create_algorithm(
       timintscheme, actdis, linsolvernumber, porodyn, porodyn, output);
 
   // initialize
@@ -140,7 +140,7 @@ void porofluidmultiphase_dyn(int restart)
   // assign poro material for evaluation of porosity
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  POROFLUIDMULTIPHASE::setup_material(comm, struct_disname, fluid_disname);
+  PoroPressureBased::setup_material(comm, struct_disname, fluid_disname);
 
   // 4.- Run of the actual problem.
   algo->time_loop();

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
@@ -12,7 +12,8 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-void POROFLUIDMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
+void PoroPressureBased::set_valid_parameters_porofluid(
+    std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
 
@@ -114,25 +115,25 @@ void POROFLUIDMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::I
 
           deprecated_selection<VectorNorm>("VECTORNORM_RESF",
               {
-                  {"L1", POROFLUIDMULTIPHASE::norm_l1},
-                  {"L1_Scaled", POROFLUIDMULTIPHASE::norm_l1_scaled},
-                  {"L2", POROFLUIDMULTIPHASE::norm_l2},
-                  {"Rms", POROFLUIDMULTIPHASE::norm_rms},
-                  {"Inf", POROFLUIDMULTIPHASE::norm_inf},
+                  {"L1", PoroPressureBased::norm_l1},
+                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
+                  {"L2", PoroPressureBased::norm_l2},
+                  {"Rms", PoroPressureBased::norm_rms},
+                  {"Inf", PoroPressureBased::norm_inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = POROFLUIDMULTIPHASE::norm_l2}),
+                  .default_value = PoroPressureBased::norm_l2}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_INC",
               {
-                  {"L1", POROFLUIDMULTIPHASE::norm_l1},
-                  {"L1_Scaled", POROFLUIDMULTIPHASE::norm_l1_scaled},
-                  {"L2", POROFLUIDMULTIPHASE::norm_l2},
-                  {"Rms", POROFLUIDMULTIPHASE::norm_rms},
-                  {"Inf", POROFLUIDMULTIPHASE::norm_inf},
+                  {"L1", PoroPressureBased::norm_l1},
+                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
+                  {"L2", PoroPressureBased::norm_l2},
+                  {"Rms", PoroPressureBased::norm_rms},
+                  {"Inf", PoroPressureBased::norm_inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = POROFLUIDMULTIPHASE::norm_l2}),
+                  .default_value = PoroPressureBased::norm_l2}),
 
           // Iterationparameters
           parameter<double>(

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
@@ -10,6 +10,8 @@
 #include "4C_inpar_bio.hpp"
 #include "4C_io_input_spec_builders.hpp"
 
+#include <Teuchos_Time.hpp>
+
 FOUR_C_NAMESPACE_OPEN
 
 void PoroPressureBased::set_valid_parameters_porofluid(
@@ -37,17 +39,18 @@ void PoroPressureBased::set_valid_parameters_porofluid(
 
           deprecated_selection<TimeIntegrationScheme>("TIMEINTEGR",
               {
-                  {"One_Step_Theta", timeint_one_step_theta},
+                  {"One_Step_Theta", TimeIntegrationScheme::one_step_theta},
               },
-              {.description = "Time Integration Scheme", .default_value = timeint_one_step_theta}),
+              {.description = "Time Integration Scheme",
+                  .default_value = TimeIntegrationScheme::one_step_theta}),
 
           deprecated_selection<CalcError>("CALCERROR",
               {
-                  {"No", calcerror_no},
-                  {"error_by_function", calcerror_byfunction},
+                  {"No", CalcError::no},
+                  {"error_by_function", CalcError::by_function},
               },
               {.description = "compute error compared to analytical solution",
-                  .default_value = calcerror_no}),
+                  .default_value = CalcError::no}),
 
           parameter<int>("CALCERRORNO",
               {.description = "function number for porofluidmultiphase error computation",
@@ -77,11 +80,11 @@ void PoroPressureBased::set_valid_parameters_porofluid(
           // parameters for finite difference check
           deprecated_selection<FdCheck>("FDCHECK",
               {
-                  {"none", fdcheck_none},
-                  {"global", fdcheck_global},
+                  {"none", FdCheck::none},
+                  {"global", FdCheck::global},
               },
               {.description = "flag for finite difference check: none, local, or global",
-                  .default_value = fdcheck_none}),
+                  .default_value = FdCheck::none}),
           parameter<double>("FDCHECKEPS",
               {.description = "dof perturbation magnitude for finite difference check (1.e-6 "
                               "seems to work very well, whereas smaller values don't)",
@@ -115,25 +118,25 @@ void PoroPressureBased::set_valid_parameters_porofluid(
 
           deprecated_selection<VectorNorm>("VECTORNORM_RESF",
               {
-                  {"L1", PoroPressureBased::norm_l1},
-                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
-                  {"L2", PoroPressureBased::norm_l2},
-                  {"Rms", PoroPressureBased::norm_rms},
-                  {"Inf", PoroPressureBased::norm_inf},
+                  {"L1", VectorNorm::l1},
+                  {"L1_Scaled", VectorNorm::l1_scaled},
+                  {"L2", VectorNorm::l2},
+                  {"Rms", VectorNorm::rms},
+                  {"Inf", VectorNorm::inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroPressureBased::norm_l2}),
+                  .default_value = VectorNorm::l2}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_INC",
               {
-                  {"L1", PoroPressureBased::norm_l1},
-                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
-                  {"L2", PoroPressureBased::norm_l2},
-                  {"Rms", PoroPressureBased::norm_rms},
-                  {"Inf", PoroPressureBased::norm_inf},
+                  {"L1", VectorNorm::l1},
+                  {"L1_Scaled", VectorNorm::l1_scaled},
+                  {"L2", VectorNorm::l2},
+                  {"Rms", VectorNorm::rms},
+                  {"Inf", VectorNorm::inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroPressureBased::norm_l2}),
+                  .default_value = VectorNorm::l2}),
 
           // Iterationparameters
           parameter<double>(
@@ -145,25 +148,25 @@ void PoroPressureBased::set_valid_parameters_porofluid(
 
           deprecated_selection<InitialField>("INITIALFIELD",
               {
-                  {"zero_field", initfield_zero_field},
-                  {"field_by_function", initfield_field_by_function},
-                  {"field_by_condition", initfield_field_by_condition},
+                  {"zero_field", InitialField::zero},
+                  {"field_by_function", InitialField::by_function},
+                  {"field_by_condition", InitialField::by_condition},
               },
-              {.description = "Initial Field for transport problem",
-                  .default_value = initfield_zero_field}),
+              {.description = "Initial Field for the porofluid problem",
+                  .default_value = InitialField::zero}),
 
           parameter<int>(
               "INITFUNCNO", {.description = "function number for scalar transport initial field",
                                 .default_value = -1}),
 
-          deprecated_selection<DivContAct>("DIVERCONT",
+          deprecated_selection<DivergenceAction>("DIVERCONT",
               {
-                  {"stop", divcont_stop},
-                  {"continue", divcont_continue},
+                  {"stop", DivergenceAction::stop},
+                  {"continue", DivergenceAction::continue_anyway},
               },
               {.description =
                       "What to do with time integration when Newton-Raphson iteration failed",
-                  .default_value = divcont_stop}),
+                  .default_value = DivergenceAction::stop}),
 
           parameter<int>(
               "FLUX_PROJ_SOLVER", {.description = "Number of linear solver used for L2 projection",
@@ -172,11 +175,11 @@ void PoroPressureBased::set_valid_parameters_porofluid(
 
           deprecated_selection<FluxReconstructionMethod>("FLUX_PROJ_METHOD",
               {
-                  {"none", gradreco_none},
-                  {"L2_projection", gradreco_l2},
+                  {"none", FluxReconstructionMethod::none},
+                  {"L2_projection", FluxReconstructionMethod::l2},
               },
               {.description = "Flag to (de)activate flux reconstruction.",
-                  .default_value = gradreco_none}),
+                  .default_value = FluxReconstructionMethod::none}),
 
           // functions used for domain integrals
           parameter<std::string>("DOMAININT_FUNCT",

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.hpp
@@ -24,65 +24,57 @@ FOUR_C_NAMESPACE_OPEN
 namespace PoroPressureBased
 {
   /// time integration schemes
-  enum TimeIntegrationScheme
+  enum class TimeIntegrationScheme
   {
-    timeint_one_step_theta
+    one_step_theta
   };
 
   /// compute error compared to analytical solution
-  enum CalcError
+  enum class CalcError
   {
-    calcerror_no,
-    calcerror_byfunction
-  };
-
-  //! type of norm to check for convergence
-  enum ConvNorm
-  {
-    convnorm_abs,  //!< absolute norm
-    convnorm_rel,  //!< relative norm
-    convnorm_mix   //!< mixed absolute-relative norm
+    no,
+    by_function
   };
 
   //! type of vector norm used for error/residual vectors
-  enum VectorNorm
+  enum class VectorNorm
   {
-    norm_undefined,
-    norm_l1,         //!< L1/linear norm
-    norm_l1_scaled,  //!< L1/linear norm scaled by length of vector
-    norm_l2,         //!< L2/Euclidean norm
-    norm_rms,        //!< root mean square (RMS) norm
-    norm_inf         //!< Maximum/infinity norm
+    undefined,
+    l1,         //!< L1/linear norm
+    l1_scaled,  //!< L1/linear norm scaled by length of vector
+    l2,         //!< L2/Euclidean norm
+    rms,        //!< root mean square (RMS) norm
+    inf         //!< Maximum/infinity norm
   };
 
   /// type of finite difference check
-  enum FdCheck
+  enum class FdCheck
   {
-    fdcheck_none,
-    fdcheck_global
+    none,
+    global
   };
 
-  /// initial field for scalar transport problem
-  enum InitialField
+  /// initial field
+  enum class InitialField
   {
-    initfield_zero_field,
-    initfield_field_by_function,
-    initfield_field_by_condition
+    zero,
+    by_function,
+    by_condition
   };
 
   /// Handling of non-converged nonlinear solver
-  enum DivContAct
+  enum class DivergenceAction
   {
-    divcont_stop,     ///< abort simulation
-    divcont_continue  ///< continue nevertheless
+    stop,            ///< abort simulation
+    continue_anyway  ///< continue anyway
   };
 
   //! reconstruction type of gradients (e.g. velocity gradient)
-  enum FluxReconstructionMethod
+  enum class FluxReconstructionMethod
   {
-    gradreco_none,
+    none,
     // gradreco_spr, super-convergent patch recovery not activated yet
-    gradreco_l2
+    l2
   };
 
   /// set the valid parameters

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.hpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
  |                                                                      |
  *----------------------------------------------------------------------*/
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   /// time integration schemes
   enum TimeIntegrationScheme
@@ -85,10 +85,10 @@ namespace POROFLUIDMULTIPHASE
     gradreco_l2
   };
 
-  /// set the lubrication parameters
-  void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
+  /// set the valid parameters
+  void set_valid_parameters_porofluid(std::map<std::string, Core::IO::InputSpec>& list);
 
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
@@ -86,8 +86,8 @@ PoroPressureBased::MeshtyingStrategyArtery::MeshtyingStrategyArtery(
       });
 
   // initialize mesh tying object
-  arttoporofluidcoupling_ = PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
-      arterydis_, porofluidmultitimint->discretization(), poroparams.sublist("ARTERY COUPLING"),
+  arttoporofluidcoupling_ = PoroPressureBased::create_and_init_artery_coupling_strategy(arterydis_,
+      porofluidmultitimint->discretization(), poroparams.sublist("ARTERY COUPLING"),
       couplingcondname, "COUPLEDDOFS_ART", "COUPLEDDOFS_PORO", evaluate_on_lateral_surface);
 
   // Initialize rhs vector

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
@@ -86,7 +86,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::MeshtyingStrategyArtery(
       });
 
   // initialize mesh tying object
-  arttoporofluidcoupling_ = PoroMultiPhaseScaTra::Utils::create_and_init_artery_coupling_strategy(
+  arttoporofluidcoupling_ = PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
       arterydis_, porofluidmultitimint->discretization(), poroparams.sublist("ARTERY COUPLING"),
       couplingcondname, "COUPLEDDOFS_ART", "COUPLEDDOFS_PORO", evaluate_on_lateral_surface);
 
@@ -219,8 +219,8 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::calculate_norms(std::vector<d
   incprenorm.resize(2);
   prenorm.resize(2);
 
-  prenorm[0] = Utils::calculate_vector_norm(vectornorminc_, *porofluidmultitimint_->phinp());
-  prenorm[1] = Utils::calculate_vector_norm(vectornorminc_, *artnettimint_->pressurenp());
+  prenorm[0] = calculate_vector_norm(vectornorminc_, *porofluidmultitimint_->phinp());
+  prenorm[1] = calculate_vector_norm(vectornorminc_, *artnettimint_->pressurenp());
 
   std::shared_ptr<const Core::LinAlg::Vector<double>> arterypressinc;
   std::shared_ptr<const Core::LinAlg::Vector<double>> porofluidinc;
@@ -228,16 +228,16 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::calculate_norms(std::vector<d
   arttoporofluidcoupling_->extract_single_field_vectors(
       comb_increment_, porofluidinc, arterypressinc);
 
-  incprenorm[0] = Utils::calculate_vector_norm(vectornorminc_, *porofluidinc);
-  incprenorm[1] = Utils::calculate_vector_norm(vectornorminc_, *arterypressinc);
+  incprenorm[0] = calculate_vector_norm(vectornorminc_, *porofluidinc);
+  incprenorm[1] = calculate_vector_norm(vectornorminc_, *arterypressinc);
 
   std::shared_ptr<const Core::LinAlg::Vector<double>> arterypressrhs;
   std::shared_ptr<const Core::LinAlg::Vector<double>> porofluidrhs;
 
   arttoporofluidcoupling_->extract_single_field_vectors(rhs_, porofluidrhs, arterypressrhs);
 
-  preresnorm[0] = Utils::calculate_vector_norm(vectornormfres_, *porofluidrhs);
-  preresnorm[1] = Utils::calculate_vector_norm(vectornormfres_, *arterypressrhs);
+  preresnorm[0] = calculate_vector_norm(vectornormfres_, *porofluidrhs);
+  preresnorm[1] = calculate_vector_norm(vectornormfres_, *arterypressrhs);
 
   return;
 }

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.cpp
@@ -28,8 +28,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | constructor                                (public) kremheller 04/18 |
  *----------------------------------------------------------------------*/
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::MeshtyingStrategyArtery(
-    POROFLUIDMULTIPHASE::TimIntImpl* porofluidmultitimint, const Teuchos::ParameterList& probparams,
+PoroPressureBased::MeshtyingStrategyArtery::MeshtyingStrategyArtery(
+    PoroPressureBased::TimIntImpl* porofluidmultitimint, const Teuchos::ParameterList& probparams,
     const Teuchos::ParameterList& poroparams)
     : MeshtyingStrategyBase(porofluidmultitimint, probparams, poroparams)
 {
@@ -114,7 +114,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::MeshtyingStrategyArtery(
 /*----------------------------------------------------------------------*
  | prepare time loop                                   kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::prepare_time_loop()
+void PoroPressureBased::MeshtyingStrategyArtery::prepare_time_loop()
 {
   artnettimint_->prepare_time_loop();
   return;
@@ -123,7 +123,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::prepare_time_loop()
 /*----------------------------------------------------------------------*
  | setup the variables to do a new time step  (public) kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::prepare_time_step()
+void PoroPressureBased::MeshtyingStrategyArtery::prepare_time_step()
 {
   artnettimint_->prepare_time_step();
   return;
@@ -133,7 +133,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::prepare_time_step()
  | current solution becomes most recent solution of next timestep       |
  |                                                     kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::update()
+void PoroPressureBased::MeshtyingStrategyArtery::update()
 {
   artnettimint_->time_update();
   return;
@@ -142,7 +142,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::update()
 /*--------------------------------------------------------------------------*
  | initialize the linear solver                            kremheller 07/20 |
  *--------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::initialize_linear_solver(
+void PoroPressureBased::MeshtyingStrategyArtery::initialize_linear_solver(
     std::shared_ptr<Core::LinAlg::Solver> solver)
 {
   const Teuchos::ParameterList& porofluidparams =
@@ -188,7 +188,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::initialize_linear_solver(
 /*--------------------------------------------------------------------------*
  | solve linear system of equations                        kremheller 04/18 |
  *--------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::linear_solve(
+void PoroPressureBased::MeshtyingStrategyArtery::linear_solve(
     std::shared_ptr<Core::LinAlg::Solver> solver,
     std::shared_ptr<Core::LinAlg::SparseOperator> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> increment,
@@ -211,7 +211,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::linear_solve(
 /*----------------------------------------------------------------------*
  | Calculate problem specific norm                     kremheller 03/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::calculate_norms(std::vector<double>& preresnorm,
+void PoroPressureBased::MeshtyingStrategyArtery::calculate_norms(std::vector<double>& preresnorm,
     std::vector<double>& incprenorm, std::vector<double>& prenorm,
     const std::shared_ptr<const Core::LinAlg::Vector<double>> increment)
 {
@@ -245,7 +245,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::calculate_norms(std::vector<d
 /*----------------------------------------------------------------------*
  | create result test for this field                   kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::create_field_test()
+void PoroPressureBased::MeshtyingStrategyArtery::create_field_test()
 {
   std::shared_ptr<Core::Utils::ResultTest> arteryresulttest = artnettimint_->create_field_test();
   Global::Problem::instance()->add_field_test(arteryresulttest);
@@ -255,7 +255,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::create_field_test()
 /*----------------------------------------------------------------------*
  |  read restart data                                  kremheller 04/18 |
  -----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::read_restart(const int step)
+void PoroPressureBased::MeshtyingStrategyArtery::read_restart(const int step)
 {
   artnettimint_->read_restart(step);
 
@@ -265,7 +265,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::read_restart(const int step)
 /*----------------------------------------------------------------------*
  | output of solution vector to BINIO                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::output()
+void PoroPressureBased::MeshtyingStrategyArtery::output()
 {
   if (porofluidmultitimint_->step() != 0) artnettimint_->output(false, nullptr);
 
@@ -275,7 +275,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::output()
 /*----------------------------------------------------------------------*
  | evaluate matrix and rhs                             kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::evaluate()
+void PoroPressureBased::MeshtyingStrategyArtery::evaluate()
 {
   arttoporofluidcoupling_->set_solution_vectors(
       porofluidmultitimint_->phinp(), porofluidmultitimint_->phin(), artnettimint_->pressurenp());
@@ -301,7 +301,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::evaluate()
  | extract and update                                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::extract_and_update_iter(
+PoroPressureBased::MeshtyingStrategyArtery::extract_and_update_iter(
     const std::shared_ptr<const Core::LinAlg::Vector<double>> inc)
 {
   std::shared_ptr<const Core::LinAlg::Vector<double>> arterypressinc;
@@ -318,7 +318,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::extract_and_update_iter(
  | artery dof row map                                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Map>
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::artery_dof_row_map() const
+PoroPressureBased::MeshtyingStrategyArtery::artery_dof_row_map() const
 {
   return arttoporofluidcoupling_->artery_dof_row_map();
 }
@@ -327,7 +327,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::artery_dof_row_map() const
  | access to block system matrix of artery poro problem kremheller 04/18 |
  *-----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase>
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::artery_porofluid_sysmat() const
+PoroPressureBased::MeshtyingStrategyArtery::artery_porofluid_sysmat() const
 {
   return comb_systemmatrix_;
 }
@@ -336,7 +336,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::artery_porofluid_sysmat() const
  | return coupled residual                             kremheller 05/18 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::artery_porofluid_rhs() const
+PoroPressureBased::MeshtyingStrategyArtery::artery_porofluid_rhs() const
 {
   return rhs_;
 }
@@ -345,7 +345,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::artery_porofluid_rhs() const
  | extract and update                                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::combined_increment(
+PoroPressureBased::MeshtyingStrategyArtery::combined_increment(
     const std::shared_ptr<const Core::LinAlg::Vector<double>> inc) const
 {
   return comb_increment_;
@@ -354,7 +354,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::combined_increment(
 /*----------------------------------------------------------------------*
  | check initial fields                                kremheller 06/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::check_initial_fields(
+void PoroPressureBased::MeshtyingStrategyArtery::check_initial_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_cont) const
 {
   arttoporofluidcoupling_->check_initial_fields(vec_cont, artnettimint_->pressurenp());
@@ -364,7 +364,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::check_initial_fields(
 /*-------------------------------------------------------------------------*
  | set element pairs that are close                       kremheller 03/19 |
  *------------------------------------------------------------------------ */
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::set_nearby_ele_pairs(
+void PoroPressureBased::MeshtyingStrategyArtery::set_nearby_ele_pairs(
     const std::map<int, std::set<int>>* nearbyelepairs)
 {
   arttoporofluidcoupling_->set_nearby_ele_pairs(nearbyelepairs);
@@ -374,7 +374,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::set_nearby_ele_pairs(
 /*-------------------------------------------------------------------------*
  | setup the strategy                                     kremheller 03/19 |
  *------------------------------------------------------------------------ */
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::setup()
+void PoroPressureBased::MeshtyingStrategyArtery::setup()
 {
   arttoporofluidcoupling_->setup();
   return;
@@ -383,7 +383,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::setup()
 /*----------------------------------------------------------------------*
  | apply mesh movement                                 kremheller 06/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::apply_mesh_movement() const
+void PoroPressureBased::MeshtyingStrategyArtery::apply_mesh_movement() const
 {
   arttoporofluidcoupling_->apply_mesh_movement();
   return;
@@ -393,7 +393,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::apply_mesh_movement() const
  | access to blood vessel volume fraction              kremheller 10/19 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROFLUIDMULTIPHASE::MeshtyingStrategyArtery::blood_vessel_volume_fraction()
+PoroPressureBased::MeshtyingStrategyArtery::blood_vessel_volume_fraction()
 {
   return arttoporofluidcoupling_->blood_vessel_volume_fraction();
 }

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
@@ -15,7 +15,7 @@
 FOUR_C_NAMESPACE_OPEN
 
 // forward declaration
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   class PoroMultiPhaseScaTraArtCouplBase;
 }
@@ -110,7 +110,7 @@ namespace PoroPressureBased
     std::shared_ptr<Core::FE::Discretization> arterydis_;
 
     //! the mesh tying object
-    std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase> arttoporofluidcoupling_;
+    std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase> arttoporofluidcoupling_;
 
     //! block systemmatrix
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> comb_systemmatrix_;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_artery.hpp
@@ -20,13 +20,13 @@ namespace PoroMultiPhaseScaTra
   class PoroMultiPhaseScaTraArtCouplBase;
 }
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   class MeshtyingStrategyArtery : public MeshtyingStrategyBase
   {
    public:
     //! constructor
-    explicit MeshtyingStrategyArtery(POROFLUIDMULTIPHASE::TimIntImpl* porofluidmultitimint,
+    explicit MeshtyingStrategyArtery(PoroPressureBased::TimIntImpl* porofluidmultitimint,
         const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams);
 
 
@@ -125,7 +125,7 @@ namespace POROFLUIDMULTIPHASE
     std::shared_ptr<Core::LinAlg::Vector<double>> comb_phinp_;
   };
 
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_base.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_base.hpp
@@ -27,20 +27,20 @@ namespace Core::LinAlg
   struct SolverParams;
 }
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   class MeshtyingStrategyBase
   {
    public:
     //! constructor
-    explicit MeshtyingStrategyBase(POROFLUIDMULTIPHASE::TimIntImpl* porofluidmultitimint,
+    explicit MeshtyingStrategyBase(PoroPressureBased::TimIntImpl* porofluidmultitimint,
         const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams)
         : porofluidmultitimint_(porofluidmultitimint),
           params_(probparams),
           poroparams_(poroparams),
-          vectornormfres_(Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::VectorNorm>(
+          vectornormfres_(Teuchos::getIntegralValue<PoroPressureBased::VectorNorm>(
               poroparams_, "VECTORNORM_RESF")),
-          vectornorminc_(Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::VectorNorm>(
+          vectornorminc_(Teuchos::getIntegralValue<PoroPressureBased::VectorNorm>(
               poroparams_, "VECTORNORM_INC"))
     {
       return;
@@ -145,7 +145,7 @@ namespace POROFLUIDMULTIPHASE
 
    protected:
     //! porofluid multi time integrator
-    POROFLUIDMULTIPHASE::TimIntImpl* porofluidmultitimint_;
+    PoroPressureBased::TimIntImpl* porofluidmultitimint_;
 
     //! parameter list of global control problem
     const Teuchos::ParameterList& params_;
@@ -154,13 +154,13 @@ namespace POROFLUIDMULTIPHASE
     const Teuchos::ParameterList& poroparams_;
 
     // vector norm for residuals
-    enum POROFLUIDMULTIPHASE::VectorNorm vectornormfres_;
+    enum PoroPressureBased::VectorNorm vectornormfres_;
 
     // vector norm for increments
-    enum POROFLUIDMULTIPHASE::VectorNorm vectornorminc_;
+    enum PoroPressureBased::VectorNorm vectornorminc_;
   };
 
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_std.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_std.cpp
@@ -78,9 +78,9 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::calculate_norms(std::vector<doub
   incprenorm.resize(1);
   prenorm.resize(1);
 
-  preresnorm[0] = Utils::calculate_vector_norm(vectornormfres_, *porofluidmultitimint_->rhs());
-  incprenorm[0] = Utils::calculate_vector_norm(vectornorminc_, *increment);
-  prenorm[0] = Utils::calculate_vector_norm(vectornorminc_, *porofluidmultitimint_->phinp());
+  preresnorm[0] = calculate_vector_norm(vectornormfres_, *porofluidmultitimint_->rhs());
+  incprenorm[0] = calculate_vector_norm(vectornorminc_, *increment);
+  prenorm[0] = calculate_vector_norm(vectornorminc_, *porofluidmultitimint_->phinp());
 
   return;
 }

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_std.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_std.cpp
@@ -15,8 +15,8 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | constructor                                (public) kremheller 04/18 |
  *----------------------------------------------------------------------*/
-POROFLUIDMULTIPHASE::MeshtyingStrategyStd::MeshtyingStrategyStd(
-    POROFLUIDMULTIPHASE::TimIntImpl* porofluidmultitimint, const Teuchos::ParameterList& probparams,
+PoroPressureBased::MeshtyingStrategyStd::MeshtyingStrategyStd(
+    PoroPressureBased::TimIntImpl* porofluidmultitimint, const Teuchos::ParameterList& probparams,
     const Teuchos::ParameterList& poroparams)
     : MeshtyingStrategyBase(porofluidmultitimint, probparams, poroparams)
 {
@@ -28,23 +28,23 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyStd::MeshtyingStrategyStd(
 /*----------------------------------------------------------------------*
  | prepare time loop                                   kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::prepare_time_loop() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::prepare_time_loop() { return; }
 
 /*----------------------------------------------------------------------*
  | setup the variables to do a new time step  (public) kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::prepare_time_step() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::prepare_time_step() { return; }
 
 /*----------------------------------------------------------------------*
  | current solution becomes most recent solution of next timestep       |
  |                                                     kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::update() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::update() { return; }
 
 /*--------------------------------------------------------------------------*
  | initialize the linear solver                            kremheller 07/20 |
  *--------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::initialize_linear_solver(
+void PoroPressureBased::MeshtyingStrategyStd::initialize_linear_solver(
     std::shared_ptr<Core::LinAlg::Solver> solver)
 {
   porofluidmultitimint_->discretization()->compute_null_space_if_necessary(solver->params());
@@ -53,7 +53,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::initialize_linear_solver(
 /*--------------------------------------------------------------------------*
  | solve linear system of equations                        kremheller 04/18 |
  *--------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::linear_solve(
+void PoroPressureBased::MeshtyingStrategyStd::linear_solve(
     std::shared_ptr<Core::LinAlg::Solver> solver,
     std::shared_ptr<Core::LinAlg::SparseOperator> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> increment,
@@ -70,7 +70,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::linear_solve(
 /*----------------------------------------------------------------------*
  | Calculate problem specific norm                     kremheller 03/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::calculate_norms(std::vector<double>& preresnorm,
+void PoroPressureBased::MeshtyingStrategyStd::calculate_norms(std::vector<double>& preresnorm,
     std::vector<double>& incprenorm, std::vector<double>& prenorm,
     const std::shared_ptr<const Core::LinAlg::Vector<double>> increment)
 {
@@ -88,28 +88,28 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::calculate_norms(std::vector<doub
 /*----------------------------------------------------------------------*
  | create result test for this field                   kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::create_field_test() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::create_field_test() { return; }
 
 /*----------------------------------------------------------------------*
  |  read restart data                                  kremheller 04/18 |
  -----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::read_restart(const int step) { return; }
+void PoroPressureBased::MeshtyingStrategyStd::read_restart(const int step) { return; }
 
 /*----------------------------------------------------------------------*
  | output of solution vector to BINIO                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::output() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::output() { return; }
 
 /*----------------------------------------------------------------------*
  | evaluate matrix and rhs                             kremheller 04/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::evaluate() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::evaluate() { return; }
 
 /*----------------------------------------------------------------------*
  | extract and update                                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROFLUIDMULTIPHASE::MeshtyingStrategyStd::extract_and_update_iter(
+PoroPressureBased::MeshtyingStrategyStd::extract_and_update_iter(
     const std::shared_ptr<const Core::LinAlg::Vector<double>> inc)
 {
   return inc;
@@ -119,7 +119,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyStd::extract_and_update_iter(
  | extract and update                                  kremheller 04/18 |
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROFLUIDMULTIPHASE::MeshtyingStrategyStd::combined_increment(
+PoroPressureBased::MeshtyingStrategyStd::combined_increment(
     const std::shared_ptr<const Core::LinAlg::Vector<double>> inc) const
 {
   return inc;
@@ -128,7 +128,7 @@ POROFLUIDMULTIPHASE::MeshtyingStrategyStd::combined_increment(
 /*----------------------------------------------------------------------*
  | check initial fields                                kremheller 06/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::check_initial_fields(
+void PoroPressureBased::MeshtyingStrategyStd::check_initial_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_cont) const
 {
   return;
@@ -137,7 +137,7 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::check_initial_fields(
 /*-------------------------------------------------------------------------*
  | set element pairs that are close                       kremheller 03/19 |
  *------------------------------------------------------------------------ */
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::set_nearby_ele_pairs(
+void PoroPressureBased::MeshtyingStrategyStd::set_nearby_ele_pairs(
     const std::map<int, std::set<int>>* nearbyelepairs)
 {
   return;
@@ -146,11 +146,11 @@ void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::set_nearby_ele_pairs(
 /*-------------------------------------------------------------------------*
  | setup the strategy                                     kremheller 03/19 |
  *------------------------------------------------------------------------ */
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::setup() { return; }
+void PoroPressureBased::MeshtyingStrategyStd::setup() { return; }
 
 /*----------------------------------------------------------------------*
  | apply mesh movement                                 kremheller 06/18 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::MeshtyingStrategyStd::apply_mesh_movement() const { return; }
+void PoroPressureBased::MeshtyingStrategyStd::apply_mesh_movement() const { return; }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_std.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_meshtying_strategy_std.hpp
@@ -14,13 +14,13 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   class MeshtyingStrategyStd : public MeshtyingStrategyBase
   {
    public:
     //! constructor
-    explicit MeshtyingStrategyStd(POROFLUIDMULTIPHASE::TimIntImpl* porofluidmultitimint,
+    explicit MeshtyingStrategyStd(PoroPressureBased::TimIntImpl* porofluidmultitimint,
         const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams);
 
 
@@ -82,7 +82,7 @@ namespace POROFLUIDMULTIPHASE
     void apply_mesh_movement() const override;
   };
 
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | ctor                                                     vuong 08/16 |
  *----------------------------------------------------------------------*/
-POROFLUIDMULTIPHASE::ResultTest::ResultTest(TimIntImpl& porotimint)
+PoroPressureBased::ResultTest::ResultTest(TimIntImpl& porotimint)
     : Core::Utils::ResultTest("POROFLUIDMULTIPHASE"), porotimint_(porotimint)
 {
   return;
@@ -31,7 +31,7 @@ POROFLUIDMULTIPHASE::ResultTest::ResultTest(TimIntImpl& porotimint)
 /*----------------------------------------------------------------------*
  | test node                                                vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::ResultTest::test_node(
+void PoroPressureBased::ResultTest::test_node(
     const Core::IO::InputParameterContainer& container, int& nerr, int& test_count)
 {
   // care for the case of multiple discretizations of the same field type
@@ -79,7 +79,7 @@ void POROFLUIDMULTIPHASE::ResultTest::test_node(
 /*----------------------------------------------------------------------*
  | test element                                        kremheller 10/19 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::ResultTest::test_element(
+void PoroPressureBased::ResultTest::test_element(
     const Core::IO::InputParameterContainer& container, int& nerr, int& test_count)
 {
   // care for the case of multiple discretizations of the same field type
@@ -127,7 +127,7 @@ void POROFLUIDMULTIPHASE::ResultTest::test_element(
 /*----------------------------------------------------------------------*
  | get nodal result to be tested                            vuong 08/16 |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::ResultTest::result_node(
+double PoroPressureBased::ResultTest::result_node(
     const std::string quantity, Core::Nodes::Node* node) const
 {
   // initialize variable for result
@@ -208,7 +208,7 @@ double POROFLUIDMULTIPHASE::ResultTest::result_node(
 /*----------------------------------------------------------------------*
  | get element result to be tested                     kremheller 10/19 |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::ResultTest::result_element(
+double PoroPressureBased::ResultTest::result_element(
     const std::string quantity, const Core::Elements::Element* element) const
 {
   // initialize variable for result
@@ -253,7 +253,7 @@ double POROFLUIDMULTIPHASE::ResultTest::result_element(
 /*-------------------------------------------------------------------------------------*
  | test special quantity not associated with a particular element or node  vuong 08/16 |
  *-------------------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::ResultTest::test_special(
+void PoroPressureBased::ResultTest::test_special(
     const Core::IO::InputParameterContainer& container, int& nerr, int& test_count)
 {
   // make sure that quantity is tested only once
@@ -276,7 +276,7 @@ void POROFLUIDMULTIPHASE::ResultTest::test_special(
 /*----------------------------------------------------------------------*
  | get special result to be tested                          vuong 08/16 |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::ResultTest::result_special(
+double PoroPressureBased::ResultTest::result_special(
     const std::string quantity  //! name of quantity to be tested
 ) const
 {

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.hpp
@@ -33,7 +33,7 @@ namespace Core::Elements
   class Element;
 }
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   // forward declaration
   class TimIntImpl;
@@ -85,7 +85,7 @@ namespace POROFLUIDMULTIPHASE
     //! time integrator
     const TimIntImpl& porotimint_;
   };
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
@@ -634,7 +634,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::collect_runtime_output_data()
   {
     // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
     std::shared_ptr<Core::LinAlg::MultiVector<double>> solidpressure_multi =
-        POROFLUIDMULTIPHASE::Utils::convert_dof_vector_to_node_based_multi_vector(
+        POROFLUIDMULTIPHASE::convert_dof_vector_to_node_based_multi_vector(
             *discret_, *solidpressure_, nds_solidpressure_, 1);
 
     visualization_writer_->append_result_data_vector_with_context(
@@ -650,7 +650,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::collect_runtime_output_data()
 
     // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
     std::shared_ptr<Core::LinAlg::MultiVector<double>> dispnp_multi =
-        POROFLUIDMULTIPHASE::Utils::convert_dof_vector_to_node_based_multi_vector(
+        POROFLUIDMULTIPHASE::convert_dof_vector_to_node_based_multi_vector(
             *discret_, *dispnp, nds_disp_, nsd_);
 
     std::vector<std::optional<std::string>> context(nsd_, "ale-displacement");
@@ -721,7 +721,7 @@ void POROFLUIDMULTIPHASE::TimIntImpl::collect_runtime_output_data()
   {
     // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
     std::shared_ptr<Core::LinAlg::MultiVector<double>> porosity_multi =
-        POROFLUIDMULTIPHASE::Utils::convert_dof_vector_to_node_based_multi_vector(
+        POROFLUIDMULTIPHASE::convert_dof_vector_to_node_based_multi_vector(
             *discret_, *porosity_, nds_solidpressure_, 1);
 
     visualization_writer_->append_result_data_vector_with_context(

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.hpp
@@ -60,7 +60,7 @@ namespace Adapter
 }
 
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   // forward declaration
   class MeshtyingStrategyBase;
@@ -232,8 +232,8 @@ namespace POROFLUIDMULTIPHASE
 
     //! set the initial scalar field phi
     virtual void set_initial_field(
-        const POROFLUIDMULTIPHASE::InitialField init,  //!< type of initial field
-        const int startfuncno                          //!< number of spatial function
+        const PoroPressureBased::InitialField init,  //!< type of initial field
+        const int startfuncno                        //!< number of spatial function
     );
 
     /*--- query and output ---------------------------------------------------*/
@@ -305,7 +305,7 @@ namespace POROFLUIDMULTIPHASE
     }
 
     //! return the meshtying strategy
-    std::shared_ptr<POROFLUIDMULTIPHASE::MeshtyingStrategyBase> mesh_tying_strategy() const
+    std::shared_ptr<PoroPressureBased::MeshtyingStrategyBase> mesh_tying_strategy() const
     {
       return strategy_;
     }
@@ -517,19 +517,19 @@ namespace POROFLUIDMULTIPHASE
     std::shared_ptr<Core::LinAlg::SerialDenseVector> domain_integrals_;
 
     //! flag for error calculation
-    const POROFLUIDMULTIPHASE::CalcError calcerr_;
+    const PoroPressureBased::CalcError calcerr_;
 
     //! flag for flux reconstruction
-    const POROFLUIDMULTIPHASE::FluxReconstructionMethod fluxrecon_;
+    const PoroPressureBased::FluxReconstructionMethod fluxrecon_;
 
     //! solver number for flux reconstruction
     const int fluxreconsolvernum_;
 
     //! what to do when nonlinear solution fails
-    enum POROFLUIDMULTIPHASE::DivContAct divcontype_;
+    enum PoroPressureBased::DivContAct divcontype_;
 
     //! flag for finite difference check
-    const POROFLUIDMULTIPHASE::FdCheck fdcheck_;
+    const PoroPressureBased::FdCheck fdcheck_;
 
     //! perturbation magnitude for finite difference check
     const double fdcheckeps_;
@@ -578,9 +578,9 @@ namespace POROFLUIDMULTIPHASE
     const int uprestart_;
 
     // vector norm for residuals
-    enum POROFLUIDMULTIPHASE::VectorNorm vectornormfres_;
+    enum PoroPressureBased::VectorNorm vectornormfres_;
     // vector norm for increments
-    enum POROFLUIDMULTIPHASE::VectorNorm vectornorminc_;
+    enum PoroPressureBased::VectorNorm vectornorminc_;
 
     //! convergence tolerance for increments
     double ittolres_;
@@ -695,7 +695,7 @@ namespace POROFLUIDMULTIPHASE
     std::shared_ptr<Core::LinAlg::Vector<double>> increment_;
 
     //! meshtying strategy (includes standard case without meshtying)
-    std::shared_ptr<POROFLUIDMULTIPHASE::MeshtyingStrategyBase> strategy_;
+    std::shared_ptr<PoroPressureBased::MeshtyingStrategyBase> strategy_;
 
     //! end time point when to switch off the starting Dirichlet boundary condition
     double starting_dbc_time_end_;
@@ -712,7 +712,7 @@ namespace POROFLUIDMULTIPHASE
     /*========================================================================*/
 
   };  // class TimIntImpl
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.hpp
@@ -230,27 +230,26 @@ namespace PoroPressureBased
 
     /*--- set, prepare, and predict ------------------------------------------*/
 
-    //! set the initial scalar field phi
-    virtual void set_initial_field(
-        const PoroPressureBased::InitialField init,  //!< type of initial field
-        const int startfuncno                        //!< number of spatial function
+    //! set the initial field
+    virtual void set_initial_field(InitialField init,  //!< type of initial field
+        int startfuncno                                //!< number of spatial function
     );
 
     /*--- query and output ---------------------------------------------------*/
 
-    //! return pressure field at time n+1
+    //! return primary variable at time n+1
     std::shared_ptr<const Core::LinAlg::Vector<double>> phinp() const override { return phinp_; }
 
-    //! return scalar field phi at time n
+    //! return primary variable at time n
     std::shared_ptr<const Core::LinAlg::Vector<double>> phin() const override { return phin_; }
 
-    //! return time derivative of scalar field phi at time n
+    //! return time derivative of the primary variable at time n
     std::shared_ptr<const Core::LinAlg::Vector<double>> phidtn() const { return phidtn_; }
 
-    //! return time derivative of scalar field phi at time n+1
+    //! return time derivative of the primary variable at time n+1
     std::shared_ptr<const Core::LinAlg::Vector<double>> phidtnp() const { return phidtnp_; }
 
-    //! return scalar field history
+    //! return primary variable history
     std::shared_ptr<const Core::LinAlg::Vector<double>> hist() const { return hist_; }
 
     //! return solid pressure field
@@ -526,7 +525,7 @@ namespace PoroPressureBased
     const int fluxreconsolvernum_;
 
     //! what to do when nonlinear solution fails
-    enum PoroPressureBased::DivContAct divcontype_;
+    enum PoroPressureBased::DivergenceAction divcontype_;
 
     //! flag for finite difference check
     const PoroPressureBased::FdCheck fdcheck_;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_ost.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_ost.cpp
@@ -17,7 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  |  Constructor (public)                                   vuong  08/16 |
  *----------------------------------------------------------------------*/
-POROFLUIDMULTIPHASE::TimIntOneStepTheta::TimIntOneStepTheta(
+PoroPressureBased::TimIntOneStepTheta::TimIntOneStepTheta(
     std::shared_ptr<Core::FE::Discretization> dis,  //!< discretization
     const int linsolvernumber,                      //!< number of linear solver
     const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams,
@@ -33,7 +33,7 @@ POROFLUIDMULTIPHASE::TimIntOneStepTheta::TimIntOneStepTheta(
 /*----------------------------------------------------------------------*
  |  set parameter for element evaluation                    vuong 06/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::set_element_time_step_parameter() const
+void PoroPressureBased::TimIntOneStepTheta::set_element_time_step_parameter() const
 {
   Teuchos::ParameterList eleparams;
 
@@ -51,7 +51,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::set_element_time_step_parameter() 
 /*-----------------------------------------------------------------------------*
  | set time for evaluation of POINT -Neumann boundary conditions   vuong 08/16 |
  *----------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::set_time_for_neumann_evaluation(
+void PoroPressureBased::TimIntOneStepTheta::set_time_for_neumann_evaluation(
     Teuchos::ParameterList& params)
 {
   params.set("total time", time_);
@@ -61,7 +61,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::set_time_for_neumann_evaluation(
 /*----------------------------------------------------------------------*
 | Print information about current time step to screen      vuong 08/16  |
 *-----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::print_time_step_info()
+void PoroPressureBased::TimIntOneStepTheta::print_time_step_info()
 {
   if (myrank_ == 0)
   {
@@ -80,7 +80,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::print_time_step_info()
  | set part of the residual vector belonging to the old timestep        |
  |                                                          vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::set_old_part_of_righthandside()
+void PoroPressureBased::TimIntOneStepTheta::set_old_part_of_righthandside()
 {
   // hist_ = phin_ + dt*(1-Theta)*phidtn_
   hist_->update(1.0, *phin_, dt_ * (1.0 - theta_), *phidtn_, 0.0);
@@ -90,7 +90,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::set_old_part_of_righthandside()
 /*----------------------------------------------------------------------*
  | perform an explicit predictor step                       vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::explicit_predictor()
+void PoroPressureBased::TimIntOneStepTheta::explicit_predictor()
 {
   phinp_->update(dt_, *phidtn_, 1.0);
 }
@@ -100,7 +100,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::explicit_predictor()
  | add actual Neumann loads                                             |
  | scaled with a factor resulting from time discretization  vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_neumann_to_residual()
+void PoroPressureBased::TimIntOneStepTheta::add_neumann_to_residual()
 {
   residual_->update(theta_ * dt_, *neumann_loads_, 1.0);
 }
@@ -109,7 +109,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_neumann_to_residual()
 /*----------------------------------------------------------------------------*
  | add global state vectors specific for time-integration scheme  vuong 08/16 |
  *---------------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_time_integration_specific_vectors()
+void PoroPressureBased::TimIntOneStepTheta::add_time_integration_specific_vectors()
 {
   discret_->set_state("hist", *hist_);
   discret_->set_state("phinp_fluid", *phinp_);
@@ -121,7 +121,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::add_time_integration_specific_vect
 /*----------------------------------------------------------------------*
  | compute time derivative                                  vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::compute_time_derivative()
+void PoroPressureBased::TimIntOneStepTheta::compute_time_derivative()
 {
   // time derivative of phi:
   // *phidt(n+1) = (phi(n+1)-phi(n)) / (theta*dt) + (1-(1/theta))*phidt(n)
@@ -136,10 +136,10 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::compute_time_derivative()
  | current solution becomes most recent solution of next timestep       |
  |                                                          vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::update()
+void PoroPressureBased::TimIntOneStepTheta::update()
 {
   // call base class
-  POROFLUIDMULTIPHASE::TimIntImpl::update();
+  PoroPressureBased::TimIntImpl::update();
 
   // compute time derivative at time n+1
   compute_time_derivative();
@@ -156,9 +156,9 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::update()
 /*----------------------------------------------------------------------*
  | write additional data required for restart               vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::output_restart()
+void PoroPressureBased::TimIntOneStepTheta::output_restart()
 {
-  POROFLUIDMULTIPHASE::TimIntImpl::output_restart();
+  PoroPressureBased::TimIntImpl::output_restart();
 
   // additional state vectors that are needed for One-Step-Theta restart
   output_->write_vector("phidtn_fluid", phidtn_);
@@ -169,10 +169,10 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::output_restart()
 /*----------------------------------------------------------------------*
  |  read restart data                                       vuong 08/16 |
  -----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::read_restart(const int step)
+void PoroPressureBased::TimIntOneStepTheta::read_restart(const int step)
 {
   // call base class
-  POROFLUIDMULTIPHASE::TimIntImpl::read_restart(step);
+  PoroPressureBased::TimIntImpl::read_restart(step);
 
   std::shared_ptr<Core::IO::DiscretizationReader> reader(nullptr);
   reader = std::make_shared<Core::IO::DiscretizationReader>(
@@ -194,7 +194,7 @@ void POROFLUIDMULTIPHASE::TimIntOneStepTheta::read_restart(const int step)
 /*--------------------------------------------------------------------*
  | calculate init time derivatives of state variables kremheller 03/17 |
  *--------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::TimIntOneStepTheta::calc_initial_time_derivative()
+void PoroPressureBased::TimIntOneStepTheta::calc_initial_time_derivative()
 {
   // standard general element parameter without stabilization
   set_element_general_parameters();

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_ost.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_ost.hpp
@@ -15,7 +15,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   class TimIntOneStepTheta : public TimIntImpl
   {
@@ -84,7 +84,7 @@ namespace POROFLUIDMULTIPHASE
 
   };  // class TimIntOneStepTheta
 
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -174,10 +174,10 @@ std::shared_ptr<Adapter::PoroFluidMultiphase> PoroPressureBased::create_algorith
 
   switch (timintscheme)
   {
-    case PoroPressureBased::timeint_one_step_theta:
+    case TimeIntegrationScheme::one_step_theta:
     {
       // create algorithm
-      algo = std::make_shared<PoroPressureBased::TimIntOneStepTheta>(
+      algo = std::make_shared<TimIntOneStepTheta>(
           dis, linsolvernumber, probparams, poroparams, output);
       break;
     }
@@ -498,7 +498,7 @@ double PoroPressureBased::calculate_vector_norm(
 {
   // L1 norm
   // norm = sum_0^i vect[i]
-  if (norm == PoroPressureBased::norm_l1)
+  if (norm == VectorNorm::l1)
   {
     double vectnorm;
     vect.norm_1(&vectnorm);
@@ -506,7 +506,7 @@ double PoroPressureBased::calculate_vector_norm(
   }
   // L2/Euclidian norm
   // norm = sqrt{sum_0^i vect[i]^2 }
-  else if (norm == PoroPressureBased::norm_l2)
+  else if (norm == VectorNorm::l2)
   {
     double vectnorm;
     vect.norm_2(&vectnorm);
@@ -514,7 +514,7 @@ double PoroPressureBased::calculate_vector_norm(
   }
   // RMS norm
   // norm = sqrt{sum_0^i vect[i]^2 }/ sqrt{length_vect}
-  else if (norm == PoroPressureBased::norm_rms)
+  else if (norm == VectorNorm::rms)
   {
     double vectnorm;
     vect.norm_2(&vectnorm);
@@ -522,14 +522,14 @@ double PoroPressureBased::calculate_vector_norm(
   }
   // infinity/maximum norm
   // norm = max( vect[i] )
-  else if (norm == PoroPressureBased::norm_inf)
+  else if (norm == VectorNorm::inf)
   {
     double vectnorm;
     vect.norm_inf(&vectnorm);
     return vectnorm;
   }
   // norm = sum_0^i vect[i]/length_vect
-  else if (norm == PoroPressureBased::norm_l1_scaled)
+  else if (norm == VectorNorm::l1_scaled)
   {
     double vectnorm;
     vect.norm_1(&vectnorm);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -539,32 +539,7 @@ double PoroPressureBased::calculate_vector_norm(
   {
     FOUR_C_THROW("Cannot handle vector norm");
     return 0;
-  }
-}  // calculate_vector_norm()
-
-/*----------------------------------------------------------------------*
- |                                                    kremheller 03/17  |
- *----------------------------------------------------------------------*/
-void PoroPressureBased::print_logo()
-{
-  std::cout << "This is a Porous Media problem with multiphase flow" << std::endl;
-  std::cout << "" << std::endl;
-  std::cout << "              +----------+" << std::endl;
-  std::cout << "              |  Krebs-  |" << std::endl;
-  std::cout << "              |  Model  |" << std::endl;
-  std::cout << "              +----------+" << std::endl;
-  std::cout << "              |          |" << std::endl;
-  std::cout << "              |          |" << std::endl;
-  std::cout << " /\\           |          /\\" << std::endl;
-  std::cout << "( /   @ @    (|)        ( /   @ @    ()" << std::endl;
-  std::cout << " \\  __| |__  /           \\  __| |__  /" << std::endl;
-  std::cout << "  \\/   \"   \\/             \\/   \"   \\/" << std::endl;
-  std::cout << " /-|       |-\\           /-|       |-\\" << std::endl;
-  std::cout << "/ /-\\     /-\\ \\         / /-\\     /-\\ \\" << std::endl;
-  std::cout << " / /-`---'-\\ \\           / /-`---'-\\ \\" << std::endl;
-  std::cout << "  /         \\             /         \\" << std::endl;
-
-  return;
+  }  // calculate_vector_norm()
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -65,7 +65,7 @@ namespace
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::setup_material(
+void PoroPressureBased::setup_material(
     MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname)
 {
   // get the fluid discretization
@@ -131,7 +131,7 @@ void POROFLUIDMULTIPHASE::setup_material(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>>
-POROFLUIDMULTIPHASE::convert_dof_vector_to_node_based_multi_vector(
+PoroPressureBased::convert_dof_vector_to_node_based_multi_vector(
     const Core::FE::Discretization& dis, const Core::LinAlg::Vector<double>& vector, const int nds,
     const int numdofpernode)
 {
@@ -158,8 +158,8 @@ POROFLUIDMULTIPHASE::convert_dof_vector_to_node_based_multi_vector(
 /*----------------------------------------------------------------------*
  | create algorithm                                                      |
  *----------------------------------------------------------------------*/
-std::shared_ptr<Adapter::PoroFluidMultiphase> POROFLUIDMULTIPHASE::create_algorithm(
-    POROFLUIDMULTIPHASE::TimeIntegrationScheme timintscheme,
+std::shared_ptr<Adapter::PoroFluidMultiphase> PoroPressureBased::create_algorithm(
+    PoroPressureBased::TimeIntegrationScheme timintscheme,
     std::shared_ptr<Core::FE::Discretization> dis, const int linsolvernumber,
     const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams,
     std::shared_ptr<Core::IO::DiscretizationWriter> output)
@@ -174,10 +174,10 @@ std::shared_ptr<Adapter::PoroFluidMultiphase> POROFLUIDMULTIPHASE::create_algori
 
   switch (timintscheme)
   {
-    case POROFLUIDMULTIPHASE::timeint_one_step_theta:
+    case PoroPressureBased::timeint_one_step_theta:
     {
       // create algorithm
-      algo = std::make_shared<POROFLUIDMULTIPHASE::TimIntOneStepTheta>(
+      algo = std::make_shared<PoroPressureBased::TimIntOneStepTheta>(
           dis, linsolvernumber, probparams, poroparams, output);
       break;
     }
@@ -192,7 +192,7 @@ std::shared_ptr<Adapter::PoroFluidMultiphase> POROFLUIDMULTIPHASE::create_algori
 /*--------------------------------------------------------------------------*
  | perform extended ghosting for artery dis                kremheller 03/19 |
  *--------------------------------------------------------------------------*/
-std::map<int, std::set<int>> POROFLUIDMULTIPHASE::extended_ghosting_artery_discretization(
+std::map<int, std::set<int>> PoroPressureBased::extended_ghosting_artery_discretization(
     Core::FE::Discretization& contdis, std::shared_ptr<Core::FE::Discretization> artdis,
     const bool evaluate_on_lateral_surface,
     const Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod couplingmethod)
@@ -287,7 +287,7 @@ std::map<int, std::set<int>> POROFLUIDMULTIPHASE::extended_ghosting_artery_discr
  | create the fully overlapping artery discretization      kremheller 03/19 |
  *--------------------------------------------------------------------------*/
 std::shared_ptr<Core::FE::Discretization>
-POROFLUIDMULTIPHASE::create_fully_overlapping_artery_discretization(
+PoroPressureBased::create_fully_overlapping_artery_discretization(
     Core::FE::Discretization& artdis, std::string disname, bool doboundaryconditions)
 {
   // we clone a search discretization of the artery discretization on which the search will be
@@ -305,7 +305,7 @@ POROFLUIDMULTIPHASE::create_fully_overlapping_artery_discretization(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> POROFLUIDMULTIPHASE::oct_tree_search(Core::FE::Discretization& contdis,
+std::map<int, std::set<int>> PoroPressureBased::oct_tree_search(Core::FE::Discretization& contdis,
     Core::FE::Discretization& artdis, Core::FE::Discretization& artsearchdis,
     const bool evaluate_on_lateral_surface, const std::vector<int> artEleGIDs,
     std::set<int>& elecolset, std::set<int>& nodecolset)
@@ -401,7 +401,7 @@ std::map<int, std::set<int>> POROFLUIDMULTIPHASE::oct_tree_search(Core::FE::Disc
 /*----------------------------------------------------------------------*
  | get axis-aligned bounding box of element            kremheller 03/19 |
  *----------------------------------------------------------------------*/
-Core::LinAlg::Matrix<3, 2> POROFLUIDMULTIPHASE::get_aabb(Core::Elements::Element* ele,
+Core::LinAlg::Matrix<3, 2> PoroPressureBased::get_aabb(Core::Elements::Element* ele,
     std::map<int, Core::LinAlg::Matrix<3, 1>>& positions, const bool evaluate_on_lateral_surface)
 {
   const Core::LinAlg::SerialDenseMatrix xyze_element(
@@ -432,7 +432,7 @@ Core::LinAlg::Matrix<3, 2> POROFLUIDMULTIPHASE::get_aabb(Core::Elements::Element
 /*----------------------------------------------------------------------*
  | get nodal positions                                 kremheller 10/19 |
  *----------------------------------------------------------------------*/
-std::map<int, Core::LinAlg::Matrix<3, 1>> POROFLUIDMULTIPHASE::get_nodal_positions(
+std::map<int, Core::LinAlg::Matrix<3, 1>> PoroPressureBased::get_nodal_positions(
     Core::FE::Discretization& dis, const Core::LinAlg::Map* nodemap)
 {
   std::map<int, Core::LinAlg::Matrix<3, 1>> positions;
@@ -453,7 +453,7 @@ std::map<int, Core::LinAlg::Matrix<3, 1>> POROFLUIDMULTIPHASE::get_nodal_positio
 /*----------------------------------------------------------------------*
  | get maximum nodal distance                          kremheller 05/18 |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::get_max_nodal_distance(
+double PoroPressureBased::get_max_nodal_distance(
     Core::Elements::Element* ele, Core::FE::Discretization& dis)
 {
   double maxdist = 0.0;
@@ -493,12 +493,12 @@ double POROFLUIDMULTIPHASE::get_max_nodal_distance(
 /*----------------------------------------------------------------------*
  | calculate vector norm                             kremheller 12/17   |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::calculate_vector_norm(
-    const enum POROFLUIDMULTIPHASE::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
+double PoroPressureBased::calculate_vector_norm(
+    const enum PoroPressureBased::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm
   // norm = sum_0^i vect[i]
-  if (norm == POROFLUIDMULTIPHASE::norm_l1)
+  if (norm == PoroPressureBased::norm_l1)
   {
     double vectnorm;
     vect.norm_1(&vectnorm);
@@ -506,7 +506,7 @@ double POROFLUIDMULTIPHASE::calculate_vector_norm(
   }
   // L2/Euclidian norm
   // norm = sqrt{sum_0^i vect[i]^2 }
-  else if (norm == POROFLUIDMULTIPHASE::norm_l2)
+  else if (norm == PoroPressureBased::norm_l2)
   {
     double vectnorm;
     vect.norm_2(&vectnorm);
@@ -514,7 +514,7 @@ double POROFLUIDMULTIPHASE::calculate_vector_norm(
   }
   // RMS norm
   // norm = sqrt{sum_0^i vect[i]^2 }/ sqrt{length_vect}
-  else if (norm == POROFLUIDMULTIPHASE::norm_rms)
+  else if (norm == PoroPressureBased::norm_rms)
   {
     double vectnorm;
     vect.norm_2(&vectnorm);
@@ -522,14 +522,14 @@ double POROFLUIDMULTIPHASE::calculate_vector_norm(
   }
   // infinity/maximum norm
   // norm = max( vect[i] )
-  else if (norm == POROFLUIDMULTIPHASE::norm_inf)
+  else if (norm == PoroPressureBased::norm_inf)
   {
     double vectnorm;
     vect.norm_inf(&vectnorm);
     return vectnorm;
   }
   // norm = sum_0^i vect[i]/length_vect
-  else if (norm == POROFLUIDMULTIPHASE::norm_l1_scaled)
+  else if (norm == PoroPressureBased::norm_l1_scaled)
   {
     double vectnorm;
     vect.norm_1(&vectnorm);
@@ -545,7 +545,7 @@ double POROFLUIDMULTIPHASE::calculate_vector_norm(
 /*----------------------------------------------------------------------*
  |                                                    kremheller 03/17  |
  *----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::print_logo()
+void PoroPressureBased::print_logo()
 {
   std::cout << "This is a Porous Media problem with multiphase flow" << std::endl;
   std::cout << "" << std::endl;

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -65,7 +65,7 @@ namespace
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void POROFLUIDMULTIPHASE::Utils::setup_material(
+void POROFLUIDMULTIPHASE::setup_material(
     MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname)
 {
   // get the fluid discretization
@@ -131,7 +131,7 @@ void POROFLUIDMULTIPHASE::Utils::setup_material(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>>
-POROFLUIDMULTIPHASE::Utils::convert_dof_vector_to_node_based_multi_vector(
+POROFLUIDMULTIPHASE::convert_dof_vector_to_node_based_multi_vector(
     const Core::FE::Discretization& dis, const Core::LinAlg::Vector<double>& vector, const int nds,
     const int numdofpernode)
 {
@@ -158,7 +158,7 @@ POROFLUIDMULTIPHASE::Utils::convert_dof_vector_to_node_based_multi_vector(
 /*----------------------------------------------------------------------*
  | create algorithm                                                      |
  *----------------------------------------------------------------------*/
-std::shared_ptr<Adapter::PoroFluidMultiphase> POROFLUIDMULTIPHASE::Utils::create_algorithm(
+std::shared_ptr<Adapter::PoroFluidMultiphase> POROFLUIDMULTIPHASE::create_algorithm(
     POROFLUIDMULTIPHASE::TimeIntegrationScheme timintscheme,
     std::shared_ptr<Core::FE::Discretization> dis, const int linsolvernumber,
     const Teuchos::ParameterList& probparams, const Teuchos::ParameterList& poroparams,
@@ -192,7 +192,7 @@ std::shared_ptr<Adapter::PoroFluidMultiphase> POROFLUIDMULTIPHASE::Utils::create
 /*--------------------------------------------------------------------------*
  | perform extended ghosting for artery dis                kremheller 03/19 |
  *--------------------------------------------------------------------------*/
-std::map<int, std::set<int>> POROFLUIDMULTIPHASE::Utils::extended_ghosting_artery_discretization(
+std::map<int, std::set<int>> POROFLUIDMULTIPHASE::extended_ghosting_artery_discretization(
     Core::FE::Discretization& contdis, std::shared_ptr<Core::FE::Discretization> artdis,
     const bool evaluate_on_lateral_surface,
     const Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod couplingmethod)
@@ -287,7 +287,7 @@ std::map<int, std::set<int>> POROFLUIDMULTIPHASE::Utils::extended_ghosting_arter
  | create the fully overlapping artery discretization      kremheller 03/19 |
  *--------------------------------------------------------------------------*/
 std::shared_ptr<Core::FE::Discretization>
-POROFLUIDMULTIPHASE::Utils::create_fully_overlapping_artery_discretization(
+POROFLUIDMULTIPHASE::create_fully_overlapping_artery_discretization(
     Core::FE::Discretization& artdis, std::string disname, bool doboundaryconditions)
 {
   // we clone a search discretization of the artery discretization on which the search will be
@@ -305,10 +305,10 @@ POROFLUIDMULTIPHASE::Utils::create_fully_overlapping_artery_discretization(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> POROFLUIDMULTIPHASE::Utils::oct_tree_search(
-    Core::FE::Discretization& contdis, Core::FE::Discretization& artdis,
-    Core::FE::Discretization& artsearchdis, const bool evaluate_on_lateral_surface,
-    const std::vector<int> artEleGIDs, std::set<int>& elecolset, std::set<int>& nodecolset)
+std::map<int, std::set<int>> POROFLUIDMULTIPHASE::oct_tree_search(Core::FE::Discretization& contdis,
+    Core::FE::Discretization& artdis, Core::FE::Discretization& artsearchdis,
+    const bool evaluate_on_lateral_surface, const std::vector<int> artEleGIDs,
+    std::set<int>& elecolset, std::set<int>& nodecolset)
 {
   // this map will be filled
   std::map<int, std::set<int>> nearbyelepairs;
@@ -401,7 +401,7 @@ std::map<int, std::set<int>> POROFLUIDMULTIPHASE::Utils::oct_tree_search(
 /*----------------------------------------------------------------------*
  | get axis-aligned bounding box of element            kremheller 03/19 |
  *----------------------------------------------------------------------*/
-Core::LinAlg::Matrix<3, 2> POROFLUIDMULTIPHASE::Utils::get_aabb(Core::Elements::Element* ele,
+Core::LinAlg::Matrix<3, 2> POROFLUIDMULTIPHASE::get_aabb(Core::Elements::Element* ele,
     std::map<int, Core::LinAlg::Matrix<3, 1>>& positions, const bool evaluate_on_lateral_surface)
 {
   const Core::LinAlg::SerialDenseMatrix xyze_element(
@@ -432,7 +432,7 @@ Core::LinAlg::Matrix<3, 2> POROFLUIDMULTIPHASE::Utils::get_aabb(Core::Elements::
 /*----------------------------------------------------------------------*
  | get nodal positions                                 kremheller 10/19 |
  *----------------------------------------------------------------------*/
-std::map<int, Core::LinAlg::Matrix<3, 1>> POROFLUIDMULTIPHASE::Utils::get_nodal_positions(
+std::map<int, Core::LinAlg::Matrix<3, 1>> POROFLUIDMULTIPHASE::get_nodal_positions(
     Core::FE::Discretization& dis, const Core::LinAlg::Map* nodemap)
 {
   std::map<int, Core::LinAlg::Matrix<3, 1>> positions;
@@ -453,7 +453,7 @@ std::map<int, Core::LinAlg::Matrix<3, 1>> POROFLUIDMULTIPHASE::Utils::get_nodal_
 /*----------------------------------------------------------------------*
  | get maximum nodal distance                          kremheller 05/18 |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::Utils::get_max_nodal_distance(
+double POROFLUIDMULTIPHASE::get_max_nodal_distance(
     Core::Elements::Element* ele, Core::FE::Discretization& dis)
 {
   double maxdist = 0.0;
@@ -493,7 +493,7 @@ double POROFLUIDMULTIPHASE::Utils::get_max_nodal_distance(
 /*----------------------------------------------------------------------*
  | calculate vector norm                             kremheller 12/17   |
  *----------------------------------------------------------------------*/
-double POROFLUIDMULTIPHASE::Utils::calculate_vector_norm(
+double POROFLUIDMULTIPHASE::calculate_vector_norm(
     const enum POROFLUIDMULTIPHASE::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
@@ -142,8 +142,6 @@ namespace PoroPressureBased
   std::shared_ptr<Core::FE::Discretization> create_fully_overlapping_artery_discretization(
       Core::FE::Discretization& artdis, std::string disname, bool doboundaryconditions);
 
-  // Print the logo
-  void print_logo();
 }  // namespace PoroPressureBased
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
@@ -39,115 +39,109 @@ namespace Adapter
 
 namespace POROFLUIDMULTIPHASE
 {
-  /// POROFLUIDMULTIPHASE::UTILS: Random stuff that might be helpful when dealing with
-  /// poromultiphase problems
-  namespace Utils
-  {
-    /// setup second materials for porosity evaluation within solid phase
-    void setup_material(
-        MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname);
+  /// setup second materials for porosity evaluation within solid phase
+  void setup_material(
+      MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname);
 
 
-    /// convert a dof based vector to a node based multi vector
-    /*!
-      For postprocessing, only vectors based on the primary dof set
-      of the discretization can be used. Hence, all other EpetraVectors
-      based on secondary dof sets are copied to EpetraMultiVectors with one
-      node based vector for each component.
+  /// convert a dof based vector to a node based multi vector
+  /*!
+    For postprocessing, only vectors based on the primary dof set
+    of the discretization can be used. Hence, all other EpetraVectors
+    based on secondary dof sets are copied to EpetraMultiVectors with one
+    node based vector for each component.
 
-      This method can be deleted, if the post processors would be adapted to
-      handle secondary dof sets.
+    This method can be deleted, if the post processors would be adapted to
+    handle secondary dof sets.
 
-      \param dis              : discretization, the vector is based on
-      \param vector           : vector to convert
-      \param nds              : number of the dof set the map of the vector corresponds to
-      \param numdofpernode    : number of dofs per node of the vector (assumed to be equal for all
-      nodes)
-     */
-    std::shared_ptr<Core::LinAlg::MultiVector<double>>
-    convert_dof_vector_to_node_based_multi_vector(const Core::FE::Discretization& dis,
-        const Core::LinAlg::Vector<double>& vector, const int nds, const int numdofpernode);
+    \param dis              : discretization, the vector is based on
+    \param vector           : vector to convert
+    \param nds              : number of the dof set the map of the vector corresponds to
+    \param numdofpernode    : number of dofs per node of the vector (assumed to be equal for all
+    nodes)
+   */
+  std::shared_ptr<Core::LinAlg::MultiVector<double>> convert_dof_vector_to_node_based_multi_vector(
+      const Core::FE::Discretization& dis, const Core::LinAlg::Vector<double>& vector,
+      const int nds, const int numdofpernode);
 
-    /// create solution algorithm depending on input file
-    std::shared_ptr<Adapter::PoroFluidMultiphase> create_algorithm(
-        POROFLUIDMULTIPHASE::TimeIntegrationScheme timintscheme,  //!< time discretization scheme
-        std::shared_ptr<Core::FE::Discretization> dis,            //!< discretization
-        const int linsolvernumber,                                //!< number of linear solver
-        const Teuchos::ParameterList& probparams,  //!< parameter list of global problem
-        const Teuchos::ParameterList& poroparams,  //!< parameter list of poro problem
-        std::shared_ptr<Core::IO::DiscretizationWriter> output  //!< output writer
-    );
+  /// create solution algorithm depending on input file
+  std::shared_ptr<Adapter::PoroFluidMultiphase> create_algorithm(
+      POROFLUIDMULTIPHASE::TimeIntegrationScheme timintscheme,  //!< time discretization scheme
+      std::shared_ptr<Core::FE::Discretization> dis,            //!< discretization
+      const int linsolvernumber,                                //!< number of linear solver
+      const Teuchos::ParameterList& probparams,               //!< parameter list of global problem
+      const Teuchos::ParameterList& poroparams,               //!< parameter list of poro problem
+      std::shared_ptr<Core::IO::DiscretizationWriter> output  //!< output writer
+  );
 
-    /**
-     * \brief extend ghosting for artery discretization
-     * @param[in] contdis  discretization of 2D/3D domain
-     * @param[in] artdis   discretization of 1D domain
-     * @param[in] evaluate_on_lateral_surface   is coupling evaluated on lateral surface?
-     * @return             set of nearby element pairs as seen from the artery discretization, each
-     *                     artery element with a vector of close 3D elements
-     */
-    std::map<int, std::set<int>> extended_ghosting_artery_discretization(
-        Core::FE::Discretization& contdis, std::shared_ptr<Core::FE::Discretization> artdis,
-        const bool evaluate_on_lateral_surface,
-        const Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod couplingmethod);
+  /**
+   * \brief extend ghosting for artery discretization
+   * @param[in] contdis  discretization of 2D/3D domain
+   * @param[in] artdis   discretization of 1D domain
+   * @param[in] evaluate_on_lateral_surface   is coupling evaluated on lateral surface?
+   * @return             set of nearby element pairs as seen from the artery discretization, each
+   *                     artery element with a vector of close 3D elements
+   */
+  std::map<int, std::set<int>> extended_ghosting_artery_discretization(
+      Core::FE::Discretization& contdis, std::shared_ptr<Core::FE::Discretization> artdis,
+      const bool evaluate_on_lateral_surface,
+      const Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod couplingmethod);
 
-    /**
-     * \brief get axis-aligned bounding box of element
-     * @param[in] ele        compute AABB for this element
-     * @param[in] positions  nodal positions of discretization
-     * @param[in] evaluate_on_lateral_surface   is coupling evaluated on lateral surface?
-     * @return               AABB of element as 3x2 Core::LinAlg::Matrix
-     */
-    Core::LinAlg::Matrix<3, 2> get_aabb(Core::Elements::Element* ele,
-        std::map<int, Core::LinAlg::Matrix<3, 1>>& positions,
-        const bool evaluate_on_lateral_surface);
+  /**
+   * \brief get axis-aligned bounding box of element
+   * @param[in] ele        compute AABB for this element
+   * @param[in] positions  nodal positions of discretization
+   * @param[in] evaluate_on_lateral_surface   is coupling evaluated on lateral surface?
+   * @return               AABB of element as 3x2 Core::LinAlg::Matrix
+   */
+  Core::LinAlg::Matrix<3, 2> get_aabb(Core::Elements::Element* ele,
+      std::map<int, Core::LinAlg::Matrix<3, 1>>& positions, const bool evaluate_on_lateral_surface);
 
-    /// maximum distance between two nodes of an element
-    double get_max_nodal_distance(Core::Elements::Element* ele, Core::FE::Discretization& dis);
+  /// maximum distance between two nodes of an element
+  double get_max_nodal_distance(Core::Elements::Element* ele, Core::FE::Discretization& dis);
 
-    /**
-     * \brief perform octtree search for NTP coupling
-     * @param[in] contdis       discretization of 2D/3D domain
-     * @param[in] artdis        discretization of 1D domain
-     * @param[in] artsearchdis  fully overlapping discretization of 1D domain on which search is
-     * performed
-     * @param[in] evaluate_on_lateral_surface   is coupling evaluated on lateral surface?
-     * @param[in] artEleGIDs   vector of artery coupling element Ids
-     * @param[out] elecolset    additional elements that need to be ghosted are filled into this set
-     * @param[out] nodecolset   additional nodes that need to be ghosted are filled into this set
-     * @return                  set of nearby element pairs as seen from the artery discretization,
-     *                          each artery element with a vector of close 3D elements
-     */
-    std::map<int, std::set<int>> oct_tree_search(Core::FE::Discretization& contdis,
-        Core::FE::Discretization& artdis, Core::FE::Discretization& artsearchdis,
-        const bool evaluate_on_lateral_surface, const std::vector<int> artEleGIDs,
-        std::set<int>& elecolset, std::set<int>& nodecolset);
+  /**
+   * \brief perform octtree search for NTP coupling
+   * @param[in] contdis       discretization of 2D/3D domain
+   * @param[in] artdis        discretization of 1D domain
+   * @param[in] artsearchdis  fully overlapping discretization of 1D domain on which search is
+   * performed
+   * @param[in] evaluate_on_lateral_surface   is coupling evaluated on lateral surface?
+   * @param[in] artEleGIDs   vector of artery coupling element Ids
+   * @param[out] elecolset    additional elements that need to be ghosted are filled into this set
+   * @param[out] nodecolset   additional nodes that need to be ghosted are filled into this set
+   * @return                  set of nearby element pairs as seen from the artery discretization,
+   *                          each artery element with a vector of close 3D elements
+   */
+  std::map<int, std::set<int>> oct_tree_search(Core::FE::Discretization& contdis,
+      Core::FE::Discretization& artdis, Core::FE::Discretization& artsearchdis,
+      const bool evaluate_on_lateral_surface, const std::vector<int> artEleGIDs,
+      std::set<int>& elecolset, std::set<int>& nodecolset);
 
-    /*!
-     * \brief get nodal positions of discretization as std::map
-     * @param[in] dis      discretization for which nodal positions will be returned
-     * @param[in] nodemap  node-map of the discretization (can be either in row or column format)
-     * @return             nodal position as a std::map<int, Core::LinAlg::Matrix<3, 1>>
-     */
-    std::map<int, Core::LinAlg::Matrix<3, 1>> get_nodal_positions(
-        Core::FE::Discretization& dis, const Core::LinAlg::Map* nodemap);
+  /*!
+   * \brief get nodal positions of discretization as std::map
+   * @param[in] dis      discretization for which nodal positions will be returned
+   * @param[in] nodemap  node-map of the discretization (can be either in row or column format)
+   * @return             nodal position as a std::map<int, Core::LinAlg::Matrix<3, 1>>
+   */
+  std::map<int, Core::LinAlg::Matrix<3, 1>> get_nodal_positions(
+      Core::FE::Discretization& dis, const Core::LinAlg::Map* nodemap);
 
-    //! Determine norm of vector
-    double calculate_vector_norm(const enum POROFLUIDMULTIPHASE::VectorNorm norm,  //!< norm to use
-        const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
-    );
+  //! Determine norm of vector
+  double calculate_vector_norm(const enum POROFLUIDMULTIPHASE::VectorNorm norm,  //!< norm to use
+      const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
+  );
 
-    /*!
-     * create (fully overlapping) search discretization
-     * @param artdis  1D artery discretization
-     * @param disname  name of fully-overlapping artery discretization
-     * @param doboundaryconditions  also do boundary conditions in fill-complete call
-     * @return  fully-overlapping artery discretization
-     */
-    std::shared_ptr<Core::FE::Discretization> create_fully_overlapping_artery_discretization(
-        Core::FE::Discretization& artdis, std::string disname, bool doboundaryconditions);
+  /*!
+   * create (fully overlapping) search discretization
+   * @param artdis  1D artery discretization
+   * @param disname  name of fully-overlapping artery discretization
+   * @param doboundaryconditions  also do boundary conditions in fill-complete call
+   * @return  fully-overlapping artery discretization
+   */
+  std::shared_ptr<Core::FE::Discretization> create_fully_overlapping_artery_discretization(
+      Core::FE::Discretization& artdis, std::string disname, bool doboundaryconditions);
 
-  }  // namespace Utils
   // Print the logo
   void print_logo();
 }  // namespace POROFLUIDMULTIPHASE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
@@ -37,7 +37,7 @@ namespace Adapter
   class PoroFluidMultiphase;
 }
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   /// setup second materials for porosity evaluation within solid phase
   void setup_material(
@@ -66,9 +66,9 @@ namespace POROFLUIDMULTIPHASE
 
   /// create solution algorithm depending on input file
   std::shared_ptr<Adapter::PoroFluidMultiphase> create_algorithm(
-      POROFLUIDMULTIPHASE::TimeIntegrationScheme timintscheme,  //!< time discretization scheme
-      std::shared_ptr<Core::FE::Discretization> dis,            //!< discretization
-      const int linsolvernumber,                                //!< number of linear solver
+      PoroPressureBased::TimeIntegrationScheme timintscheme,  //!< time discretization scheme
+      std::shared_ptr<Core::FE::Discretization> dis,          //!< discretization
+      const int linsolvernumber,                              //!< number of linear solver
       const Teuchos::ParameterList& probparams,               //!< parameter list of global problem
       const Teuchos::ParameterList& poroparams,               //!< parameter list of poro problem
       std::shared_ptr<Core::IO::DiscretizationWriter> output  //!< output writer
@@ -128,7 +128,7 @@ namespace POROFLUIDMULTIPHASE
       Core::FE::Discretization& dis, const Core::LinAlg::Map* nodemap);
 
   //! Determine norm of vector
-  double calculate_vector_norm(const enum POROFLUIDMULTIPHASE::VectorNorm norm,  //!< norm to use
+  double calculate_vector_norm(const enum PoroPressureBased::VectorNorm norm,  //!< norm to use
       const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
   );
 
@@ -144,7 +144,7 @@ namespace POROFLUIDMULTIPHASE
 
   // Print the logo
   void print_logo();
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_adapter.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_adapter.hpp
@@ -30,7 +30,7 @@ namespace Core::LinAlg
   class Solver;
 }
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   class PoroMultiPhase
   {
@@ -167,7 +167,7 @@ namespace POROMULTIPHASE
     virtual void build_artery_block_null_space(
         std::shared_ptr<Core::LinAlg::Solver>& solver, const int& arteryblocknum) = 0;
   };
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
@@ -25,7 +25,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | constructor                                              vuong 08/16  |
  *----------------------------------------------------------------------*/
-POROMULTIPHASE::PoroMultiPhaseBase::PoroMultiPhaseBase(
+PoroPressureBased::PoroMultiPhaseBase::PoroMultiPhaseBase(
     MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : AlgorithmBase(comm, globaltimeparams),
       structure_(nullptr),
@@ -39,7 +39,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::PoroMultiPhaseBase(
 /*----------------------------------------------------------------------*
  | initialize algorithm                                    vuong 08/16  |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::init(const Teuchos::ParameterList& globaltimeparams,
+void PoroPressureBased::PoroMultiPhaseBase::init(const Teuchos::ParameterList& globaltimeparams,
     const Teuchos::ParameterList& algoparams, const Teuchos::ParameterList& structparams,
     const Teuchos::ParameterList& fluidparams, const std::string& struct_disname,
     const std::string& fluid_disname, bool isale, int nds_disp, int nds_vel, int nds_solidpressure,
@@ -90,11 +90,11 @@ void POROMULTIPHASE::PoroMultiPhaseBase::init(const Teuchos::ParameterList& glob
   // algorithm construction depending on
   // time-integration (or stationary) scheme
   // -------------------------------------------------------------------
-  auto timintscheme = Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::TimeIntegrationScheme>(
+  auto timintscheme = Teuchos::getIntegralValue<PoroPressureBased::TimeIntegrationScheme>(
       fluidparams, "TIMEINTEGR");
 
   // build poro fluid time integrator
-  std::shared_ptr<Adapter::PoroFluidMultiphase> porofluid = POROFLUIDMULTIPHASE::create_algorithm(
+  std::shared_ptr<Adapter::PoroFluidMultiphase> porofluid = PoroPressureBased::create_algorithm(
       timintscheme, fluiddis, linsolvernumber, globaltimeparams, fluidparams, output);
 
   // wrap it
@@ -108,7 +108,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::init(const Teuchos::ParameterList& glob
 
 /*----------------------------------------------------------------------*
 ----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::post_init()
+void PoroPressureBased::PoroMultiPhaseBase::post_init()
 {
   // call post_setup routine of the structure field
   structure_->post_setup();
@@ -118,7 +118,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::post_init()
 /*----------------------------------------------------------------------*
  | read restart information for given time step (public)   vuong 08/16  |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::read_restart(int restart)
+void PoroPressureBased::PoroMultiPhaseBase::read_restart(int restart)
 {
   if (restart)
   {
@@ -139,7 +139,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::read_restart(int restart)
 /*----------------------------------------------------------------------*
  | time loop                                            kremheller 03/17 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::timeloop()
+void PoroPressureBased::PoroMultiPhaseBase::timeloop()
 {
   // prepare the loop
   prepare_time_loop();
@@ -160,7 +160,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::timeloop()
 /*----------------------------------------------------------------------*
  | prepare the time loop                                     vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::prepare_time_loop()
+void PoroPressureBased::PoroMultiPhaseBase::prepare_time_loop()
 {
   // initial output
   if (solve_structure_)
@@ -185,7 +185,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::prepare_time_loop()
 /*----------------------------------------------------------------------*
  | prepare one time step                                     vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::prepare_time_step()
+void PoroPressureBased::PoroMultiPhaseBase::prepare_time_step()
 {
   increment_time_and_step();
 
@@ -206,7 +206,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::prepare_time_step()
 /*----------------------------------------------------------------------*
  | Test the results of all subproblems                       vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::create_field_test()
+void PoroPressureBased::PoroMultiPhaseBase::create_field_test()
 {
   Global::Problem* problem = Global::Problem::instance();
 
@@ -217,7 +217,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::create_field_test()
 /*------------------------------------------------------------------------*
  | communicate the solution of the structure to the fluid    vuong 08/16  |
  *------------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::set_struct_solution(
+void PoroPressureBased::PoroMultiPhaseBase::set_struct_solution(
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
@@ -228,7 +228,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::set_struct_solution(
 /*------------------------------------------------------------------------*
  | communicate the structure velocity  to the fluid           vuong 08/16  |
  *------------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::set_velocity_fields(
+void PoroPressureBased::PoroMultiPhaseBase::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   fluid_->set_velocity_field(vel);
@@ -237,7 +237,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::set_velocity_fields(
 /*------------------------------------------------------------------------*
  | communicate the scatra solution to the fluid             vuong 08/16  |
  *------------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::set_scatra_solution(
+void PoroPressureBased::PoroMultiPhaseBase::set_scatra_solution(
     unsigned nds, std::shared_ptr<const Core::LinAlg::Vector<double>> scalars)
 {
   fluid_->set_scatra_solution(nds, scalars);
@@ -247,7 +247,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::set_scatra_solution(
 /*------------------------------------------------------------------------*
  | communicate the structure displacement to the fluid        vuong 08/16  |
  *------------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::set_mesh_disp(
+void PoroPressureBased::PoroMultiPhaseBase::set_mesh_disp(
     std::shared_ptr<const Core::LinAlg::Vector<double>> disp)
 {
   fluid_->apply_mesh_movement(disp);
@@ -256,7 +256,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::set_mesh_disp(
 /*----------------------------------------------------------------------*
  | update fields and output results                         vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::update_and_output()
+void PoroPressureBased::PoroMultiPhaseBase::update_and_output()
 {
   // prepare the output
   constexpr bool force_prepare = false;
@@ -280,7 +280,7 @@ void POROMULTIPHASE::PoroMultiPhaseBase::update_and_output()
 /*------------------------------------------------------------------------*
  | dof map of vector of unknowns of structure field           vuong 08/16  |
  *------------------------------------------------------------------------*/
-std::shared_ptr<const Core::LinAlg::Map> POROMULTIPHASE::PoroMultiPhaseBase::struct_dof_row_map()
+std::shared_ptr<const Core::LinAlg::Map> PoroPressureBased::PoroMultiPhaseBase::struct_dof_row_map()
     const
 {
   return structure_->dof_row_map();
@@ -289,7 +289,7 @@ std::shared_ptr<const Core::LinAlg::Map> POROMULTIPHASE::PoroMultiPhaseBase::str
 /*------------------------------------------------------------------------*
  | dof map of vector of unknowns of fluid field           vuong 08/16  |
  *------------------------------------------------------------------------*/
-std::shared_ptr<const Core::LinAlg::Map> POROMULTIPHASE::PoroMultiPhaseBase::fluid_dof_row_map()
+std::shared_ptr<const Core::LinAlg::Map> PoroPressureBased::PoroMultiPhaseBase::fluid_dof_row_map()
     const
 {
   return fluid_->dof_row_map();
@@ -299,7 +299,7 @@ std::shared_ptr<const Core::LinAlg::Map> POROMULTIPHASE::PoroMultiPhaseBase::flu
  | coupled artery-porofluid system matrix                kremheller 05/18 |
  *------------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase>
-POROMULTIPHASE::PoroMultiPhaseBase::artery_porofluid_sysmat() const
+PoroPressureBased::PoroMultiPhaseBase::artery_porofluid_sysmat() const
 {
   return fluid_->artery_porofluid_sysmat();
 }
@@ -307,7 +307,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::artery_porofluid_sysmat() const
 /*------------------------------------------------------------------------*
  | dof map of vector of unknowns of artery field         kremheller 05/18 |
  *------------------------------------------------------------------------*/
-std::shared_ptr<const Core::LinAlg::Map> POROMULTIPHASE::PoroMultiPhaseBase::artery_dof_row_map()
+std::shared_ptr<const Core::LinAlg::Map> PoroPressureBased::PoroMultiPhaseBase::artery_dof_row_map()
     const
 {
   return fluid_->artery_dof_row_map();
@@ -317,7 +317,7 @@ std::shared_ptr<const Core::LinAlg::Map> POROMULTIPHASE::PoroMultiPhaseBase::art
  | return structure displacements                             vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::struct_dispnp() const
+PoroPressureBased::PoroMultiPhaseBase::struct_dispnp() const
 {
   return structure_->dispnp();
 }
@@ -326,7 +326,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::struct_dispnp() const
  | return structure velocities                               vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::struct_velnp() const
+PoroPressureBased::PoroMultiPhaseBase::struct_velnp() const
 {
   return structure_->velnp();
 }
@@ -335,7 +335,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::struct_velnp() const
  | return fluid Flux                                         vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::MultiVector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::fluid_flux() const
+PoroPressureBased::PoroMultiPhaseBase::fluid_flux() const
 {
   return fluid_->flux();
 }
@@ -344,7 +344,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::fluid_flux() const
  | return fluid Flux                                         vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::fluid_phinp() const
+PoroPressureBased::PoroMultiPhaseBase::fluid_phinp() const
 {
   return fluid_->phinp();
 }
@@ -353,7 +353,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::fluid_phinp() const
  | return fluid Flux                                         vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::fluid_saturation() const
+PoroPressureBased::PoroMultiPhaseBase::fluid_saturation() const
 {
   return fluid_->saturation();
 }
@@ -362,7 +362,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::fluid_saturation() const
  | return fluid Flux                                         vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::fluid_pressure() const
+PoroPressureBased::PoroMultiPhaseBase::fluid_pressure() const
 {
   return fluid_->pressure();
 }
@@ -371,7 +371,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::fluid_pressure() const
  | return fluid Flux                                         vuong 08/16  |
  *------------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-POROMULTIPHASE::PoroMultiPhaseBase::solid_pressure() const
+PoroPressureBased::PoroMultiPhaseBase::solid_pressure() const
 {
   return fluid_->solid_pressure();
 }
@@ -379,7 +379,7 @@ POROMULTIPHASE::PoroMultiPhaseBase::solid_pressure() const
 /*----------------------------------------------------------------------*
  | inform user that structure is not solved            kremheller 04/17 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhaseBase::print_structure_disabled_info()
+void PoroPressureBased::PoroMultiPhaseBase::print_structure_disabled_info()
 {
   // print out Info
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.cpp
@@ -94,9 +94,8 @@ void POROMULTIPHASE::PoroMultiPhaseBase::init(const Teuchos::ParameterList& glob
       fluidparams, "TIMEINTEGR");
 
   // build poro fluid time integrator
-  std::shared_ptr<Adapter::PoroFluidMultiphase> porofluid =
-      POROFLUIDMULTIPHASE::Utils::create_algorithm(
-          timintscheme, fluiddis, linsolvernumber, globaltimeparams, fluidparams, output);
+  std::shared_ptr<Adapter::PoroFluidMultiphase> porofluid = POROFLUIDMULTIPHASE::create_algorithm(
+      timintscheme, fluiddis, linsolvernumber, globaltimeparams, fluidparams, output);
 
   // wrap it
   fluid_ = std::make_shared<Adapter::PoroFluidMultiphaseWrapper>(porofluid);

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_base.hpp
@@ -28,7 +28,7 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhaseBase : public Adapter::AlgorithmBase, public PoroMultiPhase
@@ -235,7 +235,7 @@ namespace POROMULTIPHASE
   };  // PoroMultiPhaseBase
 
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
@@ -49,7 +49,7 @@ void poromultiphase_dyn(int restart)
 
   // Setup discretizations and coupling. Assign the dof sets and return the numbers
   std::map<int, std::set<int>> nearbyelepairs =
-      POROMULTIPHASE::Utils::setup_discretizations_and_field_coupling(
+      POROMULTIPHASE::setup_discretizations_and_field_coupling(
           comm, struct_disname, fluid_disname, nds_disp, nds_vel, nds_solidpressure);
 
   // Parameter reading
@@ -67,7 +67,7 @@ void poromultiphase_dyn(int restart)
       Teuchos::getIntegralValue<POROMULTIPHASE::SolutionSchemeOverFields>(poroparams, "COUPALGO");
 
   std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> algo =
-      POROMULTIPHASE::Utils::create_poro_multi_phase_algorithm(solscheme, poroparams, comm);
+      POROMULTIPHASE::create_poro_multi_phase_algorithm(solscheme, poroparams, comm);
 
   // initialize
   algo->init(poroparams, poroparams, structdyn, fluiddyn, struct_disname, fluid_disname, true,
@@ -88,7 +88,7 @@ void poromultiphase_dyn(int restart)
   // assign poro material for evaluation of porosity
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  POROMULTIPHASE::Utils::assign_material_pointers(struct_disname, fluid_disname);
+  POROMULTIPHASE::assign_material_pointers(struct_disname, fluid_disname);
 
   // Setup the solver (only for the monolithic problem)
   algo->setup_solver();

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
@@ -37,7 +37,6 @@ void poromultiphase_dyn(int restart)
   // print problem type
   if (Core::Communication::my_mpi_rank(comm) == 0)
   {
-    PoroPressureBased::print_logo();
     std::cout << "###################################################" << std::endl;
     std::cout << "# YOUR PROBLEM TYPE: " << problem->problem_name() << std::endl;
     std::cout << "###################################################" << std::endl;
@@ -50,7 +49,7 @@ void poromultiphase_dyn(int restart)
 
   // Setup discretizations and coupling. Assign the dof sets and return the numbers
   std::map<int, std::set<int>> nearbyelepairs =
-      PoroPressureBased::setup_discretizations_and_field_coupling(
+      PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast(
           comm, struct_disname, fluid_disname, nds_disp, nds_vel, nds_solidpressure);
 
   // Parameter reading
@@ -64,11 +63,11 @@ void poromultiphase_dyn(int restart)
   // algorithm construction depending on
   // coupling scheme
   // -------------------------------------------------------------------
-  auto solscheme = Teuchos::getIntegralValue<PoroPressureBased::SolutionSchemeOverFields>(
+  auto solscheme = Teuchos::getIntegralValue<PoroPressureBased::SolutionSchemePorofluidElast>(
       poroparams, "COUPALGO");
 
   std::shared_ptr<PoroPressureBased::PoroMultiPhase> algo =
-      PoroPressureBased::create_poro_multi_phase_algorithm(solscheme, poroparams, comm);
+      PoroPressureBased::create_algorithm_porofluid_elast(solscheme, poroparams, comm);
 
   // initialize
   algo->init(poroparams, poroparams, structdyn, fluiddyn, struct_disname, fluid_disname, true,
@@ -89,7 +88,7 @@ void poromultiphase_dyn(int restart)
   // assign poro material for evaluation of porosity
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  PoroPressureBased::assign_material_pointers(struct_disname, fluid_disname);
+  PoroPressureBased::assign_material_pointers_porofluid_elast(struct_disname, fluid_disname);
 
   // Setup the solver (only for the monolithic problem)
   algo->setup_solver();

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_dyn.cpp
@@ -12,6 +12,7 @@
 #include "4C_porofluid_pressure_based_elast_adapter.hpp"
 #include "4C_porofluid_pressure_based_elast_input.hpp"
 #include "4C_porofluid_pressure_based_elast_utils.hpp"
+#include "4C_porofluid_pressure_based_utils.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>
@@ -36,7 +37,7 @@ void poromultiphase_dyn(int restart)
   // print problem type
   if (Core::Communication::my_mpi_rank(comm) == 0)
   {
-    POROMULTIPHASE::print_logo();
+    PoroPressureBased::print_logo();
     std::cout << "###################################################" << std::endl;
     std::cout << "# YOUR PROBLEM TYPE: " << problem->problem_name() << std::endl;
     std::cout << "###################################################" << std::endl;
@@ -49,7 +50,7 @@ void poromultiphase_dyn(int restart)
 
   // Setup discretizations and coupling. Assign the dof sets and return the numbers
   std::map<int, std::set<int>> nearbyelepairs =
-      POROMULTIPHASE::setup_discretizations_and_field_coupling(
+      PoroPressureBased::setup_discretizations_and_field_coupling(
           comm, struct_disname, fluid_disname, nds_disp, nds_vel, nds_solidpressure);
 
   // Parameter reading
@@ -63,11 +64,11 @@ void poromultiphase_dyn(int restart)
   // algorithm construction depending on
   // coupling scheme
   // -------------------------------------------------------------------
-  auto solscheme =
-      Teuchos::getIntegralValue<POROMULTIPHASE::SolutionSchemeOverFields>(poroparams, "COUPALGO");
+  auto solscheme = Teuchos::getIntegralValue<PoroPressureBased::SolutionSchemeOverFields>(
+      poroparams, "COUPALGO");
 
-  std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> algo =
-      POROMULTIPHASE::create_poro_multi_phase_algorithm(solscheme, poroparams, comm);
+  std::shared_ptr<PoroPressureBased::PoroMultiPhase> algo =
+      PoroPressureBased::create_poro_multi_phase_algorithm(solscheme, poroparams, comm);
 
   // initialize
   algo->init(poroparams, poroparams, structdyn, fluiddyn, struct_disname, fluid_disname, true,
@@ -88,7 +89,7 @@ void poromultiphase_dyn(int restart)
   // assign poro material for evaluation of porosity
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  POROMULTIPHASE::assign_material_pointers(struct_disname, fluid_disname);
+  PoroPressureBased::assign_material_pointers(struct_disname, fluid_disname);
 
   // Setup the solver (only for the monolithic problem)
   algo->setup_solver();

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
@@ -4,17 +4,18 @@
 // See the LICENSE.md file in the top-level for license information.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
-
 #include "4C_porofluid_pressure_based_elast_input.hpp"
 
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
+#include "4C_porofluid_pressure_based_input.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
 
-void POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
+void PoroPressureBased::set_valid_parameters_porofluid_elast(
+    std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
 
@@ -90,25 +91,25 @@ void POROMULTIPHASE::set_valid_parameters(std::map<std::string, Core::IO::InputS
 
           deprecated_selection<VectorNorm>("VECTORNORM_RESF",
               {
-                  {"L1", POROMULTIPHASE::norm_l1},
-                  {"L1_Scaled", POROMULTIPHASE::norm_l1_scaled},
-                  {"L2", POROMULTIPHASE::norm_l2},
-                  {"Rms", POROMULTIPHASE::norm_rms},
-                  {"Inf", POROMULTIPHASE::norm_inf},
+                  {"L1", PoroPressureBased::norm_l1},
+                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
+                  {"L2", PoroPressureBased::norm_l2},
+                  {"Rms", PoroPressureBased::norm_rms},
+                  {"Inf", PoroPressureBased::norm_inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = POROMULTIPHASE::norm_l2}),
+                  .default_value = PoroPressureBased::norm_l2}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_INC",
               {
-                  {"L1", POROMULTIPHASE::norm_l1},
-                  {"L1_Scaled", POROMULTIPHASE::norm_l1_scaled},
-                  {"L2", POROMULTIPHASE::norm_l2},
-                  {"Rms", POROMULTIPHASE::norm_rms},
-                  {"Inf", POROMULTIPHASE::norm_inf},
+                  {"L1", PoroPressureBased::norm_l1},
+                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
+                  {"L2", PoroPressureBased::norm_l2},
+                  {"Rms", PoroPressureBased::norm_rms},
+                  {"Inf", PoroPressureBased::norm_inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = POROMULTIPHASE::norm_l2}),
+                  .default_value = PoroPressureBased::norm_l2}),
 
           // flag for equilibration of global system of equations
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
@@ -50,13 +50,13 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
 
 
           // Coupling strategy for solvers
-          deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
+          deprecated_selection<SolutionSchemePorofluidElast>("COUPALGO",
               {
-                  {"twoway_partitioned", solscheme_twoway_partitioned},
-                  {"twoway_monolithic", solscheme_twoway_monolithic},
+                  {"twoway_partitioned", SolutionSchemePorofluidElast::twoway_partitioned},
+                  {"twoway_monolithic", SolutionSchemePorofluidElast::twoway_monolithic},
               },
               {.description = "Coupling strategies for poro multiphase solvers",
-                  .default_value = solscheme_twoway_partitioned}),
+                  .default_value = SolutionSchemePorofluidElast::twoway_partitioned}),
 
           // coupling with 1D artery network active
           parameter<bool>("ARTERY_COUPLING",

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
@@ -55,7 +55,7 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
                   {"twoway_partitioned", SolutionSchemePorofluidElast::twoway_partitioned},
                   {"twoway_monolithic", SolutionSchemePorofluidElast::twoway_monolithic},
               },
-              {.description = "Coupling strategies for poro multiphase solvers",
+              {.description = "Coupling strategies for porofluid-elasticity solvers",
                   .default_value = SolutionSchemePorofluidElast::twoway_partitioned}),
 
           // coupling with 1D artery network active
@@ -83,33 +83,33 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
           // parameters for finite difference check
           deprecated_selection<FdCheck>("FDCHECK",
               {
-                  {"none", fdcheck_none},
-                  {"global", fdcheck_global},
+                  {"none", FdCheck::none},
+                  {"global", FdCheck::global},
               },
               {.description = "flag for finite difference check: none or global",
-                  .default_value = fdcheck_none}),
+                  .default_value = FdCheck::none}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_RESF",
               {
-                  {"L1", PoroPressureBased::norm_l1},
-                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
-                  {"L2", PoroPressureBased::norm_l2},
-                  {"Rms", PoroPressureBased::norm_rms},
-                  {"Inf", PoroPressureBased::norm_inf},
+                  {"L1", VectorNorm::l1},
+                  {"L1_Scaled", VectorNorm::l1_scaled},
+                  {"L2", VectorNorm::l2},
+                  {"Rms", VectorNorm::rms},
+                  {"Inf", VectorNorm::inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroPressureBased::norm_l2}),
+                  .default_value = VectorNorm::l2}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_INC",
               {
-                  {"L1", PoroPressureBased::norm_l1},
-                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
-                  {"L2", PoroPressureBased::norm_l2},
-                  {"Rms", PoroPressureBased::norm_rms},
-                  {"Inf", PoroPressureBased::norm_inf},
+                  {"L1", VectorNorm::l1},
+                  {"L1_Scaled", VectorNorm::l1_scaled},
+                  {"L2", VectorNorm::l2},
+                  {"Rms", VectorNorm::rms},
+                  {"Inf", VectorNorm::inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroPressureBased::norm_l2}),
+                  .default_value = VectorNorm::l2}),
 
           // flag for equilibration of global system of equations
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
@@ -140,12 +140,12 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
           // flag for relaxation of partitioned scheme
           deprecated_selection<RelaxationMethods>("RELAXATION",
               {
-                  {"none", relaxation_none},
-                  {"Constant", relaxation_constant},
-                  {"Aitken", relaxation_aitken},
+                  {"none", RelaxationMethods::none},
+                  {"Constant", RelaxationMethods::constant},
+                  {"Aitken", RelaxationMethods::aitken},
               },
               {.description = "flag for relaxation of partitioned scheme",
-                  .default_value = relaxation_none}),
+                  .default_value = RelaxationMethods::none}),
 
           // parameters for relaxation of partitioned coupling
           parameter<double>(

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.hpp
@@ -23,7 +23,7 @@ namespace Core::Conditions
   class ConditionDefinition;
 }  // namespace Core::Conditions
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   /// Type of coupling strategy for POROMULTIPHASE problems
   enum SolutionSchemeOverFields
@@ -31,24 +31,6 @@ namespace POROMULTIPHASE
     solscheme_undefined,
     solscheme_twoway_partitioned,
     solscheme_twoway_monolithic
-  };
-
-  /// type of finite difference check
-  enum FdCheck
-  {
-    fdcheck_none,
-    fdcheck_global
-  };
-
-  /// type of norm to be calculated
-  enum VectorNorm
-  {
-    norm_undefined,
-    norm_l1,         //!< L1/linear norm
-    norm_l1_scaled,  //!< L1/linear norm scaled by length of vector
-    norm_l2,         //!< L2/Euclidean norm
-    norm_rms,        //!< root mean square (RMS) norm
-    norm_inf         //!< Maximum/infinity norm
   };
 
   //! relaxation methods for partitioned coupling
@@ -59,10 +41,10 @@ namespace POROMULTIPHASE
     relaxation_aitken
   };
 
-  /// set the POROMULTIPHASE parameters
-  void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
+  /// set the valid parameters
+  void set_valid_parameters_porofluid_elast(std::map<std::string, Core::IO::InputSpec>& list);
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.hpp
@@ -26,11 +26,11 @@ namespace Core::Conditions
 namespace PoroPressureBased
 {
   /// Type of coupling strategy for POROMULTIPHASE problems
-  enum SolutionSchemeOverFields
+  enum class SolutionSchemePorofluidElast
   {
-    solscheme_undefined,
-    solscheme_twoway_partitioned,
-    solscheme_twoway_monolithic
+    undefined,
+    twoway_partitioned,
+    twoway_monolithic
   };
 
   //! relaxation methods for partitioned coupling

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.hpp
@@ -25,7 +25,7 @@ namespace Core::Conditions
 
 namespace PoroPressureBased
 {
-  /// Type of coupling strategy for POROMULTIPHASE problems
+  /// type of coupling strategy for porofluid-elasticity problems
   enum class SolutionSchemePorofluidElast
   {
     undefined,
@@ -34,14 +34,14 @@ namespace PoroPressureBased
   };
 
   //! relaxation methods for partitioned coupling
-  enum RelaxationMethods
+  enum class RelaxationMethods
   {
-    relaxation_none,
-    relaxation_constant,
-    relaxation_aitken
+    none,
+    constant,
+    aitken
   };
 
-  /// set the valid parameters
+  /// set the valid parameters for porofluid-elasticity problems
   void set_valid_parameters_porofluid_elast(std::map<std::string, Core::IO::InputSpec>& list);
 
 }  // namespace PoroPressureBased

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -13,7 +13,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-POROMULTIPHASE::PoroMultiPhaseMonolithic::PoroMultiPhaseMonolithic(
+PoroPressureBased::PoroMultiPhaseMonolithic::PoroMultiPhaseMonolithic(
     MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : PoroMultiPhaseBase(comm, globaltimeparams)
 {

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.hpp
@@ -14,7 +14,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhaseMonolithic : public PoroMultiPhaseBase
@@ -27,7 +27,7 @@ namespace POROMULTIPHASE
   };  // PoroMultiPhaseMonolithic
 
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
@@ -66,12 +66,12 @@ PoroPressureBased::PoroMultiPhaseMonolithicTwoWay::PoroMultiPhaseMonolithicTwoWa
       arterypressnorm_(0.0),
       maxinc_(0.0),
       maxres_(0.0),
-      vectornormfres_(PoroPressureBased::norm_undefined),
-      vectornorminc_(PoroPressureBased::norm_undefined),
+      vectornormfres_(VectorNorm::undefined),
+      vectornorminc_(VectorNorm::undefined),
       timernewton_("", true),
       dtsolve_(0.0),
       dtele_(0.0),
-      fdcheck_(PoroPressureBased::FdCheck::fdcheck_none)
+      fdcheck_(PoroPressureBased::FdCheck::none)
 {
 }
 
@@ -209,7 +209,7 @@ void PoroPressureBased::PoroMultiPhaseMonolithicTwoWay::time_step()
       evaluate(iterinc_);
 
       // perform FD Check of monolithic system matrix
-      if (fdcheck_ == PoroPressureBased::fdcheck_global) poro_fd_check();
+      if (fdcheck_ == FdCheck::global) poro_fd_check();
     }
     else
     {

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.cpp
@@ -746,7 +746,7 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::print_header()
 void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::build_convergence_norms()
 {
   //------------------------------------------------------------ build residual force norms
-  normrhs_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_);
+  normrhs_ = calculate_vector_norm(vectornormfres_, *rhs_);
   std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_s;
   std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_f;
 
@@ -754,8 +754,8 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::build_convergence_norms()
   extract_structure_and_fluid_vectors(rhs_, rhs_s, rhs_f);
 
   // build also norms for fluid and structure
-  normrhsstruct_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_s);
-  normrhsfluid_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_f);
+  normrhsstruct_ = calculate_vector_norm(vectornormfres_, *rhs_s);
+  normrhsfluid_ = calculate_vector_norm(vectornormfres_, *rhs_f);
 
   //------------------------------------------------------------- build residual increment norms
   // displacement and fluid velocity & pressure incremental vector
@@ -766,11 +766,11 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay::build_convergence_norms()
   extract_structure_and_fluid_vectors(iterinc_, iterincs, iterincf);
 
   // build also norms for fluid and structure
-  normincstruct_ = Utils::calculate_vector_norm(vectornorminc_, *iterincs);
-  normincfluid_ = Utils::calculate_vector_norm(vectornorminc_, *iterincf);
+  normincstruct_ = calculate_vector_norm(vectornorminc_, *iterincs);
+  normincfluid_ = calculate_vector_norm(vectornorminc_, *iterincf);
 
-  double dispnorm = Utils::calculate_vector_norm(vectornorminc_, (*structure_field()->dispnp()));
-  double fluidnorm = Utils::calculate_vector_norm(vectornorminc_, (*fluid_field()->phinp()));
+  double dispnorm = calculate_vector_norm(vectornorminc_, (*structure_field()->dispnp()));
+  double fluidnorm = calculate_vector_norm(vectornorminc_, (*fluid_field()->phinp()));
 
   // take care of very small norms
   if (dispnorm < 1.0e-6) dispnorm = 1.0;
@@ -1336,10 +1336,10 @@ void POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWayArteryCoupling::build_converg
       extractor()->extract_vector(*iterinc_, 2);
 
   // build also norms for artery
-  normrhsart_ = Utils::calculate_vector_norm(vectornormfres_, *arteryrhs);
-  normincart_ = Utils::calculate_vector_norm(vectornorminc_, *arteryinc);
-  arterypressnorm_ = Utils::calculate_vector_norm(
-      vectornorminc_, (*fluid_field()->art_net_tim_int()->pressurenp()));
+  normrhsart_ = calculate_vector_norm(vectornormfres_, *arteryrhs);
+  normincart_ = calculate_vector_norm(vectornorminc_, *arteryinc);
+  arterypressnorm_ =
+      calculate_vector_norm(vectornorminc_, (*fluid_field()->art_net_tim_int()->pressurenp()));
 
   // call base class
   PoroMultiPhaseMonolithicTwoWay::build_convergence_norms();

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic_twoway.hpp
@@ -10,8 +10,8 @@
 
 #include "4C_config.hpp"
 
-#include "4C_porofluid_pressure_based_elast_input.hpp"
 #include "4C_porofluid_pressure_based_elast_monolithic.hpp"
+#include "4C_porofluid_pressure_based_input.hpp"
 
 #include <Teuchos_Time.hpp>
 
@@ -39,7 +39,7 @@ namespace Core::Conditions
   class LocsysManager;
 }
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhaseMonolithicTwoWay : public PoroMultiPhaseMonolithic
@@ -276,8 +276,8 @@ namespace POROMULTIPHASE
     double maxinc_;  //!< maximum increment
     double maxres_;  //!< maximum residual
 
-    enum POROMULTIPHASE::VectorNorm vectornormfres_;  //!< type of norm for residual
-    enum POROMULTIPHASE::VectorNorm vectornorminc_;   //!< type of norm for increments
+    enum PoroPressureBased::VectorNorm vectornormfres_;  //!< type of norm for residual
+    enum PoroPressureBased::VectorNorm vectornorminc_;   //!< type of norm for increments
 
     Teuchos::Time timernewton_;  //!< timer for measurement of solution time of newton iterations
     double dtsolve_;             //!< linear solver time
@@ -287,7 +287,7 @@ namespace POROMULTIPHASE
     std::shared_ptr<Core::Conditions::LocsysManager> locsysman_;
 
     //! flag for finite difference check
-    POROMULTIPHASE::FdCheck fdcheck_;
+    PoroPressureBased::FdCheck fdcheck_;
 
   };  // PoroMultiPhasePartitioned
 
@@ -342,7 +342,7 @@ namespace POROMULTIPHASE
   };
 
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.cpp
@@ -13,7 +13,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-POROMULTIPHASE::PoroMultiPhasePartitioned::PoroMultiPhasePartitioned(
+PoroPressureBased::PoroMultiPhasePartitioned::PoroMultiPhasePartitioned(
     MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : PoroMultiPhaseBase(comm, globaltimeparams)
 {

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned.hpp
@@ -14,7 +14,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhasePartitioned : public PoroMultiPhaseBase
@@ -27,7 +27,7 @@ namespace POROMULTIPHASE
   };  // PoroMultiPhasePartitioned
 
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned_twoway.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned_twoway.cpp
@@ -22,7 +22,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | constructor                                              vuong 08/16 |
  *----------------------------------------------------------------------*/
-POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::PoroMultiPhasePartitionedTwoWay(
+PoroPressureBased::PoroMultiPhasePartitionedTwoWay::PoroMultiPhasePartitionedTwoWay(
     MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : PoroMultiPhasePartitioned(comm, globaltimeparams),
       phiincnp_(nullptr),
@@ -39,14 +39,14 @@ POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::PoroMultiPhasePartitionedTwoWay
       itnum_(0),
       writerestartevery_(-1),
       artery_coupling_active_(false),
-      relaxationmethod_(POROMULTIPHASE::RelaxationMethods::relaxation_none)
+      relaxationmethod_(PoroPressureBased::RelaxationMethods::relaxation_none)
 {
 }
 
 /*----------------------------------------------------------------------*
  | initialization                                            vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::init(
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::init(
     const Teuchos::ParameterList& globaltimeparams, const Teuchos::ParameterList& algoparams,
     const Teuchos::ParameterList& structparams, const Teuchos::ParameterList& fluidparams,
     const std::string& struct_disname, const std::string& fluid_disname, bool isale, int nds_disp,
@@ -54,7 +54,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::init(
     const std::map<int, std::set<int>>* nearbyelepairs)
 {
   // call base class
-  POROMULTIPHASE::PoroMultiPhasePartitioned::init(globaltimeparams, algoparams, structparams,
+  PoroPressureBased::PoroMultiPhasePartitioned::init(globaltimeparams, algoparams, structparams,
       fluidparams, struct_disname, fluid_disname, isale, nds_disp, nds_vel, nds_solidpressure,
       ndsporofluid_scatra, nearbyelepairs);
 
@@ -87,14 +87,14 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::init(
   omegamin_ = algoparams.sublist("PARTITIONED").get<double>("MINOMEGA");
   omegamax_ = algoparams.sublist("PARTITIONED").get<double>("MAXOMEGA");
 
-  relaxationmethod_ = Teuchos::getIntegralValue<POROMULTIPHASE::RelaxationMethods>(
+  relaxationmethod_ = Teuchos::getIntegralValue<PoroPressureBased::RelaxationMethods>(
       algoparams.sublist("PARTITIONED"), "RELAXATION");
 }
 
 /*----------------------------------------------------------------------*
  | setup the system if necessary                             vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::setup_system()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::setup_system()
 {
   // Do nothing, just monolithic coupling needs this method
   return;
@@ -103,7 +103,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::setup_system()
 /*----------------------------------------------------------------------*
  | Outer Timeloop  without relaxation                        vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::outer_loop()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::outer_loop()
 {
   // reset counter
   itnum_ = 0;
@@ -167,7 +167,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::outer_loop()
 /*----------------------------------------------------------------------*
  | convergence check for both fields (copied form tsi)       vuong 08/16 |
  *----------------------------------------------------------------------*/
-bool POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::convergence_check(int itnum)
+bool PoroPressureBased::PoroMultiPhasePartitionedTwoWay::convergence_check(int itnum)
 {
   // convergence check based on the scalar increment
   bool stopnonliniter = false;
@@ -279,7 +279,7 @@ bool POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::convergence_check(int itnu
 /*----------------------------------------------------------------------*
  | Solve structure filed                                     vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::do_struct_step()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::do_struct_step()
 {
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
   {
@@ -300,7 +300,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::do_struct_step()
 /*----------------------------------------------------------------------*
  | Solve poro fluid field                                    vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::do_fluid_step()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::do_fluid_step()
 {
   // -------------------------------------------------------------------
   //                  solve nonlinear / linear equation
@@ -313,7 +313,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::do_fluid_step()
 /*----------------------------------------------------------------------*
  | Set relaxed fluid solution on structure             kremheller 09/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::set_relaxed_fluid_solution()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::set_relaxed_fluid_solution()
 {
   // set fluid solution on structure
   structure_field()->discretization()->set_state(1, "porofluid", *fluidphinp_);
@@ -324,7 +324,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::set_relaxed_fluid_solution
 /*----------------------------------------------------------------------*
  | Calculate relaxation parameter omega                kremheller 09/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
     std::shared_ptr<const Core::LinAlg::Vector<double>> phi, const int itnum)
 {
   // get the increment vector
@@ -333,14 +333,14 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
   // perform relaxation
   switch (relaxationmethod_)
   {
-    case POROMULTIPHASE::RelaxationMethods::relaxation_none:
+    case PoroPressureBased::RelaxationMethods::relaxation_none:
     {
       // no relaxation
       omega_ = 1.0;
       break;
     }
 
-    case POROMULTIPHASE::RelaxationMethods::relaxation_constant:
+    case PoroPressureBased::RelaxationMethods::relaxation_constant:
     {
       // constant relaxation parameter omega
       omega_ = startomega_;
@@ -349,7 +349,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
       break;
     }
 
-    case POROMULTIPHASE::RelaxationMethods::relaxation_aitken:
+    case PoroPressureBased::RelaxationMethods::relaxation_aitken:
     {
       // Aitken
       aitken_relaxation(omega_, itnum);
@@ -378,7 +378,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
 /*----------------------------------------------------------------------*
  | Perform Aitken relaxation                           kremheller 09/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::aitken_relaxation(
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::aitken_relaxation(
     double& omega, const int itnum)
 {
   // fluidphiincnpdiff =  r^{i+1}_{n+1} - r^i_{n+1}
@@ -433,7 +433,7 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::aitken_relaxation(
 /*----------------------------------------------------------------------*
  | update the current states in every iteration             vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::iter_update_states()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::iter_update_states()
 {
   // store last solutions (current states).
   // will be compared in convergence_check to the solutions,
@@ -449,12 +449,12 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::iter_update_states()
 /*-------------------------------------------------------------------------*
  | read restart information for given time step (public) kremheller 09/17  |
  *-------------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::read_restart(int restart)
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::read_restart(int restart)
 {
   if (restart)
   {
     // call base class
-    POROMULTIPHASE::PoroMultiPhaseBase::read_restart(restart);
+    PoroPressureBased::PoroMultiPhaseBase::read_restart(restart);
 
     Core::IO::DiscretizationReader reader(fluid_field()->discretization(),
         Global::Problem::instance()->input_control_file(), restart);
@@ -475,10 +475,10 @@ void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::read_restart(int restart)
 /*----------------------------------------------------------------------*
  | update fields and output results                    kremheller 09/17 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay::update_and_output()
+void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::update_and_output()
 {
   // call base class
-  POROMULTIPHASE::PoroMultiPhaseBase::update_and_output();
+  PoroPressureBased::PoroMultiPhaseBase::update_and_output();
 
   // write interface force and relaxation parameter in restart
   if (writerestartevery_ and step() % writerestartevery_ == 0)

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned_twoway.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned_twoway.cpp
@@ -39,7 +39,7 @@ PoroPressureBased::PoroMultiPhasePartitionedTwoWay::PoroMultiPhasePartitionedTwo
       itnum_(0),
       writerestartevery_(-1),
       artery_coupling_active_(false),
-      relaxationmethod_(PoroPressureBased::RelaxationMethods::relaxation_none)
+      relaxationmethod_(PoroPressureBased::RelaxationMethods::none)
 {
 }
 
@@ -333,14 +333,14 @@ void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
   // perform relaxation
   switch (relaxationmethod_)
   {
-    case PoroPressureBased::RelaxationMethods::relaxation_none:
+    case PoroPressureBased::RelaxationMethods::none:
     {
       // no relaxation
       omega_ = 1.0;
       break;
     }
 
-    case PoroPressureBased::RelaxationMethods::relaxation_constant:
+    case PoroPressureBased::RelaxationMethods::constant:
     {
       // constant relaxation parameter omega
       omega_ = startomega_;
@@ -349,7 +349,7 @@ void PoroPressureBased::PoroMultiPhasePartitionedTwoWay::perform_relaxation(
       break;
     }
 
-    case PoroPressureBased::RelaxationMethods::relaxation_aitken:
+    case PoroPressureBased::RelaxationMethods::aitken:
     {
       // Aitken
       aitken_relaxation(omega_, itnum);

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned_twoway.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_partitioned_twoway.hpp
@@ -15,7 +15,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhasePartitionedTwoWay : public PoroMultiPhasePartitioned
@@ -113,12 +113,12 @@ namespace POROMULTIPHASE
     bool artery_coupling_active_;
 
     //! relaxation method
-    POROMULTIPHASE::RelaxationMethods relaxationmethod_;
+    PoroPressureBased::RelaxationMethods relaxationmethod_;
 
   };  // PoroMultiPhasePartitioned
 
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
@@ -26,9 +26,10 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | setup discretizations and dofsets                         vuong 08/16 |
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> PoroPressureBased::setup_discretizations_and_field_coupling(
-    MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
-    int& nds_disp, int& nds_vel, int& nds_solidpressure)
+std::map<int, std::set<int>>
+PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast(MPI_Comm comm,
+    const std::string& struct_disname, const std::string& fluid_disname, int& nds_disp,
+    int& nds_vel, int& nds_solidpressure)
 {
   // Scheme   : the structure discretization is received from the input.
   //            Then, a poro fluid disc. is cloned.
@@ -138,7 +139,7 @@ std::map<int, std::set<int>> PoroPressureBased::setup_discretizations_and_field_
 /*----------------------------------------------------------------------*
  | exchange material pointers of both discretizations       vuong 08/16 |
  *----------------------------------------------------------------------*/
-void PoroPressureBased::assign_material_pointers(
+void PoroPressureBased::assign_material_pointers_porofluid_elast(
     const std::string& struct_disname, const std::string& fluid_disname)
 {
   Global::Problem* problem = Global::Problem::instance();
@@ -153,22 +154,22 @@ void PoroPressureBased::assign_material_pointers(
  | create algorithm                                                      |
  *----------------------------------------------------------------------*/
 std::shared_ptr<PoroPressureBased::PoroMultiPhase>
-PoroPressureBased::create_poro_multi_phase_algorithm(
-    PoroPressureBased::SolutionSchemeOverFields solscheme, const Teuchos::ParameterList& timeparams,
-    MPI_Comm comm)
+PoroPressureBased::create_algorithm_porofluid_elast(
+    PoroPressureBased::SolutionSchemePorofluidElast solscheme,
+    const Teuchos::ParameterList& timeparams, MPI_Comm comm)
 {
   // Creation of Coupled Problem algorithm.
   std::shared_ptr<PoroPressureBased::PoroMultiPhase> algo = nullptr;
 
   switch (solscheme)
   {
-    case PoroPressureBased::solscheme_twoway_partitioned:
+    case SolutionSchemePorofluidElast::twoway_partitioned:
     {
       // call constructor
       algo = std::make_shared<PoroPressureBased::PoroMultiPhasePartitionedTwoWay>(comm, timeparams);
       break;
     }
-    case PoroPressureBased::solscheme_twoway_monolithic:
+    case SolutionSchemePorofluidElast::twoway_monolithic:
     {
       const bool artery_coupl = timeparams.get<bool>("ARTERY_COUPLING");
       if (!artery_coupl)

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
@@ -26,9 +26,9 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | setup discretizations and dofsets                         vuong 08/16 |
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> POROMULTIPHASE::setup_discretizations_and_field_coupling(MPI_Comm comm,
-    const std::string& struct_disname, const std::string& fluid_disname, int& nds_disp,
-    int& nds_vel, int& nds_solidpressure)
+std::map<int, std::set<int>> PoroPressureBased::setup_discretizations_and_field_coupling(
+    MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
+    int& nds_disp, int& nds_vel, int& nds_solidpressure)
 {
   // Scheme   : the structure discretization is received from the input.
   //            Then, a poro fluid disc. is cloned.
@@ -78,7 +78,7 @@ std::map<int, std::set<int>> POROMULTIPHASE::setup_discretizations_and_field_cou
       case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::ntp:
       {
         // perform extended ghosting on artery discretization
-        nearbyelepairs = POROFLUIDMULTIPHASE::extended_ghosting_artery_discretization(
+        nearbyelepairs = PoroPressureBased::extended_ghosting_artery_discretization(
             *structdis, arterydis, evaluate_on_lateral_surface, arterycoupl);
         break;
       }
@@ -97,7 +97,7 @@ std::map<int, std::set<int>> POROMULTIPHASE::setup_discretizations_and_field_cou
   if (fluiddis->num_global_nodes() == 0)
   {
     // fill poro fluid discretization by cloning structure discretization
-    Core::FE::clone_discretization<POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy>(
+    Core::FE::clone_discretization<PoroPressureBased::PoroFluidMultiPhaseCloneStrategy>(
         *structdis, *fluiddis, Global::Problem::instance()->cloning_material_map());
   }
   else
@@ -138,7 +138,7 @@ std::map<int, std::set<int>> POROMULTIPHASE::setup_discretizations_and_field_cou
 /*----------------------------------------------------------------------*
  | exchange material pointers of both discretizations       vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::assign_material_pointers(
+void PoroPressureBased::assign_material_pointers(
     const std::string& struct_disname, const std::string& fluid_disname)
 {
   Global::Problem* problem = Global::Problem::instance();
@@ -152,33 +152,35 @@ void POROMULTIPHASE::assign_material_pointers(
 /*----------------------------------------------------------------------*
  | create algorithm                                                      |
  *----------------------------------------------------------------------*/
-std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> POROMULTIPHASE::create_poro_multi_phase_algorithm(
-    POROMULTIPHASE::SolutionSchemeOverFields solscheme, const Teuchos::ParameterList& timeparams,
+std::shared_ptr<PoroPressureBased::PoroMultiPhase>
+PoroPressureBased::create_poro_multi_phase_algorithm(
+    PoroPressureBased::SolutionSchemeOverFields solscheme, const Teuchos::ParameterList& timeparams,
     MPI_Comm comm)
 {
   // Creation of Coupled Problem algorithm.
-  std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> algo = nullptr;
+  std::shared_ptr<PoroPressureBased::PoroMultiPhase> algo = nullptr;
 
   switch (solscheme)
   {
-    case POROMULTIPHASE::solscheme_twoway_partitioned:
+    case PoroPressureBased::solscheme_twoway_partitioned:
     {
       // call constructor
-      algo = std::make_shared<POROMULTIPHASE::PoroMultiPhasePartitionedTwoWay>(comm, timeparams);
+      algo = std::make_shared<PoroPressureBased::PoroMultiPhasePartitionedTwoWay>(comm, timeparams);
       break;
     }
-    case POROMULTIPHASE::solscheme_twoway_monolithic:
+    case PoroPressureBased::solscheme_twoway_monolithic:
     {
       const bool artery_coupl = timeparams.get<bool>("ARTERY_COUPLING");
       if (!artery_coupl)
       {
         // call constructor
-        algo = std::make_shared<POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWay>(comm, timeparams);
+        algo =
+            std::make_shared<PoroPressureBased::PoroMultiPhaseMonolithicTwoWay>(comm, timeparams);
       }
       else
       {
         // call constructor
-        algo = std::make_shared<POROMULTIPHASE::PoroMultiPhaseMonolithicTwoWayArteryCoupling>(
+        algo = std::make_shared<PoroPressureBased::PoroMultiPhaseMonolithicTwoWayArteryCoupling>(
             comm, timeparams);
       }
       break;
@@ -191,81 +193,5 @@ std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> POROMULTIPHASE::create_poro_mult
   return algo;
 }
 
-/*----------------------------------------------------------------------*
- | calculate vector norm                             kremheller 07/17   |
- *----------------------------------------------------------------------*/
-double POROMULTIPHASE::calculate_vector_norm(
-    const enum POROMULTIPHASE::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
-{
-  // L1 norm
-  // norm = sum_0^i vect[i]
-  if (norm == POROMULTIPHASE::norm_l1)
-  {
-    double vectnorm;
-    vect.norm_1(&vectnorm);
-    return vectnorm;
-  }
-  // L2/Euclidian norm
-  // norm = sqrt{sum_0^i vect[i]^2 }
-  else if (norm == POROMULTIPHASE::norm_l2)
-  {
-    double vectnorm;
-    vect.norm_2(&vectnorm);
-    return vectnorm;
-  }
-  // RMS norm
-  // norm = sqrt{sum_0^i vect[i]^2 }/ sqrt{length_vect}
-  else if (norm == POROMULTIPHASE::norm_rms)
-  {
-    double vectnorm;
-    vect.norm_2(&vectnorm);
-    return vectnorm / sqrt((double)vect.global_length());
-  }
-  // infinity/maximum norm
-  // norm = max( vect[i] )
-  else if (norm == POROMULTIPHASE::norm_inf)
-  {
-    double vectnorm;
-    vect.norm_inf(&vectnorm);
-    return vectnorm;
-  }
-  // norm = sum_0^i vect[i]/length_vect
-  else if (norm == POROMULTIPHASE::norm_l1_scaled)
-  {
-    double vectnorm;
-    vect.norm_1(&vectnorm);
-    return vectnorm / ((double)vect.global_length());
-  }
-  else
-  {
-    FOUR_C_THROW("Cannot handle vector norm");
-    return 0;
-  }
-}  // calculate_vector_norm()
-
-/*----------------------------------------------------------------------*
- |                                                    kremheller 03/17  |
- *----------------------------------------------------------------------*/
-void POROMULTIPHASE::print_logo()
-{
-  std::cout << "This is a Porous Media problem with multiphase flow and deformation" << std::endl;
-  std::cout << "" << std::endl;
-  std::cout << "              +----------+" << std::endl;
-  std::cout << "              |  Krebs-  |" << std::endl;
-  std::cout << "              |  Model  |" << std::endl;
-  std::cout << "              +----------+" << std::endl;
-  std::cout << "              |          |" << std::endl;
-  std::cout << "              |          |" << std::endl;
-  std::cout << " /\\           |          /\\" << std::endl;
-  std::cout << "( /   @ @    (|)        ( /   @ @    ()" << std::endl;
-  std::cout << " \\  __| |__  /           \\  __| |__  /" << std::endl;
-  std::cout << "  \\/   \"   \\/             \\/   \"   \\/" << std::endl;
-  std::cout << " /-|       |-\\           /-|       |-\\" << std::endl;
-  std::cout << "/ /-\\     /-\\ \\         / /-\\     /-\\ \\" << std::endl;
-  std::cout << " / /-`---'-\\ \\           / /-`---'-\\ \\" << std::endl;
-  std::cout << "  /         \\             /         \\" << std::endl;
-
-  return;
-}
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.cpp
@@ -26,9 +26,9 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  | setup discretizations and dofsets                         vuong 08/16 |
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> POROMULTIPHASE::Utils::setup_discretizations_and_field_coupling(
-    MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
-    int& nds_disp, int& nds_vel, int& nds_solidpressure)
+std::map<int, std::set<int>> POROMULTIPHASE::setup_discretizations_and_field_coupling(MPI_Comm comm,
+    const std::string& struct_disname, const std::string& fluid_disname, int& nds_disp,
+    int& nds_vel, int& nds_solidpressure)
 {
   // Scheme   : the structure discretization is received from the input.
   //            Then, a poro fluid disc. is cloned.
@@ -78,7 +78,7 @@ std::map<int, std::set<int>> POROMULTIPHASE::Utils::setup_discretizations_and_fi
       case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::ntp:
       {
         // perform extended ghosting on artery discretization
-        nearbyelepairs = POROFLUIDMULTIPHASE::Utils::extended_ghosting_artery_discretization(
+        nearbyelepairs = POROFLUIDMULTIPHASE::extended_ghosting_artery_discretization(
             *structdis, arterydis, evaluate_on_lateral_surface, arterycoupl);
         break;
       }
@@ -97,7 +97,7 @@ std::map<int, std::set<int>> POROMULTIPHASE::Utils::setup_discretizations_and_fi
   if (fluiddis->num_global_nodes() == 0)
   {
     // fill poro fluid discretization by cloning structure discretization
-    Core::FE::clone_discretization<POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy>(
+    Core::FE::clone_discretization<POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy>(
         *structdis, *fluiddis, Global::Problem::instance()->cloning_material_map());
   }
   else
@@ -138,7 +138,7 @@ std::map<int, std::set<int>> POROMULTIPHASE::Utils::setup_discretizations_and_fi
 /*----------------------------------------------------------------------*
  | exchange material pointers of both discretizations       vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::Utils::assign_material_pointers(
+void POROMULTIPHASE::assign_material_pointers(
     const std::string& struct_disname, const std::string& fluid_disname)
 {
   Global::Problem* problem = Global::Problem::instance();
@@ -152,8 +152,7 @@ void POROMULTIPHASE::Utils::assign_material_pointers(
 /*----------------------------------------------------------------------*
  | create algorithm                                                      |
  *----------------------------------------------------------------------*/
-std::shared_ptr<POROMULTIPHASE::PoroMultiPhase>
-POROMULTIPHASE::Utils::create_poro_multi_phase_algorithm(
+std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> POROMULTIPHASE::create_poro_multi_phase_algorithm(
     POROMULTIPHASE::SolutionSchemeOverFields solscheme, const Teuchos::ParameterList& timeparams,
     MPI_Comm comm)
 {
@@ -195,7 +194,7 @@ POROMULTIPHASE::Utils::create_poro_multi_phase_algorithm(
 /*----------------------------------------------------------------------*
  | calculate vector norm                             kremheller 07/17   |
  *----------------------------------------------------------------------*/
-double POROMULTIPHASE::Utils::calculate_vector_norm(
+double POROMULTIPHASE::calculate_vector_norm(
     const enum POROMULTIPHASE::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
@@ -26,30 +26,27 @@ namespace Core::FE
 
 namespace POROMULTIPHASE
 {
-  namespace Utils
-  {
-    /// setup discretizations and dofsets
-    std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
-        const std::string& struct_disname, const std::string& fluid_disname, int& nds_disp,
-        int& nds_vel, int& nds_solidpressure);
+  /// setup discretizations and dofsets
+  std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
+      const std::string& struct_disname, const std::string& fluid_disname, int& nds_disp,
+      int& nds_vel, int& nds_solidpressure);
 
-    //! exchange material pointers of both discretizations
-    void assign_material_pointers(
-        const std::string& struct_disname, const std::string& fluid_disname);
+  //! exchange material pointers of both discretizations
+  void assign_material_pointers(
+      const std::string& struct_disname, const std::string& fluid_disname);
 
-    /// create solution algorithm depending on input file
-    std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> create_poro_multi_phase_algorithm(
-        POROMULTIPHASE::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
-        const Teuchos::ParameterList& timeparams,            //!< problem parameters (i)
-        MPI_Comm comm                                        //!< communicator(i)
-    );
+  /// create solution algorithm depending on input file
+  std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> create_poro_multi_phase_algorithm(
+      POROMULTIPHASE::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
+      const Teuchos::ParameterList& timeparams,            //!< problem parameters (i)
+      MPI_Comm comm                                        //!< communicator(i)
+  );
 
-    //! Determine norm of vector
-    double calculate_vector_norm(const enum POROMULTIPHASE::VectorNorm norm,  //!< norm to use
-        const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
-    );
+  //! Determine norm of vector
+  double calculate_vector_norm(const enum POROMULTIPHASE::VectorNorm norm,  //!< norm to use
+      const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
+  );
 
-  }  // namespace Utils
   // Print the logo
   void print_logo();
 }  // namespace POROMULTIPHASE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
@@ -24,7 +24,7 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   /// setup discretizations and dofsets
   std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
@@ -36,20 +36,12 @@ namespace POROMULTIPHASE
       const std::string& struct_disname, const std::string& fluid_disname);
 
   /// create solution algorithm depending on input file
-  std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> create_poro_multi_phase_algorithm(
-      POROMULTIPHASE::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
-      const Teuchos::ParameterList& timeparams,            //!< problem parameters (i)
-      MPI_Comm comm                                        //!< communicator(i)
+  std::shared_ptr<PoroPressureBased::PoroMultiPhase> create_poro_multi_phase_algorithm(
+      PoroPressureBased::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
+      const Teuchos::ParameterList& timeparams,               //!< problem parameters (i)
+      MPI_Comm comm                                           //!< communicator(i)
   );
-
-  //! Determine norm of vector
-  double calculate_vector_norm(const enum POROMULTIPHASE::VectorNorm norm,  //!< norm to use
-      const Core::LinAlg::Vector<double>& vect  //!< the vector of interest
-  );
-
-  // Print the logo
-  void print_logo();
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils.hpp
@@ -27,19 +27,19 @@ namespace Core::FE
 namespace PoroPressureBased
 {
   /// setup discretizations and dofsets
-  std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
-      const std::string& struct_disname, const std::string& fluid_disname, int& nds_disp,
-      int& nds_vel, int& nds_solidpressure);
+  std::map<int, std::set<int>> setup_discretizations_and_field_coupling_porofluid_elast(
+      MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
+      int& nds_disp, int& nds_vel, int& nds_solidpressure);
 
   //! exchange material pointers of both discretizations
-  void assign_material_pointers(
+  void assign_material_pointers_porofluid_elast(
       const std::string& struct_disname, const std::string& fluid_disname);
 
   /// create solution algorithm depending on input file
-  std::shared_ptr<PoroPressureBased::PoroMultiPhase> create_poro_multi_phase_algorithm(
-      PoroPressureBased::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
-      const Teuchos::ParameterList& timeparams,               //!< problem parameters (i)
-      MPI_Comm comm                                           //!< communicator(i)
+  std::shared_ptr<PoroMultiPhase> create_algorithm_porofluid_elast(
+      SolutionSchemePorofluidElast solscheme,    //!< solution scheme to build (i)
+      const Teuchos::ParameterList& timeparams,  //!< problem parameters (i)
+      MPI_Comm comm                              //!< communicator(i)
   );
 }  // namespace PoroPressureBased
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
  | define conditions to copy to the cloned discretization    vuong 08/16 |
  *----------------------------------------------------------------------*/
 std::map<std::string, std::string>
-POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::conditions_to_copy() const
+PoroPressureBased::PoroFluidMultiPhaseCloneStrategy::conditions_to_copy() const
 {
   return {{"PoroDirichlet", "Dirichlet"}, {"PoroPointNeumann", "PointNeumann"},
       {"PoroLineNeumann", "LineNeumann"}, {"PoroSurfaceNeumann", "SurfaceNeumann"},
@@ -34,7 +34,7 @@ POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::conditions_to_copy() const
 /*----------------------------------------------------------------------*
  | check for correct material                               vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::check_material_type(const int matid)
+void PoroPressureBased::PoroFluidMultiPhaseCloneStrategy::check_material_type(const int matid)
 {
   // We take the material with the ID specified by the user
   // Here we check first, whether this material is of admissible type
@@ -49,7 +49,7 @@ void POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::check_material_type(const
 /*----------------------------------------------------------------------*
  | set element-specific data (material etc.)                 vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::set_element_data(
+void PoroPressureBased::PoroFluidMultiPhaseCloneStrategy::set_element_data(
     std::shared_ptr<Core::Elements::Element> newele, Core::Elements::Element* oldele,
     const int matid, const bool isnurbsdis)
 {
@@ -76,7 +76,7 @@ void POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::set_element_data(
 /*----------------------------------------------------------------------*
  | determine whether element is copied or not               vuong 08/16 |
  *----------------------------------------------------------------------*/
-bool POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::determine_ele_type(
+bool PoroPressureBased::PoroFluidMultiPhaseCloneStrategy::determine_ele_type(
     Core::Elements::Element* actele, const bool ismyele, std::vector<std::string>& eletype)
 {
   // note: ismyele, actele remain unused here! Used only for ALE creation

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
  | define conditions to copy to the cloned discretization    vuong 08/16 |
  *----------------------------------------------------------------------*/
 std::map<std::string, std::string>
-POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::conditions_to_copy() const
+POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::conditions_to_copy() const
 {
   return {{"PoroDirichlet", "Dirichlet"}, {"PoroPointNeumann", "PointNeumann"},
       {"PoroLineNeumann", "LineNeumann"}, {"PoroSurfaceNeumann", "SurfaceNeumann"},
@@ -34,7 +34,7 @@ POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::conditions_to_copy() co
 /*----------------------------------------------------------------------*
  | check for correct material                               vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::check_material_type(const int matid)
+void POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::check_material_type(const int matid)
 {
   // We take the material with the ID specified by the user
   // Here we check first, whether this material is of admissible type
@@ -49,7 +49,7 @@ void POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::check_material_typ
 /*----------------------------------------------------------------------*
  | set element-specific data (material etc.)                 vuong 08/16 |
  *----------------------------------------------------------------------*/
-void POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::set_element_data(
+void POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::set_element_data(
     std::shared_ptr<Core::Elements::Element> newele, Core::Elements::Element* oldele,
     const int matid, const bool isnurbsdis)
 {
@@ -76,7 +76,7 @@ void POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::set_element_data(
 /*----------------------------------------------------------------------*
  | determine whether element is copied or not               vuong 08/16 |
  *----------------------------------------------------------------------*/
-bool POROMULTIPHASE::Utils::PoroFluidMultiPhaseCloneStrategy::determine_ele_type(
+bool POROMULTIPHASE::PoroFluidMultiPhaseCloneStrategy::determine_ele_type(
     Core::Elements::Element* actele, const bool ismyele, std::vector<std::string>& eletype)
 {
   // note: ismyele, actele remain unused here! Used only for ALE creation

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.hpp
@@ -21,7 +21,7 @@ namespace Core::Elements
   class Element;
 }
 
-namespace POROMULTIPHASE
+namespace PoroPressureBased
 {
   /*!
   \brief implementation of special clone strategy for automatic generation
@@ -51,7 +51,7 @@ namespace POROMULTIPHASE
     void check_material_type(const int matid);
   };  // class PoroFluidMultiPhaseCloneStrategy
 
-}  // namespace POROMULTIPHASE
+}  // namespace PoroPressureBased
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.hpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_utils_clonestrategy.hpp
@@ -23,39 +23,34 @@ namespace Core::Elements
 
 namespace POROMULTIPHASE
 {
-  namespace Utils
+  /*!
+  \brief implementation of special clone strategy for automatic generation
+         of scatra from a given fluid discretization
+
+   */
+  class PoroFluidMultiPhaseCloneStrategy
   {
-    /*!
-    \brief implementation of special clone strategy for automatic generation
-           of scatra from a given fluid discretization
+   public:
+    /// constructor
+    explicit PoroFluidMultiPhaseCloneStrategy() {}
+    /// destructor
+    virtual ~PoroFluidMultiPhaseCloneStrategy() = default;
+    /// returns conditions names to be copied (source and target name)
+    virtual std::map<std::string, std::string> conditions_to_copy() const;
 
-     */
-    class PoroFluidMultiPhaseCloneStrategy
-    {
-     public:
-      /// constructor
-      explicit PoroFluidMultiPhaseCloneStrategy() {}
-      /// destructor
-      virtual ~PoroFluidMultiPhaseCloneStrategy() = default;
-      /// returns conditions names to be copied (source and target name)
-      virtual std::map<std::string, std::string> conditions_to_copy() const;
+   protected:
+    /// determine element type std::string and whether element is copied or not
+    virtual bool determine_ele_type(
+        Core::Elements::Element* actele, const bool ismyele, std::vector<std::string>& eletype);
 
-     protected:
-      /// determine element type std::string and whether element is copied or not
-      virtual bool determine_ele_type(
-          Core::Elements::Element* actele, const bool ismyele, std::vector<std::string>& eletype);
+    /// set element-specific data (material etc.)
+    void set_element_data(std::shared_ptr<Core::Elements::Element> newele,
+        Core::Elements::Element* oldele, const int matid, const bool isnurbs);
 
-      /// set element-specific data (material etc.)
-      void set_element_data(std::shared_ptr<Core::Elements::Element> newele,
-          Core::Elements::Element* oldele, const int matid, const bool isnurbs);
+    /// check for correct material
+    void check_material_type(const int matid);
+  };  // class PoroFluidMultiPhaseCloneStrategy
 
-      /// check for correct material
-      void check_material_type(const int matid);
-
-     private:
-    };  // class PoroFluidMultiPhaseCloneStrategy
-
-  }  // namespace Utils
 }  // namespace POROMULTIPHASE
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_base.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_base.cpp
@@ -18,7 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::PoroMultiPhaseScaTraArtCouplBase(
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase::PoroMultiPhaseScaTraArtCouplBase(
     std::shared_ptr<Core::FE::Discretization> arterydis,
     std::shared_ptr<Core::FE::Discretization> contdis, const Teuchos::ParameterList& couplingparams,
     const std::string& condname, const std::string& artcoupleddofname,
@@ -82,7 +82,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::PoroMultiPhaseScaTraArtC
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::recompute_coupled_do_fs_for_ntp(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase::recompute_coupled_do_fs_for_ntp(
     std::vector<Core::Conditions::Condition*> coupcond, unsigned int couplingnode)
 {
   coupleddofs_art_ =
@@ -99,7 +99,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::recompute_coupled_d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 const std::shared_ptr<const Core::LinAlg::Map>&
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::full_map() const
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase::full_map() const
 {
   return globalex_->full_map();
 }
@@ -107,14 +107,14 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::full_map() const
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 const std::shared_ptr<Core::LinAlg::MultiMapExtractor>&
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::global_extractor() const
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase::global_extractor() const
 {
   return globalex_;
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::set_solution_vectors(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase::set_solution_vectors(
     std::shared_ptr<const Core::LinAlg::Vector<double>> phinp_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phin_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phinp_art)
@@ -124,7 +124,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::set_solution_vector
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase::set_nearby_ele_pairs(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase::set_nearby_ele_pairs(
     const std::map<int, std::set<int>>* nearbyelepairs)
 {
   // do nothing

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_base.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_base.hpp
@@ -24,7 +24,7 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! base class for coupling between artery network and poromultiphasescatra algorithm
   class PoroMultiPhaseScaTraArtCouplBase
@@ -163,7 +163,7 @@ namespace PoroMultiPhaseScaTra
     MPI_Comm comm_;
   };
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -307,8 +307,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
       Core::Elements::Element* artele = arterydis_->g_element(artelegid);
 
       // TODO: this will not work for higher order artery eles
-      const double initlength =
-          POROFLUIDMULTIPHASE::Utils::get_max_nodal_distance(artele, *arterydis_);
+      const double initlength = POROFLUIDMULTIPHASE::get_max_nodal_distance(artele, *arterydis_);
       const int numseg = (int)(gid_to_segment_[artelegid].size() / 2);
       gid_to_seglength_[artelegid].resize(numseg);
       for (int iseg = 0; iseg < numseg; iseg++)
@@ -346,8 +345,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
     Core::Elements::Element* thisele = arterydis_->g_element(artelegid);
 
     // TODO: this will not work for higher order artery eles
-    const double initlength =
-        POROFLUIDMULTIPHASE::Utils::get_max_nodal_distance(thisele, *arterydis_);
+    const double initlength = POROFLUIDMULTIPHASE::get_max_nodal_distance(thisele, *arterydis_);
 
     std::vector<double> segmentboundaries = gid_to_segment_[artelegid];
     for (unsigned int iseg = 0; iseg < segmentboundaries.size() / 2; iseg++)
@@ -415,8 +413,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
     Core::Elements::Element* artele = arterydis_->g_element(artelegid);
 
     // TODO: this will not work for higher order artery eles
-    const double initlength =
-        POROFLUIDMULTIPHASE::Utils::get_max_nodal_distance(artele, *arterydis_);
+    const double initlength = POROFLUIDMULTIPHASE::get_max_nodal_distance(artele, *arterydis_);
 
     // first add all contributions int unaffected_diams_artery_row-vector
     std::shared_ptr<Mat::Cnst1dArt> arterymat =
@@ -473,7 +470,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
     // TODO: this will not work for higher order artery eles
     const double etaA = coupl_elepairs_[i]->etadata();
     const double etaB = coupl_elepairs_[i]->eta_b();
-    const double length = POROFLUIDMULTIPHASE::Utils::get_max_nodal_distance(artele, *arterydis_);
+    const double length = POROFLUIDMULTIPHASE::get_max_nodal_distance(artele, *arterydis_);
 
     const double vol_cont = coupl_elepairs_[i]->calculate_vol_2d_3d();
     const double vol_art =
@@ -749,7 +746,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::find_free_hang
   }
   // get fully-overlapping discretization
   std::shared_ptr<Core::FE::Discretization> artconncompdis =
-      POROFLUIDMULTIPHASE::Utils::create_fully_overlapping_artery_discretization(
+      POROFLUIDMULTIPHASE::create_fully_overlapping_artery_discretization(
           *arterydis_, "conn_comp_dis", true);
 
   // vector to mark visited nodes

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -23,7 +23,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::PoroMultiPhaseScaTraArtCouplLineBased(
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::PoroMultiPhaseScaTraArtCouplLineBased(
     std::shared_ptr<Core::FE::Discretization> arterydis,
     std::shared_ptr<Core::FE::Discretization> contdis, const Teuchos::ParameterList& couplingparams,
     const std::string& condname, const std::string& artcoupleddofname,
@@ -48,10 +48,10 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::PoroMultiPhaseScaTr
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::setup()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::setup()
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup();
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup();
 
   // pre-evaluate the pairs
   pre_evaluate_coupling_pairs();
@@ -79,7 +79,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::setup()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::setup_system(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::setup_system(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
     std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
@@ -96,13 +96,13 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::setup_system(
       get_additional_dbc_for_collapsed_eles(*dbcmap_art, *rhs_art_with_collapsed);
 
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(*sysmat, rhs,
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(*sysmat, rhs,
       *sysmat_cont, *sysmat_art, rhs_cont, rhs_art_with_collapsed, *dbcmap_cont,
       *dbcmap_art->cond_map(), *dbcmap_art_with_collapsed);
 }
 
 std::shared_ptr<Core::LinAlg::Map>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::get_additional_dbc_for_collapsed_eles(
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::get_additional_dbc_for_collapsed_eles(
     const Core::LinAlg::MapExtractor& dbcmap_art,
     Core::LinAlg::Vector<double>& rhs_art_with_collapsed)
 {
@@ -171,13 +171,13 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::get_additional_dbc_
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::pre_evaluate_coupling_pairs()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::pre_evaluate_coupling_pairs()
 {
   // pre-evaluate
   for (unsigned i = 0; i < coupl_elepairs_.size(); i++) coupl_elepairs_[i]->pre_evaluate(nullptr);
 
   // delete the inactive and duplicate pairs
-  std::vector<std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>
+  std::vector<std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>
       active_coupl_elepairs;
   for (unsigned i = 0; i < coupl_elepairs_.size(); i++)
   {
@@ -296,7 +296,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::pre_evaluate_c
 
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_artery_length()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_artery_length()
 {
   // no need to do this
   if (porofluidprob_)
@@ -402,7 +402,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_integrated_diam()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_integrated_diam()
 {
   Epetra_FEVector unaffected_diams_artery_row(
       arterydis_->element_row_map()->get_epetra_map(), true);
@@ -448,7 +448,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::
     calculate_blood_vessel_volume_fraction()
 {
   bloodvesselvolfrac_ =
@@ -500,7 +500,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::set_varying_diam_flag()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::set_varying_diam_flag()
 {
   PoroMultiPhaseScaTraArtCouplNonConforming::set_varying_diam_flag();
 
@@ -520,7 +520,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::set_varying_di
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::create_gid_to_segment_vector()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::create_gid_to_segment_vector()
 {
   // fill the GID-to-segment vector
   fill_gid_to_segment_vector(coupl_elepairs_, gid_to_segment_);
@@ -589,9 +589,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::create_gid_to_
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_gid_to_segment_vector(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_gid_to_segment_vector(
     const std::vector<std::shared_ptr<
-        PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
+        PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
     std::map<int, std::vector<double>>& gid_to_seglength)
 {
   // fill the GID-to-segment vector
@@ -625,7 +625,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_gid_to_se
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::
     fe_assemble_ele_force_stiff_into_system_vector_matrix(const int& ele1gid, const int& ele2gid,
         const double& integrated_diam, std::vector<Core::LinAlg::SerialDenseVector> const& elevec,
         std::vector<std::vector<Core::LinAlg::SerialDenseMatrix>> const& elemat,
@@ -633,7 +633,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
         std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::
       fe_assemble_ele_force_stiff_into_system_vector_matrix(
           ele1gid, ele2gid, integrated_diam, elevec, elemat, sysmat, rhs);
 
@@ -644,7 +644,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::set_artery_diam_in_material()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::set_artery_diam_in_material()
 {
   // assemble
   if (integrated_diams_artery_row_->GlobalAssemble(Add, false) != 0)
@@ -699,14 +699,14 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::set_artery_dia
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::reset_integrated_diam_to_zero()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::reset_integrated_diam_to_zero()
 {
   integrated_diams_artery_row_->PutScalar(0.0);
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_artery_ele_diam_col()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_artery_ele_diam_col()
 {
   // reset
   ele_diams_artery_col_->put_scalar(0.0);
@@ -731,7 +731,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_artery_el
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::find_free_hanging_1d_elements(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::find_free_hanging_1d_elements(
     std::vector<int>& eles_to_be_deleted)
 {
   // user info
@@ -863,7 +863,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::find_free_hang
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::depth_first_search_util(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::depth_first_search_util(
     Core::Nodes::Node* actnode, std::shared_ptr<Core::LinAlg::Vector<int>> visited,
     std::shared_ptr<Core::FE::Discretization> artconncompdis,
     std::shared_ptr<const Core::LinAlg::Vector<double>> ele_diams_artery_full_overlap,
@@ -904,7 +904,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::depth_first_se
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::
     evaluate_additional_linearizationof_integrated_diam()
 {
   // linearizations
@@ -944,7 +944,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::vector<double>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::get_ele_segment_lengths(
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::get_ele_segment_lengths(
     const int artelegid)
 {
   if (porofluidprob_) return gid_to_seglength_[artelegid];
@@ -967,10 +967,10 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::get_ele_segment_len
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::is_duplicate_segment(
+bool PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::is_duplicate_segment(
     const std::vector<std::shared_ptr<
-        PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
-    PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase& possible_duplicate)
+        PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
+    PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase& possible_duplicate)
 {
   // we have to sort out duplicate segments, these might occur if the artery element
   // lies exactly between two different 2D/3D-elements
@@ -985,9 +985,9 @@ bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::is_duplicate_s
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::is_identical_segment(
+bool PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::is_identical_segment(
     const std::vector<std::shared_ptr<
-        PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
+        PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
     const int& ele1gid, const double& etaA, const double& etaB, int& elepairID)
 {
   for (unsigned i = 0; i < coupl_elepairs.size(); i++)
@@ -1010,7 +1010,7 @@ bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::is_identical_s
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::apply_mesh_movement()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::apply_mesh_movement()
 {
   // no need to do this
   if (porofluidprob_) return;
@@ -1050,7 +1050,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::apply_mesh_mov
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::print_out_coupling_method() const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::print_out_coupling_method() const
 {
   std::cout << "<   Line-based formulation                         >" << std::endl;
   PoroMultiPhaseScaTraArtCouplNonConforming::print_out_coupling_method();
@@ -1058,7 +1058,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::print_out_coup
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::output_summary() const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::output_summary() const
 {
   if (myrank_ == 0)
   {
@@ -1081,7 +1081,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::output_summary
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::blood_vessel_volume_fraction()
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::blood_vessel_volume_fraction()
 {
   return bloodvesselvolfrac_;
 }

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -307,7 +307,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
       Core::Elements::Element* artele = arterydis_->g_element(artelegid);
 
       // TODO: this will not work for higher order artery eles
-      const double initlength = POROFLUIDMULTIPHASE::get_max_nodal_distance(artele, *arterydis_);
+      const double initlength = PoroPressureBased::get_max_nodal_distance(artele, *arterydis_);
       const int numseg = (int)(gid_to_segment_[artelegid].size() / 2);
       gid_to_seglength_[artelegid].resize(numseg);
       for (int iseg = 0; iseg < numseg; iseg++)
@@ -345,7 +345,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
     Core::Elements::Element* thisele = arterydis_->g_element(artelegid);
 
     // TODO: this will not work for higher order artery eles
-    const double initlength = POROFLUIDMULTIPHASE::get_max_nodal_distance(thisele, *arterydis_);
+    const double initlength = PoroPressureBased::get_max_nodal_distance(thisele, *arterydis_);
 
     std::vector<double> segmentboundaries = gid_to_segment_[artelegid];
     for (unsigned int iseg = 0; iseg < segmentboundaries.size() / 2; iseg++)
@@ -413,7 +413,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffecte
     Core::Elements::Element* artele = arterydis_->g_element(artelegid);
 
     // TODO: this will not work for higher order artery eles
-    const double initlength = POROFLUIDMULTIPHASE::get_max_nodal_distance(artele, *arterydis_);
+    const double initlength = PoroPressureBased::get_max_nodal_distance(artele, *arterydis_);
 
     // first add all contributions int unaffected_diams_artery_row-vector
     std::shared_ptr<Mat::Cnst1dArt> arterymat =
@@ -470,7 +470,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::
     // TODO: this will not work for higher order artery eles
     const double etaA = coupl_elepairs_[i]->etadata();
     const double etaB = coupl_elepairs_[i]->eta_b();
-    const double length = POROFLUIDMULTIPHASE::get_max_nodal_distance(artele, *arterydis_);
+    const double length = PoroPressureBased::get_max_nodal_distance(artele, *arterydis_);
 
     const double vol_cont = coupl_elepairs_[i]->calculate_vol_2d_3d();
     const double vol_art =
@@ -746,7 +746,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased::find_free_hang
   }
   // get fully-overlapping discretization
   std::shared_ptr<Core::FE::Discretization> artconncompdis =
-      POROFLUIDMULTIPHASE::create_fully_overlapping_artery_discretization(
+      PoroPressureBased::create_fully_overlapping_artery_discretization(
           *arterydis_, "conn_comp_dis", true);
 
   // vector to mark visited nodes

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.hpp
@@ -16,7 +16,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   // forward declaration
   class PoroMultiPhaseScatraArteryCouplingPairBase;
@@ -68,7 +68,7 @@ namespace PoroMultiPhaseScaTra
     //! fill the GID to segment vector
     void fill_gid_to_segment_vector(
         const std::vector<std::shared_ptr<
-            PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
+            PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
         std::map<int, std::vector<double>>& gid_to_seglength);
 
     //! set the artery diameter in column based vector
@@ -144,13 +144,13 @@ namespace PoroMultiPhaseScaTra
     //! check for duplicate segment
     bool is_duplicate_segment(
         const std::vector<std::shared_ptr<
-            PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
-        PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase& possible_duplicate);
+            PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
+        PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase& possible_duplicate);
 
     //! check for identical segment
     bool is_identical_segment(
         const std::vector<std::shared_ptr<
-            PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
+            PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupl_elepairs,
         const int& ele1gid, const double& etaA, const double& etaB, int& elepairID);
 
     //! set flag if varying diameter has to be calculated
@@ -197,7 +197,7 @@ namespace PoroMultiPhaseScaTra
     //!  porofluid-problems)
     std::map<int, std::vector<double>> gid_to_seglength_;
   };
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.cpp
@@ -18,7 +18,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::PoroMultiPhaseScaTraArtCouplNodeBased(
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::PoroMultiPhaseScaTraArtCouplNodeBased(
     std::shared_ptr<Core::FE::Discretization> arterydis,
     std::shared_ptr<Core::FE::Discretization> contdis,
     const Teuchos::ParameterList& meshtyingparams, const std::string& condname,
@@ -42,7 +42,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::PoroMultiPhaseScaTr
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::init()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::init()
 {
   // ARTERY COUPLING CONDITIONS
   std::vector<std::vector<int>> condIDs;
@@ -113,14 +113,14 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::init()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup()
 {
   // do nothing
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_map_extractor(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup_map_extractor(
     Core::LinAlg::MultiMapExtractor& mapextractor, Core::FE::Discretization& dis,
     const std::vector<int>& coupleddofs)
 {
@@ -157,7 +157,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_map_extr
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_system(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup_system(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
     std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
@@ -173,7 +173,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_system(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_rhs(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup_rhs(
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
     std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_art)
@@ -183,7 +183,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_rhs(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_vector(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup_vector(
     std::shared_ptr<Core::LinAlg::Vector<double>> vec,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_art)
@@ -212,7 +212,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_vector(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_matrix(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup_matrix(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont, Core::LinAlg::SparseMatrix& sysmat_art)
 {
@@ -248,7 +248,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::setup_matrix(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::extract_single_field_vectors(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::extract_single_field_vectors(
     std::shared_ptr<const Core::LinAlg::Vector<double>> globalvec,
     std::shared_ptr<const Core::LinAlg::Vector<double>>& vec_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>>& vec_art)
@@ -278,7 +278,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::extract_single
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::check_dbc_on_coupled_dofs(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::check_dbc_on_coupled_dofs(
     Core::FE::Discretization& dis, const std::shared_ptr<const Core::LinAlg::Map>& coupleddofmap)
 {
   // object holds maps/subsets for DOFs subjected to Dirichlet BCs and otherwise
@@ -320,7 +320,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::check_dbc_on_c
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::check_initial_fields(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::check_initial_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_art)
 {
@@ -351,7 +351,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::check_initial_
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Map>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::artery_dof_row_map() const
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::artery_dof_row_map() const
 {
   return artex_->Map(0);
 }
@@ -359,14 +359,14 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::artery_dof_row_map(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Map>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::dof_row_map() const
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::dof_row_map() const
 {
   return fullmap_;
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::apply_mesh_movement()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::apply_mesh_movement()
 {
   if (!evaluate_in_ref_config_)
     FOUR_C_THROW("Evaluation in current configuration not possible for node-based coupling");
@@ -375,7 +375,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::apply_mesh_mov
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::blood_vessel_volume_fraction()
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::blood_vessel_volume_fraction()
 {
   FOUR_C_THROW("Output of vessel volume fraction not possible for node-based coupling");
 
@@ -384,7 +384,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::blood_vessel_volume
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased::print_out_coupling_method() const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::print_out_coupling_method() const
 {
   std::cout << "<   Coupling-Method : Nodebased                    >" << std::endl;
 }

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.hpp
@@ -23,7 +23,7 @@ namespace FSI
 }  // namespace FSI
 
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! Node based coupling between artery network and poromultiphasescatra algorithm
   class PoroMultiPhaseScaTraArtCouplNodeBased : public PoroMultiPhaseScaTraArtCouplBase
@@ -152,7 +152,7 @@ namespace PoroMultiPhaseScaTra
     std::shared_ptr<Coupling::Adapter::MatrixColTransform> sibtransform_;
   };
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.cpp
@@ -17,11 +17,11 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::
-    PoroMultiPhaseScaTraArtCouplNodeToPoint(std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& couplingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname)
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::PoroMultiPhaseScaTraArtCouplNodeToPoint(
+    std::shared_ptr<Core::FE::Discretization> arterydis,
+    std::shared_ptr<Core::FE::Discretization> contdis, const Teuchos::ParameterList& couplingparams,
+    const std::string& condname, const std::string& artcoupleddofname,
+    const std::string& contcoupleddofname)
     : PoroMultiPhaseScaTraArtCouplNonConforming(
           arterydis, contdis, couplingparams, condname, artcoupleddofname, contcoupleddofname)
 {
@@ -39,10 +39,10 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::setup()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::setup()
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup();
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup();
 
 
   // preevaluate coupling pairs
@@ -63,7 +63,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::setup()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::pre_evaluate_coupling_pairs()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::pre_evaluate_coupling_pairs()
 {
   // pre-evaluate
   for (auto& coupl_elepair : coupl_elepairs_) coupl_elepair->pre_evaluate(nullptr);
@@ -71,7 +71,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::pre_evaluate
   // delete the inactive pairs
   coupl_elepairs_.erase(
       std::remove_if(coupl_elepairs_.begin(), coupl_elepairs_.end(),
-          [](const std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>
+          [](const std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>
                   coupling_pair) { return not coupling_pair->is_active(); }),
       coupl_elepairs_.end());
 
@@ -88,7 +88,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::pre_evaluate
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::evaluate(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::evaluate(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
@@ -96,12 +96,12 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::evaluate(
 
 
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(sysmat, rhs);
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(sysmat, rhs);
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::setup_system(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::setup_system(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
     std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
@@ -112,14 +112,14 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::setup_system
     std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art)
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(*sysmat, rhs,
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(*sysmat, rhs,
       *sysmat_cont, *sysmat_art, rhs_cont, rhs_art, *dbcmap_cont, *dbcmap_art->cond_map(),
       *dbcmap_art->cond_map());
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::apply_mesh_movement()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::apply_mesh_movement()
 {
   if (!evaluate_in_ref_config_)
     FOUR_C_THROW("Evaluation in current configuration not possible for node-to-point coupling");
@@ -128,7 +128,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::apply_mesh_m
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::blood_vessel_volume_fraction()
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::blood_vessel_volume_fraction()
 {
   FOUR_C_THROW("Output of vessel volume fraction not possible for node-to-point coupling");
 
@@ -137,15 +137,14 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::blood_vessel_volu
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::print_out_coupling_method()
-    const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::print_out_coupling_method() const
 {
   std::cout << "<Coupling-Method: 1D node to coincident point in 3D>" << std::endl;
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint::output_coupling_pairs() const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint::output_coupling_pairs() const
 {
   if (myrank_ == 0)
   {

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.hpp
@@ -15,7 +15,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   // forward declaration
   class PoroMultiPhaseScatraArteryCouplingPairBase;
@@ -101,7 +101,7 @@ namespace PoroMultiPhaseScaTra
     //! Output Coupling pairs
     void output_coupling_pairs() const;
   };
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
@@ -30,7 +30,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::
     PoroMultiPhaseScaTraArtCouplNonConforming(std::shared_ptr<Core::FE::Discretization> arterydis,
         std::shared_ptr<Core::FE::Discretization> contdis,
         const Teuchos::ParameterList& couplingparams, const std::string& condname,
@@ -62,7 +62,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::init()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::init()
 {
   // we do not have a moving mesh
   if (Global::Problem::instance()->get_problem_type() == Core::ProblemType::porofluidmultiphase)
@@ -116,7 +116,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::init()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup()
 {
   // get the coupling method
   auto arterycoupl =
@@ -145,7 +145,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::get_coupling_idsfrom_input()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::get_coupling_idsfrom_input()
 {
   // get 1D coupling IDs from Input
   std::vector<Core::Conditions::Condition*> artCoupcond;
@@ -171,7 +171,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::get_coupli
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
@@ -193,7 +193,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(
     Core::LinAlg::BlockSparseMatrixBase& sysmat, std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
     Core::LinAlg::SparseMatrix& sysmat_cont, Core::LinAlg::SparseMatrix& sysmat_art,
     std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
@@ -230,7 +230,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_syst
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::
     create_coupling_pairs_line_surf_based()
 {
   const Teuchos::ParameterList& fluidcouplingparams =
@@ -262,8 +262,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
       if (ele_ptrs[1]->owner() == myrank_)
       {
         // construct, init and setup coupling pairs
-        std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase> newpair =
-            PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
+        std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase> newpair =
+            PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::
                 create_new_artery_coupling_pair(ele_ptrs);
         newpair->init(ele_ptrs, couplingparams_, fluidcouplingparams, coupleddofs_cont_,
             coupleddofs_art_, scale_vec_, funct_vec_, condname_,
@@ -295,7 +295,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_coupling_pairs_ntp()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::create_coupling_pairs_ntp()
 {
   const Teuchos::ParameterList& fluidcouplingparams =
       Global::Problem::instance()->poro_fluid_multi_phase_dynamic_params().sublist(
@@ -353,8 +353,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_cou
             if (ele_ptrs[1]->owner() == myrank_)
             {
               // construct, init and setup coupling pairs
-              std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>
-                  newpair = PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
+              std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>
+                  newpair = PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::
                       create_new_artery_coupling_pair(ele_ptrs);
               newpair->init(ele_ptrs, couplingparams_, fluidcouplingparams, coupleddofs_cont_,
                   coupleddofs_art_, scale_vec_, funct_vec_, condname_, penalty,
@@ -389,7 +389,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_cou
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_varying_diam_flag()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::set_varying_diam_flag()
 {
   int has_varying_diam = 0;
   // check all column elements if one of them uses the diameter law by function
@@ -419,7 +419,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_varyin
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate_coupling_pairs(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate_coupling_pairs(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
@@ -522,7 +522,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate_c
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::
     fe_assemble_ele_force_stiff_into_system_vector_matrix(const int& ele1gid, const int& ele2gid,
         const double& integrated_diam, std::vector<Core::LinAlg::SerialDenseVector> const& elevec,
         std::vector<std::vector<Core::LinAlg::SerialDenseMatrix>> const& elemat,
@@ -553,7 +553,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::fe_assemble_dm_kappa(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::fe_assemble_dm_kappa(
     const int& ele1gid, const int& ele2gid, const Core::LinAlg::SerialDenseMatrix& D_ele,
     const Core::LinAlg::SerialDenseMatrix& M_ele, const Core::LinAlg::SerialDenseVector& Kappa_ele)
 {
@@ -577,9 +577,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::fe_assembl
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
-    sum_dm_into_global_force_stiff(Core::LinAlg::BlockSparseMatrixBase& sysmat,
-        std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::sum_dm_into_global_force_stiff(
+    Core::LinAlg::BlockSparseMatrixBase& sysmat, std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
   // invert
   invert_kappa();
@@ -641,7 +640,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::invert_kappa()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::invert_kappa()
 {
   // global assemble
   if (kappa_inv_->GlobalAssemble(Add, false) != 0)
@@ -661,8 +660,8 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::invert_kap
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_artery_coupling_pair(
+std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_artery_coupling_pair(
     std::vector<Core::Elements::Element const*> const& ele_ptrs)
 {
   const Core::FE::CellType distypeart = ele_ptrs[0]->shape();
@@ -678,13 +677,13 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_arte
           switch (Global::Problem::instance()->n_dim())
           {
             case 1:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::quad4, 1>>();
             case 2:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::quad4, 2>>();
             case 3:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::quad4, 3>>();
             default:
               FOUR_C_THROW("Unsupported dimension {}.", Global::Problem::instance()->n_dim());
@@ -695,13 +694,13 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_arte
           switch (Global::Problem::instance()->n_dim())
           {
             case 1:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::hex8, 1>>();
             case 2:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::hex8, 2>>();
             case 3:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::hex8, 3>>();
             default:
               FOUR_C_THROW("Unsupported dimension {}.", Global::Problem::instance()->n_dim());
@@ -712,13 +711,13 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_arte
           switch (Global::Problem::instance()->n_dim())
           {
             case 1:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::tet4, 1>>();
             case 2:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::tet4, 2>>();
             case 3:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::tet4, 3>>();
             default:
               FOUR_C_THROW("Unsupported dimension {}.", Global::Problem::instance()->n_dim());
@@ -729,13 +728,13 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_arte
           switch (Global::Problem::instance()->n_dim())
           {
             case 1:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::tet10, 1>>();
             case 2:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::tet10, 2>>();
             case 3:
-              return std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
+              return std::make_shared<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<
                   Core::FE::CellType::line2, Core::FE::CellType::tet10, 3>>();
             default:
               FOUR_C_THROW("Unsupported dimension {}.", Global::Problem::instance()->n_dim());
@@ -755,7 +754,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::create_new_arte
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_vector(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup_vector(
     std::shared_ptr<Core::LinAlg::Vector<double>> vec,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vec_art)
@@ -769,7 +768,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_vect
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::extract_single_field_vectors(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::extract_single_field_vectors(
     std::shared_ptr<const Core::LinAlg::Vector<double>> globalvec,
     std::shared_ptr<const Core::LinAlg::Vector<double>>& vec_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>>& vec_art)
@@ -783,7 +782,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::extract_si
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Map>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::artery_dof_row_map() const
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::artery_dof_row_map() const
 {
   return globalex_->Map(1);
 }
@@ -791,14 +790,14 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::artery_dof_row_
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Map>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::dof_row_map() const
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::dof_row_map() const
 {
   return fullmap_;
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_solution_vectors(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::set_solution_vectors(
     std::shared_ptr<const Core::LinAlg::Vector<double>> phinp_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phin_cont,
     std::shared_ptr<const Core::LinAlg::Vector<double>> phinp_art)
@@ -811,7 +810,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_soluti
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::blood_vessel_volume_fraction()
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::blood_vessel_volume_fraction()
 {
   FOUR_C_THROW("Not implemented in base class");
   return nullptr;
@@ -819,8 +818,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::blood_vessel_vo
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::print_out_coupling_method()
-    const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::print_out_coupling_method() const
 {
   std::string name;
   if (coupling_method_ == Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::mp)
@@ -842,8 +840,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::print_out_
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
-    fill_function_and_scale_vectors()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::fill_function_and_scale_vectors()
 {
   scale_vec_.resize(2);
   funct_vec_.resize(2);
@@ -871,7 +868,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_time_fac_rhs()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::set_time_fac_rhs()
 {
   // set the right hand side factor
   if (contdis_->name() == "porofluid")
@@ -902,7 +899,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_time_f
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::set_nearby_ele_pairs(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::set_nearby_ele_pairs(
     const std::map<int, std::set<int>>* nearbyelepairs)
 {
   nearbyelepairs_ = *nearbyelepairs;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.hpp
@@ -26,7 +26,7 @@ namespace Core::LinAlg
 {
   class SerialDenseVector;
 }
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   // forward declaration
   class PoroMultiPhaseScatraArteryCouplingPairBase;
@@ -101,7 +101,7 @@ namespace PoroMultiPhaseScaTra
     double delete_free_hanging_eles_threshold_;
 
     //! interacting pairs of artery and continuous-discretization elements
-    std::vector<std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>>
+    std::vector<std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>
         coupl_elepairs_;
 
     //! vector with 1D coupling nodes for ntp coupling
@@ -182,7 +182,7 @@ namespace PoroMultiPhaseScaTra
 
     //! return appropriate internal implementation class (acts as a simple factory to create single
     //! pairs)
-    static std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPairBase>
+    static std::shared_ptr<PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>
     create_new_artery_coupling_pair(std::vector<Core::Elements::Element const*> const& ele_ptrs);
 
     //! set the artery diameter in material to be able to use it on 1D discretization
@@ -235,7 +235,7 @@ namespace PoroMultiPhaseScaTra
     //! coupling rhs-vector (FE)
     std::shared_ptr<Epetra_FEVector> fe_rhs_;
   };
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.cpp
@@ -30,7 +30,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::PoroMultiPhaseScatraArteryCouplingPair()
     : PoroMultiPhaseScatraArteryCouplingPairBase(),
       coupltype_(CouplingType::type_undefined),
@@ -84,7 +84,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distyp
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::init(std::vector<Core::Elements::Element const*> elements,
     const Teuchos::ParameterList& couplingparams, const Teuchos::ParameterList& fluidcouplingparams,
     const std::vector<int>& coupleddofs_cont, const std::vector<int>& coupleddofs_art,
@@ -284,7 +284,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::setup_fluid_managers_and_materials(const std::string disname,
     const double& timefacrhs_art, const double& timefacrhs_cont)
 {
@@ -495,7 +495,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::pre_evaluate(std::shared_ptr<Core::LinAlg::MultiVector<double>> gp_vector)
 {
   if (!isinit_) FOUR_C_THROW("MeshTying Pair has not yet been initialized");
@@ -519,7 +519,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::pre_evaluate_lateral_surface_coupling(Core::LinAlg::MultiVector<double>& gp_vector)
 {
   const int pid =
@@ -635,7 +635,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::pre_evaluate_centerline_coupling()
 {
   // Try to create integration segment [eta_a, eta_b]
@@ -714,7 +714,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::pre_evaluate_node_to_point_coupling()
 {
   xi_.resize(1);
@@ -750,7 +750,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::delete_unnecessary_gps(std::shared_ptr<Core::LinAlg::MultiVector<double>> gp_vector)
 {
   const int mylid = element1_->lid();
@@ -788,7 +788,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::reset_state(std::shared_ptr<Core::FE::Discretization> contdis,
     std::shared_ptr<Core::FE::Discretization> artdis)
 {
@@ -897,13 +897,13 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-double PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
-    dim>::evaluate(Core::LinAlg::SerialDenseVector* forcevec1,
-    Core::LinAlg::SerialDenseVector* forcevec2, Core::LinAlg::SerialDenseMatrix* stiffmat11,
-    Core::LinAlg::SerialDenseMatrix* stiffmat12, Core::LinAlg::SerialDenseMatrix* stiffmat21,
-    Core::LinAlg::SerialDenseMatrix* stiffmat22, Core::LinAlg::SerialDenseMatrix* D_ele,
-    Core::LinAlg::SerialDenseMatrix* M_ele, Core::LinAlg::SerialDenseVector* Kappa_ele,
-    const std::vector<double>& segmentlengths)
+double
+PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont, dim>::evaluate(
+    Core::LinAlg::SerialDenseVector* forcevec1, Core::LinAlg::SerialDenseVector* forcevec2,
+    Core::LinAlg::SerialDenseMatrix* stiffmat11, Core::LinAlg::SerialDenseMatrix* stiffmat12,
+    Core::LinAlg::SerialDenseMatrix* stiffmat21, Core::LinAlg::SerialDenseMatrix* stiffmat22,
+    Core::LinAlg::SerialDenseMatrix* D_ele, Core::LinAlg::SerialDenseMatrix* M_ele,
+    Core::LinAlg::SerialDenseVector* Kappa_ele, const std::vector<double>& segmentlengths)
 {
   if (!ispreevaluated_) FOUR_C_THROW("MeshTying Pair has not yet been pre-evaluated");
 
@@ -985,7 +985,7 @@ double PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art,
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_additional_linearizationof_integrated_diam(Core::LinAlg::SerialDenseMatrix*
                                                                   stiffmat11,
     Core::LinAlg::SerialDenseMatrix* stiffmat12)
@@ -1011,7 +1011,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-int PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+int PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::ele1_gid() const
 {
   return element1_->id();
@@ -1020,7 +1020,7 @@ int PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, di
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-int PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+int PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::ele2_gid() const
 {
   return element2_->id();
@@ -1029,7 +1029,7 @@ int PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, di
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-int PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+int PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::get_segment_id() const
 {
   return segmentid_;
@@ -1038,7 +1038,7 @@ int PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, di
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-double PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+double PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::calculate_vol_2d_3d() const
 {
   // use one-point Gauss rule
@@ -1089,7 +1089,7 @@ double PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art,
 /*------------------------------------------------------------------------*
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::set_segment_id(const int& segmentid)
 {
   segmentid_ = segmentid;
@@ -1098,7 +1098,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-double PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+double PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::apply_mesh_movement(const bool firstcall,
     std::shared_ptr<Core::FE::Discretization> contdis)
 {
@@ -1159,7 +1159,7 @@ double PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art,
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::recompute_eta_and_xi_in_deformed_configuration(const std::vector<double>& segmentlengths,
     std::vector<double>& myEta, std::vector<std::vector<double>>& myXi, double& etaA, double& etaB)
 {
@@ -1272,7 +1272,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_gpts(const std::vector<double>& eta, const std::vector<std::vector<double>>& xi,
     const std::vector<double>& segmentlengths, Core::LinAlg::SerialDenseVector* forcevec1,
     Core::LinAlg::SerialDenseVector* forcevec2, Core::LinAlg::SerialDenseMatrix* stiffmat11,
@@ -1336,7 +1336,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_ntp(const std::vector<double>& eta, const std::vector<std::vector<double>>& xi,
     Core::LinAlg::SerialDenseVector* forcevec1, Core::LinAlg::SerialDenseVector* forcevec2,
     Core::LinAlg::SerialDenseMatrix* stiffmat11, Core::LinAlg::SerialDenseMatrix* stiffmat12,
@@ -1396,7 +1396,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_dm_kappa(const std::vector<double>& eta,
     const std::vector<std::vector<double>>& xi, const std::vector<double>& segmentlengths,
     Core::LinAlg::SerialDenseMatrix* D_ele, Core::LinAlg::SerialDenseMatrix* M_ele,
@@ -1455,7 +1455,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_function_coupling(const std::vector<double>& eta,
     const std::vector<std::vector<double>>& xi, const std::vector<double>& segmentlengths,
     Core::LinAlg::SerialDenseVector* forcevec1, Core::LinAlg::SerialDenseVector* forcevec2,
@@ -1533,7 +1533,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*---------------------------------------------------------------------------------*
  *---------------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluated_nds_solid_vel(const std::vector<double>& eta,
     const std::vector<std::vector<double>>& xi, const std::vector<double>& segmentlengths,
     Core::LinAlg::SerialDenseVector& forcevec1, const double& etaA, const double& etaB)
@@ -1612,7 +1612,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_gpts_stiff(const double& w_gp, const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& jacobi, const double& pp)
 {
@@ -1670,7 +1670,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_ntp_stiff(const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& pp)
 {
@@ -1728,7 +1728,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_dm_kappa(const double& w_gp, const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& jacobi)
 {
@@ -1767,7 +1767,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_gptsntp_force(Core::LinAlg::SerialDenseVector& forcevec1,
     Core::LinAlg::SerialDenseVector& forcevec2, const Core::LinAlg::SerialDenseMatrix& stiffmat11,
     const Core::LinAlg::SerialDenseMatrix& stiffmat12,
@@ -1792,7 +1792,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::update_gptsntp_stiff(Core::LinAlg::SerialDenseMatrix& stiffmat11,
     Core::LinAlg::SerialDenseMatrix& stiffmat12, Core::LinAlg::SerialDenseMatrix& stiffmat21,
     Core::LinAlg::SerialDenseMatrix& stiffmat22)
@@ -1807,7 +1807,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::check_valid_volume_fraction_pressure_coupling(Core::LinAlg::SerialDenseMatrix& stiffmat11,
     Core::LinAlg::SerialDenseMatrix& stiffmat12, Core::LinAlg::SerialDenseMatrix& stiffmat21,
     Core::LinAlg::SerialDenseMatrix& stiffmat22)
@@ -1853,7 +1853,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::update_dm_kappa(Core::LinAlg::SerialDenseMatrix& D_ele,
     Core::LinAlg::SerialDenseMatrix& M_ele, Core::LinAlg::SerialDenseVector& Kappa_ele)
 {
@@ -1886,7 +1886,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_function_coupling(const double& w_gp,
     const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& jacobi,
@@ -1952,7 +1952,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_diam_function_and_deriv(const double artpressnpAtGP, const double& w_gp,
     const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& jacobi)
@@ -2041,7 +2041,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::set_time_fac_rhs(const double& arterydensity, Mat::MatList& contscatramat,
     const double& timefacrhs_art, const double& timefacrhs_cont)
 {
@@ -2116,7 +2116,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::extract_solid_vel(Core::FE::Discretization& contdis)
 {
   // no need for this
@@ -2141,7 +2141,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-FAD PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+FAD PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::integrate_length_to_eta_s(const FAD& eta_s)
 {
   FAD length = 0.0;
@@ -2224,7 +2224,7 @@ FAD PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, di
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::get_artery_values_at_gp(const Core::LinAlg::Matrix<1, numnodesart_>& N1, double& artpress,
     std::vector<double>& artscalar)
 {
@@ -2259,7 +2259,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::get_cont_scalar_values_at_gp(const Core::LinAlg::Matrix<1, numnodescont_>& N2,
     std::vector<double>& contscalarnp)
 {
@@ -2292,7 +2292,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::assemble_function_coupling_into_force_stiff_art(const int& i_art, const double& w_gp,
     const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& jacobi, const int& scale,
@@ -2325,7 +2325,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::assemble_function_coupling_into_force_stiff_cont(const std::vector<int>& assembleInto,
     const double& w_gp, const Core::LinAlg::Matrix<1, numnodesart_>& N1,
     const Core::LinAlg::Matrix<1, numnodescont_>& N2, const double& jacobi, const int& scale,
@@ -2373,7 +2373,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_function_and_deriv(const Core::Utils::FunctionOfAnything& funct,
     const double& artpressnpAtGP, const std::vector<double>& artscalarnpAtGP,
     const std::vector<double>& scalarnpAtGP, double& functval, std::vector<double>& artderivs,
@@ -2453,7 +2453,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::set_scalar_values_as_constants(std::vector<std::pair<std::string, double>>& constants,
     const std::vector<double>& artscalarnpAtGP, const std::vector<double>& scalarnpAtGP)
 {
@@ -2469,7 +2469,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::set_fluid_values_as_variables(std::vector<std::pair<std::string, double>>& variables,
     const double& artpressnpAtGP)
 {
@@ -2503,7 +2503,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::set_fluid_values_as_constants(std::vector<std::pair<std::string, double>>& constants,
     const double& artpressnpAtGP)
 {
@@ -2547,7 +2547,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::set_scalar_values_as_variables(std::vector<std::pair<std::string, double>>& variables,
     const std::vector<double>& artscalarnpAtGP, const std::vector<double>& scalarnpAtGP)
 {
@@ -2563,7 +2563,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_fluid_derivs(std::vector<double>& artderivs, std::vector<double>& contderivs,
     const std::vector<double>& functderivs)
 {
@@ -2618,7 +2618,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::evaluate_scalar_derivs(std::vector<double>& artderivs, std::vector<double>& contderivs,
     const std::vector<double>& functderivs)
 {
@@ -2633,7 +2633,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::create_integration_segment()
 {
   if (PROJOUTPUT)
@@ -2810,7 +2810,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*-----------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-std::vector<double> PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art,
+std::vector<double> PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art,
     distype_cont, dim>::get_all_inter_sections()
 {
   std::vector<double> intersections(0);
@@ -2880,7 +2880,7 @@ std::vector<double> PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair
 /*-----------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-bool PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+bool PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::projection_not_yet_found(const std::vector<double>& intersections, const double& eta)
 {
   for (unsigned int i = 0; i < intersections.size(); i++)
@@ -2897,7 +2897,7 @@ bool PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::inter_sect_with_2d_3d(std::vector<double>& xi, double& eta, const int& fixedPar,
     const double& fixedAt, bool& projection_valid)
 {
@@ -3260,7 +3260,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
 template <typename T>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::projection(Core::LinAlg::Matrix<numdim_, 1, T>& r1, std::vector<T>& xi,
     bool& projection_valid)
 {
@@ -3523,7 +3523,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
 template <typename T>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::get_1d_shape_functions(Core::LinAlg::Matrix<1, numnodesart_, T>& N1,
     Core::LinAlg::Matrix<1, numnodesart_, T>& N1_eta, const T& eta)
 {
@@ -3545,7 +3545,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
 template <typename T>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::get_2d_3d_shape_functions(Core::LinAlg::Matrix<1, numnodescont_, T>& N2,
     Core::LinAlg::Matrix<numdim_, numnodescont_, T>& N2_xi, const std::vector<T>& xi)
 {
@@ -3582,7 +3582,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
 template <typename T>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::compute_artery_coords_and_derivs_ref(Core::LinAlg::Matrix<numdim_, 1, T>& r1,
     Core::LinAlg::Matrix<numdim_, 1, T>& r1_eta, const Core::LinAlg::Matrix<1, numnodesart_, T>& N1,
     const Core::LinAlg::Matrix<1, numnodesart_, T>& N1_eta)
@@ -3605,7 +3605,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
  *------------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
 template <typename T>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::compute_2d_3d_coords_and_derivs_ref(Core::LinAlg::Matrix<numdim_, 1, T>& x2,
     Core::LinAlg::Matrix<numdim_, numdim_, T>& x2_xi,
     const Core::LinAlg::Matrix<1, numnodescont_, T>& N2,
@@ -3630,7 +3630,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::fill_function_vector(std::vector<const Core::Utils::FunctionOfAnything*>& my_funct_vec,
     const std::vector<int>& funct_vec, const std::vector<int>& scale_vec)
 {
@@ -3651,7 +3651,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::initialize_function(const Core::Utils::FunctionOfAnything& funct)
 {
   // safety check
@@ -3662,7 +3662,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::initialize_function_names()
 {
   pressurenames_.resize(numfluidphases_);
@@ -3730,7 +3730,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype_art, Core::FE::CellType distype_cont, int dim>
-void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
+void PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<distype_art, distype_cont,
     dim>::initialize_assemble_into_cont_dof_vector()
 {
   cont_dofs_to_assemble_functions_into_.resize(numdof_cont_);
@@ -3766,31 +3766,31 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
 
 
 // explicit template instantiations
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::quad4, 1>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::hex8, 1>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::tet4, 1>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::tet10, 1>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::quad4, 1>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::hex8, 1>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::tet4, 1>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::tet10, 1>;
 
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::quad4, 2>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::hex8, 2>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::tet4, 2>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::tet10, 2>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::quad4, 2>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::hex8, 2>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::tet4, 2>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::tet10, 2>;
 
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::quad4, 3>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::hex8, 3>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::tet4, 3>;
-template class PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<
-    Core::FE::CellType::line2, Core::FE::CellType::tet10, 3>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::quad4, 3>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::hex8, 3>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::tet4, 3>;
+template class PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPair<Core::FE::CellType::line2,
+    Core::FE::CellType::tet10, 3>;
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.cpp
@@ -463,7 +463,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
   // create phase-manager
   phasemanager_ = Discret::Elements::PoroFluidManager::PhaseManagerInterface::create_phase_manager(
       *para, numdim_, multiphasemat->material_type(),
-      POROFLUIDMULTIPHASE::Action::get_access_from_artcoupling, multiphasemat->num_mat(),
+      PoroPressureBased::Action::get_access_from_artcoupling, multiphasemat->num_mat(),
       multiphasemat->num_fluid_phases());
 
   // setup phasemanager
@@ -472,7 +472,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScatraArteryCouplingPair<distype_art, d
   // create variablemanager
   variablemanager_ = Discret::Elements::PoroFluidManager::VariableManagerInterface<numdim_,
       numnodescont_>::create_variable_manager(*para,
-      POROFLUIDMULTIPHASE::Action::get_access_from_artcoupling, multiphasemat,
+      PoroPressureBased::Action::get_access_from_artcoupling, multiphasemat,
       multiphasemat->num_mat(), multiphasemat->num_fluid_phases());
 
   // initialize the names used in functions

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp
@@ -57,7 +57,7 @@ namespace Core
     class FunctionOfAnything;
   }
 }  // namespace Core
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   class PoroMultiPhaseScatraArteryCouplingPairBase
   {
@@ -732,7 +732,7 @@ namespace PoroMultiPhaseScaTra
     std::shared_ptr<Mat::Cnst1dArt> arterymat_;
   };
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
@@ -17,7 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::PoroMultiPhaseScaTraArtCouplSurfBased(
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::PoroMultiPhaseScaTraArtCouplSurfBased(
     std::shared_ptr<Core::FE::Discretization> arterydis,
     std::shared_ptr<Core::FE::Discretization> contdis, const Teuchos::ParameterList& couplingparams,
     const std::string& condname, const std::string& artcoupleddofname,
@@ -38,7 +38,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::PoroMultiPhaseScaTr
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::pre_evaluate_coupling_pairs()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::pre_evaluate_coupling_pairs()
 {
   const int numpatch_axi = Global::Problem::instance()
                                ->poro_fluid_multi_phase_dynamic_params()
@@ -164,10 +164,10 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::pre_evaluate_c
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::setup()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::setup()
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup();
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup();
 
   // error-checks
   if (has_varying_diam_)
@@ -180,7 +180,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::setup()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::evaluate(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::evaluate(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
@@ -193,12 +193,12 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::evaluate(
   }
 
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(sysmat, rhs);
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::evaluate(sysmat, rhs);
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::setup_system(
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::setup_system(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
     std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
@@ -209,14 +209,14 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::setup_system(
     std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art)
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(*sysmat, rhs,
+  PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::setup_system(*sysmat, rhs,
       *sysmat_cont, *sysmat_art, rhs_cont, rhs_art, *dbcmap_cont, *dbcmap_art->cond_map(),
       *dbcmap_art->cond_map());
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::apply_mesh_movement()
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::apply_mesh_movement()
 {
   if (!evaluate_in_ref_config_)
     FOUR_C_THROW("Evaluation in current configuration not possible for surface-based coupling");
@@ -225,7 +225,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::apply_mesh_mov
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<const Core::LinAlg::Vector<double>>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::blood_vessel_volume_fraction()
+PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::blood_vessel_volume_fraction()
 {
   FOUR_C_THROW("Output of vessel volume fraction not possible for surface-based coupling");
 
@@ -235,7 +235,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::blood_vessel_volume
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased::print_out_coupling_method() const
+void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::print_out_coupling_method() const
 {
   std::cout << "<   surface-based formulation                      >" << std::endl;
   PoroMultiPhaseScaTraArtCouplNonConforming::print_out_coupling_method();

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.hpp
@@ -15,7 +15,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   // forward declaration
   class PoroMultiPhaseScatraArteryCouplingPairBase;
@@ -84,7 +84,7 @@ namespace PoroMultiPhaseScaTra
     //! print out the coupling method
     void print_out_coupling_method() const override;
   };
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
@@ -107,7 +107,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase::init(
         "approach instead.");
   }
 
-  poromulti_ = POROMULTIPHASE::Utils::create_poro_multi_phase_algorithm(
+  poromulti_ = POROMULTIPHASE::create_poro_multi_phase_algorithm(
       solschemeporo, globaltimeparams, get_comm());
 
   // initialize

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
@@ -134,7 +134,7 @@ namespace PoroPressureBased
 
    protected:
     //! what to do when nonlinear solution fails
-    enum PoroPressureBased::DivContAct divcontype_;
+    enum PoroPressureBased::DivergenceAction divcontype_;
     //! do we perform coupling with 1D artery
     const bool artery_coupl_;
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
@@ -39,7 +39,7 @@ namespace ScaTra
   class MeshtyingStrategyArtery;
 }
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhaseScaTraBase : public Adapter::AlgorithmBase
@@ -134,7 +134,7 @@ namespace PoroMultiPhaseScaTra
 
    protected:
     //! what to do when nonlinear solution fails
-    enum PoroMultiPhaseScaTra::DivContAct divcontype_;
+    enum PoroPressureBased::DivContAct divcontype_;
     //! do we perform coupling with 1D artery
     const bool artery_coupl_;
 
@@ -146,7 +146,7 @@ namespace PoroMultiPhaseScaTra
   };  // PoroMultiPhaseScaTraBase
 
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.hpp
@@ -104,7 +104,7 @@ namespace PoroMultiPhaseScaTra
     void apply_additional_dbc_for_vol_frac_species();
 
     //! access to poro field
-    const std::shared_ptr<POROMULTIPHASE::PoroMultiPhase>& poro_field() { return poromulti_; }
+    const std::shared_ptr<PoroPressureBased::PoroMultiPhase>& poro_field() { return poromulti_; }
 
     //! access to fluid field
     const std::shared_ptr<Adapter::ScaTraBaseAlgorithm>& scatra_algo() { return scatra_; }
@@ -117,13 +117,13 @@ namespace PoroMultiPhaseScaTra
 
    private:
     //! underlying poroelast multi phase
-    std::shared_ptr<POROMULTIPHASE::PoroMultiPhase> poromulti_;
+    std::shared_ptr<PoroPressureBased::PoroMultiPhase> poromulti_;
 
     //! underlying scatra problem
     std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra_;
 
     //! flux-reconstruction method
-    POROFLUIDMULTIPHASE::FluxReconstructionMethod fluxreconmethod_;
+    PoroPressureBased::FluxReconstructionMethod fluxreconmethod_;
 
     //! dofset of scatra field on fluid dis
     //! TODO: find a better way to do this. Perhaps this should be moved to the adapter?

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
@@ -65,7 +65,7 @@ void poromultiphasescatra_dyn(int restart)
 
   // Setup discretizations and coupling. Assign the dof sets and return the numbers
   std::map<int, std::set<int>> nearbyelepairs =
-      PoroMultiPhaseScaTra::Utils::setup_discretizations_and_field_coupling(comm, struct_disname,
+      PoroMultiPhaseScaTra::setup_discretizations_and_field_coupling(comm, struct_disname,
           fluid_disname, scatra_disname, ndsporo_disp, ndsporo_vel, ndsporo_solidpressure,
           ndsporofluid_scatra, artery_coupl);
 
@@ -77,7 +77,7 @@ void poromultiphasescatra_dyn(int restart)
       poroscatraparams, "COUPALGO");
 
   std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase> algo =
-      PoroMultiPhaseScaTra::Utils::create_poro_multi_phase_scatra_algorithm(
+      PoroMultiPhaseScaTra::create_poro_multi_phase_scatra_algorithm(
           solscheme, poroscatraparams, comm);
 
   algo->init(poroscatraparams, poroscatraparams, poroparams, structparams, fluidparams,
@@ -97,7 +97,7 @@ void poromultiphasescatra_dyn(int restart)
   // assign materials
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  PoroMultiPhaseScaTra::Utils::assign_material_pointers(
+  PoroMultiPhaseScaTra::assign_material_pointers(
       struct_disname, fluid_disname, scatra_disname, artery_coupl);
 
   // Setup Solver (necessary if poro-structure coupling solved monolithically)

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_dyn.cpp
@@ -35,7 +35,6 @@ void poromultiphasescatra_dyn(int restart)
   // print problem type
   if (Core::Communication::my_mpi_rank(comm) == 0)
   {
-    PoroMultiPhaseScaTra::print_logo();
     std::cout << "###################################################" << std::endl;
     std::cout << "# YOUR PROBLEM TYPE: " << problem->problem_name() << std::endl;
     std::cout << "###################################################" << std::endl;
@@ -65,20 +64,19 @@ void poromultiphasescatra_dyn(int restart)
 
   // Setup discretizations and coupling. Assign the dof sets and return the numbers
   std::map<int, std::set<int>> nearbyelepairs =
-      PoroMultiPhaseScaTra::setup_discretizations_and_field_coupling(comm, struct_disname,
-          fluid_disname, scatra_disname, ndsporo_disp, ndsporo_vel, ndsporo_solidpressure,
-          ndsporofluid_scatra, artery_coupl);
+      PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast_scatra(comm,
+          struct_disname, fluid_disname, scatra_disname, ndsporo_disp, ndsporo_vel,
+          ndsporo_solidpressure, ndsporofluid_scatra, artery_coupl);
 
   // -------------------------------------------------------------------
   // algorithm construction depending on
   // coupling scheme
   // -------------------------------------------------------------------
-  auto solscheme = Teuchos::getIntegralValue<PoroMultiPhaseScaTra::SolutionSchemeOverFields>(
+  auto solscheme = Teuchos::getIntegralValue<PoroPressureBased::SolutionSchemePorofluidElastScatra>(
       poroscatraparams, "COUPALGO");
 
-  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase> algo =
-      PoroMultiPhaseScaTra::create_poro_multi_phase_scatra_algorithm(
-          solscheme, poroscatraparams, comm);
+  std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraBase> algo =
+      PoroPressureBased::create_algorithm_porofluid_elast_scatra(solscheme, poroscatraparams, comm);
 
   algo->init(poroscatraparams, poroscatraparams, poroparams, structparams, fluidparams,
       scatraparams, struct_disname, fluid_disname, scatra_disname, true, ndsporo_disp, ndsporo_vel,
@@ -97,7 +95,7 @@ void poromultiphasescatra_dyn(int restart)
   // assign materials
   // note: to be done after potential restart, as in read_restart()
   //       the secondary material is destroyed
-  PoroMultiPhaseScaTra::assign_material_pointers(
+  PoroPressureBased::assign_material_pointers_porofluid_elast_scatra(
       struct_disname, fluid_disname, scatra_disname, artery_coupl);
 
   // Setup Solver (necessary if poro-structure coupling solved monolithically)

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function.cpp
@@ -27,8 +27,8 @@ namespace
 
     if (type == "TUMOR_GROWTH_LAW_HEAVISIDE")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>>(
-          PoroMultiPhaseScaTra::TumorGrowthLawHeavisideParameters{
+      return std::make_shared<PoroPressureBased::TumorGrowthLawHeaviside<dim>>(
+          PoroPressureBased::TumorGrowthLawHeavisideParameters{
               .gamma_T_growth = parameters.get<double>("gamma_T_growth"),
               .w_nl_crit = parameters.get<double>("w_nl_crit"),
               .w_nl_env = parameters.get<double>("w_nl_env"),
@@ -38,8 +38,8 @@ namespace
     }
     if (type == "NECROSIS_LAW_HEAVISIDE")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>>(
-          PoroMultiPhaseScaTra::NecrosisLawHeavisideParameters{
+      return std::make_shared<PoroPressureBased::NecrosisLawHeaviside<dim>>(
+          PoroPressureBased::NecrosisLawHeavisideParameters{
               .gamma_t_necr = parameters.get<double>("gamma_t_necr"),
               .w_nl_crit = parameters.get<double>("w_nl_crit"),
               .w_nl_env = parameters.get<double>("w_nl_env"),
@@ -49,8 +49,8 @@ namespace
     }
     if (type == "OXYGEN_CONSUMPTION_LAW_HEAVISIDE")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>>(
-          PoroMultiPhaseScaTra::OxygenConsumptionLawHeavisideParameters{
+      return std::make_shared<PoroPressureBased::OxygenConsumptionLawHeaviside<dim>>(
+          PoroPressureBased::OxygenConsumptionLawHeavisideParameters{
               .gamma_nl_growth = parameters.get<double>("gamma_nl_growth"),
               .gamma_0_nl = parameters.get<double>("gamma_0_nl"),
               .w_nl_crit = parameters.get<double>("w_nl_crit"),
@@ -60,8 +60,8 @@ namespace
     }
     if (type == "TUMOR_GROWTH_LAW_HEAVISIDE_OXY")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>>(
-          PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecroOxyParameters{
+      return std::make_shared<PoroPressureBased::TumorGrowthLawHeavisideOxy<dim>>(
+          PoroPressureBased::TumorGrowthLawHeavisideNecroOxyParameters{
               .gamma_T_growth = parameters.get<double>("gamma_T_growth"),
               .w_nl_crit = parameters.get<double>("w_nl_crit"),
               .w_nl_env = parameters.get<double>("w_nl_env"),
@@ -71,8 +71,8 @@ namespace
     }
     if (type == "TUMOR_GROWTH_LAW_HEAVISIDE_NECRO")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>>(
-          PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecroOxyParameters{
+      return std::make_shared<PoroPressureBased::TumorGrowthLawHeavisideNecro<dim>>(
+          PoroPressureBased::TumorGrowthLawHeavisideNecroOxyParameters{
               .gamma_T_growth = parameters.get<double>("gamma_T_growth"),
               .w_nl_crit = parameters.get<double>("w_nl_crit"),
               .w_nl_env = parameters.get<double>("w_nl_env"),
@@ -82,8 +82,8 @@ namespace
     }
     if (type == "OXYGEN_TRANSVASCULAR_EXCHANGE_LAW_CONT")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>>(
-          PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawContParameters{
+      return std::make_shared<PoroPressureBased::OxygenTransvascularExchangeLawCont<dim>>(
+          PoroPressureBased::OxygenTransvascularExchangeLawContParameters{
               .n = parameters.get<double>("n"),
               .Pb50 = parameters.get<double>("Pb50"),
               .CaO2_max = parameters.get<double>("CaO2_max"),
@@ -97,8 +97,8 @@ namespace
     }
     if (type == "OXYGEN_TRANSVASCULAR_EXCHANGE_LAW_DISC")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>>(
-          PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDiscParameters{
+      return std::make_shared<PoroPressureBased::OxygenTransvascularExchangeLawDisc<dim>>(
+          PoroPressureBased::OxygenTransvascularExchangeLawDiscParameters{
               .n = parameters.get<double>("n"),
               .Pb50 = parameters.get<double>("Pb50"),
               .CaO2_max = parameters.get<double>("CaO2_max"),
@@ -113,8 +113,8 @@ namespace
     }
     if (type == "LUNG_OXYGEN_EXCHANGE_LAW")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>>(
-          PoroMultiPhaseScaTra::LungOxygenExchangeLawParameters{
+      return std::make_shared<PoroPressureBased::LungOxygenExchangeLaw<dim>>(
+          PoroPressureBased::LungOxygenExchangeLawParameters{
               .rho_oxy = parameters.get<double>("rho_oxy"),
               .DiffAdVTLC = parameters.get<double>("DiffAdVTLC"),
               .alpha_oxy = parameters.get<double>("alpha_oxy"),
@@ -129,8 +129,8 @@ namespace
     }
     if (type == "LUNG_CARBONDIOXIDE_EXCHANGE_LAW")
     {
-      return std::make_shared<PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>>(
-          PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLawParameters{
+      return std::make_shared<PoroPressureBased::LungCarbonDioxideExchangeLaw<dim>>(
+          PoroPressureBased::LungCarbonDioxideExchangeLawParameters{
               .rho_CO2 = parameters.get<double>("rho_CO2"),
               .DiffsolAdVTLC = parameters.get<double>("DiffsolAdVTLC"),
               .pH = parameters.get<double>("pH"),
@@ -186,14 +186,14 @@ namespace
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraFunction<dim>::PoroMultiPhaseScaTraFunction()
+PoroPressureBased::PoroMultiPhaseScaTraFunction<dim>::PoroMultiPhaseScaTraFunction()
     : order_checked_(false)
 {
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager& function_manager)
+void PoroPressureBased::add_valid_poro_functions(Core::Utils::FunctionManager& function_manager)
 {
   using namespace Core::IO::InputSpecBuilders;
 
@@ -314,7 +314,7 @@ void PoroMultiPhaseScaTra::add_valid_poro_functions(Core::Utils::FunctionManager
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::TumorGrowthLawHeaviside(
+PoroPressureBased::TumorGrowthLawHeaviside<dim>::TumorGrowthLawHeaviside(
     const TumorGrowthLawHeavisideParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -324,7 +324,7 @@ PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::TumorGrowthLawHeaviside(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::check_order(
+void PoroPressureBased::TumorGrowthLawHeaviside<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -349,7 +349,7 @@ void PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::evaluate(
+double PoroPressureBased::TumorGrowthLawHeaviside<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -378,7 +378,7 @@ double PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::TumorGrowthLawHeaviside<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -425,7 +425,7 @@ std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<dim>::evaluate
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::NecrosisLawHeaviside(
+PoroPressureBased::NecrosisLawHeaviside<dim>::NecrosisLawHeaviside(
     const NecrosisLawHeavisideParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -435,7 +435,7 @@ PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::NecrosisLawHeaviside(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::check_order(
+void PoroPressureBased::NecrosisLawHeaviside<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -460,7 +460,7 @@ void PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::evaluate(
+double PoroPressureBased::NecrosisLawHeaviside<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -490,7 +490,7 @@ double PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::NecrosisLawHeaviside<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -560,7 +560,7 @@ std::vector<double> PoroMultiPhaseScaTra::NecrosisLawHeaviside<dim>::evaluate_de
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::OxygenConsumptionLawHeaviside(
+PoroPressureBased::OxygenConsumptionLawHeaviside<dim>::OxygenConsumptionLawHeaviside(
     const OxygenConsumptionLawHeavisideParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -569,7 +569,7 @@ PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::OxygenConsumptionLawHe
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::check_order(
+void PoroPressureBased::OxygenConsumptionLawHeaviside<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -594,7 +594,7 @@ void PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::evaluate(
+double PoroPressureBased::OxygenConsumptionLawHeaviside<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -626,7 +626,7 @@ double PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::OxygenConsumptionLawHeaviside<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -702,7 +702,7 @@ std::vector<double> PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<dim>::ev
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::TumorGrowthLawHeavisideOxy(
+PoroPressureBased::TumorGrowthLawHeavisideOxy<dim>::TumorGrowthLawHeavisideOxy(
     const TumorGrowthLawHeavisideNecroOxyParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -711,7 +711,7 @@ PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::TumorGrowthLawHeavisideOx
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::check_order(
+void PoroPressureBased::TumorGrowthLawHeavisideOxy<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -736,7 +736,7 @@ void PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::evaluate(
+double PoroPressureBased::TumorGrowthLawHeavisideOxy<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -767,7 +767,7 @@ double PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::TumorGrowthLawHeavisideOxy<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -839,7 +839,7 @@ std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<dim>::evalu
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::TumorGrowthLawHeavisideNecro(
+PoroPressureBased::TumorGrowthLawHeavisideNecro<dim>::TumorGrowthLawHeavisideNecro(
     const TumorGrowthLawHeavisideNecroOxyParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -848,7 +848,7 @@ PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::TumorGrowthLawHeaviside
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::check_order(
+void PoroPressureBased::TumorGrowthLawHeavisideNecro<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -873,7 +873,7 @@ void PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::evaluate(
+double PoroPressureBased::TumorGrowthLawHeavisideNecro<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -906,7 +906,7 @@ double PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::TumorGrowthLawHeavisideNecro<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -982,7 +982,7 @@ std::vector<double> PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<dim>::eva
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::OxygenTransvascularExchangeLawCont(
+PoroPressureBased::OxygenTransvascularExchangeLawCont<dim>::OxygenTransvascularExchangeLawCont(
     const OxygenTransvascularExchangeLawContParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -991,7 +991,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::OxygenTransvascul
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::check_order(
+void PoroPressureBased::OxygenTransvascularExchangeLawCont<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -1016,7 +1016,7 @@ void PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate(
+double PoroPressureBased::OxygenTransvascularExchangeLawCont<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1035,7 +1035,7 @@ double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate(
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
 
   // evaluate function
@@ -1049,8 +1049,7 @@ double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double>
-PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::OxygenTransvascularExchangeLawCont<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1089,7 +1088,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate_derivati
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<FAD>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
   const double heaviside_oxy((Pb - oxy_mass_frac_if / fac_if) > 0. ? 1. : 0.);
 
@@ -1113,7 +1112,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate_derivati
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::OxygenTransvascularExchangeLawDisc(
+PoroPressureBased::OxygenTransvascularExchangeLawDisc<dim>::OxygenTransvascularExchangeLawDisc(
     const OxygenTransvascularExchangeLawDiscParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters), pos_oxy_art_(-1), pos_diam_(-1)
 {
@@ -1122,7 +1121,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::OxygenTransvascul
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::check_order(
+void PoroPressureBased::OxygenTransvascularExchangeLawDisc<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -1159,7 +1158,7 @@ void PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate(
+double PoroPressureBased::OxygenTransvascularExchangeLawDisc<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1179,7 +1178,7 @@ double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate(
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
 
   // evaluate function
@@ -1193,8 +1192,7 @@ double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double>
-PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::OxygenTransvascularExchangeLawDisc<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1218,7 +1216,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate_derivati
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<FAD>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
 
   // evaluate function
@@ -1233,7 +1231,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate_derivati
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::LungOxygenExchangeLaw(
+PoroPressureBased::LungOxygenExchangeLaw<dim>::LungOxygenExchangeLaw(
     const LungOxygenExchangeLawParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -1242,7 +1240,7 @@ PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::LungOxygenExchangeLaw(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::check_order(
+void PoroPressureBased::LungOxygenExchangeLaw<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -1289,7 +1287,7 @@ void PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate(
+double PoroPressureBased::LungOxygenExchangeLaw<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1321,7 +1319,7 @@ double PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate(
   double P_oB = 0.0;
 
   // Calculate partial pressure of oxygen in blood
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
       P_oB, CoB_total, parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
   // evaluate function
@@ -1334,7 +1332,7 @@ double PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::LungOxygenExchangeLaw<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1381,7 +1379,7 @@ std::vector<double> PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate_d
   FAD P_oB = 0.0;
   FAD C_oB_total = oxy_mass_frac_bl * parameters_.rho_bl / parameters_.rho_oxy;
 
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(P_oB, C_oB_total,
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<FAD>(P_oB, C_oB_total,
       parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
 
@@ -1416,7 +1414,7 @@ std::vector<double> PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate_d
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::LungCarbonDioxideExchangeLaw(
+PoroPressureBased::LungCarbonDioxideExchangeLaw<dim>::LungCarbonDioxideExchangeLaw(
     const LungCarbonDioxideExchangeLawParameters& parameters)
     : PoroMultiPhaseScaTraFunction<dim>(), parameters_(parameters)
 {
@@ -1425,7 +1423,7 @@ PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::LungCarbonDioxideExchan
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-void PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::check_order(
+void PoroPressureBased::LungCarbonDioxideExchangeLaw<dim>::check_order(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants) const
 {
@@ -1474,7 +1472,7 @@ void PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::check_order(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-double PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::evaluate(
+double PoroPressureBased::LungCarbonDioxideExchangeLaw<dim>::evaluate(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1507,7 +1505,7 @@ double PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::evaluate(
   double P_O2B = 0.0;
 
   // Calculate partial pressure of oxygen in blood
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(P_O2B, CoB_total,
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(P_O2B, CoB_total,
       parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
   // saturation of hemoglobin with oxygen from hill equation
@@ -1535,7 +1533,7 @@ double PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 template <int dim>
-std::vector<double> PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::evaluate_derivative(
+std::vector<double> PoroPressureBased::LungCarbonDioxideExchangeLaw<dim>::evaluate_derivative(
     const std::vector<std::pair<std::string, double>>& variables,
     const std::vector<std::pair<std::string, double>>& constants, const size_t component) const
 {
@@ -1585,7 +1583,7 @@ std::vector<double> PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::eva
   FAD P_O2B = 0.0;
   FAD C_oB_total = O2_mass_frac_bl * parameters_.rho_bl / parameters_.rho_oxy;
 
-  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(P_O2B, C_oB_total,
+  PoroPressureBased::get_oxy_partial_pressure_from_concentration<FAD>(P_O2B, C_oB_total,
       parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
   // saturation of hemoglobin with oxygen from hill equation
@@ -1647,40 +1645,40 @@ std::vector<double> PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::eva
 
 // explicit instantiations
 
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<1>;
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<2>;
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeaviside<3>;
+template class PoroPressureBased::TumorGrowthLawHeaviside<1>;
+template class PoroPressureBased::TumorGrowthLawHeaviside<2>;
+template class PoroPressureBased::TumorGrowthLawHeaviside<3>;
 
-template class PoroMultiPhaseScaTra::NecrosisLawHeaviside<1>;
-template class PoroMultiPhaseScaTra::NecrosisLawHeaviside<2>;
-template class PoroMultiPhaseScaTra::NecrosisLawHeaviside<3>;
+template class PoroPressureBased::NecrosisLawHeaviside<1>;
+template class PoroPressureBased::NecrosisLawHeaviside<2>;
+template class PoroPressureBased::NecrosisLawHeaviside<3>;
 
-template class PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<1>;
-template class PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<2>;
-template class PoroMultiPhaseScaTra::OxygenConsumptionLawHeaviside<3>;
+template class PoroPressureBased::OxygenConsumptionLawHeaviside<1>;
+template class PoroPressureBased::OxygenConsumptionLawHeaviside<2>;
+template class PoroPressureBased::OxygenConsumptionLawHeaviside<3>;
 
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<1>;
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<2>;
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeavisideOxy<3>;
+template class PoroPressureBased::TumorGrowthLawHeavisideOxy<1>;
+template class PoroPressureBased::TumorGrowthLawHeavisideOxy<2>;
+template class PoroPressureBased::TumorGrowthLawHeavisideOxy<3>;
 
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<1>;
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<2>;
-template class PoroMultiPhaseScaTra::TumorGrowthLawHeavisideNecro<3>;
+template class PoroPressureBased::TumorGrowthLawHeavisideNecro<1>;
+template class PoroPressureBased::TumorGrowthLawHeavisideNecro<2>;
+template class PoroPressureBased::TumorGrowthLawHeavisideNecro<3>;
 
-template class PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<1>;
-template class PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<2>;
-template class PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<3>;
+template class PoroPressureBased::OxygenTransvascularExchangeLawCont<1>;
+template class PoroPressureBased::OxygenTransvascularExchangeLawCont<2>;
+template class PoroPressureBased::OxygenTransvascularExchangeLawCont<3>;
 
-template class PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<1>;
-template class PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<2>;
-template class PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<3>;
+template class PoroPressureBased::OxygenTransvascularExchangeLawDisc<1>;
+template class PoroPressureBased::OxygenTransvascularExchangeLawDisc<2>;
+template class PoroPressureBased::OxygenTransvascularExchangeLawDisc<3>;
 
-template class PoroMultiPhaseScaTra::LungOxygenExchangeLaw<1>;
-template class PoroMultiPhaseScaTra::LungOxygenExchangeLaw<2>;
-template class PoroMultiPhaseScaTra::LungOxygenExchangeLaw<3>;
+template class PoroPressureBased::LungOxygenExchangeLaw<1>;
+template class PoroPressureBased::LungOxygenExchangeLaw<2>;
+template class PoroPressureBased::LungOxygenExchangeLaw<3>;
 
-template class PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<1>;
-template class PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<2>;
-template class PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<3>;
+template class PoroPressureBased::LungCarbonDioxideExchangeLaw<1>;
+template class PoroPressureBased::LungCarbonDioxideExchangeLaw<2>;
+template class PoroPressureBased::LungCarbonDioxideExchangeLaw<3>;
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function.cpp
@@ -1035,7 +1035,7 @@ double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate(
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
 
   // evaluate function
@@ -1089,7 +1089,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawCont<dim>::evaluate_derivati
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<FAD>(
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
   const double heaviside_oxy((Pb - oxy_mass_frac_if / fac_if) > 0. ? 1. : 0.);
 
@@ -1179,7 +1179,7 @@ double PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate(
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
 
   // evaluate function
@@ -1218,7 +1218,7 @@ PoroMultiPhaseScaTra::OxygenTransvascularExchangeLawDisc<dim>::evaluate_derivati
   // safety check --> should not be larger than CaO2_max, which already corresponds to partial
   // pressures of ~250Pa
   CaO2 = std::max(0.0, std::min(CaO2, 1.0 * parameters_.CaO2_max));
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<FAD>(
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(
       Pb, CaO2, parameters_.CaO2_max, parameters_.Pb50, parameters_.n, parameters_.alpha_bl_eff);
 
   // evaluate function
@@ -1321,7 +1321,7 @@ double PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate(
   double P_oB = 0.0;
 
   // Calculate partial pressure of oxygen in blood
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
       P_oB, CoB_total, parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
   // evaluate function
@@ -1381,7 +1381,7 @@ std::vector<double> PoroMultiPhaseScaTra::LungOxygenExchangeLaw<dim>::evaluate_d
   FAD P_oB = 0.0;
   FAD C_oB_total = oxy_mass_frac_bl * parameters_.rho_bl / parameters_.rho_oxy;
 
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<FAD>(P_oB, C_oB_total,
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(P_oB, C_oB_total,
       parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
 
@@ -1507,7 +1507,7 @@ double PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::evaluate(
   double P_O2B = 0.0;
 
   // Calculate partial pressure of oxygen in blood
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(P_O2B, CoB_total,
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(P_O2B, CoB_total,
       parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
   // saturation of hemoglobin with oxygen from hill equation
@@ -1585,7 +1585,7 @@ std::vector<double> PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<dim>::eva
   FAD P_O2B = 0.0;
   FAD C_oB_total = O2_mass_frac_bl * parameters_.rho_bl / parameters_.rho_oxy;
 
-  PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<FAD>(P_O2B, C_oB_total,
+  PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<FAD>(P_O2B, C_oB_total,
       parameters_.NC_Hb, parameters_.P_oB50, parameters_.n, parameters_.alpha_oxy);
 
   // saturation of hemoglobin with oxygen from hill equation

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function.hpp
@@ -23,7 +23,7 @@ namespace Core::Utils
   class FunctionManager;
 }
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   /*!
    * @brief abstract class derived from FunctionOfAnything since reaction functions are cast to
@@ -465,7 +465,7 @@ namespace PoroMultiPhaseScaTra
     const LungCarbonDioxideExchangeLawParameters parameters_;
   };
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function_parameters.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function_parameters.hpp
@@ -15,7 +15,7 @@
 #include <string>
 
 FOUR_C_NAMESPACE_OPEN
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   /*!
    *  @brief struct for managing the parameters of the POROMULTIPHASESCATRA_FUNCTION
@@ -144,7 +144,7 @@ namespace PoroMultiPhaseScaTra
     double ScalingFormmHg{};
     double volfrac_blood_ref{};
   };
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
@@ -10,12 +10,14 @@
 #include "4C_fem_condition_definition.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_linalg_equilibrate.hpp"
+#include "4C_porofluid_pressure_based_input.hpp"
 #include "4C_utils_parameter_list.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
 
-void PoroMultiPhaseScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
+void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
+    std::map<std::string, Core::IO::InputSpec>& list)
 {
   using namespace Core::IO::InputSpecBuilders;
 
@@ -44,14 +46,16 @@ void PoroMultiPhaseScaTra::set_valid_parameters(std::map<std::string, Core::IO::
               {.description = "minimal number of iterations over fields", .default_value = 1}),
 
           // Coupling strategy for poroscatra solvers
-          deprecated_selection<SolutionSchemeOverFields>("COUPALGO",
+          deprecated_selection<SolutionSchemePorofluidElastScatra>("COUPALGO",
               {
-                  {"twoway_partitioned_nested", solscheme_twoway_partitioned_nested},
-                  {"twoway_partitioned_sequential", solscheme_twoway_partitioned_sequential},
-                  {"twoway_monolithic", solscheme_twoway_monolithic},
+                  {"twoway_partitioned_nested",
+                      SolutionSchemePorofluidElastScatra::twoway_partitioned_nested},
+                  {"twoway_partitioned_sequential",
+                      SolutionSchemePorofluidElastScatra::twoway_partitioned_sequential},
+                  {"twoway_monolithic", SolutionSchemePorofluidElastScatra::twoway_monolithic},
               },
               {.description = "Coupling strategies for poroscatra solvers",
-                  .default_value = solscheme_twoway_partitioned_nested}),
+                  .default_value = SolutionSchemePorofluidElastScatra::twoway_partitioned_nested}),
 
           // coupling with 1D artery network active
           parameter<bool>("ARTERY_COUPLING",
@@ -74,25 +78,25 @@ void PoroMultiPhaseScaTra::set_valid_parameters(std::map<std::string, Core::IO::
 
           deprecated_selection<VectorNorm>("VECTORNORM_RESF",
               {
-                  {"L1", PoroMultiPhaseScaTra::norm_l1},
-                  {"L1_Scaled", PoroMultiPhaseScaTra::norm_l1_scaled},
-                  {"L2", PoroMultiPhaseScaTra::norm_l2},
-                  {"Rms", PoroMultiPhaseScaTra::norm_rms},
-                  {"Inf", PoroMultiPhaseScaTra::norm_inf},
+                  {"L1", PoroPressureBased::norm_l1},
+                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
+                  {"L2", PoroPressureBased::norm_l2},
+                  {"Rms", PoroPressureBased::norm_rms},
+                  {"Inf", PoroPressureBased::norm_inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroMultiPhaseScaTra::norm_l2}),
+                  .default_value = PoroPressureBased::norm_l2}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_INC",
               {
-                  {"L1", PoroMultiPhaseScaTra::norm_l1},
-                  {"L1_Scaled", PoroMultiPhaseScaTra::norm_l1_scaled},
-                  {"L2", PoroMultiPhaseScaTra::norm_l2},
-                  {"Rms", PoroMultiPhaseScaTra::norm_rms},
-                  {"Inf", PoroMultiPhaseScaTra::norm_inf},
+                  {"L1", PoroPressureBased::norm_l1},
+                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
+                  {"L2", PoroPressureBased::norm_l2},
+                  {"Rms", PoroPressureBased::norm_rms},
+                  {"Inf", PoroPressureBased::norm_inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroMultiPhaseScaTra::norm_l2}),
+                  .default_value = PoroPressureBased::norm_l2}),
 
           // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
           parameter<bool>("ADAPTCONV", {.description = "Switch on adaptive control of linear "
@@ -145,7 +149,7 @@ void PoroMultiPhaseScaTra::set_valid_parameters(std::map<std::string, Core::IO::
           {.defaultable = true});
 }
 
-void PoroMultiPhaseScaTra::set_valid_conditions(
+void PoroPressureBased::set_valid_conditions_porofluid_elast_scatra(
     std::vector<Core::Conditions::ConditionDefinition>& condlist)
 {
   using namespace Core::IO::InputSpecBuilders;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
@@ -62,14 +62,14 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
               {.description = "Coupling with 1D blood vessels.", .default_value = false}),
 
           // no convergence of coupling scheme
-          deprecated_selection<DivContAct>("DIVERCONT",
+          deprecated_selection<DivergenceAction>("DIVERCONT",
               {
-                  {"stop", divcont_stop},
-                  {"continue", divcont_continue},
+                  {"stop", DivergenceAction::stop},
+                  {"continue", DivergenceAction::continue_anyway},
               },
               {.description = "What to do with time integration when Poromultiphase-Scatra "
                               "iteration failed",
-                  .default_value = divcont_stop})},
+                  .default_value = DivergenceAction::stop})},
       {.defaultable =
               true});  // ----------------------------------------------------------------------
   // (2) monolithic parameters
@@ -78,25 +78,25 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
 
           deprecated_selection<VectorNorm>("VECTORNORM_RESF",
               {
-                  {"L1", PoroPressureBased::norm_l1},
-                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
-                  {"L2", PoroPressureBased::norm_l2},
-                  {"Rms", PoroPressureBased::norm_rms},
-                  {"Inf", PoroPressureBased::norm_inf},
+                  {"L1", VectorNorm::l1},
+                  {"L1_Scaled", VectorNorm::l1_scaled},
+                  {"L2", VectorNorm::l2},
+                  {"Rms", VectorNorm::rms},
+                  {"Inf", VectorNorm::inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroPressureBased::norm_l2}),
+                  .default_value = VectorNorm::l2}),
 
           deprecated_selection<VectorNorm>("VECTORNORM_INC",
               {
-                  {"L1", PoroPressureBased::norm_l1},
-                  {"L1_Scaled", PoroPressureBased::norm_l1_scaled},
-                  {"L2", PoroPressureBased::norm_l2},
-                  {"Rms", PoroPressureBased::norm_rms},
-                  {"Inf", PoroPressureBased::norm_inf},
+                  {"L1", VectorNorm::l1},
+                  {"L1_Scaled", VectorNorm::l1_scaled},
+                  {"L2", VectorNorm::l2},
+                  {"Rms", VectorNorm::rms},
+                  {"Inf", VectorNorm::inf},
               },
               {.description = "type of norm to be applied to residuals",
-                  .default_value = PoroPressureBased::norm_l2}),
+                  .default_value = VectorNorm::l2}),
 
           // convergence criteria adaptivity --> note ADAPTCONV_BETTER set pretty small
           parameter<bool>("ADAPTCONV", {.description = "Switch on adaptive control of linear "
@@ -124,11 +124,11 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
           // parameters for finite difference check
           deprecated_selection<FdCheck>("FDCHECK",
               {
-                  {"none", fdcheck_none},
-                  {"global", fdcheck_global},
+                  {"none", FdCheck::none},
+                  {"global", FdCheck::global},
               },
               {.description = "flag for finite difference check: none or global",
-                  .default_value = fdcheck_none}),
+                  .default_value = FdCheck::none}),
 
           // flag for equilibration of global system of equations
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.hpp
@@ -26,48 +26,25 @@ namespace Core::Conditions
 /*----------------------------------------------------------------------*
  |                                                                      |
  *----------------------------------------------------------------------*/
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   /// Type of coupling strategy for poro scatra problems
-  enum SolutionSchemeOverFields
+  enum class SolutionSchemePorofluidElastScatra
   {
-    solscheme_twoway_partitioned_nested,
-    solscheme_twoway_partitioned_sequential,
-    solscheme_twoway_monolithic
-  };
-
-  /// type of finite difference check
-  enum FdCheck
-  {
-    fdcheck_none,
-    fdcheck_global
-  };
-
-  /// type of norm to be calculated
-  enum VectorNorm
-  {
-    norm_undefined,
-    norm_l1,         //!< L1/linear norm
-    norm_l1_scaled,  //!< L1/linear norm scaled by length of vector
-    norm_l2,         //!< L2/Euclidean norm
-    norm_rms,        //!< root mean square (RMS) norm
-    norm_inf         //!< Maximum/infinity norm
-  };
-
-  //! Handling of non-converged nonlinear solver
-  enum DivContAct
-  {
-    divcont_stop,     ///< abort simulation
-    divcont_continue  ///< continue nevertheless
+    twoway_partitioned_nested,
+    twoway_partitioned_sequential,
+    twoway_monolithic
   };
 
   /// set the poromultiphasescatra parameters
-  void set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list);
+  void set_valid_parameters_porofluid_elast_scatra(
+      std::map<std::string, Core::IO::InputSpec>& list);
 
   /// set the poromultiphasescatra conditions
-  void set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition>& condlist);
+  void set_valid_conditions_porofluid_elast_scatra(
+      std::vector<Core::Conditions::ConditionDefinition>& condlist);
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.hpp
@@ -28,7 +28,7 @@ namespace Core::Conditions
  *----------------------------------------------------------------------*/
 namespace PoroPressureBased
 {
-  /// Type of coupling strategy for poro scatra problems
+  /// type of coupling strategy for porofluid-elasticity with scalar transport problems
   enum class SolutionSchemePorofluidElastScatra
   {
     twoway_partitioned_nested,
@@ -36,11 +36,11 @@ namespace PoroPressureBased
     twoway_monolithic
   };
 
-  /// set the poromultiphasescatra parameters
+  /// set valid parameters for porofluid-elasticity with scalar transport problems
   void set_valid_parameters_porofluid_elast_scatra(
       std::map<std::string, Core::IO::InputSpec>& list);
 
-  /// set the poromultiphasescatra conditions
+  /// set valid conditions for porofluid-elasticity with scalar transport problems
   void set_valid_conditions_porofluid_elast_scatra(
       std::vector<Core::Conditions::ConditionDefinition>& condlist);
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic.hpp
@@ -14,7 +14,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhaseScaTraMonolithic : public PoroMultiPhaseScaTraBase
@@ -27,7 +27,7 @@ namespace PoroMultiPhaseScaTra
   };  // PoroMultiPhaseMonolithic
 
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
@@ -819,7 +819,7 @@ bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::converged()
 void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::build_convergence_norms()
 {
   //------------------------------------------------------------ build residual force norms
-  normrhs_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_);
+  normrhs_ = calculate_vector_norm(vectornormfres_, *rhs_);
   std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_st;
   std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_fl;
   std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_sc;
@@ -828,9 +828,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::build_convergen
   extract_3d_field_vectors(rhs_, rhs_st, rhs_fl, rhs_sc);
 
   // build also norms for structure, fluid and scatra
-  normrhsstruct_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_st);
-  normrhsfluid_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_fl);
-  normrhsscatra_ = Utils::calculate_vector_norm(vectornormfres_, *rhs_sc);
+  normrhsstruct_ = calculate_vector_norm(vectornormfres_, *rhs_st);
+  normrhsfluid_ = calculate_vector_norm(vectornormfres_, *rhs_fl);
+  normrhsscatra_ = calculate_vector_norm(vectornormfres_, *rhs_sc);
 
   //------------------------------------------------------------- build residual increment norms
   // displacement and fluid velocity & pressure incremental vector
@@ -842,16 +842,15 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::build_convergen
   extract_3d_field_vectors(iterinc_, iterincst, iterincfl, iterincsc);
 
   // build also norms for fluid and structure
-  normincstruct_ = Utils::calculate_vector_norm(vectornorminc_, *iterincst);
-  normincfluid_ = Utils::calculate_vector_norm(vectornorminc_, *iterincfl);
-  normincscatra_ = Utils::calculate_vector_norm(vectornorminc_, *iterincsc);
+  normincstruct_ = calculate_vector_norm(vectornorminc_, *iterincst);
+  normincfluid_ = calculate_vector_norm(vectornorminc_, *iterincfl);
+  normincscatra_ = calculate_vector_norm(vectornorminc_, *iterincsc);
 
   double dispnorm =
-      Utils::calculate_vector_norm(vectornorminc_, *poro_field()->structure_field()->dispnp());
-  double fluidnorm =
-      Utils::calculate_vector_norm(vectornorminc_, *poro_field()->fluid_field()->phinp());
+      calculate_vector_norm(vectornorminc_, *poro_field()->structure_field()->dispnp());
+  double fluidnorm = calculate_vector_norm(vectornorminc_, *poro_field()->fluid_field()->phinp());
   double scatranorm =
-      Utils::calculate_vector_norm(vectornorminc_, *scatra_algo()->scatra_field()->phinp());
+      calculate_vector_norm(vectornorminc_, *scatra_algo()->scatra_field()->phinp());
 
   // take care of very small norms
   if (dispnorm < 1.0e-6) dispnorm = 1.0;
@@ -1554,9 +1553,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling::
       extractor()->extract_vector(*iterinc_, struct_offset_ + 2);
 
   // build also norms for artery
-  normrhsart_ = Utils::calculate_vector_norm(vectornormfres_, *arteryrhs);
-  normincart_ = Utils::calculate_vector_norm(vectornorminc_, *arteryinc);
-  arterypressnorm_ = Utils::calculate_vector_norm(
+  normrhsart_ = calculate_vector_norm(vectornormfres_, *arteryrhs);
+  normincart_ = calculate_vector_norm(vectornorminc_, *arteryinc);
+  arterypressnorm_ = calculate_vector_norm(
       vectornorminc_, (*poro_field()->fluid_field()->art_net_tim_int()->pressurenp()));
 
   std::shared_ptr<const Core::LinAlg::Vector<double>> arteryscarhs =
@@ -1565,10 +1564,10 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling::
       extractor()->extract_vector(*iterinc_, struct_offset_ + 3);
 
   // build also norms for artery
-  normrhsartsca_ = Utils::calculate_vector_norm(vectornormfres_, *arteryscarhs);
-  normincartsca_ = Utils::calculate_vector_norm(vectornorminc_, *arteryscainc);
+  normrhsartsca_ = calculate_vector_norm(vectornormfres_, *arteryscarhs);
+  normincartsca_ = calculate_vector_norm(vectornorminc_, *arteryscainc);
   arteryscanorm_ =
-      Utils::calculate_vector_norm(vectornorminc_, *(scatramsht_->art_scatra_field()->phinp()));
+      calculate_vector_norm(vectornorminc_, *(scatramsht_->art_scatra_field()->phinp()));
 
   // call base class
   PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay::build_convergence_norms();

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
@@ -72,12 +72,12 @@ PoroPressureBased::PoroMultiPhaseScaTraMonolithicTwoWay::PoroMultiPhaseScaTraMon
       arteryscanorm_(0.0),
       maxinc_(0.0),
       maxres_(0.0),
-      vectornormfres_(PoroPressureBased::norm_undefined),
-      vectornorminc_(PoroPressureBased::norm_undefined),
+      vectornormfres_(VectorNorm::undefined),
+      vectornorminc_(VectorNorm::undefined),
       timernewton_("", true),
       dtsolve_(0.0),
       dtele_(0.0),
-      fdcheck_(PoroPressureBased::FdCheck::fdcheck_none)
+      fdcheck_(PoroPressureBased::FdCheck::none)
 {
 }
 
@@ -341,7 +341,7 @@ void PoroPressureBased::PoroMultiPhaseScaTraMonolithicTwoWay::time_step()
     {
       evaluate(iterinc_);
       // perform FD Check of monolithic system matrix
-      if (fdcheck_ == PoroPressureBased::fdcheck_global) poro_multi_phase_scatra_fd_check();
+      if (fdcheck_ == FdCheck::global) poro_multi_phase_scatra_fd_check();
     }
     else
     {

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.hpp
@@ -35,7 +35,7 @@ namespace Core::LinearSolver
   enum class SolverType;
 }
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! monolithic coupling algorithm of poromultiphasescatra framework
   class PoroMultiPhaseScaTraMonolithicTwoWay : public PoroMultiPhaseScaTraMonolithic
@@ -281,15 +281,15 @@ namespace PoroMultiPhaseScaTra
     double maxinc_;  //!< maximum increment
     double maxres_;  //!< maximum residual
 
-    enum PoroMultiPhaseScaTra::VectorNorm vectornormfres_;  //!< type of norm for residual
-    enum PoroMultiPhaseScaTra::VectorNorm vectornorminc_;   //!< type of norm for increments
+    enum PoroPressureBased::VectorNorm vectornormfres_;  //!< type of norm for residual
+    enum PoroPressureBased::VectorNorm vectornorminc_;   //!< type of norm for increments
 
     Teuchos::Time timernewton_;  //!< timer for measurement of solution time of newton iterations
     double dtsolve_;             //!< linear solver time
     double dtele_;               //!< time for element evaluation + build-up of system matrix
 
     //! flag for finite difference check
-    PoroMultiPhaseScaTra::FdCheck fdcheck_;
+    PoroPressureBased::FdCheck fdcheck_;
 
 
   };  // PoroMultiPhaseScatraMonolithic
@@ -372,7 +372,7 @@ namespace PoroMultiPhaseScaTra
   };  // PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling
 
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned.hpp
@@ -14,7 +14,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! Base class of all solid-scatra algorithms
   class PoroMultiPhaseScaTraPartitioned : public PoroMultiPhaseScaTraBase
@@ -27,7 +27,7 @@ namespace PoroMultiPhaseScaTra
   };  // PoroMultiPhasePartitioned
 
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned_twoway.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned_twoway.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::PoroMultiPhaseScaTraPartitionedTwoWay(
+PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::PoroMultiPhaseScaTraPartitionedTwoWay(
     MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : PoroMultiPhaseScaTraPartitioned(comm, globaltimeparams),
       scaincnp_(nullptr),
@@ -35,7 +35,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::PoroMultiPhaseScaTr
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::init(
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::init(
     const Teuchos::ParameterList& globaltimeparams, const Teuchos::ParameterList& algoparams,
     const Teuchos::ParameterList& poroparams, const Teuchos::ParameterList& structparams,
     const Teuchos::ParameterList& fluidparams, const Teuchos::ParameterList& scatraparams,
@@ -44,10 +44,9 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::init(
     int ndsporofluid_scatra, const std::map<int, std::set<int>>* nearbyelepairs)
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitioned::init(globaltimeparams, algoparams,
-      poroparams, structparams, fluidparams, scatraparams, struct_disname, fluid_disname,
-      scatra_disname, isale, nds_disp, nds_vel, nds_solidpressure, ndsporofluid_scatra,
-      nearbyelepairs);
+  PoroPressureBased::PoroMultiPhaseScaTraPartitioned::init(globaltimeparams, algoparams, poroparams,
+      structparams, fluidparams, scatraparams, struct_disname, fluid_disname, scatra_disname, isale,
+      nds_disp, nds_vel, nds_solidpressure, ndsporofluid_scatra, nearbyelepairs);
 
   // read input variables
   itmax_ = algoparams.get<int>("ITEMAX");
@@ -73,21 +72,21 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::init(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::setup_system()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::setup_system()
 {
   poro_field()->setup_system();
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::setup_solver()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::setup_solver()
 {
   poro_field()->setup_solver();
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::do_poro_step()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::do_poro_step()
 {
   // Newton-Raphson iteration
   poro_field()->time_step();
@@ -95,7 +94,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::do_poro_step()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::do_scatra_step()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::do_scatra_step()
 {
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
   {
@@ -115,7 +114,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::do_scatra_step
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::print_header_partitioned()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::print_header_partitioned()
 {
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
   {
@@ -136,7 +135,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::print_header_p
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::iter_update_states()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::iter_update_states()
 {
   // store scalar from first solution for convergence check (like in
   // elch_algorithm: use current values)
@@ -155,7 +154,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::iter_update_st
 /*----------------------------------------------------------------------*
  | convergence check for both fields (scatra & poro) (copied from tsi)
  *----------------------------------------------------------------------*/
-bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::convergence_check(int itnum)
+bool PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::convergence_check(int itnum)
 {
   // convergence check based on the scalar increment
   bool stopnonliniter = false;
@@ -285,7 +284,7 @@ bool PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::convergence_ch
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::
+PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWayNested::
     PoroMultiPhaseScaTraPartitionedTwoWayNested(
         MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : PoroMultiPhaseScaTraPartitionedTwoWay(comm, globaltimeparams)
@@ -294,7 +293,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::init(
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWayNested::init(
     const Teuchos::ParameterList& globaltimeparams, const Teuchos::ParameterList& algoparams,
     const Teuchos::ParameterList& poroparams, const Teuchos::ParameterList& structparams,
     const Teuchos::ParameterList& fluidparams, const Teuchos::ParameterList& scatraparams,
@@ -303,7 +302,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::init(
     int ndsporofluid_scatra, const std::map<int, std::set<int>>* nearbyelepairs)
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::init(globaltimeparams, algoparams,
+  PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::init(globaltimeparams, algoparams,
       poroparams, structparams, fluidparams, scatraparams, struct_disname, fluid_disname,
       scatra_disname, isale, nds_disp, nds_vel, nds_solidpressure, ndsporofluid_scatra,
       nearbyelepairs);
@@ -311,7 +310,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::init(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::solve()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWayNested::solve()
 {
   int itnum = 0;
   bool stopnonliniter = false;
@@ -345,7 +344,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested::solve()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential::
+PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWaySequential::
     PoroMultiPhaseScaTraPartitionedTwoWaySequential(
         MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams)
     : PoroMultiPhaseScaTraPartitionedTwoWay(comm, globaltimeparams)
@@ -354,7 +353,7 @@ PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential::
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential::init(
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWaySequential::init(
     const Teuchos::ParameterList& globaltimeparams, const Teuchos::ParameterList& algoparams,
     const Teuchos::ParameterList& poroparams, const Teuchos::ParameterList& structparams,
     const Teuchos::ParameterList& fluidparams, const Teuchos::ParameterList& scatraparams,
@@ -363,7 +362,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential::init
     int ndsporofluid_scatra, const std::map<int, std::set<int>>* nearbyelepairs)
 {
   // call base class
-  PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWay::init(globaltimeparams, algoparams,
+  PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWay::init(globaltimeparams, algoparams,
       poroparams, structparams, fluidparams, scatraparams, struct_disname, fluid_disname,
       scatra_disname, isale, nds_disp, nds_vel, nds_solidpressure, ndsporofluid_scatra,
       nearbyelepairs);
@@ -371,7 +370,7 @@ void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential::init
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential::solve()
+void PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWaySequential::solve()
 {
   int itnum = 0;
   bool stopnonliniter = false;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned_twoway.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_partitioned_twoway.hpp
@@ -15,7 +15,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   //! Base class of all partitioned solid-scatra algorithms --> virtual
   class PoroMultiPhaseScaTraPartitionedTwoWay : public PoroMultiPhaseScaTraPartitioned
@@ -141,7 +141,7 @@ namespace PoroMultiPhaseScaTra
   };  // PoroMultiPhaseScatraPartitionedTwoWayNested
 
 
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
@@ -152,7 +152,7 @@ std::map<int, std::set<int>> PoroMultiPhaseScaTra::setup_discretizations_and_fie
   // artery_scatra discretization is cloned from artery discretization
 
   std::map<int, std::set<int>> nearbyelepairs =
-      POROMULTIPHASE::setup_discretizations_and_field_coupling(
+      PoroPressureBased::setup_discretizations_and_field_coupling(
           comm, struct_disname, fluid_disname, ndsporo_disp, ndsporo_vel, ndsporo_solidpressure);
 
   Global::Problem* problem = Global::Problem::instance();
@@ -238,7 +238,7 @@ std::map<int, std::set<int>> PoroMultiPhaseScaTra::setup_discretizations_and_fie
 void PoroMultiPhaseScaTra::assign_material_pointers(const std::string& struct_disname,
     const std::string& fluid_disname, const std::string& scatra_disname, const bool artery_coupl)
 {
-  POROMULTIPHASE::assign_material_pointers(struct_disname, fluid_disname);
+  PoroPressureBased::assign_material_pointers(struct_disname, fluid_disname);
 
   Global::Problem* problem = Global::Problem::instance();
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
@@ -31,7 +31,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase>
-PoroMultiPhaseScaTra::Utils::create_poro_multi_phase_scatra_algorithm(
+PoroMultiPhaseScaTra::create_poro_multi_phase_scatra_algorithm(
     PoroMultiPhaseScaTra::SolutionSchemeOverFields solscheme,
     const Teuchos::ParameterList& timeparams, MPI_Comm comm)
 {
@@ -85,7 +85,7 @@ PoroMultiPhaseScaTra::Utils::create_poro_multi_phase_scatra_algorithm(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase>
-PoroMultiPhaseScaTra::Utils::create_and_init_artery_coupling_strategy(
+PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
     std::shared_ptr<Core::FE::Discretization> arterydis,
     std::shared_ptr<Core::FE::Discretization> contdis,
     const Teuchos::ParameterList& meshtyingparams, const std::string& condname,
@@ -139,7 +139,7 @@ PoroMultiPhaseScaTra::Utils::create_and_init_artery_coupling_strategy(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> PoroMultiPhaseScaTra::Utils::setup_discretizations_and_field_coupling(
+std::map<int, std::set<int>> PoroMultiPhaseScaTra::setup_discretizations_and_field_coupling(
     MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
     const std::string& scatra_disname, int& ndsporo_disp, int& ndsporo_vel,
     int& ndsporo_solidpressure, int& ndsporofluid_scatra, const bool artery_coupl)
@@ -152,7 +152,7 @@ std::map<int, std::set<int>> PoroMultiPhaseScaTra::Utils::setup_discretizations_
   // artery_scatra discretization is cloned from artery discretization
 
   std::map<int, std::set<int>> nearbyelepairs =
-      POROMULTIPHASE::Utils::setup_discretizations_and_field_coupling(
+      POROMULTIPHASE::setup_discretizations_and_field_coupling(
           comm, struct_disname, fluid_disname, ndsporo_disp, ndsporo_vel, ndsporo_solidpressure);
 
   Global::Problem* problem = Global::Problem::instance();
@@ -235,10 +235,10 @@ std::map<int, std::set<int>> PoroMultiPhaseScaTra::Utils::setup_discretizations_
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::Utils::assign_material_pointers(const std::string& struct_disname,
+void PoroMultiPhaseScaTra::assign_material_pointers(const std::string& struct_disname,
     const std::string& fluid_disname, const std::string& scatra_disname, const bool artery_coupl)
 {
-  POROMULTIPHASE::Utils::assign_material_pointers(struct_disname, fluid_disname);
+  POROMULTIPHASE::assign_material_pointers(struct_disname, fluid_disname);
 
   Global::Problem* problem = Global::Problem::instance();
 
@@ -260,7 +260,7 @@ void PoroMultiPhaseScaTra::Utils::assign_material_pointers(const std::string& st
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double PoroMultiPhaseScaTra::Utils::calculate_vector_norm(
+double PoroMultiPhaseScaTra::calculate_vector_norm(
     const enum PoroMultiPhaseScaTra::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
 {
   // L1 norm

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
@@ -30,47 +30,46 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase>
-PoroMultiPhaseScaTra::create_poro_multi_phase_scatra_algorithm(
-    PoroMultiPhaseScaTra::SolutionSchemeOverFields solscheme,
+std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraBase>
+PoroPressureBased::create_algorithm_porofluid_elast_scatra(
+    PoroPressureBased::SolutionSchemePorofluidElastScatra solscheme,
     const Teuchos::ParameterList& timeparams, MPI_Comm comm)
 {
   // Creation of Coupled Problem algorithm.
-  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase> algo;
+  std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraBase> algo;
 
   switch (solscheme)
   {
-    case PoroMultiPhaseScaTra::solscheme_twoway_partitioned_nested:
+    case SolutionSchemePorofluidElastScatra::twoway_partitioned_nested:
     {
       // call constructor
-      algo = std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWayNested>(
+      algo = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWayNested>(
           comm, timeparams);
       break;
     }
-    case PoroMultiPhaseScaTra::solscheme_twoway_partitioned_sequential:
+    case SolutionSchemePorofluidElastScatra::twoway_partitioned_sequential:
     {
       // call constructor
-      algo =
-          std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraPartitionedTwoWaySequential>(
-              comm, timeparams);
+      algo = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraPartitionedTwoWaySequential>(
+          comm, timeparams);
       break;
     }
-    case PoroMultiPhaseScaTra::solscheme_twoway_monolithic:
+    case SolutionSchemePorofluidElastScatra::twoway_monolithic:
     {
       const bool artery_coupl = timeparams.get<bool>("ARTERY_COUPLING");
       if (!artery_coupl)
       {
         // call constructor
-        algo = std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWay>(
+        algo = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraMonolithicTwoWay>(
             comm, timeparams);
       }
       else
       {
         // call constructor
-        algo = std::make_shared<
-            PoroMultiPhaseScaTra::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling>(
+        algo =
+            std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraMonolithicTwoWayArteryCoupling>(
 
-            comm, timeparams);
+                comm, timeparams);
       }
       break;
     }
@@ -84,8 +83,8 @@ PoroMultiPhaseScaTra::create_poro_multi_phase_scatra_algorithm(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase>
-PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
+std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase>
+PoroPressureBased::create_and_init_artery_coupling_strategy(
     std::shared_ptr<Core::FE::Discretization> arterydis,
     std::shared_ptr<Core::FE::Discretization> contdis,
     const Teuchos::ParameterList& meshtyingparams, const std::string& condname,
@@ -93,7 +92,7 @@ PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
     const bool evaluate_on_lateral_surface)
 {
   // Creation of coupling strategy.
-  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase> strategy;
+  std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase> strategy;
 
   auto arterycoupl =
       Teuchos::getIntegralValue<Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod>(
@@ -105,22 +104,22 @@ PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
     case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::mp:
     {
       if (evaluate_on_lateral_surface)
-        strategy = std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplSurfBased>(
+        strategy = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased>(
             arterydis, contdis, meshtyingparams, condname, artcoupleddofname, contcoupleddofname);
       else
-        strategy = std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplLineBased>(
+        strategy = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased>(
             arterydis, contdis, meshtyingparams, condname, artcoupleddofname, contcoupleddofname);
       break;
     }
     case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::nodal:
     {
-      strategy = std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeBased>(
+      strategy = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased>(
           arterydis, contdis, meshtyingparams, condname, artcoupleddofname, contcoupleddofname);
       break;
     }
     case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::ntp:
     {
-      strategy = std::make_shared<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplNodeToPoint>(
+      strategy = std::make_shared<PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeToPoint>(
           arterydis, contdis, meshtyingparams, condname, artcoupleddofname, contcoupleddofname);
       break;
     }
@@ -139,8 +138,9 @@ PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-std::map<int, std::set<int>> PoroMultiPhaseScaTra::setup_discretizations_and_field_coupling(
-    MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
+std::map<int, std::set<int>>
+PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast_scatra(MPI_Comm comm,
+    const std::string& struct_disname, const std::string& fluid_disname,
     const std::string& scatra_disname, int& ndsporo_disp, int& ndsporo_vel,
     int& ndsporo_solidpressure, int& ndsporofluid_scatra, const bool artery_coupl)
 {
@@ -152,7 +152,7 @@ std::map<int, std::set<int>> PoroMultiPhaseScaTra::setup_discretizations_and_fie
   // artery_scatra discretization is cloned from artery discretization
 
   std::map<int, std::set<int>> nearbyelepairs =
-      PoroPressureBased::setup_discretizations_and_field_coupling(
+      PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast(
           comm, struct_disname, fluid_disname, ndsporo_disp, ndsporo_vel, ndsporo_solidpressure);
 
   Global::Problem* problem = Global::Problem::instance();
@@ -235,10 +235,11 @@ std::map<int, std::set<int>> PoroMultiPhaseScaTra::setup_discretizations_and_fie
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::assign_material_pointers(const std::string& struct_disname,
-    const std::string& fluid_disname, const std::string& scatra_disname, const bool artery_coupl)
+void PoroPressureBased::assign_material_pointers_porofluid_elast_scatra(
+    const std::string& struct_disname, const std::string& fluid_disname,
+    const std::string& scatra_disname, const bool artery_coupl)
 {
-  PoroPressureBased::assign_material_pointers(struct_disname, fluid_disname);
+  PoroPressureBased::assign_material_pointers_porofluid_elast(struct_disname, fluid_disname);
 
   Global::Problem* problem = Global::Problem::instance();
 
@@ -256,83 +257,6 @@ void PoroMultiPhaseScaTra::assign_material_pointers(const std::string& struct_di
 
     Arteries::Utils::set_material_pointers_matching_grid(*arterydis, *artscatradis);
   }
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-double PoroMultiPhaseScaTra::calculate_vector_norm(
-    const enum PoroMultiPhaseScaTra::VectorNorm norm, const Core::LinAlg::Vector<double>& vect)
-{
-  // L1 norm
-  // norm = sum_0^i vect[i]
-  if (norm == PoroMultiPhaseScaTra::norm_l1)
-  {
-    double vectnorm;
-    vect.norm_1(&vectnorm);
-    return vectnorm;
-  }
-  // L2/Euclidian norm
-  // norm = sqrt{sum_0^i vect[i]^2 }
-  else if (norm == PoroMultiPhaseScaTra::norm_l2)
-  {
-    double vectnorm;
-    vect.norm_2(&vectnorm);
-    return vectnorm;
-  }
-  // RMS norm
-  // norm = sqrt{sum_0^i vect[i]^2 }/ sqrt{length_vect}
-  else if (norm == PoroMultiPhaseScaTra::norm_rms)
-  {
-    double vectnorm;
-    vect.norm_2(&vectnorm);
-    return vectnorm / sqrt((double)vect.global_length());
-  }
-  // infinity/maximum norm
-  // norm = max( vect[i] )
-  else if (norm == PoroMultiPhaseScaTra::norm_inf)
-  {
-    double vectnorm;
-    vect.norm_inf(&vectnorm);
-    return vectnorm;
-  }
-  // norm = sum_0^i vect[i]/length_vect
-  else if (norm == PoroMultiPhaseScaTra::norm_l1_scaled)
-  {
-    double vectnorm;
-    vect.norm_1(&vectnorm);
-    return vectnorm / ((double)vect.global_length());
-  }
-  else
-  {
-    FOUR_C_THROW("Cannot handle vector norm");
-    return 0;
-  }
-}  // calculate_vector_norm()
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void PoroMultiPhaseScaTra::print_logo()
-{
-  std::cout
-      << "This is a Porous Media problem with multiphase flow and deformation and scalar transport"
-      << std::endl;
-  std::cout << "" << std::endl;
-  std::cout << "              +----------+" << std::endl;
-  std::cout << "              |  Krebs-  |" << std::endl;
-  std::cout << "              |  Model  |" << std::endl;
-  std::cout << "              +----------+" << std::endl;
-  std::cout << "              |          |" << std::endl;
-  std::cout << "              |          |" << std::endl;
-  std::cout << " /\\           |          /\\" << std::endl;
-  std::cout << "( /   @ @    (|)        ( /   @ @    ()" << std::endl;
-  std::cout << " \\  __| |__  /           \\  __| |__  /" << std::endl;
-  std::cout << "  \\/   \"   \\/             \\/   \"   \\/" << std::endl;
-  std::cout << " /-|       |-\\           /-|       |-\\" << std::endl;
-  std::cout << "/ /-\\     /-\\ \\         / /-\\     /-\\ \\" << std::endl;
-  std::cout << " / /-`---'-\\ \\           / /-`---'-\\ \\" << std::endl;
-  std::cout << "  /         \\             /         \\" << std::endl;
-
-  return;
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.hpp
@@ -31,45 +31,35 @@ namespace Core::FE
   class Discretization;
 }  // namespace Core::FE
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   class PoroMultiPhaseScaTraBase;
   class PoroMultiPhaseScaTraArtCouplBase;
 
   //! setup discretizations and dofsets
-  std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
-      const std::string& struct_disname, const std::string& fluid_disname,
+  std::map<int, std::set<int>> setup_discretizations_and_field_coupling_porofluid_elast_scatra(
+      MPI_Comm comm, const std::string& struct_disname, const std::string& fluid_disname,
       const std::string& scatra_disname, int& ndsporo_disp, int& ndsporo_vel,
       int& ndsporo_solidpressure, int& ndsporofluid_scatra, const bool artery_coupl);
 
   //! exchange material pointers of discretizations
-  void assign_material_pointers(const std::string& struct_disname, const std::string& fluid_disname,
-      const std::string& scatra_disname, const bool artery_coupl);
+  void assign_material_pointers_porofluid_elast_scatra(const std::string& struct_disname,
+      const std::string& fluid_disname, const std::string& scatra_disname, const bool artery_coupl);
 
   //! create solution algorithm depending on input file
-  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase>
-  create_poro_multi_phase_scatra_algorithm(
-      PoroMultiPhaseScaTra::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
-      const Teuchos::ParameterList& timeparams,                  //!< problem parameters (i)
-      MPI_Comm comm                                              //!< communicator(i)
+  std::shared_ptr<PoroMultiPhaseScaTraBase> create_algorithm_porofluid_elast_scatra(
+      SolutionSchemePorofluidElastScatra solscheme,  //!< solution scheme to build (i)
+      const Teuchos::ParameterList& timeparams,      //!< problem parameters (i)
+      MPI_Comm comm                                  //!< communicator(i)
   );
 
   //! create coupling strategy for coupling with 1D network depending on input file
-  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase>
-  create_and_init_artery_coupling_strategy(std::shared_ptr<Core::FE::Discretization> arterydis,
+  std::shared_ptr<PoroMultiPhaseScaTraArtCouplBase> create_and_init_artery_coupling_strategy(
+      std::shared_ptr<Core::FE::Discretization> arterydis,
       std::shared_ptr<Core::FE::Discretization> contdis,
       const Teuchos::ParameterList& meshtyingparams, const std::string& condname,
       const std::string& artcoupleddofname, const std::string& contcoupleddofname,
       const bool evaluate_on_lateral_surface);
-
-  /**
-   * Determine norm of vector
-   * @param norm [in]: norm to use
-   * @param vect [in]: the vector of interest
-   * @return: the norm
-   */
-  double calculate_vector_norm(
-      const enum PoroMultiPhaseScaTra::VectorNorm norm, const Core::LinAlg::Vector<double>& vect);
 
   /**
    * Get oxygen partial pressure from oxygen concentration via numerical inversion
@@ -112,9 +102,7 @@ namespace PoroMultiPhaseScaTra
       FOUR_C_THROW("local Newton for computation of oxygen partial pressure unconverged");
     }
   }
-  //! Print the logo
-  void print_logo();
-}  // namespace PoroMultiPhaseScaTra
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.hpp
@@ -36,87 +36,82 @@ namespace PoroMultiPhaseScaTra
   class PoroMultiPhaseScaTraBase;
   class PoroMultiPhaseScaTraArtCouplBase;
 
-  namespace Utils
+  //! setup discretizations and dofsets
+  std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
+      const std::string& struct_disname, const std::string& fluid_disname,
+      const std::string& scatra_disname, int& ndsporo_disp, int& ndsporo_vel,
+      int& ndsporo_solidpressure, int& ndsporofluid_scatra, const bool artery_coupl);
+
+  //! exchange material pointers of discretizations
+  void assign_material_pointers(const std::string& struct_disname, const std::string& fluid_disname,
+      const std::string& scatra_disname, const bool artery_coupl);
+
+  //! create solution algorithm depending on input file
+  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase>
+  create_poro_multi_phase_scatra_algorithm(
+      PoroMultiPhaseScaTra::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
+      const Teuchos::ParameterList& timeparams,                  //!< problem parameters (i)
+      MPI_Comm comm                                              //!< communicator(i)
+  );
+
+  //! create coupling strategy for coupling with 1D network depending on input file
+  std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase>
+  create_and_init_artery_coupling_strategy(std::shared_ptr<Core::FE::Discretization> arterydis,
+      std::shared_ptr<Core::FE::Discretization> contdis,
+      const Teuchos::ParameterList& meshtyingparams, const std::string& condname,
+      const std::string& artcoupleddofname, const std::string& contcoupleddofname,
+      const bool evaluate_on_lateral_surface);
+
+  /**
+   * Determine norm of vector
+   * @param norm [in]: norm to use
+   * @param vect [in]: the vector of interest
+   * @return: the norm
+   */
+  double calculate_vector_norm(
+      const enum PoroMultiPhaseScaTra::VectorNorm norm, const Core::LinAlg::Vector<double>& vect);
+
+  /**
+   * Get oxygen partial pressure from oxygen concentration via numerical inversion
+   * templated to FAD and double
+   *
+   * @param Pb [out]: oxygen partial pressure
+   * @param CaO2 [in]: oxygen concentration
+   * @param CaO2_max [in]: maximum oxygen concentration
+   * @param Pb50 [in]: partial pressure at 50% maximum oxygen concentration
+   * @param n [in]: exponent in Hill equation
+   * @param alpha_eff [in]: effective solubility of oxygen in blood
+   */
+  template <typename T>
+  void get_oxy_partial_pressure_from_concentration(T& Pb, const T& CaO2, const double& CaO2_max,
+      const double& Pb50, const double& n, const double& alpha_eff)
   {
-    //! setup discretizations and dofsets
-    std::map<int, std::set<int>> setup_discretizations_and_field_coupling(MPI_Comm comm,
-        const std::string& struct_disname, const std::string& fluid_disname,
-        const std::string& scatra_disname, int& ndsporo_disp, int& ndsporo_vel,
-        int& ndsporo_solidpressure, int& ndsporofluid_scatra, const bool artery_coupl);
+    // start value
+    Pb = Pb50 * 2.0 * CaO2 / CaO2_max;
 
-    //! exchange material pointers of discretizations
-    void assign_material_pointers(const std::string& struct_disname,
-        const std::string& fluid_disname, const std::string& scatra_disname,
-        const bool artery_coupl);
-
-    //! create solution algorithm depending on input file
-    std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraBase>
-    create_poro_multi_phase_scatra_algorithm(
-        PoroMultiPhaseScaTra::SolutionSchemeOverFields solscheme,  //!< solution scheme to build (i)
-        const Teuchos::ParameterList& timeparams,                  //!< problem parameters (i)
-        MPI_Comm comm                                              //!< communicator(i)
-    );
-
-    //! create coupling strategy for coupling with 1D network depending on input file
-    std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase>
-    create_and_init_artery_coupling_strategy(std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& meshtyingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname,
-        const bool evaluate_on_lateral_surface);
-
-    /**
-     * Determine norm of vector
-     * @param norm [in]: norm to use
-     * @param vect [in]: the vector of interest
-     * @return: the norm
-     */
-    double calculate_vector_norm(
-        const enum PoroMultiPhaseScaTra::VectorNorm norm, const Core::LinAlg::Vector<double>& vect);
-
-    /**
-     * Get oxygen partial pressure from oxygen concentration via numerical inversion
-     * templated to FAD and double
-     *
-     * @param Pb [out]: oxygen partial pressure
-     * @param CaO2 [in]: oxygen concentration
-     * @param CaO2_max [in]: maximum oxygen concentration
-     * @param Pb50 [in]: partial pressure at 50% maximum oxygen concentration
-     * @param n [in]: exponent in Hill equation
-     * @param alpha_eff [in]: effective solubility of oxygen in blood
-     */
-    template <typename T>
-    void get_oxy_partial_pressure_from_concentration(T& Pb, const T& CaO2, const double& CaO2_max,
-        const double& Pb50, const double& n, const double& alpha_eff)
+    bool converged = false;
+    // Newton loop
+    for (int i = 0; i < 20; i++)
     {
-      // start value
-      Pb = Pb50 * 2.0 * CaO2 / CaO2_max;
-
-      bool converged = false;
-      // Newton loop
-      for (int i = 0; i < 20; i++)
+      // function
+      T f = (std::pow(Pb50, n) + std::pow(Pb, n)) * CaO2 - CaO2_max * std::pow(Pb, n) -
+            Pb * (std::pow(Pb, n) + std::pow(Pb50, n)) * alpha_eff;
+      if (fabs(f) < 1.0e-10)
       {
-        // function
-        T f = (std::pow(Pb50, n) + std::pow(Pb, n)) * CaO2 - CaO2_max * std::pow(Pb, n) -
-              Pb * (std::pow(Pb, n) + std::pow(Pb50, n)) * alpha_eff;
-        if (fabs(f) < 1.0e-10)
-        {
-          converged = true;
-          break;
-        }
-        // deriv
-        T dfdPb = n * std::pow(Pb, (n - 1)) * CaO2 - CaO2_max * n * std::pow(Pb, (n - 1)) -
-                  ((n + 1) * std::pow(Pb, n) + std::pow(Pb50, n)) * alpha_eff;
-        // update
-        Pb = Pb - f / dfdPb;
+        converged = true;
+        break;
       }
-      if (!converged)
-      {
-        FOUR_C_THROW("local Newton for computation of oxygen partial pressure unconverged");
-      }
+      // deriv
+      T dfdPb = n * std::pow(Pb, (n - 1)) * CaO2 - CaO2_max * n * std::pow(Pb, (n - 1)) -
+                ((n + 1) * std::pow(Pb, n) + std::pow(Pb50, n)) * alpha_eff;
+      // update
+      Pb = Pb - f / dfdPb;
     }
-
-  }  // namespace Utils
+    if (!converged)
+    {
+      FOUR_C_THROW("local Newton for computation of oxygen partial pressure unconverged");
+    }
+  }
   //! Print the logo
   void print_logo();
 }  // namespace PoroMultiPhaseScaTra

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_action.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_action.hpp
@@ -12,7 +12,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   /*--------------------------------------------------------------------------*/
   /*!
@@ -47,7 +47,7 @@ namespace POROFLUIDMULTIPHASE
   {
     bd_calc_Neumann,  // evaluate neumann loads
   };  // enum POROFLUIDMULTIPHASE::BoundaryAction
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_boundary_calc.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_boundary_calc.cpp
@@ -98,7 +98,7 @@ int Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<distype>::evaluate(
 
   // check for the action parameter
   const auto action =
-      Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::BoundaryAction>(params, "action");
+      Teuchos::getIntegralValue<PoroPressureBased::BoundaryAction>(params, "action");
   // evaluate action
   evaluate_action(ele, params, discretization, action, la, elemat, elevec);
 
@@ -149,14 +149,14 @@ void Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<
 template <Core::FE::CellType distype>
 int Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<distype>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
-    Core::FE::Discretization& discretization, POROFLUIDMULTIPHASE::BoundaryAction action,
+    Core::FE::Discretization& discretization, PoroPressureBased::BoundaryAction action,
     Core::Elements::LocationArray& la, std::vector<Core::LinAlg::SerialDenseMatrix*>& elemat,
     std::vector<Core::LinAlg::SerialDenseVector*>& elevec)
 {
   // switch over action type
   switch (action)
   {
-    case POROFLUIDMULTIPHASE::bd_calc_Neumann:
+    case PoroPressureBased::bd_calc_Neumann:
     {
       // check if the neumann conditions were set
       Core::Conditions::Condition* condition =
@@ -184,7 +184,7 @@ int Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<distype>::evaluate_neu
 {
   // integration points and weights
   const Core::FE::IntPointsAndWeights<nsd_> intpoints(
-      POROFLUIDMULTIPHASE::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
+      PoroPressureBased::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
 
   // find out whether we will use a time curve
   const double time = params_->time();

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_boundary_calc.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_boundary_calc.hpp
@@ -66,7 +66,7 @@ namespace Discret
 
       //! evaluate action
       virtual int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
-          Core::FE::Discretization& discretization, POROFLUIDMULTIPHASE::BoundaryAction action,
+          Core::FE::Discretization& discretization, PoroPressureBased::BoundaryAction action,
           Core::Elements::LocationArray& la, std::vector<Core::LinAlg::SerialDenseMatrix*>& elemat,
           std::vector<Core::LinAlg::SerialDenseVector*>& elevec);
 

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc.cpp
@@ -81,7 +81,7 @@ int Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::evaluate(Core::Eleme
     std::vector<Core::LinAlg::SerialDenseVector*>& elevec)
 {
   // check for the action parameter
-  const auto action = Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::Action>(params, "action");
+  const auto action = Teuchos::getIntegralValue<PoroPressureBased::Action>(params, "action");
 
   // setup
   if (setup_calc(ele, discretization, action) == -1) return -1;
@@ -101,35 +101,35 @@ int Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::evaluate(Core::Eleme
 template <Core::FE::CellType distype>
 int Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
-    Core::FE::Discretization& discretization, const POROFLUIDMULTIPHASE::Action& action,
+    Core::FE::Discretization& discretization, const PoroPressureBased::Action& action,
     Core::Elements::LocationArray& la, std::vector<Core::LinAlg::SerialDenseMatrix*>& elemat,
     std::vector<Core::LinAlg::SerialDenseVector*>& elevec)
 {
   // determine and evaluate action
   switch (action)
   {
-    case POROFLUIDMULTIPHASE::calc_mat_and_rhs:
-    case POROFLUIDMULTIPHASE::calc_initial_time_deriv:
-    case POROFLUIDMULTIPHASE::recon_flux_at_nodes:
-    case POROFLUIDMULTIPHASE::calc_domain_integrals:
+    case PoroPressureBased::calc_mat_and_rhs:
+    case PoroPressureBased::calc_initial_time_deriv:
+    case PoroPressureBased::recon_flux_at_nodes:
+    case PoroPressureBased::calc_domain_integrals:
     {
       // loop over gauss points and evaluate terms (standard call)
       gauss_point_loop(ele, elemat, elevec, discretization, la);
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_fluid_struct_coupl_mat:
+    case PoroPressureBased::calc_fluid_struct_coupl_mat:
     {
       // loop over gauss points and evaluate off-diagonal terms
       gauss_point_loop_od_struct(ele, elemat, elevec, discretization, la);
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_fluid_scatra_coupl_mat:
+    case PoroPressureBased::calc_fluid_scatra_coupl_mat:
     {
       // loop over gauss points and evaluate off-diagonal terms
       gauss_point_loop_od_scatra(ele, elemat, elevec, discretization, la);
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_pres_and_sat:
+    case PoroPressureBased::calc_pres_and_sat:
     {
       // loop over nodes and evaluate terms
       node_loop(ele, elemat, elevec, discretization, la,
@@ -137,8 +137,8 @@ int Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::evaluate_action(
       );
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_porosity:
-    case POROFLUIDMULTIPHASE::calc_solidpressure:
+    case PoroPressureBased::calc_porosity:
+    case PoroPressureBased::calc_solidpressure:
     {
       // loop over nodes and evaluate terms
       node_loop(ele, elemat, elevec, discretization, la,
@@ -147,13 +147,13 @@ int Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::evaluate_action(
       );
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_valid_dofs:
+    case PoroPressureBased::calc_valid_dofs:
     {
       // evaluate the element
       evaluate_only_element(ele, elemat, elevec, discretization, la);
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_phase_velocities:
+    case PoroPressureBased::calc_phase_velocities:
     {
       // loop over gauss points and average
       gauss_point_loop_average(ele, elemat, elevec, discretization, la);
@@ -184,7 +184,7 @@ void Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::gauss_point_loop(
 
   // integration points and weights
   const Core::FE::IntPointsAndWeights<nsd_> intpoints(
-      POROFLUIDMULTIPHASE::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
+      PoroPressureBased::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
 
   // start loop over gauss points
   gauss_point_loop(intpoints, ele, elemat, elevec, discretization, la);
@@ -202,7 +202,7 @@ void Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::gauss_point_loop_av
   prepare_gauss_point_loop(ele);
 
   const Core::FE::IntPointsAndWeights<nsd_> intpoints(
-      POROFLUIDMULTIPHASE::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
+      PoroPressureBased::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
 
   gauss_point_loop(intpoints, ele, elemat, elevec, discretization, la);
 
@@ -228,7 +228,7 @@ void Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::gauss_point_loop_od
 
   // integration points and weights
   const Core::FE::IntPointsAndWeights<nsd_> intpoints(
-      POROFLUIDMULTIPHASE::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
+      PoroPressureBased::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
 
   // start loop over gauss points
   gauss_point_loop_od_struct(intpoints, ele, elemat, elevec, discretization, la);
@@ -250,7 +250,7 @@ void Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::gauss_point_loop_od
 
   // integration points and weights
   const Core::FE::IntPointsAndWeights<nsd_> intpoints(
-      POROFLUIDMULTIPHASE::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
+      PoroPressureBased::ElementUtils::DisTypeToOptGaussRule<distype>::rule);
 
   // start loop over gauss points
   gauss_point_loop_od_scatra(intpoints, ele, elemat, elevec, discretization, la);
@@ -481,7 +481,7 @@ void Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::evaluate_only_eleme
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 int Discret::Elements::PoroFluidMultiPhaseEleCalc<distype>::setup_calc(Core::Elements::Element* ele,
-    Core::FE::Discretization& discretization, const POROFLUIDMULTIPHASE::Action& action)
+    Core::FE::Discretization& discretization, const PoroPressureBased::Action& action)
 {
   // get element coordinates
   Core::Geo::fill_initial_position_array<distype, nsd_, Core::LinAlg::Matrix<nsd_, nen_>>(

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc.hpp
@@ -78,7 +78,7 @@ namespace Discret
 
       //! element-type specific flag if second derivatives are needed
       static constexpr bool use2ndderiv_ =
-          POROFLUIDMULTIPHASE::ElementUtils::Use2ndDerivs<distype>::use;
+          PoroPressureBased::ElementUtils::Use2ndDerivs<distype>::use;
 
       /// Evaluate the element
       /*!
@@ -96,11 +96,11 @@ namespace Discret
 
       /// Setup element evaluation
       virtual int setup_calc(Core::Elements::Element* ele, Core::FE::Discretization& discretization,
-          const POROFLUIDMULTIPHASE::Action& action);
+          const PoroPressureBased::Action& action);
 
       //! evaluate action
       virtual int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
-          Core::FE::Discretization& discretization, const POROFLUIDMULTIPHASE::Action& action,
+          Core::FE::Discretization& discretization, const PoroPressureBased::Action& action,
           Core::Elements::LocationArray& la, std::vector<Core::LinAlg::SerialDenseMatrix*>& elemat,
           std::vector<Core::LinAlg::SerialDenseVector*>& elevec);
 

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc_utils.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc_utils.cpp
@@ -18,7 +18,7 @@ FOUR_C_NAMESPACE_OPEN
  * get the single phase material from the element multiphase reaction material   vuong 08/16 |
  *-------------------------------------------------------------------------------------------*/
 Mat::FluidPoroSingleReaction&
-POROFLUIDMULTIPHASE::ElementUtils::get_single_reaction_mat_from_multi_reactions_material(
+PoroPressureBased::ElementUtils::get_single_reaction_mat_from_multi_reactions_material(
     const Mat::FluidPoroMultiPhaseReactions& multiphasereacmat, int phasenum)
 {
   // get the single phase material by its ID
@@ -36,7 +36,7 @@ POROFLUIDMULTIPHASE::ElementUtils::get_single_reaction_mat_from_multi_reactions_
  * get the single phase material from the element multiphase material    vuong 08/16 |
  *-----------------------------------------------------------------------------------*/
 const Mat::FluidPoroSinglePhase&
-POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_multi_material(
+PoroPressureBased::ElementUtils::get_single_phase_mat_from_multi_material(
     const Mat::FluidPoroMultiPhase& multiphasemat, int phasenum)
 {
   // get the single phase material by its ID
@@ -55,7 +55,7 @@ POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_multi_material(
  *  get the single phase material from the element material   vuong 08/16 |
  *-------------------------------------------------------------------------*/
 const Mat::FluidPoroSinglePhase&
-POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(
+PoroPressureBased::ElementUtils::get_single_phase_mat_from_material(
     const Core::Mat::Material& material, int phasenum)
 {
   // safety check
@@ -74,7 +74,7 @@ POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(
  * get the single volfrac material from the element multiphase material kremheller 08/17 |
  *----------------------------------------------------------------------------------------*/
 const Mat::FluidPoroSingleVolFrac&
-POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_multi_material(
+PoroPressureBased::ElementUtils::get_single_vol_frac_mat_from_multi_material(
     const Mat::FluidPoroMultiPhase& multiphasemat, int volfracnum)
 {
   // get the single phase material by its ID
@@ -93,7 +93,7 @@ POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_multi_material(
  *  get the single volfrac material from the element material   kremheller 08/17 |
  *--------------------------------------------------------------------------------*/
 const Mat::FluidPoroSingleVolFrac&
-POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_material(
+PoroPressureBased::ElementUtils::get_single_vol_frac_mat_from_material(
     const Core::Mat::Material& material, int volfracnum)
 {
   // safety check
@@ -112,7 +112,7 @@ POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_material(
  * get the volume fraction pressure material from the element multiphase material kremheller 02/18 |
  *--------------------------------------------------------------------------------------------------*/
 const Mat::FluidPoroVolFracPressure&
-POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_multi_material(
+PoroPressureBased::ElementUtils::get_vol_frac_pressure_mat_from_multi_material(
     const Mat::FluidPoroMultiPhase& multiphasemat, int volfracnum)
 {
   // get the single phase material by its ID
@@ -131,7 +131,7 @@ POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_multi_material
  *  get the volume fraction pressure material from the element material   kremheller 02/18 |
  *------------------------------------------------------------------------------------------*/
 const Mat::FluidPoroVolFracPressure&
-POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_material(
+PoroPressureBased::ElementUtils::get_vol_frac_pressure_mat_from_material(
     const Core::Mat::Material& material, int volfracnum)
 {
   // safety check

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc_utils.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_calc_utils.hpp
@@ -26,7 +26,7 @@ namespace Mat
   class FluidPoroSingleReaction;
 }  // namespace Mat
 
-namespace POROFLUIDMULTIPHASE
+namespace PoroPressureBased
 {
   namespace ElementUtils
   {
@@ -385,7 +385,7 @@ namespace POROFLUIDMULTIPHASE
 
   }  // namespace ElementUtils
 
-}  // namespace POROFLUIDMULTIPHASE
+}  // namespace PoroPressureBased
 
 
 

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluate.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluate.cpp
@@ -30,23 +30,23 @@ int Discret::Elements::PoroFluidMultiPhase::evaluate(Teuchos::ParameterList& par
   const int numdofpernode = num_dof_per_node(*(nodes()[0]));
 
   // check for the action parameter
-  const auto action = Teuchos::getIntegralValue<POROFLUIDMULTIPHASE::Action>(params, "action");
+  const auto action = Teuchos::getIntegralValue<PoroPressureBased::Action>(params, "action");
   switch (action)
   {
     // all physics-related stuff is included in the implementation class(es) that can
     // be used in principle inside any element (at the moment: only PoroFluidMultiPhase element)
-    case POROFLUIDMULTIPHASE::calc_mat_and_rhs:
-    case POROFLUIDMULTIPHASE::calc_fluid_struct_coupl_mat:
-    case POROFLUIDMULTIPHASE::calc_fluid_scatra_coupl_mat:
-    case POROFLUIDMULTIPHASE::calc_error:
-    case POROFLUIDMULTIPHASE::calc_pres_and_sat:
-    case POROFLUIDMULTIPHASE::calc_solidpressure:
-    case POROFLUIDMULTIPHASE::calc_porosity:
-    case POROFLUIDMULTIPHASE::recon_flux_at_nodes:
-    case POROFLUIDMULTIPHASE::calc_phase_velocities:
-    case POROFLUIDMULTIPHASE::calc_initial_time_deriv:
-    case POROFLUIDMULTIPHASE::calc_valid_dofs:
-    case POROFLUIDMULTIPHASE::calc_domain_integrals:
+    case PoroPressureBased::calc_mat_and_rhs:
+    case PoroPressureBased::calc_fluid_struct_coupl_mat:
+    case PoroPressureBased::calc_fluid_scatra_coupl_mat:
+    case PoroPressureBased::calc_error:
+    case PoroPressureBased::calc_pres_and_sat:
+    case PoroPressureBased::calc_solidpressure:
+    case PoroPressureBased::calc_porosity:
+    case PoroPressureBased::recon_flux_at_nodes:
+    case PoroPressureBased::calc_phase_velocities:
+    case PoroPressureBased::calc_initial_time_deriv:
+    case PoroPressureBased::calc_valid_dofs:
+    case PoroPressureBased::calc_domain_integrals:
     {
       std::vector<Core::LinAlg::SerialDenseMatrix*> elemat(2);
       elemat[0] = &elemat1;

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluator.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluator.cpp
@@ -23,14 +23,14 @@ template <int nsd, int nen>
 std::shared_ptr<Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>>
 Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>::create_evaluator(
     const Discret::Elements::PoroFluidMultiPhaseEleParameter& para,
-    const POROFLUIDMULTIPHASE::Action& action, int numdofpernode, int numfluidphases,
+    const PoroPressureBased::Action& action, int numdofpernode, int numfluidphases,
     const PoroFluidManager::PhaseManagerInterface& phasemanager)
 {
   // the evaluator
   std::shared_ptr<EvaluatorInterface<nsd, nen>> evaluator = nullptr;
 
   bool inittimederiv = false;
-  if (action == POROFLUIDMULTIPHASE::calc_initial_time_deriv) inittimederiv = true;
+  if (action == PoroPressureBased::calc_initial_time_deriv) inittimederiv = true;
 
   // check if fluidphases present
   const bool hasfluidphases = (numfluidphases > 0);
@@ -42,10 +42,10 @@ Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>::create_eval
   switch (action)
   {
     // calculate true pressures and saturation
-    case POROFLUIDMULTIPHASE::calc_initial_time_deriv:
-    case POROFLUIDMULTIPHASE::calc_mat_and_rhs:
-    case POROFLUIDMULTIPHASE::calc_fluid_struct_coupl_mat:
-    case POROFLUIDMULTIPHASE::calc_fluid_scatra_coupl_mat:
+    case PoroPressureBased::calc_initial_time_deriv:
+    case PoroPressureBased::calc_mat_and_rhs:
+    case PoroPressureBased::calc_fluid_struct_coupl_mat:
+    case PoroPressureBased::calc_fluid_scatra_coupl_mat:
     {
       // initialize the evaluator for the multi phase element
       std::shared_ptr<MultiEvaluator<nsd, nen>> evaluator_multiphase =
@@ -296,7 +296,7 @@ Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>::create_eval
       evaluator = evaluator_multiphase;
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_pres_and_sat:
+    case PoroPressureBased::calc_pres_and_sat:
     {
       // initialize the evaluator for the multi phase element
       std::shared_ptr<MultiEvaluator<nsd, nen>> evaluator_multiphase =
@@ -321,21 +321,21 @@ Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>::create_eval
 
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_solidpressure:
+    case PoroPressureBased::calc_solidpressure:
     {
       std::shared_ptr<AssembleInterface> assembler = std::make_shared<AssembleStandard>(-1, false);
       evaluator = std::make_shared<EvaluatorSolidPressure<nsd, nen>>(assembler, -1);
 
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_porosity:
+    case PoroPressureBased::calc_porosity:
     {
       std::shared_ptr<AssembleInterface> assembler = std::make_shared<AssembleStandard>(-1, false);
       evaluator = std::make_shared<EvaluatorPorosity<nsd, nen>>(assembler, -1);
 
       break;
     }
-    case POROFLUIDMULTIPHASE::recon_flux_at_nodes:
+    case PoroPressureBased::recon_flux_at_nodes:
     {
       // initialize the evaluator for the multi phase element
       std::shared_ptr<MultiEvaluator<nsd, nen>> evaluator_multiphase =
@@ -362,7 +362,7 @@ Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>::create_eval
 
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_phase_velocities:
+    case PoroPressureBased::calc_phase_velocities:
     {
       std::shared_ptr<MultiEvaluator<nsd, nen>> evaluator_multiphase =
           std::make_shared<MultiEvaluator<nsd, nen>>();
@@ -382,14 +382,14 @@ Discret::Elements::PoroFluidEvaluator::EvaluatorInterface<nsd, nen>::create_eval
 
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_valid_dofs:
+    case PoroPressureBased::calc_valid_dofs:
     {
       std::shared_ptr<AssembleInterface> assembler = std::make_shared<AssembleStandard>(-1, false);
       evaluator = std::make_shared<EvaluatorValidVolFracPressures<nsd, nen>>(assembler, -1);
 
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_domain_integrals:
+    case PoroPressureBased::calc_domain_integrals:
     {
       int numscal = 0;
       if (para.has_scalar()) numscal = phasemanager.num_scal();

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluator.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluator.hpp
@@ -174,7 +174,7 @@ namespace Discret
         //! factory method
         static std::shared_ptr<EvaluatorInterface<nsd, nen>> create_evaluator(
             const Discret::Elements::PoroFluidMultiPhaseEleParameter& para,
-            const POROFLUIDMULTIPHASE::Action& action, int numdofpernode, int numfluidphases,
+            const PoroPressureBased::Action& action, int numdofpernode, int numfluidphases,
             const PoroFluidManager::PhaseManagerInterface& phasemanager);
 
         //! evaluate matrixes (stiffness)

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.cpp
@@ -33,7 +33,7 @@ FOUR_C_NAMESPACE_OPEN
 std::shared_ptr<Discret::Elements::PoroFluidManager::PhaseManagerInterface>
 Discret::Elements::PoroFluidManager::PhaseManagerInterface::create_phase_manager(
     const Discret::Elements::PoroFluidMultiPhaseEleParameter& para, int nsd,
-    Core::Materials::MaterialType mattype, const POROFLUIDMULTIPHASE::Action& action,
+    Core::Materials::MaterialType mattype, const PoroPressureBased::Action& action,
     int totalnumdofpernode, int numfluidphases)
 {
   std::shared_ptr<PhaseManagerInterface> phasemanager = nullptr;
@@ -50,7 +50,7 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::create_phase_manager
 std::shared_ptr<Discret::Elements::PoroFluidManager::PhaseManagerInterface>
 Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
     const Discret::Elements::PoroFluidMultiPhaseEleParameter& para, int nsd,
-    Core::Materials::MaterialType mattype, const POROFLUIDMULTIPHASE::Action& action,
+    Core::Materials::MaterialType mattype, const PoroPressureBased::Action& action,
     std::shared_ptr<PhaseManagerInterface> corephasemanager)
 {
   std::shared_ptr<PhaseManagerInterface> phasemanager = nullptr;
@@ -59,15 +59,15 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
   switch (action)
   {
     // calculate true pressures and saturation
-    case POROFLUIDMULTIPHASE::calc_pres_and_sat:
-    case POROFLUIDMULTIPHASE::calc_valid_dofs:
+    case PoroPressureBased::calc_pres_and_sat:
+    case PoroPressureBased::calc_valid_dofs:
     {
       // no extensions needed
       phasemanager = corephasemanager;
       break;
     }
     // calculate solid pressure
-    case POROFLUIDMULTIPHASE::calc_solidpressure:
+    case PoroPressureBased::calc_solidpressure:
     {
       // we have volume fractions --> we need PhaseManagerDerivAndPorosity because solid pressure is
       // calculated differently
@@ -84,7 +84,7 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
       }
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_phase_velocities:
+    case PoroPressureBased::calc_phase_velocities:
     {
       // derivatives needed
       if (corephasemanager->num_fluid_phases() > 0)
@@ -108,7 +108,7 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
       }
       break;
     }
-    case POROFLUIDMULTIPHASE::recon_flux_at_nodes:
+    case PoroPressureBased::recon_flux_at_nodes:
     {
       // derivatives needed
       if (corephasemanager->num_fluid_phases() > 0)
@@ -133,11 +133,11 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
       break;
     }
     // standard evaluate call
-    case POROFLUIDMULTIPHASE::calc_mat_and_rhs:
-    case POROFLUIDMULTIPHASE::calc_initial_time_deriv:
-    case POROFLUIDMULTIPHASE::calc_fluid_struct_coupl_mat:
-    case POROFLUIDMULTIPHASE::calc_fluid_scatra_coupl_mat:
-    case POROFLUIDMULTIPHASE::calc_domain_integrals:
+    case PoroPressureBased::calc_mat_and_rhs:
+    case PoroPressureBased::calc_initial_time_deriv:
+    case PoroPressureBased::calc_fluid_struct_coupl_mat:
+    case PoroPressureBased::calc_fluid_scatra_coupl_mat:
+    case PoroPressureBased::calc_domain_integrals:
     {
       // porosity (includes derivatves) needed
       phasemanager = std::make_shared<PhaseManagerDerivAndPorosity>(corephasemanager);
@@ -182,7 +182,7 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
 
       break;
     }
-    case POROFLUIDMULTIPHASE::get_access_from_scatra:
+    case PoroPressureBased::get_access_from_scatra:
     {
       // porosity (includes derivatives) needed
       phasemanager = std::make_shared<PhaseManagerDerivAndPorosity>(corephasemanager);
@@ -205,8 +205,8 @@ Discret::Elements::PoroFluidManager::PhaseManagerInterface::wrap_phase_manager(
 
       break;
     }
-    case POROFLUIDMULTIPHASE::calc_porosity:
-    case POROFLUIDMULTIPHASE::get_access_from_artcoupling:
+    case PoroPressureBased::calc_porosity:
+    case PoroPressureBased::get_access_from_artcoupling:
     {
       // porosity (includes derivatves) needed
       phasemanager = std::make_shared<PhaseManagerDerivAndPorosity>(corephasemanager);
@@ -325,7 +325,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerCore::setup(
   {
     // get the single phase material
     const Mat::FluidPoroSinglePhase& singlephasemat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(material, iphase);
+        PoroPressureBased::ElementUtils::get_single_phase_mat_from_material(material, iphase);
     invbulkmodulifluid_[iphase] = singlephasemat.inv_bulkmodulus();
 
     // get density
@@ -336,7 +336,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerCore::setup(
   {
     // get the single phase material
     const Mat::FluidPoroSingleVolFrac& singlevolfracmat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_material(
+        PoroPressureBased::ElementUtils::get_single_vol_frac_mat_from_material(
             material, ivolfrac + numfluidphases_);
 
     // get constant values
@@ -1130,7 +1130,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerReaction::setup(
   {
     // get the single phase material
     Mat::FluidPoroSingleReaction& singlephasemat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_reaction_mat_from_multi_reactions_material(
+        PoroPressureBased::ElementUtils::get_single_reaction_mat_from_multi_reactions_material(
             multiphasemat, ireac);
 
     for (int iphase = 0; iphase < totalnumdof; iphase++)
@@ -1198,7 +1198,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerReaction::evaluate_gp_stat
   {
     // get the single phase material
     Mat::FluidPoroSingleReaction& singlephasemat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_reaction_mat_from_multi_reactions_material(
+        PoroPressureBased::ElementUtils::get_single_reaction_mat_from_multi_reactions_material(
             multiphasemat, ireac);
 
     // evaluate the reaction
@@ -1379,7 +1379,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<nsd>::setup(
   {
     // get the single phase material
     const Mat::FluidPoroSinglePhase& singlephasemat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(material, iphase);
+        PoroPressureBased::ElementUtils::get_single_phase_mat_from_material(material, iphase);
     constrelpermeability_[iphase] = singlephasemat.has_constant_rel_permeability();
     constdynviscosity_[iphase] = singlephasemat.has_constant_viscosity();
 
@@ -1394,7 +1394,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<nsd>::setup(
   {
     // get the volfrac pressure material
     const Mat::FluidPoroVolFracPressure& volfracpressmat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_material(
+        PoroPressureBased::ElementUtils::get_vol_frac_pressure_mat_from_material(
             material, ivolfrac + numvolfrac + numfluidphases);
 
     constdynviscosityvolfracpress_[ivolfrac] = volfracpressmat.has_constant_viscosity();
@@ -1443,8 +1443,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<nsd>::evaluate_g
   {
     // get the single phase material
     const Mat::FluidPoroSinglePhase& singlephasemat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(
-            multiphasemat, iphase);
+        PoroPressureBased::ElementUtils::get_single_phase_mat_from_material(multiphasemat, iphase);
 
     // evaluate relative permeabilities
     relpermeabilities_[iphase] = singlephasemat.rel_permeability(phasemanager_->saturation(iphase));
@@ -1551,7 +1550,7 @@ double Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<nsd>::dyn_visc
 {
   // get the single phase material
   const Mat::FluidPoroSinglePhase& singlephasemat =
-      POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(material, phasenum);
+      PoroPressureBased::ElementUtils::get_single_phase_mat_from_material(material, phasenum);
 
   return singlephasemat.viscosity(abspressgrad);
 }
@@ -1577,7 +1576,7 @@ double Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<nsd>::dyn_visc
 {
   // get the single phase material
   const Mat::FluidPoroSinglePhase& singlephasemat =
-      POROFLUIDMULTIPHASE::ElementUtils::get_single_phase_mat_from_material(material, phasenum);
+      PoroPressureBased::ElementUtils::get_single_phase_mat_from_material(material, phasenum);
 
   return singlephasemat.viscosity_deriv(abspressgrad);
 }
@@ -1618,7 +1617,7 @@ Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<nsd>::dyn_viscosity_v
 {
   // get the single phase material
   const Mat::FluidPoroVolFracPressure& volfracpressmat =
-      POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_material(material,
+      PoroPressureBased::ElementUtils::get_vol_frac_pressure_mat_from_material(material,
           volfracpressnum + phasemanager_->num_fluid_phases() + phasemanager_->num_vol_frac());
 
   return volfracpressmat.viscosity(abspressgrad);
@@ -1647,7 +1646,7 @@ double Discret::Elements::PoroFluidManager::PhaseManagerDiffusion<
 {
   // get the single phase material
   const Mat::FluidPoroVolFracPressure& volfracpressmat =
-      POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_material(material,
+      PoroPressureBased::ElementUtils::get_vol_frac_pressure_mat_from_material(material,
           volfracpressnum + phasemanager_->num_fluid_phases() + phasemanager_->num_vol_frac());
 
   return volfracpressmat.viscosity_deriv(abspressgrad);
@@ -1712,7 +1711,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerVolFrac<nsd>::setup(
   {
     // get the single phase material
     const Mat::FluidPoroSingleVolFrac& singlevolfracmat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_material(
+        PoroPressureBased::ElementUtils::get_single_vol_frac_mat_from_material(
             material, ivolfrac + numfluidphases);
 
     // clear
@@ -1763,7 +1762,7 @@ void Discret::Elements::PoroFluidManager::PhaseManagerVolFrac<nsd>::evaluate_gp_
   {
     // get the single phase material
     const Mat::FluidPoroSingleVolFrac& singlevolfracmat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_single_vol_frac_mat_from_material(
+        PoroPressureBased::ElementUtils::get_single_vol_frac_mat_from_material(
             material, ivolfrac + numfluidphases);
 
     if (this->has_add_scalar_dependent_flux(ivolfrac))

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_phasemanager.hpp
@@ -85,13 +85,13 @@ namespace Discret
         //! factory method
         static std::shared_ptr<Discret::Elements::PoroFluidManager::PhaseManagerInterface>
         create_phase_manager(const Discret::Elements::PoroFluidMultiPhaseEleParameter& para,
-            int nsd, Core::Materials::MaterialType mattype,
-            const POROFLUIDMULTIPHASE::Action& action, int totalnumdofpernode, int numfluidphases);
+            int nsd, Core::Materials::MaterialType mattype, const PoroPressureBased::Action& action,
+            int totalnumdofpernode, int numfluidphases);
 
         //! factory method
         static std::shared_ptr<Discret::Elements::PoroFluidManager::PhaseManagerInterface>
         wrap_phase_manager(const Discret::Elements::PoroFluidMultiPhaseEleParameter& para, int nsd,
-            Core::Materials::MaterialType mattype, const POROFLUIDMULTIPHASE::Action& action,
+            Core::Materials::MaterialType mattype, const PoroPressureBased::Action& action,
             std::shared_ptr<PhaseManagerInterface> corephasemanager);
 
         //! setup (matnum is the material number of the porofluid-material on the current element)

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_variablemanager.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_variablemanager.cpp
@@ -23,7 +23,7 @@ template <int nsd, int nen>
 std::shared_ptr<Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>>
 Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>::create_variable_manager(
     const Discret::Elements::PoroFluidMultiPhaseEleParameter& para,
-    const POROFLUIDMULTIPHASE::Action& action, std::shared_ptr<Core::Mat::Material> mat,
+    const PoroPressureBased::Action& action, std::shared_ptr<Core::Mat::Material> mat,
     int numdofpernode, int numfluidphases)
 {
   std::shared_ptr<VariableManagerInterface<nsd, nen>> varmanager = nullptr;
@@ -37,7 +37,7 @@ Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>::create_
   switch (action)
   {
     // calculate true pressures and saturation
-    case POROFLUIDMULTIPHASE::calc_pres_and_sat:
+    case PoroPressureBased::calc_pres_and_sat:
     {
       // only phi values are needed
       varmanager = std::make_shared<VariableManagerPhi<nsd, nen>>(numdofpernode);
@@ -45,8 +45,8 @@ Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>::create_
       break;
     }
     // calculate solid pressure
-    case POROFLUIDMULTIPHASE::calc_solidpressure:
-    case POROFLUIDMULTIPHASE::calc_porosity:
+    case PoroPressureBased::calc_solidpressure:
+    case PoroPressureBased::calc_porosity:
     {
       // only phi values are needed
       varmanager = std::make_shared<VariableManagerPhi<nsd, nen>>(numdofpernode);
@@ -59,7 +59,7 @@ Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>::create_
       break;
     }
     // calculate the valid dofs
-    case POROFLUIDMULTIPHASE::calc_valid_dofs:
+    case PoroPressureBased::calc_valid_dofs:
     {
       // only phi values are needed
       varmanager = std::make_shared<VariableManagerPhi<nsd, nen>>(numdofpernode);
@@ -70,8 +70,8 @@ Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>::create_
 
       break;
     }
-    case POROFLUIDMULTIPHASE::recon_flux_at_nodes:
-    case POROFLUIDMULTIPHASE::calc_phase_velocities:
+    case PoroPressureBased::recon_flux_at_nodes:
+    case PoroPressureBased::calc_phase_velocities:
     {
       // state vector and gradients are needed
       varmanager = std::make_shared<VariableManagerPhiGradPhi<nsd, nen>>(numdofpernode);
@@ -83,8 +83,8 @@ Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd, nen>::create_
       break;
     }
     // read data from scatra
-    case POROFLUIDMULTIPHASE::get_access_from_scatra:
-    case POROFLUIDMULTIPHASE::get_access_from_artcoupling:
+    case PoroPressureBased::get_access_from_scatra:
+    case PoroPressureBased::get_access_from_artcoupling:
     {
       // NOTE: we do not need the variable manager struct here, since the call
       // ExtractElementsAndNodeValues will
@@ -456,7 +456,7 @@ void Discret::Elements::PoroFluidManager::VariableManagerMaximumNodalVolFracValu
   {
     // get the volfrac pressure material
     const Mat::FluidPoroVolFracPressure& volfracpressmat =
-        POROFLUIDMULTIPHASE::ElementUtils::get_vol_frac_pressure_mat_from_material(
+        PoroPressureBased::ElementUtils::get_vol_frac_pressure_mat_from_material(
             *multiphasemat_, k + numvolfrac_ + numfluidphases);
 
     // this approach proved to be the most stable one

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_variablemanager.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_variablemanager.hpp
@@ -104,7 +104,7 @@ namespace Discret
         //! factory method
         static std::shared_ptr<VariableManagerInterface<nsd, nen>> create_variable_manager(
             const Discret::Elements::PoroFluidMultiPhaseEleParameter& para,
-            const POROFLUIDMULTIPHASE::Action& action, std::shared_ptr<Core::Mat::Material> mat,
+            const PoroPressureBased::Action& action, std::shared_ptr<Core::Mat::Material> mat,
             const int numdofpernode, const int numfluidphases);
 
         //! extract element and node values from the discretization

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
@@ -106,8 +106,8 @@ void ScaTra::MeshtyingStrategyArtery::init_meshtying()
       });
 
   // init the mesh tying object, which does all the work
-  arttoscatracoupling_ = PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
-      artscatradis_, scatradis_, myscatraparams.sublist("ARTERY COUPLING"), couplingcondname,
+  arttoscatracoupling_ = PoroPressureBased::create_and_init_artery_coupling_strategy(artscatradis_,
+      scatradis_, myscatraparams.sublist("ARTERY COUPLING"), couplingcondname,
       "COUPLEDDOFS_ARTSCATRA", "COUPLEDDOFS_SCATRA", evaluate_on_lateral_surface);
 
   initialize_linear_solver(myscatraparams);

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_artery.cpp
@@ -106,7 +106,7 @@ void ScaTra::MeshtyingStrategyArtery::init_meshtying()
       });
 
   // init the mesh tying object, which does all the work
-  arttoscatracoupling_ = PoroMultiPhaseScaTra::Utils::create_and_init_artery_coupling_strategy(
+  arttoscatracoupling_ = PoroMultiPhaseScaTra::create_and_init_artery_coupling_strategy(
       artscatradis_, scatradis_, myscatraparams.sublist("ARTERY COUPLING"), couplingcondname,
       "COUPLEDDOFS_ARTSCATRA", "COUPLEDDOFS_SCATRA", evaluate_on_lateral_surface);
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_artery.hpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_artery.hpp
@@ -39,7 +39,7 @@ namespace FSI
   }  // namespace Utils
 }  // namespace FSI
 
-namespace PoroMultiPhaseScaTra
+namespace PoroPressureBased
 {
   class PoroMultiPhaseScaTraArtCouplBase;
 }
@@ -172,7 +172,7 @@ namespace ScaTra
     std::shared_ptr<Adapter::ArtNet> arttimint_;
 
     //! mesh tying object
-    std::shared_ptr<PoroMultiPhaseScaTra::PoroMultiPhaseScaTraArtCouplBase> arttoscatracoupling_;
+    std::shared_ptr<PoroPressureBased::PoroMultiPhaseScaTraArtCouplBase> arttoscatracoupling_;
 
     //! the two discretizations
     std::shared_ptr<Core::FE::Discretization> artscatradis_;

--- a/src/scatra/4C_scatra_timint_poromulti.cpp
+++ b/src/scatra/4C_scatra_timint_poromulti.cpp
@@ -206,7 +206,7 @@ void ScaTra::ScaTraTimIntPoroMulti::collect_runtime_output_data()
           // compute CaO2
           const double CaO2 = (*phinp_)[lidoxydof] * rho_bl / rho_oxy;
           // compute Pb
-          PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+          PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
               Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
           // replace value
           oxypartpress.replace_global_value(node->id(), 0, Pb);

--- a/src/scatra/4C_scatra_timint_poromulti.cpp
+++ b/src/scatra/4C_scatra_timint_poromulti.cpp
@@ -206,7 +206,7 @@ void ScaTra::ScaTraTimIntPoroMulti::collect_runtime_output_data()
           // compute CaO2
           const double CaO2 = (*phinp_)[lidoxydof] * rho_bl / rho_oxy;
           // compute Pb
-          PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+          PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
               Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
           // replace value
           oxypartpress.replace_global_value(node->id(), 0, Pb);

--- a/src/scatra_ele/4C_scatra_ele_calc_multiporo_reac.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_multiporo_reac.hpp
@@ -1485,7 +1485,7 @@ namespace Discret
         phasemanager_ =
             Discret::Elements::PoroFluidManager::PhaseManagerInterface::create_phase_manager(*para,
                 nsd, multiphase_mat()->material_type(),
-                POROFLUIDMULTIPHASE::Action::get_access_from_scatra, totalnummultiphasedofpernode,
+                PoroPressureBased::Action::get_access_from_scatra, totalnummultiphasedofpernode,
                 numfluidphases);
 
         // access from outside to the phasemanager: scatra-discretization has fluid-dis on dofset 2
@@ -1493,9 +1493,8 @@ namespace Discret
 
         // create variablemanager
         variablemanager_ = Discret::Elements::PoroFluidManager::VariableManagerInterface<nsd,
-            nen>::create_variable_manager(*para,
-            POROFLUIDMULTIPHASE::Action::get_access_from_scatra, multiphase_mat(),
-            totalnummultiphasedofpernode, numfluidphases);
+            nen>::create_variable_manager(*para, PoroPressureBased::Action::get_access_from_scatra,
+            multiphase_mat(), totalnummultiphasedofpernode, numfluidphases);
 
         return;
       }

--- a/unittests/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function_test.cpp
+++ b/unittests/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_function_test.cpp
@@ -26,7 +26,7 @@ namespace
     void SetUp() override
     {
       // function parameters
-      const auto& parameters = PoroMultiPhaseScaTra::LungOxygenExchangeLawParameters{
+      const auto& parameters = PoroPressureBased::LungOxygenExchangeLawParameters{
           .rho_oxy = 1.429e-9,
           .DiffAdVTLC = 5.36,
           .alpha_oxy = 2.1e-4,
@@ -41,10 +41,10 @@ namespace
 
       // construct LungOxygenExchangeLaw
       LungOxygenExchangeLaw_ =
-          std::make_unique<PoroMultiPhaseScaTra::LungOxygenExchangeLaw<3>>(parameters);
+          std::make_unique<PoroPressureBased::LungOxygenExchangeLaw<3>>(parameters);
     }
 
-    std::unique_ptr<PoroMultiPhaseScaTra::LungOxygenExchangeLaw<3>> LungOxygenExchangeLaw_;
+    std::unique_ptr<PoroPressureBased::LungOxygenExchangeLaw<3>> LungOxygenExchangeLaw_;
   };
 
   class LungCarbonDioxideExchangeLawTest : public ::testing::Test
@@ -53,7 +53,7 @@ namespace
     void SetUp() override
     {
       // function parameters
-      const auto& parameters = PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLawParameters{
+      const auto& parameters = PoroPressureBased::LungCarbonDioxideExchangeLawParameters{
           .rho_CO2 = 1.98e-9,
           .DiffsolAdVTLC = 4.5192e-3,
           .pH = 7.352,
@@ -72,10 +72,10 @@ namespace
 
       // construct LungCarbonDioxideExchangeLaw
       LungCarbonDioxideExchangeLaw_ =
-          std::make_unique<PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<3>>(parameters);
+          std::make_unique<PoroPressureBased::LungCarbonDioxideExchangeLaw<3>>(parameters);
     }
 
-    std::unique_ptr<PoroMultiPhaseScaTra::LungCarbonDioxideExchangeLaw<3>>
+    std::unique_ptr<PoroPressureBased::LungCarbonDioxideExchangeLaw<3>>
         LungCarbonDioxideExchangeLaw_;
   };
 

--- a/unittests/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils_test.cpp
+++ b/unittests/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils_test.cpp
@@ -50,7 +50,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, 0.0, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal
@@ -73,7 +73,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal
@@ -96,7 +96,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal
@@ -119,7 +119,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::Utils::get_oxy_partial_pressure_from_concentration<double>(
+    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal

--- a/unittests/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils_test.cpp
+++ b/unittests/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils_test.cpp
@@ -50,7 +50,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+    PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, 0.0, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal
@@ -73,7 +73,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+    PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal
@@ -96,7 +96,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+    PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal
@@ -119,7 +119,7 @@ namespace
 
     // invert to get partial pressure for this concentration
     double inverted_Pb = 0.0;
-    PoroMultiPhaseScaTra::get_oxy_partial_pressure_from_concentration<double>(
+    PoroPressureBased::get_oxy_partial_pressure_from_concentration<double>(
         inverted_Pb, CaO2, CaO2_max, Pb50, n, alpha_eff);
 
     // check if partial pressure and numerically inverted partial pressure are equal


### PR DESCRIPTION
This PR merges the three porofluid-multi-phase namespaces into one, currently called `PoroPressureBased`.

Further clean-up will be necessary to
- Rename the classes
- Rename the tests
- Clean up the enums

@lkoeglmeier @shervas This is my initial suggestion. Now that the resulting naming conflicts are resolved, we can discuss which name we prefer.