### PR TITLE
Add schema for partial 4C.yaml files

### DIFF
--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -681,6 +681,7 @@ def main(metadata_path, json_schema_path):
         metadata_path (str, pathlib.Path): 4C emitted metadata file path
         json_schema_path (str, pathlib.Path): JSON schema file path
     """
+    json_schema_path = Path(json_schema_path)
     metadata_4C, title_section, code_metadata = metadata_object_from_file(metadata_path)
     schema = get_schema(metadata_4C)
     schema["properties"].update(
@@ -690,6 +691,14 @@ def main(metadata_path, json_schema_path):
         "^FUNCT[1-9][0-9]*$": schema["properties"].pop("FUNCT<n>")
     }
     create_json_schema(schema, code_metadata["commit_hash"], json_schema_path)
+
+    # Create partial schema
+    # Remove required section
+    schema.pop("required")
+    json_schema_partial_path = json_schema_path.parent / (
+        json_schema_path.name + "_partial" + json_schema_path.suffix
+    )
+    create_json_schema(schema, code_metadata["commit_hash"], json_schema_partial_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description and Context
With #376, the section `PROBLEM TYPE` has to be provided for input files to be valid. This is really nice, I hope the dependent requiredness of more sections will follow in the future :)

However, if you use the nice `INCLUDES` feature, your IDE/FourCIPP can't validate the partial file, since the required section might be in a different file. To avoid this problem, a second schema is created with your build (called `schema_partial.json`), which validates each section in the same way, but does not warn/fail validation in case required **sections** are not present. To make life easier, a new ending should be introduced: `4C.part.yaml`. Here is an example for my VSC setup for yaml valdiation:
```json
  "yaml.schemas": {
    "/home/rei/workspace/4C/build/schema.json": [
      "*.4C.yaml"
    ],
    "/home/rei/workspace/4C/build/schema_partial.json": [
      "*.4C.part.yaml"
    ],
  },
```

## Related Issues and Pull Requests
