### PR TITLE
Remove unnecessary default log output (3D periodic BC)

### DIFF
--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_base.cpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_base.cpp
@@ -78,7 +78,7 @@ void CONSTRAINTS::SUBMODELEVALUATOR::ConstraintBase::evaluate_coupling_terms(
   {
     obj->evaluate_equation(*Q_dd_, *Q_dL_, *Q_Ld_, *constraint_vector_, *dis_np);
   }
-  Core::IO::cout(Core::IO::verbose) << "Evaluated all constraint objects" << Core::IO::endl;
+  Core::IO::cout(Core::IO::debug) << "Evaluated all constraint objects" << Core::IO::endl;
 
   // Complete
   Q_dd_->complete();

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.cpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_mpc.cpp
@@ -357,8 +357,8 @@ void CONSTRAINTS::SUBMODELEVALUATOR::RveMultiPointConstraintManager::build_perio
               Core::IO::cout(Core::IO::debug)
                   << "Position of matching Node: " << matchPosition[0] << ", " << matchPosition[1];
               if (rve_dim_ == Inpar::RveMpc::rve3d)
-                Core::IO::cout(Core::IO::verbose) << ", " << matchPosition[2];
-              Core::IO::cout(Core::IO::verbose) << Core::IO::endl;
+                Core::IO::cout(Core::IO::debug) << ", " << matchPosition[2];
+              Core::IO::cout(Core::IO::debug) << Core::IO::endl;
               for (auto nodeM : *rveBoundaryNodeIdMap[surf.first + "-"])
               {
                 if (nodeP == rveCornerNodeIdMap[surf.second]) break;
@@ -501,8 +501,8 @@ void CONSTRAINTS::SUBMODELEVALUATOR::RveMultiPointConstraintManager::build_perio
   {
     PBCs.erase(PBCs.begin() + id);
   }
-  Core::IO::cout(Core::IO::verbose)
-      << "All Node Pairs found. Following Nodes are coupled:" << Core::IO::endl;
+  Core::IO::cout(Core::IO::debug) << "All Node Pairs found. Following Nodes are coupled:"
+                                  << Core::IO::endl;
 
   // Create the vector of MPC "Elements
   int mpcId = 0;


### PR DESCRIPTION
## Description and Context

Just a small change in boundary condition output to the log file. For periodic BCs, some information is printed in "verbose mode" (Core::IO::verbose),  which is set as *Verbosity* in the SOLVER_XML_FILE; some is also printed in "debug mode" (Core::IO::debug). However, for 3D, these were mixed up a bit. So the few changes adjust the output settings.
