### PR TITLE
Remove the `typedef` keyword 

### DIFF
--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.hpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.hpp
@@ -37,7 +37,7 @@ namespace Discret
     class ArteryEleCalcLinExp : public ArteryEleCalc<distype>
     {
      private:
-      typedef ArteryEleCalc<distype> my;
+      using my = ArteryEleCalc<distype>;
 
       /// private constructor, since we are a Singleton.
       ArteryEleCalcLinExp(const int numdofpernode, const std::string& disname);

--- a/src/art_net/4C_art_net_artery_ele_calc_pres_based.hpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_pres_based.hpp
@@ -37,7 +37,7 @@ namespace Discret
     class ArteryEleCalcPresBased : public ArteryEleCalc<distype>
     {
      private:
-      typedef ArteryEleCalc<distype> my;
+      using my = ArteryEleCalc<distype>;
 
       /// private constructor, since we are a Singleton.
       ArteryEleCalcPresBased(const int numdofpernode, const std::string& disname);

--- a/src/beam3/4C_beam3_kirchhoff.hpp
+++ b/src/beam3/4C_beam3_kirchhoff.hpp
@@ -26,7 +26,7 @@
 
 #include <memory>
 
-typedef Sacado::Fad::DFad<double> FAD;
+using FAD = Sacado::Fad::DFad<double>;
 
 #define REFERENCE_NODE \
   2  // number of reference-node for the calculation of the rotation of the other triads (local

--- a/src/beam3/4C_beam3_reissner.hpp
+++ b/src/beam3/4C_beam3_reissner.hpp
@@ -26,7 +26,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-typedef Sacado::Fad::DFad<double> FAD;
+using FAD = Sacado::Fad::DFad<double>;
 
 // forward declaration ...
 namespace Core::LinAlg

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_defines.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_defines.hpp
@@ -103,10 +103,10 @@ NEIGHBORTOL ca. 3, since the sum of |xi1| and |xi2| has to be larger than three 
 FOUR_C_THROW(
     "check functionality of FAD based linearization in case of beam3k and beam3r with Hermite cl "
     "intpol");
-typedef Sacado::Fad::DFad<double> TYPE;
+using TYPE = Sacado::Fad::DFad<double>;
 // #define FADCHECKS //Decide whether FAD checks via Sacado are printed as output or not
 #else
-typedef double TYPE;
+using TYPE = double;
 #endif
 
 #define CHECKBOUNDARYCONTACT  // Detection of beam ends in order to open the contact, when one beam
@@ -227,7 +227,7 @@ FOUR_C_THROW("CONSISTENTTRANSITION does not work in combination with ENDPOINTSEG
 // #define AUTOMATICDIFFBTS                        // Decide if automatic differentiation via Sacado
 //  is used default: Off
 #ifdef AUTOMATICDIFFBTS
-typedef Sacado::Fad::DFad<double> TYPEBTS;
+using TYPEBTS = Sacado::Fad::DFad<double>;
 //  #define FADCHECKSTIFFNESS                     // Decide if FAD checks for contact stiffness are
 //  printed as output
 #ifndef FADCHECKSTIFFNESS
@@ -238,7 +238,7 @@ typedef Sacado::Fad::DFad<double> TYPEBTS;
 //    gauss points are printed as output
 #endif
 #else
-typedef double TYPEBTS;
+using TYPEBTS = double;
 #endif
 
 // #define FDCHECKSTIFFNESS                        // Decide if differentiation via finite

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_utils.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_utils.hpp
@@ -24,7 +24,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-typedef Sacado::Fad::DFad<double> FAD;
+using FAD = Sacado::Fad::DFad<double>;
 
 namespace BeamInteraction
 {

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.hpp
@@ -58,11 +58,10 @@ namespace Solid
     class BeamInteraction : public Generic
     {
      public:
-      typedef std::map<enum Inpar::BeamInteraction::SubModelType,
-          std::shared_ptr<FourC::BeamInteraction::SUBMODELEVALUATOR::Generic>>
-          Map;
-      typedef std::vector<std::shared_ptr<FourC::BeamInteraction::SUBMODELEVALUATOR::Generic>>
-          Vector;
+      using Map = std::map<enum Inpar::BeamInteraction::SubModelType,
+          std::shared_ptr<FourC::BeamInteraction::SUBMODELEVALUATOR::Generic>>;
+      using Vector =
+          std::vector<std::shared_ptr<FourC::BeamInteraction::SUBMODELEVALUATOR::Generic>>;
 
       //! constructor
       BeamInteraction();

--- a/src/contact/4C_contact_coupling2d.cpp
+++ b/src/contact/4C_contact_coupling2d.cpp
@@ -459,7 +459,7 @@ void CONTACT::Coupling2dManager::consistent_dual_shape()
   }
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // no overlap: the applied dual shape functions don't matter, as the integration domain is void
   if ((ximax == -1.0 && ximin == 1.0) || (ximax - ximin < 4. * MORTARINTLIM)) return;

--- a/src/contact/4C_contact_coupling3d.cpp
+++ b/src/contact/4C_contact_coupling3d.cpp
@@ -384,8 +384,8 @@ bool CONTACT::Coupling3d::slave_vertex_linearization(
     sIntEle->node_linearization(nodelin);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator
-      _CI;  // linearization of element center Auxc()
+  using _CI = Core::Gen::Pairedvector<int,
+      double>::const_iterator;  // linearization of element center Auxc()
   std ::vector<Core::Gen::Pairedvector<int, double>> linauxc(
       3, slave_element().num_node());  // assume 3 dofs per node
 
@@ -523,8 +523,8 @@ bool CONTACT::Coupling3d::master_vertex_linearization(
     sIntEle->node_linearization(snodelin);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator
-      _CI;  // linearization of element center Auxc()
+  using _CI = Core::Gen::Pairedvector<int,
+      double>::const_iterator;  // linearization of element center Auxc()
   std ::vector<Core::Gen::Pairedvector<int, double>> linauxc(
       3, slave_element().num_node());  // assume 3 dofs per node
 
@@ -639,7 +639,7 @@ bool CONTACT::Coupling3d::lineclip_vertex_linearization(const Mortar::Vertex& cu
   const int nmrows = master_int_element().num_node();
 
   // iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // compute factor Z
   std::array<double, 3> crossZ = {0.0, 0.0, 0.0};
@@ -840,7 +840,7 @@ bool CONTACT::Coupling3d::center_linearization(
 {
   // preparations
   int clipsize = (int)(clip().size());
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // number of nodes
   const int nsrows = slave_element().num_node();
@@ -1689,7 +1689,7 @@ void CONTACT::Coupling3dManager::consistent_dual_shape()
 
   // various variables
   double detg = 0.0;
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // initialize matrices de and me
   Core::LinAlg::SerialDenseMatrix me(nnodes, nnodes, true);
@@ -1928,8 +1928,8 @@ void CONTACT::Coupling3dManager::consistent_dual_shape()
   // (this is done according to a quite complex formula, which
   // we get from the linearization of the biorthogonality condition:
   // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-  typedef Core::Gen::Pairedvector<int,
-      Core::LinAlg::Matrix<max_nnodes + 1, max_nnodes>>::const_iterator _CIM;
+  using _CIM = Core::Gen::Pairedvector<int,
+      Core::LinAlg::Matrix<max_nnodes + 1, max_nnodes>>::const_iterator;
   for (_CIM p = derivde_new.begin(); p != derivde_new.end(); ++p)
   {
     Core::LinAlg::Matrix<max_nnodes + 1, max_nnodes>& dtmp = derivde_new[p->first];

--- a/src/contact/4C_contact_integrator.cpp
+++ b/src/contact/4C_contact_integrator.cpp
@@ -681,7 +681,7 @@ void CONTACT::Integrator::integrate_deriv_segment_2d(Mortar::Element& sele, doub
   Core::LinAlg::SerialDenseMatrix ssecderiv(nrow, 1);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int linsize = 0;
   for (int i = 0; i < nrow; ++i)
@@ -1735,7 +1735,7 @@ void CONTACT::Integrator::integrate_deriv_cell_3d_aux_plane(Mortar::Element& sel
 
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int linsize = 0;
   if (cppnormal_)
@@ -1981,7 +1981,7 @@ void CONTACT::Integrator::integrate_deriv_cell_3d_aux_plane_stl(Mortar::Element&
     sele.deriv_shape_dual(dualmap);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int linsize = 0;
   for (int i = 0; i < nrow; ++i)
@@ -2370,7 +2370,7 @@ void CONTACT::Integrator::integrate_deriv_cell_3d_aux_plane_stl(Mortar::Element&
     for (int iter = 0; iter < nrow; ++iter)
     {
       // map iterator
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(mynodes[iter]);
       if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -2728,7 +2728,7 @@ void CONTACT::Integrator::integrate_deriv_cell_3d_aux_plane_lts(Mortar::Element&
     sele.deriv_shape_dual(dualmap);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int linsize = 0;
   for (int i = 0; i < nrowL; ++i)
@@ -3129,7 +3129,7 @@ void CONTACT::Integrator::integrate_deriv_cell_3d_aux_plane_lts(Mortar::Element&
     for (int iter = 0; iter < nrowL; ++iter)
     {
       // map iterator
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(mynodes[iter]);
       if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -3786,7 +3786,7 @@ void CONTACT::Integrator::integrate_deriv_cell_3d_aux_plane_quad(Mortar::Element
   if (!myintnodes) FOUR_C_THROW("Null pointer!");
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // prepare directional derivative of dual shape functions
   // this is necessary for all slave element types except tri3
@@ -4245,7 +4245,7 @@ void CONTACT::Integrator::integrate_deriv_ele_2d(Mortar::Element& sele,
   std::shared_ptr<Core::LinAlg::SerialDenseMatrix> lagmult;
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // prepare directional derivative of dual shape functions
   // this is only necessary for quadratic dual shape functions in 2D
@@ -4589,7 +4589,7 @@ void CONTACT::Integrator::integrate_d(Mortar::Element& sele, MPI_Comm comm, bool
 
     if (lin)
     {
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       // (1) Lin(Phi) - dual shape functions
       if (duallin)
@@ -4690,8 +4690,6 @@ void CONTACT::Integrator::integrate_kappa_penalty(
   Core::LinAlg::SerialDenseVector val(nrow);
   Core::LinAlg::SerialDenseMatrix deriv(nrow, 2, true);
 
-  // map iterator
-  // typedef std::map<int,double>::const_iterator CI;
 
   // get slave element nodes themselves
   Core::Nodes::Node** mynodes = sele.nodes();
@@ -4873,7 +4871,7 @@ void CONTACT::Integrator::deriv_xi_a_b_2d(const Mortar::Element& sele, double sx
   mele.evaluate_shape(pmxib, valmxib, derivmxib, nummnode, false);
 
   // prepare linearizations
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // compute leading constant for DerivXiBMaster if start node = slave node
   if (startslave == true)
@@ -5294,7 +5292,7 @@ void CONTACT::Integrator::deriv_xi_gp_2d(const Mortar::Element& sele, const Mort
   fac_ymsl_gp -= sgpx[1];
 
   // prepare linearization
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // build directional derivative of slave GP coordinates
   Core::Gen::Pairedvector<int, double> dmap_xsl_gp(linsize + nummnode * ndof);
@@ -5459,7 +5457,7 @@ void CONTACT::Integrator::deriv_xi_gp_3d(const Mortar::Element& sele, const Mort
   lmatrix.invert();
 
   // build directional derivative of slave GP normal
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int linsize = 0;
   for (int i = 0; i < numsnode; ++i)
@@ -5562,18 +5560,6 @@ void CONTACT::Integrator::deriv_xi_gp_3d(const Mortar::Element& sele, const Mort
     derivmxi[0][p->first] += alpha * lmatrix(0, 2) * (p->second);
     derivmxi[1][p->first] += alpha * lmatrix(1, 2) * (p->second);
   }
-
-  /*
-  // check linearization
-  typedef std::map<int,double>::const_iterator CI;
-  std::cout << "\nLinearization of current master GP:" << std::endl;
-  std::cout << "-> Coordinate 1:" << std::endl;
-  for (CI p=derivmxi[0].begin();p!=derivmxi[0].end();++p)
-    std::cout << p->first << " " << p->second << std::endl;
-  std::cout << "-> Coordinate 2:" << std::endl;
-  for (CI p=derivmxi[1].begin();p!=derivmxi[1].end();++p)
-      std::cout << p->first << " " << p->second << std::endl;
-  */
 }
 
 /*----------------------------------------------------------------------*
@@ -5617,7 +5603,7 @@ void CONTACT::Integrator::deriv_xi_gp_3d_aux_plane(const Mortar::Element& ele, c
   lmatrix.invert();
 
   // start to fill linearization maps for element GP
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // see if this is an IntEle
   const Mortar::IntElement* ie = dynamic_cast<const Mortar::IntElement*>(&ele);
@@ -5674,21 +5660,6 @@ void CONTACT::Integrator::deriv_xi_gp_3d_aux_plane(const Mortar::Element& ele, c
     derivxi[0][p->first] += alpha * lmatrix(0, 2) * (p->second);
     derivxi[1][p->first] += alpha * lmatrix(1, 2) * (p->second);
   }
-
-  /*
-  // check linearization
-  typedef std::map<int,double>::const_iterator CI;
-  std::cout << "\nLinearization of current slave / master GP:" << std::endl;
-  std::cout << "-> Coordinate 1:" << std::endl;
-  for (CI p=derivxi[0].begin();p!=derivxi[0].end();++p)
-    std::cout << p->first << " " << p->second << std::endl;
-  std::cout << "-> Coordinate 2:" << std::endl;
-  for (CI p=derivxi[1].begin();p!=derivxi[1].end();++p)
-    std::cout << p->first << " " << p->second << std::endl;
-  std::cout << "-> Coordinate 3:" << std::endl;
-  for (CI p=derivxi[2].begin();p!=derivxi[2].end();++p)
-    std::cout << p->first << " " << p->second << std::endl;
-  */
 }
 
 
@@ -6568,7 +6539,7 @@ void CONTACT::Integrator::gap_3d(Mortar::Element& sele, Mortar::Element& mele,
     std::vector<Core::Gen::Pairedvector<int, double>>& dnmap_unit)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -6879,7 +6850,7 @@ void CONTACT::Integrator::gap_2d(Mortar::Element& sele, Mortar::Element& mele,
     std::vector<Core::Gen::Pairedvector<int, double>>& dnmap_unit)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = nullptr;
@@ -7113,7 +7084,7 @@ void inline CONTACT::Integrator::gp_3d_g_quad_pwlin(Mortar::Element& sele,
     std::vector<Core::Gen::Pairedvector<int, double>>& dnmap_unit)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -7433,7 +7404,7 @@ void inline CONTACT::Integrator::gp_2d_g_lin(int& iter, Mortar::Element& sele,
   double fac = 0.0;
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get the corresponding map as a reference
   std::map<int, double>& dgmap = dynamic_cast<CONTACT::Node*>(mymrtrnode)->data().get_deriv_g();
@@ -7533,7 +7504,7 @@ void inline CONTACT::Integrator::gp_3d_g_quad_pwlin_lin(int& iter, Mortar::IntEl
     const std::vector<Core::Gen::Pairedvector<int, double>>& dsxigp)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** sintnodes = sintele.nodes();
@@ -7589,7 +7560,7 @@ void inline CONTACT::Integrator::gp_3d_g_quad_lin(int& iter, Mortar::Element& se
   const int nrow = sele.num_node();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -7717,7 +7688,7 @@ void CONTACT::Integrator::gp_g_lin(int& iter, Mortar::Element& sele, Mortar::Ele
   const int ncol = mele.num_node();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -7837,7 +7808,7 @@ void CONTACT::Integrator::gp_3d_dm_lin_bound(Mortar::Element& sele, Mortar::Elem
   Core::Nodes::Node** snodes = sele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   if (shape_fcn() == Inpar::Mortar::shape_standard)
   {
@@ -8187,7 +8158,7 @@ void inline CONTACT::Integrator::gp_2d_dm_lin_bound(Mortar::Element& sele, Morta
   Core::Nodes::Node** snodes = sele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   if (shape_fcn() == Inpar::Mortar::shape_standard)
   {
@@ -8506,7 +8477,7 @@ void inline CONTACT::Integrator::gp_2d_dm_ele_lin(int& iter, bool& bound, Mortar
   mnodes = mele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(snodes[iter]);
   if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -8652,7 +8623,7 @@ void inline CONTACT::Integrator::gp_2d_dm_lin(int& iter, bool& bound, bool& linl
   mnodes = mele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // **************** no edge modification *****************************
   // (and LinM also for edge node modification case)
@@ -8924,7 +8895,7 @@ void inline CONTACT::Integrator::gp_3d_dm_quad_pwlin_lin(int& iter, Mortar::Elem
   Core::Nodes::Node** sintnodes = sintele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // **************** no edge modification *****************************
   // (and LinM also for edge node modification case)
@@ -9032,7 +9003,7 @@ void inline CONTACT::Integrator::gp_3d_dm_quad_lin(bool& duallin, Mortar::Elemen
   for (int i = 0; i < nrow; ++i) smnodes[i] = dynamic_cast<Mortar::Node*>(snodes[i]);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // **************** no edge modification *****************************
   // (and LinM also for edge node modification case)
@@ -9143,8 +9114,8 @@ void inline CONTACT::Integrator::gp_3d_dm_quad_lin(bool& duallin, Mortar::Elemen
           // (1) Lin(Phi) - dual shape functions
           if (duallin)
           {
-            typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator
-                _CIM;
+            using _CIM =
+                Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
             for (_CIM p = dualmap.begin(); p != dualmap.end(); ++p)
             {
               double lmderiv_d = 0.0;
@@ -9198,8 +9169,8 @@ void inline CONTACT::Integrator::gp_3d_dm_quad_lin(bool& duallin, Mortar::Elemen
             // (1) Lin(Phi) - dual shape functions
             if (duallin)
             {
-              typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator
-                  _CIM;
+              using _CIM =
+                  Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
               fac = wgt * sval[k] * jac;
               for (_CIM p = dualmap.begin(); p != dualmap.end(); ++p)
                 for (int m = 0; m < nrow; ++m)
@@ -9248,8 +9219,8 @@ void inline CONTACT::Integrator::gp_3d_dm_quad_lin(bool& duallin, Mortar::Elemen
             // (1) Lin(Phi) - dual shape functions
             if (duallin)
             {
-              typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator
-                  _CIM;
+              using _CIM =
+                  Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
               fac = wgt * sval[k] * jac;
               for (_CIM p = dualmap.begin(); p != dualmap.end(); ++p)
                 for (int m = 0; m < nrow; ++m)
@@ -9392,7 +9363,7 @@ void inline CONTACT::Integrator::gp_3d_dm_lin(Mortar::Element& sele, Mortar::Ele
   const int ncol = mele.num_node();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // standard shape functions
   if (shape_fcn() == Inpar::Mortar::shape_standard)
@@ -9624,7 +9595,7 @@ void inline CONTACT::Integrator::gp_2d_wear(Mortar::Element& sele, Mortar::Eleme
   linsize = linsize * 2;
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   //***********************************************************************
   // Here, the tangential relative slip increment is used and NOT the
@@ -9954,7 +9925,7 @@ void inline CONTACT::Integrator::gp_3d_wear(Mortar::Element& sele, Mortar::Eleme
   Core::Nodes::Node** mnodes = mele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   //***********************************************************************
   // Here, the tangential relative slip increment is used and NOT the
@@ -10568,7 +10539,7 @@ void inline CONTACT::Integrator::gp_2d_te_master_lin(int& iter,  // like k
   if (!mnodes) FOUR_C_THROW("Null pointer!");
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(mnodes[iter]);
   if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -10692,7 +10663,7 @@ void inline CONTACT::Integrator::gp_2d_te_lin(int& iter, Mortar::Element& sele,
   if (!snodes) FOUR_C_THROW("Null pointer!");
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(snodes[iter]);
   if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -10891,7 +10862,7 @@ void inline CONTACT::Integrator::gp_3d_te_lin(int& iter, Mortar::Element& sele,
   if (!snodes) FOUR_C_THROW("Null pointer!");
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(snodes[iter]);
   if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -11143,7 +11114,7 @@ void inline CONTACT::Integrator::gp_3d_te_master_lin(int& iter, Mortar::Element&
   if (!mnodes) FOUR_C_THROW("Null pointer!");
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   Mortar::Node* mymrtrnode = dynamic_cast<Mortar::Node*>(mnodes[iter]);
   if (!mymrtrnode) FOUR_C_THROW("Null pointer!");
@@ -11367,7 +11338,7 @@ void inline CONTACT::Integrator::gp_2d_slip_incr(Mortar::Element& sele, Mortar::
     Core::Gen::Pairedvector<int, double>& dslipgp, int& linsize)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -11536,7 +11507,7 @@ void inline CONTACT::Integrator::gp_3d_slip_incr(Mortar::Element& sele, Mortar::
     std::vector<Core::Gen::Pairedvector<int, double>>& dslipgp)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -11918,7 +11889,7 @@ void inline CONTACT::Integrator::gp_2d_slip_incr_lin(int& iter, Mortar::Element&
   double fac = 0.0;
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   FriNode* snode = dynamic_cast<FriNode*>(snodes[iter]);
   if (snode->is_on_boundor_ce()) return;
@@ -11969,7 +11940,7 @@ void inline CONTACT::Integrator::gp_3d_slip_incr_lin(int& iter, Mortar::Element&
   double nrow = sele.num_node();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   FriNode* snode = dynamic_cast<FriNode*>(snodes[iter]);
 
@@ -12054,7 +12025,7 @@ void inline CONTACT::Integrator::gp_2d_wear_lin(int& iter, Mortar::Element& sele
   Core::Nodes::Node** snodes = sele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get the corresponding map as a reference
   CONTACT::Node* cnode = dynamic_cast<CONTACT::Node*>(snodes[iter]);
@@ -12152,7 +12123,7 @@ void inline CONTACT::Integrator::gp_3d_wear_lin(int& iter, Mortar::Element& sele
   Core::Nodes::Node** snodes = sele.nodes();
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get the corresponding map as a reference
   CONTACT::Node* cnode = dynamic_cast<CONTACT::Node*>(snodes[iter]);
@@ -12259,7 +12230,7 @@ void inline CONTACT::Integrator::gp_ncoup_deriv(Mortar::Element& sele, Mortar::E
     std::vector<Core::Gen::Pairedvector<int, double>>& dnmap_unit, bool quadratic, int nintrow)
 {
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();
@@ -12528,7 +12499,7 @@ void inline CONTACT::Integrator::gp_ncoup_deriv(Mortar::Element& sele, Mortar::E
   }
 
   // h.Willmann Write Deformation Gradient Determinant Linearization to map
-  typedef std::map<int, double>::iterator I;
+  using I = std::map<int, double>::iterator;
 
   if (slaveporo)
   {
@@ -12614,8 +12585,8 @@ void inline CONTACT::Integrator::gp_ncoup_lin(int& iter, Mortar::Element& sele,
   // evaluated on the slave side interface surface
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
-  typedef std::map<int, double>::const_iterator CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
+  using CI = std::map<int, double>::const_iterator;
 
   // get slave element nodes themselves
   Core::Nodes::Node** snodes = sele.nodes();

--- a/src/contact/4C_contact_interface_tools.cpp
+++ b/src/contact/4C_contact_interface_tools.cpp
@@ -810,7 +810,7 @@ void CONTACT::Interface::fd_check_mortar_d_deriv()
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     Node* cnode = dynamic_cast<Node*>(node);
 
-    typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+    using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
     if ((int)(cnode->mo_data().get_d().size()) == 0) continue;
 
@@ -873,8 +873,8 @@ void CONTACT::Interface::fd_check_mortar_d_deriv()
 
       if ((int)(kcnode->mo_data().get_d().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using CI = std::map<int, double>::const_iterator;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       for (_CI it = kcnode->mo_data().get_d().begin(); it != kcnode->mo_data().get_d().end(); ++it)
         newD[it->first] = it->second;
@@ -980,8 +980,8 @@ void CONTACT::Interface::fd_check_mortar_d_deriv()
 
       if ((int)(kcnode->mo_data().get_d().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using CI = std::map<int, double>::const_iterator;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       for (_CI it = kcnode->mo_data().get_d().begin(); it != kcnode->mo_data().get_d().end(); ++it)
         newD[it->first] = it->second;
@@ -1081,9 +1081,6 @@ void CONTACT::Interface::fd_check_mortar_m_deriv()
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     Node* cnode = dynamic_cast<Node*>(node);
 
-    // typedef std::map<int,std::map<int,double> >::const_iterator CIM;
-    // typedef std::map<int,double>::const_iterator CI;
-
     if ((int)(cnode->mo_data().get_m().size()) == 0) continue;
 
     refM = cnode->mo_data().get_m();
@@ -1143,7 +1140,7 @@ void CONTACT::Interface::fd_check_mortar_m_deriv()
 
       if ((int)(kcnode->mo_data().get_m().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       // store M-values into refM
       newM = kcnode->mo_data().get_m();
@@ -1249,7 +1246,7 @@ void CONTACT::Interface::fd_check_mortar_m_deriv()
 
       if ((int)(kcnode->mo_data().get_m().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       // store M-values into refM
       newM = kcnode->mo_data().get_m();
@@ -5274,7 +5271,7 @@ void CONTACT::Interface::fd_check_penalty_trac_nor()
 
       if ((int)(cnode->data().get_deriv_z()).size() != 0)
       {
-        typedef std::map<int, double>::const_iterator CI;
+        using CI = std::map<int, double>::const_iterator;
         std::map<int, double>& derivzmap = cnode->data().get_deriv_z()[d];
 
         // print derivz-values to screen and store

--- a/src/contact/4C_contact_interpolator.cpp
+++ b/src/contact/4C_contact_interpolator.cpp
@@ -637,7 +637,7 @@ void NTS::Interpolator::interpolate_master_temp_3d(
 void NTS::Interpolator::nw_t_e_2d(CONTACT::Node& mynode, double& area, double& jumpval,
     Core::Gen::Pairedvector<int, double>& dslipmatrix)
 {
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // multiply the two shape functions
   double prod1 = abs(jumpval);
@@ -676,7 +676,7 @@ void NTS::Interpolator::nw_slip_2d(CONTACT::Node& mynode, Mortar::Element& mele,
   const int ncol = mele.num_node();
   const int ndof = mynode.num_dof();
 
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   Core::Gen::Pairedvector<int, double> dslipgp(linsize + ndof * ncol);
 
@@ -818,7 +818,7 @@ void NTS::Interpolator::nw_wear_2d(CONTACT::Node& mynode, Mortar::Element& mele,
   const int ncol = mele.num_node();
   const int ndof = mynode.num_dof();
 
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   std::array<double, 3> gpt = {0.0, 0.0, 0.0};
   std::array<double, 3> gplm = {0.0, 0.0, 0.0};
@@ -1078,7 +1078,7 @@ void NTS::Interpolator::nw_gap_2d(CONTACT::Node& mynode, Mortar::Element& sele,
   // **************************
   // linearization
   // **************************
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
   Core::Gen::Pairedvector<int, double> dgapgp(10 * ncol);
 
   //*************************************************************
@@ -1166,7 +1166,7 @@ void NTS::Interpolator::nw_gap_3d(CONTACT::Node& mynode, Mortar::Element& mele,
   // **************************
   // linearization
   // **************************
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // TODO: linsize for parallel simulations buggy. 100 for safety
   Core::Gen::Pairedvector<int, double> dgapgp(3 * ncol + 3 * mynode.get_linsize() + 100);
@@ -1237,7 +1237,7 @@ void NTS::Interpolator::nw_master_temp(CONTACT::Node& mynode, Mortar::Element& m
   // **************************
   // linearization
   // **************************
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   std::map<int, double>& dTpdT = mynode.tsi_data().deriv_temp_master_temp();
   dTpdT.clear();
@@ -1267,7 +1267,7 @@ void NTS::Interpolator::nw_d_m_2d(CONTACT::Node& mynode, Mortar::Element& sele,
     Core::LinAlg::SerialDenseMatrix& mderiv, Core::Gen::Pairedvector<int, double>& dmxi)
 {
   const int ncol = mele.num_node();
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // node-wise M value
   for (int k = 0; k < ncol; ++k)
@@ -1315,7 +1315,7 @@ void NTS::Interpolator::nw_d_m_3d(CONTACT::Node& mynode, Mortar::Element& mele,
 {
   const int ncol = mele.num_node();
 
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // node-wise M value
   for (int k = 0; k < ncol; ++k)
@@ -1443,7 +1443,7 @@ void NTS::Interpolator::deriv_xi_gp_2d(Mortar::Element& sele, Mortar::Element& m
   fac_ymsl_gp -= sgpx[1];
 
   // prepare linearization
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // build directional derivative of slave GP coordinates
   Core::Gen::Pairedvector<int, double> dmap_xsl_gp(linsize + nummnode * ndof);
@@ -1607,7 +1607,7 @@ void NTS::Interpolator::deriv_xi_gp_3d(Mortar::Element& sele, Mortar::Element& m
   lmatrix.invert();
 
   // build directional derivative of slave GP normal
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int linsize = 0;
   for (int i = 0; i < numsnode; ++i)

--- a/src/contact/4C_contact_line_coupling.cpp
+++ b/src/contact/4C_contact_line_coupling.cpp
@@ -226,7 +226,7 @@ void CONTACT::LineToSurfaceCoupling3d::consist_dual_shape()
 
   // various variables
   double detg = 0.0;
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // initialize matrices de and me
   Core::LinAlg::SerialDenseMatrix me(nnodes, nnodes, true);
@@ -382,8 +382,8 @@ void CONTACT::LineToSurfaceCoupling3d::consist_dual_shape()
   // (this is done according to a quite complex formula, which
   // we get from the linearization of the biorthogonality condition:
   // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-  typedef Core::Gen::Pairedvector<int,
-      Core::LinAlg::Matrix<max_nnodes + 1, max_nnodes>>::const_iterator _CIM;
+  using _CIM = Core::Gen::Pairedvector<int,
+      Core::LinAlg::Matrix<max_nnodes + 1, max_nnodes>>::const_iterator;
   for (_CIM p = derivde_new.begin(); p != derivde_new.end(); ++p)
   {
     Core::LinAlg::Matrix<max_nnodes + 1, max_nnodes>& dtmp = derivde_new[p->first];
@@ -1456,7 +1456,7 @@ void CONTACT::LineToSurfaceCoupling3d::lineclip_vertex_linearization(Mortar::Ver
   const int nmrows = surface_element().num_node();
 
   // iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // compute factor Z
   std::array<double, 3> crossZ = {0.0, 0.0, 0.0};
@@ -1715,7 +1715,7 @@ bool CONTACT::LineToSurfaceCoupling3d::auxiliary_plane()
  *----------------------------------------------------------------------*/
 bool CONTACT::LineToSurfaceCoupling3d::auxiliary_line()
 {
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   int nnodes = line_element()->num_node();
   if (nnodes != 2) FOUR_C_THROW("Auxiliary line calculation only for line2 elements!");
@@ -2027,8 +2027,8 @@ void CONTACT::LineToSurfaceCoupling3d::slave_vertex_linearization(
     for (int dim = 0; dim < 3; ++dim) snodelin[in][dim][smrtrnodes[in]->dofs()[dim]] += 1.;
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator
-      _CI;  // linearization of element center Auxc()
+  using _CI = Core::Gen::Pairedvector<int,
+      double>::const_iterator;  // linearization of element center Auxc()
   //  std::vector<Core::Gen::Pairedvector<int  ,double> >
   //  linauxc(3,10*surface_element().num_node());
   //  // assume 3 dofs per node
@@ -2223,8 +2223,8 @@ void CONTACT::LineToSurfaceCoupling3d::master_vertex_linearization(
     for (int dim = 0; dim < 3; ++dim) nodelin[in][dim][smrtrnodes[in]->dofs()[dim]] += 1.;
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator
-      _CI;  // linearization of element center Auxc()
+  using _CI = Core::Gen::Pairedvector<int,
+      double>::const_iterator;  // linearization of element center Auxc()
   //  std  ::vector<Core::Gen::Pairedvector<int  ,double> > linauxc(3,surface_element().num_node());
   //  // assume 3 dofs per node
   //
@@ -2397,8 +2397,8 @@ void CONTACT::LineToLineCouplingPoint3d::evaluate_terms(double* sxi, double* mxi
   line_master_element()->evaluate_shape(mxi, mval, mderiv, nnodes);
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
-  typedef std::map<int, double>::const_iterator CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
+  using CI = std::map<int, double>::const_iterator;
 
   int linsize = 0;
   for (int i = 0; i < nrow; ++i)
@@ -2952,7 +2952,7 @@ void CONTACT::LineToLineCouplingPoint3d::line_intersection(double* sxi, double* 
   const int nnodes = 2;
 
   // prepare linearizations
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // calculate slave vector
   Node* ns1 = dynamic_cast<Node*>(line_slave_element()->nodes()[0]);
@@ -3345,7 +3345,7 @@ double CONTACT::LineToLineCouplingPoint3d::calc_current_angle(
     Core::Gen::Pairedvector<int, double>& lineAngle)
 {
   // define iterator for linerization
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // slave edge vector and master vector edge
   std::array<double, 3> vs = {0.0, 0.0, 0.0};

--- a/src/contact/4C_contact_node.cpp
+++ b/src/contact/4C_contact_node.cpp
@@ -753,7 +753,7 @@ void CONTACT::Node::build_averaged_edge_tangent()
   //**************************************************
   //      LINEARIZATION
   //**************************************************
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   for (int j = 0; j < (int)((data().get_deriv_tangent()).size()); ++j)
     (data().get_deriv_tangent())[j].clear();
@@ -985,7 +985,7 @@ void CONTACT::Node::deriv_averaged_normal(
   // normalize directional derivative
   // (length differs for weighted/unweighted case but not the procedure!)
   // (be careful with reference / copy of derivative maps!)
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
   Core::Gen::Pairedvector<int, double>& derivnx = data().get_deriv_n()[0];
   Core::Gen::Pairedvector<int, double>& derivny = data().get_deriv_n()[1];
   Core::Gen::Pairedvector<int, double>& derivnz = data().get_deriv_n()[2];
@@ -1118,7 +1118,7 @@ void CONTACT::Node::deriv_averaged_normal(
 
     // normalize txi directional derivative
     // (identical to normalization of normal derivative)
-    typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+    using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
     Core::Gen::Pairedvector<int, double>& derivtxix = data().get_deriv_txi()[0];
     Core::Gen::Pairedvector<int, double>& derivtxiy = data().get_deriv_txi()[1];
     Core::Gen::Pairedvector<int, double>& derivtxiz = data().get_deriv_txi()[2];

--- a/src/contact/4C_contact_node.hpp
+++ b/src/contact/4C_contact_node.hpp
@@ -208,7 +208,7 @@ namespace CONTACT
      */
     virtual std::map<int, double>& get_deriv_d(int& k)
     {
-      typedef std::map<int, std::map<int, double>>::const_iterator CI;
+      using CI = std::map<int, std::map<int, double>>::const_iterator;
       CI p = derivd_.find(k);
       if (p == derivd_.end()) FOUR_C_THROW("GetDerivD: No map entry existing for given index");
       return derivd_[k];
@@ -223,7 +223,7 @@ namespace CONTACT
      */
     virtual std::map<int, double>& get_deriv_m(int& k)
     {
-      typedef std::map<int, std::map<int, double>>::const_iterator CI;
+      using CI = std::map<int, std::map<int, double>>::const_iterator;
       CI p = derivm_.find(k);
       if (p == derivm_.end()) FOUR_C_THROW("GetDerivM: No map entry existing for given index");
       return derivm_[k];

--- a/src/contact/4C_contact_tsi_interface.cpp
+++ b/src/contact/4C_contact_tsi_interface.cpp
@@ -72,7 +72,7 @@ void CONTACT::TSIInterface::assemble_lin_stick(Core::LinAlg::SparseMatrix& linst
   // consistent equation is:
   // mu(d,T)*(z_n-c_n*g)ut = 0
 
-  typedef std::map<int, double>::const_iterator _CI;
+  using _CI = std::map<int, double>::const_iterator;
   // loop over all stick nodes of the interface
   for (int i = 0; i < sticknodes->NumMyElements(); ++i)
   {
@@ -195,7 +195,7 @@ void CONTACT::TSIInterface::assemble_lin_slip(Core::LinAlg::SparseMatrix& linsli
   // consistent equation is:
   // || z_t^tr || z_t - \mu (z_n -c_n*wgap) z_t^tr = 0
 
-  typedef std::map<int, double>::const_iterator _CI;
+  using _CI = std::map<int, double>::const_iterator;
   // loop over all stick nodes of the interface
   for (int i = 0; i < slipnodes->NumMyElements(); ++i)
   {
@@ -556,8 +556,8 @@ void CONTACT::TSIInterface::assemble_dm_lin_diss(Core::LinAlg::SparseMatrix* d_L
   // there's no dissipation without friction
   if (!friction_) return;
 
-  typedef std::map<int, double>::const_iterator _cim;
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _cip;
+  using _cim = std::map<int, double>::const_iterator;
+  using _cip = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   const double dt = interface_params().get<double>("TIMESTEP");
 
@@ -680,9 +680,9 @@ void CONTACT::TSIInterface::assemble_lin_l_mn_dm_temp(
   // get out if there's nothing to do
   if (lin_disp == nullptr) FOUR_C_THROW("called to assemble something but didn't provide a matrix");
 
-  typedef std::map<int, double>::const_iterator _cim;
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _cip;
-  typedef std::map<int, std::map<int, double>>::const_iterator _cimm;
+  using _cim = std::map<int, double>::const_iterator;
+  using _cip = Core::Gen::Pairedvector<int, double>::const_iterator;
+  using _cimm = std::map<int, std::map<int, double>>::const_iterator;
 
   // loop over all LM slave nodes (row map)
   for (int j = 0; j < activenodes_->NumMyElements(); ++j)
@@ -758,8 +758,8 @@ void CONTACT::TSIInterface::assemble_dm_l_mn(const double fac, Core::LinAlg::Spa
   // get out if there's nothing to do
   if (DM_LMn == nullptr) FOUR_C_THROW("called to assemble something but didn't provide a matrix");
 
-  typedef std::map<int, double>::const_iterator _cim;
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _cip;
+  using _cim = std::map<int, double>::const_iterator;
+  using _cip = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // loop over all LM slave nodes (row map)
   for (int j = 0; j < activenodes_->NumMyElements(); ++j)

--- a/src/contact/4C_contact_wear_interface.cpp
+++ b/src/contact/4C_contact_wear_interface.cpp
@@ -395,8 +395,8 @@ void Wear::WearInterface::assemble_lin_t_d(Core::LinAlg::SparseMatrix& lintgloba
     if (fnode->wear_data().get_t().size() > 0)
     {
       // map iterator
-      typedef std::map<int, double>::const_iterator CI;
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using CI = std::map<int, double>::const_iterator;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       std::map<int, double>& nmap = fnode->wear_data().get_t()[0];
 
@@ -538,8 +538,8 @@ void Wear::WearInterface::assemble_lin_t_d_master(Core::LinAlg::SparseMatrix& li
     if (fnode->wear_data().get_t().size() > 0)
     {
       // map iterator
-      typedef std::map<int, double>::const_iterator CI;
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+      using CI = std::map<int, double>::const_iterator;
+      using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       std::map<int, double>& nmap = fnode->wear_data().get_t()[0];
 
@@ -787,8 +787,6 @@ void Wear::WearInterface::assemble_lin_t_lm(Core::LinAlg::SparseMatrix& lintglob
     considerednodes = slipnodes_;
   }
 
-  // typedef std::map<int,double>::const_iterator CI;
-
   // loop over all LM slave nodes (row map)
   for (int j = 0; j < considerednodes->NumMyElements(); ++j)
   {
@@ -797,7 +795,7 @@ void Wear::WearInterface::assemble_lin_t_lm(Core::LinAlg::SparseMatrix& lintglob
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     CONTACT::FriNode* fnode = dynamic_cast<CONTACT::FriNode*>(node);
 
-    typedef std::map<int, double>::const_iterator CI;
+    using CI = std::map<int, double>::const_iterator;
 
     if (fnode->wear_data().get_t().size() > 0)
     {
@@ -845,8 +843,6 @@ void Wear::WearInterface::assemble_lin_t_lm_master(Core::LinAlg::SparseMatrix& l
       Core::LinAlg::allreduce_e_map(*(slipmasternodes_));
 
 
-  // typedef std::map<int,double>::const_iterator CI;
-
   // loop over all LM slave nodes (row map)
   for (int j = 0; j < slmasternodes->NumMyElements(); ++j)
   {
@@ -855,7 +851,7 @@ void Wear::WearInterface::assemble_lin_t_lm_master(Core::LinAlg::SparseMatrix& l
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     CONTACT::FriNode* fnode = dynamic_cast<CONTACT::FriNode*>(node);
 
-    typedef std::map<int, double>::const_iterator CI;
+    using CI = std::map<int, double>::const_iterator;
 
     if (fnode->wear_data().get_t().size() > 0)
     {
@@ -3642,7 +3638,7 @@ void Wear::WearInterface::assemble_wear_cond_rhs(Core::LinAlg::Vector<double>& r
 
   double wcoeff = interface_params().get<double>("WEARCOEFF");
 
-  typedef std::map<int, double>::const_iterator CI;
+  using CI = std::map<int, double>::const_iterator;
 
   for (int i = 0; i < considerednodes->NumMyElements(); ++i)
   {
@@ -3732,7 +3728,7 @@ void Wear::WearInterface::assemble_wear_cond_rhs_master(Epetra_FEVector& RHS)
 
   double wcoeff = interface_params().get<double>("WEARCOEFF_MASTER");
 
-  typedef std::map<int, double>::const_iterator CI;
+  using CI = std::map<int, double>::const_iterator;
 
   const std::shared_ptr<Core::LinAlg::Map> slmasternodes =
       Core::LinAlg::allreduce_e_map(*(slipmasternodes_));

--- a/src/contact/4C_contact_wear_interface_tools.cpp
+++ b/src/contact/4C_contact_wear_interface_tools.cpp
@@ -428,7 +428,7 @@ void Wear::WearInterface::fd_check_deriv_e_d(Core::LinAlg::SparseMatrix& linedis
   std::vector<double> newt(nrow);
 
   int dim = n_dim();
-  typedef std::map<int, double>::const_iterator CI;
+  using CI = std::map<int, double>::const_iterator;
 
   // store reference
   // loop over proc's slave nodes
@@ -744,7 +744,7 @@ void Wear::WearInterface::fd_check_deriv_e_d_master(Core::LinAlg::SparseMatrix& 
   std::vector<double> newt(nrow);
 
   int dim = n_dim();
-  typedef std::map<int, double>::const_iterator CI;
+  using CI = std::map<int, double>::const_iterator;
 
   // store reference
   // loop over proc's slave nodes
@@ -1063,7 +1063,7 @@ void Wear::WearInterface::fd_check_deriv_t_d(Core::LinAlg::SparseMatrix& lintdis
   std::vector<double> newt(nrow);
 
   int dim = n_dim();
-  typedef std::map<int, double>::const_iterator CI;
+  using CI = std::map<int, double>::const_iterator;
 
   // store reference
   // loop over proc's slave nodes
@@ -1256,7 +1256,7 @@ void Wear::WearInterface::fd_check_deriv_t_d_master(Core::LinAlg::SparseMatrix& 
   std::vector<double> newt(nrow);
 
   int dim = n_dim();
-  typedef std::map<int, double>::const_iterator CI;
+  using CI = std::map<int, double>::const_iterator;
 
   // store reference
   // loop over proc's slave nodes
@@ -2519,9 +2519,6 @@ void Wear::WearInterface::fd_check_mortar_t_deriv()
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     CONTACT::FriNode* cnode = dynamic_cast<CONTACT::FriNode*>(node);
 
-    // typedef std::map<int,std::map<int,double> >::const_iterator CID;
-    // typedef std::map<int,double>::const_iterator CI;
-
     if ((int)(cnode->wear_data().get_t().size()) == 0) continue;
 
     //    for( int d=0; d<dim; d++ )
@@ -2585,7 +2582,7 @@ void Wear::WearInterface::fd_check_mortar_t_deriv()
 
       if ((int)(kcnode->wear_data().get_t().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       for (int d = 0; d < 1; d++)
       {
@@ -2690,9 +2687,6 @@ void Wear::WearInterface::fd_check_mortar_t_master_deriv()
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     CONTACT::FriNode* cnode = dynamic_cast<CONTACT::FriNode*>(node);
 
-    // typedef std::map<int,std::map<int,double> >::const_iterator CID;
-    // typedef std::map<int,double>::const_iterator CI;
-
     if ((int)(cnode->wear_data().get_t().size()) == 0) continue;
 
     int dof = cnode->dofs()[0];
@@ -2756,7 +2750,7 @@ void Wear::WearInterface::fd_check_mortar_t_master_deriv()
 
       if ((int)(kcnode->wear_data().get_t().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       for (int d = 0; d < 1; d++)
       {
@@ -2870,7 +2864,7 @@ void Wear::WearInterface::fd_check_mortar_t_master_deriv()
 
       if ((int)(kcnode->wear_data().get_t().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       for (int d = 0; d < 1; d++)
       {
@@ -2975,16 +2969,10 @@ void Wear::WearInterface::fd_check_mortar_e_deriv()
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     CONTACT::FriNode* cnode = dynamic_cast<CONTACT::FriNode*>(node);
 
-    // typedef std::map<int,std::map<int,double> >::const_iterator CID;
-    // typedef std::map<int,double>::const_iterator CI;
-
     if ((int)(cnode->wear_data().get_e().size()) == 0) continue;
 
-    //    for( int d=0; d<dim; d++ )
-    //    {
     int dof = cnode->dofs()[0];
     refE[dof] = cnode->wear_data().get_e()[0];
-    //    }
 
     refDerivE[gid] = cnode->wear_data().get_deriv_e();
   }
@@ -3041,7 +3029,7 @@ void Wear::WearInterface::fd_check_mortar_e_deriv()
 
       if ((int)(kcnode->wear_data().get_e().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       for (int d = 0; d < 1; d++)
       {
@@ -3146,9 +3134,6 @@ void Wear::WearInterface::fd_check_mortar_e_master_deriv()
     if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
     CONTACT::FriNode* cnode = dynamic_cast<CONTACT::FriNode*>(node);
 
-    // typedef std::map<int,std::map<int,double> >::const_iterator CID;
-    // typedef std::map<int,double>::const_iterator CI;
-
     if ((int)(cnode->wear_data().get_e().size()) == 0) continue;
 
     int dof = cnode->dofs()[0];
@@ -3212,7 +3197,7 @@ void Wear::WearInterface::fd_check_mortar_e_master_deriv()
 
       if ((int)(kcnode->wear_data().get_e().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       for (int d = 0; d < 1; d++)
       {
@@ -3327,7 +3312,7 @@ void Wear::WearInterface::fd_check_mortar_e_master_deriv()
 
       if ((int)(kcnode->wear_data().get_e().size()) == 0) continue;
 
-      typedef std::map<int, double>::const_iterator CI;
+      using CI = std::map<int, double>::const_iterator;
 
       for (int d = 0; d < 1; d++)
       {

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_gausspoints.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_gausspoints.hpp
@@ -237,8 +237,8 @@ namespace Core::FE
       int point_;
     };
 
-    typedef GaussPointIterator iterator;
-    typedef GaussPointIterator const_iterator;
+    using iterator = GaussPointIterator;
+    using const_iterator = GaussPointIterator;
 
     /// construct the optimal (normal) rule for a given element shape
     explicit GaussIntegration(Core::FE::CellType distype);

--- a/src/core/fem/src/geometry/4C_fem_geometry_geo_utils.hpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_geo_utils.hpp
@@ -22,10 +22,10 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core::Geo
 {
   //! shortcut for a vector of BoundaryIntCells
-  typedef std::vector<Core::Geo::BoundaryIntCell> BoundaryIntCells;
+  using BoundaryIntCells = std::vector<Core::Geo::BoundaryIntCell>;
 
   //! shortcut for a vector of BoundaryCell pointers
-  typedef std::vector<std::shared_ptr<Core::Geo::BoundaryIntCell>> BoundaryIntCellPtrs;
+  using BoundaryIntCellPtrs = std::vector<std::shared_ptr<Core::Geo::BoundaryIntCell>>;
 
 
   //! based on this element property, one can speed up geometry algorithms

--- a/src/core/io/src/4C_io_vtk_writer_base.cpp
+++ b/src/core/io/src/4C_io_vtk_writer_base.cpp
@@ -577,7 +577,7 @@ void VtkWriterBase::write_vtk_footer_master_file()
 
 
   // generate information about 'pieces' (piece = part that is written by individual processor)
-  typedef std::vector<std::string> pptags_type;
+  using pptags_type = std::vector<std::string>;
   const pptags_type& ppiecetags = this->writer_p_piece_tags();
 
   if (numproc_ != ppiecetags.size()) FOUR_C_THROW("Incorrect number of Pieces.");

--- a/src/core/io/src/legacy/4C_io_legacy_table.cpp
+++ b/src/core/io/src/legacy/4C_io_legacy_table.cpp
@@ -904,7 +904,7 @@ MAP* symbol_map(const SYMBOL* symbol)
 
 */
 /*----------------------------------------------------------------------*/
-typedef enum TokenType
+enum TokenType
 {
   tok_none,
   tok_done,
@@ -916,7 +916,7 @@ typedef enum TokenType
   tok_equal,
   tok_indent,
   tok_dedent
-} TOKEN_TYPE;
+};
 
 
 /*----------------------------------------------------------------------*/
@@ -933,14 +933,13 @@ typedef enum TokenType
 /*----------------------------------------------------------------------*/
 struct ParserData
 {
-  TOKEN_TYPE tok;
+  TokenType tok;
   char* token_string;
   int token_int;
   double token_real;
 
   char* file_buffer;
   int file_size;
-  /*char* filename;*/
 
   int pos;
   int lineno;

--- a/src/core/io/src/legacy/4C_io_legacy_table_iter.cpp
+++ b/src/core/io/src/legacy/4C_io_legacy_table_iter.cpp
@@ -17,7 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 
  */
 /*----------------------------------------------------------------------*/
-void init_map_iterator(MAP_ITERATOR* iterator, MAP* map)
+void init_map_iterator(MapIterator* iterator, MAP* map)
 {
   iterator->stack.count = 0;
   iterator->map = map;
@@ -31,11 +31,11 @@ void init_map_iterator(MAP_ITERATOR* iterator, MAP* map)
 
  */
 /*----------------------------------------------------------------------*/
-static void push_map_node(MAP_ITERATOR* iterator, MapNode* map_node)
+static void push_map_node(MapIterator* iterator, MapNode* map_node)
 {
-  STACK_ELEMENT* new_element;
+  StackElement* new_element;
 
-  new_element = new STACK_ELEMENT;
+  new_element = new StackElement;
   new_element->map_node = map_node;
   new_element->snext = iterator->stack.head.snext;
   iterator->stack.head.snext = new_element;
@@ -48,9 +48,9 @@ static void push_map_node(MAP_ITERATOR* iterator, MapNode* map_node)
 
  */
 /*----------------------------------------------------------------------*/
-static void pop_map_node(MAP_ITERATOR* iterator)
+static void pop_map_node(MapIterator* iterator)
 {
-  STACK_ELEMENT* tmp_free;
+  StackElement* tmp_free;
 
   if (iterator->stack.count == 0)
   {
@@ -74,7 +74,7 @@ static void pop_map_node(MAP_ITERATOR* iterator)
 
  */
 /*----------------------------------------------------------------------*/
-int next_map_node(MAP_ITERATOR* iterator)
+int next_map_node(MapIterator* iterator)
 {
   int result = 0;
 
@@ -129,6 +129,6 @@ int next_map_node(MAP_ITERATOR* iterator)
 
  */
 /*----------------------------------------------------------------------*/
-MapNode* iterator_get_node(MAP_ITERATOR* iterator) { return iterator->stack.head.snext->map_node; }
+MapNode* iterator_get_node(MapIterator* iterator) { return iterator->stack.head.snext->map_node; }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/legacy/4C_io_legacy_table_iter.hpp
+++ b/src/core/io/src/legacy/4C_io_legacy_table_iter.hpp
@@ -20,11 +20,11 @@ FOUR_C_NAMESPACE_OPEN
 
  */
 /*----------------------------------------------------------------------*/
-typedef struct StackElement
+struct StackElement
 {
   struct StackElement* snext;
   MapNode* map_node;
-} STACK_ELEMENT;
+};
 
 
 /*----------------------------------------------------------------------*/
@@ -33,11 +33,11 @@ typedef struct StackElement
 
  */
 /*----------------------------------------------------------------------*/
-typedef struct Stack
+struct Stack
 {
   int count;
-  STACK_ELEMENT head;
-} STACK;
+  StackElement head;
+};
 
 
 /*----------------------------------------------------------------------*/
@@ -49,18 +49,18 @@ typedef struct Stack
 
  */
 /*----------------------------------------------------------------------*/
-typedef struct MapIterator
+struct MapIterator
 {
   MAP* map;
-  STACK stack;
-} MAP_ITERATOR;
+  Stack stack;
+};
 
 
-void init_map_iterator(MAP_ITERATOR* iterator, MAP* map);
+void init_map_iterator(MapIterator* iterator, MAP* map);
 
-int next_map_node(MAP_ITERATOR* iterator);
+int next_map_node(MapIterator* iterator);
 
-MapNode* iterator_get_node(MAP_ITERATOR* iterator);
+MapNode* iterator_get_node(MapIterator* iterator);
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/core/linalg/src/dense/4C_linalg_FADmatrix_utils.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_FADmatrix_utils.hpp
@@ -14,7 +14,7 @@
 
 #include <Sacado.hpp>
 
-typedef Sacado::Fad::DFad<double> FAD;
+using FAD = Sacado::Fad::DFad<double>;
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizeblockmatrix.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizeblockmatrix.hpp
@@ -20,7 +20,7 @@ namespace Core::LinAlg
   class BlockMatrix
   {
    public:
-    typedef typename ValueType::scalar_type scalar_type;
+    using scalar_type = typename ValueType::scalar_type;
 
     BlockMatrix() { std::fill(blocks_, blocks_ + brows * bcols, static_cast<ValueType*>(nullptr)); }
 

--- a/src/core/linalg/src/dense/4C_linalg_serialdensevector.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_serialdensevector.hpp
@@ -42,7 +42,7 @@ namespace Core::LinAlg
   };
 
   // type definition for serial integer vector
-  typedef Teuchos::SerialDenseVector<int, int> IntSerialDenseVector;
+  using IntSerialDenseVector = Teuchos::SerialDenseVector<int, int>;
 
   /*!
     \brief Update vector components with scaled values of a,

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_hierarchies.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_hierarchies.cpp
@@ -227,8 +227,8 @@ void Core::LinearSolver::AMGNxN::Hierarchies::setup()
           NumLevel_this_block, Teuchos::null);
 
       // some local typedefs
-      typedef Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node> Matrix;
-      typedef MueLu::SmootherBase<Scalar, LocalOrdinal, GlobalOrdinal, Node> SmootherBase;
+      using Matrix = Xpetra::Matrix<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
+      using SmootherBase = MueLu::SmootherBase<Scalar, LocalOrdinal, GlobalOrdinal, Node>;
 
       Teuchos::RCP<Matrix> myA = Teuchos::null;
       Teuchos::RCP<Epetra_CrsMatrix> myAcrs = Teuchos::null;

--- a/src/core/utils/src/numerics/4C_utils_fad.hpp
+++ b/src/core/utils/src/numerics/4C_utils_fad.hpp
@@ -214,10 +214,10 @@ namespace Core::FADUtils
   struct HigherOrderFadType
   {
     //! Nested type of this Fad type.
-    typedef typename HigherOrderFadType<n - 1, BaseFadType>::type nested_type;
+    using nested_type = typename HigherOrderFadType<n - 1, BaseFadType>::type;
 
     //! Fad type of this object.
-    typedef typename Sacado::mpl::apply<BaseFadType, nested_type>::type type;
+    using type = typename Sacado::mpl::apply<BaseFadType, nested_type>::type;
   };
 
   /**
@@ -226,7 +226,7 @@ namespace Core::FADUtils
   template <typename BaseFadType>
   struct HigherOrderFadType<1, BaseFadType>
   {
-    typedef BaseFadType type;
+    using type = BaseFadType;
   };
 
 
@@ -242,7 +242,7 @@ namespace Core::FADUtils
   struct HigherOrderFadValue
   {
     //! Type of nested value.
-    typedef typename FadType::value_type nested_type;
+    using nested_type = typename FadType::value_type;
 
     /**
      * \brief Set a value of this Fad type.

--- a/src/core/utils/src/stl_extension/4C_utils_pairedobj_insert_policy.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_pairedobj_insert_policy.hpp
@@ -38,13 +38,13 @@ namespace Core::Gen
   template <typename Key, typename T>
   class DefaultInsertPolicy
   {
-    typedef DefaultInsertPolicy<Key, T> class_type;
+    using class_type = DefaultInsertPolicy<Key, T>;
 
    protected:
-    typedef std::pair<Key, T> pair_type;
-    typedef std::vector<pair_type> pairedvector_type;
-    typedef typename pairedvector_type::iterator iterator;
-    typedef typename pairedvector_type::const_iterator const_iterator;
+    using pair_type = std::pair<Key, T>;
+    using pairedvector_type = std::vector<pair_type>;
+    using iterator = typename pairedvector_type::iterator;
+    using const_iterator = typename pairedvector_type::const_iterator;
 
    public:
     iterator begin(const iterator& first) { return first; }
@@ -138,14 +138,14 @@ namespace Core::Gen
   template <typename Key, typename T>
   class QuickInsertPolicy : public DefaultInsertPolicy<Key, T>
   {
-    typedef QuickInsertPolicy<Key, T> class_type;
+    using class_type = QuickInsertPolicy<Key, T>;
 
    protected:
-    typedef DefaultInsertPolicy<Key, T> base_type;
-    typedef typename base_type::pair_type pair_type;
-    typedef typename base_type::pairedvector_type pairedvector_type;
-    typedef typename base_type::iterator iterator;
-    typedef typename base_type::const_iterator const_iterator;
+    using base_type = DefaultInsertPolicy<Key, T>;
+    using pair_type = typename base_type::pair_type;
+    using pairedvector_type = typename base_type::pairedvector_type;
+    using iterator = typename base_type::iterator;
+    using const_iterator = typename base_type::const_iterator;
 
    public:
     /** @brief return a constant number of offset values
@@ -415,14 +415,14 @@ namespace Core::Gen
   template <typename Key, typename T>
   class InsertAndSortPolicy : public DefaultInsertPolicy<Key, T>
   {
-    typedef InsertAndSortPolicy<Key, T> class_type;
+    using class_type = InsertAndSortPolicy<Key, T>;
 
    protected:
-    typedef DefaultInsertPolicy<Key, T> base_type;
-    typedef typename base_type::pair_type pair_type;
-    typedef typename base_type::pairedvector_type pairedvector_type;
-    typedef typename base_type::iterator iterator;
-    typedef typename base_type::const_iterator const_iterator;
+    using base_type = DefaultInsertPolicy<Key, T>;
+    using pair_type = typename base_type::pair_type;
+    using pairedvector_type = typename base_type::pairedvector_type;
+    using iterator = typename base_type::iterator;
+    using const_iterator = typename base_type::const_iterator;
 
    public:
     InsertAndSortPolicy()

--- a/src/core/utils/src/stl_extension/4C_utils_pairedvector.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_pairedvector.hpp
@@ -54,14 +54,14 @@ namespace Core::Gen
   class Pairedvector : protected InsertPolicy
   {
    private:
-    typedef Pairedvector<Key, T, InsertPolicy> class_type;
-    typedef InsertPolicy base_type;
-    typedef typename base_type::pairedvector_type pairedvector_type;
-    typedef typename base_type::pair_type pair_type;
+    using class_type = Pairedvector<Key, T, InsertPolicy>;
+    using base_type = InsertPolicy;
+    using pairedvector_type = typename base_type::pairedvector_type;
+    using pair_type = typename base_type::pair_type;
 
    public:
-    typedef typename base_type::iterator iterator;
-    typedef typename base_type::const_iterator const_iterator;
+    using iterator = typename base_type::iterator;
+    using const_iterator = typename base_type::const_iterator;
 
     /**
      *  @brief  constructor creates no elements, but reserves the maximum

--- a/src/cut/4C_cut_coloredgraph.hpp
+++ b/src/cut/4C_cut_coloredgraph.hpp
@@ -68,7 +68,7 @@ namespace Cut
     class Graph
     {
      public:
-      typedef std::map<int, plain_int_set>::const_iterator const_iterator;
+      using const_iterator = std::map<int, plain_int_set>::const_iterator;
 
       explicit Graph(int color_split) : color_split_(color_split) {}
 
@@ -218,7 +218,7 @@ namespace Cut
     class CycleList
     {
      public:
-      typedef CycleListIterator iterator;
+      using iterator = CycleListIterator;
 
       void add_points(Graph& graph, Graph& used, Graph& cycle, plain_int_set& free,
           const std::vector<std::pair<Point*, Point*>>& all_lines);

--- a/src/cut/4C_cut_element.hpp
+++ b/src/cut/4C_cut_element.hpp
@@ -1021,10 +1021,6 @@ namespace Cut
     }
   };
 
-  // typedef EntityIdLess<Element> ElementIdLess;
-  //
-  // inline int EntityId( const Element & e ) { return e.Id(); }
-
 }  // namespace Cut
 
 

--- a/src/cut/4C_cut_find_cycles.hpp
+++ b/src/cut/4C_cut_find_cycles.hpp
@@ -33,27 +33,26 @@ namespace Cut
 
   namespace Impl
   {
-    typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
+    using graph_t = boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
         boost::property<boost::vertex_name_t, Point*,
             boost::property<boost::vertex_color_t, boost::default_color_type,
                 boost::property<boost::vertex_index_t, int>>>,
-        boost::property<boost::edge_index_t, int>>
-        graph_t;
+        boost::property<boost::edge_index_t, int>>;
 
-    typedef boost::graph_traits<graph_t>::vertex_descriptor vertex_t;
-    typedef boost::graph_traits<graph_t>::edge_descriptor edge_t;
+    using vertex_t = boost::graph_traits<graph_t>::vertex_descriptor;
+    using edge_t = boost::graph_traits<graph_t>::edge_descriptor;
 
-    typedef boost::graph_traits<graph_t>::vertex_iterator vertex_iterator;
-    typedef boost::graph_traits<graph_t>::edge_iterator edge_iterator;
-    typedef boost::graph_traits<graph_t>::adjacency_iterator adjacency_iterator;
-    typedef boost::graph_traits<graph_t>::out_edge_iterator out_edge_iterator;
+    using vertex_iterator = boost::graph_traits<graph_t>::vertex_iterator;
+    using edge_iterator = boost::graph_traits<graph_t>::edge_iterator;
+    using adjacency_iterator = boost::graph_traits<graph_t>::adjacency_iterator;
+    using out_edge_iterator = boost::graph_traits<graph_t>::out_edge_iterator;
 
-    typedef boost::property_map<graph_t, boost::vertex_name_t>::type name_map_t;
-    typedef boost::property_map<graph_t, boost::vertex_color_t>::type color_map_t;
-    typedef boost::property_map<graph_t, boost::vertex_index_t>::type vertex_index_map_t;
-    typedef boost::property_map<graph_t, boost::edge_index_t>::type edge_index_map_t;
+    using name_map_t = boost::property_map<graph_t, boost::vertex_name_t>::type;
+    using color_map_t = boost::property_map<graph_t, boost::vertex_color_t>::type;
+    using vertex_index_map_t = boost::property_map<graph_t, boost::vertex_index_t>::type;
+    using edge_index_map_t = boost::property_map<graph_t, boost::edge_index_t>::type;
 
-    typedef boost::color_traits<boost::property_traits<color_map_t>::value_type> color_t;
+    using color_t = boost::color_traits<boost::property_traits<color_map_t>::value_type>;
 
     /// boost::graph visitor that is used to create a spanning tree from a graph
     class SpanningTreeCreator : public boost::default_bfs_visitor
@@ -173,18 +172,18 @@ namespace Cut
       int c_;
     };
 
-    typedef boost::filtered_graph<graph_t, EdgeFilter> filtered_graph_t;
+    using filtered_graph_t = boost::filtered_graph<graph_t, EdgeFilter>;
 
-    typedef std::vector<vertex_t> cycle_t;
+    using cycle_t = std::vector<vertex_t>;
 
 #ifdef CUT_USE_SORTED_VECTOR
-    typedef SortedVector<cycle_t*> plain_cycle_set;
-    typedef SortedVector<vertex_t> plain_vertex_set;
-    typedef SortedVector<std::pair<vertex_t, vertex_t>> plain_graph_edge_set;
+    using plain_cycle_set = SortedVector<cycle_t*>;
+    using plain_vertex_set = SortedVector<vertex_t>;
+    using plain_graph_edge_set = SortedVector<std::pair<vertex_t, vertex_t>>;
 #else
-    typedef std::set<cycle_t*> plain_cycle_set;
-    typedef std::set<vertex_t> plain_vertex_set;
-    typedef std::set<std::pair<vertex_t, vertex_t>> plain_graph_edge_set;
+    using plain_cycle_set = std::set<cycle_t*>;
+    using plain_vertex_set = std::set<vertex_t>;
+    using plain_graph_edge_set = std::set<std::pair<vertex_t, vertex_t>>;
 #endif
 
     void find_cycles(graph_t& g, plain_cycle_set& base_cycles);

--- a/src/cut/4C_cut_levelsetintersection.hpp
+++ b/src/cut/4C_cut_levelsetintersection.hpp
@@ -33,7 +33,7 @@ namespace Cut
   */
   class LevelSetIntersection : public virtual ParentIntersection
   {
-    typedef ParentIntersection my;
+    using my = ParentIntersection;
 
 
    public:

--- a/src/cut/4C_cut_meshintersection.hpp
+++ b/src/cut/4C_cut_meshintersection.hpp
@@ -33,7 +33,7 @@ namespace Cut
   */
   class MeshIntersection : public virtual ParentIntersection
   {
-    typedef ParentIntersection my;
+    using my = ParentIntersection;
 
 
    public:

--- a/src/cut/4C_cut_point.cpp
+++ b/src/cut/4C_cut_point.cpp
@@ -965,7 +965,7 @@ void Cut::Point::erased_containing_cut_pairs(Edge* edge)
 
 void Cut::Point::AddCreationInfo(const std::pair<Side*, Edge*>& cut_pair, const std::string& info)
 {
-  typedef std::map<std::pair<Side*, Edge*>, std::string>::iterator info_iterator;
+  using info_iterator = std::map<std::pair<Side*, Edge*>, std::string>::iterator;
   std::pair<info_iterator, bool> inserted = creation_info_.insert(std::make_pair(cut_pair, info));
   if (not inserted.second)
   {

--- a/src/cut/4C_cut_point.hpp
+++ b/src/cut/4C_cut_point.hpp
@@ -529,7 +529,7 @@ namespace Cut
     }
   };
 
-  typedef EntityIdLess<Point> PointPidLess;
+  using PointPidLess = EntityIdLess<Point>;
 
   /// position on edge based comparison for sorting and searching
   class PointPositionLess
@@ -556,16 +556,16 @@ namespace Cut
   };
 
 #ifdef CUT_USE_SORTED_VECTOR
-  typedef SortedVector<Point*, true, PointPidLess> PointSet;
-  typedef SortedVector<Point*, true, PointPositionLess> PointPositionSet;
+  using PointSet = SortedVector<Point*, true, PointPidLess>;
+  using PointPositionSet = SortedVector<Point*, true, PointPositionLess>;
 
-  typedef SortedVector<std::shared_ptr<Point>, true, PointPidLess> RCPPointSet;
+  using RCPPointSet = SortedVector<std::shared_ptr<Point>, true, PointPidLess>;
 
 #else
-  typedef std::set<Point*, PointPidLess> PointSet;
-  typedef std::set<Point*, PointPositionLess> PointPositionSet;
+  using PointSet = std::set<Point*, PointPidLess>;
+  using PointPositionSet = std::set<Point*, PointPositionLess>;
 
-  typedef std::set<std::shared_ptr<Point>, PointPidLess> RCPPointSet;
+  using RCPPointSet = std::set<std::shared_ptr<Point>, PointPidLess>;
 
 #endif
 

--- a/src/cut/4C_cut_pointgraph.cpp
+++ b/src/cut/4C_cut_pointgraph.cpp
@@ -320,19 +320,19 @@ bool Cut::Impl::find_cycles(graph_t& g, Cut::Cycle& cycle,
   for (boost::tie(ei, ei_end) = boost::edges(g); ei != ei_end; ++ei)
     boost::put(e_index, *ei, edge_count++);
 
-  typedef std::vector<edge_t> vec_t;
+  using vec_t = std::vector<edge_t>;
   std::vector<vec_t> embedding(boost::num_vertices(g));
 
 
   // Use geometry to build embedding. The only safe way to do it.
 
 #ifdef CLN_CALC_OUTSIDE_KERNEL
-  typedef Core::CLN::ClnWrapper floatType;
+  using floatType = Core::CLN::ClnWrapper;
   // NOTE: Cln can be used, if one get problem with double arc and there is no other way to fix it
   // However, if running cln with as custom memory manager, this should be changed ( mostly to free
   // objects in a container, similarly as in cut_kernel )
 #else
-  typedef double floatType;
+  using floatType = double;
 #endif
 
   vertex_iterator vi, vi_end;
@@ -607,7 +607,7 @@ void Cut::Impl::PointGraph::Graph::find_cycles(Side* side, Cycle& cycle)
   {
     for (int i = 0; i < num_comp; ++i)
     {
-      typedef boost::filtered_graph<graph_t, EdgeFilter> filtered_graph_t;
+      using filtered_graph_t = boost::filtered_graph<graph_t, EdgeFilter>;
       EdgeFilter filter(g, component, i);
       filtered_graph_t fg(g, filter);
 
@@ -791,7 +791,7 @@ void Cut::Impl::PointGraph::Graph::find_cycles(
     {
       for (int i = 0; i < num_comp; ++i)
       {
-        typedef boost::filtered_graph<graph_t, EdgeFilter> filtered_graph_t;
+        using filtered_graph_t = boost::filtered_graph<graph_t, EdgeFilter>;
         EdgeFilter filter(g, component, i);
         filtered_graph_t fg(g, filter);
 

--- a/src/cut/4C_cut_pointgraph.hpp
+++ b/src/cut/4C_cut_pointgraph.hpp
@@ -117,8 +117,8 @@ namespace Cut
       PointGraph(unsigned dim) : graph_(create_graph(dim)) { /* intentionally left blank */ };
 
      public:
-      typedef std::vector<Cycle>::iterator facet_iterator;
-      typedef std::vector<std::vector<Cycle>>::iterator hole_iterator;
+      using facet_iterator = std::vector<Cycle>::iterator;
+      using hole_iterator = std::vector<std::vector<Cycle>>::iterator;
 
       PointGraph(Mesh& mesh, Element* element, Side* side, Location location, Strategy strategy);
 

--- a/src/cut/4C_cut_pointgraph_simple.hpp
+++ b/src/cut/4C_cut_pointgraph_simple.hpp
@@ -132,7 +132,7 @@ namespace Cut
         bool correct_rotation_direction_;
       };  // struct Graph
 
-      typedef std::vector<Cycle>::const_iterator surface_const_iterator;
+      using surface_const_iterator = std::vector<Cycle>::const_iterator;
 
       inline surface_const_iterator sbegin() const
       {

--- a/src/cut/4C_cut_selfcut.cpp
+++ b/src/cut/4C_cut_selfcut.cpp
@@ -333,8 +333,8 @@ void Cut::SelfCut::operations_for_node_merging(
 template <typename A, typename B>
 void Cut::SelfCut::modify_edge_or_side_map(std::map<A, B>& data, int nod, int replwith)
 {
-  typedef typename std::map<A, B>::iterator ittype;
-  typedef typename A::iterator A_ittype;
+  using ittype = typename std::map<A, B>::iterator;
+  using A_ittype = typename A::iterator;
 
   std::vector<ittype> eraseThese;
 
@@ -368,7 +368,7 @@ void Cut::SelfCut::modify_edge_or_side_map(std::map<A, B>& data, int nod, int re
     }
   }
 
-  typedef typename std::vector<ittype>::iterator itc;
+  using itc = typename std::vector<ittype>::iterator;
 
   // delete the elements with "wrong" key
   for (itc ite = eraseThese.begin(); ite != eraseThese.end(); ite++)

--- a/src/cut/4C_cut_side.cpp
+++ b/src/cut/4C_cut_side.cpp
@@ -684,7 +684,7 @@ bool Cut::Side::create_parallel_cut_surface(Mesh& mesh, Element* element, Side& 
   {
     // map to find out which location id  on parallel surface each point has
     std::map<Point*, unsigned int> unique_points;
-    typedef std::map<Point*, unsigned int> unique_points_map;
+    using unique_points_map = std::map<Point*, unsigned int>;
 
     // trying to find duplicate points and remove points between them
     for (std::vector<Point*>::iterator it = cut_points_for_lines.begin();

--- a/src/cut/4C_cut_sorted_vector.hpp
+++ b/src/cut/4C_cut_sorted_vector.hpp
@@ -27,26 +27,26 @@ namespace Cut
   class SortedVector
   {
    public:
-    typedef SortedVector<K, b_no_duplicates, Pr, A> Myt_;
-    typedef std::vector<K, A> Cont;
-    typedef typename Cont::allocator_type allocator_type;
-    typedef typename Cont::size_type size_type;
-    typedef typename Cont::difference_type difference_type;
-    typedef typename Cont::reference reference;
-    typedef typename Cont::const_reference const_reference;
-    typedef typename Cont::value_type value_type;
-    typedef K key_type;
-    typedef typename Cont::iterator iterator;
-    typedef typename Cont::const_iterator const_iterator;
-    typedef Pr key_compare;
-    typedef Pr value_compare;
+    using Myt_ = SortedVector<K, b_no_duplicates, Pr, A>;
+    using Cont = std::vector<K, A>;
+    using allocator_type = typename Cont::allocator_type;
+    using size_type = typename Cont::size_type;
+    using difference_type = typename Cont::difference_type;
+    using reference = typename Cont::reference;
+    using const_reference = typename Cont::const_reference;
+    using value_type = typename Cont::value_type;
+    using key_type = K;
+    using iterator = typename Cont::iterator;
+    using const_iterator = typename Cont::const_iterator;
+    using key_compare = Pr;
+    using value_compare = Pr;
 
-    typedef typename Cont::const_reverse_iterator const_reverse_iterator;
-    typedef typename Cont::reverse_iterator reverse_iterator;
+    using const_reverse_iterator = typename Cont::const_reverse_iterator;
+    using reverse_iterator = typename Cont::reverse_iterator;
 
-    typedef std::pair<iterator, iterator> Pairii_;
-    typedef std::pair<const_iterator, const_iterator> Paircc_;
-    typedef std::pair<iterator, bool> Pairib_;
+    using Pairii_ = std::pair<iterator, iterator>;
+    using Paircc_ = std::pair<const_iterator, const_iterator>;
+    using Pairib_ = std::pair<iterator, bool>;
 
     explicit SortedVector(const Pr& pred = Pr(), const A& al = A()) : less_(pred), vec_(al) {}
 

--- a/src/cut/4C_cut_utils.hpp
+++ b/src/cut/4C_cut_utils.hpp
@@ -51,22 +51,22 @@ namespace Cut
 
 #ifdef CUT_USE_SORTED_VECTOR
 
-  typedef SortedVector<int> plain_int_set;
+  using plain_int_set = SortedVector<int>;
 
-  typedef SortedVector<Node*> plain_node_set;
-  typedef SortedVector<Edge*> plain_edge_set;
-  typedef SortedVector<Side*> plain_side_set;
-  typedef SortedVector<Element*> plain_element_set;
+  using plain_node_set = SortedVector<Node*>;
+  using plain_edge_set = SortedVector<Edge*>;
+  using plain_side_set = SortedVector<Side*>;
+  using plain_element_set = SortedVector<Element*>;
 
-  typedef SortedVector<Point*> plain_point_set;
-  typedef SortedVector<Line*> plain_line_set;
-  typedef SortedVector<Facet*> plain_facet_set;
-  typedef SortedVector<VolumeCell*> plain_volumecell_set;
+  using plain_point_set = SortedVector<Point*>;
+  using plain_line_set = SortedVector<Line*>;
+  using plain_facet_set = SortedVector<Facet*>;
+  using plain_volumecell_set = SortedVector<VolumeCell*>;
 
-  typedef SortedVector<std::pair<Point*, Point*>> point_line_set;
+  using point_line_set = SortedVector<std::pair<Point*, Point*>>;
 
-  typedef SortedVector<BoundaryCell*> plain_boundarycell_set;
-  typedef SortedVector<IntegrationCell*> plain_integrationcell_set;
+  using plain_boundarycell_set = SortedVector<BoundaryCell*>;
+  using plain_integrationcell_set = SortedVector<IntegrationCell*>;
 
   template <class Set>
   void set_erase(Set& s, typename Set::iterator& i)
@@ -76,22 +76,22 @@ namespace Cut
 
 #else
 
-  typedef std::set<int> plain_int_set;
+  using plain_int_set = std::set<int>;
 
-  typedef std::set<Node*> plain_node_set;
-  typedef std::set<Edge*> plain_edge_set;
-  typedef std::set<Side*> plain_side_set;
-  typedef std::set<Element*> plain_element_set;
+  using plain_node_set = std::set<Node*>;
+  using plain_edge_set = std::set<Edge*>;
+  using plain_side_set = std::set<Side*>;
+  using plain_element_set = std::set<Element*>;
 
-  typedef std::set<Point*> plain_point_set;
-  typedef std::set<Line*> plain_line_set;
-  typedef std::set<Facet*> plain_facet_set;
-  typedef std::set<VolumeCell*> plain_volumecell_set;
+  using plain_point_set = std::set<Point*>;
+  using plain_line_set = std::set<Line*>;
+  using plain_facet_set = std::set<Facet*>;
+  using plain_volumecell_set = std::set<VolumeCell*>;
 
-  typedef std::set<std::pair<Point*, Point*>> point_line_set;
+  using point_line_set = std::set<std::pair<Point*, Point*>>;
 
-  typedef std::set<BoundaryCell*> plain_boundarycell_set;
-  typedef std::set<IntegrationCell*> plain_integrationcell_set;
+  using plain_boundarycell_set = std::set<BoundaryCell*>;
+  using plain_integrationcell_set = std::set<IntegrationCell*>;
 
   template <class set>
   void set_erase(set& s, typename set::iterator& i)

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc_std.hpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc_std.hpp
@@ -29,7 +29,7 @@ namespace Discret
     template <Core::FE::CellType distype>
     class FluidEleBoundaryCalcStd : public FluidBoundaryImpl<distype>
     {
-      typedef Discret::Elements::FluidBoundaryImpl<distype> my;
+      using my = Discret::Elements::FluidBoundaryImpl<distype>;
 
      public:
       /// Singleton access method

--- a/src/fluid_ele/4C_fluid_ele_calc_loma.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_loma.hpp
@@ -23,7 +23,7 @@ namespace Discret
     template <Core::FE::CellType distype>
     class FluidEleCalcLoma : public FluidEleCalc<distype>
     {
-      typedef Discret::Elements::FluidEleCalc<distype> my;
+      using my = Discret::Elements::FluidEleCalc<distype>;
 
       using my::nen_;
       using my::nsd_;

--- a/src/fluid_ele/4C_fluid_ele_calc_std.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_std.hpp
@@ -22,7 +22,7 @@ namespace Discret
     template <Core::FE::CellType distype>
     class FluidEleCalcStd : public FluidEleCalc<distype>
     {
-      typedef Discret::Elements::FluidEleCalc<distype> my;
+      using my = Discret::Elements::FluidEleCalc<distype>;
 
      public:
       /// Singleton access method

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem.hpp
@@ -71,7 +71,7 @@ namespace Discret
       /// private assignment operator since we are a Singleton.
       FluidEleCalcXFEM& operator=(FluidEleCalcXFEM const& copy);
 
-      typedef FluidEleCalc<distype> my;
+      using my = FluidEleCalc<distype>;
       using my::nen_;
       using my::nsd_;
       using my::numdofpernode_;

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem_coupling.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem_coupling.cpp
@@ -72,33 +72,21 @@ SlaveElementInterface<distype>::create_slave_element_representation(
   {
     switch (slave_ele->shape())
     {
-        //      case Core::FE::CellType::tri3:
-        //      {
-        //        typedef
-        //        SlaveElementRepresentation<distype,Core::FE::CellType::tri3,3>
-        //        SlaveEleType; sla = new SlaveEleType(slave_xyz); break;
-        //      }
-        //      case Core::FE::CellType::tri6:
-        //      {
-        //        typedef
-        //        SlaveElementRepresentation<distype,Core::FE::CellType::tri6,3>
-        //        SlaveEleType; sla = new SlaveEleType(slave_xyz); break;
-        //      }
       case Core::FE::CellType::quad4:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::quad4, 3> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::quad4, 3>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::quad8, 3> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::quad8, 3>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::quad9, 3> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::quad9, 3>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
@@ -112,51 +100,39 @@ SlaveElementInterface<distype>::create_slave_element_representation(
   {
     switch (slave_ele->shape())
     {
-        //      case Core::FE::CellType::tri3:
-        //      {
-        //        typedef
-        //        SlaveElementRepresentation<distype,Core::FE::CellType::tri3,4>
-        //        SlaveEleType; sla = new SlaveEleType(slave_xyz); break;
-        //      }
-        //      case Core::FE::CellType::tri6:
-        //      {
-        //        typedef
-        //        SlaveElementRepresentation<distype,Core::FE::CellType::tri6,4>
-        //        SlaveEleType; sla = new SlaveEleType(slave_xyz); break;
-        //      }
       case Core::FE::CellType::quad4:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::quad4, 4> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::quad4, 4>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::quad8, 4> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::quad8, 4>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::quad9, 4> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::quad9, 4>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::hex8:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::hex8, 4> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::hex8, 4>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::hex20:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::hex20, 4> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::hex20, 4>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
       case Core::FE::CellType::hex27:
       {
-        typedef SlaveElementRepresentation<distype, Core::FE::CellType::hex27, 4> SlaveEleType;
+        using SlaveEleType = SlaveElementRepresentation<distype, Core::FE::CellType::hex27, 4>;
         sla = new SlaveEleType(slave_xyz);
         break;
       }
@@ -178,7 +154,7 @@ NitscheInterface<distype>::create_nitsche_coupling_x_fluid_wdbc(
     const Discret::Elements::FluidEleParameterXFEM& fldparaxfem)
 {
   NitscheInterface* nit = nullptr;
-  typedef NitscheCoupling<distype, Core::FE::CellType::dis_none, 3> NitscheCouplType;
+  using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::dis_none, 3>;
   nit = new NitscheCouplType(C_umum, rhC_um, fldparaxfem);
 
   return std::shared_ptr<NitscheInterface<distype>>(nit);
@@ -203,31 +179,21 @@ NitscheInterface<distype>::create_nitsche_coupling_x_fluid_wdbc(Core::Elements::
   {
     switch (bele->shape())
     {
-      //      case Core::FE::CellType::tri3:
-      //      {
-      //        typedef NitscheCoupling<distype,Core::FE::CellType::tri3,3>
-      //        NitscheCouplType; nit = new NitscheCouplType(bele_xyz,C_umum,rhC_um,); break;
-      //      }
-      //      case Core::FE::CellType::tri6:
-      //      {
-      //        typedef NitscheCoupling<distype,Core::FE::CellType::tri6,3>
-      //        NitscheCouplType; nit = new NitscheCouplType(bele_xyz,C_umum,rhC_um,); break;
-      //      }
       case Core::FE::CellType::quad4:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad4, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad4, 3>;
         nit = new NitscheCouplType(bele_xyz, C_umum, rhC_um, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad8, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad8, 3>;
         nit = new NitscheCouplType(bele_xyz, C_umum, rhC_um, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad9, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad9, 3>;
         nit = new NitscheCouplType(bele_xyz, C_umum, rhC_um, fldparaxfem);
         break;
       }
@@ -240,31 +206,21 @@ NitscheInterface<distype>::create_nitsche_coupling_x_fluid_wdbc(Core::Elements::
   {
     switch (bele->shape())
     {
-      //      case Core::FE::CellType::tri3:
-      //      {
-      //        typedef NitscheCoupling<distype,Core::FE::CellType::tri3,3>
-      //        NitscheCouplType; nit = new NitscheCouplType(bele_xyz,C_umum,rhC_um,); break;
-      //      }
-      //      case Core::FE::CellType::tri6:
-      //      {
-      //        typedef NitscheCoupling<distype,Core::FE::CellType::tri6,3>
-      //        NitscheCouplType; nit = new NitscheCouplType(bele_xyz,C_umum,rhC_um,); break;
-      //      }
       case Core::FE::CellType::quad4:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad4, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad4, 4>;
         nit = new NitscheCouplType(bele_xyz, C_umum, rhC_um, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad8, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad8, 4>;
         nit = new NitscheCouplType(bele_xyz, C_umum, rhC_um, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad9, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad9, 4>;
         nit = new NitscheCouplType(bele_xyz, C_umum, rhC_um, fldparaxfem);
         break;
       }
@@ -301,37 +257,23 @@ NitscheInterface<distype>::create_nitsche_coupling_x_fluid_sided(Core::Elements:
   {
     switch (bele->shape())
     {
-        //    case Core::FE::CellType::tri3:
-        //    {
-        //      typedef NitscheCoupling<distype,Core::FE::CellType::tri3,3>
-        //      NitscheCouplType; nit = new
-        //      NitscheCouplType(bele_xyz,C_umum,C_usum,C_umus,C_usus,rhC_um,rhC_us,is_viscAdjointSymmetric);
-        //      break;
-        //    }
-        //    case Core::FE::CellType::tri6:
-        //    {
-        //      typedef NitscheCoupling<distype,Core::FE::CellType::tri6,3>
-        //      NitscheCouplType; nit = new
-        //      NitscheCouplType(bele_xyz,C_umum,C_usum,C_umus,C_usus,rhC_um,rhC_us,is_viscAdjointSymmetric);
-        //      break;
-        //    }
       case Core::FE::CellType::quad4:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad4, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad4, 3>;
         nit = new NitscheCouplType(
             bele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad8, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad8, 3>;
         nit = new NitscheCouplType(
             bele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad9, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad9, 3>;
         nit = new NitscheCouplType(
             bele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
@@ -345,37 +287,23 @@ NitscheInterface<distype>::create_nitsche_coupling_x_fluid_sided(Core::Elements:
   {
     switch (bele->shape())
     {
-      //    case Core::FE::CellType::tri3:
-      //    {
-      //      typedef NitscheCoupling<distype,Core::FE::CellType::tri3,4>
-      //      NitscheCouplType; nit = new
-      //      NitscheCouplType(bele_xyz,C_umum,C_usum,C_umus,C_usus,rhC_um,rhC_us,is_viscAdjointSymmetric);
-      //      break;
-      //    }
-      //    case Core::FE::CellType::tri6:
-      //    {
-      //      typedef NitscheCoupling<distype,Core::FE::CellType::tri6,4>
-      //      NitscheCouplType; nit = new
-      //      NitscheCouplType(bele_xyz,C_umum,C_usum,C_umus,C_usus,rhC_um,rhC_us,is_viscAdjointSymmetric);
-      //      break;
-      //    }
       case Core::FE::CellType::quad4:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad4, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad4, 4>;
         nit = new NitscheCouplType(
             bele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad8, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad8, 4>;
         nit = new NitscheCouplType(
             bele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::quad9, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::quad9, 4>;
         nit = new NitscheCouplType(
             bele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
@@ -411,37 +339,23 @@ NitscheInterface<distype>::create_nitsche_coupling_two_sided(Core::Elements::Ele
   {
     switch (vele->shape())
     {
-        //    case Core::FE::CellType::tet4:
-        //    {
-        //      typedef NitscheCoupling<distype,Core::FE::CellType::tet4,4>
-        //      NitscheCouplType; nit = new
-        //      NitscheCouplType(vele_xyz,C_umum,C_usum,C_umus,C_usus,rhC_um,rhC_us,is_viscAdjointSymmetric);
-        //      break;
-        //    }
-        //    case Core::FE::CellType::tet10:
-        //    {
-        //      typedef NitscheCoupling<distype,Core::FE::CellType::tet10,4>
-        //      NitscheCouplType; nit = new
-        //      NitscheCouplType(vele_xyz,C_umum,C_usum,C_umus,C_usus,rhC_um,rhC_us,is_viscAdjointSymmetric);
-        //      break;
-        //    }
       case Core::FE::CellType::hex8:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::hex8, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::hex8, 4>;
         nit = new NitscheCouplType(
             vele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
       }
       case Core::FE::CellType::hex20:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::hex20, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::hex20, 4>;
         nit = new NitscheCouplType(
             vele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
       }
       case Core::FE::CellType::hex27:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::hex27, 4> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::hex27, 4>;
         nit = new NitscheCouplType(
             vele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
@@ -457,7 +371,7 @@ NitscheInterface<distype>::create_nitsche_coupling_two_sided(Core::Elements::Ele
     {
       case Core::FE::CellType::hex8:
       {
-        typedef NitscheCoupling<distype, Core::FE::CellType::hex8, 3> NitscheCouplType;
+        using NitscheCouplType = NitscheCoupling<distype, Core::FE::CellType::hex8, 3>;
         nit = new NitscheCouplType(
             vele_xyz, C_umum, C_usum, C_umus, C_usus, rhC_um, rhC_us, fldparaxfem);
         break;
@@ -483,7 +397,7 @@ HybridLMInterface<distype>::create_hybrid_lm_coupling_x_fluid_wdbc(
 )
 {
   HybridLMInterface* hybridlm = nullptr;
-  typedef HybridLMCoupling<distype, Core::FE::CellType::dis_none, 3> HybridLMCouplType;
+  using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::dis_none, 3>;
   hybridlm = new HybridLMCouplType(is_viscAdjointSymmetric);
 
   return std::shared_ptr<HybridLMInterface<distype>>(hybridlm);
@@ -511,31 +425,21 @@ HybridLMInterface<distype>::create_hybrid_lm_coupling_x_fluid_wdbc(
 
   switch (bele->shape())
   {
-      //    case Core::FE::CellType::tri3:
-      //    {
-      //      typedef HybridLMCoupling<distype,Core::FE::CellType::tri3,3>
-      //      HybridLMCouplType; return Teuchos::rcp(new HybridLMCouplType(bele_xyz)); break;
-      //    }
-      //    case Core::FE::CellType::tri6:
-      //    {
-      //      typedef HybridLMCoupling<distype,Core::FE::CellType::tri6,3>
-      //      HybridLMCouplType; return Teuchos::rcp(new HybridLMCouplType(bele_xyz)); break;
-      //    }
     case Core::FE::CellType::quad4:
     {
-      typedef HybridLMCoupling<distype, Core::FE::CellType::quad4, 3> HybridLMCouplType;
+      using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad4, 3>;
       return std::make_shared<HybridLMCouplType>(bele_xyz, is_viscAdjointSymmetric);
       break;
     }
     case Core::FE::CellType::quad8:
     {
-      typedef HybridLMCoupling<distype, Core::FE::CellType::quad8, 3> HybridLMCouplType;
+      using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad8, 3>;
       return std::make_shared<HybridLMCouplType>(bele_xyz, is_viscAdjointSymmetric);
       break;
     }
     case Core::FE::CellType::quad9:
     {
-      typedef HybridLMCoupling<distype, Core::FE::CellType::quad9, 3> HybridLMCouplType;
+      using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad9, 3>;
       return std::make_shared<HybridLMCouplType>(bele_xyz, is_viscAdjointSymmetric);
       break;
     }
@@ -574,37 +478,23 @@ HybridLMInterface<distype>::create_hybrid_lm_coupling_x_fluid_sided(
   {
     switch (bele->shape())
     {
-        //    case Core::FE::CellType::tri3:
-        //    {
-        //      typedef HybridLMCoupling<distype,Core::FE::CellType::tri3,3>
-        //      HybridLMCouplType; hlm = new
-        //      HybridLMCouplType(bele_xyz,C_usum,C_umus,rhC_us,G_s_us,G_us_s,is_viscAdjointSymmetric);
-        //      break;
-        //    }
-        //    case Core::FE::CellType::tri6:
-        //    {
-        //      typedef HybridLMCoupling<distype,Core::FE::CellType::tri6,3>
-        //      HybridLMCouplType; hlm = new
-        //      HybridLMCouplType(bele_xyz,C_usum,C_umus,rhC_us,G_s_us,G_us_s,is_viscAdjointSymmetric);
-        //      break;
-        //    }
       case Core::FE::CellType::quad4:
       {
-        typedef HybridLMCoupling<distype, Core::FE::CellType::quad4, 3> HybridLMCouplType;
+        using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad4, 3>;
         hlm = new HybridLMCouplType(
             bele_xyz, C_usum, C_umus, rhC_us, G_s_us, G_us_s, is_viscAdjointSymmetric);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef HybridLMCoupling<distype, Core::FE::CellType::quad8, 3> HybridLMCouplType;
+        using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad8, 3>;
         hlm = new HybridLMCouplType(
             bele_xyz, C_usum, C_umus, rhC_us, G_s_us, G_us_s, is_viscAdjointSymmetric);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef HybridLMCoupling<distype, Core::FE::CellType::quad9, 3> HybridLMCouplType;
+        using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad9, 3>;
         hlm = new HybridLMCouplType(
             bele_xyz, C_usum, C_umus, rhC_us, G_s_us, G_us_s, is_viscAdjointSymmetric);
         break;
@@ -618,37 +508,23 @@ HybridLMInterface<distype>::create_hybrid_lm_coupling_x_fluid_sided(
   {
     switch (bele->shape())
     {
-        //      case Core::FE::CellType::tri3:
-        //      {
-        //        typedef HybridLMCoupling<distype,Core::FE::CellType::tri3,4>
-        //        HybridLMCouplType; hlm = new
-        //        HybridLMCouplType(bele_xyz,C_usum,C_umus,rhC_us,G_s_us,G_us_s,is_viscAdjointSymmetric);
-        //        break;
-        //      }
-        //      case Core::FE::CellType::tri6:
-        //      {
-        //        typedef HybridLMCoupling<distype,Core::FE::CellType::tri6,4>
-        //        HybridLMCouplType; hlm = new
-        //        HybridLMCouplType(bele_xyz,C_usum,C_umus,rhC_us,G_s_us,G_us_s,is_viscAdjointSymmetric);
-        //        break;
-        //      }
       case Core::FE::CellType::quad4:
       {
-        typedef HybridLMCoupling<distype, Core::FE::CellType::quad4, 4> HybridLMCouplType;
+        using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad4, 4>;
         hlm = new HybridLMCouplType(
             bele_xyz, C_usum, C_umus, rhC_us, G_s_us, G_us_s, is_viscAdjointSymmetric);
         break;
       }
       case Core::FE::CellType::quad8:
       {
-        typedef HybridLMCoupling<distype, Core::FE::CellType::quad8, 4> HybridLMCouplType;
+        using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad8, 4>;
         hlm = new HybridLMCouplType(
             bele_xyz, C_usum, C_umus, rhC_us, G_s_us, G_us_s, is_viscAdjointSymmetric);
         break;
       }
       case Core::FE::CellType::quad9:
       {
-        typedef HybridLMCoupling<distype, Core::FE::CellType::quad9, 4> HybridLMCouplType;
+        using HybridLMCouplType = HybridLMCoupling<distype, Core::FE::CellType::quad9, 4>;
         hlm = new HybridLMCouplType(
             bele_xyz, C_usum, C_umus, rhC_us, G_s_us, G_us_s, is_viscAdjointSymmetric);
         break;

--- a/src/fluid_ele/4C_fluid_ele_calc_xwall.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xwall.hpp
@@ -25,7 +25,7 @@ namespace Discret
     template <Core::FE::CellType distype, Discret::Elements::Fluid::EnrichmentType enrtype>
     class FluidEleCalcXWall : public FluidEleCalc<distype, enrtype>
     {
-      typedef Discret::Elements::FluidEleCalc<distype, enrtype> my;
+      using my = Discret::Elements::FluidEleCalc<distype, enrtype>;
 
       using my::nen_;
       using my::nsd_;

--- a/src/fsi/src/4C_fsi_dyn.cpp
+++ b/src/fsi/src/4C_fsi_dyn.cpp
@@ -480,7 +480,7 @@ void fsi_ale_drt()
 
   const Teuchos::ParameterList& fsidyn = problem->fsi_dynamic_params();
 
-  auto coupling = Teuchos::getIntegralValue<FSI_COUPLING>(fsidyn, "COUPALGO");
+  auto coupling = Teuchos::getIntegralValue<FsiCoupling>(fsidyn, "COUPALGO");
   switch (coupling)
   {
     case fsi_iter_monolithicfluidsplit:

--- a/src/inpar/4C_inpar_bio.hpp
+++ b/src/inpar/4C_inpar_bio.hpp
@@ -23,15 +23,6 @@ namespace Core::Conditions
   class ConditionDefinition;
 }
 
-// ToDo: move these enums to namespace Inpar::ArteryNetwork etc.
-//       is the typedef really needed?
-
-/*!----------------------------------------------------------------------
-\brief enum of arterial network dynamic types
-This is the enumeration of all types of different integration schemes
-
-*-----------------------------------------------------------------------*/
-
 
 /*!----------------------------------------------------------------------
 \brief enum of reduced dimensional airways dynamic types

--- a/src/inpar/4C_inpar_bio.hpp
+++ b/src/inpar/4C_inpar_bio.hpp
@@ -29,12 +29,12 @@ namespace Core::Conditions
 This is the enumeration of all types of different integration schemes
 
 *-----------------------------------------------------------------------*/
-typedef enum RedAirwaysDyntype
+enum RedAirwaysDyntype
 {
   one_step_theta,
   linear,
   nonlinear
-} _RED_AIRWAYS_DYNTYPE;
+};
 
 
 namespace Inpar

--- a/src/inpar/4C_inpar_fsi.hpp
+++ b/src/inpar/4C_inpar_fsi.hpp
@@ -26,7 +26,7 @@ namespace Core::Conditions
 /*----------------------------------------------------------------------*/
 /* The coupling methods for FSI. */
 /*----------------------------------------------------------------------*/
-typedef enum FsiCoupling
+enum FsiCoupling
 {
   fsi_coupling_freesurface = -1,
   fsi_coupling_undefined = 0,
@@ -57,7 +57,7 @@ typedef enum FsiCoupling
   fsi_iter_sliding_monolithicfluidsplit,
   fsi_iter_sliding_monolithicstructuresplit,
   fsi_iter_mortar_monolithicfluidsplit_saddlepoint
-} FSI_COUPLING;
+};
 
 namespace Inpar
 {

--- a/src/inpar/4C_inpar_fsi.hpp
+++ b/src/inpar/4C_inpar_fsi.hpp
@@ -26,7 +26,6 @@ namespace Core::Conditions
 /*----------------------------------------------------------------------*/
 /* The coupling methods for FSI. */
 /*----------------------------------------------------------------------*/
-// ToDo: put into the namespace Inpar::FSI ! No typedef?
 typedef enum FsiCoupling
 {
   fsi_coupling_freesurface = -1,

--- a/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.hpp
+++ b/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.hpp
@@ -24,20 +24,20 @@ namespace Mat
   {
     namespace PAR
     {
-      typedef enum DistrType
+      enum DistrType
       {
         distr_type_undefined = 0,
         distr_type_vonmisesfisher = 1,
         distr_type_bingham = 2
-      } DISTR_TYPE_;
+      };
 
-      typedef enum StrategyType
+      enum StrategyType
       {
         strategy_type_undefined = 0,
         strategy_type_standard = 1,
         strategy_type_bydistributionfunction = 2,
         strategy_type_dispersedtransverselyisotropic = 3
-      } STRATEGY_TYPE_;
+      };
 
       /*!
        * @brief material parameters for generalized structural tensor with distribution

--- a/src/mortar/4C_mortar_coupling3d_classes.cpp
+++ b/src/mortar/4C_mortar_coupling3d_classes.cpp
@@ -268,7 +268,7 @@ bool Mortar::IntElement::map_to_parent(const std::vector<Core::Gen::Pairedvector
   FOUR_C_THROW("MapToParent() function is outdated");
 
   // map iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // *********************************************************************
   // do mapping for given IntElement and Element
@@ -756,7 +756,7 @@ double Mortar::IntCell::jacobian()
 void Mortar::IntCell::deriv_jacobian(Core::Gen::Pairedvector<int, double>& derivjac)
 {
   // define iterator
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // 1d line element
   if (shape() == Core::FE::CellType::line2)

--- a/src/mortar/4C_mortar_element.cpp
+++ b/src/mortar/4C_mortar_element.cpp
@@ -741,7 +741,7 @@ void Mortar::Element::deriv_unit_normal_at_xi(
   // non-unit normal derivative
   std::vector<Core::Gen::Pairedvector<int, double>> derivnnu(
       3, nderiv);  // assume that each node has 3 dofs...
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+  using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // now the derivative
   for (int n = 0; n < nnodes; ++n)

--- a/src/mortar/4C_mortar_element_shapefct.cpp
+++ b/src/mortar/4C_mortar_element_shapefct.cpp
@@ -2651,7 +2651,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
           FOUR_C_THROW(
               "Mortar::Element shape function for LM incompatible with number of element nodes!");
 #endif
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         std::shared_ptr<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>> derivae =
@@ -2726,7 +2726,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -2765,7 +2765,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
           FOUR_C_THROW(
               "Mortar::Element shape function for LM incompatible with number of element nodes!");
 #endif
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         std::shared_ptr<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>> derivae =
@@ -2841,7 +2841,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -2959,7 +2959,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
               "Mortar::Element shape function for LM incompatible with number of element nodes!");
 #endif
 
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         std::shared_ptr<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>> derivae =
@@ -3059,7 +3059,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Ae * Me = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -3103,7 +3103,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
             std::make_shared<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>>(
                 nnodes * 3, 0, Core::LinAlg::SerialDenseMatrix(nnodes, nnodes));
 
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         // prepare computation with Gauss quadrature
@@ -3179,7 +3179,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -3302,7 +3302,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
             std::make_shared<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>>(
                 nnodes * 3, 0, Core::LinAlg::SerialDenseMatrix(nnodes, nnodes));
 
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         // prepare computation with Gauss quadrature
@@ -3378,7 +3378,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -3498,7 +3498,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
             std::make_shared<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>>(
                 nnodes * 3, 0, Core::LinAlg::SerialDenseMatrix(nnodes, nnodes));
 
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         // prepare computation with Gauss quadrature
@@ -3570,7 +3570,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Me * Ae = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -3672,7 +3672,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
       // establish fundamental data
       double detg = 0.0;
       const int nnodes = num_node();
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+      using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       // empty shape function vals + derivs
       Core::LinAlg::SerialDenseVector valquad(nnodes);
@@ -3861,7 +3861,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
       // establish fundamental data
       double detg = 0.0;
       const int nnodes = num_node();
-      typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+      using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
       // empty shape function vals + derivs
       Core::LinAlg::SerialDenseVector valquad(nnodes);
@@ -4066,7 +4066,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
             std::make_shared<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>>(
                 nnodes * 3, 0, Core::LinAlg::SerialDenseMatrix(nnodes, nnodes));
 
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         // prepare computation with Gauss quadrature
@@ -4162,7 +4162,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Ae * Me = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -4207,7 +4207,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
             std::make_shared<Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>>(
                 nnodes * 3, 0, Core::LinAlg::SerialDenseMatrix(nnodes, nnodes));
 
-        typedef Core::Gen::Pairedvector<int, double>::const_iterator CI;
+        using CI = Core::Gen::Pairedvector<int, double>::const_iterator;
         Core::LinAlg::SerialDenseMatrix ae(nnodes, nnodes, true);
 
         // prepare computation with Gauss quadrature
@@ -4303,7 +4303,7 @@ void Mortar::Element::shape_function_linearizations(Mortar::Element::ShapeType s
         // (this is done according to a quite complex formula, which
         // we get from the linearization of the biorthogonality condition:
         // Lin (Ae * Me = De) -> Lin(Ae)=Lin(De)*Inv(Me)-Ae*Lin(Me)*Inv(Me) )
-        typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+        using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
         for (_CIM p = derivde_me.begin(); p != derivde_me.end(); ++p)
         {
           Core::LinAlg::SerialDenseMatrix& dtmp = derivde_me[p->first];
@@ -4837,7 +4837,7 @@ bool Mortar::Element::deriv_shape_dual(
   Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix> dummy(
       nnodes * nnodes * 3 * 10, 0, Core::LinAlg::SerialDenseMatrix(nnodes, nnodes, true));
 
-  typedef Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator _CIM;
+  using _CIM = Core::Gen::Pairedvector<int, Core::LinAlg::SerialDenseMatrix>::const_iterator;
   for (_CIM p = derivdual.begin(); p != derivdual.end(); ++p)
   {
     for (int i = 0; i < nnodes; ++i)

--- a/src/mortar/4C_mortar_matrix_transform.hpp
+++ b/src/mortar/4C_mortar_matrix_transform.hpp
@@ -29,12 +29,12 @@ namespace Mortar
 {
   class MatrixRowColTransformer
   {
-    typedef Core::Gen::Pairedvector<CONTACT::MatBlockType, std::shared_ptr<Epetra_Export>>
-        plain_block_export_pairs;
+    using plain_block_export_pairs =
+        Core::Gen::Pairedvector<CONTACT::MatBlockType, std::shared_ptr<Epetra_Export>>;
 
    public:
-    typedef Core::Gen::Pairedvector<CONTACT::MatBlockType, std::shared_ptr<Core::LinAlg::Map>*>
-        plain_block_map_pairs;
+    using plain_block_map_pairs =
+        Core::Gen::Pairedvector<CONTACT::MatBlockType, std::shared_ptr<Core::LinAlg::Map>*>;
 
    public:
     /// constructor

--- a/src/mortar/4C_mortar_projector.cpp
+++ b/src/mortar/4C_mortar_projector.cpp
@@ -1570,7 +1570,7 @@ bool Mortar::ProjectorCalc<distype>::project_s_node_by_m_nodal_normal_3d_lin(
   //   Lin deta = - inv(dF) * Lin F             //
   //**********************************************
   // prepare linearizations
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   // get linsize
   int linsize = 0;
@@ -1882,7 +1882,7 @@ bool Mortar::ProjectorCalc<distype>::project_s_node_by_m_nodal_normal_2d_lin(
   //   Lin deta = - inv(dF) * Lin F             //
   //**********************************************
   // prepare linearizations
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   std::vector<Core::Gen::Pairedvector<int, double>> etaLin(3, 1000);
   std::vector<Core::Gen::Pairedvector<int, double>> fLin(3, 1000);
@@ -2309,7 +2309,7 @@ bool Mortar::ProjectorCalc<distype>::project_s_node_by_m_normal_2d_lin(const Mor
   //   Lin deta = - inv(dF) * Lin F             //
   //**********************************************
   // prepare linearizations
-  typedef Core::Gen::Pairedvector<int, double>::const_iterator _CI;
+  using _CI = Core::Gen::Pairedvector<int, double>::const_iterator;
 
   std::vector<Core::Gen::Pairedvector<int, double>> etaLin(3, 1000);
   std::vector<Core::Gen::Pairedvector<int, double>> fLin(3, 1000);

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp
@@ -24,7 +24,7 @@
 #include <memory>
 
 // define Fad object for evaluation
-typedef Sacado::Fad::DFad<double> FAD;
+using FAD = Sacado::Fad::DFad<double>;
 
 // forward declaration
 

--- a/src/post/4C_post_ensight_writer.hpp
+++ b/src/post/4C_post_ensight_writer.hpp
@@ -71,9 +71,9 @@ const int subhex18map[4][8] = {{0, 4, 8, 7, 9, 13, 17, 16}, {4, 1, 5, 8, 13, 10,
 class EnsightWriter : public PostWriterBase
 {
  public:
-  typedef std::map<Core::FE::CellType, int> NumElePerDisType;
+  using NumElePerDisType = std::map<Core::FE::CellType, int>;
 
-  typedef std::map<Core::FE::CellType, std::vector<int>> EleGidPerDisType;
+  using EleGidPerDisType = std::map<Core::FE::CellType, std::vector<int>>;
 
   //! constructor, does nothing (SetField must be called before usage)
   EnsightWriter(PostField* field, const std::string& name);

--- a/src/post/4C_post_filter_base.cpp
+++ b/src/post/4C_post_filter_base.cpp
@@ -47,7 +47,7 @@ void PostFilterBase::write_any_results(PostField* field, const char* type, const
   PostResult result = PostResult(field);
   result.next_result();
 
-  MAP_ITERATOR iter;
+  MapIterator iter;
   init_map_iterator(&iter, result.group());
 
   while (next_map_node(&iter))

--- a/src/post/4C_post_vtk_vti_writer.cpp
+++ b/src/post/4C_post_vtk_vti_writer.cpp
@@ -394,7 +394,7 @@ void PostVtiWriter::writer_prep_timestep()
 
   const std::shared_ptr<Core::FE::Discretization> dis = field_->discretization();
   // collect all possible values of the x-, y- and z-coordinate
-  typedef std::set<double, LessTol<double>> set_tol;
+  using set_tol = std::set<double, LessTol<double>>;
   set_tol collected_coords[3];
   for (int n = 0; n < dis->num_my_col_nodes(); ++n)
   {

--- a/src/post/4C_post_vtk_writer.cpp
+++ b/src/post/4C_post_vtk_writer.cpp
@@ -123,7 +123,7 @@ void PostVtkWriter::write_vtk_footer()
   currentout_ << std::flush;
 
   // Also start master file on processor 0
-  typedef std::vector<std::string> pptags_type;
+  using pptags_type = std::vector<std::string>;
   const pptags_type& ppiecetags = this->writer_p_piece_tags();
   if (myrank_ == 0)
   {

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.hpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.hpp
@@ -122,7 +122,7 @@ namespace ScaTra
 
    private:
     //! abbreviation
-    typedef MortarCellCalc<distype_s, distype_m> my;
+    using my = MortarCellCalc<distype_s, distype_m>;
 
    protected:
     using my::nen_master_;
@@ -213,8 +213,8 @@ namespace ScaTra
 
    private:
     //! abbreviation
-    typedef MortarCellCalc<distype_s, distype_m> my;
-    typedef MortarCellCalcElch<distype_s, distype_m> myelch;
+    using my = MortarCellCalc<distype_s, distype_m>;
+    using myelch = MortarCellCalcElch<distype_s, distype_m>;
     using my::nen_master_;
     using my::nen_slave_;
     using my::nsd_slave_;
@@ -291,7 +291,7 @@ namespace ScaTra
 
    private:
     //! abbreviation
-    typedef MortarCellCalc<distype_s, distype_m> my;
+    using my = MortarCellCalc<distype_s, distype_m>;
     using my::nen_master_;
     using my::nen_slave_;
     using my::nsd_slave_;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.hpp
@@ -27,7 +27,7 @@ namespace Discret
     template <Core::FE::CellType distype, int probdim = Core::FE::dim<distype> + 1>
     class ScaTraEleBoundaryCalcElch : public ScaTraEleBoundaryCalc<distype, probdim>
     {
-      typedef Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim> my;
+      using my = Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>;
 
      protected:
       using my::nen_;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.hpp
@@ -22,8 +22,8 @@ namespace Discret
     template <Core::FE::CellType distype, int probdim = Core::FE::dim<distype> + 1>
     class ScaTraEleBoundaryCalcElchNP : public ScaTraEleBoundaryCalcElch<distype, probdim>
     {
-      typedef Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim> my;
-      typedef Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim> myelch;
+      using my = Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>;
+      using myelch = Discret::Elements::ScaTraEleBoundaryCalcElch<distype, probdim>;
       using my::nen_;
 
      public:

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.hpp
@@ -22,7 +22,7 @@ namespace Discret
     template <Core::FE::CellType distype, int probdim = Core::FE::dim<distype> + 1>
     class ScaTraEleBoundaryCalcLoma : public ScaTraEleBoundaryCalc<distype, probdim>
     {
-      typedef Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim> my;
+      using my = Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>;
       using my::nen_;
       using my::nsd_;
       using my::nsd_ele_;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.hpp
@@ -21,7 +21,7 @@ namespace Discret
     template <Core::FE::CellType distype, int probdim = Core::FE::dim<distype> + 1>
     class ScaTraEleBoundaryCalcPoro : public ScaTraEleBoundaryCalc<distype, probdim>
     {
-      typedef Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim> my;
+      using my = Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>;
       using my::nen_;
       using my::nsd_;
       using my::nsd_ele_;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_std.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_std.hpp
@@ -21,7 +21,7 @@ namespace Discret
     template <Core::FE::CellType distype, int probdim = Core::FE::dim<distype> + 1>
     class ScaTraEleBoundaryCalcStd : public ScaTraEleBoundaryCalc<distype, probdim>
     {
-      typedef Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim> my;
+      using my = Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>;
 
      public:
       /// Singleton access method

--- a/src/scatra_ele/4C_scatra_ele_calc_advanced_reaction.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_advanced_reaction.hpp
@@ -42,7 +42,7 @@ namespace Discret
       ScaTraEleCalcAdvReac(const int numdofpernode, const int numscal, const std::string& disname);
 
      private:
-      typedef ScaTraEleCalc<distype, probdim> my;
+      using my = ScaTraEleCalc<distype, probdim>;
 
      protected:
       using my::nen_;

--- a/src/scatra_ele/4C_scatra_ele_calc_aniso.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_aniso.hpp
@@ -31,7 +31,7 @@ namespace Discret
       ScaTraEleCalcAniso(const int numdofpernode, const int numscal, const std::string& disname);
 
      private:
-      typedef ScaTraEleCalc<distype, probdim> my;
+      using my = ScaTraEleCalc<distype, probdim>;
 
      protected:
       using my::nen_;

--- a/src/scatra_ele/4C_scatra_ele_calc_artery.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_artery.hpp
@@ -35,7 +35,7 @@ namespace Discret
 
      private:
      public:
-      typedef ScaTraEleCalc<distype, probdim> my;
+      using my = ScaTraEleCalc<distype, probdim>;
       using my::nen_;
       using my::nsd_;
       using my::nsd_ele_;
@@ -136,7 +136,7 @@ namespace Discret
     template <int nsd, int nen>
     class ScaTraEleInternalVariableManagerArtery : public ScaTraEleInternalVariableManager<nsd, nen>
     {
-      typedef ScaTraEleInternalVariableManager<nsd, nen> my;
+      using my = ScaTraEleInternalVariableManager<nsd, nen>;
 
      public:
       ScaTraEleInternalVariableManagerArtery(int numscal)

--- a/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain.hpp
@@ -32,9 +32,9 @@ namespace Discret
       ScaTraEleCalcCardiacMonodomain(
           const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype, probdim> my;
-      typedef ScaTraEleCalcAniso<distype, probdim> aniso;
-      typedef ScaTraEleCalcAdvReac<distype, probdim> advreac;
+      using my = ScaTraEleCalc<distype, probdim>;
+      using aniso = ScaTraEleCalcAniso<distype, probdim>;
+      using advreac = ScaTraEleCalcAdvReac<distype, probdim>;
       using my::nen_;
       using my::nsd_;
       using my::nsd_ele_;

--- a/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain_hdg.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain_hdg.hpp
@@ -34,10 +34,6 @@ namespace Discret
       ScaTraEleCalcHDGCardiacMonodomain(
           const int numdofpernode, const int numscal, const std::string& disname);
 
-      //    typedef ScaTraEleCalc<distype,probdim> my;
-      //    typedef ScaTraEleCalcAniso<distype,probdim> aniso;
-      //    typedef ScaTraEleCalcAdvReac<distype,probdim> advreac;
-
       std::vector<Core::LinAlg::SerialDenseVector> values_mat_gp_all_;
       std::vector<double> gp_mat_alpha_;
 

--- a/src/scatra_ele/4C_scatra_ele_calc_chemo.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_chemo.hpp
@@ -27,7 +27,7 @@ namespace Discret
       ScaTraEleCalcChemo(const int numdofpernode, const int numscal, const std::string& disname);
 
      private:
-      typedef ScaTraEleCalc<distype, probdim> my;
+      using my = ScaTraEleCalc<distype, probdim>;
       using my::nen_;
       using my::nsd_;
       using varmanager = ScaTraEleInternalVariableManager<nsd_, nen_>;

--- a/src/scatra_ele/4C_scatra_ele_calc_chemo_reac.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_chemo_reac.hpp
@@ -32,9 +32,9 @@ namespace Discret
       ScaTraEleCalcChemoReac(
           const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype, probdim> my;
-      typedef ScaTraEleCalcChemo<distype, probdim> chemo;
-      typedef ScaTraEleCalcAdvReac<distype, probdim> advreac;
+      using my = ScaTraEleCalc<distype, probdim>;
+      using chemo = ScaTraEleCalcChemo<distype, probdim>;
+      using advreac = ScaTraEleCalcAdvReac<distype, probdim>;
 
      public:
       //! Singleton access method

--- a/src/scatra_ele/4C_scatra_ele_calc_loma.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_loma.hpp
@@ -26,7 +26,7 @@ namespace Discret
       //! private constructor for singletons
       ScaTraEleCalcLoma(const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype> my;
+      using my = ScaTraEleCalc<distype>;
       using my::nen_;
       using my::nsd_;
 

--- a/src/scatra_ele/4C_scatra_ele_calc_ls.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_ls.hpp
@@ -25,7 +25,7 @@ namespace Discret
       //! private constructor for singletons
       ScaTraEleCalcLS(const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype> my;
+      using my = ScaTraEleCalc<distype>;
       using my::nen_;
       using my::nsd_;
 

--- a/src/scatra_ele/4C_scatra_ele_calc_lsreinit.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_lsreinit.hpp
@@ -34,7 +34,7 @@ namespace Discret
       //! private constructor for singletons
       ScaTraEleCalcLsReinit(const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype, prob_dim> my;
+      using my = ScaTraEleCalc<distype, prob_dim>;
       using my::nen_;
       using my::nsd_;
       using my::nsd_ele_;
@@ -335,7 +335,7 @@ namespace Discret
     class ScaTraEleInternalVariableManagerLsReinit
         : public ScaTraEleInternalVariableManager<nsd, nen>
     {
-      typedef ScaTraEleInternalVariableManager<nsd, nen> my;
+      using my = ScaTraEleInternalVariableManager<nsd, nen>;
 
      public:
       ScaTraEleInternalVariableManagerLsReinit(int numscal)

--- a/src/scatra_ele/4C_scatra_ele_calc_multiporo_reac.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_multiporo_reac.hpp
@@ -51,10 +51,10 @@ namespace Discret
       ScaTraEleCalcMultiPoroReac(
           const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype> my;
-      typedef ScaTraEleCalcPoroReac<distype> pororeac;
-      typedef ScaTraEleCalcPoro<distype> poro;
-      typedef ScaTraEleCalcAdvReac<distype> advreac;
+      using my = ScaTraEleCalc<distype>;
+      using pororeac = ScaTraEleCalcPoroReac<distype>;
+      using poro = ScaTraEleCalcPoro<distype>;
+      using advreac = ScaTraEleCalcAdvReac<distype>;
       using my::nen_;
       using my::nsd_;
 
@@ -383,7 +383,7 @@ namespace Discret
     class ScaTraEleInternalVariableManagerMultiPoro
         : public ScaTraEleInternalVariableManager<nsd, nen>
     {
-      typedef ScaTraEleInternalVariableManager<nsd, nen> my;
+      using my = ScaTraEleInternalVariableManager<nsd, nen>;
 
      public:
       ScaTraEleInternalVariableManagerMultiPoro(int numscal)

--- a/src/scatra_ele/4C_scatra_ele_calc_no_physics.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_no_physics.hpp
@@ -34,7 +34,7 @@ namespace Discret
     {
      public:
       //! abbreviation
-      typedef ScaTraEleCalc<distype, probdim> my;
+      using my = ScaTraEleCalc<distype, probdim>;
 
       //! singleton access method
       static ScaTraEleCalcNoPhysics<distype, probdim>* instance(

--- a/src/scatra_ele/4C_scatra_ele_calc_poro.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro.hpp
@@ -35,7 +35,7 @@ namespace Discret
       ScaTraEleCalcPoro(const int numdofpernode, const int numscal, const std::string& disname);
 
      private:
-      typedef ScaTraEleCalc<distype> my;
+      using my = ScaTraEleCalc<distype>;
       using my::nen_;
       using my::nsd_;
       using my::nsd_ele_;
@@ -219,7 +219,7 @@ namespace Discret
     template <int nsd, int nen>
     class ScaTraEleInternalVariableManagerPoro : public ScaTraEleInternalVariableManager<nsd, nen>
     {
-      typedef ScaTraEleInternalVariableManager<nsd, nen> my;
+      using my = ScaTraEleInternalVariableManager<nsd, nen>;
 
      public:
       ScaTraEleInternalVariableManagerPoro(int numscal)

--- a/src/scatra_ele/4C_scatra_ele_calc_poro_reac.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro_reac.hpp
@@ -28,9 +28,9 @@ namespace Discret
       /// protected constructor, since we are a Singleton.
       ScaTraEleCalcPoroReac(const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype> my;
-      typedef ScaTraEleCalcPoro<distype> poro;
-      typedef ScaTraEleCalcAdvReac<distype> advreac;
+      using my = ScaTraEleCalc<distype>;
+      using poro = ScaTraEleCalcPoro<distype>;
+      using advreac = ScaTraEleCalcAdvReac<distype>;
 
      public:
       /// Singleton access method

--- a/src/scatra_ele/4C_scatra_ele_calc_poro_reac_ECM.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro_reac_ECM.hpp
@@ -32,10 +32,10 @@ namespace Discret
       ScaTraEleCalcPoroReacECM(
           const int numdofpernode, const int numscal, const std::string& disname);
 
-      typedef ScaTraEleCalc<distype> my;
-      typedef ScaTraEleCalcPoroReac<distype> pororeac;
-      typedef ScaTraEleCalcPoro<distype> poro;
-      typedef ScaTraEleCalcAdvReac<distype> advreac;
+      using my = ScaTraEleCalc<distype>;
+      using pororeac = ScaTraEleCalcPoroReac<distype>;
+      using poro = ScaTraEleCalcPoro<distype>;
+      using advreac = ScaTraEleCalcAdvReac<distype>;
       using my::nen_;
       using my::nsd_;
 

--- a/src/scatra_ele/4C_scatra_ele_calc_std.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_std.hpp
@@ -24,7 +24,7 @@ namespace Discret
     {
      public:
       //! abbreviation
-      typedef ScaTraEleCalc<distype, probdim> my;
+      using my = ScaTraEleCalc<distype, probdim>;
 
 
       //! singleton access method

--- a/src/scatra_ele/4C_scatra_ele_sti_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_sti_elch.hpp
@@ -116,7 +116,7 @@ namespace Discret
     {
      public:
       //! abbreviation
-      typedef ScaTraEleInternalVariableManager<nsd, nen> vm;
+      using vm = ScaTraEleInternalVariableManager<nsd, nen>;
 
       //! constructor
       ScaTraEleInternalVariableManagerSTIElch(const int& numscal)

--- a/src/scatra_ele/4C_scatra_ele_utils_elch_diffcond.hpp
+++ b/src/scatra_ele/4C_scatra_ele_utils_elch_diffcond.hpp
@@ -29,8 +29,8 @@ namespace Discret
     class ScaTraEleUtilsElchDiffCond : public ScaTraEleUtilsElchElectrode<distype>
     {
       //! abbreviations
-      typedef ScaTraEleUtilsElch<distype> myelch;
-      typedef ScaTraEleUtilsElchElectrode<distype> myelectrode;
+      using myelch = ScaTraEleUtilsElch<distype>;
+      using myelectrode = ScaTraEleUtilsElchElectrode<distype>;
 
      public:
       //! singleton access method

--- a/src/scatra_ele/4C_scatra_ele_utils_elch_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_utils_elch_electrode.hpp
@@ -26,7 +26,7 @@ namespace Discret
     class ScaTraEleUtilsElchElectrode : public ScaTraEleUtilsElch<distype>
     {
       //! abbreviation
-      typedef ScaTraEleUtilsElch<distype> myelch;
+      using myelch = ScaTraEleUtilsElch<distype>;
 
      public:
       //! singleton access method

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_interface_preconditioner.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_interface_preconditioner.hpp
@@ -37,9 +37,8 @@ namespace NOX
       {
         class Preconditioner;
       }  // namespace Interface
-      // typedef
-      typedef std::map<NOX::Nln::SolutionType, Teuchos::RCP<Interface::Preconditioner>>
-          PrecInterfaceMap;
+      using PrecInterfaceMap =
+          std::map<NOX::Nln::SolutionType, Teuchos::RCP<Interface::Preconditioner>>;
 
       namespace Interface
       {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_interface_required.hpp
@@ -141,10 +141,8 @@ namespace NOX
           //! @}
         };
       }  // end namespace Interface
-      // typedef
-      typedef std::map<NOX::Nln::SolutionType,
-          Teuchos::RCP<NOX::Nln::CONSTRAINT::Interface::Required>>
-          ReqInterfaceMap;
+      using ReqInterfaceMap =
+          std::map<NOX::Nln::SolutionType, Teuchos::RCP<NOX::Nln::CONSTRAINT::Interface::Required>>;
     }  // namespace CONSTRAINT
   }  // end namespace Nln
 }  // end namespace NOX

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
@@ -137,7 +137,7 @@ void NOX::Nln::GlobalData::check_input() const
   if (lin_solvers_.size() == 0)
     FOUR_C_THROW("The linear solver map has the size 0! Required size > 0.");
 
-  typedef std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>::const_iterator CI;
+  using CI = std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>::const_iterator;
   for (CI iter = lin_solvers_.begin(); iter != lin_solvers_.end(); ++iter)
     if (iter->second.is_null())
     {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_prepostoperator.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_prepostoperator.hpp
@@ -48,7 +48,7 @@ namespace NOX
       class PrePostOperator
       {
        public:
-        typedef std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>> Map;
+        using Map = std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
 
        private:
         //! Disallow default constructor.

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -670,7 +670,7 @@ const Core::LinAlg::SparseMatrix& NOX::Nln::LinearSystem::get_jacobian_block(
   {
     case LinSystem::LinalgBlockSparseMatrix:
     {
-      typedef Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy> linalg_bsm;
+      using linalg_bsm = Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>;
       const linalg_bsm& jac_block = dynamic_cast<const linalg_bsm&>(jacobian());
 
       if (rbid >= static_cast<unsigned>(jac_block.rows()) or
@@ -848,8 +848,8 @@ void NOX::Nln::LinearSystem::convert_jacobian_to_dense_matrix(
   {
     case NOX::Nln::LinSystem::LinalgBlockSparseMatrix:
     {
-      typedef Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>
-          linalg_blocksparsematrix;
+      using linalg_blocksparsematrix =
+          Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>;
       const linalg_blocksparsematrix& block_sparse =
           dynamic_cast<const linalg_blocksparsematrix&>(jacobian());
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -49,7 +49,7 @@ namespace NOX
     class LinearSystem : public ::NOX::Epetra::LinearSystem
     {
      public:
-      typedef std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>> SolverMap;
+      using SolverMap = std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>;
 
      protected:
       //! Source of the RowMatrix if using a native preconditioner

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_prepostoperator.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_prepostoperator.hpp
@@ -51,7 +51,7 @@ namespace NOX
       class PrePostOperator
       {
        public:
-        typedef std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>> Map;
+        using Map = std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
 
        private:
         //! Disallow default constructor.

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_prepostoperator.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_prepostoperator.hpp
@@ -30,7 +30,7 @@ namespace NOX
       class PrePostOperator
       {
        public:
-        typedef std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>> map;
+        using map = std::map<enum PrePostOpType, Teuchos::RCP<NOX::Nln::Abstract::PrePostOperator>>;
 
         /// disallow the following
         PrePostOperator() = delete;

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -482,8 +482,8 @@ void Solid::TimeInt::Implicit::check_for_time_step_increase(Inpar::Solid::Conver
 void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
     const NOX::Nln::Group& curr_grp) const
 {
-  typedef Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>
-      LinalgBlockSparseMatrix;
+  using LinalgBlockSparseMatrix =
+      Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>;
 
   if (not get_data_io().is_write_jacobian_to_matlab()) return;
 

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.hpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.hpp
@@ -50,8 +50,8 @@ namespace Solid
     class Factory
     {
      private:
-      typedef std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>
-          LinSolMap;
+      using LinSolMap =
+          std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Core::LinAlg::Solver>>;
 
      public:
       //! constructor

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -77,9 +77,8 @@ namespace Solid
      */
     class Data : public Solid::Elements::ParamsInterface
     {
-      typedef std::map<enum NOX::Nln::StatusTest::QuantityType,
-          enum ::NOX::Abstract::Vector::NormType>
-          quantity_norm_type_map;
+      using quantity_norm_type_map =
+          std::map<enum NOX::Nln::StatusTest::QuantityType, enum ::NOX::Abstract::Vector::NormType>;
 
      public:
       //! constructor

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
@@ -77,9 +77,9 @@ namespace Solid
   class ModelEvaluatorManager
   {
    public:
-    typedef std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Solid::ModelEvaluator::Generic>>
-        Map;
-    typedef std::vector<std::shared_ptr<Solid::ModelEvaluator::Generic>> Vector;
+    using Map =
+        std::map<enum Inpar::Solid::ModelType, std::shared_ptr<Solid::ModelEvaluator::Generic>>;
+    using Vector = std::vector<std::shared_ptr<Solid::ModelEvaluator::Generic>>;
 
     //! constructor
     ModelEvaluatorManager();

--- a/src/timestepping/4C_timestepping_mstep.hpp
+++ b/src/timestepping/4C_timestepping_mstep.hpp
@@ -187,7 +187,7 @@ namespace TimeStepping
   {
    protected:
     //! template base class
-    typedef TimIntMStepBase<STATE> MStepBase;
+    using MStepBase = TimIntMStepBase<STATE>;
 
    public:
     //! @name Life
@@ -279,7 +279,7 @@ namespace TimeStepping
   {
    protected:
     //! base template class
-    typedef TimIntMStepBase<Core::LinAlg::Vector<double>> MStepBase;
+    using MStepBase = TimIntMStepBase<Core::LinAlg::Vector<double>>;
 
    public:
     //! @name Life

--- a/src/w1/4C_w1_poro_p1_scatra.hpp
+++ b/src/w1/4C_w1_poro_p1_scatra.hpp
@@ -32,7 +32,7 @@ namespace Discret
     template <Core::FE::CellType distype>
     class Wall1PoroP1Scatra : public Wall1PoroP1<distype>
     {
-      typedef Discret::Elements::Wall1PoroP1<distype> my;
+      using my = Discret::Elements::Wall1PoroP1<distype>;
 
      public:
       //@}

--- a/src/w1/4C_w1_poro_scatra.hpp
+++ b/src/w1/4C_w1_poro_scatra.hpp
@@ -32,7 +32,7 @@ namespace Discret
     template <Core::FE::CellType distype>
     class Wall1PoroScatra : public Wall1Poro<distype>
     {
-      typedef Discret::Elements::Wall1Poro<distype> my;
+      using my = Discret::Elements::Wall1Poro<distype>;
 
      public:
       //@}

--- a/src/xfem/4C_xfem_coupling_base.hpp
+++ b/src/xfem/4C_xfem_coupling_base.hpp
@@ -37,7 +37,7 @@ namespace Discret
 
 namespace XFEM
 {
-  typedef std::pair<Inpar::XFEM::EleCouplingCondType, Core::Conditions::Condition*> EleCoupCond;
+  using EleCoupCond = std::pair<Inpar::XFEM::EleCouplingCondType, Core::Conditions::Condition*>;
 
   Inpar::XFEM::EleCouplingCondType cond_type_string_to_enum(const std::string& condname);
 

--- a/src/xfem/4C_xfem_multi_field_mapextractor.hpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.hpp
@@ -129,7 +129,7 @@ namespace XFEM
    */
   class MultiFieldMapExtractor
   {
-    typedef std::vector<std::shared_ptr<const Core::FE::Discretization>> XDisVec;
+    using XDisVec = std::vector<std::shared_ptr<const Core::FE::Discretization>>;
 
     // number of map extractor types
     static constexpr unsigned NUM_MAP_TYPES = 2;

--- a/tests/cut_test/cut_test_main.cpp
+++ b/tests/cut_test/cut_test_main.cpp
@@ -296,7 +296,7 @@ void test_hex8quad4selfcut92();
 
 void test_hex8quad4aligned_edges();
 
-typedef void (*testfunct)();
+using testfunct = void (*)();
 
 /**
  * \brief Run a given test and store errors if necessary.

--- a/unittests/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_mortar_test.cpp
+++ b/unittests/beaminteraction/4C_beaminteraction_beam_to_solid_volume_meshtying_mortar_test.cpp
@@ -142,9 +142,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex8Line2)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex8 solid_type;
-    typedef GEOMETRYPAIR::t_line2 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex8;
+    using lambda_type = GEOMETRYPAIR::t_line2;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -313,9 +313,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex8Line3)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex8 solid_type;
-    typedef GEOMETRYPAIR::t_line3 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex8;
+    using lambda_type = GEOMETRYPAIR::t_line3;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -523,9 +523,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex8Line4)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex8 solid_type;
-    typedef GEOMETRYPAIR::t_line4 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex8;
+    using lambda_type = GEOMETRYPAIR::t_line4;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -772,9 +772,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex20Line2)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex20 solid_type;
-    typedef GEOMETRYPAIR::t_line2 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex20;
+    using lambda_type = GEOMETRYPAIR::t_line2;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -1051,9 +1051,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex20Line3)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex20 solid_type;
-    typedef GEOMETRYPAIR::t_line3 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex20;
+    using lambda_type = GEOMETRYPAIR::t_line3;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -1405,9 +1405,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex20Line4)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex20 solid_type;
-    typedef GEOMETRYPAIR::t_line4 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex20;
+    using lambda_type = GEOMETRYPAIR::t_line4;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -1834,9 +1834,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex27Line2)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex27 solid_type;
-    typedef GEOMETRYPAIR::t_line2 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex27;
+    using lambda_type = GEOMETRYPAIR::t_line2;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -2176,9 +2176,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex27Line3)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex27 solid_type;
-    typedef GEOMETRYPAIR::t_line3 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex27;
+    using lambda_type = GEOMETRYPAIR::t_line3;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -2614,9 +2614,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Hex27Line4)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex27 solid_type;
-    typedef GEOMETRYPAIR::t_line4 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_hex27;
+    using lambda_type = GEOMETRYPAIR::t_line4;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -3148,9 +3148,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Tet4Line2)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_tet4 solid_type;
-    typedef GEOMETRYPAIR::t_line2 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_tet4;
+    using lambda_type = GEOMETRYPAIR::t_line2;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -3283,9 +3283,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Tet4Line3)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_tet4 solid_type;
-    typedef GEOMETRYPAIR::t_line3 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_tet4;
+    using lambda_type = GEOMETRYPAIR::t_line3;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -3445,9 +3445,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Tet4Line4)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_tet4 solid_type;
-    typedef GEOMETRYPAIR::t_line4 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_tet4;
+    using lambda_type = GEOMETRYPAIR::t_line4;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -3634,9 +3634,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Tet10Line2)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_tet10 solid_type;
-    typedef GEOMETRYPAIR::t_line2 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_tet10;
+    using lambda_type = GEOMETRYPAIR::t_line2;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -3823,9 +3823,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Tet10Line3)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_tet10 solid_type;
-    typedef GEOMETRYPAIR::t_line3 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_tet10;
+    using lambda_type = GEOMETRYPAIR::t_line3;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>
@@ -4057,9 +4057,9 @@ namespace
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2Tet10Line4)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_tet10 solid_type;
-    typedef GEOMETRYPAIR::t_line4 lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_tet10;
+    using lambda_type = GEOMETRYPAIR::t_line4;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>

--- a/unittests/beaminteraction/script/unittest_beam_to_solid_volume_mortar.wls
+++ b/unittests/beaminteraction/script/unittest_beam_to_solid_volume_mortar.wls
@@ -200,9 +200,9 @@ functionStringPre="  /**
   TEST_F(BeamToSolidVolumeMeshtyingPairMortarTest, TestBeamToSolidMeshtyingMortarHermite2mathematica_solid_Typemathematica_mortar_Type)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_mathematica_solid_type solid_type;
-    typedef GEOMETRYPAIR::t_mathematica_mortar_type lambda_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using solid_type = GEOMETRYPAIR::t_mathematica_solid_type;
+    using lambda_type = GEOMETRYPAIR::t_mathematica_mortar_type;
 
     // Create the mesh tying mortar pair.
     BeamInteraction::BeamToSolidVolumeMeshtyingPairMortar<beam_type, solid_type, lambda_type>

--- a/unittests/fbi/4C_beam_to_fluid_meshtying_pair_gauss_point_test.cpp
+++ b/unittests/fbi/4C_beam_to_fluid_meshtying_pair_gauss_point_test.cpp
@@ -167,8 +167,8 @@ namespace
   TEST_F(BeamToFluidMeshtyingPairGPTSTest, TestBeamToFluidMeshtyingHex8MovingBeam)
   {
     // Element types.
-    typedef GEOMETRYPAIR::t_hermite beam_type;
-    typedef GEOMETRYPAIR::t_hex8 fluid_type;
+    using beam_type = GEOMETRYPAIR::t_hermite;
+    using fluid_type = GEOMETRYPAIR::t_hex8;
 
     // Definition of variables for this test case.
     Core::LinAlg::Matrix<beam_type::n_dof_, 1, double> q_beam;


### PR DESCRIPTION
Implements https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases

When `typedef` was used in commented code (a surprising amount of times), I removed the commented code.