### PR TITLE
Some refactoring of the group related methods in nonlinear solvers

### DIFF
--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
@@ -122,7 +122,7 @@ Solid::ModelEvaluator::PartitionedFSI::solve_relaxation_linear(
       const_cast<Solid::Nln::SOLVER::Generic&>(*(ti_impl->get_nln_solver_ptr()));
 
   // get the solution group
-  ::NOX::Abstract::Group& grp = nlnsolver.solution_group();
+  ::NOX::Abstract::Group& grp = nlnsolver.get_solution_group();
   NOX::Nln::Group* grp_ptr = dynamic_cast<NOX::Nln::Group*>(&grp);
   if (grp_ptr == nullptr) FOUR_C_THROW("Dynamic cast failed!");
 

--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
@@ -109,7 +109,7 @@ void Solid::TimeInt::Explicit::evaluate()
 {
   check_init_setup();
   throw_if_state_not_in_sync_with_nox_group();
-  ::NOX::Abstract::Group& grp = nln_solver().solution_group();
+  ::NOX::Abstract::Group& grp = nln_solver().get_solution_group();
 
   auto* grp_ptr = dynamic_cast<NOX::Nln::Group*>(&grp);
   if (grp_ptr == nullptr) FOUR_C_THROW("Dynamic cast failed!");

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -84,7 +84,7 @@ void Solid::TimeInt::Implicit::set_state(const std::shared_ptr<Core::LinAlg::Vec
   integrator_ptr()->set_state(*x);
   ::NOX::Epetra::Vector x_nox(
       Teuchos::rcpFromRef(*x->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
-  nln_solver().solution_group().setX(x_nox);
+  nln_solver().get_solution_group().setX(x_nox);
   set_state_in_sync_with_nox_group(true);
 }
 
@@ -109,7 +109,7 @@ void Solid::TimeInt::Implicit::prepare_time_step()
   double& time_np = data_global_state().get_time_np();
   time_np = data_global_state().get_time_n() + (*data_global_state().get_delta_time())[0]; */
 
-  ::NOX::Abstract::Group& grp = nln_solver().solution_group();
+  ::NOX::Abstract::Group& grp = nln_solver().get_solution_group();
   predictor().predict(grp);
 }
 
@@ -130,7 +130,7 @@ int Solid::TimeInt::Implicit::integrate_step()
 {
   check_init_setup();
   // do the predictor step
-  ::NOX::Abstract::Group& grp = nln_solver().solution_group();
+  ::NOX::Abstract::Group& grp = nln_solver().get_solution_group();
   predictor().predict(grp);
   return solve();
 }
@@ -158,7 +158,7 @@ void Solid::TimeInt::Implicit::update_state_incrementally(
 
   check_init_setup();
   throw_if_state_not_in_sync_with_nox_group();
-  ::NOX::Abstract::Group& grp = nln_solver().solution_group();
+  ::NOX::Abstract::Group& grp = nln_solver().get_solution_group();
 
   auto* grp_ptr = dynamic_cast<NOX::Nln::Group*>(&grp);
   FOUR_C_ASSERT(grp_ptr != nullptr, "Dynamic cast failed!");
@@ -202,7 +202,7 @@ void Solid::TimeInt::Implicit::evaluate()
 {
   check_init_setup();
   throw_if_state_not_in_sync_with_nox_group();
-  ::NOX::Abstract::Group& grp = nln_solver().solution_group();
+  ::NOX::Abstract::Group& grp = nln_solver().get_solution_group();
 
   auto* grp_ptr = dynamic_cast<NOX::Nln::Group*>(&grp);
   FOUR_C_ASSERT(grp_ptr != nullptr, "Dynamic cast failed!");

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -227,14 +227,6 @@ const ::NOX::Abstract::Group& Solid::TimeInt::Implicit::get_solution_group() con
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::shared_ptr<::NOX::Abstract::Group> Solid::TimeInt::Implicit::solution_group_ptr()
-{
-  check_init_setup();
-  return Core::Utils::shared_ptr_from_ref(nln_solver().solution_group());
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 Inpar::Solid::ConvergenceStatus Solid::TimeInt::Implicit::perform_error_action(
     Inpar::Solid::ConvergenceStatus nonlinsoldiv)
 {

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.hpp
@@ -129,9 +129,6 @@ namespace Solid
       //! returns the current solution group
       [[nodiscard]] const ::NOX::Abstract::Group& get_solution_group() const override;
 
-      //! returns the current solution group ptr
-      std::shared_ptr<::NOX::Abstract::Group> solution_group_ptr() override;
-
       Solid::IMPLICIT::Generic& impl_int()
       {
         check_init_setup();

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicitbase.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicitbase.hpp
@@ -88,9 +88,6 @@ namespace Solid
      protected:
       /// Returns the current solution group (pure virtual)
       virtual const ::NOX::Abstract::Group& get_solution_group() const = 0;
-
-      //! Returns the current solution group ptr
-      virtual std::shared_ptr<::NOX::Abstract::Group> solution_group_ptr() = 0;
     };
   }  // namespace TimeInt
 }  // namespace Solid

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.cpp
@@ -61,18 +61,12 @@ Teuchos::RCP<::NOX::Abstract::Group>& Solid::Nln::SOLVER::Generic::group_ptr()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-::NOX::Abstract::Group& Solid::Nln::SOLVER::Generic::group()
-{
-  check_init();
-  FOUR_C_ASSERT(group_ptr_, "The group pointer should be initialized beforehand!");
-  return *group_ptr_;
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 ::NOX::Abstract::Group& Solid::Nln::SOLVER::Generic::get_solution_group()
 {
-  return group();
+  check_init_setup();
+  FOUR_C_ASSERT(group_ptr_, "The group pointer should be initialized beforehand!");
+
+  return *group_ptr_;
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.cpp
@@ -70,7 +70,10 @@ Teuchos::RCP<::NOX::Abstract::Group>& Solid::Nln::SOLVER::Generic::group_ptr()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-::NOX::Abstract::Group& Solid::Nln::SOLVER::Generic::solution_group() { return group(); }
+::NOX::Abstract::Group& Solid::Nln::SOLVER::Generic::get_solution_group()
+{
+  return group();
+}
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.hpp
@@ -81,7 +81,7 @@ namespace Solid
          *
          *  The nox group has to be initialized in one of the derived setup() routines beforehand.
          */
-        ::NOX::Abstract::Group& solution_group();
+        ::NOX::Abstract::Group& get_solution_group();
         const ::NOX::Abstract::Group& get_solution_group() const;
 
         //! Get the number of nonlinear iterations

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.hpp
@@ -188,7 +188,6 @@ namespace Solid
         /*! returns the nox group (pointer) (only for internal use)
          *
          *  The nox group has to be initialized in one of the derived setup() routines. */
-        ::NOX::Abstract::Group& group();
         Teuchos::RCP<::NOX::Abstract::Group>& group_ptr();
 
        protected:

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
@@ -197,9 +197,6 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::solve()
   if (data_sdyn().get_divergence_action() == Inpar::Solid::divcont_stop)
     problem_->check_final_status(finalstatus);
 
-  // copy the solution group into the class variable
-  group() = nlnsolver_->getSolutionGroup();
-
   return convert_final_status(finalstatus);
 }
 

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
@@ -115,9 +115,6 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::SingleStep::solve()
   //// do one non-linear step using solve
   ::NOX::StatusTest::StatusType stepstatus = nlnsolver_->solve();
 
-  // copy the solution group into the class variable
-  group() = nlnsolver_->getSolutionGroup();
-
   integrator().set_state(Core::LinAlg::Vector<double>(x_epetra.getEpetraVector()));
 
   return convert_final_status(stepstatus);

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
@@ -104,9 +104,9 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::SingleStep::solve()
 {
   check_init_setup();
 
-  auto& nln_group = dynamic_cast<NOX::Nln::Group&>(group());
+  auto& nln_group = dynamic_cast<NOX::Nln::Group&>(*group_ptr());
 
-  const auto& x_epetra = dynamic_cast<const ::NOX::Epetra::Vector&>(group().getX());
+  const auto& x_epetra = dynamic_cast<const ::NOX::Epetra::Vector&>(group_ptr()->getX());
 
   nln_group.set_is_valid_newton(true);  // to circumvent the check in ::NOX::Solver::SingleStep
   nln_group.set_is_valid_rhs(false);    // force to compute the RHS


### PR DESCRIPTION
## Description and Context
Some accessor methods were diplicated, some were obsolete. There were also unnecessary copy-to-self calls in the `Solver::NOX` and `Solver::SingleStep`. I have cleaned all this up.

## Related Issues and Pull Requests
#359