### PR TITLE
Add runtime output to 1d arteries

### DIFF
--- a/src/art_net/4C_art_net_explicitintegration.hpp
+++ b/src/art_net/4C_art_net_explicitintegration.hpp
@@ -14,6 +14,7 @@
 #include "4C_art_net_timint.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_io.hpp"
+#include "4C_io_discretization_visualization_writer_mesh.hpp"
 #include "4C_linalg_mapextractor.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 #include "4C_linalg_vector.hpp"
@@ -101,6 +102,10 @@ namespace Arteries
 
     */
     void output(bool CoupledTo3D, std::shared_ptr<Teuchos::ParameterList> CouplingParams) override;
+
+    void output_restart(bool CoupledTo3D, int step);
+
+    void collect_runtime_output_data(bool CoupledTo3D, int step);
 
     /*!
     \brief Test results
@@ -261,6 +266,9 @@ namespace Arteries
     //! @name 1D artery values at the junctions
     std::shared_ptr<std::map<const int, std::shared_ptr<Arteries::Utils::JunctionNodeParams>>>
         junc_nodal_vals_;
+
+   private:
+    std::unique_ptr<Core::IO::DiscretizationVisualizationWriterMesh> visualization_writer_{nullptr};
     //@}
 
     //@}


### PR DESCRIPTION
## Description and Context
This pr enables the vtk-based output in the 1D artery elements
The old output mechanism was deleted. At least as far as I have seen, it has only output the owner so far. Maybe I miss something. To check the new output, the variables were temporarily added to the `4C_post_processor_single_field_writer.cpp`.

