### PR TITLE
[structure] Debug time adaptivity with joint explicit

### DIFF
--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -292,6 +292,13 @@ bool NOX::Nln::LinearSystem::applyJacobianInverse(Teuchos::ParameterList& linear
   // Zero out the delta X of the linear problem if requested by user.
   if (zeroInitialGuess_) result.init(0.0);
 
+  // solve the linear system
+  if (jacobian().NormInf() == 0.0)
+  {
+    std::cout << "WARNING: You are about to invert a singular matrix! Skipping linear solve ...";
+    return true;
+  }
+
   // Create Epetra linear problem object for the linear solve
   /* Note: We switch from LINALG_objects to pure Epetra_objects.
    * This is necessary for the linear solver.


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Using the new structure time integration with time adaptivity based on the joint explicit scheme results in a singular system matrix consisting of only zeros for the explicit time integration scheme. This PR serves for debugging and discussion purpose.

There are several open questions to me:
- Why is the system matrix for the explicit time integrator zero and thus singular? (see #711)
- Why do we even need to solve a linear system for the explicit time integrator in the first place (and especially in the lumped mass matrix case)? (explanation given in #683)
- Why do we funnel things through the NOX single step class for the explicit time integration case? (explanation given in #683)
- It seems like the linear solve, correct mass matrix usage etc. doesn't has an influence on the values generated by the auxiliary time integrator and thus the error estimation if a time step is accepted or not.

The current implementation has a bad taste to it ... not only is it actively throwing errors but not stopping it also seems to be a nice feature with a once again hacky vibe to it.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #683 