### PR TITLE
[Epetra] Remove unused includes

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d.hpp
@@ -16,10 +16,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_FECrsMatrix.h>
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/cardiovascular0d/4C_cardiovascular0d_4elementwindkessel.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_4elementwindkessel.hpp
@@ -17,10 +17,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_FECrsMatrix.h>
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/cardiovascular0d/4C_cardiovascular0d_arterialproxdist.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_arterialproxdist.hpp
@@ -16,10 +16,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_FECrsMatrix.h>
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.hpp
@@ -15,8 +15,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
 #include <Teuchos_ParameterList.hpp>
 
 #include <memory>
@@ -157,7 +155,7 @@ namespace Utils
     }
 
     /*!
-     \brief Return EpetraMap that determined distribution of Cardiovascular0D functions and
+     \brief Return map that determined distribution of Cardiovascular0D functions and
      pressures over processors
     */
     std::shared_ptr<Core::LinAlg::Map> get_cardiovascular0_d_map() const

--- a/src/cardiovascular0d/4C_cardiovascular0d_respiratory_syspulperiphcirculation.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_respiratory_syspulperiphcirculation.hpp
@@ -16,10 +16,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_FECrsMatrix.h>
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/cardiovascular0d/4C_cardiovascular0d_syspulcirculation.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_syspulcirculation.hpp
@@ -16,10 +16,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_FECrsMatrix.h>
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/constraint/4C_constraint_manager.hpp
+++ b/src/constraint/4C_constraint_manager.hpp
@@ -14,9 +14,6 @@
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN
@@ -166,7 +163,7 @@ namespace CONSTRAINTS
     std::shared_ptr<Core::LinAlg::Vector<double>> get_error() const { return constrainterr_; }
 
     /*!
-     \brief Return EpetraMap that determined distribution of constraints and lagrange
+     \brief Return map that determined distribution of constraints and lagrange
      multiplier over processors
     */
     std::shared_ptr<Core::LinAlg::Map> get_constraint_map() const { return constrmap_; };

--- a/src/constraint/4C_constraint_penalty.hpp
+++ b/src/constraint/4C_constraint_penalty.hpp
@@ -14,8 +14,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_Operator.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/constraint/4C_constraint_solver.hpp
+++ b/src/constraint/4C_constraint_solver.hpp
@@ -14,9 +14,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/constraint/4C_constraint_springdashpot_manager.hpp
+++ b/src/constraint/4C_constraint_springdashpot_manager.hpp
@@ -13,9 +13,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_Operator.h>
-#include <Epetra_RowMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/contact/4C_contact_nitsche_utils.cpp
+++ b/src/contact/4C_contact_nitsche_utils.cpp
@@ -7,8 +7,6 @@
 
 #include "4C_contact_nitsche_utils.hpp"
 
-#include <Epetra_FECrsMatrix.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/fem/src/general/utils/4C_fem_general_extract_values.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_extract_values.cpp
@@ -13,8 +13,6 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_FEVector.h>
-
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -18,7 +18,6 @@
 #include "4C_utils_exceptions.hpp"
 
 #include <Epetra_Import.h>
-#include <Epetra_Operator.h>
 #include <Teuchos_SerialDenseSolver.hpp>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.hpp
@@ -12,8 +12,6 @@
 
 #include "4C_linalg_multi_vector.hpp"
 
-#include <Epetra_BlockMap.h>
-
 #include <memory>
 #include <vector>
 

--- a/src/core/linalg/src/sparse/4C_linalg_projected_precond.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_projected_precond.hpp
@@ -14,7 +14,6 @@
 #include "4C_comm_mpi_utils.hpp"
 
 #include <Epetra_Operator.h>
-#include <mpi.h>
 
 #include <memory>
 

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrixbase.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrixbase.hpp
@@ -13,7 +13,6 @@
 #include "4C_linalg_sparseoperator.hpp"
 
 #include <Epetra_CrsMatrix.h>
-#include <Epetra_FECrsMatrix.h>
 
 #include <optional>
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
@@ -12,14 +12,11 @@
 
 #include "4C_fem_dofset_interface.hpp"
 #include "4C_linalg_blocksparsematrix.hpp"
-#include "4C_linalg_graph.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 #include <Epetra_CrsMatrix.h>
-#include <Epetra_Export.h>
-#include <Epetra_Import.h>
 
 #include <memory>
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.hpp
@@ -17,8 +17,6 @@
 #include "4C_linalg_serialdensematrix.hpp"
 
 #include <Epetra_CrsMatrix.h>
-#include <Epetra_Export.h>
-#include <Epetra_Import.h>
 
 #include <memory>
 

--- a/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
@@ -10,15 +10,11 @@
 #include "4C_linalg_vector.hpp"
 
 #include "4C_comm_mpi_utils.hpp"
+#include "4C_linalg_map.hpp"
 #include "4C_linalg_multi_vector.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 
 #include <Epetra_Map.h>
-
-
-
-// Epetra related headers
-#include "4C_linalg_map.hpp"
 
 #include <memory>
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -15,8 +15,6 @@
 #include "4C_utils_enum.hpp"
 
 #include <BelosTypes.hpp>  // for Belos verbosity codes
-#include <Epetra_LinearProblem.h>
-#include <ml_MultiLevelPreconditioner.h>  // includes for ML parameter list validation
 #include <Teuchos_ParameterList.hpp>
 #include <Teuchos_StandardParameterEntryValidators.hpp>
 #include <Teuchos_TimeMonitor.hpp>

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.hpp
@@ -14,7 +14,6 @@
 #include "4C_linalg_vector.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_LinearProblem.h>
 #include <Epetra_Operator.h>
 #include <Teuchos_ParameterList.hpp>
 

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
@@ -10,13 +10,8 @@
 
 #include "4C_config.hpp"
 
-#include "4C_linalg_graph.hpp"
-#include "4C_linalg_map.hpp"
 #include "4C_linalg_vector.hpp"
-#include "4C_utils_parameter_list.fwd.hpp"
 
-#include <Epetra_CrsMatrix.h>
-#include <Epetra_LinearProblem.h>
 #include <Epetra_Operator.h>
 
 #include <memory>

--- a/src/ehl/4C_ehl_monolithic.hpp
+++ b/src/ehl/4C_ehl_monolithic.hpp
@@ -19,7 +19,6 @@
 #include "4C_inpar_structure.hpp"
 #include "4C_lubrication_input.hpp"
 
-#include <Epetra_FEVector.h>
 #include <Teuchos_Time.hpp>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -15,7 +15,6 @@
 #include "4C_linear_solver_method_linalg.hpp"
 
 #include <Epetra_CrsMatrix.h>
-#include <Epetra_LinearProblem.h>
 #include <Epetra_Operator.h>
 #include <Epetra_RowMatrix.h>
 #include <Epetra_VbrMatrix.h>

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
@@ -10,11 +10,9 @@
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_vector.hpp"
 
-#include <Epetra_RowMatrix.h>
 #include <NOX_Abstract_Group.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Vector.H>
-#include <NOX_Epetra_VectorSpace.H>
 #include <NOX_Utils.H>
 
 #include <iostream>

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
@@ -10,11 +10,8 @@
 
 #include "4C_config.hpp"
 
-#include <Epetra_Import.h>
 #include <Epetra_Operator.h>
-#include <mpi.h>
 #include <NOX_Abstract_Group.H>
-#include <NOX_Common.H>
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Vector.H>

--- a/src/mixture/4C_mixture_rule_function.cpp
+++ b/src/mixture/4C_mixture_rule_function.cpp
@@ -13,8 +13,6 @@
 #include "4C_mixture_constituent.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_ConfigDefs.h>
-
 #include <algorithm>
 #include <iosfwd>
 #include <memory>

--- a/src/mixture/4C_mixture_rule_growthremodel.cpp
+++ b/src/mixture/4C_mixture_rule_growthremodel.cpp
@@ -14,7 +14,6 @@
 #include "4C_mixture_growth_strategy.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_ConfigDefs.h>
 #include <Teuchos_ParameterList.hpp>
 
 #include <algorithm>

--- a/src/mixture/4C_mixture_rule_map.cpp
+++ b/src/mixture/4C_mixture_rule_map.cpp
@@ -13,8 +13,6 @@
 #include "4C_mixture_constituent.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_ConfigDefs.h>
-
 #include <algorithm>
 #include <iosfwd>
 #include <memory>

--- a/src/mixture/4C_mixture_rule_simple.cpp
+++ b/src/mixture/4C_mixture_rule_simple.cpp
@@ -12,8 +12,6 @@
 #include "4C_mixture_constituent.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_ConfigDefs.h>
-
 #include <algorithm>
 #include <iosfwd>
 #include <memory>

--- a/src/mortar/4C_mortar_matrix_transform.cpp
+++ b/src/mortar/4C_mortar_matrix_transform.cpp
@@ -9,7 +9,6 @@
 
 #include "4C_linalg_sparsematrix.hpp"
 
-#include <Epetra_Distributor.h>
 #include <Epetra_Export.h>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/mortar/4C_mortar_utils.hpp
+++ b/src/mortar/4C_mortar_utils.hpp
@@ -15,8 +15,6 @@
 #include "4C_mortar_coupling3d_classes.hpp"
 
 #include <Epetra_CrsMatrix.h>
-#include <Epetra_Export.h>
-#include <Epetra_Import.h>
 
 #include <memory>
 

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
@@ -27,8 +27,6 @@
 #include "4C_w1_poro_p1_scatra_eletypes.hpp"
 #include "4C_w1_poro_scatra_eletypes.hpp"
 
-#include <Epetra_Time.h>
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
@@ -21,14 +21,10 @@
 #include "4C_solver_nonlin_nox_linearsystem_factory.hpp"
 #include "4C_solver_nonlin_nox_singlestep_group.hpp"
 
-#include <Epetra_Operator.h>
-#include <NOX_Epetra_Interface_Jacobian.H>
-#include <NOX_Epetra_Interface_Preconditioner.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_StatusTest_Generic.H>
-#include <NOX_Utils.H>
 #include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -25,8 +25,6 @@
 #include "4C_structure_aux.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <Epetra_LinearProblem.h>
-
 FOUR_C_NAMESPACE_OPEN
 
 


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR removes a bunch of `Epetra` related includes. Now the remaining includes reflect the work done so far way better. `Epetra` objects left over in the physics are mostly related to:
- `Epetra_FEVector`
- `Epetra_FEGraph`
- `Epetra_CrsMatrix`
- `Epetra_Import`
- `Epetra_Export`

which matches the list related to linear algebra objects listed in #189.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #189.