### PR TITLE
Remove Epetra related variable naming and old comments

### DIFF
--- a/src/ale/4C_ale_ale3.hpp
+++ b/src/ale/4C_ale_ale3.hpp
@@ -404,20 +404,23 @@ namespace Discret
                                            ///< configuration (false)
           ) = 0;
 
-      virtual void static_ke_nonlinear(Ale3* ele,     ///< pointer to element
-          Core::FE::Discretization& discretization,   ///< discretization
-          std::vector<int>& lm,                       ///< node owner procs
-          Core::LinAlg::SerialDenseMatrix& sys_mat,   ///< element stiffness matrix (to be filled)
-          Core::LinAlg::SerialDenseVector& residual,  ///< element residual vector (to be filled)
-          std::vector<double>& my_dispnp,             ///< nodal displacements
-          Teuchos::ParameterList& params,             ///< parameter list
+      virtual void static_ke_nonlinear(Ale3* ele,    ///< pointer to element
+          Core::FE::Discretization& discretization,  ///< discretization
+          std::vector<int>& lm,                      ///< node owner procs
+          Core::LinAlg::SerialDenseMatrix&
+              element_matrix,  ///< element stiffness matrix (to be filled)
+          Core::LinAlg::SerialDenseVector&
+              element_residual,            ///< element residual vector (to be filled)
+          std::vector<double>& my_dispnp,  ///< nodal displacements
+          Teuchos::ParameterList& params,  ///< parameter list
           const bool spatialconfiguration  ///< use spatial configuration (true), material
                                            ///< configuration (false)
           ) = 0;
 
-      virtual void static_ke_laplace(Ale3* ele,       ///< pointer to element
-          Core::FE::Discretization& dis,              ///< discretization
-          Core::LinAlg::SerialDenseMatrix& sys_mat,   ///< element stiffnes matrix (to be filled)
+      virtual void static_ke_laplace(Ale3* ele,  ///< pointer to element
+          Core::FE::Discretization& dis,         ///< discretization
+          Core::LinAlg::SerialDenseMatrix&
+              element_matrix,                         ///< element stiffnes matrix (to be filled)
           Core::LinAlg::SerialDenseVector& residual,  ///< element residual vector (to be filled)
           std::vector<double>& my_dispnp,             ///< nodal displacements
           std::shared_ptr<Core::Mat::Material> material,  ///< material law
@@ -437,9 +440,10 @@ namespace Discret
       static Ale3Impl<distype>* instance(
           Core::Utils::SingletonAction action = Core::Utils::SingletonAction::create);
 
-      void static_ke_laplace(Ale3* ele,               ///< pointer to element
-          Core::FE::Discretization& dis,              ///< discretization
-          Core::LinAlg::SerialDenseMatrix& sys_mat,   ///< element stiffnes matrix (to be filled)
+      void static_ke_laplace(Ale3* ele,   ///< pointer to element
+          Core::FE::Discretization& dis,  ///< discretization
+          Core::LinAlg::SerialDenseMatrix&
+              element_matrix,                         ///< element stiffnes matrix (to be filled)
           Core::LinAlg::SerialDenseVector& residual,  ///< element residual vector (to be filled)
           std::vector<double>& my_dispnp,             ///< nodal displacements
           std::shared_ptr<Core::Mat::Material> material,  ///< material law
@@ -449,21 +453,23 @@ namespace Discret
 
       void static_ke_spring(Ale3* ele,  ///< pointer to element
           Core::LinAlg::SerialDenseMatrix&
-              sys_mat_epetra,  ///< element stiffness matrix (to be filled)
+              element_matrix,  ///< element stiffness matrix (to be filled)
           Core::LinAlg::SerialDenseVector&
-              residual_epetra,                       ///< element residual vector (to be filled)
+              element_residual,                      ///< element residual vector (to be filled)
           const std::vector<double>& displacements,  ///< nodal displacements
           const bool spatialconfiguration            ///< use spatial configuration (true), material
                                                      ///< configuration (false)
           ) override;
 
-      void static_ke_nonlinear(Ale3* ele,             ///< pointer to element
-          Core::FE::Discretization& discretization,   ///< discretization
-          std::vector<int>& lm,                       ///< node owner procs
-          Core::LinAlg::SerialDenseMatrix& sys_mat,   ///< element stiffness matrix (to be filled)
-          Core::LinAlg::SerialDenseVector& residual,  ///< element residual vector (to be filled)
-          std::vector<double>& my_dispnp,             ///< nodal displacements
-          Teuchos::ParameterList& params,             ///< parameter list
+      void static_ke_nonlinear(Ale3* ele,            ///< pointer to element
+          Core::FE::Discretization& discretization,  ///< discretization
+          std::vector<int>& lm,                      ///< node owner procs
+          Core::LinAlg::SerialDenseMatrix&
+              element_matrix,  ///< element stiffness matrix (to be filled)
+          Core::LinAlg::SerialDenseVector&
+              element_residual,            ///< element residual vector (to be filled)
+          std::vector<double>& my_dispnp,  ///< nodal displacements
+          Teuchos::ParameterList& params,  ///< parameter list
           const bool spatialconfiguration  ///< use spatial configuration (true), material
                                            ///< configuration (false)
           ) override;

--- a/src/ale/4C_ale_ale3_evaluate.cpp
+++ b/src/ale/4C_ale_ale3_evaluate.cpp
@@ -911,12 +911,12 @@ inline void Discret::Elements::Ale3Impl<distype>::ale3_tors_spring_nurbs27(
 /*----------------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 void Discret::Elements::Ale3Impl<distype>::static_ke_spring(Ale3* ele,
-    Core::LinAlg::SerialDenseMatrix& sys_mat_epetra,
-    Core::LinAlg::SerialDenseVector& residual_epetra, const std::vector<double>& displacements,
+    Core::LinAlg::SerialDenseMatrix& element_matrix,
+    Core::LinAlg::SerialDenseVector& element_residual, const std::vector<double>& displacements,
     const bool spatialconfiguration)
 {
-  Core::LinAlg::Matrix<3 * iel, 3 * iel> sys_mat(sys_mat_epetra.values(), true);
-  Core::LinAlg::Matrix<3 * iel, 1> residual(residual_epetra.values(), true);
+  Core::LinAlg::Matrix<3 * iel, 3 * iel> sys_mat(element_matrix.values(), true);
+  Core::LinAlg::Matrix<3 * iel, 1> residual(element_residual.values(), true);
   int node_i, node_j;  // end nodes of spring
   double length;       // length of edge
   double dx, dy, dz;   // deltas in each direction
@@ -1347,13 +1347,12 @@ void Discret::Elements::Ale3Impl<distype>::static_ke_spring(Ale3* ele,
 template <Core::FE::CellType distype>
 void Discret::Elements::Ale3Impl<distype>::static_ke_nonlinear(Ale3* ele,
     Core::FE::Discretization& dis, std::vector<int>& lm,
-    Core::LinAlg::SerialDenseMatrix& sys_mat_epetra,
-    Core::LinAlg::SerialDenseVector& residual_epetra, std::vector<double>& my_dispnp,
+    Core::LinAlg::SerialDenseMatrix& element_matrix,
+    Core::LinAlg::SerialDenseVector& element_residual, std::vector<double>& my_dispnp,
     Teuchos::ParameterList& params, const bool spatialconfiguration)
 {
   const int numdof = NODDOF_ALE3 * iel;
-  // A view to sys_mat_epetra
-  Core::LinAlg::Matrix<numdof, numdof> sys_mat(sys_mat_epetra.values(), true);
+  Core::LinAlg::Matrix<numdof, numdof> sys_mat(element_matrix.values(), true);
   // update element geometry
   Core::LinAlg::Matrix<iel, NUMDIM_ALE3> xrefe;  // material coord. of element
   Core::LinAlg::Matrix<iel, NUMDIM_ALE3> xcurr;  // current  coord. of element
@@ -1530,7 +1529,7 @@ void Discret::Elements::Ale3Impl<distype>::static_ke_nonlinear(Ale3* ele,
     // end of call material law ccccccccccccccccccccccccccccccccccccccccccccccc
 
     // integrate internal force vector f = f + (B^T . sigma) * detJ * w(gp)
-    Core::LinAlg::Matrix<numdof, 1> residual(residual_epetra, true);
+    Core::LinAlg::Matrix<numdof, 1> residual(element_residual, true);
     residual.multiply_tn(detJ * intpoints.qwgt[iquad], bop, stress_f, 1.0);
 
     // integrate `elastic' and `initial-displacement' stiffness matrix
@@ -1570,7 +1569,7 @@ void Discret::Elements::Ale3Impl<distype>::static_ke_nonlinear(Ale3* ele,
 /*----------------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 void Discret::Elements::Ale3Impl<distype>::static_ke_laplace(Ale3* ele,
-    Core::FE::Discretization& dis, Core::LinAlg::SerialDenseMatrix& sys_mat_epetra,
+    Core::FE::Discretization& dis, Core::LinAlg::SerialDenseMatrix& element_matrix,
     Core::LinAlg::SerialDenseVector& residual, std::vector<double>& my_dispnp,
     std::shared_ptr<Core::Mat::Material> material, const bool spatialconfiguration)
 {
@@ -1579,8 +1578,7 @@ void Discret::Elements::Ale3Impl<distype>::static_ke_laplace(Ale3* ele,
   //      "using it.");
 
   const int nd = 3 * iel;
-  // A view to sys_mat_epetra
-  Core::LinAlg::Matrix<nd, nd> sys_mat(sys_mat_epetra.values(), true);
+  Core::LinAlg::Matrix<nd, nd> sys_mat(element_matrix.values(), true);
 
   //  get material using class StVenantKirchhoff
   //  if (material->material_type()!=Core::Materials::m_stvenant)

--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
@@ -67,18 +67,17 @@ Discret::Elements::ArteryEleCalcLinExp<distype>::instance(
 template <Core::FE::CellType distype>
 int Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate(Artery* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+    std::shared_ptr<Core::Mat::Material> mat)
 {
   // the number of nodes
   const int numnode = my::iel_;
 
   // construct views
-  Core::LinAlg::Matrix<2 * my::iel_, 2 * my::iel_> elemat1(elemat1_epetra.values(), true);
-  Core::LinAlg::Matrix<2 * my::iel_, 1> elevec1(elevec1_epetra.values(), true);
+  Core::LinAlg::Matrix<2 * my::iel_, 2 * my::iel_> elemat_1(elemat1.values(), true);
+  Core::LinAlg::Matrix<2 * my::iel_, 1> elevec_1(elevec1.values(), true);
   // elemat2, elevec2, and elevec3 are never used anyway
 
   //----------------------------------------------------------------------
@@ -122,7 +121,7 @@ int Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate(Artery* ele,
   // ---------------------------------------------------------------------
   // call routine for calculating element matrix and right hand side
   // ---------------------------------------------------------------------
-  sysmat(ele, eqnp, eareanp, elemat1, elevec1, mat, dt);
+  sysmat(ele, eqnp, eareanp, elemat_1, elevec_1, mat, dt);
 
 
   return 0;
@@ -133,11 +132,9 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate_service(Artery* ele,
     const Arteries::Action action, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
   switch (action)
   {
@@ -191,18 +188,16 @@ int Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate_service(Artery* el
 template <Core::FE::CellType distype>
 int Discret::Elements::ArteryEleCalcLinExp<distype>::scatra_evaluate(Artery* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization, std::vector<int>& lm,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
   // the number of nodes
   const int numnode = my::iel_;
 
   // construct views
-  Core::LinAlg::Matrix<2 * my::iel_, 2 * my::iel_> elemat1(elemat1_epetra.values(), true);
-  Core::LinAlg::Matrix<2 * my::iel_, 1> elevec1(elevec1_epetra.values(), true);
+  Core::LinAlg::Matrix<2 * my::iel_, 2 * my::iel_> elemat_1(elemat1.values(), true);
+  Core::LinAlg::Matrix<2 * my::iel_, 1> elevec_1(elevec1.values(), true);
   // elemat2, elevec2, and elevec3 are never used anyway
 
   //----------------------------------------------------------------------
@@ -275,7 +270,7 @@ int Discret::Elements::ArteryEleCalcLinExp<distype>::scatra_evaluate(Artery* ele
   }
 
   // call routine for calculating element matrix and right hand side
-  scatra_sysmat(ele, escatran, ewfnp, ewbnp, eareanp, earean, elemat1, elevec1, *mat, dt);
+  scatra_sysmat(ele, escatran, ewfnp, ewbnp, eareanp, earean, elemat_1, elevec_1, *mat, dt);
   return 0;
 }
 

--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.hpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.hpp
@@ -49,29 +49,23 @@ namespace Discret
 
       int evaluate(Artery* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       int scatra_evaluate(Artery* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       int evaluate_service(Artery* ele, const Arteries::Action action,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       /*!

--- a/src/art_net/4C_art_net_artery_ele_calc_pres_based.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_pres_based.cpp
@@ -57,23 +57,22 @@ Discret::Elements::ArteryEleCalcPresBased<distype>::instance(
 template <Core::FE::CellType distype>
 int Discret::Elements::ArteryEleCalcPresBased<distype>::evaluate(Artery* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+    std::shared_ptr<Core::Mat::Material> mat)
 {
   // the number of nodes
   const int numnode = my::iel_;
 
   // construct views
-  Core::LinAlg::Matrix<numnode, numnode> elemat1(elemat1_epetra.values(), true);
-  Core::LinAlg::Matrix<numnode, 1> elevec1(elevec1_epetra.values(), true);
+  Core::LinAlg::Matrix<numnode, numnode> elemat_1(elemat1.values(), true);
+  Core::LinAlg::Matrix<numnode, 1> elevec_1(elevec1.values(), true);
 
   // ---------------------------------------------------------------------
   // call routine for calculating element matrix and right hand side
   // ---------------------------------------------------------------------
-  sysmat(ele, discretization, la, elemat1, elevec1, mat);
+  sysmat(ele, discretization, la, elemat_1, elevec_1, mat);
 
   return 0;
 }
@@ -84,16 +83,14 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ArteryEleCalcPresBased<distype>::evaluate_service(Artery* ele,
     const Arteries::Action action, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
   switch (action)
   {
     case Arteries::calc_flow_pressurebased:
-      evaluate_flow(ele, discretization, la, elevec1_epetra, mat);
+      evaluate_flow(ele, discretization, la, elevec1, mat);
       break;
     default:
       FOUR_C_THROW("Unknown type of action {} for Artery (PressureBased formulation)", action);
@@ -105,11 +102,9 @@ int Discret::Elements::ArteryEleCalcPresBased<distype>::evaluate_service(Artery*
 template <Core::FE::CellType distype>
 int Discret::Elements::ArteryEleCalcPresBased<distype>::scatra_evaluate(Artery* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization, std::vector<int>& lm,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
   FOUR_C_THROW(
       "not implemented by pressure-based formulation, should be done by cloned "

--- a/src/art_net/4C_art_net_artery_ele_calc_pres_based.hpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_pres_based.hpp
@@ -49,29 +49,23 @@ namespace Discret
 
       int evaluate(Artery* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       int scatra_evaluate(Artery* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       int evaluate_service(Artery* ele, const Arteries::Action action,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
 

--- a/src/art_net/4C_art_net_artery_ele_interface.hpp
+++ b/src/art_net/4C_art_net_artery_ele_interface.hpp
@@ -50,32 +50,24 @@ namespace Discret
       //! evaluate the element
       virtual int evaluate(Artery* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       //! evaluate service (other quantities apart from rhs and matrix)
       virtual int evaluate_service(Artery* ele, const Arteries::Action action,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       //! evaluate scalar transport (only lin-exp formulation uses this)
       virtual int scatra_evaluate(Artery* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat) = 0;
     };
   }  // namespace Elements
 }  // namespace Discret

--- a/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
@@ -929,7 +929,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
 
         R_bending.scale(EI * wgt / std::pow(jacobi_, 3));
 
-        // shifting values from fixed size matrix to epetra matrix *stiffmatrix
+        // shifting values from fixed size matrix to flexible size matrix *stiffmatrix
         for (int i = 0; i < dofpn * nnode; i++)
         {
           for (int j = 0; j < dofpn * nnode; j++)
@@ -971,7 +971,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
         Res_bending.scale(EI * wgt);
         Res_tension.scale(EA * wgt);
 
-        // shifting values from fixed size vector to epetra vector *force
+        // shifting values from fixed size vector to flexible size vector *force
         for (int i = 0; i < dofpn * nnode; i++)
         {
 #ifndef ANS_BEAM3EB
@@ -1276,7 +1276,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
 #ifdef SWITCHINEXTENSIBLEON
     if (force != nullptr)
     {
-      // shifting values from fixed size vector to epetra vector *force
+      // shifting values from fixed size vector to flexible size vector *force
       for (int i = 0; i < 15; i++)
       {
         (*force)(i) += Res_inextensibility(i).val();
@@ -1582,7 +1582,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
         R_bending.scale(EI * wgt / jacobi_);
 
 #ifndef INEXTENSIBLE
-        // shifting values from fixed size matrix to epetra matrix *stiffmatrix
+        // shifting values from fixed size matrix to flexible size matrix *stiffmatrix
         for (int i = 0; i < dofpn * nnode; i++)
         {
           for (int j = 0; j < dofpn * nnode; j++)
@@ -1599,7 +1599,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
           }
         }  // for(int i = 0; i < dofpn*nnode; i++)
 #else
-        // shifting values from fixed size matrix to epetra matrix *stiffmatrix
+        // shifting values from fixed size matrix to flexible size matrix *stiffmatrix
         int i1 = 0;
         int j1 = 0;
         for (int i = 0; i < 12; i++)
@@ -1663,7 +1663,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
         Res_tension.scale(EA * wgt);
 
 #ifndef INEXTENSIBLE
-        // shifting values from fixed size vector to epetra vector *force
+        // shifting values from fixed size vector to flexible size vector *force
         for (int i = 0; i < dofpn * nnode; i++)
         {
 #ifndef ANS_BEAM3EB
@@ -1678,7 +1678,7 @@ void Discret::Elements::Beam3eb::calc_internal_and_inertia_forces_and_stiff(
         }
 #else
         int i1 = 0;
-        // shifting values from fixed size vector to epetra vector *force
+        // shifting values from fixed size vector to flexible size vector *force
         for (int i = 0; i < dofpn * nnode; i++)
         {
           if (i < 6)
@@ -2084,7 +2084,7 @@ void Discret::Elements::Beam3eb::evaluate_stochastic_forces(
   Core::LinAlg::Matrix<3, 1> gamma(Core::LinAlg::Initialization::zero);
   get_damping_coefficients(gamma);
 
-  /*get pointer at Epetra multivector in parameter list linking to random numbers for stochastic
+  /*get pointer at multivector in parameter list linking to random numbers for stochastic
    * forces with zero mean and standard deviation (2*kT / dt)^0.5; note carefully: a space between
    * the two subsequal ">" signs is mandatory for the C++ parser in order to avoid confusion with
    * ">>" for streams*/

--- a/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
+++ b/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
@@ -3027,7 +3027,7 @@ void Discret::Elements::Beam3k::evaluate_stochastic_forces(
   Core::LinAlg::Matrix<3, 1> gamma(Core::LinAlg::Initialization::zero);
   get_damping_coefficients(gamma);
 
-  /* get pointer at Epetra multivector in parameter list linking to random numbers for stochastic
+  /* get pointer at multivector in parameter list linking to random numbers for stochastic
    * forces with zero mean and standard deviation (2*kT / dt)^0.5 */
   std::shared_ptr<Core::LinAlg::MultiVector<double>> randomforces =
       brownian_dyn_params_interface().get_random_forces();

--- a/src/beam3/4C_beam3_reissner_evaluate.cpp
+++ b/src/beam3/4C_beam3_reissner_evaluate.cpp
@@ -2684,7 +2684,7 @@ void Discret::Elements::Beam3r::evaluate_stochastic_forces(Teuchos::ParameterLis
   get_damping_coefficients(sqrt_gamma);
   for (unsigned int i = 0; i < 2; ++i) sqrt_gamma(i) = std::sqrt(sqrt_gamma(i));
 
-  /* get pointer at Epetra multivector in parameter list linking to random numbers for stochastic
+  /* get pointer at multivector in parameter list linking to random numbers for stochastic
    * forces with zero mean and standard deviation (2*kT / dt)^0.5 */
   std::shared_ptr<Core::LinAlg::MultiVector<double>> randomforces =
       brownian_dyn_params_interface().get_random_forces();

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -989,7 +989,7 @@ bool Beam3ContactOctTree::locate_all()
   bbox2octant_ = std::make_shared<Core::LinAlg::MultiVector<double>>(
       *(searchdis_.element_col_map()), maxnumoctglobal, true);
 
-  // fill epetra vector
+  // fill vector
   if (!Core::Communication::my_mpi_rank(searchdis_.get_comm()))
   {
     bbox2octant_->PutScalar(-9.0);

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.hpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.hpp
@@ -195,40 +195,40 @@ class Beam3ContactOctTree
   //! \brief translate std::vec<std::vec<type> > > to Core::LinAlg::MultiVector<double>
   template <class TYPE>
   void std_vec_to_epetra_multi_vec(
-      std::vector<std::vector<TYPE>>& stdvec, Core::LinAlg::MultiVector<double>& epetravec)
+      std::vector<std::vector<TYPE>>& stdvector, Core::LinAlg::MultiVector<double>& vector)
   {
     if (std::strcmp(typeid(TYPE).name(), "i") != 0 && std::strcmp(typeid(TYPE).name(), "f") != 0 &&
         std::strcmp(typeid(TYPE).name(), "d") != 0)
       FOUR_C_THROW("Template of wrong type {}! Only int, float, and double are permitted!",
           typeid(TYPE).name());
-    if (epetravec.MyLength() != (int)stdvec.size()) FOUR_C_THROW("Sizes differ!");
-    for (int i = 0; i < (int)stdvec.size(); i++)
+    if (vector.MyLength() != (int)stdvector.size()) FOUR_C_THROW("Sizes differ!");
+    for (int i = 0; i < (int)stdvector.size(); i++)
     {
-      if ((int)stdvec[i].size() > epetravec.NumVectors())
-        FOUR_C_THROW("stdvec[{}].size() = {} is larger than epetravec.NumVectors() = {}", i,
-            (int)stdvec[i].size(), epetravec.NumVectors());
-      for (int j = 0; j < (int)stdvec[i].size(); j++) epetravec(j)[i] = (TYPE)stdvec[i][j];
+      if ((int)stdvector[i].size() > vector.NumVectors())
+        FOUR_C_THROW("stdvector[{}].size() = {} is larger than vector.NumVectors() = {}", i,
+            (int)stdvector[i].size(), vector.NumVectors());
+      for (int j = 0; j < (int)stdvector[i].size(); j++) vector(j)[i] = (TYPE)stdvector[i][j];
     }
     return;
   }
   //! \brief translate Core::LinAlg::MultiVector<double> to std::vec<std::vec<type> > >
   template <class TYPE>
   void epetra_multi_vec_to_std_vec(
-      Core::LinAlg::MultiVector<double>& epetravec, std::vector<std::vector<TYPE>>& stdvec)
+      Core::LinAlg::MultiVector<double>& vector, std::vector<std::vector<TYPE>>& stdvector)
   {
     if (std::strcmp(typeid(TYPE).name(), "i") != 0 && std::strcmp(typeid(TYPE).name(), "f") != 0 &&
         std::strcmp(typeid(TYPE).name(), "d") != 0)
       FOUR_C_THROW("Template of wrong type {}! Only int, float, and double are permitted!",
           typeid(TYPE).name());
-    if (epetravec.MyLength() != (int)stdvec.size()) FOUR_C_THROW("Sizes differ!");
-    for (int i = 0; i < epetravec.NumVectors(); i++)
+    if (vector.MyLength() != (int)stdvector.size()) FOUR_C_THROW("Sizes differ!");
+    for (int i = 0; i < vector.NumVectors(); i++)
     {
-      for (int j = 0; j < epetravec.MyLength(); j++)
+      for (int j = 0; j < vector.MyLength(); j++)
       {
-        if ((int)stdvec[j].size() < epetravec.NumVectors())
-          FOUR_C_THROW("stdvec[{}].size() = {} is larger than epetravec.NumVectors() = {}", j,
-              (int)stdvec[j].size(), epetravec.NumVectors());
-        stdvec[j][i] = epetravec(i)[j];
+        if ((int)stdvector[j].size() < vector.NumVectors())
+          FOUR_C_THROW("stdvector[{}].size() = {} is larger than vector.NumVectors() = {}", j,
+              (int)stdvector[j].size(), vector.NumVectors());
+        stdvector[j][i] = vector(i)[j];
       }
     }
     return;

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.hpp
@@ -106,7 +106,7 @@ namespace BeamInteraction
      *
      * Some nodes / elements in the discretization need additional Lagrange multiplier DOFs. We need
      * to be able to know which pair refers to which Lagrange multipliers. In this setup routine, a
-     * Epetra multi vector is created, that maps all centerline nodes and beam elements, to a
+     * multi vector is created, that maps all centerline nodes and beam elements, to a
      * Lagrange multiplier DOF.
      *
      * @param discret Pointer to the discretization.

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -101,13 +101,13 @@ Cardiovascular0D::ProperOrthogonalDecomposition::reduce_diagonal(Core::LinAlg::S
   // left multiply V^T * (M * V)
   std::shared_ptr<Core::LinAlg::MultiVector<double>> M_red_mvec =
       std::make_shared<Core::LinAlg::MultiVector<double>>(*structmapr_, M_tmp.NumVectors(), true);
-  multiply_epetra_multi_vectors(
+  multiply_multi_vectors(
       *projmatrix_, 'T', M_tmp, 'N', *redstructmapr_, *structrimpo_, *M_red_mvec);
 
   // convert Core::LinAlg::MultiVector<double> to Core::LinAlg::SparseMatrix
   std::shared_ptr<Core::LinAlg::SparseMatrix> M_red =
       std::make_shared<Core::LinAlg::SparseMatrix>(*structmapr_, 0, false, true);
-  epetra_multi_vector_to_linalg_sparse_matrix(*M_red_mvec, *structmapr_, nullptr, *M_red);
+  multi_vector_to_linalg_sparse_matrix(*M_red_mvec, *structmapr_, nullptr, *M_red);
 
   return M_red;
 }
@@ -128,7 +128,7 @@ Cardiovascular0D::ProperOrthogonalDecomposition::reduce_off_diagonal(Core::LinAl
   std::shared_ptr<Core::LinAlg::Map> rangemap = std::make_shared<Core::LinAlg::Map>(M.domain_map());
   std::shared_ptr<Core::LinAlg::SparseMatrix> M_red =
       std::make_shared<Core::LinAlg::SparseMatrix>(*rangemap, 0, false, true);
-  epetra_multi_vector_to_linalg_sparse_matrix(*M_tmp, *rangemap, structmapr_, *M_red);
+  multi_vector_to_linalg_sparse_matrix(*M_tmp, *rangemap, structmapr_, *M_red);
 
   return M_red;
 }
@@ -140,7 +140,7 @@ Cardiovascular0D::ProperOrthogonalDecomposition::reduce_rhs(Core::LinAlg::MultiV
 {
   std::shared_ptr<Core::LinAlg::MultiVector<double>> v_red =
       std::make_shared<Core::LinAlg::MultiVector<double>>(*structmapr_, 1, true);
-  multiply_epetra_multi_vectors(*projmatrix_, 'T', v, 'N', *redstructmapr_, *structrimpo_, *v_red);
+  multiply_multi_vectors(*projmatrix_, 'T', v, 'N', *redstructmapr_, *structrimpo_, *v_red);
 
   return v_red;
 }
@@ -179,7 +179,7 @@ Cardiovascular0D::ProperOrthogonalDecomposition::extend_solution(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Cardiovascular0D::ProperOrthogonalDecomposition::multiply_epetra_multi_vectors(
+void Cardiovascular0D::ProperOrthogonalDecomposition::multiply_multi_vectors(
     Core::LinAlg::MultiVector<double>& multivect1, char multivect1Trans,
     Core::LinAlg::MultiVector<double>& multivect2, char multivect2Trans, Core::LinAlg::Map& redmap,
     Epetra_Import& impo, Core::LinAlg::MultiVector<double>& result)
@@ -202,7 +202,7 @@ void Cardiovascular0D::ProperOrthogonalDecomposition::multiply_epetra_multi_vect
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Cardiovascular0D::ProperOrthogonalDecomposition::epetra_multi_vector_to_linalg_sparse_matrix(
+void Cardiovascular0D::ProperOrthogonalDecomposition::multi_vector_to_linalg_sparse_matrix(
     Core::LinAlg::MultiVector<double>& multivect, Core::LinAlg::Map& rangemap,
     std::shared_ptr<Core::LinAlg::Map> domainmap, Core::LinAlg::SparseMatrix& sparsemat)
 {

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.hpp
@@ -69,13 +69,13 @@ namespace Cardiovascular0D
     void read_pod_basis_vectors_from_file(const std::string& absolute_path_to_pod_file,
         std::shared_ptr<Core::LinAlg::MultiVector<double>>& projmatrix);
 
-    //! Multiply two Epetra MultiVectors
-    void multiply_epetra_multi_vectors(Core::LinAlg::MultiVector<double>&, char,
+    //! Multiply two multi vectors
+    void multiply_multi_vectors(Core::LinAlg::MultiVector<double>&, char,
         Core::LinAlg::MultiVector<double>&, char, Core::LinAlg::Map&, Epetra_Import&,
         Core::LinAlg::MultiVector<double>&);
 
     //! Core::LinAlg::MultiVector<double> to Core::LinAlg::SparseMatrix
-    void epetra_multi_vector_to_linalg_sparse_matrix(Core::LinAlg::MultiVector<double>& multivect,
+    void multi_vector_to_linalg_sparse_matrix(Core::LinAlg::MultiVector<double>& multivect,
         Core::LinAlg::Map& rangemap, std::shared_ptr<Core::LinAlg::Map> domainmap,
         Core::LinAlg::SparseMatrix& sparsemat);
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_respiratory_syspulperiphcirculation.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_respiratory_syspulperiphcirculation.cpp
@@ -1240,7 +1240,7 @@ void Utils::CardiovascularRespiratory0DSysPulPeriphCirculation::evaluate_respira
   (*volvec)[34] = V_alv_np;
 
   // we misuse the vol vector to carry information about the O2 saturation S_O2 of the respective
-  // compartment in order to avoid introducing another Epetra vector for this purpose the vol vector
+  // compartment in order to avoid introducing another vector for this purpose the vol vector
   // has plenty of zero entries after LID 34, and it is time-integrated and post-processed to
   // t_{n+\theta} inside the manager
 

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -243,7 +243,7 @@ void Constraints::ConstrManager::evaluate_force_stiff(const double time,
   p.set("scaleConstrMat", scConMat);
   p.set("vector curve factors", fact_);
   // Convert Core::LinAlg::Vector<double> containing lagrange multipliers to an completely
-  // redundant Epetra_vector since every element with the constraint condition needs them
+  // redundant vector since every element with the constraint condition needs them
   std::shared_ptr<Core::LinAlg::Vector<double>> lagrMultVecDense =
       std::make_shared<Core::LinAlg::Vector<double>>(*redconstrmap_);
   Core::LinAlg::export_to(*lagr_mult_vec_, *lagrMultVecDense);

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -128,7 +128,7 @@ void Coupling::Adapter::Coupling::setup_coupling(const Core::FE::Discretization&
   match_nodes(
       masterdis, slavedis, patchedmasternodes, permslavenodes, slavenodes, matchall, tolerance);
 
-  // Epetra maps in original distribution
+  // maps in original distribution
 
   std::shared_ptr<Core::LinAlg::Map> masternodemap =
       std::make_shared<Core::LinAlg::Map>(-1, patchedmasternodes.size(), patchedmasternodes.data(),
@@ -271,7 +271,7 @@ void Coupling::Adapter::Coupling::setup_coupling(const Core::FE::Discretization&
 
   match_nodes(masterdis, slavedis, mastervect, permslavenodes, slavevect, matchall, tolerance);
 
-  // Epetra maps in original distribution
+  // maps in original distribution
 
   std::shared_ptr<Core::LinAlg::Map> masternodemap =
       std::make_shared<Core::LinAlg::Map>(-1, mastervect.size(), mastervect.data(), 0,
@@ -300,7 +300,7 @@ void Coupling::Adapter::Coupling::setup_coupling(const Core::FE::Discretization&
     FOUR_C_THROW("got {} master nodes but {} slave nodes for coupling",
         masternodemap.NumGlobalElements(), slavenodemap.NumGlobalElements());
 
-  // just copy Epetra maps
+  // just copy maps
 
   std::shared_ptr<Core::LinAlg::Map> mymasternodemap =
       std::make_shared<Core::LinAlg::Map>(masternodemap);

--- a/src/cut/4C_cut_levelsetintersection.hpp
+++ b/src/cut/4C_cut_levelsetintersection.hpp
@@ -91,7 +91,7 @@ namespace Cut
    private:
     MPI_Comm get_comm() const
     {
-      if (not comm_) FOUR_C_THROW("Epetra communicator was not initialized!");
+      if (not comm_) FOUR_C_THROW("MPI communicator was not initialized!");
 
       return comm_;
     }

--- a/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.hpp
+++ b/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.hpp
@@ -102,7 +102,7 @@ namespace BeamInteraction
      *
      * Some nodes / elements in the discretization need additional Lagrange multiplier DOFs. We need
      * to be able to know which pair refers to which Lagrange multipliers. In this setup routine, a
-     * Epetra multi vector is created, that maps all centerline nodes and beam elements, to a
+     * multi vector is created, that maps all centerline nodes and beam elements, to a
      * Lagrange multiplier DOF.
      *
      */

--- a/src/fluid/4C_fluid_timint_genalpha.cpp
+++ b/src/fluid/4C_fluid_timint_genalpha.cpp
@@ -286,7 +286,7 @@ void FLD::TimIntGenAlpha::gen_alpha_intermediate_values(
   //       n+alphaF
   //    vec         = alpha_F * vecnp     + (1-alpha_F) *  vecn
 
-  // do stupid conversion into Epetra map
+  // do stupid conversion into map
   Core::LinAlg::Map vecmap(vecnp->get_block_map().NumGlobalElements(),
       vecnp->get_block_map().NumMyElements(), vecnp->get_block_map().MyGlobalElements(), 0,
       vecnp->get_block_map().Comm());

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
@@ -213,8 +213,8 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
     Discret::Elements::FluidBoundary* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Conditions::Condition& condition,
-    std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseMatrix* elemat1_epetra)
+    std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseMatrix* elemat1)
 {
   // find out whether we will use a time curve
   const double time = fldparatimint_->time();
@@ -432,11 +432,11 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
           const double valfac = val[idim] * fac_time_dens * functfac;
           for (int inode = 0; inode < bdrynen_; ++inode)
           {
-            elevec1_epetra[inode * numdofpernode_ + idim] += funct_(inode) * valfac;
+            elevec1[inode * numdofpernode_ + idim] += funct_(inode) * valfac;
             if (fldparatimint_->is_new_ost_implementation())
             {
               const double valfacn = val[idim] * fac_time_densn * functfacn;
-              elevec1_epetra[inode * numdofpernode_ + idim] += funct_(inode) * valfacn;
+              elevec1[inode * numdofpernode_ + idim] += funct_(inode) * valfacn;
             }
           }  // end is_new_ost_implementation
         }  // if onoff
@@ -470,13 +470,12 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
           const double valfac = val[0] * fac_time_dens * functfac;
           for (int inode = 0; inode < bdrynen_; ++inode)
           {
-            elevec1_epetra[inode * numdofpernode_ + idim] +=
-                funct_(inode) * valfac * (-unitnormal_(idim));
+            elevec1[inode * numdofpernode_ + idim] += funct_(inode) * valfac * (-unitnormal_(idim));
 
             if (fldparatimint_->is_new_ost_implementation())
             {
               const double valfacn = val[0] * fac_time_densn * functfacn;
-              elevec1_epetra[inode * numdofpernode_ + idim] +=
+              elevec1[inode * numdofpernode_ + idim] +=
                   funct_(inode) * valfacn * (-unitnormal_(idim));
             }
           }  // end is_new_ost_implementation
@@ -574,7 +573,7 @@ void Discret::Elements::FluidBoundaryImpl<distype>::neumann_inflow(
   myvelaf = Core::FE::extract_values(*velaf, lm);
   myscaaf = Core::FE::extract_values(*scaaf, lm);
 
-  // create Epetra objects for scalar array and velocities
+  // create objects for scalar array and velocities
   Core::LinAlg::Matrix<nsd_, bdrynen_> evelaf(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<bdrynen_, 1> epreaf(Core::LinAlg::Initialization::zero);
   Core::LinAlg::Matrix<bdrynen_, 1> escaaf(Core::LinAlg::Initialization::zero);

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc.hpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc.hpp
@@ -94,7 +94,7 @@ namespace Discret
       //! Evaluate a Neumann boundary condition
       int evaluate_neumann(Discret::Elements::FluidBoundary* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Conditions::Condition& condition,
-          std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra,
+          std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1,
           Core::LinAlg::SerialDenseMatrix* elemat1) override;
 
      protected:

--- a/src/fluid_ele/4C_fluid_ele_boundary_interface.hpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_interface.hpp
@@ -54,8 +54,7 @@ namespace Discret
       virtual int evaluate_neumann(Discret::Elements::FluidBoundary* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Conditions::Condition& condition, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseMatrix* elemat1) = 0;
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseMatrix* elemat1) = 0;
     };
 
   }  // namespace Elements

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
@@ -504,8 +504,7 @@ template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::FluidBoundaryParent<distype>::flow_dep_pressure_bc(
     Discret::Elements::FluidBoundary* surfele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& plm,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra,
-    Core::LinAlg::SerialDenseVector::Base& elevec_epetra)
+    Core::LinAlg::SerialDenseMatrix::Base& elemat1, Core::LinAlg::SerialDenseVector::Base& elevec1)
 {
   // initialize pressure value and pressure derivative at boundary
   double pressure = 0.0;
@@ -607,10 +606,10 @@ void Discret::Elements::FluidBoundaryParent<distype>::flow_dep_pressure_bc(
 
     // reshape element matrices and vectors and init to zero, construct views
     const int peledim = (nsd + 1) * piel;
-    elemat_epetra.shape(peledim, peledim);
-    elevec_epetra.size(peledim);
-    Core::LinAlg::Matrix<peledim, peledim> elemat(elemat_epetra.values(), true);
-    Core::LinAlg::Matrix<peledim, 1> elevec(elevec_epetra.values(), true);
+    elemat1.shape(peledim, peledim);
+    elevec1.size(peledim);
+    Core::LinAlg::Matrix<peledim, peledim> elemat(elemat1.values(), true);
+    Core::LinAlg::Matrix<peledim, 1> elevec(elevec1.values(), true);
 
     // get local node coordinates
     Core::LinAlg::Matrix<nsd, piel> pxyze(Core::LinAlg::Initialization::zero);
@@ -1241,8 +1240,7 @@ template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::FluidBoundaryParent<distype>::slip_supp_bc(
     Discret::Elements::FluidBoundary* surfele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& plm,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra,
-    Core::LinAlg::SerialDenseVector::Base& elevec_epetra)
+    Core::LinAlg::SerialDenseMatrix::Base& elemat1, Core::LinAlg::SerialDenseVector::Base& elevec1)
 {
   //---------------------------------------------------------------------
   // get time-integration parameters
@@ -1266,10 +1264,10 @@ void Discret::Elements::FluidBoundaryParent<distype>::slip_supp_bc(
 
   // reshape element matrices and vectors and init to zero, construct views
   const int peledim = (nsd + 1) * piel;
-  elemat_epetra.shape(peledim, peledim);
-  elevec_epetra.size(peledim);
-  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat_epetra.values(), true);
-  Core::LinAlg::Matrix<peledim, 1> elevec(elevec_epetra.values(), true);
+  elemat1.shape(peledim, peledim);
+  elevec1.size(peledim);
+  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat1.values(), true);
+  Core::LinAlg::Matrix<peledim, 1> elevec(elevec1.values(), true);
 
   // get local node coordinates
   Core::LinAlg::Matrix<nsd, piel> pxyze(Core::LinAlg::Initialization::zero);
@@ -1574,8 +1572,7 @@ template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::FluidBoundaryParent<distype>::navier_slip_bc(
     Discret::Elements::FluidBoundary* surfele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& plm,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra,
-    Core::LinAlg::SerialDenseVector::Base& elevec_epetra)
+    Core::LinAlg::SerialDenseMatrix::Base& elemat1, Core::LinAlg::SerialDenseVector::Base& elevec1)
 {
   //---------------------------------------------------------------------
   // get time-integration parameters
@@ -1599,10 +1596,10 @@ void Discret::Elements::FluidBoundaryParent<distype>::navier_slip_bc(
 
   // reshape element matrices and vectors and init to zero, construct views
   const int peledim = (nsd + 1) * piel;
-  elemat_epetra.shape(peledim, peledim);
-  elevec_epetra.size(peledim);
-  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat_epetra.values(), true);
-  Core::LinAlg::Matrix<peledim, 1> elevec(elevec_epetra.values(), true);
+  elemat1.shape(peledim, peledim);
+  elevec1.size(peledim);
+  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat1.values(), true);
+  Core::LinAlg::Matrix<peledim, 1> elevec(elevec1.values(), true);
 
   // get local node coordinates
   Core::LinAlg::Matrix<nsd, piel> pxyze(Core::LinAlg::Initialization::zero);
@@ -1834,8 +1831,7 @@ template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::FluidBoundaryParent<distype>::evaluate_weak_dbc(
     Discret::Elements::FluidBoundary* surfele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& plm,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra,
-    Core::LinAlg::SerialDenseVector::Base& elevec_epetra)
+    Core::LinAlg::SerialDenseMatrix::Base& elemat1, Core::LinAlg::SerialDenseVector::Base& elevec1)
 {
   //---------------------------------------------------------------------
   // get condition information
@@ -1941,10 +1937,10 @@ void Discret::Elements::FluidBoundaryParent<distype>::evaluate_weak_dbc(
 
   // reshape element matrices and vectors and init to zero, construct views
   const int peledim = (nsd + 1) * piel;
-  elemat_epetra.shape(peledim, peledim);
-  elevec_epetra.size(peledim);
-  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat_epetra.values(), true);
-  Core::LinAlg::Matrix<peledim, 1> elevec(elevec_epetra.values(), true);
+  elemat1.shape(peledim, peledim);
+  elevec1.size(peledim);
+  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat1.values(), true);
+  Core::LinAlg::Matrix<peledim, 1> elevec(elevec1.values(), true);
 
   // get local node coordinates
   Core::LinAlg::Matrix<nsd, piel> pxyze(Core::LinAlg::Initialization::zero);
@@ -3718,8 +3714,7 @@ template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::FluidBoundaryParent<distype>::estimate_nitsche_trace_max_eigenvalue(
     Core::Elements::FaceElement* surfele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& blm,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra1,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra2)
+    Core::LinAlg::SerialDenseMatrix::Base& elemat1, Core::LinAlg::SerialDenseMatrix::Base& elemat2)
 {
   //---------------------------------------------------------------------
   // get parent element data
@@ -3737,10 +3732,10 @@ void Discret::Elements::FluidBoundaryParent<distype>::estimate_nitsche_trace_max
 
   // reshape element matrices and vectors and init to zero, construct views
   const int peledim = nsd * piel;
-  elemat_epetra1.shape(peledim, peledim);
-  elemat_epetra2.shape(peledim, peledim);
-  Core::LinAlg::Matrix<peledim, peledim> Amat(elemat_epetra1.values(), true);
-  Core::LinAlg::Matrix<peledim, peledim> Bmat(elemat_epetra2.values(), true);
+  elemat1.shape(peledim, peledim);
+  elemat2.shape(peledim, peledim);
+  Core::LinAlg::Matrix<peledim, peledim> Amat(elemat1.values(), true);
+  Core::LinAlg::Matrix<peledim, peledim> Bmat(elemat2.values(), true);
 
   // get local node coordinates
   Core::LinAlg::Matrix<nsd, piel> pxyze(Core::LinAlg::Initialization::zero);
@@ -4243,7 +4238,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::estimate_nitsche_trace_max
 
   // Solve the local eigen value problem Ax = lambda Bx. The function generalized_eigen
   // returns the maximum Eigenvalue of the problem.
-  const double maxeigenvalue = Core::LinAlg::generalized_eigen(elemat_epetra1, elemat_epetra2);
+  const double maxeigenvalue = Core::LinAlg::generalized_eigen(elemat1, elemat2);
 
   // fill the map: every side id has it's own parameter beta
   (*params.get<std::shared_ptr<std::map<int, double>>>(
@@ -4260,8 +4255,7 @@ template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
 void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
     Discret::Elements::FluidBoundary* surfele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& plm,
-    Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra,
-    Core::LinAlg::SerialDenseVector::Base& elevec_epetra)
+    Core::LinAlg::SerialDenseMatrix::Base& elemat, Core::LinAlg::SerialDenseVector::Base& elevec)
 {
   //--------------------------------------------------
   // get my parent element
@@ -4305,11 +4299,11 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
   // Reshape element matrices and vectors and init to zero, construct views
   const int peledim = (nsd + 1) * piel;
 
-  elemat_epetra.shape(peledim, peledim);
-  elevec_epetra.size(peledim);
+  elemat.shape(peledim, peledim);
+  elevec.size(peledim);
 
-  Core::LinAlg::Matrix<peledim, peledim> elemat(elemat_epetra.values(), true);
-  Core::LinAlg::Matrix<peledim, 1> elevec(elevec_epetra.values(), true);
+  Core::LinAlg::Matrix<peledim, peledim> elemat1(elemat.values(), true);
+  Core::LinAlg::Matrix<peledim, 1> elevec1(elevec.values(), true);
 
   //--------------------------------------------------
   // get the condition information
@@ -5701,9 +5695,9 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
           {
             for (int j = 0; j < nsd + 1; ++j)
             {
-              elemat(A * (nsd + 1) + i, B * (nsd + 1) + j) -= mat_v_sigma_o_n(A * nsd + i, rr) *
-                                                              inv_r_sigma(rr, mm) *
-                                                              mat_r_up_block(mm, B * (nsd + 1) + j);
+              elemat1(A * (nsd + 1) + i, B * (nsd + 1) + j) -=
+                  mat_v_sigma_o_n(A * nsd + i, rr) * inv_r_sigma(rr, mm) *
+                  mat_r_up_block(mm, B * (nsd + 1) + j);
             }
           }
         }
@@ -5719,9 +5713,9 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
       {
         for (int mm = 0; mm < numstressdof_ * piel; ++mm)
         {
-          elevec(A * (nsd + 1) + i) -= timefacrhs * mat_v_sigma_o_n(A * nsd + i, rr) *
-                                       inv_r_sigma(rr, mm) *
-                                       (-vec_r_o_n_u_minus_g(mm) - vec_r_epsu(mm) - vec_r_p(mm));
+          elevec1(A * (nsd + 1) + i) -= timefacrhs * mat_v_sigma_o_n(A * nsd + i, rr) *
+                                        inv_r_sigma(rr, mm) *
+                                        (-vec_r_o_n_u_minus_g(mm) - vec_r_epsu(mm) - vec_r_p(mm));
         }
       }
     }

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.hpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.hpp
@@ -160,8 +160,8 @@ namespace Discret
       template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
       void estimate_nitsche_trace_max_eigenvalue(Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          std::vector<int>& lm, Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra1,
-          Core::LinAlg::SerialDenseMatrix::Base& elemat_epetra2);
+          std::vector<int>& lm, Core::LinAlg::SerialDenseMatrix::Base& elemat1,
+          Core::LinAlg::SerialDenseMatrix::Base& elemat2);
 
       template <Core::FE::CellType bdistype, Core::FE::CellType pdistype>
       void mix_hyb_dirichlet(Discret::Elements::FluidBoundary* ele, Teuchos::ParameterList& params,

--- a/src/fluid_ele/4C_fluid_ele_calc.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc.hpp
@@ -137,7 +137,7 @@ namespace Discret
       virtual int calc_mass_matrix(Discret::Elements::Fluid* ele,
           //    Teuchos::ParameterList&              params,
           Core::FE::Discretization& discretization, const std::vector<int>& lm,
-          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1_epetra
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1
           //    const Core::FE::GaussIntegration & intpoints
       );
 
@@ -228,22 +228,17 @@ namespace Discret
        */
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) override;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) override;
 
       /// Evaluate the element at specified gauss points
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints, bool offdiag = false) override;
 
       int compute_error_interface(Discret::Elements::Fluid* ele,  ///< fluid element
@@ -266,12 +261,9 @@ namespace Discret
       /// Evaluate the XFEM cut element
       int evaluate_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const std::vector<Core::FE::GaussIntegration>& intpoints,
           const Cut::plain_volumecell_set& cells, bool offdiag = false) override
       {
@@ -321,10 +313,9 @@ namespace Discret
               side_coupling,                          ///< side coupling matrices
           Teuchos::ParameterList& params,             ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat,  ///< material
-          Core::LinAlg::SerialDenseMatrix&
-              elemat1_epetra,  ///< local system matrix of intersected element
+          Core::LinAlg::SerialDenseMatrix& elemat1,  ///< local system matrix of intersected element
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,                      ///< local element vector of intersected element
+              elevec1,                             ///< local element vector of intersected element
           Core::LinAlg::SerialDenseMatrix& Cuiui,  ///< coupling matrix of a side with itself
           const Cut::plain_volumecell_set& vcSet   ///< set of plain volume cells
           ) override
@@ -345,8 +336,8 @@ namespace Discret
           Teuchos::ParameterList& params,                    ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat_master,  ///< material for the coupled side
           std::shared_ptr<Core::Mat::Material>& mat_slave,   ///< material for the coupled side
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   ///< element vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,          ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,          ///< element vector
           const Cut::plain_volumecell_set& vcSet,            ///< volumecell sets in this element
           std::map<int, std::vector<Core::LinAlg::SerialDenseMatrix>>&
               side_coupling,                       ///< side coupling matrices
@@ -359,7 +350,7 @@ namespace Discret
       }
 
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& dis,
-          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra,
+          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1,
           const Core::FE::GaussIntegration& intpoints) override
       {
         FOUR_C_THROW("Implemented in derived xfem class!");
@@ -367,7 +358,7 @@ namespace Discret
       }
 
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& dis,
-          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra) override
+          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1) override
       {
         FOUR_C_THROW("Implemented in derived xfem class!");
         return;

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
@@ -43,15 +43,12 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcHDG<distype>::evaluate(Discret::Elements::Fluid* ele,
     Core::FE::Discretization& discretization, const std::vector<int>& lm,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, const Core::FE::GaussIntegration&,
-    bool offdiag)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration&, bool offdiag)
 {
-  return this->evaluate(ele, discretization, lm, params, mat, elemat1_epetra, elemat2_epetra,
-      elevec1_epetra, elevec2_epetra, elevec3_epetra, offdiag);
+  return this->evaluate(
+      ele, discretization, lm, params, mat, elemat1, elemat2, elevec1, elevec2, elevec3, offdiag);
 }
 
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.hpp
@@ -138,22 +138,17 @@ namespace Discret
        */
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) override;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) override;
 
       /// Evaluate the element at specified gauss points
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints, bool offdiag = false) override;
 
       int compute_error_interface(Discret::Elements::Fluid* ele,  ///< fluid element
@@ -176,12 +171,9 @@ namespace Discret
       /// Evaluate the XFEM cut element
       int evaluate_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const std::vector<Core::FE::GaussIntegration>& intpoints,
           const Cut::plain_volumecell_set& cells, bool offdiag = false) override
       {
@@ -204,10 +196,9 @@ namespace Discret
               side_coupling,                          ///< side coupling matrices
           Teuchos::ParameterList& params,             ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat,  ///< material
-          Core::LinAlg::SerialDenseMatrix&
-              elemat1_epetra,  ///< local system matrix of intersected element
+          Core::LinAlg::SerialDenseMatrix& elemat1,  ///< local system matrix of intersected element
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,                      ///< local element vector of intersected element
+              elevec1,                             ///< local element vector of intersected element
           Core::LinAlg::SerialDenseMatrix& Cuiui,  ///< coupling matrix of a side with itself
           const Cut::plain_volumecell_set& vcSet   ///< set of plain volume cells
           ) override
@@ -227,8 +218,8 @@ namespace Discret
           Teuchos::ParameterList& params,                    ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat_master,  ///< material master side
           std::shared_ptr<Core::Mat::Material>& mat_slave,   ///< material slave side
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   ///< element vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,          ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,          ///< element vector
           const Cut::plain_volumecell_set& vcSet,            ///< volumecell sets in this element
           std::map<int, std::vector<Core::LinAlg::SerialDenseMatrix>>&
               side_coupling,                       ///< side coupling matrices
@@ -241,7 +232,7 @@ namespace Discret
       }
 
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& dis,
-          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra,
+          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1,
           const Core::FE::GaussIntegration& intpoints) override
       {
         FOUR_C_THROW("Not implemented!");
@@ -249,7 +240,7 @@ namespace Discret
       }
 
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& dis,
-          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra) override
+          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1) override
       {
         FOUR_C_THROW("Not implemented!");
         return;

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
@@ -74,15 +74,12 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::evaluate(Discret::Elements::Fluid* ele,
     Core::FE::Discretization& discretization, const std::vector<int>& lm,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, const Core::FE::GaussIntegration&,
-    bool offdiag)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration&, bool offdiag)
 {
-  return this->evaluate(ele, discretization, lm, params, mat, elemat1_epetra, elemat2_epetra,
-      elevec1_epetra, elevec2_epetra, elevec3_epetra, offdiag);
+  return this->evaluate(
+      ele, discretization, lm, params, mat, elemat1, elemat2, elevec1, elevec2, elevec3, offdiag);
 }
 
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.hpp
@@ -131,22 +131,17 @@ namespace Discret
        */
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) override;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) override;
 
       /// Evaluate the element at specified gauss points
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints, bool offdiag = false) override;
 
       int compute_error_interface(Discret::Elements::Fluid* ele,  ///< fluid element
@@ -169,12 +164,9 @@ namespace Discret
       /// Evaluate the XFEM cut element
       int evaluate_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const std::vector<Core::FE::GaussIntegration>& intpoints,
           const Cut::plain_volumecell_set& cells, bool offdiag = false) override
       {
@@ -197,10 +189,9 @@ namespace Discret
               side_coupling,                          ///< side coupling matrices
           Teuchos::ParameterList& params,             ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat,  ///< material
-          Core::LinAlg::SerialDenseMatrix&
-              elemat1_epetra,  ///< local system matrix of intersected element
+          Core::LinAlg::SerialDenseMatrix& elemat1,  ///< local system matrix of intersected element
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,                      ///< local element vector of intersected element
+              elevec1,                             ///< local element vector of intersected element
           Core::LinAlg::SerialDenseMatrix& Cuiui,  ///< coupling matrix of a side with itself
           const Cut::plain_volumecell_set& vcSet   ///< set of plain volume cells
           ) override
@@ -220,8 +211,8 @@ namespace Discret
           Teuchos::ParameterList& params,                    ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat_master,  ///< material master side
           std::shared_ptr<Core::Mat::Material>& mat_slave,   ///< material slave side
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   ///< element vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,          ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,          ///< element vector
           const Cut::plain_volumecell_set& vcSet,            ///< volumecell sets in this element
           std::map<int, std::vector<Core::LinAlg::SerialDenseMatrix>>&
               side_coupling,                       ///< side coupling matrices
@@ -234,7 +225,7 @@ namespace Discret
       }
 
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& dis,
-          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra,
+          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1,
           const Core::FE::GaussIntegration& intpoints) override
       {
         FOUR_C_THROW("Not implemented!");
@@ -242,7 +233,7 @@ namespace Discret
       }
 
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& dis,
-          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1_epetra) override
+          const std::vector<int>& lm, Core::LinAlg::SerialDenseVector& elevec1) override
       {
         FOUR_C_THROW("Not implemented!");
         return;

--- a/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
@@ -1225,7 +1225,7 @@ int Discret::Elements::FluidInternalSurfaceStab<distype, pdistype,
       }
     }
     else
-      FOUR_C_THROW("unknown assembly pattern for given number of epetra block matrices");
+      FOUR_C_THROW("unknown assembly pattern for given number of block matrices");
   }
 
   // elemat.print(cout);

--- a/src/fluid_ele/4C_fluid_ele_calc_loma.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_loma.cpp
@@ -48,18 +48,16 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcLoma<distype>::evaluate(Discret::Elements::Fluid* ele,
     Core::FE::Discretization& discretization, const std::vector<int>& lm,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, bool offdiag)
 {
   if (not offdiag)
-    return my::evaluate(ele, discretization, lm, params, mat, elemat1_epetra, elemat2_epetra,
-        elevec1_epetra, elevec2_epetra, elevec3_epetra, my::intpoints_);
+    return my::evaluate(ele, discretization, lm, params, mat, elemat1, elemat2, elevec1, elevec2,
+        elevec3, my::intpoints_);
   else
-    return evaluate_od(ele, discretization, lm, params, mat, elemat1_epetra, elemat2_epetra,
-        elevec1_epetra, elevec2_epetra, elevec3_epetra, my::intpoints_);
+    return evaluate_od(ele, discretization, lm, params, mat, elemat1, elemat2, elevec1, elevec2,
+        elevec3, my::intpoints_);
 }
 
 
@@ -70,17 +68,15 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcLoma<distype>::evaluate_od(Discret::Elements::Fluid* ele,
     Core::FE::Discretization& discretization, const std::vector<int>& lm,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, const Core::FE::GaussIntegration& intpoints)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration& intpoints)
 {
   // rotationally symmetric periodic bc's: do setup for current element
   my::rotsymmpbc_->setup(ele);
 
   // construct view
-  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, nen_> elemat1(elemat1_epetra, true);
+  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, nen_> elemat_1(elemat1, true);
 
   // ---------------------------------------------------------------------
   // call routine for calculation of body force in element nodes,
@@ -198,7 +194,7 @@ int Discret::Elements::FluidEleCalcLoma<distype>::evaluate_od(Discret::Elements:
   // set element id
   my::eid_ = ele->id();
   // call inner evaluate (does not know about element or discretization object)
-  int result = evaluate_od(params, ebofoaf, eprescpgaf, elemat1, evelaf, epreaf, epream, escaaf,
+  int result = evaluate_od(params, ebofoaf, eprescpgaf, elemat_1, evelaf, epreaf, epream, escaaf,
       emhist, eaccam, escadtam, escabofoaf, eveln, escaam, edispnp, egridv, mat, ele->is_ale(),
       CsDeltaSq, CiDeltaSq, intpoints);
 

--- a/src/fluid_ele/4C_fluid_ele_calc_loma.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_loma.hpp
@@ -35,23 +35,18 @@ namespace Discret
 
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) override;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) override;
 
       /// Evaluate the element at specified gauss points for porous flow
       virtual int evaluate_od(Discret::Elements::Fluid* ele,
           Core::FE::Discretization& discretization, const std::vector<int>& lm,
           Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          const Core::FE::GaussIntegration& intpoints);
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration& intpoints);
 
      private:
       /// private Constructor since we are a Singleton.

--- a/src/fluid_ele/4C_fluid_ele_calc_poro.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro.hpp
@@ -69,23 +69,21 @@ namespace Discret
         \param lm               (i) location matrix of element
         \param params           (i) element parameter list
         \param mat              (i) material
-        \param elemat1_epetra   (o) element matrix to calculate
-        \param elemat2_epetra   (o) element matrix to calculate
-        \param elevec1_epetra   (o) element vector to calculate
-        \param elevec2_epetra   (o) element vector to calculate
-        \param elevec3_epetra   (o) element vector to calculate
+        \param elemat1          (o) element matrix to calculate
+        \param elemat2          (o) element matrix to calculate
+        \param elevec1          (o) element vector to calculate
+        \param elevec2          (o) element vector to calculate
+        \param elevec3          (o) element vector to calculate
         \param offdiag          (i) flag indicating whether diagonal or off diagonal blocks are to
         be calculated
 
        */
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) override;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) override;
 
       /*!
         \brief calculate element matrix and rhs for porous flow (2)
@@ -95,22 +93,19 @@ namespace Discret
         \param lm               (i) location matrix of element
         \param params           (i) element parameter list
         \param mat              (i) material
-        \param elemat1_epetra   (o) element matrix to calculate
-        \param elemat2_epetra   (o) element matrix to calculate
-        \param elevec1_epetra   (o) element vector to calculate
-        \param elevec2_epetra   (o) element vector to calculate
-        \param elevec3_epetra   (o) element vector to calculate
+        \param elemat1          (o) element matrix to calculate
+        \param elemat2          (o) element matrix to calculate
+        \param elevec1          (o) element vector to calculate
+        \param elevec2          (o) element vector to calculate
+        \param elevec3          (o) element vector to calculate
         \param intpoints        (i) Gaussian integration points
 
        */
       virtual int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints);
 
       /*!
@@ -122,23 +117,20 @@ namespace Discret
         \param lm               (i) location matrix of element
         \param params           (i) element parameter list
         \param mat              (i) material
-        \param elemat1_epetra   (o) element matrix to calculate
-        \param elemat2_epetra   (o) element matrix to calculate
-        \param elevec1_epetra   (o) element vector to calculate
-        \param elevec2_epetra   (o) element vector to calculate
-        \param elevec3_epetra   (o) element vector to calculate
+        \param elemat1          (o) element matrix to calculate
+        \param elemat2          (o) element matrix to calculate
+        \param elevec1          (o) element vector to calculate
+        \param elevec2          (o) element vector to calculate
+        \param elevec3          (o) element vector to calculate
         \param intpoints        (i) Gaussian integration points
 
        */
       virtual int evaluate_od(Discret::Elements::Fluid* ele,
           Core::FE::Discretization& discretization, const std::vector<int>& lm,
           Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          const Core::FE::GaussIntegration& intpoints);
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration& intpoints);
 
 
       //! Evaluate supporting methods of the element

--- a/src/fluid_ele/4C_fluid_ele_calc_poro_p1.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro_p1.cpp
@@ -41,11 +41,9 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate(Discret::Elements::Fluid* ele,
     Core::FE::Discretization& discretization, const std::vector<int>& lm,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, const Core::FE::GaussIntegration& intpoints)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration& intpoints)
 {
   //----------------------------------------------------------------
   // Now do the nurbs specific stuff (for isogeometric elements)
@@ -184,12 +182,12 @@ int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate(Discret::Elements::
       ele, Base::xyze_);
 
   // construct views
-  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, (nsd_ + 1) * nen_> elemat1(elemat1_epetra, true);
-  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, 1> elevec1(elevec1_epetra, true);
+  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, (nsd_ + 1) * nen_> elemat_1(elemat1, true);
+  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, 1> elevec_1(elevec1, true);
   // elemat2 and elevec2+3 are currently not in use
 
   // call inner evaluate (does not know about element or discretization object)
-  int result = Base::evaluate(params, ebofoaf, elemat1, elevec1, evelaf, epreaf, evelnp, eveln,
+  int result = Base::evaluate(params, ebofoaf, elemat_1, elevec_1, evelaf, epreaf, evelnp, eveln,
       eprenp, epren, emhist, echist, epressnp_timederiv, epressam_timederiv, epressn_timederiv,
       eaccam, edispnp, edispn, egridv, egridvn, escaaf, &eporositynp, &eporositydot, &eporositydotn,
       mat, ele->is_ale(), intpoints);
@@ -277,11 +275,9 @@ template <Core::FE::CellType distype>
 int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate_od(Discret::Elements::Fluid* ele,
     Core::FE::Discretization& discretization, const std::vector<int>& lm,
     Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, const Core::FE::GaussIntegration& intpoints)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, const Core::FE::GaussIntegration& intpoints)
 {
   //----------------------------------------------------------------
   // Now do the nurbs specific stuff (for isogeometric elements)
@@ -307,10 +303,10 @@ int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate_od(Discret::Element
   Base::rotsymmpbc_->setup(ele);
 
   // construct views
-  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, (nsd_ + 1) * nen_> elemat1(elemat1_epetra, true);
+  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, (nsd_ + 1) * nen_> elemat_1(elemat1, true);
   //  Core::LinAlg::Matrix<(nsd_+1)*nen_,(nsd_+1)*nen_>
-  //  elemat2(elemat2_epetra,true);
-  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, 1> elevec1(elevec1_epetra, true);
+  //  elemat_2(elemat2,true);
+  Core::LinAlg::Matrix<(nsd_ + 1) * nen_, 1> elevec_1(elevec1, true);
   // elevec2 and elevec3 are currently not in use
 
   // ---------------------------------------------------------------------
@@ -408,9 +404,10 @@ int Discret::Elements::FluidEleCalcPoroP1<distype>::evaluate_od(Discret::Element
       ele, Base::xyze_);
 
   // call inner evaluate (does not know about element or discretization object)
-  int result = evaluate_od(params, ebofoaf, elemat1, elevec1, evelaf, epreaf, evelnp, eveln, eprenp,
-      epren, emhist, echist, epressnp_timederiv, epressam_timederiv, epressn_timederiv, eaccam,
-      edispnp, edispn, egridv, egridvn, escaaf, &eporositynp, mat, ele->is_ale(), intpoints);
+  int result =
+      evaluate_od(params, ebofoaf, elemat_1, elevec_1, evelaf, epreaf, evelnp, eveln, eprenp, epren,
+          emhist, echist, epressnp_timederiv, epressam_timederiv, epressn_timederiv, eaccam,
+          edispnp, edispn, egridv, egridvn, escaaf, &eporositynp, mat, ele->is_ale(), intpoints);
 
   return result;
 }

--- a/src/fluid_ele/4C_fluid_ele_calc_poro_p1.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro_p1.hpp
@@ -68,22 +68,19 @@ namespace Discret
       \param lm               (i) location matrix of element
       \param params           (i) element parameter list
       \param mat              (i) material
-      \param elemat1_epetra   (o) element matrix to calculate
-      \param elemat2_epetra   (o) element matrix to calculate
-      \param elevec1_epetra   (o) element vector to calculate
-      \param elevec2_epetra   (o) element vector to calculate
-      \param elevec3_epetra   (o) element vector to calculate
+      \param elemat1          (o) element matrix to calculate
+      \param elemat2          (o) element matrix to calculate
+      \param elevec1          (o) element vector to calculate
+      \param elevec2          (o) element vector to calculate
+      \param elevec3          (o) element vector to calculate
       \param intpoints        (i) Gaussian integration points
 
       */
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints) override;
 
       /*!
@@ -95,22 +92,19 @@ namespace Discret
       \param lm               (i) location matrix of element
       \param params           (i) element parameter list
       \param mat              (i) material
-      \param elemat1_epetra   (o) element matrix to calculate
-      \param elemat2_epetra   (o) element matrix to calculate
-      \param elevec1_epetra   (o) element vector to calculate
-      \param elevec2_epetra   (o) element vector to calculate
-      \param elevec3_epetra   (o) element vector to calculate
+      \param elemat1          (o) element matrix to calculate
+      \param elemat2          (o) element matrix to calculate
+      \param elevec1          (o) element vector to calculate
+      \param elevec2          (o) element vector to calculate
+      \param elevec3          (o) element vector to calculate
       \param intpoints        (i) Gaussian integration points
 
       */
       int evaluate_od(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints) override;
 
      protected:

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem.hpp
@@ -116,19 +116,16 @@ namespace Discret
       /// evaluate the XFEM cut element
       int evaluate_xfem(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const std::vector<Core::FE::GaussIntegration>& intpoints,
           const Cut::plain_volumecell_set& cells, bool offdiag = false) override;
 
       /// evaluate the shape functions in the XFEM
       int integrate_shape_function_xfem(Discret::Elements::Fluid* ele,
           Core::FE::Discretization& discretization, const std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
+          Core::LinAlg::SerialDenseVector& elevec1,
           const std::vector<Core::FE::GaussIntegration>& intpoints,
           const Cut::plain_volumecell_set& cells) override;
 
@@ -171,10 +168,9 @@ namespace Discret
               side_coupling,                          ///< side coupling matrices
           Teuchos::ParameterList& params,             ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat,  ///< material
-          Core::LinAlg::SerialDenseMatrix&
-              elemat1_epetra,  ///< local system matrix of intersected element
+          Core::LinAlg::SerialDenseMatrix& elemat1,  ///< local system matrix of intersected element
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,                      ///< local element vector of intersected element
+              elevec1,                             ///< local element vector of intersected element
           Core::LinAlg::SerialDenseMatrix& Cuiui,  ///< coupling matrix of a side with itself
           const Cut::plain_volumecell_set& vcSet   ///< set of plain volume cells
           ) override;
@@ -191,8 +187,8 @@ namespace Discret
           Teuchos::ParameterList& params,                    ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat_master,  ///< material for the coupled side
           std::shared_ptr<Core::Mat::Material>& mat_slave,   ///< material for the coupled side
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   ///< element vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,          ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,          ///< element vector
           const Cut::plain_volumecell_set& vcSet,            ///< volumecell sets in this element
           std::map<int, std::vector<Core::LinAlg::SerialDenseMatrix>>&
               side_coupling,                       ///< side coupling matrices
@@ -204,7 +200,7 @@ namespace Discret
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele,  ///< fluid element
           Core::FE::Discretization& dis,                             ///< discretization
           const std::vector<int>& lm,                                ///< local map
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,           ///< element vector
+          Core::LinAlg::SerialDenseVector& elevec1,                  ///< element vector
           const Core::FE::GaussIntegration& intpoints                ///< integration points
           ) override;
 
@@ -212,7 +208,7 @@ namespace Discret
       void calculate_continuity_xfem(Discret::Elements::Fluid* ele,  ///< fluid element
           Core::FE::Discretization& dis,                             ///< discretization
           const std::vector<int>& lm,                                ///< local map
-          Core::LinAlg::SerialDenseVector& elevec1_epetra            ///< element vector
+          Core::LinAlg::SerialDenseVector& elevec1                   ///< element vector
           ) override;
 
      private:
@@ -302,7 +298,7 @@ namespace Discret
           const Core::LinAlg::Matrix<nen_, 1>& funct_m,  ///< coupling master shape functions
           const Core::LinAlg::Matrix<nsd_, 1>&
               itraction_jump,  ///< prescribed interface traction, jump height for coupled problems
-          Core::LinAlg::SerialDenseMatrix::Base& elevec1_epetra  ///< element vector
+          Core::LinAlg::SerialDenseMatrix::Base& elevec1  ///< element vector
       );
 
       //! build traction vector w.r.t fluid domain

--- a/src/fluid_ele/4C_fluid_ele_calc_xwall.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xwall.hpp
@@ -56,12 +56,10 @@ namespace Discret
 
       int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) override;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) override;
 
       void sysmat(const Core::LinAlg::Matrix<nsd_, nen_>& ebofoaf,
           const Core::LinAlg::Matrix<nsd_, nen_>& eprescpgaf,

--- a/src/fluid_ele/4C_fluid_ele_interface.hpp
+++ b/src/fluid_ele/4C_fluid_ele_interface.hpp
@@ -77,33 +77,26 @@ namespace Discret
        */
       virtual int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra, bool offdiag = false) = 0;
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
+          bool offdiag = false) = 0;
 
       /// evaluate element at specified Gauss points
       virtual int evaluate(Discret::Elements::Fluid* ele, Core::FE::Discretization& discretization,
           const std::vector<int>& lm, Teuchos::ParameterList& params,
-          std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          std::shared_ptr<Core::Mat::Material>& mat, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3,
           const Core::FE::GaussIntegration& intpoints, bool offdiag = false) = 0;
 
       /// Evaluate the XFEM cut element
       virtual int evaluate_xfem(Discret::Elements::Fluid* ele,
           Core::FE::Discretization& discretization, const std::vector<int>& lm,
           Teuchos::ParameterList& params, std::shared_ptr<Core::Mat::Material>& mat,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           const std::vector<Core::FE::GaussIntegration>& intpoints,
           const Cut::plain_volumecell_set& cells, bool offdiag = false) = 0;
 
@@ -158,10 +151,9 @@ namespace Discret
               side_coupling,                          ///< side coupling matrices
           Teuchos::ParameterList& params,             ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat,  ///< material
-          Core::LinAlg::SerialDenseMatrix&
-              elemat1_epetra,  ///< local system matrix of intersected element
+          Core::LinAlg::SerialDenseMatrix& elemat1,  ///< local system matrix of intersected element
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,                      ///< local element vector of intersected element
+              elevec1,                             ///< local element vector of intersected element
           Core::LinAlg::SerialDenseMatrix& Cuiui,  ///< coupling matrix of a side with itself
           const Cut::plain_volumecell_set& vcSet   ///< set of plain volume cells
           ) = 0;
@@ -178,8 +170,8 @@ namespace Discret
           Teuchos::ParameterList& params,                    ///< parameter list
           std::shared_ptr<Core::Mat::Material>& mat_master,  ///< material for the coupled side
           std::shared_ptr<Core::Mat::Material>& mat_slave,   ///< material for the coupled side
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   ///< element vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,          ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,          ///< element vector
           const Cut::plain_volumecell_set& vcSet,            ///< volumecell sets in this element
           std::map<int, std::vector<Core::LinAlg::SerialDenseMatrix>>&
               side_coupling,                       ///< side coupling matrices
@@ -189,12 +181,12 @@ namespace Discret
 
       virtual void calculate_continuity_xfem(Discret::Elements::Fluid* ele,
           Core::FE::Discretization& dis, const std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
+          Core::LinAlg::SerialDenseVector& elevec1,
           const Core::FE::GaussIntegration& intpoints) = 0;
 
       virtual void calculate_continuity_xfem(Discret::Elements::Fluid* ele,
           Core::FE::Discretization& dis, const std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra) = 0;
+          Core::LinAlg::SerialDenseVector& elevec1) = 0;
     };
 
   }  // namespace Elements

--- a/src/fluid_ele/4C_fluid_ele_intfaces_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_intfaces_calc.cpp
@@ -274,8 +274,7 @@ void Discret::Elements::FluidIntFaceImpl<distype>::assemble_internal_faces_using
   {
     TEUCHOS_FUNC_TIME_MONITOR("XFEM::Edgestab EOS: assemble FE matrix");
 
-    // calls the Assemble function for EpetraFECrs matrices including communication of non-row
-    // entries
+    // calls the Assemble function for matrices including communication of non-row entries
     if (assemblemat)
     {
       if (eos_gp_pattern == Inpar::FLUID::EOS_GP_Pattern_uvwp)

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -778,7 +778,7 @@ void FLD::XFluid::assemble_mat_and_rhs(int itnum)
 
     //-------------------------------------------------------------------------------
     // finalize the complete matrix
-    // REMARK: for EpetraFECrs matrices Complete() calls the GlobalAssemble() routine to gather
+    // REMARK: for matrices Complete() calls the GlobalAssemble() routine to gather
     // entries from all processors and calls a fill_complete for the first run. For further
     // Newton-steps then the optimized FEAssemble routine is used for speedup.
     state_->sysmat_->complete();
@@ -838,7 +838,7 @@ void FLD::XFluid::assemble_mat_and_rhs_vol_terms()
   const int numrowele = discret_->num_my_row_elements();
 
   // REMARK: in this XFEM framework the whole evaluate routine uses only row elements
-  // and assembles into EpetraFECrs matrix
+  // and assembles into matrix
   // this is 4C-unusual but more efficient in all XFEM applications
   for (int i = 0; i < numrowele; ++i)
   {
@@ -1212,8 +1212,7 @@ void FLD::XFluid::assemble_mat_and_rhs_vol_terms()
             Core::Communication::my_mpi_rank(strategy.systemvector1()->get_comm()));
         {
           TEUCHOS_FUNC_TIME_MONITOR("FLD::XFluid::XFluidState::Evaluate 6) FEAssemble");
-          // calls the Assemble function for EpetraFECrs matrices including communication of non-row
-          // entries
+          // calls the Assemble function for matrices including communication of non-row entries
           state_->sysmat_->fe_assemble(strategy.elematrix1(), la[0].lm_, myowner, la[0].lm_);
         }
         // REMARK:: call Assemble without lmowner
@@ -1262,8 +1261,7 @@ void FLD::XFluid::assemble_mat_and_rhs_vol_terms()
       {
         TEUCHOS_FUNC_TIME_MONITOR("FLD::XFluid::XFluidState::Evaluate 6) FEAssemble");
 
-        // calls the Assemble function for EpetraFECrs matrices including communication of non-row
-        // entries
+        // calls the Assemble function for matrices including communication of non-row entries
         state_->sysmat_->fe_assemble(strategy.elematrix1(), la[0].lm_, myowner, la[0].lm_);
       }
 
@@ -1305,7 +1303,7 @@ void FLD::XFluid::assemble_mat_and_rhs_face_terms(
     const int numrowintfaces = xdiscret->num_my_row_faces();
 
     // REMARK: in this XFEM framework the whole evaluate routine uses only row internal faces
-    // and assembles into EpetraFECrs matrix
+    // and assembles into matrix
     // this is 4C-unusual but more efficient in all XFEM applications
     for (int i = 0; i < numrowintfaces; ++i)
     {
@@ -1350,7 +1348,7 @@ void FLD::XFluid::integrate_shape_function(Teuchos::ParameterList& eleparams,
   const int numrowele = discret.num_my_row_elements();
 
   // REMARK: in this XFEM framework the whole evaluate routine uses only row elements
-  // and assembles into EpetraFECrs matrix
+  // and assembles into matrix
   // this is 4C-unusual but more efficient in all XFEM applications
   for (int i = 0; i < numrowele; ++i)
   {
@@ -1605,7 +1603,7 @@ void FLD::XFluid::assemble_mat_and_rhs_gradient_penalty(
 
   //-------------------------------------------------------------------------------
   // finalize the complete matrix
-  // REMARK: for EpetraFECrs matrices Complete() calls the GlobalAssemble() routine to gather
+  // REMARK: for matrices Complete() calls the GlobalAssemble() routine to gather
   // entries from all processors
   sysmat_gp->complete();
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid_state.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid_state.cpp
@@ -139,7 +139,7 @@ bool FLD::XFluidFluidState::destroy()
 {
   // destroy system matrix
   std::cout << "Destroying the xffluidsysmat_ is not possible at the moment. Internally more "
-               "strong RCPs point to the EpetraMatrix. This has to be checked!!!"
+               "strong RCPs point to the matrix. This has to be checked!!!"
             << std::endl;
 
   XFEM::destroy_rcp_object(xffluidvelnp_);

--- a/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
@@ -77,7 +77,7 @@ void FLD::XFluidState::CouplingState::complete_coupling_matrices_and_rhs(
 {
   if (!is_active_) return;
 
-  // REMARK: for EpetraFECrs matrices Complete() calls the GlobalAssemble() routine to gather
+  // REMARK: for matrices Complete() calls the GlobalAssemble() routine to gather
   // entries from all processors (domain-map are the columns, range-map are the rows)
   C_xs_->complete(slavedofrowmap, xfluiddofrowmap);
   C_sx_->complete(xfluiddofrowmap, slavedofrowmap);
@@ -141,7 +141,7 @@ FLD::XFluidState::XFluidState(const std::shared_ptr<XFEM::ConditionManager>& con
  *----------------------------------------------------------------------*/
 void FLD::XFluidState::init_system_matrix()
 {
-  // create an EpetraFECrs matrix that does communication for non-local rows and columns
+  // create a matrix that does communication for non-local rows and columns
   // * this enables to do the evaluate loop over just row elements instead of col elements
   // * time consuming assemble for cut elements is done only once on a unique row processor
   // REMARK: call the SparseMatrix: * explicitdirichlet = false (is used in ApplyDirichlet, true

--- a/src/fluid_xfluid/4C_fluid_xfluid_state.hpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state.hpp
@@ -199,7 +199,7 @@ namespace FLD
     /// dof-colmap of intersected fluid
     std::shared_ptr<const Core::LinAlg::Map> xfluiddofcolmap_;
 
-    /// system matrix (internally EpetraFECrs)
+    /// system matrix
     std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_;
 
     /// a vector of zeros to be used to enforce zero dirichlet boundary conditions

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -52,7 +52,7 @@ namespace Inpar::SOLVER
             },
             {.description =
                     "Type of internal preconditioner to use.\nNote! this preconditioner will "
-                    "only be used if the input operator\nsupports the Epetra_RowMatrix "
+                    "only be used if the input operator\nsupports the Epetra "
                     "interface and the client does not pass\nin an external preconditioner!",
                 .default_value = Core::LinearSolver::PreconditionerType::ilu}),
 

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -992,7 +992,7 @@ void ScaTra::LevelSetAlgorithm::redistribute(Core::LinAlg::Graph& nodegraph)
   //      to be redistributed, too
   FOUR_C_THROW("Fix Redistribution!");
   //--------------------------------------------------------------------
-  // Now update all Core::LinAlg::Vectors and Epetra_Matrix to the new dofmap
+  // Now update all vectors and matrices to the new dofmap
   //--------------------------------------------------------------------
 
   discret_->compute_null_space_if_necessary(solver_->params(), true);

--- a/src/lubrication/src/4C_lubrication_ele_calc.hpp
+++ b/src/lubrication/src/4C_lubrication_ele_calc.hpp
@@ -92,38 +92,30 @@ namespace Discret
        */
       int evaluate(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       // Evaluate the off-diagonal coupling block of monotlitic EHL matrix
       int evaluate_ehl_mon(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate action
       virtual int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const FourC::Lubrication::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra);
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3);
 
       //! evaluate service routine
       int evaluate_service(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       /*========================================================================*/
       //! @name static member variables

--- a/src/lubrication/src/4C_lubrication_ele_interface.hpp
+++ b/src/lubrication/src/4C_lubrication_ele_interface.hpp
@@ -62,19 +62,15 @@ namespace Discret
        */
       virtual int evaluate(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) = 0;
 
       virtual int evaluate_ehl_mon(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) = 0;
 
       /*!
         This class does not provide a definition for this function; it
@@ -84,11 +80,9 @@ namespace Discret
       */
       virtual int evaluate_service(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) = 0;
     };
   }  // namespace Elements
 }  // namespace Discret

--- a/src/lubrication/src/4C_lubrication_timint_implicit.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_implicit.cpp
@@ -1001,7 +1001,7 @@ void Lubrication::TimIntImpl::output_state()
         discret_->get_state(nds_disp_, "dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot extract displacement field from discretization");
 
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     Core::LinAlg::MultiVector<double> dispnp_multi(*discret_->node_row_map(), nsd_, true);
     for (int inode = 0; inode < discret_->num_my_row_nodes(); ++inode)
     {

--- a/src/mat/4C_mat_plasticnlnlogneohooke.cpp
+++ b/src/mat/4C_mat_plasticnlnlogneohooke.cpp
@@ -458,13 +458,12 @@ void Mat::PlasticNlnLogNeoHooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defg
   // Here we start the principal stress based algorithm
   // ***************************************************
 
-  // convert to epetra format and solve eigenvalue problem
+  // convert and solve eigenvalue problem
   // this matrix contains spatial eigen directions (the second
   // index corresponds to the eigenvalue)
   Core::LinAlg::SerialDenseMatrix n(3, 3);
   Core::LinAlg::SerialDenseVector lambda_trial_square(3);
 
-  // convert Input Matrix in Epetra format
   for (int i = 0; i < 3; i++)
     for (int j = 0; j < 3; j++) n(i, j) = Be_trial(i, j);
 

--- a/src/mat/4C_mat_superelastic_sma.cpp
+++ b/src/mat/4C_mat_superelastic_sma.cpp
@@ -381,7 +381,6 @@ void Mat::SuperElasticSMA::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
   cauchy_green_tensor.multiply_nt(*defgrd, *defgrd);
 
   // To compute the spectral decomposition, the Cauchy-Green tensor
-  // must be converted to Epetra format
   Core::LinAlg::SerialDenseMatrix cauchy_green_eigenvectors(3, 3);
   Core::LinAlg::SerialDenseVector cauchy_green_eigenvalues(3);
 

--- a/src/membrane/4C_membrane.hpp
+++ b/src/membrane/4C_membrane.hpp
@@ -341,11 +341,10 @@ namespace Discret
       \return 0 if successful, negative otherwise
       */
       int evaluate(Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          std::vector<int>& lm, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          std::vector<int>& lm, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
 
       /*!

--- a/src/membrane/4C_membrane_scatra.hpp
+++ b/src/membrane/4C_membrane_scatra.hpp
@@ -201,11 +201,10 @@ namespace Discret
       \return 0 if successful, negative otherwise
       */
       int evaluate(Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //@}
 

--- a/src/membrane/4C_membrane_scatra_evaluate.cpp
+++ b/src/membrane/4C_membrane_scatra_evaluate.cpp
@@ -102,17 +102,15 @@ void Discret::Elements::MembraneScatra<distype>::pre_evaluate(Teuchos::Parameter
 template <Core::FE::CellType distype>
 int Discret::Elements::MembraneScatra<distype>::evaluate(Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   // in some cases we need to write/change some data before evaluating
   pre_evaluate(params, discretization, la);
 
-  Membrane<distype>::evaluate(params, discretization, la[0].lm_, elemat1_epetra, elemat2_epetra,
-      elevec1_epetra, elevec2_epetra, elevec3_epetra);
+  Membrane<distype>::evaluate(
+      params, discretization, la[0].lm_, elemat1, elemat2, elevec1, elevec2, elevec3);
 
   return 0;
 }

--- a/src/mortar/4C_mortar_dofset.cpp
+++ b/src/mortar/4C_mortar_dofset.cpp
@@ -75,7 +75,7 @@ int Mortar::DofSet::assign_degrees_of_freedom(
     }
   }
 
-  // we have new vectors, so recreate Epetra maps and replace old ones with them
+  // we have new vectors, so recreate maps and replace old ones with them
   std::shared_ptr<Core::LinAlg::Map> newdofrowmap =
       std::make_shared<Core::LinAlg::Map>(-1, nummyrow, myrow.data(), 0, dofrowmap_->Comm());
   std::shared_ptr<Core::LinAlg::Map> newdofcolmap =

--- a/src/mortar/4C_mortar_manager_base.hpp
+++ b/src/mortar/4C_mortar_manager_base.hpp
@@ -83,7 +83,7 @@ namespace Mortar
     //! @name Access methods
 
     /*!
-    \brief Get Epetra communicator
+    \brief Get communicator
 
     */
     MPI_Comm get_comm() const { return comm_; }

--- a/src/mortar/4C_mortar_strategy_base.hpp
+++ b/src/mortar/4C_mortar_strategy_base.hpp
@@ -218,7 +218,7 @@ namespace Mortar
     //! Get problem dimension
     int n_dim() const { return dim_; }
 
-    //! Get Epetra communicator
+    //! Get communicator
     MPI_Comm get_comm() const { return comm_; }
 
     //! Get the underlying problem dof row map

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
@@ -631,7 +631,7 @@ void PoroPressureBased::TimIntImpl::collect_runtime_output_data()
   // solid pressure
   if (output_solidpress_)
   {
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     std::shared_ptr<Core::LinAlg::MultiVector<double>> solidpressure_multi =
         PoroPressureBased::convert_dof_vector_to_node_based_multi_vector(
             *discret_, *solidpressure_, nds_solidpressure_, 1);
@@ -647,7 +647,7 @@ void PoroPressureBased::TimIntImpl::collect_runtime_output_data()
         discret_->get_state(nds_disp_, "dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot extract displacement field from discretization");
 
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     std::shared_ptr<Core::LinAlg::MultiVector<double>> dispnp_multi =
         PoroPressureBased::convert_dof_vector_to_node_based_multi_vector(
             *discret_, *dispnp, nds_disp_, nsd_);
@@ -718,7 +718,7 @@ void PoroPressureBased::TimIntImpl::collect_runtime_output_data()
   // porosity
   if (output_porosity_)
   {
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     std::shared_ptr<Core::LinAlg::MultiVector<double>> porosity_multi =
         PoroPressureBased::convert_dof_vector_to_node_based_multi_vector(
             *discret_, *porosity_, nds_solidpressure_, 1);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.hpp
@@ -47,8 +47,8 @@ namespace PoroPressureBased
   /// convert a dof based vector to a node based multi vector
   /*!
     For postprocessing, only vectors based on the primary dof set
-    of the discretization can be used. Hence, all other EpetraVectors
-    based on secondary dof sets are copied to EpetraMultiVectors with one
+    of the discretization can be used. Hence, all other vectors
+    based on secondary dof sets are copied to multi vectors with one
     node based vector for each component.
 
     This method can be deleted, if the post processors would be adapted to

--- a/src/post/4C_post_common.cpp
+++ b/src/post/4C_post_common.cpp
@@ -200,7 +200,7 @@ int PostProblem::field_pos(const PostField* field) const
 
 
 /*----------------------------------------------------------------------*
- * returns the Epetra Communicator object
+ * returns the MPI communicator object
  *----------------------------------------------------------------------*/
 MPI_Comm PostProblem::get_comm() { return comm_; }
 
@@ -857,7 +857,7 @@ void PostResult::open_result_files(MAP* field_info)
 
 /*----------------------------------------------------------------------*
  * reads the data of the result vector 'name' from the current result
- * block and returns it as an Epetra Vector.
+ * block and returns it as an vector.
  *----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Vector<double>> PostResult::read_result(const std::string name)
 {
@@ -918,7 +918,7 @@ PostResult::read_result_serialdensematrix(const std::string name)
 
 /*----------------------------------------------------------------------*
  * reads the data of the result vector 'name' from the current result
- * block and returns it as an Epetra Vector.
+ * block and returns it as an multi vector.
  *----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::MultiVector<double>> PostResult::read_multi_result(
     const std::string name)

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -119,13 +119,11 @@ void sysmat(Discret::Elements::RedAcinus* ele, Core::LinAlg::SerialDenseVector& 
 template <Core::FE::CellType distype>
 int Discret::Elements::AcinusImpl<distype>::evaluate(RedAcinus* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& lm,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
-  const int elemVecdim = elevec1_epetra.length();
+  const int elemVecdim = elevec1.length();
 
   Discret::ReducedLung::EvaluationData& evaluation_data =
       Discret::ReducedLung::EvaluationData::get();
@@ -195,15 +193,14 @@ int Discret::Elements::AcinusImpl<distype>::evaluate(RedAcinus* ele, Teuchos::Pa
   elem_params.lungVolume_nm = evaluation_data.lungVolume_nm;
 
   // Call routine for calculating element matrix and right hand side
-  sysmat<distype>(
-      ele, epnp, epn, epnm, elemat1_epetra, elevec1_epetra, *mat, elem_params, time, dt);
+  sysmat<distype>(ele, epnp, epn, epnm, elemat1, elevec1, *mat, elem_params, time, dt);
 
   // Put zeros on second line of matrix and rhs in case of interacinar linker
   if (myial[1] > 0.0)
   {
-    elemat1_epetra(1, 0) = 0.0;
-    elemat1_epetra(1, 1) = 0.0;
-    elevec1_epetra(1) = 0.0;
+    elemat1(1, 0) = 0.0;
+    elemat1(1, 1) = 0.0;
+    elevec1(1) = 0.0;
   }
 
   return 0;

--- a/src/red_airways/4C_red_airways_acinus_impl.hpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.hpp
@@ -37,12 +37,9 @@ namespace Discret
       virtual ~RedAcinusImplInterface() = default;  /// Evaluate the element
       virtual int evaluate(RedAcinus* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       virtual void initial(RedAcinus* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
@@ -50,8 +47,7 @@ namespace Discret
 
       virtual void evaluate_terminal_bc(RedAcinus* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseVector& elevec1, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       virtual void calc_flow_rates(RedAcinus* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
@@ -97,11 +93,9 @@ namespace Discret
       */
       int evaluate(RedAcinus* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       void evaluate_terminal_bc(RedAcinus* ele, Teuchos::ParameterList& params,

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -568,13 +568,11 @@ Discret::Elements::RedAirwayImplInterface* Discret::Elements::RedAirwayImplInter
 template <Core::FE::CellType distype>
 int Discret::Elements::AirwayImpl<distype>::evaluate(RedAirway* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, std::vector<int>& lm,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
-  const int elemVecdim = elevec1_epetra.length();
+  const int elemVecdim = elevec1.length();
 
   Discret::ReducedLung::EvaluationData& evaluation_data =
       Discret::ReducedLung::EvaluationData::get();
@@ -670,7 +668,7 @@ int Discret::Elements::AirwayImpl<distype>::evaluate(RedAirway* ele, Teuchos::Pa
   // ---------------------------------------------------------------------
   // call routine for calculating element matrix and right hand side
   // ---------------------------------------------------------------------
-  sysmat<distype>(ele, epnp, epn, epnm, elemat1_epetra, elevec1_epetra, mat, elem_params, time, dt,
+  sysmat<distype>(ele, epnp, epn, epnm, elemat1, elevec1, mat, elem_params, time, dt,
       evaluation_data.compute_awacinter);
 
   return 0;

--- a/src/red_airways/4C_red_airways_airway_impl.hpp
+++ b/src/red_airways/4C_red_airways_airway_impl.hpp
@@ -37,12 +37,9 @@ namespace Discret
       virtual ~RedAirwayImplInterface() = default;  /// Evaluate the element
       virtual int evaluate(RedAirway* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       virtual void initial(RedAirway* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
@@ -51,8 +48,7 @@ namespace Discret
 
       virtual void evaluate_terminal_bc(RedAirway* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseVector& elevec1, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       virtual void calc_flow_rates(RedAirway* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
@@ -98,11 +94,9 @@ namespace Discret
        */
       int evaluate(RedAirway* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       /*!

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -67,11 +67,9 @@ Discret::Elements::InterAcinarDepImpl<distype>::InterAcinarDepImpl()
 template <Core::FE::CellType distype>
 int Discret::Elements::InterAcinarDepImpl<distype>::evaluate(RedInterAcinarDep* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization, std::vector<int>& lm,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra, std::shared_ptr<Core::Mat::Material> mat)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat)
 {
   // Get the vector with inter-acinar linkers
   std::shared_ptr<const Core::LinAlg::Vector<double>> ial =
@@ -81,7 +79,7 @@ int Discret::Elements::InterAcinarDepImpl<distype>::evaluate(RedInterAcinarDep* 
   std::vector<double> myial = Core::FE::extract_values(*ial, lm);
 
   // Calculate the system matrix for inter-acinar linkers
-  sysmat(myial, elemat1_epetra, elevec1_epetra);
+  sysmat(myial, elemat1, elevec1);
 
   return 0;
 }

--- a/src/red_airways/4C_red_airways_interacinardep_impl.hpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.hpp
@@ -37,22 +37,18 @@ namespace Discret
       virtual ~RedInterAcinarDepImplInterface() = default;  /// Evaluate the element
       virtual int evaluate(RedInterAcinarDep* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       virtual void initial(RedInterAcinarDep* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<const Core::Mat::Material> material) = 0;
 
       virtual void evaluate_terminal_bc(RedInterAcinarDep* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          std::shared_ptr<Core::Mat::Material> mat) = 0;
+          Core::LinAlg::SerialDenseVector& elevec1, std::shared_ptr<Core::Mat::Material> mat) = 0;
 
       virtual void calc_flow_rates(RedInterAcinarDep* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::LinAlg::SerialDenseVector& a_volumen,
@@ -95,11 +91,9 @@ namespace Discret
        */
       int evaluate(RedInterAcinarDep* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra,
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3,
           std::shared_ptr<Core::Mat::Material> mat) override;
 
       /*!

--- a/src/reduced_lung/4C_reduced_lung_helpers.hpp
+++ b/src/reduced_lung/4C_reduced_lung_helpers.hpp
@@ -130,11 +130,11 @@ namespace ReducedLung
   };
 
   /*!
-   * @brief Create the Epetra map with the locally owned dofs spanning the computation domain that
+   * @brief Create the map with the locally owned dofs spanning the computation domain that
    * are necessary for the solution vector.
    *
    * The 4C discretization gives a mpi distribution of the Reduced Lung elements. From this
-   * distribution and the knowledge about the number of dofs in every element, the new Epetra map
+   * distribution and the knowledge about the number of dofs in every element, the new map
    * mapping the local dofs to their global ids is created. Example: The dofs of element k have
    * global ids in the range first_global_dof_of_ele[k] to first_global_dof_of_ele[k] + dofs of
    * element k.
@@ -142,18 +142,18 @@ namespace ReducedLung
    * @param comm Communicator of the 4C discretization.
    * @param airways Vector of locally owned airways.
    * @param terminal_units Vector of locally owned terminal units.
-   * @return Epetra map specifying the dof-distribution over all ranks.
+   * @return map specifying the dof-distribution over all ranks.
    */
   Core::LinAlg::Map create_domain_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units);
 
   /*!
-   * @brief Create the Epetra map with the locally owned row indices of the system matrix, i.e. the
+   * @brief Create the map with the locally owned row indices of the system matrix, i.e. the
    * distribution of the system's equation.
    *
    * The row indices are uniquely tied to the system equations. Given the locally owned
    * elements and nodes in the 4C discretization, the related equation ids are created and stored in
-   * this Epetra map. Every element provides state equations, every node provides information about
+   * this map. Every element provides state equations, every node provides information about
    * its elements. Depending on the number of connected elements at one node, different sets and
    * numbers of equations are needed.
    * Per owned element: one or two equations and row ids.
@@ -170,7 +170,7 @@ namespace ReducedLung
    * child element ids).
    * @param boundary_conditions Vector with boundary condition information. Here, only the boundary
    * element ids are needed.
-   * @return Epetra map with locally owned rows.
+   * @return map with locally owned rows.
    */
   Core::LinAlg::Map create_row_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units, const std::vector<Connection>& connections,
@@ -178,7 +178,7 @@ namespace ReducedLung
       const std::vector<BoundaryCondition>& boundary_conditions);
 
   /*!
-   * @brief Create the Epetra map with the dof indices relevant for the locally owned
+   * @brief Create the map with the dof indices relevant for the locally owned
    * equations/rows.
    *
    * This map connects the equations (rows of matrix and rhs vector) with their relevant dofs.
@@ -197,7 +197,7 @@ namespace ReducedLung
    * child element ids).
    * @param boundary_conditions Vector with boundary condition information. Here, only the boundary
    * element ids are needed.
-   * @return Epetra map with distribution of column indices for the system matrix.
+   * @return map with distribution of column indices for the system matrix.
    */
   Core::LinAlg::Map create_column_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units, const std::map<int, int>& global_dof_per_ele,

--- a/src/reduced_lung/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/4C_reduced_lung_main.cpp
@@ -360,7 +360,7 @@ namespace ReducedLung
       n_local_equations++;
     }
 
-    // Create all necessary epetra maps for matrix, rhs, and dof-vector.
+    // Create all necessary maps for matrix, rhs, and dof-vector.
     const auto& epetra_comm = Core::Communication::as_epetra_comm(comm);
     // Map with all dof ids belonging to the local elements (airways and terminal units).
     const Core::LinAlg::Map locally_owned_dof_map =

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -2930,7 +2930,7 @@ void ScaTra::ScaTraTimIntElch::apply_dirichlet_bc(const double time,
         }  // relevant condition
       }  // loop over all conditions
 
-      // transform set into vector and then into Epetra map
+      // transform set into vector and then into map
       std::vector<int> dbcgidsvec(dbcgids.begin(), dbcgids.end());
       auto dbcmap = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(dbcgids.size()),
           dbcgidsvec.data(), dof_row_map()->IndexBase(), dof_row_map()->Comm());

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -743,7 +743,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
     write_coupling_to_csv(
         glob_macro_micro_coupled_node_gids, glob_macro_slave_node_master_node_gids);
 
-  // setup Epetra maps for coupled nodes
+  // setup maps for coupled nodes
   Core::LinAlg::Map master_node_map(-1, static_cast<int>(my_macro_node_gids.size()),
       &my_macro_node_gids[0], 0, Core::Communication::as_epetra_comm(comm));
   Core::LinAlg::Map slave_node_map(-1, static_cast<int>(my_micro_node_gids.size()),

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1763,7 +1763,7 @@ void ScaTra::ScaTraTimIntImpl::collect_runtime_output_data()
     auto convel = discret_->get_state(nds_vel(), "convective velocity field");
     if (convel == nullptr) FOUR_C_THROW("Cannot get state vector convective velocity");
 
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     auto convel_multi = Core::LinAlg::MultiVector<double>(*discret_->node_row_map(), nsd_, true);
     for (int inode = 0; inode < discret_->num_my_row_nodes(); ++inode)
     {
@@ -1811,7 +1811,7 @@ void ScaTra::ScaTraTimIntImpl::collect_runtime_output_data()
         discret_->get_state(nds_disp(), "dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot extract displacement field from discretization");
 
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     auto dispnp_multi = Core::LinAlg::MultiVector<double>(*discret_->node_row_map(), nsd_, true);
     for (int inode = 0; inode < discret_->num_my_row_nodes(); ++inode)
     {

--- a/src/scatra/4C_scatra_timint_poromulti.cpp
+++ b/src/scatra/4C_scatra_timint_poromulti.cpp
@@ -141,7 +141,7 @@ void ScaTra::ScaTraTimIntPoroMulti::collect_runtime_output_data()
         discret_->get_state(nds_disp(), "dispnp");
     if (dispnp == nullptr) FOUR_C_THROW("Cannot extract displacement field from discretization");
 
-    // convert dof-based Epetra vector into node-based Epetra multi-vector for postprocessing
+    // convert dof-based vector into node-based multi-vector for postprocessing
     auto dispnp_multi = Core::LinAlg::MultiVector<double>(*discret_->node_row_map(), nsd_, true);
     for (int inode = 0; inode < discret_->num_my_row_nodes(); ++inode)
     {

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.hpp
@@ -148,20 +148,16 @@ namespace Discret
       //! Evaluate the element (using location array)
       int evaluate(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate action
       virtual int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra);
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3);
 
       //! evaluate Neumann boundary condition
       int evaluate_neumann(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
@@ -512,8 +508,7 @@ namespace Discret
       void weak_dirichlet(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization,
           std::shared_ptr<const Core::Mat::Material> material,
-          Core::LinAlg::SerialDenseMatrix& elemat_epetra,
-          Core::LinAlg::SerialDenseVector& elevec_epetra);
+          Core::LinAlg::SerialDenseMatrix& elemat, Core::LinAlg::SerialDenseVector& elevec);
 
 
       //! calculate boundary conditions for impl. Characteristic Galerkin time integration, just for
@@ -521,20 +516,20 @@ namespace Discret
       template <Core::FE::CellType bdistype,
           Core::FE::CellType pdistype>
       void reinit_characteristic_galerkin_boundary(
-          Core::Elements::FaceElement* ele,                //!< transport element
-          Teuchos::ParameterList& params,                  //!< parameter list
-          Core::FE::Discretization& discretization,        //!< discretization
-          const Core::Mat::Material& material,             //!< material
-          Core::LinAlg::SerialDenseMatrix& elemat_epetra,  //!< ele sysmat
-          Core::LinAlg::SerialDenseVector& elevec_epetra   //!< ele rhs
+          Core::Elements::FaceElement* ele,          //!< transport element
+          Teuchos::ParameterList& params,            //!< parameter list
+          Core::FE::Discretization& discretization,  //!< discretization
+          const Core::Mat::Material& material,       //!< material
+          Core::LinAlg::SerialDenseMatrix& elemat,   //!< ele sysmat
+          Core::LinAlg::SerialDenseVector& elevec    //!< ele rhs
       );
 
       //! evaluate Robin boundary condition
       virtual void calc_robin_boundary(Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
           Core::Elements::LocationArray& la,  ///< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra, const double scalar);
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseVector& elevec1,
+          const double scalar);
 
       //! evaluate integral of all positive fluxes on s2i condition
       virtual void calc_s2_i_coupling_flux(const Core::Elements::FaceElement* ele,

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch.hpp
@@ -51,11 +51,11 @@ namespace Discret
           Core::FE::Discretization& discretization,          //!< discretization
           ScaTra::BoundaryAction action,                     //!< action
           Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,   //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,   //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra    //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
           ) override;
 
       //! evaluate an electrode kinetics boundary condition
@@ -84,8 +84,8 @@ namespace Discret
           Teuchos::ParameterList& params,                                 ///< parameter list
           Core::FE::Discretization& discretization,                       ///< discretization
           Core::Elements::LocationArray& la,                              ///< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,                ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  ///< element right-hand side vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,                       ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,  ///< element right-hand side vector
           const double
               scalar  ///< scaling factor for element matrix and right-hand side contributions
       );
@@ -111,8 +111,8 @@ namespace Discret
       //! evaluate linearization of nernst equation
       void calc_nernst_linearization(Core::Elements::FaceElement* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra);
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseVector& elevec1);
 
       //! calculate cell voltage
       void calc_cell_voltage(

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.cpp
@@ -54,16 +54,16 @@ Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::ScaTraEleBound
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_action(
-    Core::Elements::FaceElement* ele,                 //!< boundary element
-    Teuchos::ParameterList& params,                   //!< parameter list
-    Core::FE::Discretization& discretization,         //!< discretization
-    ScaTra::BoundaryAction action,                    //!< action
-    Core::Elements::LocationArray& la,                //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+    Core::Elements::FaceElement* ele,          //!< boundary element
+    Teuchos::ParameterList& params,            //!< parameter list
+    Core::FE::Discretization& discretization,  //!< discretization
+    ScaTra::BoundaryAction action,             //!< action
+    Core::Elements::LocationArray& la,         //!< location array
+    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
+    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
+    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
+    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
+    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
 )
 {
   // determine and evaluate action
@@ -71,16 +71,15 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchNP<distype, probdim>::evaluate_a
   {
     case ScaTra::BoundaryAction::calc_elch_boundary_kinetics:
     {
-      myelch::calc_elch_boundary_kinetics(
-          ele, params, discretization, la, elemat1_epetra, elevec1_epetra, 1.);
+      myelch::calc_elch_boundary_kinetics(ele, params, discretization, la, elemat1, elevec1, 1.);
 
       break;
     }
 
     default:
     {
-      myelch::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      myelch::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_NP.hpp
@@ -43,11 +43,11 @@ namespace Discret
           Core::FE::Discretization& discretization,          //!< discretization
           ScaTra::BoundaryAction action,                     //!< action
           Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,   //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,   //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra    //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
           ) override;
 
       //! evaluate Neumann boundary condition

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.cpp
@@ -58,16 +58,16 @@ Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype,
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::evaluate_action(
-    Core::Elements::FaceElement* ele,                 //!< boundary element
-    Teuchos::ParameterList& params,                   //!< parameter list
-    Core::FE::Discretization& discretization,         //!< discretization
-    ScaTra::BoundaryAction action,                    //!< action
-    Core::Elements::LocationArray& la,                //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+    Core::Elements::FaceElement* ele,          //!< boundary element
+    Teuchos::ParameterList& params,            //!< parameter list
+    Core::FE::Discretization& discretization,  //!< discretization
+    ScaTra::BoundaryAction action,             //!< action
+    Core::Elements::LocationArray& la,         //!< location array
+    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
+    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
+    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
+    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
+    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
 )
 {
   // determine and evaluate action
@@ -102,16 +102,16 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchDiffCond<distype, probdim>::eval
         FOUR_C_THROW("Invalid material!");
 
       // process electrode kinetics boundary condition
-      myelch::calc_elch_boundary_kinetics(ele, params, discretization, la, elemat1_epetra,
-          elevec1_epetra, dmedc_->get_phase_poro(0));
+      myelch::calc_elch_boundary_kinetics(
+          ele, params, discretization, la, elemat1, elevec1, dmedc_->get_phase_poro(0));
 
       break;
     }
 
     default:
     {
-      myelch::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      myelch::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_diffcond.hpp
@@ -48,11 +48,10 @@ namespace Discret
 
       int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       int evaluate_neumann(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Conditions::Condition& condition,

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.cpp
@@ -358,32 +358,28 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype, probdim>::evaluate_action(
     Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
   {
     case ScaTra::BoundaryAction::calc_s2icoupling_growthgrowth:
     {
-      evaluate_s2_i_coupling_growth_growth(
-          ele, params, discretization, la, elemat1_epetra, elevec1_epetra);
+      evaluate_s2_i_coupling_growth_growth(ele, params, discretization, la, elemat1, elevec1);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_growthscatra:
     {
-      evaluate_s2_i_coupling_growth_scatra(
-          ele, params, discretization, la, elemat1_epetra, elemat2_epetra);
+      evaluate_s2_i_coupling_growth_scatra(ele, params, discretization, la, elemat1, elemat2);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_scatragrowth:
     {
-      evaluate_s2_i_coupling_scatra_growth(ele, params, discretization, la, elemat1_epetra);
+      evaluate_s2_i_coupling_scatra_growth(ele, params, discretization, la, elemat1);
       break;
     }
 
@@ -395,8 +391,8 @@ int Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeGrowth<distype, probdim
 
     default:
     {
-      myelch::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      myelch::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }  // switch action

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_growth.hpp
@@ -47,11 +47,11 @@ namespace Discret
           Core::FE::Discretization& discretization,          //!< discretization
           ScaTra::BoundaryAction action,                     //!< action
           Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,   //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,   //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra    //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
           ) override;
 
       //! evaluate minimum and maximum interfacial overpotential associated with scatra-scatra

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.cpp
@@ -387,25 +387,23 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcElchElectrodeSTIThermo<distype,
     probdim>::evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
   {
     case ScaTra::BoundaryAction::calc_s2icoupling_od:
     {
-      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1_epetra);
+      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1);
       break;
     }
 
     default:
     {
-      myelectrode::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      myelectrode::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }  // switch action

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_elch_electrode_sti_thermo.hpp
@@ -114,11 +114,11 @@ namespace Discret
           Core::FE::Discretization& discretization,          //!< discretization
           ScaTra::BoundaryAction action,                     //!< action
           Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,   //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,   //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra    //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
           ) override;
 
       //! extract nodal state variables associated with boundary element

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.cpp
@@ -64,11 +64,9 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcLoma<distype, probdim>::evaluate_action(
     Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
@@ -82,8 +80,8 @@ int Discret::Elements::ScaTraEleBoundaryCalcLoma<distype, probdim>::evaluate_act
 
     default:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.hpp
@@ -36,11 +36,10 @@ namespace Discret
       //! evaluate action
       int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      private:
       //! private constructor for singletons

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.cpp
@@ -66,11 +66,9 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcPoro<distype, probdim>::evaluate_action(
     Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
@@ -82,8 +80,8 @@ int Discret::Elements::ScaTraEleBoundaryCalcPoro<distype, probdim>::evaluate_act
     case ScaTra::BoundaryAction::calc_normal_vectors:
     case ScaTra::BoundaryAction::integrate_shape_functions:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
     case ScaTra::BoundaryAction::add_convective_mass_flux:
@@ -161,8 +159,8 @@ int Discret::Elements::ScaTraEleBoundaryCalcPoro<distype, probdim>::evaluate_act
         isnodalporosity_ = false;
 
       // for the moment we ignore the return values of this method
-      calc_convective_flux(ele, ephinp, econvel, elevec1_epetra);
-      // vector<double> locfluxintegral = calc_convective_flux(ele,ephinp,evel,elevec1_epetra);
+      calc_convective_flux(ele, ephinp, econvel, elevec1);
+      // vector<double> locfluxintegral = calc_convective_flux(ele,ephinp,evel,elevec1);
       // std::cout<<"locfluxintegral[0] = "<<locfluxintegral[0]<<std::endl;
 
       break;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_poro.hpp
@@ -34,11 +34,10 @@ namespace Discret
       //! evaluate action
       int evaluate_action(Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      protected:
       //! compute integral of convective mass/heat flux over boundary surface

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.cpp
@@ -712,32 +712,29 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleBoundaryCalcSTIElectrode<distype, probdim>::evaluate_action(
     Core::Elements::FaceElement* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, ScaTra::BoundaryAction action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
   {
     case ScaTra::BoundaryAction::calc_s2icoupling:
     {
-      evaluate_s2_i_coupling(
-          ele, params, discretization, la, elemat1_epetra, elemat2_epetra, elevec1_epetra);
+      evaluate_s2_i_coupling(ele, params, discretization, la, elemat1, elemat2, elevec1);
       break;
     }
 
     case ScaTra::BoundaryAction::calc_s2icoupling_od:
     {
-      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1_epetra, elemat2_epetra);
+      evaluate_s2_i_coupling_od(ele, params, discretization, la, elemat1, elemat2);
       break;
     }
 
     default:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_sti_electrode.hpp
@@ -161,11 +161,11 @@ namespace Discret
           Core::FE::Discretization& discretization,          //!< discretization
           ScaTra::BoundaryAction action,                     //!< action
           Core::Elements::LocationArray& la,                 //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,   //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,   //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,   //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,   //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra    //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,          //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,          //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,          //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,          //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3           //!< element right-hand side vector 3
           ) override;
 
       //! extract nodal state variables associated with boundary element

--- a/src/scatra_ele/4C_scatra_ele_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc.cpp
@@ -156,11 +156,9 @@ int Discret::Elements::ScaTraEleCalc<distype, probdim>::setup_calc(
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalc<distype, probdim>::evaluate(Core::Elements::Element* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   //--------------------------------------------------------------------------------
   // preparations for element
@@ -185,12 +183,12 @@ int Discret::Elements::ScaTraEleCalc<distype, probdim>::evaluate(Core::Elements:
   // calculate element coefficient matrix and rhs
   //--------------------------------------------------------------------------------
 
-  sysmat(ele, elemat1_epetra, elevec1_epetra, elevec2_epetra);
+  sysmat(ele, elemat1, elevec1, elevec2);
 
   // perform finite difference check on element level
   if (scatrapara_->fd_check() == Inpar::ScaTra::fdcheck_local and
       ele->owner() == Core::Communication::my_mpi_rank(discretization.get_comm()))
-    fd_check(ele, elemat1_epetra, elevec1_epetra, elevec2_epetra);
+    fd_check(ele, elemat1, elevec1, elevec2);
 
   // ---------------------------------------------------------------------
   // output values of Prt, diffeff and Cs_delta_sq_Prt (channel flow only)

--- a/src/scatra_ele/4C_scatra_ele_calc.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc.hpp
@@ -95,46 +95,36 @@ namespace Discret
        */
       int evaluate(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate action
       virtual int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra);
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3);
 
       //! evaluate action for off-diagonal system matrix block
       virtual int evaluate_action_od(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra);
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3);
 
       //! evaluate service routine
       int evaluate_service(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       int evaluate_od(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       /*========================================================================*/
       //! @name static member variables

--- a/src/scatra_ele/4C_scatra_ele_calc_OD.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_OD.cpp
@@ -22,11 +22,9 @@ FOUR_C_NAMESPACE_OPEN
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalc<distype, probdim>::evaluate_od(Core::Elements::Element* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   //--------------------------------------------------------------------------------
   // preparations for element
@@ -48,8 +46,8 @@ int Discret::Elements::ScaTraEleCalc<distype, probdim>::evaluate_od(Core::Elemen
   const auto action = Teuchos::getIntegralValue<ScaTra::Action>(params, "action");
 
   // evaluate action
-  evaluate_action_od(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-      elevec1_epetra, elevec2_epetra, elevec3_epetra);
+  evaluate_action_od(
+      ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
   return 0;
 }
@@ -62,25 +60,23 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalc<distype, probdim>::evaluate_action_od(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
   {
     case ScaTra::Action::calc_scatra_mono_odblock_mesh:
     {
-      sysmat_od_mesh(ele, elemat1_epetra, nsd_);
+      sysmat_od_mesh(ele, elemat1, nsd_);
 
       break;
     }
 
     case ScaTra::Action::calc_scatra_mono_odblock_fluid:
     {
-      sysmat_od_fluid(ele, elemat1_epetra, nsd_ + 1);
+      sysmat_od_fluid(ele, elemat1, nsd_ + 1);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain.hpp
@@ -47,11 +47,10 @@ namespace Discret
       //! evaluate the element
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      protected:
       /*========================================================================*/

--- a/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain_hdg.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_cardiac_monodomain_hdg.hpp
@@ -45,11 +45,9 @@ namespace Discret
       //! evaluate the element
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra)
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
       {
         return 0;
       };

--- a/src/scatra_ele/4C_scatra_ele_calc_elch.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch.cpp
@@ -42,20 +42,17 @@ Discret::Elements::ScaTraEleCalcElch<distype, probdim>::ScaTraEleCalcElch(
 template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalcElch<distype, probdim>::evaluate(Core::Elements::Element* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // call base class routine
-  my::evaluate(ele, params, discretization, la, elemat1_epetra, elemat2_epetra, elevec1_epetra,
-      elevec2_epetra, elevec3_epetra);
+  my::evaluate(ele, params, discretization, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
   // for certain ELCH problem formulations we have to provide
   // additional flux terms / currents across Dirichlet boundaries
   if (elchparams_->boundary_flux_coupling())
-    correction_for_flux_across_dc(discretization, la[0].lm_, elemat1_epetra, elevec1_epetra);
+    correction_for_flux_across_dc(discretization, la[0].lm_, elemat1, elevec1);
 
   return 0;
 }

--- a/src/scatra_ele/4C_scatra_ele_calc_elch.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch.hpp
@@ -48,20 +48,17 @@ namespace Discret
       //! evaluate the element
       int evaluate(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate action
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      protected:
       /*========================================================================*/
@@ -165,8 +162,8 @@ namespace Discret
           Teuchos::ParameterList& params,                                   ///< parameter list
           Core::FE::Discretization& discretization,                         ///< discretization
           std::vector<int>& lm,                                             ///< location vector
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,                  ///< element matrix
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  ///< element right-hand side vector
+          Core::LinAlg::SerialDenseMatrix& elemat1,                         ///< element matrix
+          Core::LinAlg::SerialDenseVector& elevec1,  ///< element right-hand side vector
           const double
               scalar  ///< scaling factor for element matrix and right-hand side contributions
       );

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond.hpp
@@ -292,11 +292,10 @@ namespace Discret
       //! evaluate action
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! evaluate an electrode boundary kinetics point condition
       void evaluate_elch_boundary_kinetics_point(
@@ -380,8 +379,7 @@ namespace Discret
 
       void calc_elch_domain_kinetics(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, std::vector<int>& lm,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra);
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseVector& elevec1);
 
       void evaluate_electrode_status(
           const Core::Elements::Element* ele,        ///< the actual boundary element

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond_multiscale.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond_multiscale.hpp
@@ -82,11 +82,10 @@ namespace Discret
       //! evaluate action
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! compute element matrix and element right-hand side vector
       void sysmat(Core::Elements::Element* ele,       //!< element

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond_sti_thermo.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond_sti_thermo.cpp
@@ -170,16 +170,16 @@ void Discret::Elements::ScaTraEleCalcElchDiffCondSTIThermo<distype>::calc_mat_an
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcElchDiffCondSTIThermo<distype>::evaluate_action_od(
-    Core::Elements::Element* ele,                     //!< current element
-    Teuchos::ParameterList& params,                   //!< parameter list
-    Core::FE::Discretization& discretization,         //!< discretization
-    const ScaTra::Action& action,                     //!< action parameter
-    Core::Elements::LocationArray& la,                //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+    Core::Elements::Element* ele,              //!< current element
+    Teuchos::ParameterList& params,            //!< parameter list
+    Core::FE::Discretization& discretization,  //!< discretization
+    const ScaTra::Action& action,              //!< action parameter
+    Core::Elements::LocationArray& la,         //!< location array
+    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
+    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
+    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
+    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
+    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
 )
 {
   // determine and evaluate action
@@ -187,7 +187,7 @@ int Discret::Elements::ScaTraEleCalcElchDiffCondSTIThermo<distype>::evaluate_act
   {
     case ScaTra::Action::calc_scatra_mono_odblock_scatrathermo:
     {
-      sysmat_od_scatra_thermo(ele, elemat1_epetra);
+      sysmat_od_scatra_thermo(ele, elemat1);
 
       break;
     }
@@ -195,8 +195,8 @@ int Discret::Elements::ScaTraEleCalcElchDiffCondSTIThermo<distype>::evaluate_act
     default:
     {
       // call base class routine
-      my::evaluate_action_od(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action_od(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond_sti_thermo.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_diffcond_sti_thermo.hpp
@@ -57,11 +57,11 @@ namespace Discret
           Core::FE::Discretization& discretization,         //!< discretization
           const ScaTra::Action& action,                     //!< action parameter
           Core::Elements::LocationArray& la,                //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,         //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,         //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,         //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,         //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3          //!< element right-hand side vector 3
           ) override;
 
       //! extract quantities for element evaluation

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_electrode.hpp
@@ -40,11 +40,10 @@ namespace Discret
       //! evaluate action
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      protected:
       //! protected constructor for singletons

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_electrode_sti_thermo.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_electrode_sti_thermo.cpp
@@ -104,18 +104,16 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcElchElectrodeSTIThermo<distype>::evaluate_action_od(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
   {
     case ScaTra::Action::calc_scatra_mono_odblock_scatrathermo:
     {
-      sysmat_od_scatra_thermo(ele, elemat1_epetra);
+      sysmat_od_scatra_thermo(ele, elemat1);
 
       break;
     }
@@ -123,8 +121,8 @@ int Discret::Elements::ScaTraEleCalcElchElectrodeSTIThermo<distype>::evaluate_ac
     default:
     {
       // call base class routine
-      my::evaluate_action_od(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action_od(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_elch_electrode_sti_thermo.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_elch_electrode_sti_thermo.hpp
@@ -56,11 +56,11 @@ namespace Discret
           Core::FE::Discretization& discretization,         //!< discretization
           const ScaTra::Action& action,                     //!< action parameter
           Core::Elements::LocationArray& la,                //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,         //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,         //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,         //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,         //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3          //!< element right-hand side vector 3
           ) override;
 
       //! extract quantities for element evaluation

--- a/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
@@ -169,11 +169,9 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   // check if this is an hdg element
   Discret::Elements::ScaTraHDG* hdgele = dynamic_cast<Discret::Elements::ScaTraHDG*>(ele);
@@ -207,7 +205,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
       shapes_->evaluate(*ele);
       read_global_vectors(ele, discretization, la);
 
-      return update_interior_variables(hdgele, params, elevec1_epetra);
+      return update_interior_variables(hdgele, params, elevec1);
       break;
     }
 
@@ -215,7 +213,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
     {
       shapes_->evaluate(*ele);
       read_global_vectors(ele, discretization, la);
-      return node_based_values(ele, discretization, elevec1_epetra);
+      return node_based_values(ele, discretization, elevec1);
       break;
     }
 
@@ -224,7 +222,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
       element_init(ele);
       prepare_material_params(ele);
       // set initial field
-      return set_initial_field(ele, params, elevec1_epetra, elevec2_epetra);
+      return set_initial_field(ele, params, elevec1, elevec2);
 
       break;
     }
@@ -239,8 +237,8 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
         local_solver_->compute_matrices(ele);
         local_solver_->condense_local_part(hdgele);
       }
-      elemat1_epetra.putScalar(0.0);
-      local_solver_->add_diff_mat(elemat1_epetra, hdgele);
+      elemat1.putScalar(0.0);
+      local_solver_->add_diff_mat(elemat1, hdgele);
 
       break;
     }
@@ -252,7 +250,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
     case ScaTra::Action::project_field:
     {
       shapes_->evaluate(*ele);
-      return project_field(ele, discretization, params, elevec1_epetra, elevec2_epetra, la);
+      return project_field(ele, discretization, params, elevec1, elevec2, la);
       break;
     }
     case ScaTra::Action::time_update_material:
@@ -274,7 +272,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
     {
       if (params.isParameter("faceconsider"))
       {
-        return project_dirich_field(ele, params, discretization, la, elevec1_epetra);
+        return project_dirich_field(ele, params, discretization, la, elevec1);
       }
       break;
     }
@@ -289,7 +287,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
         int nfdofs = Core::FE::PolynomialSpaceCache<nsd_ - 1>::instance().create(parameter)->size();
         sumindex += nfdofs;
       }
-      local_solver_->compute_neumann_bc(ele, params, face, elevec1_epetra, sumindex);
+      local_solver_->compute_neumann_bc(ele, params, face, elevec1, sumindex);
       break;
     }
     case ScaTra::Action::calc_padaptivity:
@@ -303,7 +301,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::evaluate_service(
     {
       shapes_->evaluate(*ele);
       read_global_vectors(ele, discretization, la);
-      return calc_error(ele, params, elevec1_epetra);
+      return calc_error(ele, params, elevec1);
       break;
     }
     default:

--- a/src/scatra_ele/4C_scatra_ele_calc_hdg.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_hdg.hpp
@@ -51,11 +51,9 @@ namespace Discret
       //! evaluate service routine
       int evaluate_service(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //! interpolates an HDG solution to the element nodes for output
       virtual int node_based_values(Core::Elements::Element* ele,

--- a/src/scatra_ele/4C_scatra_ele_calc_loma.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_loma.hpp
@@ -37,11 +37,10 @@ namespace Discret
 
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      private:
       /*========================================================================*/

--- a/src/scatra_ele/4C_scatra_ele_calc_ls.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_ls.hpp
@@ -36,11 +36,10 @@ namespace Discret
 
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      private:
       // calculate error compared to analytical solution

--- a/src/scatra_ele/4C_scatra_ele_calc_lsreinit.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_lsreinit.hpp
@@ -55,19 +55,16 @@ namespace Discret
       //! evaluate the element
       int evaluate(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      protected:
       //! calculate matrix and rhs. Here the whole thing is hidden. Hyperbolic reinit.
@@ -104,18 +101,17 @@ namespace Discret
 
       void eval_reinitialization(const Core::LinAlg::Vector<double>& phinp,
           const std::vector<int>& lm, Core::Elements::Element* ele, Teuchos::ParameterList& params,
-          Core::FE::Discretization& discretization, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra);
+          Core::FE::Discretization& discretization, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseVector& elevec1);
 
       void eval_reinitialization_embedded(const std::vector<int>& lm, Core::Elements::Element* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra);
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseVector& elevec1);
 
       void eval_reinitialization_std(const Core::LinAlg::Vector<double>& phinp,
           const std::vector<int>& lm, Core::Elements::Element* ele, Teuchos::ParameterList& params,
-          Core::FE::Discretization& discretization, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra);
+          Core::FE::Discretization& discretization, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseVector& elevec1);
 
       /*========================================================================*/
       //! @name overloaded methods for evaluation of individual terms

--- a/src/scatra_ele/4C_scatra_ele_calc_no_physics.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_no_physics.hpp
@@ -43,11 +43,10 @@ namespace Discret
       //! evaluate the element
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
      protected:
       //! protected constructor for singletons

--- a/src/scatra_ele/4C_scatra_ele_calc_poro.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro.cpp
@@ -65,11 +65,9 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcPoro<distype>::evaluate_action(Core::Elements::Element* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     const ScaTra::Action& action, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
@@ -88,13 +86,13 @@ int Discret::Elements::ScaTraEleCalcPoro<distype>::evaluate_action(Core::Element
       extract_element_and_node_values_poro(ele, params, discretization, la);
 
       // calculate scalars and domain integral
-      calculate_scalars(ele, elevec1_epetra, inverting, false);
+      calculate_scalars(ele, elevec1, inverting, false);
 
       break;
     }
     default:
-      return my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      return my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
   }
 

--- a/src/scatra_ele/4C_scatra_ele_calc_poro.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_poro.hpp
@@ -53,41 +53,40 @@ namespace Discret
       //                        Teuchos::ParameterList&       params,
       //                        Core::FE::Discretization &         discretization,
       //                        const std::vector<int> &      lm,
-      //                        Core::LinAlg::SerialDenseMatrix&     elemat1_epetra,
-      //                        Core::LinAlg::SerialDenseMatrix&     elemat2_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec1_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec2_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec3_epetra);
+      //                        Core::LinAlg::SerialDenseMatrix&     elemat1,
+      //                        Core::LinAlg::SerialDenseMatrix&     elemat2,
+      //                        Core::LinAlg::SerialDenseVector&     elevec1,
+      //                        Core::LinAlg::SerialDenseVector&     elevec2,
+      //                        Core::LinAlg::SerialDenseVector&     elevec3);
 
      protected:
       //! evaluate action
       int evaluate_action(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, const ScaTra::Action& action,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+          Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) override;
 
       //   int EvaluateODMesh(  Core::Elements::Element*                 ele,
       //                        Teuchos::ParameterList&       params,
       //                        Core::FE::Discretization &         discretization,
       //                        const std::vector<int> &      lm,
-      //                        Core::LinAlg::SerialDenseMatrix&     elemat1_epetra,
-      //                        Core::LinAlg::SerialDenseMatrix&     elemat2_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec1_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec2_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec3_epetra);
+      //                        Core::LinAlg::SerialDenseMatrix&     elemat1,
+      //                        Core::LinAlg::SerialDenseMatrix&     elemat2,
+      //                        Core::LinAlg::SerialDenseVector&     elevec1,
+      //                        Core::LinAlg::SerialDenseVector&     elevec2,
+      //                        Core::LinAlg::SerialDenseVector&     elevec3);
       //
       //   int EvaluateODFluid(  Core::Elements::Element*                 ele,
       //                        Teuchos::ParameterList&       params,
       //                        Core::FE::Discretization &         discretization,
       //                        const std::vector<int> &      lm,
-      //                        Core::LinAlg::SerialDenseMatrix&     elemat1_epetra,
-      //                        Core::LinAlg::SerialDenseMatrix&     elemat2_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec1_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec2_epetra,
-      //                        Core::LinAlg::SerialDenseVector&     elevec3_epetra);
+      //                        Core::LinAlg::SerialDenseMatrix&     elemat1,
+      //                        Core::LinAlg::SerialDenseMatrix&     elemat2,
+      //                        Core::LinAlg::SerialDenseVector&     elevec1,
+      //                        Core::LinAlg::SerialDenseVector&     elevec2,
+      //                        Core::LinAlg::SerialDenseVector&     elevec3);
       //
       //   //! calculate matrix and rhs. Here the whole thing is hidden.
       //   virtual void sysmat_od_mesh(

--- a/src/scatra_ele/4C_scatra_ele_calc_service_cardiac_monodomain.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_cardiac_monodomain.cpp
@@ -25,11 +25,9 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalcCardiacMonodomain<distype, probdim>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   //(for now) only first dof set considered
   const std::vector<int>& lm = la[0].lm_;
@@ -182,8 +180,8 @@ int Discret::Elements::ScaTraEleCalcCardiacMonodomain<distype, probdim>::evaluat
 
     default:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }  // switch(action)

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond_multiscale.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_diffcond_multiscale.cpp
@@ -174,11 +174,9 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalcElchDiffCondMultiScale<distype, probdim>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // extract multi-scale material
   auto elchmat = std::dynamic_pointer_cast<const Mat::ElchMat>(ele->material());
@@ -310,8 +308,8 @@ int Discret::Elements::ScaTraEleCalcElchDiffCondMultiScale<distype, probdim>::ev
 
     default:
     {
-      mydiffcond::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      mydiffcond::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_service_elch_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_elch_electrode.cpp
@@ -22,32 +22,30 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalcElchElectrode<distype, probdim>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)
   {
     case ScaTra::Action::calc_elch_electrode_soc_and_c_rate:
     {
-      calculate_electrode_soc_and_c_rate(ele, discretization, la, elevec1_epetra);
+      calculate_electrode_soc_and_c_rate(ele, discretization, la, elevec1);
 
       break;
     }
     case ScaTra::Action::calc_elch_elctrode_mean_concentration:
     {
-      calculate_mean_electrode_concentration(ele, discretization, la, elevec1_epetra);
+      calculate_mean_electrode_concentration(ele, discretization, la, elevec1);
 
       break;
     }
 
     default:
     {
-      myelch::evaluate_action(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      myelch::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_service_loma.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_loma.cpp
@@ -26,11 +26,9 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcLoma<distype>::evaluate_action(Core::Elements::Element* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     const ScaTra::Action& action, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   const std::vector<int>& lm = la[0].lm_;
 
@@ -62,14 +60,14 @@ int Discret::Elements::ScaTraEleCalcLoma<distype>::evaluate_action(Core::Element
       // NOTE: add integral values only for elements which are NOT ghosted!
       if (ele->owner() == Core::Communication::my_mpi_rank(discretization.get_comm()))
         // calculate domain and bodyforce integral
-        calculate_domain_and_bodyforce(elevec1_epetra, ele);
+        calculate_domain_and_bodyforce(elevec1, ele);
 
       break;
     }
     default:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }  // switch(action)

--- a/src/scatra_ele/4C_scatra_ele_calc_service_ls.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_ls.cpp
@@ -24,11 +24,9 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcLS<distype>::evaluate_action(Core::Elements::Element* ele,
     Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
     const ScaTra::Action& action, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   //(for now) only first dof set considered
   const std::vector<int>& lm = la[0].lm_;
@@ -51,16 +49,16 @@ int Discret::Elements::ScaTraEleCalcLS<distype>::evaluate_action(Core::Elements:
       Core::FE::extract_my_values<Core::LinAlg::Matrix<nen_, 1>>(*phizero, ephizero, lm);
 
       // check if length suffices
-      if (elevec1_epetra.length() < 1) FOUR_C_THROW("Result vector too short");
+      if (elevec1.length() < 1) FOUR_C_THROW("Result vector too short");
 
-      cal_error_compared_to_analyt_solution(ele, ephizero, params, elevec1_epetra);
+      cal_error_compared_to_analyt_solution(ele, ephizero, params, elevec1);
 
       break;
     }
     default:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }  // switch(action)

--- a/src/scatra_ele/4C_scatra_ele_calc_service_lsreinit.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_lsreinit.cpp
@@ -24,11 +24,9 @@ template <Core::FE::CellType distype, unsigned prob_dim>
 int Discret::Elements::ScaTraEleCalcLsReinit<distype, prob_dim>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   const std::vector<int>& lm = la[0].lm_;
 
@@ -69,7 +67,7 @@ int Discret::Elements::ScaTraEleCalcLsReinit<distype, prob_dim>::evaluate_action
       // Step 2: calculate matrix and rhs
       //------------------------------------------------------
 
-      sysmat_correction(penalty, elemat1_epetra, elevec1_epetra);
+      sysmat_correction(penalty, elemat1, elevec1);
 
       break;
     }
@@ -87,14 +85,14 @@ int Discret::Elements::ScaTraEleCalcLsReinit<distype, prob_dim>::evaluate_action
       // get current direction
       const int dir = params.get<int>("direction");
 
-      sysmat_nodal_vel(dir, elemat1_epetra, elevec1_epetra);
+      sysmat_nodal_vel(dir, elemat1, elevec1);
 
       break;
     }
     default:
     {
-      my::evaluate_action(ele, params, discretization, action, la, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
       break;
     }
   }  // switch(action)

--- a/src/scatra_ele/4C_scatra_ele_calc_service_no_physics.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_no_physics.cpp
@@ -19,11 +19,9 @@ template <Core::FE::CellType distype, int probdim>
 int Discret::Elements::ScaTraEleCalcNoPhysics<distype, probdim>::evaluate_action(
     Core::Elements::Element* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, const ScaTra::Action& action,
-    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // determine and evaluate action
   switch (action)

--- a/src/scatra_ele/4C_scatra_ele_calc_service_turbulence.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_turbulence.cpp
@@ -1631,9 +1631,9 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::calc_dissipation(
     // we have to set a vector, which is however only required for one
     // special case (computation of fine-scale subgrid diffusivity for non-incremental
     // solver -> only artificial subgrid diffusivity) not considered here
-    Core::LinAlg::SerialDenseVector elevec1_epetra_subgrdiff_dummy;
+    Core::LinAlg::SerialDenseVector elevec1_subgrdiff_dummy;
     if (turbparams_->fssgd())
-      calc_fine_scale_subgr_diff(sgdiff, elevec1_epetra_subgrdiff_dummy, ele, vol, 0, densnp[0],
+      calc_fine_scale_subgr_diff(sgdiff, elevec1_subgrdiff_dummy, ele, vol, 0, densnp[0],
           diffmanager_->get_isotropic_diff(0), scatravarmanager_->con_vel(0));
 
     // calculation of stabilization parameter at element center
@@ -1751,9 +1751,9 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::calc_dissipation(
       // we have to set a vector, which is however only required for one
       // special case (computation of fine-scale subgrid diffusivity for non-incremental
       // solver -> only artificial subgrid diffusivity) not considered here
-      Core::LinAlg::SerialDenseVector elevec1_epetra_subgrdiff_dummy;
+      Core::LinAlg::SerialDenseVector elevec1_subgrdiff_dummy;
       if (turbparams_->fssgd())
-        calc_fine_scale_subgr_diff(sgdiff, elevec1_epetra_subgrdiff_dummy, ele, vol, 0, densnp[0],
+        calc_fine_scale_subgr_diff(sgdiff, elevec1_subgrdiff_dummy, ele, vol, 0, densnp[0],
             diffmanager_->get_isotropic_diff(0), scatravarmanager_->con_vel(0));
 
       // calculation of subgrid-scale velocity at integration point if required

--- a/src/scatra_ele/4C_scatra_ele_calc_sti_diffcond.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_sti_diffcond.cpp
@@ -323,16 +323,16 @@ void Discret::Elements::ScaTraEleCalcSTIDiffCond<distype>::calc_mat_and_rhs_sore
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcSTIDiffCond<distype>::evaluate_action_od(
-    Core::Elements::Element* ele,                     //!< current element
-    Teuchos::ParameterList& params,                   //!< parameter list
-    Core::FE::Discretization& discretization,         //!< discretization
-    const ScaTra::Action& action,                     //!< action parameter
-    Core::Elements::LocationArray& la,                //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+    Core::Elements::Element* ele,              //!< current element
+    Teuchos::ParameterList& params,            //!< parameter list
+    Core::FE::Discretization& discretization,  //!< discretization
+    const ScaTra::Action& action,              //!< action parameter
+    Core::Elements::LocationArray& la,         //!< location array
+    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
+    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
+    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
+    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
+    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
 )
 {
   // determine and evaluate action
@@ -340,7 +340,7 @@ int Discret::Elements::ScaTraEleCalcSTIDiffCond<distype>::evaluate_action_od(
   {
     case ScaTra::Action::calc_scatra_mono_odblock_thermoscatra:
     {
-      sysmat_od_thermo_scatra(ele, elemat1_epetra);
+      sysmat_od_thermo_scatra(ele, elemat1);
 
       break;
     }
@@ -348,8 +348,8 @@ int Discret::Elements::ScaTraEleCalcSTIDiffCond<distype>::evaluate_action_od(
     default:
     {
       // call base class routine
-      my::evaluate_action_od(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action_od(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_sti_diffcond.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_sti_diffcond.hpp
@@ -60,11 +60,11 @@ namespace Discret
           Core::FE::Discretization& discretization,         //!< discretization
           const ScaTra::Action& action,                     //!< action parameter
           Core::Elements::LocationArray& la,                //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,         //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,         //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,         //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,         //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3          //!< element right-hand side vector 3
           ) override;
 
       //! calculate element matrix and element right-hand side vector

--- a/src/scatra_ele/4C_scatra_ele_calc_sti_electrode.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_sti_electrode.cpp
@@ -274,16 +274,16 @@ void Discret::Elements::ScaTraEleCalcSTIElectrode<distype>::calc_mat_and_rhs_sor
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraEleCalcSTIElectrode<distype>::evaluate_action_od(
-    Core::Elements::Element* ele,                     //!< current element
-    Teuchos::ParameterList& params,                   //!< parameter list
-    Core::FE::Discretization& discretization,         //!< discretization
-    const ScaTra::Action& action,                     //!< action parameter
-    Core::Elements::LocationArray& la,                //!< location array
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-    Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+    Core::Elements::Element* ele,              //!< current element
+    Teuchos::ParameterList& params,            //!< parameter list
+    Core::FE::Discretization& discretization,  //!< discretization
+    const ScaTra::Action& action,              //!< action parameter
+    Core::Elements::LocationArray& la,         //!< location array
+    Core::LinAlg::SerialDenseMatrix& elemat1,  //!< element matrix 1
+    Core::LinAlg::SerialDenseMatrix& elemat2,  //!< element matrix 2
+    Core::LinAlg::SerialDenseVector& elevec1,  //!< element right-hand side vector 1
+    Core::LinAlg::SerialDenseVector& elevec2,  //!< element right-hand side vector 2
+    Core::LinAlg::SerialDenseVector& elevec3   //!< element right-hand side vector 3
 )
 {
   // determine and evaluate action
@@ -291,7 +291,7 @@ int Discret::Elements::ScaTraEleCalcSTIElectrode<distype>::evaluate_action_od(
   {
     case ScaTra::Action::calc_scatra_mono_odblock_thermoscatra:
     {
-      sysmat_od_thermo_scatra(ele, elemat1_epetra);
+      sysmat_od_thermo_scatra(ele, elemat1);
 
       break;
     }
@@ -299,8 +299,8 @@ int Discret::Elements::ScaTraEleCalcSTIElectrode<distype>::evaluate_action_od(
     default:
     {
       // call base class routine
-      my::evaluate_action_od(ele, params, discretization, action, la, elemat1_epetra,
-          elemat2_epetra, elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      my::evaluate_action_od(
+          ele, params, discretization, action, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/scatra_ele/4C_scatra_ele_calc_sti_electrode.hpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_sti_electrode.hpp
@@ -59,11 +59,11 @@ namespace Discret
           Core::FE::Discretization& discretization,         //!< discretization
           const ScaTra::Action& action,                     //!< action parameter
           Core::Elements::LocationArray& la,                //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< element matrix 1
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< element matrix 2
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< element right-hand side vector 1
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,  //!< element right-hand side vector 2
-          Core::LinAlg::SerialDenseVector& elevec3_epetra   //!< element right-hand side vector 3
+          Core::LinAlg::SerialDenseMatrix& elemat1,         //!< element matrix 1
+          Core::LinAlg::SerialDenseMatrix& elemat2,         //!< element matrix 2
+          Core::LinAlg::SerialDenseVector& elevec1,         //!< element right-hand side vector 1
+          Core::LinAlg::SerialDenseVector& elevec2,         //!< element right-hand side vector 2
+          Core::LinAlg::SerialDenseVector& elevec3          //!< element right-hand side vector 3
           ) override;
 
       //! calculate element matrix and element right-hand side vector

--- a/src/scatra_ele/4C_scatra_ele_hdg_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg_boundary_calc.cpp
@@ -110,8 +110,7 @@ template <Core::FE::CellType distype>
 int Discret::Elements::ScaTraHDGBoundaryImpl<distype>::evaluate_neumann(
     Discret::Elements::ScaTraHDGBoundary* ele, Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseVector& elevec1)
 {
   Core::LinAlg::SerialDenseVector dummy_vec2, dummy_vec3;
   Core::LinAlg::SerialDenseMatrix dummy_mat2;
@@ -144,8 +143,8 @@ int Discret::Elements::ScaTraHDGBoundaryImpl<distype>::evaluate_neumann(
     {
       // i is the number we were searching for!!!!
       params.set<int>("face", i);
-      ele->parent_element()->evaluate(params, discretization, la, elemat1_epetra, dummy_mat2,
-          elevec1_epetra, dummy_vec2, dummy_vec3);
+      ele->parent_element()->evaluate(
+          params, discretization, la, elemat1, dummy_mat2, elevec1, dummy_vec2, dummy_vec3);
       // break;
     }
   }

--- a/src/scatra_ele/4C_scatra_ele_hdg_boundary_calc.hpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg_boundary_calc.hpp
@@ -48,8 +48,8 @@ namespace Discret
        */
       virtual int evaluate_neumann(Discret::Elements::ScaTraHDGBoundary* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra) = 0;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseVector& elevec1) = 0;
 
       //! Internal implementation class for ScaTraHDGBoundary elements
       static ScaTraHDGBoundaryImplInterface* impl(const Core::Elements::Element* ele);
@@ -80,8 +80,8 @@ namespace Discret
       //! Evaluate a Neumann boundary condition
       int evaluate_neumann(Discret::Elements::ScaTraHDGBoundary* ele,
           Teuchos::ParameterList& params, Core::FE::Discretization& discretization,
-          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra) override;
+          Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+          Core::LinAlg::SerialDenseVector& elevec1) override;
 
      private:
       //! node coordinates for boundary element

--- a/src/scatra_ele/4C_scatra_ele_interface.hpp
+++ b/src/scatra_ele/4C_scatra_ele_interface.hpp
@@ -55,27 +55,21 @@ namespace Discret
        */
       virtual int evaluate(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) = 0;
 
       virtual int evaluate_service(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) = 0;
 
       virtual int evaluate_od(Core::Elements::Element* ele, Teuchos::ParameterList& params,
           Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,
-          Core::LinAlg::SerialDenseVector& elevec2_epetra,
-          Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+          Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+          Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+          Core::LinAlg::SerialDenseVector& elevec3) = 0;
     };
   }  // namespace Elements
 }  // namespace Discret

--- a/src/ssi/4C_ssi_str_model_evaluator_base.cpp
+++ b/src/ssi/4C_ssi_str_model_evaluator_base.cpp
@@ -68,16 +68,16 @@ void Solid::ModelEvaluator::BaseSSI::determine_stress_strain()
     const int nodelid = discret().node_row_map()->LID(nodegid);
 
     // extract dof lid of first degree of freedom associated with current node in second nodeset
-    const int dofgid_epetra = discret().dof(2, node, 0);
-    const int doflid_epetra = mechanical_stress_state_np_->get_block_map().LID(dofgid_epetra);
-    if (doflid_epetra < 0) FOUR_C_THROW("Local ID not found in epetra vector!");
+    const int dofgid = discret().dof(2, node, 0);
+    const int doflid = mechanical_stress_state_np_->get_block_map().LID(dofgid);
+    if (doflid < 0) FOUR_C_THROW("Local ID not found in vector!");
 
-    (*mechanical_stress_state_np_)[doflid_epetra] = (nodal_stresses_source(0))[nodelid];
-    (*mechanical_stress_state_np_)[doflid_epetra + 1] = (nodal_stresses_source(1))[nodelid];
-    (*mechanical_stress_state_np_)[doflid_epetra + 2] = (nodal_stresses_source(2))[nodelid];
-    (*mechanical_stress_state_np_)[doflid_epetra + 3] = (nodal_stresses_source(3))[nodelid];
-    (*mechanical_stress_state_np_)[doflid_epetra + 4] = (nodal_stresses_source(4))[nodelid];
-    (*mechanical_stress_state_np_)[doflid_epetra + 5] = (nodal_stresses_source(5))[nodelid];
+    (*mechanical_stress_state_np_)[doflid] = (nodal_stresses_source(0))[nodelid];
+    (*mechanical_stress_state_np_)[doflid + 1] = (nodal_stresses_source(1))[nodelid];
+    (*mechanical_stress_state_np_)[doflid + 2] = (nodal_stresses_source(2))[nodelid];
+    (*mechanical_stress_state_np_)[doflid + 3] = (nodal_stresses_source(3))[nodelid];
+    (*mechanical_stress_state_np_)[doflid + 4] = (nodal_stresses_source(4))[nodelid];
+    (*mechanical_stress_state_np_)[doflid + 5] = (nodal_stresses_source(5))[nodelid];
   }
 }
 

--- a/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
@@ -101,11 +101,9 @@ Thermo::TemperBoundaryImpl<distype>::TemperBoundaryImpl(int numdofpernode)
 template <Core::FE::CellType distype>
 int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
     Teuchos::ParameterList& params, const Core::FE::Discretization& discretization,
-    const Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    const Core::Elements::LocationArray& la, Core::LinAlg::SerialDenseMatrix& elemat1,
+    Core::LinAlg::SerialDenseMatrix& elemat2, Core::LinAlg::SerialDenseVector& elevec1,
+    Core::LinAlg::SerialDenseVector& elevec2, Core::LinAlg::SerialDenseVector& elevec3)
 {
   // what actions are available
   // ( action=="calc_thermo_fextconvection" )
@@ -135,8 +133,8 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
         ele, xyze_);
 
     // set views, here we assemble on the boundary dofs only!
-    Core::LinAlg::Matrix<nen_, nen_> etang(elemat1_epetra.values(), true);  // view only!
-    Core::LinAlg::Matrix<nen_, 1> efext(elevec1_epetra.values(), true);     // view only!
+    Core::LinAlg::Matrix<nen_, nen_> etang(elemat1.values(), true);  // view only!
+    Core::LinAlg::Matrix<nen_, 1> efext(elevec1.values(), true);     // view only!
 
     // get current condition
     std::shared_ptr<Core::Conditions::Condition> cond =
@@ -250,7 +248,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
     {
       // set views, here we assemble on the boundary dofs only!
       Core::LinAlg::Matrix<nen_, (nsd_ + 1) * nen_> etangcoupl(
-          elemat2_epetra.values(), true);  // view only!
+          elemat2.values(), true);  // view only!
 
       // and now get the current displacements/velocities
       if (discretization.has_state(1, "displacement"))
@@ -343,7 +341,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate(const FaceElement* ele,
 
         // set views, here we assemble on the boundary dofs only!
         Core::LinAlg::Matrix<nen_, (nsd_ + 1) * nen_> etangcoupl(
-            elemat1_epetra.values(), true);  // view only!
+            elemat1.values(), true);  // view only!
 
         // get current condition
         std::shared_ptr<Core::Conditions::Condition> cond =

--- a/src/thermo/src/element/4C_thermo_ele_boundary_impl.hpp
+++ b/src/thermo/src/element/4C_thermo_ele_boundary_impl.hpp
@@ -41,11 +41,9 @@ namespace Thermo
     //! must be defined in TemperBoundaryImpl.
     virtual int evaluate(const FaceElement* ele, Teuchos::ParameterList& params,
         const Core::FE::Discretization& discretization, const Core::Elements::LocationArray& la,
-        Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-        Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-        Core::LinAlg::SerialDenseVector& elevec1_epetra,
-        Core::LinAlg::SerialDenseVector& elevec2_epetra,
-        Core::LinAlg::SerialDenseVector& elevec3_epetra) = 0;
+        Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+        Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+        Core::LinAlg::SerialDenseVector& elevec3) = 0;
 
     //! Evaluate a Neumann boundary condition
     //!
@@ -54,7 +52,7 @@ namespace Thermo
     virtual int evaluate_neumann(const Core::Elements::Element* ele, Teuchos::ParameterList& params,
         const Core::FE::Discretization& discretization,
         const Core::Conditions::Condition& condition, const std::vector<int>& lm,
-        Core::LinAlg::SerialDenseVector& elevec1_epetra) = 0;
+        Core::LinAlg::SerialDenseVector& elevec1) = 0;
 
     //! Internal implementation class for thermo elements
     static TemperBoundaryImplInterface* impl(const Core::Elements::Element* ele);
@@ -115,17 +113,15 @@ namespace Thermo
     //! Evaluate (la required in case of multiple dofsets)
     int evaluate(const FaceElement* ele, Teuchos::ParameterList& params,
         const Core::FE::Discretization& discretization, const Core::Elements::LocationArray& la,
-        Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-        Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-        Core::LinAlg::SerialDenseVector& elevec1_epetra,
-        Core::LinAlg::SerialDenseVector& elevec2_epetra,
-        Core::LinAlg::SerialDenseVector& elevec3_epetra) override;
+        Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+        Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+        Core::LinAlg::SerialDenseVector& elevec3) override;
 
     //! Evaluate a Neumann boundary condition
     int evaluate_neumann(const Core::Elements::Element* ele, Teuchos::ParameterList& params,
         const Core::FE::Discretization& discretization,
         const Core::Conditions::Condition& condition, const std::vector<int>& lm,
-        Core::LinAlg::SerialDenseVector& elevec1_epetra) override;
+        Core::LinAlg::SerialDenseVector& elevec1) override;
 
    private:
     //! prepare the evaluation of NURBS shape functions

--- a/src/thermo/src/element/4C_thermo_ele_impl.hpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.hpp
@@ -47,16 +47,16 @@ namespace Discret
       //!  This class does not provide a definition for this function, it
       //!  must be defined in TemperImpl.
       virtual int evaluate(const Core::Elements::Element* ele,  //!< current element
-          Teuchos::ParameterList& params,                   //!< parameter list, containing e.g., dt
-          const Core::FE::Discretization& discretization,   //!< current discretisation
-          const Core::Elements::LocationArray& la,          //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< conductivity matrix
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< capacity matrix
+          Teuchos::ParameterList& params,                  //!< parameter list, containing e.g., dt
+          const Core::FE::Discretization& discretization,  //!< current discretisation
+          const Core::Elements::LocationArray& la,         //!< location array
+          Core::LinAlg::SerialDenseMatrix& elemat1,        //!< conductivity matrix
+          Core::LinAlg::SerialDenseMatrix& elemat2,        //!< capacity matrix
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,  //!< internal force, view on heat flux in x-direction
+              elevec1,  //!< internal force, view on heat flux in x-direction
           Core::LinAlg::SerialDenseVector&
-              elevec2_epetra,  //!< external force, view on heat flux in y-direction
-          Core::LinAlg::SerialDenseVector& elevec3_epetra  //!< view on heat flux in z-direction
+              elevec2,  //!< external force, view on heat flux in y-direction
+          Core::LinAlg::SerialDenseVector& elevec3  //!< view on heat flux in z-direction
           ) = 0;
 
       //! Evaluate the element
@@ -68,8 +68,8 @@ namespace Discret
           const Core::FE::Discretization& discretization,               //!< current discretisation
           const std::vector<int>&
               lm,  //!< location vector, EvalNeumann is called only on own discretisation
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< view on external force vector
-          Core::LinAlg::SerialDenseMatrix* elemat1_epetra   //!< matrix is not needed
+          Core::LinAlg::SerialDenseVector& elevec1,  //!< view on external force vector
+          Core::LinAlg::SerialDenseMatrix* elemat1   //!< matrix is not needed
           ) = 0;
 
       //! Internal implementation class for thermo elements
@@ -124,17 +124,17 @@ namespace Discret
       static constexpr int nquad_ = Thermo::DisTypeToNumGaussPoints<distype>::nquad;
 
       //! Evaluate for multiple dofsets
-      int evaluate(const Core::Elements::Element* ele,      //!< current element
-          Teuchos::ParameterList& params,                   //!< parameter list, containing e.g., dt
-          const Core::FE::Discretization& discretization,   //!< current discretisation
-          const Core::Elements::LocationArray& la,          //!< location array
-          Core::LinAlg::SerialDenseMatrix& elemat1_epetra,  //!< conductivity matrix
-          Core::LinAlg::SerialDenseMatrix& elemat2_epetra,  //!< capacity matrix
+      int evaluate(const Core::Elements::Element* ele,     //!< current element
+          Teuchos::ParameterList& params,                  //!< parameter list, containing e.g., dt
+          const Core::FE::Discretization& discretization,  //!< current discretisation
+          const Core::Elements::LocationArray& la,         //!< location array
+          Core::LinAlg::SerialDenseMatrix& elemat1,        //!< conductivity matrix
+          Core::LinAlg::SerialDenseMatrix& elemat2,        //!< capacity matrix
           Core::LinAlg::SerialDenseVector&
-              elevec1_epetra,  //!< internal force, view on heat flux in x-direction
+              elevec1,  //!< internal force, view on heat flux in x-direction
           Core::LinAlg::SerialDenseVector&
-              elevec2_epetra,  //!< external force, view on heat flux in y-direction
-          Core::LinAlg::SerialDenseVector& elevec3_epetra  //!< view on heat flux in z-direction
+              elevec2,  //!< external force, view on heat flux in y-direction
+          Core::LinAlg::SerialDenseVector& elevec3  //!< view on heat flux in z-direction
           ) override;
 
       //! Evaluate the element
@@ -143,8 +143,8 @@ namespace Discret
           const Core::FE::Discretization& discretization,       //!< current discretisation
           const std::vector<int>&
               lm,  //!< location vector, EvalNeumann is called only on own discretisation
-          Core::LinAlg::SerialDenseVector& elevec1_epetra,  //!< view on external force vector
-          Core::LinAlg::SerialDenseMatrix* elemat1_epetra   //!< matrix is not needed
+          Core::LinAlg::SerialDenseVector& elevec1,  //!< view on external force vector
+          Core::LinAlg::SerialDenseMatrix* elemat1   //!< matrix is not needed
           ) override;
 
      private:

--- a/src/w1/4C_w1_poro_p1_evaluate.cpp
+++ b/src/w1/4C_w1_poro_p1_evaluate.cpp
@@ -49,11 +49,9 @@ void Discret::Elements::Wall1PoroP1<distype>::compute_porosity_and_linearization
 template <Core::FE::CellType distype>
 int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   this->set_params_interface_ptr(params);
   Core::Elements::ActionType act = Core::Elements::none;
@@ -84,8 +82,7 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
       // in some cases we need to write/change some data before evaluating
       Base::pre_evaluate(params, discretization, la);
 
-      my_evaluate(params, discretization, la, elemat1_epetra, elemat2_epetra, elevec1_epetra,
-          elevec2_epetra, elevec3_epetra);
+      my_evaluate(params, discretization, la, elemat1, elemat2, elevec1, elevec2, elevec3);
     }
     break;
     //==================================================================================
@@ -95,8 +92,8 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
       Base::pre_evaluate(params, discretization, la);
 
       // evaluate parent solid element
-      Wall1::evaluate(params, discretization, la[0].lm_, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      Wall1::evaluate(
+          params, discretization, la[0].lm_, elemat1, elemat2, elevec1, elevec2, elevec3);
     }
     break;
     //==================================================================================
@@ -111,11 +108,11 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
       Core::LinAlg::SerialDenseVector elevec2_sub;
       Core::LinAlg::SerialDenseVector elevec3_sub;
 
-      if (elemat1_epetra.values()) elemat1_sub.shape(Base::numdof_, Base::numdof_);
-      if (elemat2_epetra.values()) elemat2_sub.shape(Base::numdof_, Base::numdof_);
-      if (elevec1_epetra.values()) elevec1_sub.resize(Base::numdof_);
-      if (elevec2_epetra.values()) elevec2_sub.resize(Base::numdof_);
-      if (elevec3_epetra.values()) elevec3_sub.resize(Base::numdof_);
+      if (elemat1.values()) elemat1_sub.shape(Base::numdof_, Base::numdof_);
+      if (elemat2.values()) elemat2_sub.shape(Base::numdof_, Base::numdof_);
+      if (elevec1.values()) elevec1_sub.resize(Base::numdof_);
+      if (elevec2.values()) elevec2_sub.resize(Base::numdof_);
+      if (elevec3.values()) elevec3_sub.resize(Base::numdof_);
 
       std::vector<int> lm_sub;
       for (int i = 0; i < Base::numnod_; i++)
@@ -126,7 +123,7 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
           elevec2_sub, elevec3_sub);
 
 
-      if (elemat1_epetra.values())
+      if (elemat1.values())
       {
         for (int i = 0; i < Base::numnod_; i++)
         {
@@ -135,14 +132,14 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
             for (int k = 0; k < Base::numnod_; k++)
             {
               for (int l = 0; l < Base::numdim_; l++)
-                elemat1_epetra(i * noddof_ + j, k * noddof_ + l) =
+                elemat1(i * noddof_ + j, k * noddof_ + l) =
                     elemat1_sub(i * Base::noddof_ + j, k * Base::noddof_ + l);
             }
           }
         }
       }
 
-      if (elemat2_epetra.values())
+      if (elemat2.values())
       {
         for (int i = 0; i < Base::numnod_; i++)
         {
@@ -151,37 +148,36 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
             for (int k = 0; k < Base::numnod_; k++)
             {
               for (int l = 0; l < Base::numdim_; l++)
-                elemat2_epetra(i * noddof_ + j, k * noddof_ + l) =
+                elemat2(i * noddof_ + j, k * noddof_ + l) =
                     elemat2_sub(i * Base::noddof_ + j, k * Base::noddof_ + l);
             }
           }
         }
       }
 
-      if (elevec1_epetra.values())
+      if (elevec1.values())
       {
         for (int i = 0; i < Base::numnod_; i++)
           for (int j = 0; j < Base::numdim_; j++)
-            elevec1_epetra(i * noddof_ + j) = elevec1_sub(i * Base::noddof_ + j);
+            elevec1(i * noddof_ + j) = elevec1_sub(i * Base::noddof_ + j);
       }
 
-      if (elevec2_epetra.values())
+      if (elevec2.values())
       {
         for (int i = 0; i < Base::numnod_; i++)
           for (int j = 0; j < Base::numdim_; j++)
-            elevec2_epetra(i * noddof_ + j) = elevec2_sub(i * Base::noddof_ + j);
+            elevec2(i * noddof_ + j) = elevec2_sub(i * Base::noddof_ + j);
       }
 
-      if (elevec3_epetra.values())
+      if (elevec3.values())
       {
         for (int i = 0; i < Base::numnod_; i++)
           for (int j = 0; j < Base::numdim_; j++)
-            elevec3_epetra(i * noddof_ + j) = elevec3_sub(i * Base::noddof_ + j);
+            elevec3(i * noddof_ + j) = elevec3_sub(i * Base::noddof_ + j);
       }
 
       // add volume coupling specific terms
-      my_evaluate(params, discretization, la, elemat1_epetra, elemat2_epetra, elevec1_epetra,
-          elevec2_epetra, elevec3_epetra);
+      my_evaluate(params, discretization, la, elemat1, elemat2, elevec1, elevec2, elevec3);
     }
     break;
   }
@@ -192,11 +188,9 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate(Teuchos::ParameterList& pa
 template <Core::FE::CellType distype>
 int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   this->set_params_interface_ptr(params);
   Core::Elements::ActionType act = Core::Elements::none;
@@ -232,11 +226,11 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
       if (la.size() > 1)
       {
         // stiffness
-        Core::LinAlg::Matrix<numdof_, numdof_> elemat1(elemat1_epetra.values(), true);
+        Core::LinAlg::Matrix<numdof_, numdof_> elemat_1(elemat1.values(), true);
         // damping
-        Core::LinAlg::Matrix<numdof_, numdof_> elemat2(elemat2_epetra.values(), true);
+        Core::LinAlg::Matrix<numdof_, numdof_> elemat_2(elemat2.values(), true);
         // internal force vector
-        Core::LinAlg::Matrix<numdof_, 1> elevec1(elevec1_epetra.values(), true);
+        Core::LinAlg::Matrix<numdof_, 1> elevec_1(elevec1.values(), true);
         // elevec2+3 are not used anyway
 
         // build the location vector only for the structure field
@@ -249,13 +243,13 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
             discretization, 0, la[0].lm_, &mydisp, &myporosity, "displacement");
 
         Core::LinAlg::Matrix<numdof_, numdof_>* matptr = nullptr;
-        if (elemat1.is_initialized()) matptr = &elemat1;
+        if (elemat_1.is_initialized()) matptr = &elemat_1;
 
         enum Inpar::Solid::DampKind damping =
             params.get<enum Inpar::Solid::DampKind>("damping", Inpar::Solid::damp_none);
         Core::LinAlg::Matrix<numdof_, numdof_>* matptr2 = nullptr;
-        if (elemat2.is_initialized() and (damping == Inpar::Solid::damp_material))
-          matptr2 = &elemat2;
+        if (elemat_2.is_initialized() and (damping == Inpar::Solid::damp_material))
+          matptr2 = &elemat_2;
 
         // need current fluid state,
         // call the fluid discretization: fluid equates 2nd dofset
@@ -281,7 +275,7 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
 
         // calculate tangent stiffness matrix
         nonlinear_stiffness_poroelast(lm, mydisp, myvel, &myporosity, myfluidvel, myepreaf, matptr,
-            matptr2, &elevec1, params);
+            matptr2, &elevec_1, params);
       }
     }
     break;
@@ -291,8 +285,8 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
     case Core::Elements::struct_poro_calc_fluidcoupling:
     {
       // stiffness
-      Core::LinAlg::Matrix<numdof_, (Base::numdim_ + 1) * Base::numnod_> elemat1(
-          elemat1_epetra.values(), true);
+      Core::LinAlg::Matrix<numdof_, (Base::numdim_ + 1) * Base::numnod_> elemat_1(
+          elemat1.values(), true);
 
       // elemat2,elevec1-3 are not used anyway
 
@@ -300,7 +294,7 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
       std::vector<int> lm = la[0].lm_;
 
       Core::LinAlg::Matrix<numdof_, (Base::numdim_ + 1) * Base::numnod_>* matptr = nullptr;
-      if (elemat1.is_initialized()) matptr = &elemat1;
+      if (elemat_1.is_initialized()) matptr = &elemat_1;
 
       // need current fluid state,
       // call the fluid discretization: fluid equates 2nd dofset
@@ -342,7 +336,7 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
     case Core::Elements::struct_calc_internalforce:
     {
       // internal force vector
-      Core::LinAlg::Matrix<numdof_, 1> elevec1(elevec1_epetra.values(), true);
+      Core::LinAlg::Matrix<numdof_, 1> elevec_1(elevec1.values(), true);
       // elemat2,elevec2+3 are not used anyway
 
       // build the location vector only for the structure field
@@ -372,7 +366,7 @@ int Discret::Elements::Wall1PoroP1<distype>::my_evaluate(Teuchos::ParameterList&
             discretization, 0, la[0].lm_, &myvel, nullptr, "velocity");
 
         nonlinear_stiffness_poroelast(lm, mydisp, myvel, &myporosity, myfluidvel, myepreaf, nullptr,
-            nullptr, &elevec1, params);
+            nullptr, &elevec_1, params);
       }
     }
     break;

--- a/src/w1/4C_w1_scatra_evaluate.cpp
+++ b/src/w1/4C_w1_scatra_evaluate.cpp
@@ -71,11 +71,9 @@ void Discret::Elements::Wall1Scatra::pre_evaluate(Teuchos::ParameterList& params
  *----------------------------------------------------------------------*/
 int Discret::Elements::Wall1Scatra::my_evaluate(Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   return 0;
 }
@@ -85,11 +83,9 @@ int Discret::Elements::Wall1Scatra::my_evaluate(Teuchos::ParameterList& params,
  *----------------------------------------------------------------------*/
 int Discret::Elements::Wall1Scatra::evaluate(Teuchos::ParameterList& params,
     Core::FE::Discretization& discretization, Core::Elements::LocationArray& la,
-    Core::LinAlg::SerialDenseMatrix& elemat1_epetra,
-    Core::LinAlg::SerialDenseMatrix& elemat2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec1_epetra,
-    Core::LinAlg::SerialDenseVector& elevec2_epetra,
-    Core::LinAlg::SerialDenseVector& elevec3_epetra)
+    Core::LinAlg::SerialDenseMatrix& elemat1, Core::LinAlg::SerialDenseMatrix& elemat2,
+    Core::LinAlg::SerialDenseVector& elevec1, Core::LinAlg::SerialDenseVector& elevec2,
+    Core::LinAlg::SerialDenseVector& elevec3)
 {
   set_params_interface_ptr(params);
 
@@ -118,11 +114,11 @@ int Discret::Elements::Wall1Scatra::evaluate(Teuchos::ParameterList& params,
       //    MyEvaluate(params,
       //                      discretization,
       //                      la,
-      //                      elemat1_epetra,
-      //                      elemat2_epetra,
-      //                      elevec1_epetra,
-      //                      elevec2_epetra,
-      //                      elevec3_epetra);
+      //                      elemat1,
+      //                      elemat2,
+      //                      elevec1,
+      //                      elevec2,
+      //                      elevec3);
       //  }
       //  break;
       //  case Wall1_Scatra::postprocess_stress:
@@ -130,11 +126,11 @@ int Discret::Elements::Wall1Scatra::evaluate(Teuchos::ParameterList& params,
       //    Wall1::evaluate(params,
       //                          discretization,
       //                          la[0].lm_,
-      //                          elemat1_epetra,
-      //                          elemat2_epetra,
-      //                          elevec1_epetra,
-      //                          elevec2_epetra,
-      //                          elevec3_epetra);
+      //                          elemat1,
+      //                          elemat2,
+      //                          elevec1,
+      //                          elevec2,
+      //                          elevec3);
       //  }
       //  break;
     /*case Wall1_Scatra::calc_struct_update_istep:
@@ -142,11 +138,11 @@ int Discret::Elements::Wall1Scatra::evaluate(Teuchos::ParameterList& params,
       So3Ele::evaluate(params,
                         discretization,
                         la[0].lm_,
-                        elemat1_epetra,
-                        elemat2_epetra,
-                        elevec1_epetra,
-                        elevec2_epetra,
-                        elevec3_epetra);
+                        elemat1,
+                        elemat2,
+                        elevec1,
+                        elevec2,
+                        elevec3);
     }
     break;*/
     //==================================================================================
@@ -156,11 +152,10 @@ int Discret::Elements::Wall1Scatra::evaluate(Teuchos::ParameterList& params,
 
       pre_evaluate(params, discretization, la);
 
-      Wall1::evaluate(params, discretization, la[0].lm_, elemat1_epetra, elemat2_epetra,
-          elevec1_epetra, elevec2_epetra, elevec3_epetra);
+      Wall1::evaluate(
+          params, discretization, la[0].lm_, elemat1, elemat2, elevec1, elevec2, elevec3);
 
-      my_evaluate(params, discretization, la, elemat1_epetra, elemat2_epetra, elevec1_epetra,
-          elevec2_epetra, elevec3_epetra);
+      my_evaluate(params, discretization, la, elemat1, elemat2, elevec1, elevec2, elevec3);
 
       break;
     }

--- a/src/xfem/4C_xfem_discretization.hpp
+++ b/src/xfem/4C_xfem_discretization.hpp
@@ -32,7 +32,7 @@ namespace XFEM
     \brief Standard Constructor
 
     \param name (in): name of this discretization
-    \param comm (in): An epetra comm object associated with this discretization
+    \param comm (in): An comm object associated with this discretization
     */
     DiscretizationXFEM(const std::string name, MPI_Comm comm, unsigned int n_dim);
 

--- a/src/xfem/4C_xfem_discretization_utils.hpp
+++ b/src/xfem/4C_xfem_discretization_utils.hpp
@@ -168,7 +168,7 @@ namespace XFEM
     \brief Standard Constructor
 
     \param name: name of this discretization
-    \param comm: Epetra comm object associated with this discretization
+    \param comm: comm object associated with this discretization
     \param n_dim: number of space dimensions of this discretization
     */
     DiscretizationXWall(const std::string name, MPI_Comm comm, unsigned int n_dim);

--- a/src/xfem/4C_xfem_multi_field_mapextractor.hpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.hpp
@@ -658,7 +658,6 @@ namespace XFEM
 
     int max_num_reserved_dofs_per_node_;
 
-    /// Epetra communicator
     MPI_Comm comm_;
 
     /// vector containing pointers to all the input discretizations

--- a/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
+++ b/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
@@ -334,7 +334,7 @@ void XFEM::XFluidContactComm::get_states(const int fluidele_id, const std::vecto
   }
 
   // 2 // get element xyze
-  /// element coordinates in EpetraMatrix
+  /// element coordinates in matrix
   ele_xyze.shape(3, fluidele->num_node());
   for (int i = 0; i < fluidele->num_node(); ++i)
   {

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
@@ -92,7 +92,7 @@ void XFEM::XfluidTimeintBase::type(int iter, int iterMax)
 
 
 /*------------------------------------------------------------------------------------------------*
- * assign the Epetra vectors which shall be computed to the                                       *
+ * assign the vectors which shall be computed to the                                              *
  * algorithms data structure                                                         schott 07/12 *
  *------------------------------------------------------------------------------------------------*/
 void XFEM::XfluidTimeintBase::handle_vectors(
@@ -3168,8 +3168,8 @@ bool XFEM::XfluidStd::within_limits(Core::LinAlg::Matrix<3, 1>& xsi_, const doub
 }
 
 /*------------------------------------------------------------------------------------------------*
- * setting the computed data for the standard degrees of freedom into the according * Epetra
- *Vectors for all handled nodes                                              schott 07/12 *
+ * setting the computed data for the standard degrees of freedom into the according        *
+ * vectors for all handled nodes                                              schott 07/12 *
  *------------------------------------------------------------------------------------------------*/
 void XFEM::XfluidStd::set_final_data()
 {

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.hpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.hpp
@@ -398,11 +398,11 @@ namespace XFEM
     //! initialize data to be set in every computation
     void handle_vectors(std::vector<std::shared_ptr<Core::LinAlg::Vector<double>>>& newRowVectorsn);
 
-    //! return the number of Epetra vectors which shall get new values for a given node with
+    //! return the number of vectors which shall get new values for a given node with
     //! according data
     size_t vector_size(TimeIntData* data) const { return vector_size(data->type_); };
 
-    //! return the number of Epetra vectors which shall get new values for a given type
+    //! return the number of vectors which shall get new values for a given type
     size_t vector_size(TimeIntData::Type currtype) const
     {
       if (newVectors_.size() == 0)


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR aims to remove all old `Epetra` related comments and in addition refactors variable names, such that they don't contain any explicit mentions of `Epetra`.

If I do a local search for `Epetra` most finds are now related to actual objects, includes and conversion functions as `to_epetra_comm()` etc. This should help us to find actual appearances of `Epetra` in our code base more easily.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #189 