### PR TITLE
Fix docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,9 +7,9 @@ on:
       - main
     paths:
       - '.github/workflows/docker.yml'
-      - 'dependencies/current/'
-      - 'dependencies/testing/'
-      - 'docker/dependencies/'
+      - 'dependencies/current/**'
+      - 'dependencies/testing/**'
+      - 'docker/dependencies/**'
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The rule to run the workflow on the main branch was missing some '**' to match all files under the respective folders.

The `4c-dependencies-ubuntu24.04:main` has not been updated correctly. This is fixed once this PR is merged.