### PR TITLE
Exodus: reorder indices for hex27

### DIFF
--- a/apps/pre_exodus/4C_pre_exodus_writedat.cpp
+++ b/apps/pre_exodus/4C_pre_exodus_writedat.cpp
@@ -337,8 +337,8 @@ std::set<int> EXODUS::get_ns_from_bc_entity(
   {
     std::set<int> allnodes;
     const auto& eb = m.get_element_block(e.id);
-    std::shared_ptr<const std::map<int, std::vector<int>>> eles = eb.get_ele_conn();
-    for (const auto& ele : *eles)
+    const std::map<int, std::vector<int>>& eles = eb.get_ele_conn();
+    for (const auto& ele : eles)
     {
       const std::vector<int> nodes = ele.second;
       for (auto node : nodes) allnodes.insert(node);
@@ -481,14 +481,14 @@ void EXODUS::write_dat_eles(
 void EXODUS::dat_eles(const Core::IO::Exodus::ElementBlock& eb, const EXODUS::ElemDef& acte,
     int& startele, std::ostream& outfile, const int eb_id)
 {
-  auto eles = eb.get_ele_conn();
-  for (const auto& ele : *eles)
+  const auto& eles = eb.get_ele_conn();
+  for (const auto& ele : eles)
   {
     std::stringstream dat;  // first build up the std::string for actual element line
     const std::vector<int> nodes = ele.second;
     dat << "   " << startele;
     dat << " " << acte.ename;  // e.g. "SOLID"
-    dat << " " << Core::FE::cell_type_to_string(shape_to_cell_type(eb.get_shape()));
+    dat << " " << Core::FE::cell_type_to_string(eb.get_shape());
     dat << "  ";
     for (auto node : nodes) dat << node << " ";
     dat << "   " << acte.desc;  // e.g. "MAT 1"

--- a/src/core/io/src/4C_io_exodus.hpp
+++ b/src/core/io/src/4C_io_exodus.hpp
@@ -128,54 +128,25 @@ namespace Core::IO::Exodus
   class ElementBlock
   {
    public:
-    enum Shape
-    {
-      dis_none,  ///< unknown dis type
-      quad4,     ///< 4 noded quadrilateral
-      quad8,     ///< 8 noded quadrilateral
-      quad9,     ///< 9 noded quadrilateral
-      shell4,
-      shell8,
-      shell9,
-      tri3,        ///< 3 noded triangle
-      tri6,        ///< 6 noded triangle
-      hex8,        ///< 8 noded hexahedra
-      hex20,       ///< 20 noded hexahedra
-      hex27,       ///< 27 noded hexahedra
-      tet4,        ///< 4 noded tetrahedra
-      tet10,       ///< 10 noded tetrahedra
-      wedge6,      ///< 6 noded wedge
-      wedge15,     ///< 15 noded wedge
-      pyramid5,    ///< 5 noded pyramid
-      bar2,        ///< 2 noded line
-      bar3,        ///< 3 noded line
-      point1,      ///< 1 noded point
-      max_distype  ///<  end marker. must be the last entry
-    };
+    ElementBlock(FE::CellType cell_type, std::map<int, std::vector<int>> eleconn, std::string name);
 
-    ElementBlock(ElementBlock::Shape DisType,
-        std::shared_ptr<std::map<int, std::vector<int>>>& eleconn,  // Element connectivity
-        std::string name);
+    FE::CellType get_shape() const { return cell_type_; }
 
-    ElementBlock::Shape get_shape() const { return distype_; }
+    int get_num_ele() const { return eleconn_.size(); }
 
-    int get_num_ele() const { return eleconn_->size(); }
-
-    std::shared_ptr<std::map<int, std::vector<int>>> get_ele_conn() const { return eleconn_; }
+    const std::map<int, std::vector<int>>& get_ele_conn() const { return eleconn_; }
 
     const std::vector<int>& get_ele_nodes(int i) const;
 
     std::string get_name() const { return name_; }
 
-    int get_ele_node(int ele, int node) const;
-
     void print(std::ostream& os, bool verbose = false) const;
 
    private:
-    Shape distype_;
+    FE::CellType cell_type_;
 
     //! Element Connectivity
-    std::shared_ptr<std::map<int, std::vector<int>>> eleconn_;
+    std::map<int, std::vector<int>> eleconn_;
 
     std::string name_;
   };
@@ -215,13 +186,6 @@ namespace Core::IO::Exodus
     std::map<int, std::vector<int>> sides_;
     std::string name_;
   };
-
-  ElementBlock::Shape string_to_shape(const std::string shape);
-
-  std::string shape_to_string(const ElementBlock::Shape shape);
-
-  Core::FE::CellType shape_to_cell_type(const ElementBlock::Shape shape);
-
 }  // namespace Core::IO::Exodus
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -846,7 +846,7 @@ namespace
             eb_id);
 
         const auto& element_name = current_block_data->get<std::string>("ELEMENT_NAME");
-        const auto cell_type = Core::IO::Exodus::shape_to_cell_type(eb.get_shape());
+        const auto cell_type = eb.get_shape();
         const auto cell_type_string = Core::FE::cell_type_to_string(cell_type);
 
         Core::Elements::ElementDefinition ed;
@@ -869,7 +869,7 @@ namespace
         linedef.fully_parse(element_parser, element_data);
 
 
-        for (const auto& ele_nodes : *eb.get_ele_conn() | std::views::values)
+        for (const auto& ele_nodes : eb.get_ele_conn() | std::views::values)
         {
           auto ele = Core::Communication::factory(element_name, cell_type_string, ele_count, 0);
           if (!ele) FOUR_C_THROW("element creation failed");

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1496,7 +1496,7 @@ namespace
         for (const auto& [id, eb] : element_blocks)
         {
           std::set<int> nodes;
-          for (const auto& connectivity : *eb.get_ele_conn() | std::views::values)
+          for (const auto& connectivity : eb.get_ele_conn() | std::views::values)
           {
             nodes.insert(connectivity.begin(), connectivity.end());
           }


### PR DESCRIPTION
Closes #707

I further simplified the duplication we have in our Exodus code and removed the Shape enum.