### PR TITLE
Put magic_enum reflection into EnumTools namespace

### DIFF
--- a/doc/documentation/src/developer_guide/codingguidelines.rst
+++ b/doc/documentation/src/developer_guide/codingguidelines.rst
@@ -82,8 +82,9 @@ Enums
 - By default, use scoped ``enum class`` instead of unscoped ``enum``.
 - Use enums instead of strings for parameters that take one from a fixed set of values.
 - You do not have to write conversion functions between enum constants and strings.
-  Use ``magic_enum::enum_name`` to get the name of an enum constant and ``magic_enum::enum_cast`` to convert a string to
-  an enum constant.
+  Use ``EnumTools::enum_name`` to get the name of an enum constant and ``EnumTools::enum_cast`` to convert a string to
+  an enum constant. ``EnumTools::operator<<`` and ``EnumTools::operator>>`` allow for easy interaction
+  with std streams.
 
 See also `Enum.3 <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum3-prefer-class-enums-over-plain-enums>`_.
 

--- a/src/core/io/src/4C_io_input_parameter_container.hpp
+++ b/src/core/io/src/4C_io_input_parameter_container.hpp
@@ -56,7 +56,8 @@ namespace Core::IO
     /**
      * \brief Add @data to the container at the given key @name.
      *
-     * If an entry with given @p name already exists, it will be overwritten.
+     * If an entry with given @p name already exists, it will be overwritten. The type must be
+     * one of the SupportedType of the input framework.
      */
     template <typename T>
     void add(const std::string& name, const T& data);
@@ -77,7 +78,7 @@ namespace Core::IO
     [[nodiscard]] auto groups() const;
 
     /**
-     * Check if a group with the name @p name exists.
+     * Check if a group with the given @p name exists.
      */
     [[nodiscard]] bool has_group(const std::string& name) const;
 

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -45,7 +45,7 @@ namespace Core::IO
       template <SupportedType T>
       void operator()(std::ostream& out, const T& val) const
       {
-        using magic_enum::iostream_operators::operator<<;
+        using EnumTools::operator<<;
         out << val;
       }
 
@@ -118,7 +118,7 @@ namespace Core::IO
       requires(std::is_enum_v<Enum>)
     struct PrettyTypeName<Enum>
     {
-      std::string operator()() { return std::string{magic_enum::enum_type_name<Enum>()}; }
+      std::string operator()() { return std::string{EnumTools::enum_type_name<Enum>()}; }
     };
 
     template <typename T>
@@ -174,7 +174,7 @@ namespace Core::IO
         FOUR_C_ASSERT(node.is_map(), "Expected a map node.");
         node["type"] = "enum";
         node["choices"] |= ryml::SEQ;
-        for (const auto& choice_string : magic_enum::enum_values<Enum>())
+        for (const auto& choice_string : EnumTools::enum_values<Enum>())
         {
           auto entry = node["choices"].append_child();
           // Write every choice entry as a map to easily extend the information at a later point.
@@ -1445,7 +1445,7 @@ bool Core::IO::Internal::ParameterSpec<T>::match(ConstYamlNodeRef node,
     if constexpr (std::is_enum_v<T>)
     {
       std::string choices_string;
-      for (const auto& e : magic_enum::enum_names<T>())
+      for (const auto& e : EnumTools::enum_names<T>())
       {
         choices_string += std::string(e) + "|";
       }
@@ -1850,7 +1850,7 @@ void Core::IO::Internal::SelectionSpec<T>::print(std::ostream& stream, std::size
   {
     stream << "\n";
     stream << "//" << std::string(indent + 2, ' ') << " if value of " << based_on.selector << " is "
-           << magic_enum::enum_name<T>(selector_value);
+           << EnumTools::enum_name<T>(selector_value);
     spec.impl().print(stream, indent + 4);
   }
   stream << "\n";
@@ -1973,12 +1973,12 @@ Core::IO::InputSpec Core::IO::InputSpecBuilders::selection(
     std::string name, Internal::BasedOn<T> based_on, SelectionData data)
 {
   // Ensure that every enum constant is mapped to a spec.
-  for (const auto& e : magic_enum::enum_values<T>())
+  for (const auto& e : EnumTools::enum_values<T>())
   {
     FOUR_C_ASSERT_ALWAYS(based_on.choices.contains(e),
         "You need to give an InputSpec for every possible value of enum '{}'. Missing "
         "choice for enum constant '{}'.",
-        magic_enum::enum_type_name<T>(), magic_enum::enum_name(e));
+        EnumTools::enum_type_name<T>(), EnumTools::enum_name(e));
   }
 
   std::size_t max_specs_for_choices = std::ranges::max_element(

--- a/src/core/io/src/4C_io_value_parser.hpp
+++ b/src/core/io/src/4C_io_value_parser.hpp
@@ -12,9 +12,8 @@
 
 #include "4C_io_input_types.hpp"
 #include "4C_utils_demangle.hpp"
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
-
-#include <magic_enum/magic_enum.hpp>
 
 #include <array>
 #include <filesystem>
@@ -199,7 +198,7 @@ namespace Core::IO
     {
       std::string string;
       read_internal(string);
-      auto val = magic_enum::enum_cast<Enum>(string);
+      auto val = EnumTools::enum_cast<Enum>(string);
       if (val)
       {
         value = *val;
@@ -207,7 +206,7 @@ namespace Core::IO
       else
       {
         FOUR_C_THROW("Could not parse value '{}' as an enum constant of type '{}'.", string,
-            magic_enum::enum_type_name<Enum>());
+            EnumTools::enum_type_name<Enum>());
       }
     }
 

--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -10,9 +10,9 @@
 
 #include "4C_config.hpp"
 
+#include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <magic_enum/magic_enum.hpp>
 #include <ryml.hpp>      // IWYU pragma: export
 #include <ryml_std.hpp>  // IWYU pragma: export
 
@@ -173,7 +173,7 @@ namespace Core::IO
   {
     FOUR_C_ASSERT_ALWAYS(node.node.has_val(), "Expected a value node.");
     auto substr = node.node.val();
-    auto val = magic_enum::enum_cast<T>(std::string_view(substr.data(), substr.size()));
+    auto val = EnumTools::enum_cast<T>(std::string_view(substr.data(), substr.size()));
     if (val)
     {
       value = *val;
@@ -181,7 +181,7 @@ namespace Core::IO
     else
     {
       FOUR_C_THROW("Could not parse value '{}' as an enum constant of type '{}'.",
-          std::string_view(substr.data(), substr.size()), magic_enum::enum_type_name<T>());
+          std::string_view(substr.data(), substr.size()), EnumTools::enum_type_name<T>());
     }
   }
 
@@ -233,7 +233,7 @@ template <typename T>
   requires(std::is_enum_v<T>)
 void Core::IO::emit_value_as_yaml(YamlNodeRef node, const T& value)
 {
-  std::string_view str = magic_enum::enum_name(value);
+  std::string_view str = EnumTools::enum_name(value);
   node.node << ryml::csubstr(str.data(), str.size());
 }
 

--- a/src/core/linalg/src/dense/4C_linalg_utils_densematrix_funct.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_densematrix_funct.hpp
@@ -23,9 +23,6 @@ exponential and the logarithm, along with specific derivatives in namespace Core
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 
-#include <magic_enum/magic_enum.hpp>
-
-#include <cstddef>
 #include <optional>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.cpp
@@ -573,7 +573,7 @@ Core::LinAlg::TensorInterpolation::SecondOrderTensorInterpolator<loc_dim>::get_i
     FOUR_C_THROW(
         "We do not have an implementation for RotationInterpolationType {} and EigenvalInterpType "
         "{}!",
-        magic_enum::enum_name(rot_interp_type_), magic_enum::enum_name(eigenval_interp_type_));
+        rot_interp_type_, eigenval_interp_type_);
   }
   return output;
 }

--- a/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.hpp
@@ -16,8 +16,6 @@
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <magic_enum/magic_enum.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg

--- a/src/core/utils/src/stl_extension/4C_utils_enum.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_enum.hpp
@@ -16,12 +16,24 @@
 // 2) Include magic_enum header.
 #include <magic_enum/magic_enum_format.hpp>
 #include <magic_enum/magic_enum_iostream.hpp>
+#include <magic_enum/magic_enum_switch.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
-// Import the stream insertion and extraction operators for enums.
-using magic_enum::iostream_operators::operator<<;
-using magic_enum::iostream_operators::operator>>;
+/**
+ * This namespace contains helpers for static reflection of enums.
+ *
+ * @note The implementation is currently provided by the magic_enum library.
+ */
+namespace EnumTools
+{
+  // Import the stream insertion and extraction operators for enums.
+  using magic_enum::iostream_operators::operator<<;
+  using magic_enum::iostream_operators::operator>>;
+
+  // Import everything from magic_enum into our namespace.
+  using namespace magic_enum;
+}  // namespace EnumTools
 
 FOUR_C_NAMESPACE_CLOSE
 

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -848,8 +848,8 @@ void PoroElast::Monolithic::print_newton_iter_header_stream(std::ostringstream& 
 {
   oss << "------------------------------------------------------------" << std::endl;
   oss << "                   Newton-Raphson Scheme                    " << std::endl;
-  oss << "                NormRES " << magic_enum::enum_name(vectornormfres_);
-  oss << "     NormINC " << magic_enum::enum_name(vectornorminc_) << "                    "
+  oss << "                NormRES " << EnumTools::enum_name(vectornormfres_);
+  oss << "     NormINC " << EnumTools::enum_name(vectornorminc_) << "                    "
       << std::endl;
   oss << "------------------------------------------------------------" << std::endl;
 

--- a/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_monolithic.cpp
@@ -711,8 +711,8 @@ void PoroElastScaTra::PoroScatraMono::print_newton_iter_header(FILE* ofile)
 
   oss << "------------------------------------------------------------" << std::endl;
   oss << "                   Newton-Raphson Scheme                    " << std::endl;
-  oss << "                NormRES " << magic_enum::enum_name(vectornormfres_);
-  oss << "     NormINC " << magic_enum::enum_name(vectornorminc_) << "                    "
+  oss << "                NormRES " << EnumTools::enum_name(vectornormfres_);
+  oss << "     NormINC " << EnumTools::enum_name(vectornorminc_) << "                    "
       << std::endl;
   oss << "------------------------------------------------------------" << std::endl;
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_timint_implicit.cpp
@@ -1710,6 +1710,7 @@ inline void PoroPressureBased::TimIntImpl::print_convergence_values_first_iter(
 {
   if (myrank_ == 0)
   {
+    using EnumTools::operator<<;
     std::cout << "|  " << std::setw(3) << itnum << "/" << std::setw(3) << itemax << "   | "
               << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
               << std::setw(3) << vectornormfres_ << "]  | ";
@@ -1744,6 +1745,7 @@ inline void PoroPressureBased::TimIntImpl::print_convergence_values(
 {
   if (myrank_ == 0)
   {
+    using EnumTools::operator<<;
     std::cout << "|  " << std::setw(3) << itnum << "/" << std::setw(3) << itemax << "   | "
               << std::setw(10) << std::setprecision(3) << std::scientific << ittolres_ << " ["
               << std::setw(3) << vectornormfres_ << "]  | ";

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_monolithic.cpp
@@ -841,11 +841,11 @@ void PoroPressureBased::PorofluidElastMonolithic::newton_error_check()
       printf(
           "|  Max. rel. increment [%s]:  %10.3E  < %10.3E                                      "
           "|\n",
-          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
+          EnumTools::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%s]:  %10.3E  < %10.3E                                      "
           "|\n",
-          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
+          EnumTools::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+--------------+--------------+--------------+--------------+"
           "-----------------+\n");
@@ -862,10 +862,10 @@ void PoroPressureBased::PorofluidElastMonolithic::newton_error_check()
           itmax_);
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E    %10.3E                                    |\n",
-          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
+          EnumTools::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E    %10.3E                                    |\n",
-          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
+          EnumTools::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+----------------+------------------+--------------------+---------------"
           "---+\n");

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_monolithic_twoway.cpp
@@ -961,11 +961,11 @@ void PoroPressureBased::PoroMultiPhaseScaTraMonolithicTwoWay::newton_error_check
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E  < %10.3E                                        "
           "       |\n",
-          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
+          EnumTools::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E  < %10.3E                                        "
           "       |\n",
-          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
+          EnumTools::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+-------------+-------------+--------------+------------+-----"
           "-------+-----------------+\n");
@@ -986,11 +986,11 @@ void PoroPressureBased::PoroMultiPhaseScaTraMonolithicTwoWay::newton_error_check
       printf(
           "|  Max. rel. increment [%3s]:  %10.3E    %10.3E                                        "
           "|\n",
-          magic_enum::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
+          EnumTools::enum_name(vectornorminc_).data(), maxinc_, ittolinc_);
       printf(
           "|  Maximum    residual [%3s]:  %10.3E    %10.3E                                        "
           "|\n",
-          magic_enum::enum_name(vectornormfres_).data(), maxres_, ittolres_);
+          EnumTools::enum_name(vectornormfres_).data(), maxres_, ittolres_);
       printf(
           "+--------------+-------------+-------------+--------------+------------+-----"
           "-------+-----------------+\n");

--- a/src/solid_3D_ele/4C_solid_3D_ele_factory.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_factory.cpp
@@ -21,8 +21,6 @@
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <magic_enum/magic_enum_switch.hpp>
-
 #include <type_traits>
 
 FOUR_C_NAMESPACE_OPEN
@@ -206,13 +204,13 @@ Discret::Elements::SolidCalcVariant Discret::Elements::create_solid_calculation_
   return Core::FE::cell_type_switch<Internal::ImplementedSolidCellTypes>(celltype,
       [&](auto celltype_t)
       {
-        return magic_enum::enum_switch(
+        return EnumTools::enum_switch(
             [&](auto kinemtype_t)
             {
-              return magic_enum::enum_switch(
+              return EnumTools::enum_switch(
                   [&](auto eletech_t)
                   {
-                    return magic_enum::enum_switch(
+                    return EnumTools::enum_switch(
                         [&](auto prestress_tech_t) -> SolidCalcVariant
                         {
                           constexpr Core::FE::CellType celltype_c = celltype_t();

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_factory.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_factory.cpp
@@ -13,8 +13,6 @@
 #include "4C_solid_3D_ele_properties.hpp"
 #include "4C_utils_enum.hpp"
 
-#include <magic_enum/magic_enum_switch.hpp>
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace
@@ -122,13 +120,13 @@ Discret::Elements::create_solid_scatra_calculation_interface(Core::FE::CellType 
   return Core::FE::cell_type_switch<Internal::ImplementedSolidScatraCellTypes>(celltype,
       [&](auto celltype_t)
       {
-        return magic_enum::enum_switch(
+        return EnumTools::enum_switch(
             [&](auto kinemtype_t)
             {
-              return magic_enum::enum_switch(
+              return EnumTools::enum_switch(
                   [&](auto eletech_t)
                   {
-                    return magic_enum::enum_switch(
+                    return EnumTools::enum_switch(
                         [&](auto prestress_tech_t) -> SolidScatraCalcVariant
                         {
                           constexpr Core::FE::CellType celltype_c = celltype_t();

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -2843,7 +2843,7 @@ void Solid::TimInt::set_force_interface(
 
 std::string Solid::TimInt::method_title() const
 {
-  return std::string(magic_enum::enum_name(method_name()));
+  return std::string(EnumTools::enum_name(method_name()));
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -924,7 +924,7 @@ bool Solid::TimeInt::Base::has_final_state_been_written() const
 
 std::string Solid::TimeInt::Base::method_title() const
 {
-  return std::string(magic_enum::enum_name(method_name()));
+  return std::string(EnumTools::enum_name(method_name()));
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/thermo/src/implicit/4C_thermo_timint_genalpha.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_genalpha.cpp
@@ -102,7 +102,7 @@ Thermo::TimIntGenAlpha::TimIntGenAlpha(const Teuchos::ParameterList& ioparams,
               << "   alpha_f = " << alphaf_ << std::endl
               << "   alpha_m = " << alpham_ << std::endl
               << "   gamma = " << gamma_ << std::endl
-              << "   midavg = " << magic_enum::enum_name(midavg_) << std::endl;
+              << "   midavg = " << EnumTools::enum_name(midavg_) << std::endl;
   }
 
   // determine capacity and initial temperature rates


### PR DESCRIPTION
This PR properly encapsulates the magic_enum dependency in a namespace `EnumTools`. Previously, I tried to make the enum IO operators available globally but this cannot work due to the lookup rules of C++.

FYI @dragos-ana 