### PR TITLE
List all our CMake variables in the documentation

### DIFF
--- a/doc/documentation/CMakeLists.txt
+++ b/doc/documentation/CMakeLists.txt
@@ -42,6 +42,10 @@ if(FOUR_C_BUILD_DOCUMENTATION)
       cmake ${PROJECT_SOURCE_DIR} --list-presets >
       ${_sphinx_OUT_DIR}/reference_docs/4C-cmake-presets.txt
     COMMAND
+      bash ${CMAKE_CURRENT_SOURCE_DIR}/scripts/extract_cmake_variables.sh
+      ${PROJECT_BINARY_DIR}/CMakeCache.txt >
+      ${_sphinx_OUT_DIR}/reference_docs/4C-cmake-variables.csv
+    COMMAND
       ${SPHINX_EXECUTABLE} -W -n -q -b html # warnings are errors and be nit-picky
       -i "${CMAKE_CURRENT_SOURCE_DIR}/src" -i "${_sphinx_OUT_DIR}/reference_docs" -i
       "${PROJECT_SOURCE_DIR}/tests/framework-test" -i "${_sphinx_TPLDEPEND_DIR}" -o

--- a/doc/documentation/scripts/extract_cmake_variables.sh
+++ b/doc/documentation/scripts/extract_cmake_variables.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# This script extracts CMake variables from the CMakeCache.txt file.
+CACHE_FILE=$1
+
+awk '
+BEGIN {
+  print "Variable,Type,Description"
+  doc = ""
+}
+/^\/\// {
+  line = $0
+  gsub("^//", "", line)
+  gsub(/^[ \t]+|[ \t]+$/, "", line)
+  doc = (doc == "") ? line : doc " " line
+  next
+}
+/^[^#].*:/ {
+  split($0, a, ":")
+  name = a[1]
+  split(a[2], t, "=")
+  type = t[1]
+  if (name ~ /^FOUR_C/ && type != "INTERNAL") {
+    gsub(/"/, "\"\"", doc)
+    printf "\"``%s``\",\"%s\",\"%s\"\n", name, type, doc
+  }
+  doc = ""  # reset for next block
+}
+' ${CACHE_FILE}

--- a/doc/documentation/src/developer_guide/developer_cmake.rst
+++ b/doc/documentation/src/developer_guide/developer_cmake.rst
@@ -1,7 +1,7 @@
-.. _cmakepresets:
+.. _developer_cmake:
 
-CMake presets
---------------
+CMake
+-----
 
 CMake presets are |FOURC|'s recommended way to configure and manage different configurations of |FOURC|.
 This small article will go through a few of them. The experts should also read the
@@ -70,13 +70,24 @@ Don't be overwhelmed by the options you could potentially set.
   optimizes the build setup for iterative development cycles.
 - We try to detect reasonable defaults for you internally.
 
-Over time you might realize that you want to turn on additional dependencies or features.
-To see which other options you can set, consult the console output of CMake or run `ccmake .` in the build folder.
-Alternatively, all options are also printed with their ``ON`` or ``OFF`` state whenever ``cmake`` runs.
+Reference of all CMake variables
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**Remark:** Variables either start with the prefix `FOUR_C_` indicating that this variable only affects |FOURC| itself,
-or they start with `CMAKE_` indicating that the variable (potentially) affects all dependent projects in a way
+Over time you might realize that you want to turn on additional dependencies or features.
+To see which other options you can set, consult the console output of CMake or run ``ccmake .`` in the build folder.
+Alternatively, many options are also printed with their ``ON`` or ``OFF`` state whenever ``cmake`` runs.
+
+**Remark:** Variables either start with the prefix ``FOUR_C_`` indicating that this variable only affects |FOURC| itself,
+or they start with ``CMAKE_`` indicating that the variable (potentially) affects all dependent projects in a way
 specified directly in the CMake documentation.
+
+This is a list of all variables that are available to configure |FOURC|:
+
+.. csv-table::
+    :file: /4C-cmake-variables.csv
+    :header-rows: 1
+    :widths: 20, 20, 60
+
 
 Configuration from the IDE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/documentation/src/installation/installation.rst
+++ b/doc/documentation/src/installation/installation.rst
@@ -173,7 +173,7 @@ In a preset within this file, you should define a few options that are important
 - the build directory. It is good practice to indicate the value for ``CMAKE_BUILD_TYPE`` in the folder name, e.g. by
   ``"binaryDir": "<4C-basedir>/builds/release-build"`` (the folder name is completely up to you).
 
-More information about the cmake presets can be found :ref:`here <cmakepresets>`.
+More information about the cmake presets can be found :ref:`here <developer_cmake>`.
 
 
 .. note::


### PR DESCRIPTION
I've been meaning to do that for quite some time: add a list of all variables that CMake understands to the documentation. Looks like this:

![image](https://github.com/user-attachments/assets/eb4a274e-626c-4321-8985-291a29dd7d32)

The better configuration necessary for #664 will only make sense if people know which variables exist. The table is not perfect yet, as seen for the entries with `UNINITIALIZED` type. We can add a nicer entry for these in the next steps.
