### PR TITLE
CMake: ensure that cache variables are set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,13 +137,21 @@ enable_testing()
 
 # NOTE: --mca orte_tmpdir_base [...] can be removed for openmpi >= 4.1.1 according to
 # https://github.com/open-mpi/ompi/issues/8510#issuecomment-1329297350
-set(MPIEXEC_EXTRA_OPTS_FOR_TESTING
-    "--bind-to none --use-hwthread-cpus --mca orte_tmpdir_base ${PROJECT_BINARY_DIR}/tmp"
-    )
+four_c_process_cache_variable(
+  FOUR_C_MPIEXEC_ARGS_FOR_TESTING
+  TYPE
+  STRING
+  DESCRIPTION
+  "Arguments to pass to mpiexec for testing."
+  DEFAULT
+  "--bind-to none --use-hwthread-cpus --mca orte_tmpdir_base ${PROJECT_BINARY_DIR}/tmp"
+  )
+# We might need to add more arguments. Initialize with the user input.
+set(_mpiexec_all_args_for_testing ${FOUR_C_MPIEXEC_ARGS_FOR_TESTING})
 
 if(FOUR_C_ENABLE_ADDRESS_SANITIZER)
   # Do not detect leaks, we only care about UB inducing memory issues
-  string(APPEND MPIEXEC_EXTRA_OPTS_FOR_TESTING " -x LSAN_OPTIONS=detect_leaks=0")
+  string(APPEND _mpiexec_all_args_for_testing " -x LSAN_OPTIONS=detect_leaks=0")
   set(FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS "LSAN_OPTIONS=detect_leaks=0")
 endif()
 

--- a/cmake/functions/four_c_auto_define_tests.cmake
+++ b/cmake/functions/four_c_auto_define_tests.cmake
@@ -56,11 +56,11 @@ function(_set_up_unit_test_target _module_under_test _target)
 
   # the first process will write a unit test report
   separate_arguments(
-    MPIEXEC_EXTRA_OPTS_FOR_TESTING_LIST UNIX_COMMAND ${MPIEXEC_EXTRA_OPTS_FOR_TESTING}
+    _mpiexec_all_args_for_testing_list UNIX_COMMAND ${_mpiexec_all_args_for_testing}
     )
 
   set(mpi_arguments
-      ${MPIEXEC_EXTRA_OPTS_FOR_TESTING_LIST}
+      ${_mpiexec_all_args_for_testing_list}
       -np
       1
       $<TARGET_FILE:${_target}>
@@ -73,7 +73,7 @@ function(_set_up_unit_test_target _module_under_test _target)
       APPEND
       mpi_arguments
       :
-      ${MPIEXEC_EXTRA_OPTS_FOR_TESTING_LIST}
+      ${_mpiexec_all_args_for_testing_list}
       -np
       ${remaining_procs}
       $<TARGET_FILE:${_target}>

--- a/cmake/functions/four_c_configure_dependency.cmake
+++ b/cmake/functions/four_c_configure_dependency.cmake
@@ -209,6 +209,16 @@ function(four_c_configure_dependency _package_name)
   four_c_process_global_option(
     FOUR_C_WITH_${_package_name_sanitized} "Build 4C with ${_package_name}" ${_parsed_DEFAULT}
     )
+  # Add a cache entry to set the root directory of the package.
+  four_c_process_cache_variable(
+    FOUR_C_${_package_name_sanitized}_ROOT
+    TYPE
+    PATH
+    DESCRIPTION
+    "Root directory of ${_package_name}"
+    DEFAULT
+    ""
+    )
 
   if(${_parsed_DEFAULT} STREQUAL "ON")
     if(NOT FOUR_C_WITH_${_package_name_sanitized})

--- a/cmake/functions/four_c_process_global_option.cmake
+++ b/cmake/functions/four_c_process_global_option.cmake
@@ -13,10 +13,59 @@ function(four_c_process_global_option option_name description default)
   if(NOT option_name MATCHES "FOUR_C_.*")
     message(FATAL_ERROR "Disallowed option '${option_name}'. Option needs to start with 'FOUR_C_'.")
   endif()
-  option("${option_name}" "${description}" "${default}")
+  option("${option_name}" "${description} (default: ${default})" "${default}")
   if(${option_name})
     message(STATUS "Option ${option_name} = ON")
   else()
     message(STATUS "Option ${option_name} = OFF")
   endif()
+endfunction()
+
+# Initialize a cache variable. This function is almost equivalent to the builtin CMake
+# set() command, except that it also prints info on whether the variable is set and allows to
+# ensure a consistent style. Note that you need to use four_c_process_global_option() for the
+# common case of a BOOL variable.
+#
+# Usage:
+#   four_c_initialize_cache_variable(variable_name
+#     TYPE <STRING|FILEPATH|PATH>
+#     DESCRIPTION "Description of the variable"
+#     DEFAULT "Default value of the variable")
+#
+function(four_c_process_cache_variable variable_name)
+  if(NOT variable_name MATCHES "FOUR_C_.*")
+    message(
+      FATAL_ERROR
+        "Disallowed variable name '${variable_name}'. Variable name needs to start with 'FOUR_C_'."
+      )
+  endif()
+
+  set(options "")
+  set(oneValueArgs TYPE DESCRIPTION DEFAULT)
+  set(multiValueArgs "")
+  cmake_parse_arguments(
+    _parsed
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+    )
+
+  if(DEFINED _parsed_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "There are unparsed arguments: ${_parsed_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # Ensure that only one of the options STRING or (FILE)PATH for the cache variable type is set.
+  if(NOT _parsed_TYPE MATCHES "STRING|FILEPATH|PATH")
+    message(
+      FATAL_ERROR
+        "Invalid type '${_parsed_TYPE}' for cache variable '${variable_name}'. Allowed types are STRING, FILEPATH and PATH."
+      )
+  endif()
+
+  set(${variable_name}
+      "${_parsed_DEFAULT}"
+      CACHE ${_parsed_TYPE} "${_parsed_DESCRIPTION} (default: ${_parsed_DEFAULT})"
+      )
+  message(STATUS "Cache variable ${variable_name} = ${${variable_name}}")
 endfunction()

--- a/cmake/functions/four_c_testing_functions.cmake
+++ b/cmake/functions/four_c_testing_functions.cmake
@@ -291,12 +291,12 @@ function(four_c_test)
     set(test_command
         "mkdir -p ${test_directory} \
                 && ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> --to-yaml ${base_test_file} ${test_directory}/converted_input.yaml \
-                && ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_OPTS_FOR_TESTING} -np ${base_NP} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> ${test_directory}/converted_input.yaml ${test_directory}/xxx"
+                && ${MPIEXEC_EXECUTABLE} ${_mpiexec_all_args_for_testing} -np ${base_NP} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> ${test_directory}/converted_input.yaml ${test_directory}/xxx"
         )
   else()
     set(test_command
         "mkdir -p ${test_directory} \
-                && ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_OPTS_FOR_TESTING} -np ${base_NP} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> ${base_test_file} ${test_directory}/xxx"
+                && ${MPIEXEC_EXECUTABLE} ${_mpiexec_all_args_for_testing} -np ${base_NP} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> ${base_test_file} ${test_directory}/xxx"
         )
   endif()
 
@@ -362,7 +362,7 @@ function(four_c_test)
         )
     set(restart_test_directory ${PROJECT_BINARY_DIR}/framework_test_output/${name_of_test})
     set(test_command
-        "mkdir -p ${restart_test_directory} && ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_OPTS_FOR_TESTING} -np ${restart_NP} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> ${restart_test_file} ${restart_test_directory}/xxx restartfrom=${test_directory}/xxx restart=${_parsed_RESTART_STEP}"
+        "mkdir -p ${restart_test_directory} && ${MPIEXEC_EXECUTABLE} ${_mpiexec_all_args_for_testing} -np ${restart_NP} $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> ${restart_test_file} ${restart_test_directory}/xxx restartfrom=${test_directory}/xxx restart=${_parsed_RESTART_STEP}"
         )
 
     # Optional OpenMP threads per processor
@@ -419,7 +419,7 @@ function(four_c_test)
     # parallel run
     set(name_of_ensight_test "${name_of_test}-post_ensight_parallel")
     set(ensight_command
-        "${MPIEXEC_EXECUTABLE}\ ${MPIEXEC_EXTRA_OPTS_FOR_TESTING}\ -np\ ${_parsed_NP}\ ./post_ensight\ --file=${test_directory}/xxx\ --output=${test_directory}/xxx_parallel --outputtype=bin\ --stress=ndxyz && ${FOUR_C_PYTHON_VENV_BUILD}/bin/python3 ${PROJECT_SOURCE_DIR}/tests/post_processing_test/ensight_comparison.py ${source_file} ${test_directory}/xxx_parallel_structure.case"
+        "${MPIEXEC_EXECUTABLE}\ ${_mpiexec_all_args_for_testing}\ -np\ ${_parsed_NP}\ ./post_ensight\ --file=${test_directory}/xxx\ --output=${test_directory}/xxx_parallel --outputtype=bin\ --stress=ndxyz && ${FOUR_C_PYTHON_VENV_BUILD}/bin/python3 ${PROJECT_SOURCE_DIR}/tests/post_processing_test/ensight_comparison.py ${source_file} ${test_directory}/xxx_parallel_structure.case"
         )
     _add_test_with_options(
       NAME_OF_TEST
@@ -484,7 +484,7 @@ function(four_c_test_nested_parallelism name_of_input_file_1 name_of_input_file_
     NAME ${name_of_input_file_1}-nestedPar
     COMMAND
       bash -c
-      "mkdir -p ${test_directory} &&  ${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_OPTS_FOR_TESTING} -np 3 $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> -ngroup=2 -glayout=1,2 -nptype=separateDatFiles ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_1} ${test_directory}/xxx ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_2} ${test_directory}/xxxAdditional"
+      "mkdir -p ${test_directory} &&  ${MPIEXEC_EXECUTABLE} ${_mpiexec_all_args_for_testing} -np 3 $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> -ngroup=2 -glayout=1,2 -nptype=separateDatFiles ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_1} ${test_directory}/xxx ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_2} ${test_directory}/xxxAdditional"
     )
 
   require_fixture(${name_of_input_file_1}-nestedPar test_cleanup)
@@ -497,7 +497,7 @@ function(four_c_test_nested_parallelism name_of_input_file_1 name_of_input_file_
       NAME ${name_of_input_file_1}-nestedPar-restart
       COMMAND
         bash -c
-        "${MPIEXEC_EXECUTABLE} ${MPIEXEC_EXTRA_OPTS_FOR_TESTING} -np 3 $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> -ngroup=2 -glayout=1,2 -nptype=separateDatFiles ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_1} ${test_directory}/xxx restart=${restart_step} ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_2} ${test_directory}/xxxAdditional restart=${restart_step}"
+        "${MPIEXEC_EXECUTABLE} ${_mpiexec_all_args_for_testing} -np 3 $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}> -ngroup=2 -glayout=1,2 -nptype=separateDatFiles ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_1} ${test_directory}/xxx restart=${restart_step} ${PROJECT_SOURCE_DIR}/tests/input_files/${name_of_input_file_2} ${test_directory}/xxxAdditional restart=${restart_step}"
       )
 
     require_fixture(
@@ -558,7 +558,7 @@ function(four_c_test_framework)
   endif()
 
   set(_run_4C
-      ${MPIEXEC_EXECUTABLE}\ ${MPIEXEC_EXTRA_OPTS_FOR_TESTING}\ -np\ ${num_proc}\ $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>\ ${test_directory}/xxx.4C.yaml\ ${test_directory}/xxx
+      ${MPIEXEC_EXECUTABLE}\ ${_mpiexec_all_args_for_testing}\ -np\ ${num_proc}\ $<TARGET_FILE:${FOUR_C_EXECUTABLE_NAME}>\ ${test_directory}/xxx.4C.yaml\ ${test_directory}/xxx
       ) # 4C is run using the generated input file
 
   add_test(
@@ -584,7 +584,7 @@ function(four_c_test_cut_test num_proc)
 
   set(RUNTESTS
       # Run all the cuttests with num_proc except from alex53
-      ${MPIEXEC_EXECUTABLE}\ ${MPIEXEC_EXTRA_OPTS_FOR_TESTING}\ -np\ ${num_proc}\ ${PROJECT_BINARY_DIR}/cut_test\ --ignore_test=alex53
+      ${MPIEXEC_EXECUTABLE}\ ${_mpiexec_all_args_for_testing}\ -np\ ${num_proc}\ ${PROJECT_BINARY_DIR}/cut_test\ --ignore_test=alex53
       # Run alex53 serially
       ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS}\ ${PROJECT_BINARY_DIR}/cut_test\ --test=alex53
       )
@@ -645,7 +645,7 @@ function(
       ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS}\ ./post_ensight\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_SER_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
       )
   set(RUNPOSTFILTER_PAR
-      ${MPIEXEC_EXECUTABLE}\ ${MPIEXEC_EXTRA_OPTS_FOR_TESTING}\ -np\ ${num_proc}\ ./post_ensight\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_PAR_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
+      ${MPIEXEC_EXECUTABLE}\ ${_mpiexec_all_args_for_testing}\ -np\ ${num_proc}\ ./post_ensight\ --file=${test_directory}/xxx${IDENTIFIER}\ --output=${test_directory}/xxx${IDENTIFIER}_PAR_${name_of_input_file}\ --stress=${stresstype}\ --strain=${straintype}\ --start=${startstep}
       )
 
   # remove file ending of input file for reference file

--- a/cmake/setup_tests.cmake
+++ b/cmake/setup_tests.cmake
@@ -6,20 +6,32 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 if(FOUR_C_BUILD_TYPE_UPPER STREQUAL "DEBUG")
-  set(FOUR_C_TEST_TIMEOUT_SCALE
-      4
-      CACHE STRING "Scale timeout of tests by this factor."
-      )
+  set(_default_timeout_scale 4)
 else()
-  set(FOUR_C_TEST_TIMEOUT_SCALE
-      1
-      CACHE STRING "Scale timeout of tests by this factor."
-      )
+  set(_default_timeout_scale 1)
 endif()
-message(STATUS "Global test timeout scale is ${FOUR_C_TEST_TIMEOUT_SCALE}.")
+four_c_process_cache_variable(
+  FOUR_C_TEST_TIMEOUT_SCALE
+  TYPE
+  STRING
+  DESCRIPTION
+  "Scale timeout of tests by this factor."
+  DEFAULT
+  ${_default_timeout_scale}
+  )
 
 math(EXPR FOUR_C_TEST_GLOBAL_TIMEOUT "120*${FOUR_C_TEST_TIMEOUT_SCALE}")
 message(STATUS "The scaled global test timeout is ${FOUR_C_TEST_GLOBAL_TIMEOUT} s.")
+
+four_c_process_cache_variable(
+  FOUR_C_PVPYTHON
+  TYPE
+  FILEPATH
+  DESCRIPTION
+  "Path to the pvpython executable used for post-processing tests"
+  DEFAULT
+  "pvpython-not-set"
+  )
 
 # Fetch GoogleTest and setup the unit tests if option is enabled
 four_c_process_global_option(FOUR_C_WITH_GOOGLETEST "Use GoogleTest for unit testing" ON)


### PR DESCRIPTION
Follows #724 

@ischeider @ppraegla I think this PR will fix #664 since the `mpiexec` args are now configurable. We might want to do this differently in the future -- should there even be a default? I hope it works for now.

@georghammerl I added the default values of CMake variables to the table introduced in #724.