### PR TITLE
Remove INVALID_TEMPLATE_QUALIFIER

### DIFF
--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -433,16 +433,15 @@ void Adapter::StructureBaseAlgorithmNew::set_model_types(
     case Core::ProblemType::ssi:
     case Core::ProblemType::ssti:
     {
-      if (prbdyn_->INVALID_TEMPLATE_QUALIFIER
-              isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>("Partitioned Coupling Model"))
+      if (prbdyn_->isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
+              "Partitioned Coupling Model"))
       {
-        if (prbdyn_->INVALID_TEMPLATE_QUALIFIER
-                isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
-                    "Monolithic Coupling Model"))
+        if (prbdyn_->isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
+                "Monolithic Coupling Model"))
           FOUR_C_THROW("Cannot have both partitioned and monolithic coupling at the same time!");
         const auto coupling_model_ptr =
-            prbdyn_->INVALID_TEMPLATE_QUALIFIER
-                get<std::shared_ptr<Solid::ModelEvaluator::Generic>>("Partitioned Coupling Model");
+            prbdyn_->get<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
+                "Partitioned Coupling Model");
         if (!coupling_model_ptr)
           FOUR_C_THROW("The partitioned coupling model pointer is not allowed to be nullptr!");
         // set the model type
@@ -452,13 +451,12 @@ void Adapter::StructureBaseAlgorithmNew::set_model_types(
             "Partitioned Coupling Model", coupling_model_ptr);
       }
 
-      else if (prbdyn_->INVALID_TEMPLATE_QUALIFIER
-                   isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
-                       "Monolithic Coupling Model"))
+      else if (prbdyn_->isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
+                   "Monolithic Coupling Model"))
       {
         const auto coupling_model_ptr =
-            prbdyn_->INVALID_TEMPLATE_QUALIFIER
-                get<std::shared_ptr<Solid::ModelEvaluator::Generic>>("Monolithic Coupling Model");
+            prbdyn_->get<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
+                "Monolithic Coupling Model");
         if (!coupling_model_ptr)
           FOUR_C_THROW("The monolithic coupling model pointer is not allowed to be nullptr!");
         // set the model type
@@ -468,12 +466,11 @@ void Adapter::StructureBaseAlgorithmNew::set_model_types(
             "Monolithic Coupling Model", coupling_model_ptr);
       }
 
-      else if (prbdyn_->INVALID_TEMPLATE_QUALIFIER
-                   isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>("Basic Coupling Model"))
+      else if (prbdyn_->isType<std::shared_ptr<Solid::ModelEvaluator::Generic>>(
+                   "Basic Coupling Model"))
       {
         const auto coupling_model_ptr =
-            prbdyn_->INVALID_TEMPLATE_QUALIFIER
-                get<std::shared_ptr<Solid::ModelEvaluator::Generic>>("Basic Coupling Model");
+            prbdyn_->get<std::shared_ptr<Solid::ModelEvaluator::Generic>>("Basic Coupling Model");
         if (!coupling_model_ptr)
           FOUR_C_THROW("The basic coupling model pointer is not allowed to be nullptr!");
         // set the model type

--- a/src/scatra_ele/4C_scatra_ele_calc_lsreinit.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_lsreinit.cpp
@@ -142,9 +142,8 @@ void Discret::Elements::ScaTraEleCalcLsReinit<distype, prob_dim>::eval_reinitial
       Core::Geo::BoundaryIntCellPtrs boundaryIntCells = Core::Geo::BoundaryIntCellPtrs(0);
 
       // check the type: ToDo change to FOUR_C_ASSERT
-      if (not params.INVALID_TEMPLATE_QUALIFIER
-              isType<std::shared_ptr<const std::map<int, Core::Geo::BoundaryIntCellPtrs>>>(
-                  "boundary cells"))
+      if (not params.isType<std::shared_ptr<const std::map<int, Core::Geo::BoundaryIntCellPtrs>>>(
+              "boundary cells"))
         FOUR_C_THROW("The given boundary cells have the wrong type!");
 
       const std::shared_ptr<const std::map<int, Core::Geo::BoundaryIntCellPtrs>>& allcells =

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_prepostoperator.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_prepostoperator.cpp
@@ -51,11 +51,10 @@ void NOX::Nln::GROUP::PrePostOperator::reset(Teuchos::ParameterList& groupOption
 
   /* Check if a pre/post operator for the group is provided
    * by the user. */
-  if (groupOptionsSubList.INVALID_TEMPLATE_QUALIFIER isType<Teuchos::RCP<Map>>(
-          "User Defined Pre/Post Operator"))
+  if (groupOptionsSubList.isType<Teuchos::RCP<Map>>("User Defined Pre/Post Operator"))
   {
-    prePostOperatorMapPtr_ = groupOptionsSubList.INVALID_TEMPLATE_QUALIFIER get<Teuchos::RCP<Map>>(
-        "User Defined Pre/Post Operator");
+    prePostOperatorMapPtr_ =
+        groupOptionsSubList.get<Teuchos::RCP<Map>>("User Defined Pre/Post Operator");
     havePrePostOperator_ = true;
   }
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_prepostoperator.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_prepostoperator.cpp
@@ -51,11 +51,10 @@ void NOX::Nln::LinSystem::PrePostOperator::reset(Teuchos::ParameterList& linearS
 
   /* Check if a pre/post processor for the linear system is provided
    * by the user. */
-  if (linearSolverSubList.INVALID_TEMPLATE_QUALIFIER isType<Teuchos::RCP<Map>>(
-          "User Defined Pre/Post Operator"))
+  if (linearSolverSubList.isType<Teuchos::RCP<Map>>("User Defined Pre/Post Operator"))
   {
-    prePostOperatorMapPtr_ = linearSolverSubList.INVALID_TEMPLATE_QUALIFIER get<Teuchos::RCP<Map>>(
-        "User Defined Pre/Post Operator");
+    prePostOperatorMapPtr_ =
+        linearSolverSubList.get<Teuchos::RCP<Map>>("User Defined Pre/Post Operator");
     havePrePostOperator_ = true;
   }
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_prepostoperator.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_prepostoperator.cpp
@@ -26,11 +26,10 @@ void NOX::Nln::LineSearch::PrePostOperator::reset(Teuchos::ParameterList& linese
 
   /* Check if a pre/post operator for linesearch is provided
    * by the user. */
-  if (linesearchSublist.INVALID_TEMPLATE_QUALIFIER isType<Teuchos::RCP<map>>(
-          "User Defined Pre/Post Operator"))
+  if (linesearchSublist.isType<Teuchos::RCP<map>>("User Defined Pre/Post Operator"))
   {
-    prePostOperatorMapPtr_ = linesearchSublist.INVALID_TEMPLATE_QUALIFIER get<Teuchos::RCP<map>>(
-        "User Defined Pre/Post Operator");
+    prePostOperatorMapPtr_ =
+        linesearchSublist.get<Teuchos::RCP<map>>("User Defined Pre/Post Operator");
     havePrePostOperator_ = true;
   }
 }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -1301,8 +1301,7 @@ void Solid::ModelEvaluator::Structure::evaluate_internal(Teuchos::ParameterList&
         "Please use the Solid::Elements::Interface and its derived "
         "classes to set and get parameters.");
   }
-  if (not p.INVALID_TEMPLATE_QUALIFIER isType<std::shared_ptr<Core::Elements::ParamsInterface>>(
-          "interface"))
+  if (not p.isType<std::shared_ptr<Core::Elements::ParamsInterface>>("interface"))
     FOUR_C_THROW("The given parameter has the wrong type!");
 
   // FixMe as soon as possible: write data to the parameter list.
@@ -1339,8 +1338,7 @@ void Solid::ModelEvaluator::Structure::evaluate_internal_specified_elements(
         "Please use the Solid::Elements::Interface and its derived "
         "classes to set and get parameters.");
   }
-  if (not p.INVALID_TEMPLATE_QUALIFIER isType<std::shared_ptr<Core::Elements::ParamsInterface>>(
-          "interface"))
+  if (not p.isType<std::shared_ptr<Core::Elements::ParamsInterface>>("interface"))
     FOUR_C_THROW("The given parameter has the wrong type!");
 
   // write data to the parameter list.
@@ -1374,8 +1372,7 @@ void Solid::ModelEvaluator::Structure::evaluate_neumann(Teuchos::ParameterList& 
         "Please use the Solid::Elements::Interface and its derived "
         "classes to set and get parameters.");
   }
-  if (not p.INVALID_TEMPLATE_QUALIFIER isType<std::shared_ptr<Core::Elements::ParamsInterface>>(
-          "interface"))
+  if (not p.isType<std::shared_ptr<Core::Elements::ParamsInterface>>("interface"))
     FOUR_C_THROW("The given parameter has the wrong type!");
   discret().evaluate_neumann(p, eval_vec, eval_mat.get());
   discret().clear_state();


### PR DESCRIPTION
We got the macro `INVALID_TEMPLATE_QUALIFIER` from Teuchos, but it expands to nothing. It probably expanded to `template` at some point. I scraped Trilinos' history because I was curious. This diff https://github.com/trilinos/Trilinos/commit/e84d37591efa83266c521a9e7cac4c38fb4a4985#diff-4512baff44d86eb6c683befac0f69efc98d906b6f47c762ec0e5a0a8af4e59c0R3-R12 suggests that there were once buggy compilers. 