### PR TITLE
Clean scatra set state methods

### DIFF
--- a/src/adapter/4C_adapter_scatra_fluid_coupling_algorithm.cpp
+++ b/src/adapter/4C_adapter_scatra_fluid_coupling_algorithm.cpp
@@ -84,11 +84,14 @@ void Adapter::ScaTraFluidCouplingAlgorithm::setup()
   // transfer the initial convective velocity from initial fluid field to scalar transport field
   // subgrid scales not transferred since they are zero at time t=0.0
   if (!volcoupl_fluidscatra_)
-    scatra_field()->set_velocity_field(fluid_field()->convective_vel(), nullptr, nullptr, nullptr);
+  {
+    scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
+  }
   else
-    scatra_field()->set_velocity_field(
-        volcoupl_fluidscatra_->apply_vector_mapping21(*fluid_field()->convective_vel()), nullptr,
-        nullptr, nullptr);
+  {
+    scatra_field()->set_convective_velocity(
+        *volcoupl_fluidscatra_->apply_vector_mapping21(*fluid_field()->convective_vel()));
+  }
 
   // ensure that both single field solvers use the same
   // time integration scheme

--- a/src/elch/4C_elch_dyn.cpp
+++ b/src/elch/4C_elch_dyn.cpp
@@ -108,10 +108,10 @@ void elch_dyn(int restart)
       if (restart) scatraonly.scatra_field()->read_restart(restart);
 
       // set velocity field
-      // note: The order read_restart() before set_velocity_field() is important here!!
-      // for time-dependent velocity fields, set_velocity_field() is additionally called in each
-      // prepare_time_step()-call
-      scatraonly.scatra_field()->set_velocity_field();
+      // note: The order read_restart() before set_velocity_field_from_function() is important
+      // here!! for time-dependent velocity fields, set_velocity_field_from_function() is
+      // additionally called in each prepare_time_step()-call
+      scatraonly.scatra_field()->set_velocity_field_from_function();
 
       // enter time loop to solve problem with given convective velocity
       scatraonly.scatra_field()->time_loop();

--- a/src/elch/4C_elch_moving_boundary_algorithm.cpp
+++ b/src/elch/4C_elch_moving_boundary_algorithm.cpp
@@ -111,8 +111,9 @@ void ElCh::MovingBoundaryAlgorithm::time_loop()
   if (not pseudotransient_)
   {
     // transfer convective velocity = fluid velocity - grid velocity
-    scatra_field()->set_velocity_field(fluid_field()->convective_vel(),  // = velnp - grid velocity
-        fluid_field()->hist(), nullptr, nullptr);
+    scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
+    scatra_field()->set_velocity_field(
+        fluid_field()->hist(), fluid_field()->convective_vel(), nullptr);
   }
 
   // transfer moving mesh data
@@ -248,10 +249,10 @@ void ElCh::MovingBoundaryAlgorithm::solve_scatra()
 {
   if (Core::Communication::my_mpi_rank(get_comm()) == 0)
   {
-    std::cout << std::endl;
-    std::cout << "************************" << std::endl;
-    std::cout << "       ELCH SOLVER      " << std::endl;
-    std::cout << "************************" << std::endl;
+    std::cout << '\n';
+    std::cout << "************************" << '\n';
+    std::cout << "       ELCH SOLVER      " << '\n';
+    std::cout << "************************" << '\n';
   }
 
   switch (fluid_field()->tim_int_scheme())
@@ -259,22 +260,20 @@ void ElCh::MovingBoundaryAlgorithm::solve_scatra()
     case Inpar::FLUID::timeint_npgenalpha:
     case Inpar::FLUID::timeint_afgenalpha:
       FOUR_C_THROW("ConvectiveVel() not implemented for Gen.Alpha versions");
-      break;
     case Inpar::FLUID::timeint_one_step_theta:
     case Inpar::FLUID::timeint_bdf2:
     {
       if (not pseudotransient_)
       {
         // transfer convective velocity = fluid velocity - grid velocity
+        scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
         scatra_field()->set_velocity_field(
-            fluid_field()->convective_vel(),  // = velnp - grid velocity
-            fluid_field()->hist(), nullptr, nullptr);
+            fluid_field()->hist(), fluid_field()->convective_vel(), nullptr);
       }
     }
     break;
     default:
       FOUR_C_THROW("Time integration scheme not supported");
-      break;
   }
 
   // transfer moving mesh data

--- a/src/elch/4C_elch_moving_boundary_algorithm.cpp
+++ b/src/elch/4C_elch_moving_boundary_algorithm.cpp
@@ -81,7 +81,7 @@ void ElCh::MovingBoundaryAlgorithm::setup()
   }
 
   // transfer moving mesh data
-  scatra_field()->apply_mesh_movement(ale_field()->dispnp());
+  scatra_field()->apply_mesh_movement(*ale_field()->dispnp());
 
   // initialize the multivector for all possible cases
   fluxn_ = scatra_field()->calc_flux_at_boundary(false);
@@ -116,7 +116,7 @@ void ElCh::MovingBoundaryAlgorithm::time_loop()
   }
 
   // transfer moving mesh data
-  scatra_field()->apply_mesh_movement(ale_field()->dispnp());
+  scatra_field()->apply_mesh_movement(*ale_field()->dispnp());
 
   // time loop
   while (not_finished())
@@ -278,7 +278,7 @@ void ElCh::MovingBoundaryAlgorithm::solve_scatra()
   }
 
   // transfer moving mesh data
-  scatra_field()->apply_mesh_movement(ale_field()->dispnp());
+  scatra_field()->apply_mesh_movement(*ale_field()->dispnp());
 
   // solve coupled electrochemistry equations
   scatra_field()->solve();

--- a/src/elch/4C_elch_moving_boundary_algorithm.cpp
+++ b/src/elch/4C_elch_moving_boundary_algorithm.cpp
@@ -112,8 +112,7 @@ void ElCh::MovingBoundaryAlgorithm::time_loop()
   {
     // transfer convective velocity = fluid velocity - grid velocity
     scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
-    scatra_field()->set_velocity_field(
-        fluid_field()->hist(), fluid_field()->convective_vel(), nullptr);
+    scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->convective_vel());
   }
 
   // transfer moving mesh data
@@ -267,8 +266,7 @@ void ElCh::MovingBoundaryAlgorithm::solve_scatra()
       {
         // transfer convective velocity = fluid velocity - grid velocity
         scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
-        scatra_field()->set_velocity_field(
-            fluid_field()->hist(), fluid_field()->convective_vel(), nullptr);
+        scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->convective_vel());
       }
     }
     break;

--- a/src/elch/4C_elch_moving_boundary_algorithm.cpp
+++ b/src/elch/4C_elch_moving_boundary_algorithm.cpp
@@ -112,7 +112,8 @@ void ElCh::MovingBoundaryAlgorithm::time_loop()
   {
     // transfer convective velocity = fluid velocity - grid velocity
     scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
-    scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->convective_vel());
+    scatra_field()->set_velocity_field(*fluid_field()->convective_vel());
+    scatra_field()->set_acceleration_field(*fluid_field()->hist());
   }
 
   // transfer moving mesh data
@@ -266,7 +267,8 @@ void ElCh::MovingBoundaryAlgorithm::solve_scatra()
       {
         // transfer convective velocity = fluid velocity - grid velocity
         scatra_field()->set_convective_velocity(*fluid_field()->convective_vel());
-        scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->convective_vel());
+        scatra_field()->set_velocity_field(*fluid_field()->convective_vel());
+        scatra_field()->set_acceleration_field(*fluid_field()->hist());
       }
     }
     break;

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -615,11 +615,11 @@ void FS3I::PartFPS3I::set_struct_scatra_solution()
 void FS3I::PartFPS3I::set_mesh_disp()
 {
   // fluid field
-  scatravec_[0]->scatra_field()->apply_mesh_movement(fpsi_->fluid_field()->dispnp());
+  scatravec_[0]->scatra_field()->apply_mesh_movement(*fpsi_->fluid_field()->dispnp());
 
   // Poro field
   scatravec_[1]->scatra_field()->apply_mesh_movement(
-      fpsi_->poro_field()->structure_field()->dispnp());
+      *fpsi_->poro_field()->structure_field()->dispnp());
 }
 
 

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -651,8 +651,8 @@ void FS3I::PartFPS3I::set_velocity_fields()
 
       for (unsigned i = 0; i < scatravec_.size(); ++i)
       {
-        std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra = scatravec_[i];
-        scatra->scatra_field()->set_velocity_field(convel[i], nullptr, vel[i], nullptr);
+        scatravec_[i]->scatra_field()->set_convective_velocity(*convel[i]);
+        scatravec_[i]->scatra_field()->set_velocity_field(nullptr, vel[i], nullptr);
       }
       break;
     }

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -637,10 +637,9 @@ void FS3I::PartFPS3I::set_velocity_fields()
     case Inpar::ScaTra::velocity_zero:
     case Inpar::ScaTra::velocity_function:
     {
-      for (unsigned i = 0; i < scatravec_.size(); ++i)
+      for (auto scatra : scatravec_)
       {
-        std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra = scatravec_[i];
-        scatra->scatra_field()->set_velocity_field();
+        scatra->scatra_field()->set_velocity_field_from_function();
       }
       break;
     }

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -652,7 +652,7 @@ void FS3I::PartFPS3I::set_velocity_fields()
       for (unsigned i = 0; i < scatravec_.size(); ++i)
       {
         scatravec_[i]->scatra_field()->set_convective_velocity(*convel[i]);
-        scatravec_[i]->scatra_field()->set_velocity_field(nullptr, vel[i], nullptr);
+        scatravec_[i]->scatra_field()->set_velocity_field(nullptr, vel[i]);
       }
       break;
     }

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -670,7 +670,7 @@ void FS3I::PartFPS3I::set_wall_shear_stresses()
   for (unsigned i = 0; i < scatravec_.size(); ++i)
   {
     std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra = scatravec_[i];
-    scatra->scatra_field()->set_wall_shear_stresses(wss[i]);
+    scatra->scatra_field()->set_wall_shear_stresses(*wss[i]);
   }
 }
 

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -685,7 +685,7 @@ void FS3I::PartFPS3I::set_pressure_fields()
   for (unsigned i = 0; i < scatravec_.size(); ++i)
   {
     std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra = scatravec_[i];
-    scatra->scatra_field()->set_pressure_field(pressure[i]);
+    scatra->scatra_field()->set_pressure_field(*pressure[i]);
   }
 }
 

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -652,7 +652,7 @@ void FS3I::PartFPS3I::set_velocity_fields()
       for (unsigned i = 0; i < scatravec_.size(); ++i)
       {
         scatravec_[i]->scatra_field()->set_convective_velocity(*convel[i]);
-        scatravec_[i]->scatra_field()->set_velocity_field(nullptr, vel[i]);
+        scatravec_[i]->scatra_field()->set_velocity_field(*vel[i]);
       }
       break;
     }

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -762,7 +762,7 @@ void FS3I::PartFS3I::set_wall_shear_stresses() const
   for (unsigned i = 0; i < scatravec_.size(); ++i)
   {
     std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra = scatravec_[i];
-    scatra->scatra_field()->set_wall_shear_stresses(vol_mortar_master_to_slavei(i, wss[i]));
+    scatra->scatra_field()->set_wall_shear_stresses(*vol_mortar_master_to_slavei(i, wss[i]));
   }
 }
 

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -705,7 +705,7 @@ void FS3I::PartFS3I::set_velocity_fields() const
     scatravec_[i]->scatra_field()->set_convective_velocity(
         *vol_mortar_master_to_slavei(i, convel[i]));
     scatravec_[i]->scatra_field()->set_velocity_field(
-        nullptr, vol_mortar_master_to_slavei(i, vel[i]), nullptr);
+        nullptr, vol_mortar_master_to_slavei(i, vel[i]));
   }
 }
 

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -702,9 +702,10 @@ void FS3I::PartFS3I::set_velocity_fields() const
 
   for (unsigned i = 0; i < scatravec_.size(); ++i)
   {
-    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra = scatravec_[i];
-    scatra->scatra_field()->set_velocity_field(vol_mortar_master_to_slavei(i, convel[i]), nullptr,
-        vol_mortar_master_to_slavei(i, vel[i]), nullptr);
+    scatravec_[i]->scatra_field()->set_convective_velocity(
+        *vol_mortar_master_to_slavei(i, convel[i]));
+    scatravec_[i]->scatra_field()->set_velocity_field(
+        nullptr, vol_mortar_master_to_slavei(i, vel[i]), nullptr);
   }
 }
 

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -704,8 +704,7 @@ void FS3I::PartFS3I::set_velocity_fields() const
   {
     scatravec_[i]->scatra_field()->set_convective_velocity(
         *vol_mortar_master_to_slavei(i, convel[i]));
-    scatravec_[i]->scatra_field()->set_velocity_field(
-        nullptr, vol_mortar_master_to_slavei(i, vel[i]));
+    scatravec_[i]->scatra_field()->set_velocity_field(*vol_mortar_master_to_slavei(i, vel[i]));
   }
 }
 

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -683,12 +683,12 @@ void FS3I::PartFS3I::set_mesh_disp() const
   // fluid field
   std::shared_ptr<Adapter::ScaTraBaseAlgorithm> fluidscatra = scatravec_[0];
   fluidscatra->scatra_field()->apply_mesh_movement(
-      fluid_to_fluid_scalar(fsi_->fluid_field()->dispnp()));
+      *fluid_to_fluid_scalar(fsi_->fluid_field()->dispnp()));
 
   // structure field
   std::shared_ptr<Adapter::ScaTraBaseAlgorithm> structscatra = scatravec_[1];
   structscatra->scatra_field()->apply_mesh_movement(
-      structure_to_structure_scalar(fsi_->structure_field()->dispnp()));
+      *structure_to_structure_scalar(fsi_->structure_field()->dispnp()));
 }
 
 

--- a/src/fs3i/4C_fs3i_partitioned_2wc.cpp
+++ b/src/fs3i/4C_fs3i_partitioned_2wc.cpp
@@ -103,8 +103,7 @@ void FS3I::PartFS3I2Wc::initial_calculations()
 {
   // set initial fluid velocity field for evaluation of initial scalar
   // time derivative in fluid-based scalar transport
-  scatravec_[0]->scatra_field()->set_velocity_field(
-      fsi_->fluid_field()->velnp(), nullptr, nullptr, nullptr);
+  scatravec_[0]->scatra_field()->set_convective_velocity(*fsi_->fluid_field()->velnp());
 
   // set initial value of thermodynamic pressure in fluid-based scalar
   // transport

--- a/src/levelset/4C_levelset_algorithm.hpp
+++ b/src/levelset/4C_levelset_algorithm.hpp
@@ -66,15 +66,6 @@ namespace ScaTra
     //! set the velocity field (zero or field by function) (pure level-set problems)
     void set_velocity_field(bool init = false);
 
-    /// set convective velocity field (+ pressure and acceleration field as
-    /// well as fine-scale velocity field, if required) (function for coupled fluid problems)
-    void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> vel,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel, bool setpressure = false,
-        bool init = false);
-
-
     // output position of center of mass assuming a smoothed interfaces
     void mass_center_using_smoothing();
 

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -29,35 +29,12 @@ FOUR_C_NAMESPACE_OPEN
 void ScaTra::LevelSetAlgorithm::set_velocity_field(bool init)
 {
   // call function of base class
-  ScaTraTimIntImpl::set_velocity_field();
+  ScaTraTimIntImpl::set_velocity_field_from_function();
 
   // note: This function is only called from the level-set dyn. This is ok, since
   //       we only want to initialize conveln_ at the beginning of the simulation.
   //       for the remainder, it is updated as usual. For the dependent velocity fields
   //       the base class function is called in prepare_time_step().
-}
-
-
-/*----------------------------------------------------------------------*
- | set convective velocity field (+ pressure and acceleration field as  |
- | well as fine-scale velocity field, if required)      rasthofer 11/13 |
- *----------------------------------------------------------------------*/
-void ScaTra::LevelSetAlgorithm::set_velocity_field(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> vel,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel, bool setpressure, bool init)
-{
-  // call routine of base class
-  ScaTraTimIntImpl::set_velocity_field(convvel, acc, vel, fsvel, setpressure);
-
-  // manipulate velocity field away from the interface
-  if (extract_interface_vel_) manipulate_fluid_field_for_gfunc();
-
-  // estimate velocity at contact points, i.e., intersection points of interface and (no-slip) walls
-  if (cpbc_) apply_contact_point_boundary_condition();
-
-  return;
 }
 
 

--- a/src/loma/4C_loma_algorithm.cpp
+++ b/src/loma/4C_loma_algorithm.cpp
@@ -532,8 +532,6 @@ void LowMach::Algorithm::mono_loop()
     // check convergence and stop iteration loop if convergence is achieved
     stopnonliniter = convergence_check(itnum);
   }
-
-  return;
 }
 
 
@@ -548,21 +546,19 @@ void LowMach::Algorithm::set_fluid_values_in_scatra()
     case Inpar::FLUID::timeint_afgenalpha:
     {
       scatra_field()->set_velocity_field(
-          fluid_field()->velaf(), fluid_field()->accam(), nullptr, fluid_field()->fs_vel(), true);
+          fluid_field()->velaf(), fluid_field()->accam(), nullptr, fluid_field()->fs_vel());
     }
     break;
     case Inpar::FLUID::timeint_one_step_theta:
     case Inpar::FLUID::timeint_bdf2:
     {
       scatra_field()->set_velocity_field(
-          fluid_field()->velnp(), fluid_field()->hist(), nullptr, fluid_field()->fs_vel(), true);
+          fluid_field()->velnp(), fluid_field()->hist(), nullptr, fluid_field()->fs_vel());
     }
     break;
     default:
       FOUR_C_THROW("Time integration scheme not supported");
-      break;
   }
-  return;
 }
 
 

--- a/src/loma/4C_loma_algorithm.cpp
+++ b/src/loma/4C_loma_algorithm.cpp
@@ -313,7 +313,7 @@ void LowMach::Algorithm::initial_calculations()
 {
   // set initial velocity field for evaluation of initial scalar time derivative in SCATRA
   scatra_field()->set_convective_velocity(*fluid_field()->velnp());
-  scatra_field()->set_velocity_field(nullptr, fluid_field()->velnp());
+  scatra_field()->set_velocity_field(*fluid_field()->velnp());
   if (scatra_field()->fine_scale_velocity_field_required())
   {
     scatra_field()->set_fine_scale_velocity(*fluid_field()->fs_vel());
@@ -543,8 +543,9 @@ void LowMach::Algorithm::set_fluid_values_in_scatra()
   {
     case Inpar::FLUID::timeint_afgenalpha:
     {
+      scatra_field()->set_acceleration_field(*fluid_field()->accam());
       scatra_field()->set_convective_velocity(*fluid_field()->velaf());
-      scatra_field()->set_velocity_field(fluid_field()->accam(), fluid_field()->velaf());
+      scatra_field()->set_velocity_field(*fluid_field()->velaf());
       if (scatra_field()->fine_scale_velocity_field_required() and
           fluid_field()->fs_vel() != nullptr)
       {
@@ -555,8 +556,9 @@ void LowMach::Algorithm::set_fluid_values_in_scatra()
     case Inpar::FLUID::timeint_one_step_theta:
     case Inpar::FLUID::timeint_bdf2:
     {
+      scatra_field()->set_acceleration_field(*fluid_field()->hist());
       scatra_field()->set_convective_velocity(*fluid_field()->velnp());
-      scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->velnp());
+      scatra_field()->set_velocity_field(*fluid_field()->velnp());
       if (scatra_field()->fine_scale_velocity_field_required() and
           fluid_field()->fs_vel() != nullptr)
       {

--- a/src/loma/4C_loma_algorithm.cpp
+++ b/src/loma/4C_loma_algorithm.cpp
@@ -311,10 +311,9 @@ void LowMach::Algorithm::time_loop()
 /*----------------------------------------------------------------------*/
 void LowMach::Algorithm::initial_calculations()
 {
-  // set initial velocity field for evaluation of initial scalar time
-  // derivative in SCATRA
-  scatra_field()->set_velocity_field(
-      fluid_field()->velnp(), nullptr, nullptr, fluid_field()->fs_vel());
+  // set initial velocity field for evaluation of initial scalar time derivative in SCATRA
+  scatra_field()->set_convective_velocity(*fluid_field()->velnp());
+  scatra_field()->set_velocity_field(nullptr, fluid_field()->velnp(), fluid_field()->fs_vel());
 
   // set initial value of thermodynamic pressure in SCATRA
   std::dynamic_pointer_cast<ScaTra::ScaTraTimIntLoma>(scatra_field())->set_initial_therm_pressure();
@@ -328,11 +327,6 @@ void LowMach::Algorithm::initial_calculations()
   fluid_field()->set_scalar_fields(scatra_field()->phinp(),
       std::dynamic_pointer_cast<ScaTra::ScaTraTimIntLoma>(scatra_field())->therm_press_np(),
       nullptr, scatra_field()->discretization());
-
-  // write initial fields
-  // output();
-
-  return;
 }
 
 
@@ -545,15 +539,17 @@ void LowMach::Algorithm::set_fluid_values_in_scatra()
   {
     case Inpar::FLUID::timeint_afgenalpha:
     {
+      scatra_field()->set_convective_velocity(*fluid_field()->velaf());
       scatra_field()->set_velocity_field(
-          fluid_field()->velaf(), fluid_field()->accam(), nullptr, fluid_field()->fs_vel());
+          fluid_field()->accam(), fluid_field()->velaf(), fluid_field()->fs_vel());
     }
     break;
     case Inpar::FLUID::timeint_one_step_theta:
     case Inpar::FLUID::timeint_bdf2:
     {
+      scatra_field()->set_convective_velocity(*fluid_field()->velnp());
       scatra_field()->set_velocity_field(
-          fluid_field()->velnp(), fluid_field()->hist(), nullptr, fluid_field()->fs_vel());
+          fluid_field()->hist(), fluid_field()->velnp(), fluid_field()->fs_vel());
     }
     break;
     default:

--- a/src/loma/4C_loma_algorithm.cpp
+++ b/src/loma/4C_loma_algorithm.cpp
@@ -313,7 +313,11 @@ void LowMach::Algorithm::initial_calculations()
 {
   // set initial velocity field for evaluation of initial scalar time derivative in SCATRA
   scatra_field()->set_convective_velocity(*fluid_field()->velnp());
-  scatra_field()->set_velocity_field(nullptr, fluid_field()->velnp(), fluid_field()->fs_vel());
+  scatra_field()->set_velocity_field(nullptr, fluid_field()->velnp());
+  if (scatra_field()->fine_scale_velocity_field_required())
+  {
+    scatra_field()->set_fine_scale_velocity(*fluid_field()->fs_vel());
+  }
 
   // set initial value of thermodynamic pressure in SCATRA
   std::dynamic_pointer_cast<ScaTra::ScaTraTimIntLoma>(scatra_field())->set_initial_therm_pressure();
@@ -540,16 +544,24 @@ void LowMach::Algorithm::set_fluid_values_in_scatra()
     case Inpar::FLUID::timeint_afgenalpha:
     {
       scatra_field()->set_convective_velocity(*fluid_field()->velaf());
-      scatra_field()->set_velocity_field(
-          fluid_field()->accam(), fluid_field()->velaf(), fluid_field()->fs_vel());
+      scatra_field()->set_velocity_field(fluid_field()->accam(), fluid_field()->velaf());
+      if (scatra_field()->fine_scale_velocity_field_required() and
+          fluid_field()->fs_vel() != nullptr)
+      {
+        scatra_field()->set_fine_scale_velocity(*fluid_field()->fs_vel());
+      }
     }
     break;
     case Inpar::FLUID::timeint_one_step_theta:
     case Inpar::FLUID::timeint_bdf2:
     {
       scatra_field()->set_convective_velocity(*fluid_field()->velnp());
-      scatra_field()->set_velocity_field(
-          fluid_field()->hist(), fluid_field()->velnp(), fluid_field()->fs_vel());
+      scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->velnp());
+      if (scatra_field()->fine_scale_velocity_field_required() and
+          fluid_field()->fs_vel() != nullptr)
+      {
+        scatra_field()->set_fine_scale_velocity(*fluid_field()->fs_vel());
+      }
     }
     break;
     default:

--- a/src/loma/4C_loma_dyn.cpp
+++ b/src/loma/4C_loma_dyn.cpp
@@ -104,10 +104,10 @@ void loma_dyn(int restart)
       if (restart) (scatraonly.scatra_field())->read_restart(restart);
 
       // set initial velocity field
-      // note: The order read_restart() before set_velocity_field() is important here!!
-      // for time-dependent velocity fields, set_velocity_field() is additionally called in each
-      // prepare_time_step()-call
-      (scatraonly.scatra_field())->set_velocity_field();
+      // note: The order read_restart() before set_velocity_field_from_function() is important
+      // here!! for time-dependent velocity fields, set_velocity_field_from_function() is
+      // additionally called in each prepare_time_step()-call
+      (scatraonly.scatra_field())->set_velocity_field_from_function();
 
       // enter time loop to solve problem with given convective velocity field
       (scatraonly.scatra_field())->time_loop();

--- a/src/mat/4C_mat_scatra_multiscale_gp.cpp
+++ b/src/mat/4C_mat_scatra_multiscale_gp.cpp
@@ -237,7 +237,9 @@ void Mat::ScatraMultiScaleGP::init()
     global_micro_state().microdisnum_microtimint_map_[microdisnum_]->setup();
 
     // set initial velocity field
-    global_micro_state().microdisnum_microtimint_map_[microdisnum_]->set_velocity_field();
+    global_micro_state()
+        .microdisnum_microtimint_map_[microdisnum_]
+        ->set_velocity_field_from_function();
 
     // create counter for number of macro-scale Gauss points associated with micro-scale time
     // integrator

--- a/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
@@ -203,7 +203,7 @@ void PoroElastScaTra::PoroScatraBase::set_mesh_disp()
     dispnp = volcoupl_fluidscatra_->apply_vector_mapping21(*fluid_field()->dispnp());
   }
 
-  scatra_->scatra_field()->apply_mesh_movement(dispnp);
+  scatra_->scatra_field()->apply_mesh_movement(*dispnp);
 
   std::shared_ptr<const Core::LinAlg::Vector<double>> sdispnp = nullptr;
 

--- a/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
@@ -180,7 +180,7 @@ void PoroElastScaTra::PoroScatraBase::set_velocity_fields()
   }
 
   scatra_->scatra_field()->set_convective_velocity(*convel);
-  scatra_->scatra_field()->set_velocity_field(nullptr, velnp);
+  scatra_->scatra_field()->set_velocity_field(*velnp);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
@@ -179,12 +179,7 @@ void PoroElastScaTra::PoroScatraBase::set_velocity_fields()
     velnp = volcoupl_fluidscatra_->apply_vector_mapping21(*poro_->fluid_field()->velnp());
   }
 
-  scatra_->scatra_field()->set_velocity_field(convel,  // convective vel.
-      nullptr,                                         // acceleration
-      velnp,                                           // velocity
-      nullptr,                                         // fsvel
-      true                                             // set pressure
-  );
+  scatra_->scatra_field()->set_velocity_field(convel, nullptr, velnp, nullptr);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
@@ -180,7 +180,7 @@ void PoroElastScaTra::PoroScatraBase::set_velocity_fields()
   }
 
   scatra_->scatra_field()->set_convective_velocity(*convel);
-  scatra_->scatra_field()->set_velocity_field(nullptr, velnp, nullptr);
+  scatra_->scatra_field()->set_velocity_field(nullptr, velnp);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_base.cpp
@@ -179,7 +179,8 @@ void PoroElastScaTra::PoroScatraBase::set_velocity_fields()
     velnp = volcoupl_fluidscatra_->apply_vector_mapping21(*poro_->fluid_field()->velnp());
   }
 
-  scatra_->scatra_field()->set_velocity_field(convel, nullptr, velnp, nullptr);
+  scatra_->scatra_field()->set_convective_velocity(*convel);
+  scatra_->scatra_field()->set_velocity_field(nullptr, velnp, nullptr);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
@@ -292,7 +292,7 @@ void PoroPressureBased::PoroMultiPhaseScaTraBase::set_poro_solution()
   if (poroscatra == nullptr) FOUR_C_THROW("cast to ScaTraTimIntPoroMulti failed!");
 
   // set displacements
-  poroscatra->apply_mesh_movement(poromulti_->struct_dispnp());
+  poroscatra->apply_mesh_movement(*poromulti_->struct_dispnp());
 
   // set the fluid solution
   poroscatra->set_solution_field_of_multi_fluid(

--- a/src/scatra/4C_scatra_algorithm.cpp
+++ b/src/scatra/4C_scatra_algorithm.cpp
@@ -234,8 +234,9 @@ void ScaTra::ScaTraAlgorithm::prepare_time_step_convection()
   //(fluid initial field was set inside the constructor of fluid base class)
   if (step() == 1)
   {
+    scatra_field()->set_acceleration_field(*fluid_field()->hist());
     scatra_field()->set_convective_velocity(*fluid_field()->velnp());
-    scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->velnp());
+    scatra_field()->set_velocity_field(*fluid_field()->velnp());
   }
 
   // prepare time step (+ initialize one-step-theta scheme correctly with
@@ -298,9 +299,9 @@ void ScaTra::ScaTraAlgorithm::set_velocity_field()
     case Inpar::FLUID::timeint_npgenalpha:
     case Inpar::FLUID::timeint_afgenalpha:
     {
+      scatra_field()->set_acceleration_field(*fluid_to_scatra(fluid_field()->accam()));
       scatra_field()->set_convective_velocity(*fluid_to_scatra(fluid_field()->velaf()));
-      scatra_field()->set_velocity_field(
-          fluid_to_scatra(fluid_field()->accam()), fluid_to_scatra(fluid_field()->velaf()));
+      scatra_field()->set_velocity_field(*fluid_to_scatra(fluid_field()->velaf()));
       if (scatra_field()->fine_scale_velocity_field_required() and
           fluid_field()->fs_vel() != nullptr)
       {
@@ -312,9 +313,9 @@ void ScaTra::ScaTraAlgorithm::set_velocity_field()
     case Inpar::FLUID::timeint_bdf2:
     case Inpar::FLUID::timeint_stationary:
     {
+      scatra_field()->set_acceleration_field(*fluid_to_scatra(fluid_field()->hist()));
       scatra_field()->set_convective_velocity(*fluid_to_scatra(fluid_field()->velnp()));
-      scatra_field()->set_velocity_field(
-          fluid_to_scatra(fluid_field()->hist()), fluid_to_scatra(fluid_field()->velnp()));
+      scatra_field()->set_velocity_field(*fluid_to_scatra(fluid_field()->velnp()));
       if (scatra_field()->fine_scale_velocity_field_required() and
           fluid_field()->fs_vel() != nullptr)
       {

--- a/src/scatra/4C_scatra_algorithm.cpp
+++ b/src/scatra/4C_scatra_algorithm.cpp
@@ -225,7 +225,6 @@ void ScaTra::ScaTraAlgorithm::prepare_time_step_convection()
     default:
     {
       FOUR_C_THROW("Selected time integration scheme is not available!");
-      break;
     }
   }
 
@@ -234,8 +233,10 @@ void ScaTra::ScaTraAlgorithm::prepare_time_step_convection()
   // transfer the initial(!!) convective velocity
   //(fluid initial field was set inside the constructor of fluid base class)
   if (step() == 1)
-    scatra_field()->set_velocity_field(
-        fluid_field()->velnp(), fluid_field()->hist(), nullptr, nullptr);
+  {
+    scatra_field()->set_convective_velocity(*fluid_field()->velnp());
+    scatra_field()->set_velocity_field(fluid_field()->hist(), fluid_field()->velnp(), nullptr);
+  }
 
   // prepare time step (+ initialize one-step-theta scheme correctly with
   // velocity given above)
@@ -243,7 +244,6 @@ void ScaTra::ScaTraAlgorithm::prepare_time_step_convection()
 }
 
 /*----------------------------------------------------------------------*
- | Print scatra solver type to screen                        fang 08/14 |
  *----------------------------------------------------------------------*/
 void ScaTra::ScaTraAlgorithm::print_scatra_solver()
 {
@@ -305,7 +305,8 @@ void ScaTra::ScaTraAlgorithm::set_velocity_field()
     case Inpar::FLUID::timeint_npgenalpha:
     case Inpar::FLUID::timeint_afgenalpha:
     {
-      scatra_field()->set_velocity_field(fluid_to_scatra(fluid_field()->velaf()),
+      scatra_field()->set_convective_velocity(*fluid_to_scatra(fluid_field()->velaf()));
+      scatra_field()->set_velocity_field(
           fluid_to_scatra(fluid_field()->accam()), fluid_to_scatra(fluid_field()->velaf()), fsvel);
       break;
     }
@@ -313,7 +314,8 @@ void ScaTra::ScaTraAlgorithm::set_velocity_field()
     case Inpar::FLUID::timeint_bdf2:
     case Inpar::FLUID::timeint_stationary:
     {
-      scatra_field()->set_velocity_field(fluid_to_scatra(fluid_field()->velnp()),
+      scatra_field()->set_convective_velocity(*fluid_to_scatra(fluid_field()->velnp()));
+      scatra_field()->set_velocity_field(
           fluid_to_scatra(fluid_field()->hist()), fluid_to_scatra(fluid_field()->velnp()), fsvel);
       break;
     }

--- a/src/scatra/4C_scatra_cardiac_monodomain_dyn.cpp
+++ b/src/scatra/4C_scatra_cardiac_monodomain_dyn.cpp
@@ -172,10 +172,10 @@ void scatra_cardiac_monodomain_dyn(int restart)
       if (restart) scatraonly.scatra_field()->read_restart(restart);
 
       // set initial velocity field
-      // note: The order read_restart() before set_velocity_field() is important here!!
-      // for time-dependent velocity fields, set_velocity_field() is additionally called in each
-      // prepare_time_step()-call
-      (scatraonly.scatra_field())->set_velocity_field();
+      // note: The order read_restart() before set_velocity_field_from_function() is important
+      // here!! for time-dependent velocity fields, set_velocity_field_from_function() is
+      // additionally called in each prepare_time_step()-call
+      (scatraonly.scatra_field())->set_velocity_field_from_function();
 
       // enter time loop to solve problem with given convective velocity
       (scatraonly.scatra_field())->time_loop();

--- a/src/scatra/4C_scatra_dyn.cpp
+++ b/src/scatra/4C_scatra_dyn.cpp
@@ -169,10 +169,10 @@ void scatra_dyn(int restart)
       if (restart) scatraonly.scatra_field()->read_restart(restart);
 
       // set initial velocity field
-      // note: The order read_restart() before set_velocity_field() is important here!!
-      // for time-dependent velocity fields, set_velocity_field() is additionally called in each
-      // prepare_time_step()-call
-      scatraonly.scatra_field()->set_velocity_field();
+      // note: The order read_restart() before set_velocity_field_from_function() is important
+      // here!! for time-dependent velocity fields, set_velocity_field_from_function() is
+      // additionally called in each prepare_time_step()-call
+      scatraonly.scatra_field()->set_velocity_field_from_function();
 
       // set external force
       if (scatraonly.scatra_field()->has_external_force())

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -97,7 +97,7 @@ void ScaTra::ScaTraTimIntElchSCL::setup()
 
   redistribute_micro_discretization();
 
-  micro_scatra_field()->set_velocity_field();
+  micro_scatra_field()->set_velocity_field_from_function();
 
   micro_timint_->setup();
 

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1366,22 +1366,18 @@ void ScaTra::ScaTraTimIntImpl::set_external_force() const
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void ScaTra::ScaTraTimIntImpl::set_wall_shear_stresses(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> wss)
+    const Core::LinAlg::Vector<double>& wall_shear_stress) const
 {
-  if (wss == nullptr) FOUR_C_THROW("WSS state is nullptr");
-
-#ifdef FOUR_C_ENABLE_ASSERTIONS
   // We rely on the fact, that the nodal distribution of both fields is the same.
   // Although Scatra discretization was constructed as a clone of the fluid or
   // structure mesh, respectively, at the beginning, the nodal distribution may
   // have changed meanwhile (e.g., due to periodic boundary conditions applied only
   // to the fluid field)!
   // We have to be sure that everything is still matching.
-  if (not wss->get_map().SameAs(*discret_->dof_row_map(nds_wall_shear_stress())))
-    FOUR_C_THROW("Maps are NOT identical. Emergency!");
-#endif
+  FOUR_C_ASSERT(wall_shear_stress.get_map().SameAs(*discret_->dof_row_map(nds_wall_shear_stress())),
+      "Maps are NOT identical. Emergency!");
 
-  discret_->set_state(nds_wall_shear_stress(), "WallShearStress", *wss);
+  discret_->set_state(nds_wall_shear_stress(), "WallShearStress", wall_shear_stress);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1644,8 +1644,7 @@ void ScaTra::ScaTraTimIntImpl::update()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void ScaTra::ScaTraTimIntImpl::apply_mesh_movement(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp)
+void ScaTra::ScaTraTimIntImpl::apply_mesh_movement(const Core::LinAlg::Vector<double>& dispnp) const
 {
   //---------------------------------------------------------------------------
   // only required in ALE case
@@ -1654,12 +1653,9 @@ void ScaTra::ScaTraTimIntImpl::apply_mesh_movement(
   {
     TEUCHOS_FUNC_TIME_MONITOR("SCATRA: apply mesh movement");
 
-    // check existence of displacement vector
-    if (dispnp == nullptr) FOUR_C_THROW("Got null pointer for displacements!");
-
     // provide scatra discretization with displacement field
-    discret_->set_state(nds_disp(), "dispnp", *dispnp);
-  }  // if (isale_)
+    discret_->set_state(nds_disp(), "dispnp", dispnp);
+  }
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1146,7 +1146,7 @@ void ScaTra::ScaTraTimIntImpl::prepare_time_step()
   // -------------------------------------------------------------------
   //     update velocity field if given by function (it might depend on time)
   // -------------------------------------------------------------------
-  if (velocity_field_type_ == Inpar::ScaTra::velocity_function) set_velocity_field();
+  if (velocity_field_type_ == Inpar::ScaTra::velocity_function) set_velocity_field_from_function();
 
   // -------------------------------------------------------------------
   //     update external force given by function (it might depend on time)
@@ -1225,7 +1225,7 @@ void ScaTra::ScaTraTimIntImpl::prepare_linear_solve()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void ScaTra::ScaTraTimIntImpl::set_velocity_field()
+void ScaTra::ScaTraTimIntImpl::set_velocity_field_from_function()
 {
   // safety check
   if (nds_vel() >= discret_->num_dof_sets())
@@ -1233,9 +1233,9 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field()
 
   // initialize velocity vectors
   std::shared_ptr<Core::LinAlg::Vector<double>> convel =
-      Core::LinAlg::create_vector(*discret_->dof_row_map(nds_vel()), true);
+      create_vector(*discret_->dof_row_map(nds_vel()), true);
   std::shared_ptr<Core::LinAlg::Vector<double>> vel =
-      Core::LinAlg::create_vector(*discret_->dof_row_map(nds_vel()), true);
+      create_vector(*discret_->dof_row_map(nds_vel()), true);
 
   switch (velocity_field_type_)
   {
@@ -1254,7 +1254,7 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field()
       for (int lnodeid = 0; lnodeid < discret_->num_my_row_nodes(); lnodeid++)
       {
         // get the processor local node
-        Core::Nodes::Node* lnode = discret_->l_row_node(lnodeid);
+        const Core::Nodes::Node* lnode = discret_->l_row_node(lnodeid);
 
         // get dofs associated with current node
         std::vector<int> nodedofs = discret_->dof(nds_vel(), lnode);
@@ -1467,7 +1467,7 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel, const bool setpressure)
+    std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel)
 {
   // time measurement
   TEUCHOS_FUNC_TIME_MONITOR("SCATRA: set convective velocity field");

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1463,6 +1463,20 @@ void ScaTra::ScaTraTimIntImpl::set_mean_concentration(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
+void ScaTra::ScaTraTimIntImpl::set_acceleration_field(
+    const Core::LinAlg::Vector<double>& acceleration) const
+{
+  // time measurement
+  TEUCHOS_FUNC_TIME_MONITOR("SCATRA: set acceleration");
+
+  FOUR_C_ASSERT(nds_vel() < discret_->num_dof_sets(), "Too few dof sets on scatra discretization!");
+
+  // provide scatra discretization with acceleration field if required
+  discret_->set_state(nds_vel(), "acceleration field", acceleration);
+}
+
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
 void ScaTra::ScaTraTimIntImpl::set_convective_velocity(
     const Core::LinAlg::Vector<double>& convective_velocity) const
 {
@@ -1515,12 +1529,10 @@ bool ScaTra::ScaTraTimIntImpl::fine_scale_velocity_field_required() const
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void ScaTra::ScaTraTimIntImpl::set_velocity_field(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
+void ScaTra::ScaTraTimIntImpl::set_velocity_field(const Core::LinAlg::Vector<double>& velocity)
 {
   // time measurement
-  TEUCHOS_FUNC_TIME_MONITOR("SCATRA: set velocity fields");
+  TEUCHOS_FUNC_TIME_MONITOR("SCATRA: set velocity field");
 
   // checks
   FOUR_C_ASSERT(velocity_field_type_ == Inpar::ScaTra::velocity_Navier_Stokes,
@@ -1528,10 +1540,7 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field(
   FOUR_C_ASSERT(nds_vel() < discret_->num_dof_sets(), "Too few dof sets on scatra discretization!");
 
   // provide scatra discretization with velocity
-  if (vel != nullptr) discret_->set_state(nds_vel(), "velocity field", *vel);
-
-  // provide scatra discretization with acceleration field if required
-  if (acc != nullptr) discret_->set_state(nds_vel(), "acceleration field", *acc);
+  discret_->set_state(nds_vel(), "velocity field", velocity);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1391,22 +1391,18 @@ void ScaTra::ScaTraTimIntImpl::set_old_part_of_righthandside()
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void ScaTra::ScaTraTimIntImpl::set_pressure_field(
-    std::shared_ptr<const Core::LinAlg::Vector<double>> pressure)
+    const Core::LinAlg::Vector<double>& pressure) const
 {
-  if (pressure == nullptr) FOUR_C_THROW("Pressure state is nullptr");
-
-#ifdef FOUR_C_ENABLE_ASSERTIONS
   // We rely on the fact, that the nodal distribution of both fields is the same.
   // Although Scatra discretization was constructed as a clone of the fluid or
   // structure mesh, respectively, at the beginning, the nodal distribution may
   // have changed meanwhile (e.g., due to periodic boundary conditions applied only
   // to the fluid field)!
   // We have to be sure that everything is still matching.
-  if (not pressure->get_map().SameAs(*discret_->dof_row_map(nds_pressure())))
-    FOUR_C_THROW("Maps are NOT identical. Emergency!");
-#endif
+  FOUR_C_ASSERT(pressure.get_map().SameAs(*discret_->dof_row_map(nds_pressure())),
+      "Maps are NOT identical. Emergency!");
 
-  discret_->set_state(nds_pressure(), "Pressure", *pressure);
+  discret_->set_state(nds_pressure(), "Pressure", pressure);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -262,7 +262,8 @@ namespace ScaTra
     //! set the @wall_shear_stress vector to the scalar transport discretization
     void set_wall_shear_stresses(const Core::LinAlg::Vector<double>& wall_shear_stress) const;
 
-    void set_pressure_field(std::shared_ptr<const Core::LinAlg::Vector<double>> pressure);
+    //! set the @pressure vector to the scalar transport discretization
+    void set_pressure_field(const Core::LinAlg::Vector<double>& pressure) const;
 
     void set_membrane_concentration(
         std::shared_ptr<const Core::LinAlg::Vector<double>> MembraneConc);

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -247,17 +247,21 @@ namespace ScaTra
     //! set the @convective_velocity vector to the scalar transport discretization
     void set_convective_velocity(const Core::LinAlg::Vector<double>& convective_velocity) const;
 
+    //! set the @fine_scale_velocity vector to the scalar transport discretization
+    void set_fine_scale_velocity(const Core::LinAlg::Vector<double>& fine_scale_velocity) const;
+
+    //! return whether setting of the fine scale velocity is required
+    [[nodiscard]] bool fine_scale_velocity_field_required() const;
+
     /*!
      * @brief set velocity field (+ pressure and acceleration field as well as fine-scale velocity
      * field, if required)
      *
      * @param acc     acceleration vector
      * @param vel     velocity vector
-     * @param fsvel   fine-scale velocity vector
      */
     void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> vel,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel);
+        std::shared_ptr<const Core::LinAlg::Vector<double>> vel);
 
     void set_wall_shear_stresses(std::shared_ptr<const Core::LinAlg::Vector<double>> wss);
 

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -244,6 +244,9 @@ namespace ScaTra
      */
     void set_external_force() const;
 
+    //! set the @acceleration vector to the scalar transport discretization
+    void set_acceleration_field(const Core::LinAlg::Vector<double>& acceleration) const;
+
     //! set the @convective_velocity vector to the scalar transport discretization
     void set_convective_velocity(const Core::LinAlg::Vector<double>& convective_velocity) const;
 
@@ -253,15 +256,8 @@ namespace ScaTra
     //! return whether setting of the fine scale velocity is required
     [[nodiscard]] bool fine_scale_velocity_field_required() const;
 
-    /*!
-     * @brief set velocity field (+ pressure and acceleration field as well as fine-scale velocity
-     * field, if required)
-     *
-     * @param acc     acceleration vector
-     * @param vel     velocity vector
-     */
-    void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> vel);
+    //! set the @velocity vector to the scalar transport discretization
+    void set_velocity_field(const Core::LinAlg::Vector<double>& velocity);
 
     void set_wall_shear_stresses(std::shared_ptr<const Core::LinAlg::Vector<double>> wss);
 

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -227,7 +227,7 @@ namespace ScaTra
     virtual void explicit_predictor() const;
 
     //! set the velocity field (zero or field by function)
-    virtual void set_velocity_field();
+    void set_velocity_field_from_function();
 
     /*! Set external force field
 
@@ -244,16 +244,19 @@ namespace ScaTra
      */
     void set_external_force() const;
 
-    //! set convective velocity field (+ pressure and acceleration field as
-    //! well as fine-scale velocity field, if required)
-    virtual void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>>
-                                        convvel,  //!< convective velocity/press. vector
-        std::shared_ptr<const Core::LinAlg::Vector<double>> acc,    //!< acceleration vector
-        std::shared_ptr<const Core::LinAlg::Vector<double>> vel,    //!< velocity vector
-        std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel,  //!< fine-scale velocity vector
-        const bool setpressure =
-            false  //!< flag whether the fluid pressure needs to be known for the scatra
-    );
+    /*!
+     * @brief set convective velocity field (+ pressure and acceleration field as well as fine-scale
+     * velocity field, if required)
+     *
+     * @param convvel convective velocity/press. vector
+     * @param acc     acceleration vector
+     * @param vel     velocity vector
+     * @param fsvel   fine-scale velocity vector
+     */
+    void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> vel,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel);
 
     void set_wall_shear_stresses(std::shared_ptr<const Core::LinAlg::Vector<double>> wss);
 

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -383,7 +383,7 @@ namespace ScaTra
      *
      * @param[in] dispnp  displacement vector
      */
-    void apply_mesh_movement(std::shared_ptr<const Core::LinAlg::Vector<double>> dispnp);
+    void apply_mesh_movement(const Core::LinAlg::Vector<double>& dispnp) const;
 
     //! calculate fluxes inside domain and/or on boundary
     void calc_flux(const bool writetofile  //!< flag for writing flux info to file

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -259,7 +259,8 @@ namespace ScaTra
     //! set the @velocity vector to the scalar transport discretization
     void set_velocity_field(const Core::LinAlg::Vector<double>& velocity);
 
-    void set_wall_shear_stresses(std::shared_ptr<const Core::LinAlg::Vector<double>> wss);
+    //! set the @wall_shear_stress vector to the scalar transport discretization
+    void set_wall_shear_stresses(const Core::LinAlg::Vector<double>& wall_shear_stress) const;
 
     void set_pressure_field(std::shared_ptr<const Core::LinAlg::Vector<double>> pressure);
 

--- a/src/scatra/4C_scatra_timint_implicit.hpp
+++ b/src/scatra/4C_scatra_timint_implicit.hpp
@@ -244,17 +244,18 @@ namespace ScaTra
      */
     void set_external_force() const;
 
+    //! set the @convective_velocity vector to the scalar transport discretization
+    void set_convective_velocity(const Core::LinAlg::Vector<double>& convective_velocity) const;
+
     /*!
-     * @brief set convective velocity field (+ pressure and acceleration field as well as fine-scale
-     * velocity field, if required)
+     * @brief set velocity field (+ pressure and acceleration field as well as fine-scale velocity
+     * field, if required)
      *
-     * @param convvel convective velocity/press. vector
      * @param acc     acceleration vector
      * @param vel     velocity vector
      * @param fsvel   fine-scale velocity vector
      */
-    void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
+    void set_velocity_field(std::shared_ptr<const Core::LinAlg::Vector<double>> acc,
         std::shared_ptr<const Core::LinAlg::Vector<double>> vel,
         std::shared_ptr<const Core::LinAlg::Vector<double>> fsvel);
 

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -114,7 +114,7 @@ void SSI::SSIBase::setup()
   ssicoupling_->setup();
 
   // in case of an ssi  multi scale formulation we need to set the displacement here
-  auto dummy_vec = std::make_shared<Core::LinAlg::Vector<double>>(
+  auto dummy_vec = Core::LinAlg::Vector<double>(
       *Global::Problem::instance()->get_dis("structure")->dof_row_map(), true);
   ssicoupling_->set_mesh_disp(scatra_base_algorithm(), dummy_vec);
 
@@ -519,7 +519,7 @@ void SSI::SSIBase::test_results(MPI_Comm comm) const
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSI::SSIBase::set_struct_solution(std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
+void SSI::SSIBase::set_struct_solution(const Core::LinAlg::Vector<double>& disp,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel, const bool set_mechanical_stress)
 {
   // safety checks
@@ -614,7 +614,7 @@ void SSI::SSIBase::set_mechanical_stress_state(
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSI::SSIBase::set_mesh_disp(std::shared_ptr<const Core::LinAlg::Vector<double>> disp)
+void SSI::SSIBase::set_mesh_disp(const Core::LinAlg::Vector<double>& disp)
 {
   // safety checks
   check_is_init();

--- a/src/ssi/4C_ssi_base.hpp
+++ b/src/ssi/4C_ssi_base.hpp
@@ -214,7 +214,7 @@ namespace SSI
     [[nodiscard]] std::shared_ptr<ScaTra::ScaTraTimIntImpl> scatra_manifold() const;
 
     /// set structure solution on other fields
-    void set_struct_solution(std::shared_ptr<const Core::LinAlg::Vector<double>> disp,
+    void set_struct_solution(const Core::LinAlg::Vector<double>& disp,
         std::shared_ptr<const Core::LinAlg::Vector<double>> vel, bool set_mechanical_stress);
 
     /// set scatra solution on other fields
@@ -377,7 +377,7 @@ namespace SSI
     [[nodiscard]] bool is_init() const { return isinit_; }
 
     /// set structure mesh displacement on scatra field
-    void set_mesh_disp(std::shared_ptr<const Core::LinAlg::Vector<double>> disp);
+    void set_mesh_disp(const Core::LinAlg::Vector<double>& disp);
 
     /// set structure velocity field on scatra field
     void set_velocity_fields(std::shared_ptr<const Core::LinAlg::Vector<double>> vel);

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -142,7 +142,7 @@ void SSI::SSICouplingMatchingVolume::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   scatra->scatra_field()->set_convective_velocity(*convvel);
-  scatra->scatra_field()->set_velocity_field(nullptr, vel);
+  scatra->scatra_field()->set_velocity_field(*vel);
 }
 
 /*----------------------------------------------------------------------*/
@@ -290,7 +290,7 @@ void SSI::SSICouplingNonMatchingBoundary::set_velocity_fields(
   scatra->scatra_field()->set_convective_velocity(
       *adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*convvel)));
   scatra->scatra_field()->set_velocity_field(
-      nullptr, adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)));
+      *adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)));
 }
 
 /*----------------------------------------------------------------------*/
@@ -410,7 +410,7 @@ void SSI::SSICouplingNonMatchingVolume::set_velocity_fields(
   scatra->scatra_field()->set_convective_velocity(
       *volcoupl_structurescatra_->apply_vector_mapping21(*convvel));
   scatra->scatra_field()->set_velocity_field(
-      nullptr, volcoupl_structurescatra_->apply_vector_mapping21(*vel));
+      *volcoupl_structurescatra_->apply_vector_mapping21(*vel));
 }
 
 /*----------------------------------------------------------------------*/
@@ -606,7 +606,7 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   scatra->scatra_field()->set_convective_velocity(*convvel);
-  scatra->scatra_field()->set_velocity_field(nullptr, vel);
+  scatra->scatra_field()->set_velocity_field(*vel);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -129,8 +129,7 @@ void SSI::SSICouplingMatchingVolume::set_mechanical_stress_state(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 void SSI::SSICouplingMatchingVolume::set_mesh_disp(
-    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> disp)
+    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra, const Core::LinAlg::Vector<double>& disp)
 {
   scatra->scatra_field()->apply_mesh_movement(disp);
 }
@@ -278,11 +277,10 @@ void SSI::SSICouplingNonMatchingBoundary::assign_material_pointers(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 void SSI::SSICouplingNonMatchingBoundary::set_mesh_disp(
-    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> disp)
+    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra, const Core::LinAlg::Vector<double>& disp)
 {
   scatra->scatra_field()->apply_mesh_movement(
-      adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*disp)));
+      *adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(disp)));
 }
 
 /*----------------------------------------------------------------------*/
@@ -402,11 +400,10 @@ void SSI::SSICouplingNonMatchingVolume::assign_material_pointers(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 void SSI::SSICouplingNonMatchingVolume::set_mesh_disp(
-    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> disp)
+    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra, const Core::LinAlg::Vector<double>& disp)
 {
   scatra->scatra_field()->apply_mesh_movement(
-      volcoupl_structurescatra_->apply_vector_mapping21(*disp));
+      *volcoupl_structurescatra_->apply_vector_mapping21(disp));
 }
 
 /*----------------------------------------------------------------------*/
@@ -604,8 +601,7 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::assign_material_pointers(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 void SSI::SSICouplingMatchingVolumeAndBoundary::set_mesh_disp(
-    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> disp)
+    std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra, const Core::LinAlg::Vector<double>& disp)
 {
   scatra->scatra_field()->apply_mesh_movement(disp);
 }

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -142,7 +142,7 @@ void SSI::SSICouplingMatchingVolume::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   scatra->scatra_field()->set_convective_velocity(*convvel);
-  scatra->scatra_field()->set_velocity_field(nullptr, vel, nullptr);
+  scatra->scatra_field()->set_velocity_field(nullptr, vel);
 }
 
 /*----------------------------------------------------------------------*/
@@ -290,7 +290,7 @@ void SSI::SSICouplingNonMatchingBoundary::set_velocity_fields(
   scatra->scatra_field()->set_convective_velocity(
       *adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*convvel)));
   scatra->scatra_field()->set_velocity_field(
-      nullptr, adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)), nullptr);
+      nullptr, adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)));
 }
 
 /*----------------------------------------------------------------------*/
@@ -410,7 +410,7 @@ void SSI::SSICouplingNonMatchingVolume::set_velocity_fields(
   scatra->scatra_field()->set_convective_velocity(
       *volcoupl_structurescatra_->apply_vector_mapping21(*convvel));
   scatra->scatra_field()->set_velocity_field(
-      nullptr, volcoupl_structurescatra_->apply_vector_mapping21(*vel), nullptr);
+      nullptr, volcoupl_structurescatra_->apply_vector_mapping21(*vel));
 }
 
 /*----------------------------------------------------------------------*/
@@ -606,7 +606,7 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   scatra->scatra_field()->set_convective_velocity(*convvel);
-  scatra->scatra_field()->set_velocity_field(nullptr, vel, nullptr);
+  scatra->scatra_field()->set_velocity_field(nullptr, vel);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -141,7 +141,8 @@ void SSI::SSICouplingMatchingVolume::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
-  scatra->scatra_field()->set_velocity_field(convvel, nullptr, vel, nullptr);
+  scatra->scatra_field()->set_convective_velocity(*convvel);
+  scatra->scatra_field()->set_velocity_field(nullptr, vel, nullptr);
 }
 
 /*----------------------------------------------------------------------*/
@@ -286,9 +287,10 @@ void SSI::SSICouplingNonMatchingBoundary::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
+  scatra->scatra_field()->set_convective_velocity(
+      *adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*convvel)));
   scatra->scatra_field()->set_velocity_field(
-      adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*convvel)), nullptr,
-      adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)), nullptr);
+      nullptr, adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)), nullptr);
 }
 
 /*----------------------------------------------------------------------*/
@@ -405,9 +407,10 @@ void SSI::SSICouplingNonMatchingVolume::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
+  scatra->scatra_field()->set_convective_velocity(
+      *volcoupl_structurescatra_->apply_vector_mapping21(*convvel));
   scatra->scatra_field()->set_velocity_field(
-      volcoupl_structurescatra_->apply_vector_mapping21(*convvel), nullptr,
-      volcoupl_structurescatra_->apply_vector_mapping21(*vel), nullptr);
+      nullptr, volcoupl_structurescatra_->apply_vector_mapping21(*vel), nullptr);
 }
 
 /*----------------------------------------------------------------------*/
@@ -602,7 +605,8 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
-  scatra->scatra_field()->set_velocity_field(convvel, nullptr, vel, nullptr);
+  scatra->scatra_field()->set_convective_velocity(*convvel);
+  scatra->scatra_field()->set_velocity_field(nullptr, vel, nullptr);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -141,11 +141,7 @@ void SSI::SSICouplingMatchingVolume::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
-  scatra->scatra_field()->set_velocity_field(convvel,  // convective vel.
-      nullptr,                                         // acceleration
-      vel,                                             // velocity
-      nullptr                                          // fsvel
-  );
+  scatra->scatra_field()->set_velocity_field(convvel, nullptr, vel, nullptr);
 }
 
 /*----------------------------------------------------------------------*/
@@ -291,12 +287,8 @@ void SSI::SSICouplingNonMatchingBoundary::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   scatra->scatra_field()->set_velocity_field(
-      adaptermeshtying_->master_to_slave(
-          *extractor_->extract_cond_vector(*convvel)),  // convective vel.
-      nullptr,                                          // acceleration
-      adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)),  // velocity
-      nullptr                                                                      // fsvel
-  );
+      adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*convvel)), nullptr,
+      adaptermeshtying_->master_to_slave(*extractor_->extract_cond_vector(*vel)), nullptr);
 }
 
 /*----------------------------------------------------------------------*/
@@ -414,11 +406,8 @@ void SSI::SSICouplingNonMatchingVolume::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
   scatra->scatra_field()->set_velocity_field(
-      volcoupl_structurescatra_->apply_vector_mapping21(*convvel),  // convective vel.
-      nullptr,                                                      // acceleration
-      volcoupl_structurescatra_->apply_vector_mapping21(*vel),      // velocity
-      nullptr                                                       // fsvel
-  );
+      volcoupl_structurescatra_->apply_vector_mapping21(*convvel), nullptr,
+      volcoupl_structurescatra_->apply_vector_mapping21(*vel), nullptr);
 }
 
 /*----------------------------------------------------------------------*/
@@ -613,11 +602,7 @@ void SSI::SSICouplingMatchingVolumeAndBoundary::set_velocity_fields(
     std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
     std::shared_ptr<const Core::LinAlg::Vector<double>> vel)
 {
-  scatra->scatra_field()->set_velocity_field(convvel,  // convective vel.
-      nullptr,                                         // acceleration
-      vel,                                             // velocity
-      nullptr                                          // fsvel
-  );
+  scatra->scatra_field()->set_velocity_field(convvel, nullptr, vel, nullptr);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssi/4C_ssi_coupling.hpp
+++ b/src/ssi/4C_ssi_coupling.hpp
@@ -69,7 +69,7 @@ namespace SSI
     //! \param scatra    underlying scatra problem of the SSI problem
     //! \param disp      displacement field to set
     virtual void set_mesh_disp(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> disp) = 0;
+        const Core::LinAlg::Vector<double>& disp) = 0;
 
     //! \brief set structure velocity fields on other field
     //!
@@ -119,7 +119,7 @@ namespace SSI
         unsigned nds) override;
 
     void set_mesh_disp(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> disp) override;
+        const Core::LinAlg::Vector<double>& disp) override;
 
     void set_velocity_fields(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
         std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
@@ -172,8 +172,8 @@ namespace SSI
   class SSICouplingNonMatchingBoundary : public SSICouplingBase
   {
    public:
-    SSICouplingNonMatchingBoundary()
-        : adaptermeshtying_(nullptr), extractor_(nullptr), issetup_(false), isinit_(false) {};
+    SSICouplingNonMatchingBoundary() = default;
+
     void init(const int ndim, std::shared_ptr<Core::FE::Discretization> structdis,
         std::shared_ptr<SSI::SSIBase> ssi_base) override;
 
@@ -189,7 +189,7 @@ namespace SSI
     }
 
     void set_mesh_disp(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> disp) override;
+        const Core::LinAlg::Vector<double>& disp) override;
 
     void set_velocity_fields(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
         std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
@@ -278,7 +278,7 @@ namespace SSI
     }
 
     void set_mesh_disp(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> disp) override;
+        const Core::LinAlg::Vector<double>& disp) override;
 
     void set_velocity_fields(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
         std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,
@@ -355,7 +355,7 @@ namespace SSI
     }
 
     void set_mesh_disp(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> disp) override;
+        const Core::LinAlg::Vector<double>& disp) override;
 
     void set_velocity_fields(std::shared_ptr<Adapter::ScaTraBaseAlgorithm> scatra,
         std::shared_ptr<const Core::LinAlg::Vector<double>> convvel,

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -568,7 +568,7 @@ void SSI::SsiMono::read_restart(int restart)
  *--------------------------------------------------------------------------*/
 void SSI::SsiMono::prepare_time_loop()
 {
-  set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
+  set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(),
       is_s2i_kinetics_with_pseudo_contact());
 
   // calculate initial potential field if needed
@@ -589,7 +589,7 @@ void SSI::SsiMono::prepare_time_step()
   increment_time_and_step();
 
   // pass structural degrees of freedom to scalar transport discretization
-  set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
+  set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(),
       is_s2i_kinetics_with_pseudo_contact());
 
   // prepare time step for scalar transport field
@@ -1155,7 +1155,7 @@ void SSI::SsiMono::distribute_solution_all_fields(const bool restore_velocity)
   }
 
   // distribute states to other fields
-  set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
+  set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(),
       is_s2i_kinetics_with_pseudo_contact());
   set_scatra_solution(scatra_field()->phinp());
   if (is_scatra_manifold()) set_scatra_manifold_solution(*scatra_manifold()->phinp());

--- a/src/ssi/4C_ssi_partitioned_1wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_1wc.cpp
@@ -167,7 +167,7 @@ void SSI::SSIPart1WCSolidToScatra::prepare_time_step(bool printheader)
   if (structure_field()->step() % diffsteps == 0)
   {
     if (is_s2i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
-    set_struct_solution(structure_field()->dispn(), structure_field()->veln(),
+    set_struct_solution(*structure_field()->dispn(), structure_field()->veln(),
         is_s2i_kinetics_with_pseudo_contact());
     scatra_field()->prepare_time_step();
   }
@@ -238,7 +238,7 @@ void SSI::SSIPart1WCSolidToScatra::timeloop()
     if (structure_field()->step() % diffsteps == 0)
     {
       if (is_s2i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
-      set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
+      set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(),
           is_s2i_kinetics_with_pseudo_contact());
       do_scatra_step();  // It has its own time and timestep variables, and it increments them by
                          // itself.
@@ -289,7 +289,7 @@ void SSI::SSIPart1WCScatraToSolid::timeloop()
 
   // set zero velocity and displacement field for scatra
   auto zeros_structure = Core::LinAlg::create_vector(*structure_field()->dof_row_map(), true);
-  set_struct_solution(zeros_structure, zeros_structure, false);
+  set_struct_solution(*zeros_structure, zeros_structure, false);
 
   scatra_field()->prepare_time_loop();
 

--- a/src/ssi/4C_ssi_partitioned_2wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_2wc.cpp
@@ -145,7 +145,7 @@ void SSI::SSIPart2WC::do_struct_step()
   if (is_s2i_kinetics_with_pseudo_contact()) structure_field()->determine_stress_strain();
 
   //  set mesh displacement and velocity fields
-  return set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(),
+  return set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(),
       is_s2i_kinetics_with_pseudo_contact());
 }
 
@@ -196,7 +196,7 @@ void SSI::SSIPart2WC::prepare_time_loop()
   constexpr bool force_prepare = true;
   structure_field()->prepare_output(force_prepare);
   structure_field()->output();
-  set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(), false);
+  set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(), false);
   scatra_field()->prepare_time_loop();
 }
 
@@ -207,7 +207,7 @@ void SSI::SSIPart2WC::prepare_time_step(bool printheader)
 {
   increment_time_and_step();
 
-  set_struct_solution(structure_field()->dispnp(), structure_field()->velnp(), false);
+  set_struct_solution(*structure_field()->dispnp(), structure_field()->velnp(), false);
   scatra_field()->prepare_time_step();
 
   // if adaptive time stepping and different time step size: calculate time step in scatra
@@ -503,7 +503,7 @@ void SSI::SSIPart2WCSolidToScatraRelax::outer_loop()
     // begin nonlinear solver / outer iteration ***************************
 
     // set relaxed mesh displacements and velocity field
-    set_struct_solution(dispnp, velnp, is_s2i_kinetics_with_pseudo_contact());
+    set_struct_solution(*dispnp, velnp, is_s2i_kinetics_with_pseudo_contact());
 
     // solve scalar transport equation
     do_scatra_step();

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -290,9 +290,9 @@ void SSTI::SSTIAlgorithm::distribute_structure_solution() const
   const auto convective_velocity = Core::LinAlg::create_vector(*structure_->dof_row_map());
 
   scatra_field()->set_convective_velocity(*convective_velocity);
-  scatra_field()->set_velocity_field(nullptr, structure_->velnp(), nullptr);
+  scatra_field()->set_velocity_field(nullptr, structure_->velnp());
   thermo_field()->set_convective_velocity(*convective_velocity);
-  thermo_field()->set_velocity_field(nullptr, structure_->velnp(), nullptr);
+  thermo_field()->set_velocity_field(nullptr, structure_->velnp());
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -289,8 +289,10 @@ void SSTI::SSTIAlgorithm::distribute_structure_solution() const
   // convective velocity is set to zero
   const auto convective_velocity = Core::LinAlg::create_vector(*structure_->dof_row_map());
 
-  scatra_field()->set_velocity_field(convective_velocity, nullptr, structure_->velnp(), nullptr);
-  thermo_field()->set_velocity_field(convective_velocity, nullptr, structure_->velnp(), nullptr);
+  scatra_field()->set_convective_velocity(*convective_velocity);
+  scatra_field()->set_velocity_field(nullptr, structure_->velnp(), nullptr);
+  thermo_field()->set_convective_velocity(*convective_velocity);
+  thermo_field()->set_velocity_field(nullptr, structure_->velnp(), nullptr);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -281,10 +281,10 @@ void SSTI::SSTIAlgorithm::test_results(MPI_Comm comm) const
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSTI::SSTIAlgorithm::distribute_structure_solution()
+void SSTI::SSTIAlgorithm::distribute_structure_solution() const
 {
-  scatra_field()->apply_mesh_movement(structure_->dispnp());
-  thermo_field()->apply_mesh_movement(structure_->dispnp());
+  scatra_field()->apply_mesh_movement(*structure_->dispnp());
+  thermo_field()->apply_mesh_movement(*structure_->dispnp());
 
   // convective velocity is set to zero
   const auto convective_velocity = Core::LinAlg::create_vector(*structure_->dof_row_map());
@@ -295,7 +295,7 @@ void SSTI::SSTIAlgorithm::distribute_structure_solution()
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSTI::SSTIAlgorithm::distribute_scatra_solution()
+void SSTI::SSTIAlgorithm::distribute_scatra_solution() const
 {
   structure_field()->discretization()->set_state(
       1, "scalarfield", *scatra_->scatra_field()->phinp());

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -290,9 +290,9 @@ void SSTI::SSTIAlgorithm::distribute_structure_solution() const
   const auto convective_velocity = Core::LinAlg::create_vector(*structure_->dof_row_map());
 
   scatra_field()->set_convective_velocity(*convective_velocity);
-  scatra_field()->set_velocity_field(nullptr, structure_->velnp());
+  scatra_field()->set_velocity_field(*structure_->velnp());
   thermo_field()->set_convective_velocity(*convective_velocity);
-  thermo_field()->set_velocity_field(nullptr, structure_->velnp());
+  thermo_field()->set_velocity_field(*structure_->velnp());
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/ssti/4C_ssti_algorithm.hpp
+++ b/src/ssti/4C_ssti_algorithm.hpp
@@ -133,8 +133,8 @@ namespace SSTI
     //! distribute states between subproblems
     //@{
     void distribute_solution_all_fields();
-    void distribute_scatra_solution();
-    void distribute_structure_solution();
+    void distribute_scatra_solution() const;
+    void distribute_structure_solution() const;
     void distribute_thermo_solution();
     //@}
 

--- a/src/sti/4C_sti_algorithm.cpp
+++ b/src/sti/4C_sti_algorithm.cpp
@@ -220,8 +220,8 @@ void STI::Algorithm::prepare_time_step()
   increment_time_and_step();
 
   // provide scatra and thermo fields with velocities
-  scatra_->scatra_field()->set_velocity_field();
-  thermo_->scatra_field()->set_velocity_field();
+  scatra_->scatra_field()->set_velocity_field_from_function();
+  thermo_->scatra_field()->set_velocity_field_from_function();
 
   // pass thermo degrees of freedom to scatra discretization for preparation of first time step
   // (calculation of initial time derivatives etc.)

--- a/src/sti/4C_sti_dyn.cpp
+++ b/src/sti/4C_sti_dyn.cpp
@@ -164,8 +164,8 @@ void sti_dyn(const int& restartstep  //! time step for restart
   if (restartstep) sti_algorithm->read_restart(restartstep);
 
   // provide scatra and thermo fields with velocities
-  sti_algorithm->scatra_field()->set_velocity_field();
-  sti_algorithm->thermo_field()->set_velocity_field();
+  sti_algorithm->scatra_field()->set_velocity_field_from_function();
+  sti_algorithm->thermo_field()->set_velocity_field_from_function();
 
   // enter time loop and solve scatra-thermo interaction problem
   sti_algorithm->time_loop();


### PR DESCRIPTION
## Description and Context
Mainly, the set_velocity_field method was a complete mess where you needed to hand in nullptrs, etc., when you did not want to communicate the requested quantity.
This and similar methods that also call set state on the scalar transport discretization are refactored, such that they now consume a const reference to the data instead of a shared pointer. This way, only those smaller methods that are actually required are called, which used to be indicated with nullptrs.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
