### PR TITLE
Make internal node numbering consistent with input

### DIFF
--- a/src/ale/4C_ale_resulttest.cpp
+++ b/src/ale/4C_ale_resulttest.cpp
@@ -32,7 +32,6 @@ void ALE::AleResultTest::test_node(
   if (dis != aledis_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(aledis_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/art_net/4C_art_net_artery_resulttest.cpp
+++ b/src/art_net/4C_art_net_artery_resulttest.cpp
@@ -46,7 +46,6 @@ void Arteries::ArteryResultTest::test_node(
   if (dis != dis_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/core/fem/src/general/element/4C_fem_general_element.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.cpp
@@ -198,11 +198,10 @@ void Core::Elements::Element::set_node_ids(const int nnode, const int* nodes)
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::Elements::Element::set_node_ids_one_based_index(
+void Core::Elements::Element::set_node_ids(
     const std::string& distype, const Core::IO::InputParameterContainer& container)
 {
   nodeid_ = container.get<std::vector<int>>(distype);
-  for (int& i : nodeid_) i -= 1;
   node_.resize(0);
 }
 

--- a/src/core/fem/src/general/element/4C_fem_general_element.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.hpp
@@ -725,7 +725,7 @@ might become invalid after a redistribution of the discretization.
      * Set the list of node ids this element is connected to. Here, the index
      * starts at 1, not 0. This is used for the legacy element input.
      */
-    void set_node_ids_one_based_index(
+    void set_node_ids(
         const std::string& distype, const Core::IO::InputParameterContainer& container);
 
     /*!

--- a/src/core/io/src/4C_io_input_file_utils.cpp
+++ b/src/core/io/src/4C_io_input_file_utils.cpp
@@ -150,7 +150,7 @@ void Core::IO::read_design(InputFile& input, const std::string& name,
                                (name == "DVOL" && dname == "DVOLUME"),
           "Wrong design node name: {}. Expected {}.", dname, name);
 
-      topology[dobj - 1].insert(nodeid - 1);
+      topology[dobj - 1].insert(nodeid);
     }
     else  // fancy specification of the design nodes by specifying min or max of the domain
     {     // works best on rectangular domains ;)

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -298,7 +298,7 @@ namespace
         Core::IO::InputParameterContainer data;
         linedef.fully_parse(element_parser, data);
 
-        ele->set_node_ids_one_based_index(distype, data);
+        ele->set_node_ids(distype, data);
         ele->read_element(eletype, distype, data);
 
         // add element to discretization
@@ -690,7 +690,7 @@ namespace
 
       if (type == "NODE")
       {
-        int nodeid = parser.read<int>() - 1;
+        const int nodeid = parser.read<int>();
         parser.consume("COORD");
         auto coords = parser.read<std::vector<double>>(3);
 
@@ -709,13 +709,13 @@ namespace
       // this node is a Nurbs control point
       else if (type == "CP")
       {
-        int cpid = parser.read<int>() - 1;
+        const int cpid = parser.read<int>();
         parser.consume("COORD");
         auto coords = parser.read<std::vector<double>>(3);
         double weight = parser.read<double>();
 
         max_node_id = std::max(max_node_id, cpid) + 1;
-        if (cpid != line_count)
+        if (cpid != line_count + 1)
           FOUR_C_THROW(
               "Reading of control points {} failed: They must be numbered consecutive!!", cpid);
         std::vector<std::shared_ptr<Core::FE::Discretization>> diss =
@@ -745,7 +745,7 @@ namespace
         std::vector<std::array<double, 3>> fibers;
         std::map<Core::Nodes::AngleType, double> angles;
 
-        int nodeid = parser.read<int>() - 1;
+        const int nodeid = parser.read<int>();
         parser.consume("COORD");
         auto coords = parser.read<std::vector<double>>(3);
         max_node_id = std::max(max_node_id, nodeid) + 1;

--- a/src/fluid/4C_fluid_result_test.cpp
+++ b/src/fluid/4C_fluid_result_test.cpp
@@ -45,7 +45,6 @@ void FLD::FluidResultTest::test_node(
   if (dis != fluiddis_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(fluiddis_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/fsi/src/utils/4C_fsi_resulttest.cpp
+++ b/src/fsi/src/utils/4C_fsi_resulttest.cpp
@@ -205,7 +205,6 @@ void FSI::FSIResultTest::test_node(
     const Core::IO::InputParameterContainer& container, int& nerr, int& test_count)
 {
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(slavedisc_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/lubrication/src/4C_lubrication_resulttest.cpp
+++ b/src/lubrication/src/4C_lubrication_resulttest.cpp
@@ -39,7 +39,6 @@ void Lubrication::ResultTest::test_node(
   if (dis != dis_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/particle_wall/4C_particle_wall_result_test.cpp
+++ b/src/particle_wall/4C_particle_wall_result_test.cpp
@@ -48,7 +48,6 @@ void PARTICLEWALL::WallResultTest::test_node(
 
   // extract node id
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(walldiscretization_->have_global_node(node));
   int havenodeonanyproc(0);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
@@ -39,7 +39,6 @@ void PoroPressureBased::ResultTest::test_node(
   if (dis != porotimint_.discretization()->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(porotimint_.discretization()->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -443,7 +443,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int inode = 0; inode < numnp; ++inode)
             {
               if (myrank_ == 0)  // proc0 can write its elements immediately
-                write(geofile, proc0map->LID(nodes[inode]->id()) + 1);
+                write(geofile, proc0map->LID(nodes[inode]->id()));
               else  // elements on other procs have to store their global node ids
                 nodevector.push_back(nodes[inode]->id());
             }
@@ -456,7 +456,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int inode = 0; inode < numnp; ++inode)
             {
               if (myrank_ == 0)  // proc0 can write its elements immediately
-                write(geofile, proc0map->LID(nodes[Hex20_FourCToEnsightGold[inode]]->id()) + 1);
+                write(geofile, proc0map->LID(nodes[Hex20_FourCToEnsightGold[inode]]->id()));
               else  // elements on other procs have to store their global node ids
                 nodevector.push_back(nodes[Hex20_FourCToEnsightGold[inode]]->id());
             }
@@ -468,7 +468,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::hex16); ++isubele)
               for (int isubnode = 0; isubnode < 8; ++isubnode)
                 if (myrank_ == 0)  // proc0 can write its elements immediately
-                  write(geofile, proc0map->LID(nodes[subhex16map[isubele][isubnode]]->id()) + 1);
+                  write(geofile, proc0map->LID(nodes[subhex16map[isubele][isubnode]]->id()));
                 else  // elements on other procs have to store their global node ids
                   nodevector.push_back(nodes[subhex16map[isubele][isubnode]]->id());
             break;
@@ -479,7 +479,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::hex18); ++isubele)
               for (int isubnode = 0; isubnode < 8; ++isubnode)
                 if (myrank_ == 0)  // proc0 can write its elements immediately
-                  write(geofile, proc0map->LID(nodes[subhex18map[isubele][isubnode]]->id()) + 1);
+                  write(geofile, proc0map->LID(nodes[subhex18map[isubele][isubnode]]->id()));
                 else  // elements on other procs have to store their global node ids
                   nodevector.push_back(nodes[subhex18map[isubele][isubnode]]->id());
             break;
@@ -490,7 +490,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::hex27); ++isubele)
               for (int isubnode = 0; isubnode < 8; ++isubnode)
                 if (myrank_ == 0)  // proc0 can write its elements immediately
-                  write(geofile, proc0map->LID(nodes[subhexmap[isubele][isubnode]]->id()) + 1);
+                  write(geofile, proc0map->LID(nodes[subhexmap[isubele][isubnode]]->id()));
                 else  // elements on other procs have to store their global node ids
                   nodevector.push_back(nodes[subhexmap[isubele][isubnode]]->id());
             break;
@@ -501,7 +501,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::quad9); ++isubele)
               for (int isubnode = 0; isubnode < 4; ++isubnode)
                 if (myrank_ == 0)  // proc0 can write its elements immediately
-                  write(geofile, proc0map->LID(nodes[subquadmap[isubele][isubnode]]->id()) + 1);
+                  write(geofile, proc0map->LID(nodes[subquadmap[isubele][isubnode]]->id()));
                 else  // elements on other procs have to store their global node ids
                   nodevector.push_back(nodes[subquadmap[isubele][isubnode]]->id());
             break;
@@ -512,7 +512,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
             for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::line3); ++isubele)
               for (int isubnode = 0; isubnode < 2; ++isubnode)
                 if (myrank_ == 0)  // proc0 can write its elements immediately
-                  write(geofile, proc0map->LID(nodes[sublinemap[isubele][isubnode]]->id()) + 1);
+                  write(geofile, proc0map->LID(nodes[sublinemap[isubele][isubnode]]->id()));
                 else  // elements on other procs have to store their global node ids
                   nodevector.push_back(nodes[sublinemap[isubele][isubnode]]->id());
             break;
@@ -528,7 +528,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
               for (int inode = 0; inode < numnp; ++inode)
               {
                 if (myrank_ == 0)  // proc0 can write its elements immediately
-                  write(geofile, proc0map->LID(nodes[inode]->id()) + 1);
+                  write(geofile, proc0map->LID(nodes[inode]->id()));
                 else  // elements on other procs have to store their global node ids
                   nodevector.push_back(nodes[inode]->id());
               }
@@ -545,7 +545,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
               for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::quad9); ++isubele)
                 for (int isubnode = 0; isubnode < 4; ++isubnode)
                   if (myrank_ == 0)  // proc0 can write its elements immediately
-                    write(geofile, proc0map->LID(nodes[subquadmap[isubele][isubnode]]->id()) + 1);
+                    write(geofile, proc0map->LID(nodes[subquadmap[isubele][isubnode]]->id()));
                   else  // elements on other procs have to store their global node ids
                     nodevector.push_back(nodes[subquadmap[isubele][isubnode]]->id());
             }
@@ -561,7 +561,7 @@ void EnsightWriter::write_cells(std::ofstream& geofile,
               for (int isubele = 0; isubele < get_num_sub_ele(Core::FE::CellType::hex27); ++isubele)
                 for (int isubnode = 0; isubnode < 8; ++isubnode)
                   if (myrank_ == 0)  // proc0 can write its elements immediately
-                    write(geofile, proc0map->LID(nodes[subhexmap[isubele][isubnode]]->id()) + 1);
+                    write(geofile, proc0map->LID(nodes[subhexmap[isubele][isubnode]]->id()));
                   else  // elements on other procs have to store their global node ids
                     nodevector.push_back(nodes[subhexmap[isubele][isubnode]]->id());
             }
@@ -657,7 +657,7 @@ void EnsightWriter::write_node_connectivity_par(std::ofstream& geofile,
       for (int i = 0; i < (int)nodeids.size(); ++i)
       {
         // using the same map as for the writing the node coordinates
-        int id = (proc0map.LID(nodeids[i])) + 1;
+        int id = (proc0map.LID(nodeids[i]));
         write(geofile, id);
       }
       nodeids.clear();
@@ -2379,8 +2379,7 @@ void EnsightWriter::write_coordinates_for_polynomial_shapefunctions(std::ofstrea
       // first write node global ids (default)
       for (int inode = 0; inode < proc0map->NumGlobalElements(); ++inode)
       {
-        write(geofile, proc0map->GID(inode) + 1);
-        // gid+1 delivers the node numbering of the input file starting with 1
+        write(geofile, proc0map->GID(inode));
       }
     }
     // now write the coordinate information

--- a/src/red_airways/4C_red_airways_resulttest.cpp
+++ b/src/red_airways/4C_red_airways_resulttest.cpp
@@ -42,7 +42,6 @@ void Airway::RedAirwayResultTest::test_node(
   if (dis != dis_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(dis_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/scatra/4C_scatra_resulttest.cpp
+++ b/src/scatra/4C_scatra_resulttest.cpp
@@ -34,7 +34,6 @@ void ScaTra::ScaTraResultTest::test_node(
   if (dis != scatratimint_->discretization()->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(scatratimint_->discretization()->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/structure/4C_structure_resulttest.cpp
+++ b/src/structure/4C_structure_resulttest.cpp
@@ -43,7 +43,6 @@ void StruResultTest::test_node(
   if (dis != strudisc_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(strudisc_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
@@ -186,7 +186,6 @@ void Solid::ResultTest::test_node(
   if (dis != strudisc_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(strudisc_->have_global_node(node));
   int isnodeofanybody(0);

--- a/src/thermo/src/utils/4C_thermo_resulttest.cpp
+++ b/src/thermo/src/utils/4C_thermo_resulttest.cpp
@@ -36,7 +36,6 @@ void Thermo::ResultTest::test_node(
   if (dis != thrdisc_->name()) return;
 
   int node = container.get<int>("NODE");
-  node -= 1;
 
   int havenode(thrdisc_->have_global_node(node));
   int isnodeofanybody(0);

--- a/tests/input_files/contact3D_exodus_in.4C.yaml
+++ b/tests/input_files/contact3D_exodus_in.4C.yaml
@@ -82,13 +82,13 @@ DESIGN SURF DIRICH CONDITIONS:
 RESULT DESCRIPTION:
   - STRUCTURE:
       DIS: structure
-      NODE: 1270
+      NODE: 1269
       QUANTITY: dispx
       VALUE: -8.31974725251016095e-03
       TOLERANCE: 1e-8
   - STRUCTURE:
       DIS: structure
-      NODE: 1372
+      NODE: 1371
       QUANTITY: dispx
       VALUE: -8.36015173005985428e-03
       TOLERANCE: 1e-8

--- a/tests/input_files/fluid_exodus_in.4C.yaml
+++ b/tests/input_files/fluid_exodus_in.4C.yaml
@@ -65,73 +65,73 @@ DESIGN POINT DIRICH CONDITIONS:
 RESULT DESCRIPTION:
   - FLUID:
       DIS: "fluid"
-      NODE: 2912
+      NODE: 2911
       QUANTITY: "velx"
       VALUE: 0
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 2912
+      NODE: 2911
       QUANTITY: "vely"
       VALUE: 0
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 2912
+      NODE: 2911
       QUANTITY: "pressure"
       VALUE: 2.316272235592883
       TOLERANCE: 1e-10
   - FLUID:
       DIS: "fluid"
-      NODE: 4034
+      NODE: 4033
       QUANTITY: "velx"
       VALUE: 0
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 4034
+      NODE: 4033
       QUANTITY: "vely"
       VALUE: 0
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 4034
+      NODE: 4033
       QUANTITY: "pressure"
       VALUE: 1.5110014506671248
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 6667
+      NODE: 6666
       QUANTITY: "velx"
       VALUE: 0.8140348125434049
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 6667
+      NODE: 6666
       QUANTITY: "vely"
       VALUE: -0.022743581282554975
       TOLERANCE: 1e-10
   - FLUID:
       DIS: "fluid"
-      NODE: 6667
+      NODE: 6666
       QUANTITY: "pressure"
       VALUE: 2.0581385928541125
       TOLERANCE: 1e-10
   - FLUID:
       DIS: "fluid"
-      NODE: 6998
+      NODE: 6997
       QUANTITY: "velx"
       VALUE: 0.9708173796517694
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 6998
+      NODE: 6997
       QUANTITY: "vely"
       VALUE: -7.977045433472414e-16
       TOLERANCE: 1e-08
   - FLUID:
       DIS: "fluid"
-      NODE: 6998
+      NODE: 6997
       QUANTITY: "pressure"
       VALUE: 1.8450141345624358
       TOLERANCE: 1e-10


### PR DESCRIPTION
This PR makes the internal node numbers equal to the node numbers specified in the dat-style or Exodus input.

Closes #731 