### PR TITLE
Increase width for the discretization name during result test output

### DIFF
--- a/src/core/utils/src/result_test/4C_utils_result_test.cpp
+++ b/src/core/utils/src/result_test/4C_utils_result_test.cpp
@@ -70,7 +70,7 @@ int Core::Utils::ResultTest::compare_values(
 
   if (type != "SPECIAL")
   {
-    msghead << std::left << std::setw(12) << container.get_or<std::string>("DIS", "");
+    msghead << std::left << std::setw(16) << container.get_or<std::string>("DIS", "");
   }
 
   msghead << std::left << std::setw(8) << quantity.c_str();


### PR DESCRIPTION
## Description and Context
Increase the width for the discretization name during result test output, as there have been discretization names, e.g., scatra_manifold, that have been too long. In this case, the discretization name and the quantity name were merged, making it harder to interpret.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
