### PR TITLE
Remove some unused Condition and Discretization evaluation code

### DIFF
--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -1789,11 +1789,7 @@ namespace Core::FE
      *  \param condid        (in): condition ID */
     void evaluate_condition(Teuchos::ParameterList& params,
         std::shared_ptr<Core::LinAlg::Vector<double>> systemvector, const std::string& condstring,
-        const int condid = -1)
-    {
-      evaluate_condition(
-          params, nullptr, nullptr, systemvector, nullptr, nullptr, condstring, condid);
-    }
+        const int condid = -1);
 
     /** \brief Evaluate a specified condition
      *
@@ -1806,10 +1802,7 @@ namespace Core::FE
      *  \param condstring (in): Name of condition to be evaluated
      *  \param condid     (in): condition ID */
     void evaluate_condition(
-        Teuchos::ParameterList& params, const std::string& condstring, const int condid = -1)
-    {
-      evaluate_condition(params, nullptr, nullptr, nullptr, nullptr, nullptr, condstring, condid);
-    }
+        Teuchos::ParameterList& params, const std::string& condstring, const int condid = -1);
 
     /*!
     \brief Evaluate a specific condition
@@ -1817,10 +1810,6 @@ namespace Core::FE
     Loop all conditions attached to the discretization and evaluate them.
     This method considers all conditions in condition_ with the names
     matching the user-provided string condstring.
-    It takes a current time from the parameter list params named "total time"
-    and evaluates the appropriate time curves at that time for each
-    condition separately. If "total time" is not included
-    in the parameters, no time curves are used.
 
       \param params (in):        List of parameters for use at element level
       \param systemmatrix1 (out): Sparse matrix that may be changed by

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
@@ -224,12 +224,7 @@ namespace Core::FE
         }
       };
 
-      /** \brief constructor
-       *
-       *  Intentionally left blank! */
-      Dbc() {};
-
-      /// destructor
+      /// Virtual destructor.
       virtual ~Dbc() = default;
 
       /** \brief Extract parameters and setup some temporal variables, before the actual
@@ -419,12 +414,6 @@ namespace Core::FE
        *  priority. The corresponding entries in the systemvectors remain
        *  untouched.
        *
-       *  \version rauch 06/2016
-       *  Shifted and rearranged parts of the former implementation to
-       *  read_dirichlet_condition(...). This fixes inconsistency in hierarchy
-       *  handling. Now, the Dirichlet conditions are first read by
-       *  read_dirichlet_condition(...). Then, they are applied by
-       *  do_dirichlet_condition(...).
        */
       virtual void do_dirichlet_condition(const Teuchos::ParameterList& params,
           const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
@@ -62,43 +62,6 @@ namespace Core::FE
         const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
         const Core::LinAlg::Map* col_ele_map = nullptr);
 
-    /** \brief Evaluate the elements of the given discretization and fill the
-     *         system matrices and vectors
-     *
-     *  This evaluate routine supports the evaluation of a subset of all column
-     *  elements inside the given discretization. If the \c col_ele_map pointer
-     *  is not set or set to \c nullptr, this routine generates almost no overhead
-     *  and is equivalent to the more familiar implementation in Core::FE::Discretization.
-     *
-     *  \param discret      (in)  : discretization containing the considered elements
-     *  \param eparams      (in)  : element parameter list
-     *  \param systemmatrix (out) : system-matrix vector which is supposed to be filled
-     *  \param systemvector (out) : system-vector vector which is supposed to be filled
-     *  \param col_ele_map  (in)  : column element map, which can be a subset of the
-     *                              discretization column map ( optional )
-     */
-    void evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
-        std::vector<std::shared_ptr<Core::LinAlg::SparseOperator>>& systemmatrices,
-        std::vector<std::shared_ptr<Core::LinAlg::Vector<double>>>& systemvector,
-        const Core::LinAlg::Map* col_ele_map = nullptr);
-
-    /** \brief Evaluate the elements of the given discretization and fill the
-     *         system matrices and vectors
-     *
-     *  This evaluate routine supports the evaluation of a subset of all column
-     *  elements inside the given discretization. If the \c col_ele_map pointer
-     *  is not set or set to \c nullptr, this routine generates almost no overhead
-     *  and is equivalent to the more familiar implementation in Core::FE::Discretization.
-     *
-     *  \param discret      (in)  : discretization containing the considered elements
-     *  \param eparams      (in)  : element parameter list
-     *  \param strategy     (out) : assemble strategy containing all the system vectors
-     *                              and matrices
-     *  \param col_ele_map  (in)  : column element map, which can be a subset of the
-     *                              discretization column map ( optional )
-     */
-    void evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
-        Core::FE::AssembleStrategy& strategy, const Core::LinAlg::Map* col_ele_map = nullptr);
 
     /** \brief Evaluate Dirichlet boundary conditions
      *

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
@@ -40,11 +40,11 @@ std::shared_ptr<const Core::FE::Utils::Dbc> Core::FE::Utils::build_dbc(
 {
   // HDG discretization
   if (dynamic_cast<const Core::FE::DiscretizationHDG*>(discret_ptr) != nullptr)
-    return std::shared_ptr<const Core::FE::Utils::Dbc>(new const Core::FE::Utils::DbcHDG());
+    return std::make_shared<const Core::FE::Utils::DbcHDG>();
 
   // Nurbs discretization
   if (dynamic_cast<const Core::FE::Nurbs::NurbsDiscretization*>(discret_ptr) != nullptr)
-    return std::shared_ptr<const Core::FE::Utils::Dbc>(new const Core::FE::Utils::DbcNurbs());
+    return std::make_shared<const Core::FE::Utils::DbcNurbs>();
 
   // default case
   return std::make_shared<const Core::FE::Utils::Dbc>();

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_evaluate.cpp
@@ -16,6 +16,79 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace
+{
+  void evaluate_internal(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
+      Core::FE::AssembleStrategy& strategy, const Core::LinAlg::Map* col_ele_map)
+  {
+    FOUR_C_ASSERT_ALWAYS(discret.filled(), "fill_complete() was not called");
+    FOUR_C_ASSERT_ALWAYS(discret.have_dofs(), "assign_degrees_of_freedom() was not called");
+
+    int row = strategy.first_dof_set();
+    int col = strategy.second_dof_set();
+
+    Core::Elements::LocationArray la(discret.num_dof_sets());
+
+    bool is_subset = false;
+    if (not col_ele_map)
+      col_ele_map = discret.element_col_map();
+    else
+      is_subset = true;
+
+    // loop over column elements
+    const int numcolele = col_ele_map->NumMyElements();
+    const int* ele_gids = col_ele_map->MyGlobalElements();
+
+    for (int i = 0; i < numcolele; ++i)
+    {
+      Core::Elements::Element* actele = nullptr;
+      if (is_subset)
+      {
+        const int egid = ele_gids[i];
+        actele = discret.g_element(egid);
+      }
+      else
+        actele = discret.l_col_element(i);
+
+      {
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate LocationVector");
+        // get element location vector, dirichlet flags and ownerships
+        actele->location_vector(discret, la, false);
+      }
+
+      {
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate Resize");
+
+        // get dimension of element matrices and vectors
+        // Reshape element matrices and vectors and init to zero
+        strategy.clear_element_storage(la[row].size(), la[col].size());
+      }
+
+      {
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate elements");
+        // call the element evaluate method
+        int err =
+            actele->evaluate(eparams, discret, la, strategy.elematrix1(), strategy.elematrix2(),
+                strategy.elevector1(), strategy.elevector2(), strategy.elevector3());
+        if (err)
+          FOUR_C_THROW("Proc {}: Element {} returned err={}",
+              Core::Communication::my_mpi_rank(discret.get_comm()), actele->id(), err);
+      }
+
+      {
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate assemble");
+        int eid = actele->id();
+        strategy.assemble_matrix1(eid, la[row].lm_, la[col].lm_, la[row].lmowner_, la[col].stride_);
+        strategy.assemble_matrix2(eid, la[row].lm_, la[col].lm_, la[row].lmowner_, la[col].stride_);
+        strategy.assemble_vector1(la[row].lm_, la[row].lmowner_);
+        strategy.assemble_vector2(la[row].lm_, la[row].lmowner_);
+        strategy.assemble_vector3(la[row].lm_, la[row].lmowner_);
+      }
+
+    }  // loop over all considered elements
+  }
+}  // namespace
+
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 void Core::FE::Utils::evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
@@ -23,110 +96,10 @@ void Core::FE::Utils::evaluate(Core::FE::Discretization& discret, Teuchos::Param
     const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
     const Core::LinAlg::Map* col_ele_map)
 {
-  std::vector<std::shared_ptr<Core::LinAlg::SparseOperator>> systemmatrices(2, nullptr);
-  std::vector<std::shared_ptr<Core::LinAlg::Vector<double>>> systemvectors(3, nullptr);
-
-  systemmatrices[0] = systemmatrix;
-  systemvectors[0] = systemvector;
-
-  evaluate(discret, eparams, systemmatrices, systemvectors, col_ele_map);
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-void Core::FE::Utils::evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
-    std::vector<std::shared_ptr<Core::LinAlg::SparseOperator>>& systemmatrices,
-    std::vector<std::shared_ptr<Core::LinAlg::Vector<double>>>& systemvectors,
-    const Core::LinAlg::Map* col_ele_map)
-{
-  FOUR_C_ASSERT(systemmatrices.size() <= 2,
-      "Currently a maximum number of two "
-      "system-matrices is supported!");
-  FOUR_C_ASSERT(systemvectors.size() <= 3,
-      "Currently a maximum number of three "
-      "system-vectors is supported!");
-
-  if (systemmatrices.size() < 2) systemmatrices.resize(2, nullptr);
-  if (systemvectors.size() < 3) systemvectors.resize(3, nullptr);
-
-  Core::FE::AssembleStrategy strategy(0, 0, systemmatrices[0], systemmatrices[1], systemvectors[0],
-      systemvectors[1], systemvectors[2]);
-  evaluate(discret, eparams, strategy, col_ele_map);
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-void Core::FE::Utils::evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
-    Core::FE::AssembleStrategy& strategy, const Core::LinAlg::Map* col_ele_map)
-{
   TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate");
-
-  if (!discret.filled()) FOUR_C_THROW("fill_complete() was not called");
-  if (!discret.have_dofs()) FOUR_C_THROW("assign_degrees_of_freedom() was not called");
-
-  int row = strategy.first_dof_set();
-  int col = strategy.second_dof_set();
-
-  Core::Elements::LocationArray la(discret.num_dof_sets());
-
-  bool is_subset = false;
-  if (not col_ele_map)
-    col_ele_map = discret.element_col_map();
-  else
-    is_subset = true;
-
-  // loop over column elements
-  const int numcolele = col_ele_map->NumMyElements();
-  const int* ele_gids = col_ele_map->MyGlobalElements();
-
-  for (int i = 0; i < numcolele; ++i)
-  {
-    Core::Elements::Element* actele = nullptr;
-    if (is_subset)
-    {
-      const int egid = ele_gids[i];
-      actele = discret.g_element(egid);
-    }
-    else
-      actele = discret.l_col_element(i);
-
-    {
-      TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate LocationVector");
-      // get element location vector, dirichlet flags and ownerships
-      actele->location_vector(discret, la, false);
-    }
-
-    {
-      TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate Resize");
-
-      // get dimension of element matrices and vectors
-      // Reshape element matrices and vectors and init to zero
-      strategy.clear_element_storage(la[row].size(), la[col].size());
-    }
-
-    {
-      TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate elements");
-      // call the element evaluate method
-      int err = actele->evaluate(eparams, discret, la, strategy.elematrix1(), strategy.elematrix2(),
-          strategy.elevector1(), strategy.elevector2(), strategy.elevector3());
-      if (err)
-        FOUR_C_THROW("Proc {}: Element {} returned err={}",
-            Core::Communication::my_mpi_rank(discret.get_comm()), actele->id(), err);
-    }
-
-    {
-      TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate assemble");
-      int eid = actele->id();
-      strategy.assemble_matrix1(eid, la[row].lm_, la[col].lm_, la[row].lmowner_, la[col].stride_);
-      strategy.assemble_matrix2(eid, la[row].lm_, la[col].lm_, la[row].lmowner_, la[col].stride_);
-      strategy.assemble_vector1(la[row].lm_, la[row].lmowner_);
-      strategy.assemble_vector2(la[row].lm_, la[row].lmowner_);
-      strategy.assemble_vector3(la[row].lm_, la[row].lmowner_);
-    }
-
-  }  // loop over all considered elements
-
-  return;
+  Core::FE::AssembleStrategy strategy(0, 0, systemmatrix, nullptr, systemvector, nullptr, nullptr);
+  evaluate_internal(discret, eparams, strategy, col_ele_map);
 }
+
 
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
- The implicit time variable in conditions was unused (good -- it should not be done in this implicit way).
- We had a few `evaluate` helpers that were never used.