### PR TITLE
Clean up MapExtractor

### DIFF
--- a/src/ale/4C_ale_utils_mapextractor.hpp
+++ b/src/ale/4C_ale_utils_mapextractor.hpp
@@ -61,14 +61,306 @@ namespace ALE
       std::shared_ptr<std::set<int>> conditioned_element_map(
           const Core::FE::Discretization& dis) const;
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(fsi_cond, cond_fsi)
-      MAP_EXTRACTOR_VECTOR_METHODS(fs_cond, cond_fs)
-      MAP_EXTRACTOR_VECTOR_METHODS(lung_asi_cond, cond_lung_asi)
-      MAP_EXTRACTOR_VECTOR_METHODS(ale_wear_cond, cond_ale_wear)
-      MAP_EXTRACTOR_VECTOR_METHODS(au_cond, cond_au)
-      MAP_EXTRACTOR_VECTOR_METHODS(fpsi_cond, cond_fpsi)
-      MAP_EXTRACTOR_VECTOR_METHODS(mortar, cond_mortar)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fsi);
+      }
+      void extract_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fsi);
+      }
+      void insert_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fsi_cond_map() const { return Map(cond_fsi); }
+      bool fsi_cond_relevant() const { return fsi_cond_map()->NumGlobalElements() != 0; }
+      void fsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fsi, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fs_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fs);
+      }
+      void extract_fs_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fs, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fs_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fs);
+      }
+      void insert_fs_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fs, full);
+      }
+      void add_fs_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fs, full);
+      }
+      void add_fs_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fs, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fs_cond_map() const { return Map(cond_fs); }
+      bool fs_cond_relevant() const { return fs_cond_map()->NumGlobalElements() != 0; }
+      void fs_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fs, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_lung_asi);
+      }
+      void extract_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_lung_asi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_lung_asi);
+      }
+      void insert_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_lung_asi, full);
+      }
+      void add_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_lung_asi, full);
+      }
+      void add_lung_asi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_lung_asi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& lung_asi_cond_map() const
+      {
+        return Map(cond_lung_asi);
+      }
+      bool lung_asi_cond_relevant() const { return lung_asi_cond_map()->NumGlobalElements() != 0; }
+      void lung_asi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_lung_asi, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_ale_wear_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_ale_wear);
+      }
+      void extract_ale_wear_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_ale_wear, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_ale_wear_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_ale_wear);
+      }
+      void insert_ale_wear_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_ale_wear, full);
+      }
+      void add_ale_wear_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_ale_wear, full);
+      }
+      void add_ale_wear_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_ale_wear, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& ale_wear_cond_map() const
+      {
+        return Map(cond_ale_wear);
+      }
+      bool ale_wear_cond_relevant() const { return ale_wear_cond_map()->NumGlobalElements() != 0; }
+      void ale_wear_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_ale_wear, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_au_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_au);
+      }
+      void extract_au_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_au, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_au_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_au);
+      }
+      void insert_au_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_au, full);
+      }
+      void add_au_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_au, full);
+      }
+      void add_au_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_au, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& au_cond_map() const { return Map(cond_au); }
+      bool au_cond_relevant() const { return au_cond_map()->NumGlobalElements() != 0; }
+      void au_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_au, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fpsi);
+      }
+      void extract_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fpsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fpsi);
+      }
+      void insert_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fpsi, full);
+      }
+      void add_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fpsi, full);
+      }
+      void add_fpsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fpsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fpsi_cond_map() const
+      {
+        return Map(cond_fpsi);
+      }
+      bool fpsi_cond_relevant() const { return fpsi_cond_map()->NumGlobalElements() != 0; }
+      void fpsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fpsi, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_mortar_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_mortar);
+      }
+      void extract_mortar_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_mortar, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_mortar_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_mortar);
+      }
+      void insert_mortar_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_mortar, full);
+      }
+      void add_mortar_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_mortar, full);
+      }
+      void add_mortar_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_mortar, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& mortar_map() const
+      {
+        return Map(cond_mortar);
+      }
+      bool mortar_relevant() const { return mortar_map()->NumGlobalElements() != 0; }
+      void mortar_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_mortar, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the fsi and ale meshtying at the same time
@@ -84,8 +376,78 @@ namespace ALE
       /// setup the whole thing
       void setup(const Core::FE::Discretization& dis);
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(FSI, cond_fsi)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_FSI_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fsi);
+      }
+      void extract_FSI_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_FSI_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fsi);
+      }
+      void insert_FSI_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fsi, full);
+      }
+      void add_FSI_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full);
+      }
+      void add_FSI_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& FSI_map() const { return Map(cond_fsi); }
+      bool FSI_relevant() const { return FSI_map()->NumGlobalElements() != 0; }
+      void FSI_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fsi, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the fluid_fluid_Coupling
@@ -101,8 +463,84 @@ namespace ALE
       /// setup the whole thing
       void setup(const Core::FE::Discretization& dis);
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(xfluid_fluid_cond, cond_xfluidfluid)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_xfluid_fluid_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_xfluidfluid);
+      }
+      void extract_xfluid_fluid_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_xfluidfluid, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_xfluid_fluid_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_xfluidfluid);
+      }
+      void insert_xfluid_fluid_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_xfluidfluid, full);
+      }
+      void add_xfluid_fluid_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_xfluidfluid, full);
+      }
+      void add_xfluid_fluid_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_xfluidfluid, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& xfluid_fluid_cond_map() const
+      {
+        return Map(cond_xfluidfluid);
+      }
+      bool xfluid_fluid_cond_relevant() const
+      {
+        return xfluid_fluid_cond_map()->NumGlobalElements() != 0;
+      }
+      void xfluid_fluid_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_xfluidfluid, scalar);
+      }
     };
   }  // namespace Utils
 }  // namespace ALE

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.hpp
@@ -67,9 +67,114 @@ namespace BeamInteraction
         solid = 2
       };
 
-      MAP_EXTRACTOR_VECTOR_METHODS(beam, beam)
-      MAP_EXTRACTOR_VECTOR_METHODS(sphere, sphere)
-      MAP_EXTRACTOR_VECTOR_METHODS(solid, solid)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_beam_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, beam);
+      }
+      void extract_beam_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, beam, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_beam_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, beam);
+      }
+      void insert_beam_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, beam, full);
+      }
+      void add_beam_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, beam, full);
+      }
+      void add_beam_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, beam, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& beam_map() const { return Map(beam); }
+      bool beam_relevant() const { return beam_map()->NumGlobalElements() != 0; }
+      void beam_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, beam, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_sphere_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, sphere);
+      }
+      void extract_sphere_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, sphere, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_sphere_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, sphere);
+      }
+      void insert_sphere_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, sphere, full);
+      }
+      void add_sphere_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, sphere, full);
+      }
+      void add_sphere_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, sphere, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& sphere_map() const { return Map(sphere); }
+      bool sphere_relevant() const { return sphere_map()->NumGlobalElements() != 0; }
+      void sphere_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, sphere, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_solid_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, solid);
+      }
+      void extract_solid_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, solid, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_solid_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, solid);
+      }
+      void insert_solid_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, solid, full);
+      }
+      void add_solid_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, solid, full);
+      }
+      void add_solid_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, solid, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& solid_map() const { return Map(solid); }
+      bool solid_relevant() const { return solid_map()->NumGlobalElements() != 0; }
+      void solid_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, solid, scalar);
+      }
     };
 
     /// class for comparing Core::Elements::Element* (and Core::Nodes::Node*) in a std::set

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
@@ -18,11 +18,6 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-Core::LinAlg::MultiMapExtractor::MultiMapExtractor() {}
-
-
-/*----------------------------------------------------------------------*/
-/*----------------------------------------------------------------------*/
 Core::LinAlg::MultiMapExtractor::MultiMapExtractor(const Core::LinAlg::Map& fullmap,
     const std::vector<std::shared_ptr<const Core::LinAlg::Map>>& maps)
 {
@@ -73,8 +68,6 @@ void Core::LinAlg::MultiMapExtractor::check_for_valid_map_extractor() const
       }
     }
   }
-
-  return;
 }
 
 
@@ -329,11 +322,6 @@ void Core::LinAlg::MultiMapExtractor::scale(
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-Core::LinAlg::MapExtractor::MapExtractor() {}
-
-
-/*----------------------------------------------------------------------*/
-/*----------------------------------------------------------------------*/
 Core::LinAlg::MapExtractor::MapExtractor(const Core::LinAlg::Map& fullmap,
     std::shared_ptr<const Core::LinAlg::Map> condmap,
     std::shared_ptr<const Core::LinAlg::Map> othermap)
@@ -372,42 +360,35 @@ Core::LinAlg::MapExtractor::MapExtractor(const Core::LinAlg::Map& fullmap,
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::LinAlg::MapExtractor::setup(const Core::LinAlg::Map& fullmap,
-    const std::shared_ptr<const Core::LinAlg::Map>& condmap,
-    const std::shared_ptr<const Core::LinAlg::Map>& othermap)
+void Core::LinAlg::MapExtractor::setup(const Core::LinAlg::Map& full_map,
+    const std::shared_ptr<const Core::LinAlg::Map>& cond_map,
+    const std::shared_ptr<const Core::LinAlg::Map>& other_map)
 {
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps;
-  maps.push_back(othermap);
-  maps.push_back(condmap);
-  MultiMapExtractor::setup(fullmap, maps);
+  maps.push_back(other_map);
+  maps.push_back(cond_map);
+  MultiMapExtractor::setup(full_map, maps);
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::LinAlg::MapExtractor::setup(const Core::LinAlg::Map& fullmap,
-    const std::shared_ptr<const Core::LinAlg::Map>& partialmap, bool iscondmap)
+void Core::LinAlg::MapExtractor::setup(
+    const Core::LinAlg::Map& full_map, const std::shared_ptr<const Core::LinAlg::Map>& cond_map)
 {
-  // initialise other DOFs by inserting all DOFs of full map
-  std::set<int> othergids;
-  const int* fullgids = fullmap.MyGlobalElements();
-  copy(fullgids, fullgids + fullmap.NumMyElements(), inserter(othergids, othergids.begin()));
+  std::span<const int> full_gids(full_map.MyGlobalElements(), full_map.NumMyElements());
+  std::span<const int> cond_gids(cond_map->MyGlobalElements(), cond_map->NumMyElements());
 
-  // throw away all DOFs which are in condmap
-  if (partialmap->NumMyElements() > 0)
-  {
-    const int* condgids = partialmap->MyGlobalElements();
-    for (int lid = 0; lid < partialmap->NumMyElements(); ++lid) othergids.erase(condgids[lid]);
-  }
+  // The set_difference algorithm requires the input ranges to be sorted.
+  FOUR_C_ASSERT(std::ranges::is_sorted(full_gids), "Internal error: GIDs in map not sorted.");
+  FOUR_C_ASSERT(std::ranges::is_sorted(cond_gids), "Internal error: GIDs in map not sorted.");
 
-  // create (non-overlapping) othermap for non-condmap DOFs
-  std::shared_ptr<Core::LinAlg::Map> othermap =
-      Core::LinAlg::create_map(othergids, Core::Communication::unpack_epetra_comm(fullmap.Comm()));
+  std::vector<int> other_gids;
+  std::ranges::set_difference(full_gids, cond_gids, std::back_inserter(other_gids));
 
-  // create the extractor based on choice 'iscondmap'
-  if (iscondmap)
-    setup(fullmap, partialmap, othermap);
-  else
-    setup(fullmap, othermap, partialmap);
+  auto other_map = Core::LinAlg::create_map(
+      other_gids, Core::Communication::unpack_epetra_comm(full_map.Comm()));
+
+  setup(full_map, cond_map, other_map);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.hpp
@@ -232,54 +232,6 @@ namespace Core::LinAlg
   };
 
 
-/// Add all kinds of support methods to derived classes of MultiMapExtractor.
-#define MAP_EXTRACTOR_VECTOR_METHODS(name, pos)                                           \
-  std::shared_ptr<Core::LinAlg::Vector<double>> extract_##name##_vector(                  \
-      const Core::LinAlg::Vector<double>& full) const                                     \
-  {                                                                                       \
-    return MultiMapExtractor::extract_vector(full, pos);                                  \
-  }                                                                                       \
-                                                                                          \
-  void extract_##name##_vector(                                                           \
-      const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const \
-  {                                                                                       \
-    extract_vector(full, pos, cond);                                                      \
-  }                                                                                       \
-                                                                                          \
-  std::shared_ptr<Core::LinAlg::Vector<double>> insert_##name##_vector(                   \
-      const Core::LinAlg::Vector<double>& cond) const                                     \
-  {                                                                                       \
-    return insert_vector(cond, pos);                                                      \
-  }                                                                                       \
-                                                                                          \
-  void insert_##name##_vector(                                                            \
-      const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const \
-  {                                                                                       \
-    insert_vector(cond, pos, full);                                                       \
-  }                                                                                       \
-                                                                                          \
-  void add_##name##_vector(                                                               \
-      const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const \
-  {                                                                                       \
-    add_vector(cond, pos, full);                                                          \
-  }                                                                                       \
-                                                                                          \
-  void add_##name##_vector(double scale, const Core::LinAlg::Vector<double>& cond,        \
-      Core::LinAlg::Vector<double>& full) const                                           \
-  {                                                                                       \
-    add_vector(cond, pos, full, scale);                                                   \
-  }                                                                                       \
-                                                                                          \
-  const std::shared_ptr<const Core::LinAlg::Map>& name##_map() const { return Map(pos); } \
-                                                                                          \
-  bool name##_relevant() const { return name##_map()->NumGlobalElements() != 0; }         \
-                                                                                          \
-  void name##_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const         \
-  {                                                                                       \
-    put_scalar(full, pos, scalar);                                                        \
-  }
-
-
   /// Split a dof row map in two and establish the communication pattern between those maps
   /*!
 
@@ -360,8 +312,78 @@ namespace Core::LinAlg
 
     //@}
 
-    MAP_EXTRACTOR_VECTOR_METHODS(cond, 1)
-    MAP_EXTRACTOR_VECTOR_METHODS(other, 0)
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, 1);
+    }
+    void extract_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, 1, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, 1);
+    }
+    void insert_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, 1, full);
+    }
+    void add_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, 1, full);
+    }
+    void add_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, 1, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& cond_map() const { return Map(1); }
+    bool cond_relevant() const { return cond_map()->NumGlobalElements() != 0; }
+    void cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, 1, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, 0);
+    }
+    void extract_other_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, 0, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, 0);
+    }
+    void insert_other_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, 0, full);
+    }
+    void add_other_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, 0, full);
+    }
+    void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, 0, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(0); }
+    bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+    void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, 0, scalar);
+    }
   };
 
 }  // namespace Core::LinAlg

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.hpp
@@ -44,10 +44,16 @@ namespace Core::LinAlg
   class MultiMapExtractor
   {
    public:
-    /// create an uninitialized (empty) extractor
-    MultiMapExtractor();
+    /**
+     * @brief Default constructor.
+     *
+     * You will need to call setup() before using this object.
+     */
+    MultiMapExtractor() = default;
 
-    /// destructor
+    /**
+     * Virtual destructor.
+     */
     virtual ~MultiMapExtractor() = default;
 
     /// create an extractor from fullmap to the given set of maps
@@ -151,7 +157,7 @@ namespace Core::LinAlg
       \param block number of vector to extract
       \param partial vector to fill
      */
-    virtual void extract_vector(const Core::LinAlg::MultiVector<double>& full, int block,
+    void extract_vector(const Core::LinAlg::MultiVector<double>& full, int block,
         Core::LinAlg::MultiVector<double>& partial) const;
 
 
@@ -182,7 +188,7 @@ namespace Core::LinAlg
       \param block number of partial vector
       \param full vector to copy into
      */
-    virtual void insert_vector(const Core::LinAlg::MultiVector<double>& partial, int block,
+    void insert_vector(const Core::LinAlg::MultiVector<double>& partial, int block,
         Core::LinAlg::MultiVector<double>& full) const;
 
     //@}
@@ -197,7 +203,7 @@ namespace Core::LinAlg
       \param full vector to copy into
       \param scale scaling factor for partial vector
      */
-    virtual void add_vector(const Core::LinAlg::MultiVector<double>& partial, int block,
+    void add_vector(const Core::LinAlg::MultiVector<double>& partial, int block,
         Core::LinAlg::MultiVector<double>& full, double scale = 1.0) const;
 
     //@}
@@ -271,9 +277,7 @@ namespace Core::LinAlg
   void name##_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const         \
   {                                                                                       \
     put_scalar(full, pos, scalar);                                                        \
-  }                                                                                       \
-                                                                                          \
-  double name##_norm2(const Core::LinAlg::Vector<double>& full) const { return norm2(full, pos); }
+  }
 
 
   /// Split a dof row map in two and establish the communication pattern between those maps
@@ -306,14 +310,19 @@ namespace Core::LinAlg
   class MapExtractor : public MultiMapExtractor
   {
    public:
-    /** \brief empty constructor
+    /**
+     * @brief Default constructor.
      *
-     *  You have to call a setup() routine of your choice. */
-    MapExtractor();
+     * You have to call a setup() routine of your choice before you can do anything with this
+     * object.
+     */
+    MapExtractor() = default;
 
-    /** \brief  constructor
+    /**
+     * @brief Constructor
      *
-     *  Calls setup() from known maps */
+     *  Calls setup() from known maps.
+     */
     MapExtractor(const Core::LinAlg::Map& fullmap, std::shared_ptr<const Core::LinAlg::Map> condmap,
         std::shared_ptr<const Core::LinAlg::Map> othermap);
 
@@ -330,23 +339,29 @@ namespace Core::LinAlg
     /** \name Setup */
     //@{
 
-    /// setup from known maps
-    void setup(const Core::LinAlg::Map& fullmap,
-        const std::shared_ptr<const Core::LinAlg::Map>& condmap,
-        const std::shared_ptr<const Core::LinAlg::Map>& othermap);
+    /**
+     * @brief Set up the MapExtractor from a full map, a "cond" map and an "other" map.
+     *
+     * The set union of the indices in @p cond_map and @p other_map must be equal to those in the
+     * @p full_map. The @p cond_map and @p other_map must be non-overlapping.
+     */
+    void setup(const Core::LinAlg::Map& full_map,
+        const std::shared_ptr<const Core::LinAlg::Map>& cond_map,
+        const std::shared_ptr<const Core::LinAlg::Map>& other_map);
 
-    /// setup creates non-overlapping othermap/condmap which is complementary to condmap/othermap
-    /// with respect to fullmap depending on boolean 'iscondmap'
-
-    void setup(const Core::LinAlg::Map& fullmap,
-        const std::shared_ptr<const Core::LinAlg::Map>& partialmap, bool iscondmap = true);
+    /**
+     * @brief Set up the MapExtractor from a full map and a "cond" map.
+     *
+     * In contrast to the other setup() call, this call constructs the other map as the set
+     * difference between @p full_map and the @p cond_map.
+     */
+    void setup(const Core::LinAlg::Map& full_map,
+        const std::shared_ptr<const Core::LinAlg::Map>& cond_map);
 
     //@}
 
     MAP_EXTRACTOR_VECTOR_METHODS(cond, 1)
     MAP_EXTRACTOR_VECTOR_METHODS(other, 0)
-
-   private:
   };
 
 }  // namespace Core::LinAlg

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
@@ -155,14 +155,6 @@ std::shared_ptr<Core::LinAlg::Vector<double>> Core::LinAlg::create_vector(
   return std::make_shared<Core::LinAlg::Vector<double>>(rowmap, init);
 }
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::LinAlg::create_multi_vector(
-    const Epetra_BlockMap& rowmap, const int numrows, const bool init)
-{
-  return std::make_shared<Core::LinAlg::MultiVector<double>>(rowmap, numrows, init);
-}
-
 
 std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::LinAlg::create_multi_vector(
     const Map& rowmap, const int numrows, const bool init)
@@ -175,31 +167,18 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::LinAlg::create_multi_ve
 std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::create_map(
     const std::set<int>& gids, MPI_Comm comm)
 {
-  std::vector<int> mapvec;
-  mapvec.reserve(gids.size());
-  mapvec.assign(gids.begin(), gids.end());
-  std::shared_ptr<Core::LinAlg::Map> map = std::make_shared<Core::LinAlg::Map>(
-      -1, mapvec.size(), mapvec.data(), 0, Core::Communication::as_epetra_comm(comm));
-  mapvec.clear();
-  return map;
+  std::vector<int> mapvec(gids.begin(), gids.end());
+  return create_map(mapvec, comm);
 }
 
 /*----------------------------------------------------------------------*
- | create Core::LinAlg::Map with out-of-bound check                 farah 06/14|
  *----------------------------------------------------------------------*/
 std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::create_map(
     const std::vector<int>& gids, MPI_Comm comm)
 {
-  std::shared_ptr<Core::LinAlg::Map> map;
-
-  if ((int)gids.size() > 0)
-    map = std::make_shared<Core::LinAlg::Map>(
-        -1, gids.size(), gids.data(), 0, Core::Communication::as_epetra_comm(comm));
-  else
-    map = std::make_shared<Core::LinAlg::Map>(
-        -1, gids.size(), nullptr, 0, Core::Communication::as_epetra_comm(comm));
-
-  return map;
+  const int* my_gids = (gids.size() > 0) ? gids.data() : nullptr;
+  return std::make_shared<Core::LinAlg::Map>(
+      -1, gids.size(), my_gids, 0, Core::Communication::as_epetra_comm(comm));
 }
 
 /*----------------------------------------------------------------------*

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
@@ -73,16 +73,6 @@ namespace Core::LinAlg
       const Map& rowmap, const bool init = true);
 
   /*!
-   \brief Create a new Core::LinAlg::MultiVector<double> and return RefcountPtr to it
-
-   \param rowmap (in): row map of vector
-   \param rowmap (in): number of vectors
-   \param init (in): initialize vector to zero upon construction
-   */
-  std::shared_ptr<Core::LinAlg::MultiVector<double>> create_multi_vector(
-      const Epetra_BlockMap& rowmap, const int numrows, const bool init = true);
-
-  /*!
   \brief Create a new Core::LinAlg::MultiVector<double> and return RefcountPtr to it
 
   \param rowmap (in): row map of vector

--- a/src/fluid/4C_fluid_utils_mapextractor.hpp
+++ b/src/fluid/4C_fluid_utils_mapextractor.hpp
@@ -58,11 +58,192 @@ namespace FLD
       std::shared_ptr<std::set<int>> conditioned_element_map(
           const Core::FE::Discretization& dis) const;
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(fsi_cond, cond_fsi)
-      MAP_EXTRACTOR_VECTOR_METHODS(lung_asi_cond, cond_lung_asi)
-      MAP_EXTRACTOR_VECTOR_METHODS(mortar_cond, cond_mortar)
-      MAP_EXTRACTOR_VECTOR_METHODS(au_cond, cond_au)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fsi);
+      }
+      void extract_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fsi);
+      }
+      void insert_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fsi_cond_map() const { return Map(cond_fsi); }
+      bool fsi_cond_relevant() const { return fsi_cond_map()->NumGlobalElements() != 0; }
+      void fsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fsi, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_lung_asi);
+      }
+      void extract_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_lung_asi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_lung_asi);
+      }
+      void insert_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_lung_asi, full);
+      }
+      void add_lung_asi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_lung_asi, full);
+      }
+      void add_lung_asi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_lung_asi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& lung_asi_cond_map() const
+      {
+        return Map(cond_lung_asi);
+      }
+      bool lung_asi_cond_relevant() const { return lung_asi_cond_map()->NumGlobalElements() != 0; }
+      void lung_asi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_lung_asi, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_mortar_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_mortar);
+      }
+      void extract_mortar_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_mortar, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_mortar_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_mortar);
+      }
+      void insert_mortar_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_mortar, full);
+      }
+      void add_mortar_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_mortar, full);
+      }
+      void add_mortar_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_mortar, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& mortar_cond_map() const
+      {
+        return Map(cond_mortar);
+      }
+      bool mortar_cond_relevant() const { return mortar_cond_map()->NumGlobalElements() != 0; }
+      void mortar_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_mortar, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_au_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_au);
+      }
+      void extract_au_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_au, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_au_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_au);
+      }
+      void insert_au_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_au, full);
+      }
+      void add_au_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_au, full);
+      }
+      void add_au_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_au, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& au_cond_map() const { return Map(cond_au); }
+      bool au_cond_relevant() const { return au_cond_map()->NumGlobalElements() != 0; }
+      void au_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_au, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the part of fluid with volumetric surface flow
@@ -79,8 +260,85 @@ namespace FLD
       /// setup the whole thing
       void setup(const Core::FE::Discretization& dis);
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(volumetric_surface_flow_cond, cond_vol_surf_flow)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_volumetric_surface_flow_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_vol_surf_flow);
+      }
+      void extract_volumetric_surface_flow_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_vol_surf_flow, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_volumetric_surface_flow_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_vol_surf_flow);
+      }
+      void insert_volumetric_surface_flow_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_vol_surf_flow, full);
+      }
+      void add_volumetric_surface_flow_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_vol_surf_flow, full);
+      }
+      void add_volumetric_surface_flow_cond_vector(double scale,
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_vol_surf_flow, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& volumetric_surface_flow_cond_map() const
+      {
+        return Map(cond_vol_surf_flow);
+      }
+      bool volumetric_surface_flow_cond_relevant() const
+      {
+        return volumetric_surface_flow_cond_map()->NumGlobalElements() != 0;
+      }
+      void volumetric_surface_flow_cond_put_scalar(
+          Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_vol_surf_flow, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the part of fluid with Krylov space projection
@@ -100,8 +358,78 @@ namespace FLD
       std::shared_ptr<std::set<int>> conditioned_element_map(
           const Core::FE::Discretization& dis) const;
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(ksp_cond, cond_ksp)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_ksp_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_ksp);
+      }
+      void extract_ksp_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_ksp, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_ksp_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_ksp);
+      }
+      void insert_ksp_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_ksp, full);
+      }
+      void add_ksp_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_ksp, full);
+      }
+      void add_ksp_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_ksp, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& ksp_cond_map() const { return Map(cond_ksp); }
+      bool ksp_cond_relevant() const { return ksp_cond_map()->NumGlobalElements() != 0; }
+      void ksp_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_ksp, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the velocity-pressure split
@@ -111,8 +439,78 @@ namespace FLD
       /// setup the whole thing
       void setup(const Core::FE::Discretization& dis);
 
-      MAP_EXTRACTOR_VECTOR_METHODS(velocity, 0)
-      MAP_EXTRACTOR_VECTOR_METHODS(pressure, 1)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_velocity_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, 0);
+      }
+      void extract_velocity_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, 0, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_velocity_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, 0);
+      }
+      void insert_velocity_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, 0, full);
+      }
+      void add_velocity_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, 0, full);
+      }
+      void add_velocity_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, 0, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& velocity_map() const { return Map(0); }
+      bool velocity_relevant() const { return velocity_map()->NumGlobalElements() != 0; }
+      void velocity_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, 0, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_pressure_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, 1);
+      }
+      void extract_pressure_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, 1, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_pressure_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, 1);
+      }
+      void insert_pressure_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, 1, full);
+      }
+      void add_pressure_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, 1, full);
+      }
+      void add_pressure_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, 1, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& pressure_map() const { return Map(1); }
+      bool pressure_relevant() const { return pressure_map()->NumGlobalElements() != 0; }
+      void pressure_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, 1, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the fsi and ale meshtying at the same time
@@ -131,8 +529,78 @@ namespace FLD
       void setup(std::shared_ptr<const Core::LinAlg::Map>& additionalothermap,
           const FLD::Utils::FsiMapExtractor& extractor);
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(fsi, cond_fsi)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fsi_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fsi);
+      }
+      void extract_fsi_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fsi_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fsi);
+      }
+      void insert_fsi_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fsi_map() const { return Map(cond_fsi); }
+      bool fsi_relevant() const { return fsi_map()->NumGlobalElements() != 0; }
+      void fsi_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fsi, scalar);
+      }
     };
 
     /// specific MultiMapExtractor to handle the fluid field
@@ -150,8 +618,81 @@ namespace FLD
           std::shared_ptr<const Core::LinAlg::Map> fluidmap,
           std::shared_ptr<const Core::LinAlg::Map> xfluidmap);
 
-      MAP_EXTRACTOR_VECTOR_METHODS(fluid, cond_fluid)
-      MAP_EXTRACTOR_VECTOR_METHODS(x_fluid, cond_xfluid)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fluid_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fluid);
+      }
+      void extract_fluid_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fluid, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fluid_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fluid);
+      }
+      void insert_fluid_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fluid, full);
+      }
+      void add_fluid_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fluid, full);
+      }
+      void add_fluid_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fluid, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fluid_map() const { return Map(cond_fluid); }
+      bool fluid_relevant() const { return fluid_map()->NumGlobalElements() != 0; }
+      void fluid_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fluid, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_x_fluid_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_xfluid);
+      }
+      void extract_x_fluid_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_xfluid, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_x_fluid_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_xfluid);
+      }
+      void insert_x_fluid_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_xfluid, full);
+      }
+      void add_x_fluid_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_xfluid, full);
+      }
+      void add_x_fluid_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_xfluid, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& x_fluid_map() const
+      {
+        return Map(cond_xfluid);
+      }
+      bool x_fluid_relevant() const { return x_fluid_map()->NumGlobalElements() != 0; }
+      void x_fluid_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_xfluid, scalar);
+      }
     };
 
   }  // namespace Utils

--- a/src/fpsi/4C_fpsi_utils.hpp
+++ b/src/fpsi/4C_fpsi_utils.hpp
@@ -129,9 +129,117 @@ namespace FPSI
       std::shared_ptr<std::set<int>> conditioned_element_map(
           const Core::FE::Discretization& dis) const;
 
-      MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-      MAP_EXTRACTOR_VECTOR_METHODS(fsi_cond, cond_fsi)
-      MAP_EXTRACTOR_VECTOR_METHODS(fpsi_cond, cond_fpsi)
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_other);
+      }
+      void extract_other_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_other, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_other);
+      }
+      void insert_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_other, full);
+      }
+      void add_other_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full);
+      }
+      void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_other, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+      bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+      void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_other, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fsi);
+      }
+      void extract_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fsi);
+      }
+      void insert_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full);
+      }
+      void add_fsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fsi_cond_map() const { return Map(cond_fsi); }
+      bool fsi_cond_relevant() const { return fsi_cond_map()->NumGlobalElements() != 0; }
+      void fsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fsi, scalar);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> extract_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full) const
+      {
+        return MultiMapExtractor::extract_vector(full, cond_fpsi);
+      }
+      void extract_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+      {
+        extract_vector(full, cond_fpsi, cond);
+      }
+      std::shared_ptr<Core::LinAlg::Vector<double>> insert_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond) const
+      {
+        return insert_vector(cond, cond_fpsi);
+      }
+      void insert_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        insert_vector(cond, cond_fpsi, full);
+      }
+      void add_fpsi_cond_vector(
+          const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fpsi, full);
+      }
+      void add_fpsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+          Core::LinAlg::Vector<double>& full) const
+      {
+        add_vector(cond, cond_fpsi, full, scale);
+      }
+      const std::shared_ptr<const Core::LinAlg::Map>& fpsi_cond_map() const
+      {
+        return Map(cond_fpsi);
+      }
+      bool fpsi_cond_relevant() const { return fpsi_cond_map()->NumGlobalElements() != 0; }
+      void fpsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+      {
+        put_scalar(full, cond_fpsi, scalar);
+      }
     };
 
   }  // namespace Utils

--- a/src/structure/4C_structure_aux.hpp
+++ b/src/structure/4C_structure_aux.hpp
@@ -54,13 +54,267 @@ namespace Solid
     std::shared_ptr<std::set<int>> conditioned_element_map(
         const Core::FE::Discretization& dis) const;
 
-    MAP_EXTRACTOR_VECTOR_METHODS(other, cond_other)
-    MAP_EXTRACTOR_VECTOR_METHODS(fsi_cond, cond_fsi)
-    MAP_EXTRACTOR_VECTOR_METHODS(lung_asi_cond, cond_lung_asi)
-    MAP_EXTRACTOR_VECTOR_METHODS(ale_wear_cond, cond_ale_wear)
-    MAP_EXTRACTOR_VECTOR_METHODS(fpsi_cond, cond_fpsi)
-    MAP_EXTRACTOR_VECTOR_METHODS(immersed_cond, cond_immersed)
-    MAP_EXTRACTOR_VECTOR_METHODS(pasi_cond, cond_pasi)
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_other_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_other);
+    }
+    void extract_other_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_other, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_other_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_other);
+    }
+    void insert_other_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_other, full);
+    }
+    void add_other_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_other, full);
+    }
+    void add_other_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_other, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& other_map() const { return Map(cond_other); }
+    bool other_relevant() const { return other_map()->NumGlobalElements() != 0; }
+    void other_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_other, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_fsi_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_fsi);
+    }
+    void extract_fsi_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_fsi, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_fsi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_fsi);
+    }
+    void insert_fsi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_fsi, full);
+    }
+    void add_fsi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_fsi, full);
+    }
+    void add_fsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_fsi, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& fsi_cond_map() const { return Map(cond_fsi); }
+    bool fsi_cond_relevant() const { return fsi_cond_map()->NumGlobalElements() != 0; }
+    void fsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_fsi, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_lung_asi_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_lung_asi);
+    }
+    void extract_lung_asi_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_lung_asi, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_lung_asi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_lung_asi);
+    }
+    void insert_lung_asi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_lung_asi, full);
+    }
+    void add_lung_asi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_lung_asi, full);
+    }
+    void add_lung_asi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_lung_asi, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& lung_asi_cond_map() const
+    {
+      return Map(cond_lung_asi);
+    }
+    bool lung_asi_cond_relevant() const { return lung_asi_cond_map()->NumGlobalElements() != 0; }
+    void lung_asi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_lung_asi, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_ale_wear_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_ale_wear);
+    }
+    void extract_ale_wear_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_ale_wear, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_ale_wear_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_ale_wear);
+    }
+    void insert_ale_wear_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_ale_wear, full);
+    }
+    void add_ale_wear_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_ale_wear, full);
+    }
+    void add_ale_wear_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_ale_wear, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& ale_wear_cond_map() const
+    {
+      return Map(cond_ale_wear);
+    }
+    bool ale_wear_cond_relevant() const { return ale_wear_cond_map()->NumGlobalElements() != 0; }
+    void ale_wear_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_ale_wear, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_fpsi_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_fpsi);
+    }
+    void extract_fpsi_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_fpsi, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_fpsi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_fpsi);
+    }
+    void insert_fpsi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_fpsi, full);
+    }
+    void add_fpsi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_fpsi, full);
+    }
+    void add_fpsi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_fpsi, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& fpsi_cond_map() const { return Map(cond_fpsi); }
+    bool fpsi_cond_relevant() const { return fpsi_cond_map()->NumGlobalElements() != 0; }
+    void fpsi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_fpsi, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_immersed_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_immersed);
+    }
+    void extract_immersed_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_immersed, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_immersed_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_immersed);
+    }
+    void insert_immersed_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_immersed, full);
+    }
+    void add_immersed_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_immersed, full);
+    }
+    void add_immersed_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_immersed, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& immersed_cond_map() const
+    {
+      return Map(cond_immersed);
+    }
+    bool immersed_cond_relevant() const { return immersed_cond_map()->NumGlobalElements() != 0; }
+    void immersed_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_immersed, scalar);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> extract_pasi_cond_vector(
+        const Core::LinAlg::Vector<double>& full) const
+    {
+      return MultiMapExtractor::extract_vector(full, cond_pasi);
+    }
+    void extract_pasi_cond_vector(
+        const Core::LinAlg::Vector<double>& full, Core::LinAlg::Vector<double>& cond) const
+    {
+      extract_vector(full, cond_pasi, cond);
+    }
+    std::shared_ptr<Core::LinAlg::Vector<double>> insert_pasi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond) const
+    {
+      return insert_vector(cond, cond_pasi);
+    }
+    void insert_pasi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      insert_vector(cond, cond_pasi, full);
+    }
+    void add_pasi_cond_vector(
+        const Core::LinAlg::Vector<double>& cond, Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_pasi, full);
+    }
+    void add_pasi_cond_vector(double scale, const Core::LinAlg::Vector<double>& cond,
+        Core::LinAlg::Vector<double>& full) const
+    {
+      add_vector(cond, cond_pasi, full, scale);
+    }
+    const std::shared_ptr<const Core::LinAlg::Map>& pasi_cond_map() const { return Map(cond_pasi); }
+    bool pasi_cond_relevant() const { return pasi_cond_map()->NumGlobalElements() != 0; }
+    void pasi_cond_put_scalar(Core::LinAlg::Vector<double>& full, double scalar) const
+    {
+      put_scalar(full, cond_pasi, scalar);
+    }
   };
 }  // namespace Solid
 


### PR DESCRIPTION
- Clean up of some doc strings and modern C++ issues.
- Second commit: inline a code-generating macro. It is a pain to work with this code otherwise. Most of the generated methods are unused. I would like to merge this state so the coverage report shows us which ones (in an easily digestible way).