### PR TITLE
Move problematic poromultielastscatra tests to UMFPACK

### DIFF
--- a/tests/input_files/poromultielastscatra_2D_quad4_linebased_artery_coupling_vessel_collapse_free_hanging.dat
+++ b/tests/input_files/poromultielastscatra_2D_quad4_linebased_artery_coupling_vessel_collapse_free_hanging.dat
@@ -99,7 +99,7 @@ INITIALFIELD                    field_by_condition
 INITFUNCNO                      2
 --------------------------------------------------------------------SOLVER 1
 NAME                            solver
-SOLVER                          Superlu
+SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS
 MAT 2 MAT_FluidPoroMultiPhaseReactions LOCAL No PERMEABILITY 1.0e-9 NUMMAT 3 MATIDS 10 11 12 NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE 3 NUMREAC 2 REACIDS 20 21
 

--- a/tests/input_files/poromultielastscatra_2D_quad4_nodetopoint_artery_airway_coupling_mono.dat
+++ b/tests/input_files/poromultielastscatra_2D_quad4_nodetopoint_artery_airway_coupling_mono.dat
@@ -90,7 +90,7 @@ SOLVESCATRA                     yes
 INITIALFIELD                    field_by_condition
 --------------------------------------------------------------------SOLVER 1
 NAME                            solver
-SOLVER                          Superlu
+SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_FluidPoroMultiPhaseReactions LOCAL No PERMEABILITY 1.2e-3 NUMMAT 3 MATIDS 12 13 14 NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE 1 NUMREAC 1 REACIDS 50
 MAT 50 MAT_FluidPoroSingleReaction NUMSCAL 4 TOTALNUMDOF 3 NUMVOLFRAC 1 SCALE 1 1 1 COUPLING scalar_by_function FUNCTID 4

--- a/tests/input_files/poromultielastscatra_3D_hex8_nodetopoint_artery_airway_coupling_mono.dat
+++ b/tests/input_files/poromultielastscatra_3D_hex8_nodetopoint_artery_airway_coupling_mono.dat
@@ -88,7 +88,7 @@ SOLVESCATRA                     yes
 INITIALFIELD                    field_by_condition
 --------------------------------------------------------------------SOLVER 1
 NAME                            solver
-SOLVER                          Superlu
+SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_FluidPoroMultiPhaseReactions LOCAL No PERMEABILITY 1.2e-3 NUMMAT 3 MATIDS 12 13 14 NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE 1 NUMREAC 1 REACIDS 50
 MAT 50 MAT_FluidPoroSingleReaction NUMSCAL 2 TOTALNUMDOF 3 NUMVOLFRAC 1 SCALE 1 1 1 COUPLING scalar_by_function FUNCTID 4

--- a/tests/input_files/poromultielastscatra_3D_tet10_nodetopoint_coupling_mono.dat
+++ b/tests/input_files/poromultielastscatra_3D_tet10_nodetopoint_coupling_mono.dat
@@ -88,7 +88,7 @@ SOLVESCATRA                     yes
 INITIALFIELD                    field_by_condition
 --------------------------------------------------------------------SOLVER 1
 NAME                            solver
-SOLVER                          Superlu
+SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_FluidPoroMultiPhaseReactions LOCAL No PERMEABILITY 1.2e-3 NUMMAT 3 MATIDS 12 13 14 NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE 1 NUMREAC 1 REACIDS 50
 MAT 50 MAT_FluidPoroSingleReaction NUMSCAL 1 TOTALNUMDOF 3 NUMVOLFRAC 1 SCALE 1 1 1 COUPLING scalar_by_function FUNCTID 4

--- a/tests/input_files/poromultielastscatra_3D_tet4_surfbased_artery_coupling_mono_network.dat
+++ b/tests/input_files/poromultielastscatra_3D_tet4_surfbased_artery_coupling_mono_network.dat
@@ -98,7 +98,7 @@ SOLVESCATRA                     yes
 INITIALFIELD                    field_by_condition
 --------------------------------------------------------------------SOLVER 1
 NAME                            solver
-SOLVER                          Superlu
+SOLVER                          UMFPACK
 -------------------------------------------------------------------MATERIALS
 MAT 1 MAT_FluidPoroMultiPhaseReactions LOCAL No PERMEABILITY 1.0e-3 NUMMAT 2 MATIDS 14 15 NUMFLUIDPHASES_IN_MULTIPHASEPORESPACE 0 NUMREAC 1 REACIDS 50
 MAT 50 MAT_FluidPoroSingleReaction NUMSCAL 1 TOTALNUMDOF 2 NUMVOLFRAC 1 SCALE 1 -1 COUPLING scalar_by_function FUNCTID 7


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Not sure ... these tests use `Superlu`, which sometimes freaks out, sometimes not ... using `UMFPACK` resulted in a way more stable behavior.

@bwirthl @lkoeglmeier @shervas Is that ok for you? I think some of these tests are also pretty big, would make sense at some point to use a block preconditioner with an iterative method for solving the linear systems ... I have no idea how the linear systems looks like though.