### PR TITLE
Remove calls to exit() after FOUR_C_THROW

### DIFF
--- a/apps/global_full/4C_global_full_init_control.cpp
+++ b/apps/global_full/4C_global_full_init_control.cpp
@@ -41,7 +41,7 @@ void ntaini_ccadiscret(int argc, char** argv, std::string& inputfile_name,
       printf("Try again!\n");
     }
     MPI_Finalize();
-    exit(1);
+    exit(EXIT_FAILURE);
   }
   else if (argc <= 2)
   {
@@ -51,7 +51,7 @@ void ntaini_ccadiscret(int argc, char** argv, std::string& inputfile_name,
       printf("Try again!\n");
     }
     MPI_Finalize();
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 
 

--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -362,7 +362,7 @@ int main(int argc, char* argv[])
           printf("The default is to replace the original suffix by .4C.yaml.\n");
           printf("However, the file '%s' already exists. I will not continue\n",
               outputfile_name.c_str());
-          exit(1);
+          exit(EXIT_FAILURE);
         }
       }
       else

--- a/apps/post_monitor/4C_post_monitor.cpp
+++ b/apps/post_monitor/4C_post_monitor.cpp
@@ -786,7 +786,6 @@ void StructMonWriter::write_str_results(std::ofstream& outfile, PostProblem& pro
     else
     {
       FOUR_C_THROW("trying to write something that is not a stress or a strain");
-      exit(1);
     }
 
     // get pointer to discretisation of actual field
@@ -1398,7 +1397,6 @@ void ThermoMonWriter::write_thermo_results(std::ofstream& outfile, PostProblem& 
     else
     {
       FOUR_C_THROW("trying to write something that is not a heatflux or a temperature gradient");
-      exit(1);
     }
 
     // get pointer to discretisation of actual field

--- a/apps/post_processor/4C_post_processor_structure_stress.cpp
+++ b/apps/post_processor/4C_post_processor_structure_stress.cpp
@@ -644,7 +644,6 @@ void StructureFilter::write_eigen_stress(
   else
   {
     FOUR_C_THROW("trying to write something that is not a stress or a strain");
-    exit(1);
   }
 
 

--- a/apps/post_processor/4C_post_processor_thermo_heatflux.cpp
+++ b/apps/post_processor/4C_post_processor_thermo_heatflux.cpp
@@ -292,7 +292,6 @@ void ThermoFilter::write_heatflux(
   else
   {
     FOUR_C_THROW("trying to write something that is not a heatflux or a temperature gradient");
-    exit(1);
   }
 
   if (kind == nodebased)

--- a/src/art_net/4C_art_net_art_terminal_bc.cpp
+++ b/src/art_net/4C_art_net_art_terminal_bc.cpp
@@ -95,13 +95,11 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
       if (Rf < 0.0 || Rf > 1.0)
       {
         FOUR_C_THROW("forced reflection (Rf = {}) should always belong to the range :[0  1.0]", Rf);
-        exit(1);
       }
     }
     else
     {
       FOUR_C_THROW("{} is not defined as a 1D artery's inlet BC type", Type);
-      exit(1);
     }
 
     // -----------------------------------------------------------------
@@ -117,7 +115,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     else
     {
       FOUR_C_THROW("no inlet boundary condition defined!");
-      exit(1);
     }
   }
   else if (params.get<std::string>("Condition Name") == "Art_redD_3D_CouplingCond")
@@ -136,7 +133,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
       FOUR_C_THROW(
           "Cannot prescribe a boundary condition from 3D to reduced D, if the parameters passed "
           "don't exist");
-      exit(1);
     }
 
     // -----------------------------------------------------------------
@@ -198,13 +194,11 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     else
     {
       FOUR_C_THROW("{}, is an unimplemented type of coupling", Type);
-      exit(1);
     }
   }
   else
   {
     FOUR_C_THROW("No such condition Name");
-    exit(1);
   }
 
   // -------------------------------------------------------------------
@@ -281,7 +275,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
           FOUR_C_THROW(
               "Inflow boundary condition for Newton-Raphson exceeded the maximum allowed "
               "iterations");
-          exit(1);
         }
       }
     }
@@ -319,7 +312,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     else
     {
       FOUR_C_THROW("{} is not defined!", BC);
-      exit(1);
     }
   }  // If BC is prescribed at the inlet
   else if (IO == 1)  // If BC is prescribed at the outlet
@@ -385,7 +377,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
           FOUR_C_THROW(
               "Inflow boundary condition for Newton-Raphson exceeded the maximum allowed "
               "iterations");
-          exit(1);
         }
       }
     }
@@ -425,7 +416,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
   else
   {
     FOUR_C_THROW("IO flag must be either 1 (for outlets) or 0 (for inlets)\n");
-    exit(1);
   }
 
   // -------------------------------------------------------------------
@@ -441,7 +431,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
       FOUR_C_THROW(
           "Cannot prescribe a boundary condition from 3D to reduced D, if the parameters passed "
           "don't exist");
-      exit(1);
     }
 
     // -----------------------------------------------------------------
@@ -490,7 +479,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     {
       std::string str = (condition->parameters().get<std::string>("ReturnedVariable"));
       FOUR_C_THROW("{}, is an unimplemented type of coupling", str);
-      exit(1);
     }
     std::stringstream returnedBCwithId;
     returnedBCwithId << returnedBC << "_" << ID;
@@ -510,7 +498,6 @@ void Arteries::Utils::solve_prescribed_terminal_bc(Core::FE::Discretization& act
     {
       FOUR_C_THROW(
           "The 3D map for (1D - 3D coupling) has no variable ({}) for ID [{}]", returnedBC, ID);
-      exit(1);
     }
 
     // update the 1D map
@@ -653,7 +640,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
     if (wk_type == "R")  // a resister with a peripheral Pressure (Pout)
     {
       FOUR_C_THROW("So far, only the 3 element windkessel model is implemented\n");
-      exit(1);
       // ---------------------------------------------------------------
       // Read in the wind kessel parameters
       // ---------------------------------------------------------------
@@ -677,7 +663,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       if (R < 0.0)
       {
         FOUR_C_THROW("terminal resistance must be greater or equal to zero\n");
-        exit(1);
       }
 
       if (curve[0].has_value() && curve[0].value())
@@ -715,7 +700,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         if (count > 40)
         {
           FOUR_C_THROW("1 windkessel element (resistive) boundary condition didn't converge!");
-          exit(1);
         }
       }
 
@@ -726,7 +710,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
     else if (wk_type == "RC")  // an RC circuit with a peripheral Pressure (Pout)
     {
       FOUR_C_THROW("So far, only the 3 element windkessel model is implemented\n");
-      exit(1);
 
       // ---------------------------------------------------------------
       // Read in the wind kessel parameters
@@ -776,7 +759,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       if (R <= 0.0 || C <= 0.0)
       {
         FOUR_C_THROW("terminal resistance and capacitance must be always greater than zero\n");
-        exit(1);
       }
 
       // Calculate W2
@@ -854,7 +836,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       if (R1 < 0.0 || C <= 0.0 || R2 <= 0.0)
       {
         FOUR_C_THROW("terminal resistances and capacitance must always be greater than zero\n");
-        exit(1);
       }
 
       // ---------------------------------------------------------------
@@ -895,7 +876,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
         if (i > 40)
         {
           FOUR_C_THROW("3 element windkessel Newton Raphson is not converging\n");
-          exit(1);
         }
       }
 
@@ -906,7 +886,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
     else if (wk_type == "RCRL")  // four element windkessel model
     {
       FOUR_C_THROW("So far, only the 3 element windkessel model is implemented\n");
-      exit(1);
       // ---------------------------------------------------------------
       // Read in the wind kessel parameters
       // ---------------------------------------------------------------
@@ -982,7 +961,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
       if (R1 <= 0.0 || C <= 0.0 || R2 <= 0.0 || L <= 0.0)
       {
         FOUR_C_THROW("terminal resistance and capacitance must be always greater than zero\n");
-        exit(1);
       }
       // Calculate W2
 
@@ -990,12 +968,10 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
     else if (wk_type == "none")
     {
       FOUR_C_THROW("So far, only the 3 element windkessel model is implemented\n");
-      exit(1);
     }
     else
     {
       FOUR_C_THROW("\"{}\" is not supported type of windkessel model\n", wk_type);
-      exit(1);
     }
 
     // -----------------------------------------------------------------
@@ -1006,7 +982,6 @@ void Arteries::Utils::solve_expl_windkessel_bc(Core::FE::Discretization& actdis,
   else
   {
     FOUR_C_THROW("so far windkessel BC supports only ExplicitWindkessel");
-    exit(1);
   }
 
 }  // void Arteries::Utils::SolveExplWindkesselBC

--- a/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc_lin_exp.cpp
@@ -1299,7 +1299,6 @@ void Discret::Elements::ArteryEleCalcLinExp<distype>::evaluate_terminal_bc(Arter
       {
         FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
             Core::Communication::my_mpi_rank(discretization.get_comm()));
-        exit(1);
       }
 
       if (TermIO == -1)

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
@@ -1842,7 +1842,6 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::diffuse_crosslinker()
       {
         FOUR_C_THROW(
             "Unrealistic number {} of bonds for a crosslinker.", cldata_i->get_number_of_bonds());
-        exit(EXIT_FAILURE);
       }
     }
   }
@@ -1919,8 +1918,6 @@ int BeamInteraction::SubmodelEvaluator::Crosslinking::get_single_occupied_cl_bsp
     return 1;
   else
     FOUR_C_THROW("numbond = 1 but both binding spots store invalid element GIDs!");
-
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -2751,7 +2748,6 @@ bool BeamInteraction::SubmodelEvaluator::Crosslinking::check_linker_and_filament
     default:
     {
       FOUR_C_THROW("Unknown linker type.");
-      exit(EXIT_FAILURE);
     }
   }
 
@@ -3030,7 +3026,6 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::update_my_crosslinker_bin
             "You should not be here, crosslinker has unrealistic number "
             "{} of bonds.",
             cldata_i->get_number_of_bonds());
-        exit(EXIT_FAILURE);
       }
     }
   }
@@ -3104,7 +3099,6 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::update_my_element_binding
             "You should not be here, crosslinker has unrealistic number "
             "{} of bonds.",
             cldata_i->get_number_of_bonds());
-        exit(EXIT_FAILURE);
       }
     }
   }
@@ -3317,7 +3311,6 @@ int BeamInteraction::SubmodelEvaluator::Crosslinking::un_bind_crosslinker()
       {
         FOUR_C_THROW(
             "Unrealistic number {} of bonds for a crosslinker.", cldata_i->get_number_of_bonds());
-        exit(EXIT_FAILURE);
       }
     }
   }
@@ -3588,7 +3581,6 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::unbind_crosslinker_in_bin
         {
           FOUR_C_THROW(" Unrealistic number {} of bonds for a crosslinker.",
               cldata_i->get_number_of_bonds());
-          exit(EXIT_FAILURE);
         }
       }
     }

--- a/src/contact/4C_contact_abstract_strategy.cpp
+++ b/src/contact/4C_contact_abstract_strategy.cpp
@@ -2924,7 +2924,6 @@ double CONTACT::AbstractStrategy::get_potential_value(
 {
   FOUR_C_THROW("The currently active strategy \"{}\" does not support this method!",
       CONTACT::solving_strategy_to_string(type()));
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -2937,7 +2936,6 @@ double CONTACT::AbstractStrategy::get_linearized_potential_value_terms(
 {
   FOUR_C_THROW("The currently active strategy \"{}\" does not support this method!",
       CONTACT::solving_strategy_to_string(type()));
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/contact/4C_contact_abstract_strategy.hpp
+++ b/src/contact/4C_contact_abstract_strategy.hpp
@@ -202,7 +202,6 @@ namespace CONTACT
     {
       // currently not supported for the abstract strategy
       FOUR_C_THROW("slave_n_dof_row_map() seems currently unsupported!");
-      exit(EXIT_FAILURE);
     }
 
     /*! \brief Return the slave dof row map in the tangential directions
@@ -278,7 +277,6 @@ namespace CONTACT
         const enum CONTACT::VecBlockType& bt) const
     {
       FOUR_C_THROW("Not yet implemented!");
-      exit(EXIT_FAILURE);
 
       return nullptr;
     };
@@ -314,7 +312,6 @@ namespace CONTACT
         Core::LinAlg::Vector<double>& f, const double& timefac_np) const
     {
       FOUR_C_THROW("Not yet implemented!");
-      exit(EXIT_FAILURE);
 
       return nullptr;
     };
@@ -333,7 +330,6 @@ namespace CONTACT
         const CONTACT::ParamsInterface* cparams = nullptr) const
     {
       FOUR_C_THROW("Not yet implemented!");
-      exit(EXIT_FAILURE);
 
       return nullptr;
     };
@@ -353,7 +349,6 @@ namespace CONTACT
         std::shared_ptr<Core::LinAlg::SparseMatrix>& kteff, const double& timefac_np) const
     {
       FOUR_C_THROW("Not yet implemented!");
-      exit(EXIT_FAILURE);
 
       return nullptr;
     };

--- a/src/contact/4C_contact_integrator_factory.cpp
+++ b/src/contact/4C_contact_integrator_factory.cpp
@@ -89,7 +89,6 @@ std::shared_ptr<CONTACT::Integrator> CONTACT::INTEGRATOR::Factory::build_integra
     {
       FOUR_C_THROW("Unsupported solving strategy! (stype = {})",
           CONTACT::solving_strategy_to_string(sol_type));
-      exit(EXIT_FAILURE);
     }
   }  // end switch
 

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -171,8 +171,6 @@ void NOX::Nln::CONTACT::LinearSystem::set_linear_problem_for_solve(
     {
       FOUR_C_THROW("Unsupported matrix type! Type = {}",
           NOX::Nln::LinSystem::operator_type_to_string(jacType_));
-
-      exit(EXIT_FAILURE);
     }
   }
 }
@@ -379,8 +377,6 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
       FOUR_C_THROW(
           "You are trying to solve a pure diagonal matrix. This is currently not"
           "supported, but feel free to extend the functionality.");
-
-      exit(EXIT_FAILURE);
     }
     case 1:
     {

--- a/src/contact/4C_contact_noxinterface.cpp
+++ b/src/contact/4C_contact_noxinterface.cpp
@@ -388,11 +388,9 @@ double CONTACT::NoxInterface::get_model_value(NOX::Nln::MeritFunction::MeritFctN
     }
     default:
       FOUR_C_THROW("Unsupported Merit function name! (enum = {})", name);
-      exit(EXIT_FAILURE);
   }
 
   FOUR_C_THROW("Impossible to reach this point.");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -416,11 +414,9 @@ double CONTACT::NoxInterface::get_linearized_model_terms(const Core::LinAlg::Vec
     }
     default:
       FOUR_C_THROW("Unsupported Merit function name! (enum = {})", name);
-      exit(EXIT_FAILURE);
   }
 
   FOUR_C_THROW("Impossible to reach this point.");
-  exit(EXIT_FAILURE);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact/4C_contact_wear_interface.hpp
+++ b/src/contact/4C_contact_wear_interface.hpp
@@ -342,7 +342,6 @@ namespace Wear
         return wdofmap_;
       else
         FOUR_C_THROW("CONTACT::WearInterface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -355,7 +354,6 @@ namespace Wear
         return wmdofmap_;
       else
         FOUR_C_THROW("CONTACT::WearInterface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -368,7 +366,6 @@ namespace Wear
         return sndofmap_;
       else
         FOUR_C_THROW("CONTACT::WearInterface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -381,7 +378,6 @@ namespace Wear
         return mndofmap_;
       else
         FOUR_C_THROW("CONTACT::WearInterface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -394,7 +390,6 @@ namespace Wear
         return activmasternodes_;
       else
         FOUR_C_THROW("CONTACT::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -407,7 +402,6 @@ namespace Wear
         return slipmasternodes_;
       else
         FOUR_C_THROW("CONTACT::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -420,7 +414,6 @@ namespace Wear
         return slipmn_;
       else
         FOUR_C_THROW("CONTACT::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
 

--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -107,7 +107,7 @@ namespace Core::Communication
               printf("Try again!\n");
             }
             MPI_Finalize();
-            exit(1);
+            exit(EXIT_FAILURE);
           }
         }
         // case without given group layout
@@ -130,7 +130,7 @@ namespace Core::Communication
               printf("Try again!\n");
             }
             MPI_Finalize();
-            exit(1);
+            exit(EXIT_FAILURE);
           }
 
           // equal size of the groups
@@ -196,7 +196,7 @@ namespace Core::Communication
             printf("Try again!\n");
           }
           MPI_Finalize();
-          exit(1);
+          exit(EXIT_FAILURE);
         }
       }
 
@@ -216,7 +216,7 @@ namespace Core::Communication
             argument.c_str());
         printf("Please refer to ./4C --help and try again!\n");
         MPI_Finalize();
-        exit(1);
+        exit(EXIT_FAILURE);
       }
 
     }  // end for(int i=0; i<int(conf.size()); i++)
@@ -233,7 +233,7 @@ namespace Core::Communication
         printf("Try again!\n");
       }
       MPI_Finalize();
-      exit(1);
+      exit(EXIT_FAILURE);
     }
 
     // do the splitting of the communicator
@@ -317,7 +317,7 @@ namespace Core::Communication
     // if GPID is not part of the current group
     printf("\n\n\nERROR: GPID (%d) is not in this group (%d) \n\n\n\n", GPID, group_id_);
     MPI_Abort(gcomm_, EXIT_FAILURE);
-    exit(1);
+    exit(EXIT_FAILURE);
 
     return -1;
   }

--- a/src/core/fem/src/general/nurbs/4C_fem_general_utils_nurbs_shapefunctions.hpp
+++ b/src/core/fem/src/general/nurbs/4C_fem_general_utils_nurbs_shapefunctions.hpp
@@ -3857,7 +3857,6 @@ namespace Core::FE::Nurbs
       }
       default:
         FOUR_C_THROW("dimension of the element is not correct");
-        exit(EXIT_FAILURE);
     }
   }
 
@@ -3886,7 +3885,6 @@ namespace Core::FE::Nurbs
       }
       default:
         FOUR_C_THROW("dimension of the element is not correct");
-        exit(EXIT_FAILURE);
     }
   }
 
@@ -3913,7 +3911,6 @@ namespace Core::FE::Nurbs
       }
       default:
         FOUR_C_THROW("dimension of the element is not correct");
-        exit(EXIT_FAILURE);
     }
   }
 

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_local_connectivity_matrices.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_local_connectivity_matrices.hpp
@@ -1303,7 +1303,6 @@ namespace Core::FE
       {
         FOUR_C_THROW(
             "discretization type {} not yet implemented", Core::FE::cell_type_to_string(distype));
-        exit(EXIT_FAILURE);
       }
     }
     return pos;

--- a/src/core/fem/src/geometry/4C_fem_geometry_element_volume.hpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_element_volume.hpp
@@ -190,7 +190,6 @@ namespace Core::Geo
         return element_area_t<Core::FE::CellType::quad9>(xyze);
       default:
         FOUR_C_THROW("Unsupported surface element type!");
-        exit(EXIT_FAILURE);
     }
 
     return -1.0;

--- a/src/core/utils/src/stl_extension/4C_utils_pairedobj_insert_policy.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_pairedobj_insert_policy.hpp
@@ -219,8 +219,6 @@ namespace Core::Gen
         if (it->first == k) return it;
         ++it;
       }
-
-      exit(EXIT_FAILURE);
     }
 
     /** @brief Quick linear search routine (const version)
@@ -250,8 +248,6 @@ namespace Core::Gen
         if (cit->first == k) return cit;
         ++cit;
       }
-
-      exit(EXIT_FAILURE);
     }
 
     /** @brief repetitive access of the paired_vector entries in the same order

--- a/src/cut/4C_cut_boundarycell.cpp
+++ b/src/cut/4C_cut_boundarycell.cpp
@@ -467,7 +467,6 @@ void Cut::Quad4BoundaryCell::element_center(Core::LinAlg::Matrix<3, 1>& midpoint
 Core::LinAlg::Matrix<3, 1> Cut::Point1BoundaryCell::get_normal_vector()
 {
   FOUR_C_THROW("There is no normal for Point1 boundarycell");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -487,7 +486,6 @@ Core::LinAlg::Matrix<3, 1> Cut::Line2BoundaryCell::get_normal_vector()
 Core::LinAlg::Matrix<3, 1> Cut::Tri3BoundaryCell::get_normal_vector()
 {
   FOUR_C_THROW("Call Transform function to get normal for Tri3 boundarycell");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -495,7 +493,6 @@ Core::LinAlg::Matrix<3, 1> Cut::Tri3BoundaryCell::get_normal_vector()
 Core::LinAlg::Matrix<3, 1> Cut::Quad4BoundaryCell::get_normal_vector()
 {
   FOUR_C_THROW("Call Transform function to get normal for Quad4 boundarycell");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/cut/4C_cut_elementhandle.cpp
+++ b/src/cut/4C_cut_elementhandle.cpp
@@ -96,7 +96,6 @@ void Cut::ElementHandle::volume_cell_gauss_points(
       {
         FOUR_C_THROW("non supported element integration type for given volume-cell {}",
             vc->parent_element()->get_element_integration_type());
-        exit(EXIT_FAILURE);
       }
     }
 
@@ -190,7 +189,6 @@ void Cut::ElementHandle::append_volume_cell_gauss_points_tessellation(
       default:
         FOUR_C_THROW("unsupported integration cell type ( cell type = {} )",
             Core::FE::cell_type_to_string(ic->shape()));
-        exit(EXIT_FAILURE);
     }
   }
 }
@@ -323,7 +321,6 @@ std::shared_ptr<Core::FE::GaussPointsComposite> Cut::ElementHandle::gauss_points
           default:
             FOUR_C_THROW("unsupported integration cell type ( cell type = {} )",
                 Core::FE::cell_type_to_string(ic->shape()));
-            exit(EXIT_FAILURE);
         }
       }
     }

--- a/src/cut/4C_cut_facet_integration.cpp
+++ b/src/cut/4C_cut_facet_integration.cpp
@@ -281,7 +281,6 @@ std::vector<double> Cut::FacetIntegration::compute_alpha(
   else
   {
     FOUR_C_THROW("The facet integration type undefined");
-    exit(1);
   }
   return alfa;
 }
@@ -428,7 +427,6 @@ double Cut::FacetIntegration::integrate_facet()
     if (projType != Cut::proj_x and projType != Cut::proj_y and projType != Cut::proj_z)
     {
       FOUR_C_THROW("projection plane is not defined");
-      exit(1);
     }
 
     boundary_facet_integration(cornersLocal, facet_integ, projType);
@@ -527,7 +525,6 @@ void Cut::FacetIntegration::boundary_facet_integration(
     else
     {
       FOUR_C_THROW("The facet integration type not supported");
-      exit(1);
     }
   }
 
@@ -911,7 +908,6 @@ void Cut::FacetIntegration::divergence_integration_rule_new(
         default:
           FOUR_C_THROW("unsupported integration cell type ( cell type = {} )",
               Core::FE::cell_type_to_string(bcell->shape()));
-          exit(EXIT_FAILURE);
       }
       double wei = iquad.weight() * drs * normalX;
 

--- a/src/cut/4C_cut_integrationcell.cpp
+++ b/src/cut/4C_cut_integrationcell.cpp
@@ -109,7 +109,6 @@ int Cut::Hex8IntegrationCell::cubature_degree(Core::FE::CellType elementshape) c
       return 6;
     default:
       FOUR_C_THROW("no rule defined for this element type");
-      exit(EXIT_FAILURE);
   }
 }
 
@@ -137,7 +136,6 @@ int Cut::Tet4IntegrationCell::cubature_degree(Core::FE::CellType elementshape) c
       return 6;
     default:
       FOUR_C_THROW("no rule defined for this element type");
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/cut/4C_cut_integrationcellcreator.cpp
+++ b/src/cut/4C_cut_integrationcellcreator.cpp
@@ -59,7 +59,6 @@ bool Cut::IntegrationCellCreator::create_cells(
       }
       default:
         FOUR_C_THROW("Wrong element dimension! ( element dim = {} )", element->n_dim());
-        exit(EXIT_FAILURE);
     }
 
     // pyramids are not save right now.
@@ -112,7 +111,6 @@ bool Cut::IntegrationCellCreator::create_cell(
     default:
       FOUR_C_THROW(
           "unsupported element shape ( shape = {} )", Core::FE::cell_type_to_string(shape));
-      exit(EXIT_FAILURE);
   }
   // if the create process was successful, we can finally create the integration cell
   if (success)
@@ -176,7 +174,6 @@ void Cut::IntegrationCellCreator::add_side(Cut::BoundaryCellPosition bcell_posit
     default:
     {
       FOUR_C_THROW("Unknown boundary creation position type! ( enum = {} )", bcell_position);
-      exit(EXIT_FAILURE);
     }
   }
 }
@@ -379,7 +376,6 @@ bool Cut::IntegrationCellCreator::create_tet4_cell(
   else
   {
     FOUR_C_THROW("This cannot happen!");
-    exit(EXIT_FAILURE);
   }
 }
 

--- a/src/cut/4C_cut_intersection.cpp
+++ b/src/cut/4C_cut_intersection.cpp
@@ -188,11 +188,8 @@ bool Cut::Intersection<probdim, edgetype, sidetype, debug, dimedge, dimside, num
           "The given side element type is currently unsupported! \n"
           "( dim = {} | sideType = {} ",
           dimside, Core::FE::cell_type_to_string(sidetype).c_str());
-      exit(EXIT_FAILURE);
     }
   }
-  // this cannot be reached
-  exit(EXIT_FAILURE);
 }
 
 /*--------------------------------------------------------------------------*
@@ -1404,7 +1401,6 @@ std::shared_ptr<Cut::IntersectionBase> Cut::IntersectionFactory::create_intersec
           Core::FE::cell_type_to_string(edge_type).c_str());
       break;
   }
-  exit(EXIT_FAILURE);
 }
 
 

--- a/src/cut/4C_cut_intersection.hpp
+++ b/src/cut/4C_cut_intersection.hpp
@@ -63,7 +63,6 @@ namespace Cut
       default:
         return "Unknown IntersectionStatus";
     }
-    exit(EXIT_FAILURE);
   };
 
   inline IntersectionStatus intersection_status2_enum(unsigned num_cut_points)
@@ -77,7 +76,6 @@ namespace Cut
       default:
         return intersect_multiple_cut_points;
     }
-    exit(EXIT_FAILURE);
   }
 
   /*--------------------------------------------------------------------------*/
@@ -301,7 +299,6 @@ namespace Cut
     {
       if (mesh_ptr_ != nullptr) return *mesh_ptr_;
       FOUR_C_THROW("The mesh pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
     /// get a pointer to the mesh object
@@ -309,7 +306,6 @@ namespace Cut
     {
       if (mesh_ptr_ != nullptr) return mesh_ptr_;
       FOUR_C_THROW("The mesh pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
     /// get a reference to the edge object
@@ -317,7 +313,6 @@ namespace Cut
     {
       if (edge_ptr_ != nullptr) return *edge_ptr_;
       FOUR_C_THROW("The edge pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
     /// get a pointer to the edge object
@@ -325,7 +320,6 @@ namespace Cut
     {
       if (edge_ptr_ != nullptr) return edge_ptr_;
       FOUR_C_THROW("The edge pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
     /// get a reference to the side object
@@ -333,7 +327,6 @@ namespace Cut
     {
       if (side_ptr_ != nullptr) return *side_ptr_;
       FOUR_C_THROW("The side pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
     /// get a pointer to the side object
@@ -341,7 +334,6 @@ namespace Cut
     {
       if (side_ptr_ != nullptr) return side_ptr_;
       FOUR_C_THROW("The side pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
     /// get a pointer to the cut options object
@@ -349,7 +341,6 @@ namespace Cut
     {
       if (options_ptr_ != nullptr) return options_ptr_;
       FOUR_C_THROW("The option pointer is not yet initialized!");
-      exit(EXIT_FAILURE);
     }
 
    private:
@@ -1336,9 +1327,7 @@ namespace Cut
               "Unsupported SideType! If meaningful, add your sideType here. \n"
               "Given SideType = {}",
               Core::FE::cell_type_to_string(side_type).c_str());
-          exit(EXIT_FAILURE);
       }
-      exit(EXIT_FAILURE);
     }
 
     template <Core::FE::CellType edge_type, Core::FE::CellType side_type>
@@ -1355,7 +1344,6 @@ namespace Cut
           break;
         default:
           FOUR_C_THROW("Unsupported ProbDim! ( probdim = {} )", probdim);
-          exit(EXIT_FAILURE);
       }
       return inter_ptr;
     };

--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -794,9 +794,7 @@ namespace Cut::Kernel
         return "FAILED";
       default:
         FOUR_C_THROW("Unknown Newton status!");
-        exit(EXIT_FAILURE);
     }
-    exit(EXIT_FAILURE);
   }
 
   /*--------------------------------------------------------------------------*/
@@ -1900,9 +1898,7 @@ namespace Cut::Kernel
               distance_[0] * distance_[0] + distance_[1] * distance_[1]);
         default:
           FOUR_C_THROW("Unsupported probDim and dimSide combination!");
-          exit(EXIT_FAILURE);
       }
-      exit(EXIT_FAILURE);
     }
 
     /// return the signed distance of the point px_ to the given side
@@ -2183,7 +2179,6 @@ namespace Cut::Kernel
         return normal_in_yz_plane;
 
       FOUR_C_THROW("Couldn't detect a feasible plane for the given normal vector!");
-      exit(EXIT_FAILURE);
     }
 
     /** \build Build the linear system of equations for the Newton scheme
@@ -2307,7 +2302,6 @@ namespace Cut::Kernel
           default:
           {
             FOUR_C_THROW("Shouldn't happen!");
-            exit(EXIT_FAILURE);
           }
         }
 
@@ -2568,7 +2562,6 @@ namespace Cut::Kernel
               break;
             default:
               FOUR_C_THROW("A scalar signed distance value is not available!");
-              exit(EXIT_FAILURE);
           }
         }
         std::pair<bool, Core::CLN::ClnWrapper> cond_pair = this->condition_number();
@@ -2968,7 +2961,6 @@ namespace Cut::Kernel
             break;
           default:
             FOUR_C_THROW("A scalar signed distance value is not available!");
-            exit(EXIT_FAILURE);
         }
       }
       bool got_topology_info = get_topology_information();

--- a/src/cut/4C_cut_levelsetside.hpp
+++ b/src/cut/4C_cut_levelsetside.hpp
@@ -43,7 +43,6 @@ namespace Cut
       FOUR_C_THROW(
           "No dimension information for level set sides. It's "
           "likely that you can't call the calling function for level-set sides!");
-      exit(EXIT_FAILURE);
     }
 
     /// problem dimension
@@ -55,14 +54,12 @@ namespace Cut
       FOUR_C_THROW(
           "No number of nodes information for level set sides. It's "
           "likely that you can't call the calling function for level-set sides!");
-      exit(EXIT_FAILURE);
     }
 
     /// \brief Returns the topology data for the side from Shards library
     const CellTopologyData* topology() const override
     {
       FOUR_C_THROW("No topology data for level-set sides!");
-      exit(EXIT_FAILURE);
     }
 
     /** Get the cut points between the levelset side and the specified edge */
@@ -89,7 +86,6 @@ namespace Cut
     bool is_closer_side(const double* startpoint_xyz, Cut::Side* other, bool& is_closer) override
     {
       FOUR_C_THROW("no is_closer_side routine for level set cut side");
-      exit(EXIT_FAILURE);
     }
 
     /*! \brief Returns the global coordinates of the nodes of this side */
@@ -119,13 +115,11 @@ namespace Cut
     bool within_side(const double* xyz, double* rs, double& dist) override
     {
       FOUR_C_THROW("no WithinSide check implemented");
-      exit(EXIT_FAILURE);
     }
 
     bool ray_cut(const double* p1_xyz, const double* p2_xyz, double* rs, double& line_xi) override
     {
       FOUR_C_THROW("no RayCut with level set cut side implemented");
-      exit(EXIT_FAILURE);
     }
 
     /*! \brief Calculates the local coordinates (rsd) with respect to the element shape
@@ -136,7 +130,6 @@ namespace Cut
         const double* xyz, double* rst, bool allow_dist = false, double tol = POSITIONTOL) override
     {
       FOUR_C_THROW("no local coordinates on level set cut side");
-      exit(EXIT_FAILURE);
     }
 
     /*! \brief get local coordinates (rst) with respect to the element shape

--- a/src/cut/4C_cut_line_integration.cpp
+++ b/src/cut/4C_cut_line_integration.cpp
@@ -1387,7 +1387,6 @@ namespace
     }
 
     FOUR_C_THROW("The base function for boundarycell integration undefined");
-    exit(1);
     return 0.0;
   }
 
@@ -1960,7 +1959,6 @@ namespace
       return basef_surf;
     }
     FOUR_C_THROW("The base function for boundarycell integration undefined");
-    exit(1);
     return 0.0;
   }
 
@@ -2528,7 +2526,6 @@ namespace
       return basef_surf;
     }
     FOUR_C_THROW("The base function for boundarycell integration undefined");
-    exit(1);
     return 0.0;
   }
 }  // namespace

--- a/src/cut/4C_cut_mesh.cpp
+++ b/src/cut/4C_cut_mesh.cpp
@@ -81,7 +81,6 @@ Cut::Element* Cut::Mesh::create_element(
       return create_wedge6(eid, nids);
     default:
       FOUR_C_THROW("unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
   return nullptr;
 }
@@ -100,7 +99,6 @@ Cut::Side* Cut::Mesh::create_side(int sid, const std::vector<int>& nids, Core::F
       return create_tri3_side(sid, nids);
     default:
       FOUR_C_THROW("unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
   return nullptr;
 }
@@ -2647,9 +2645,7 @@ Cut::Element* Cut::Mesh::get_element(
       return get_element<3>(eid, nodes, top_data, active);
     default:
       FOUR_C_THROW("Element dimension out of range! ( dim = {} )", top_data.dimension);
-      exit(EXIT_FAILURE);
   }
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/cut/4C_cut_meshhandle.cpp
+++ b/src/cut/4C_cut_meshhandle.cpp
@@ -81,7 +81,6 @@ Cut::SideHandle* Cut::MeshHandle::create_side(
       default:
         FOUR_C_THROW(
             "unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-        exit(EXIT_FAILURE);
     }
     quadraticsides_[sid] = std::shared_ptr<QuadraticSideHandle>(qsh);
     return qsh;
@@ -89,7 +88,6 @@ Cut::SideHandle* Cut::MeshHandle::create_side(
   else
   {
     FOUR_C_THROW("unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-    exit(EXIT_FAILURE);
   }
 }
 
@@ -695,7 +693,6 @@ void Cut::MeshHandle::create_element_sides(const std::vector<int>& nids, Core::F
     }
     default:
       FOUR_C_THROW("unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
 }
 
@@ -771,7 +768,6 @@ Cut::ElementHandle* Cut::MeshHandle::create_element(
         default:
           FOUR_C_THROW(
               "unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-          exit(EXIT_FAILURE);
       }
       quadraticelements_[eid] = std::shared_ptr<QuadraticElementHandle>(qeh);
       create_element_sides(nids, distype);
@@ -779,7 +775,6 @@ Cut::ElementHandle* Cut::MeshHandle::create_element(
     }
     default:
       FOUR_C_THROW("unsupported distype ( distype = {} )", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/cut/4C_cut_output.cpp
+++ b/src/cut/4C_cut_output.cpp
@@ -141,10 +141,8 @@ char Cut::Output::gmsh_element_type(Core::FE::CellType shape)
     }
     default:
       FOUR_C_THROW("Unsupported cell shape! ( shape = {} )", Core::FE::cell_type_to_string(shape));
-      exit(EXIT_FAILURE);
   }
   // impossible to reach this point
-  exit(EXIT_FAILURE);
 }
 
 /*--------------------------------------------------------------------------------------*
@@ -252,7 +250,6 @@ void Cut::Output::gmsh_side_dump(std::ofstream& file, const Side* s, bool to_loc
       std::stringstream str;
       str << "unknown element type in gmsh_side_dump for " << nodes.size() << " nodes!";
       FOUR_C_THROW("{}", str.str());
-      exit(EXIT_FAILURE);
   }
   gmsh_element_dump(file, nodes, elementtype, to_local, ele);
 }
@@ -277,7 +274,6 @@ void Cut::Output::gmsh_tri_side_dump(
       std::stringstream str;
       str << "unknown element type in GmshTriSideDump for " << points.size() << " points!";
       FOUR_C_THROW("{}", str.str());
-      exit(EXIT_FAILURE);
     }
   }
 

--- a/src/cut/4C_cut_pointgraph.cpp
+++ b/src/cut/4C_cut_pointgraph.cpp
@@ -1151,7 +1151,6 @@ std::shared_ptr<Cut::Impl::PointGraph::Graph> Cut::Impl::PointGraph::create_grap
       return std::make_shared<PointGraph::Graph>();
     default:
       FOUR_C_THROW("Unsupported element dimension!");
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/cut/4C_cut_pointpool.hpp
+++ b/src/cut/4C_cut_pointpool.hpp
@@ -178,11 +178,9 @@ namespace Cut
               x, cut_edge, cut_side, get_tolerance(x, tolerance), merge_strategy_);
         default:
           FOUR_C_THROW("Unsupported problem dimension! (probdim = {})", probdim_);
-          exit(EXIT_FAILURE);
       }
 
       FOUR_C_THROW("Impossible to reach this line!");
-      exit(EXIT_FAILURE);
     }
 
     /// get the pointer to a stored point if possible

--- a/src/cut/4C_cut_position.cpp
+++ b/src/cut/4C_cut_position.cpp
@@ -304,10 +304,7 @@ std::shared_ptr<Cut::Position> Cut::PositionFactory::create_position(
       return create_concrete_position<Core::FE::CellType::wedge6>(element, point, floattype);
     default:
       FOUR_C_THROW("Unsupported distype = {}", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
-
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -343,10 +340,7 @@ std::shared_ptr<Cut::Position> Cut::PositionFactory::create_position(
       return create_concrete_position<Core::FE::CellType::wedge6>(element, xyz, floattype);
     default:
       FOUR_C_THROW("Unsupported distype = {}", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
-
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -380,10 +374,7 @@ std::shared_ptr<Cut::Position> Cut::PositionFactory::create_position(const doubl
       return create_concrete_position<Core::FE::CellType::wedge6>(xyze, xyz, floattype);
     default:
       FOUR_C_THROW("Unsupported distype = {}", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
-
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -428,10 +419,7 @@ std::shared_ptr<Cut::Position> Cut::PositionFactory::create_position(
       return create_concrete_position<Core::FE::CellType::wedge6>(nodes, xyz, floattype);
     default:
       FOUR_C_THROW("Unsupported distype = {}", Core::FE::cell_type_to_string(distype));
-      exit(EXIT_FAILURE);
   }
-
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/cut/4C_cut_position.hpp
+++ b/src/cut/4C_cut_position.hpp
@@ -66,7 +66,6 @@ namespace Cut
         default:
           return "Unknown PositionStatus";
       }
-      exit(EXIT_FAILURE);
     };
 
    public:
@@ -169,11 +168,7 @@ namespace Cut
 
     /*! \brief Return the scalar signed perpendicular distance between
      *         given point and embedded element */
-    virtual double distance() const
-    {
-      FOUR_C_THROW("Unsupported for the standard case!");
-      exit(EXIT_FAILURE);
-    }
+    virtual double distance() const { FOUR_C_THROW("Unsupported for the standard case!"); }
 
     /*! \brief Return the signed perpendicular distance vector between
      *         given point and embedded element.
@@ -211,7 +206,6 @@ namespace Cut
     virtual bool within_limits_tol(const double& Tol, const bool& allow_dist) const
     {
       FOUR_C_THROW("Unsupported for the standard case!");
-      exit(EXIT_FAILURE);
     }
 
    protected:
@@ -483,7 +477,6 @@ namespace Cut
           return xsi_aug_(dim, 0);
         default:
           FOUR_C_THROW("A scalar signed distance value is not available!");
-          exit(EXIT_FAILURE);
       }
     }
 
@@ -611,7 +604,6 @@ namespace Cut
         FOUR_C_THROW(
             "Wrong template combination: ProbDim must be unequal"
             " element Dim for the embedded case.");
-        exit(EXIT_FAILURE);
       }
     };
 
@@ -625,7 +617,6 @@ namespace Cut
         FOUR_C_THROW(
             "Wrong template combination: ProbDim must be larger"
             " than the element Dim for the embedded case.");
-        exit(EXIT_FAILURE);
       }
     };
 
@@ -639,7 +630,6 @@ namespace Cut
         FOUR_C_THROW(
             "Wrong template combination: ProbDim must be larger"
             " than the element Dim for the embedded case.");
-        exit(EXIT_FAILURE);
       }
     };
 
@@ -653,7 +643,6 @@ namespace Cut
         FOUR_C_THROW(
             "Wrong template combination: ProbDim must be larger"
             " than the element Dim for the embedded case.");
-        exit(EXIT_FAILURE);
       }
     };
 
@@ -668,7 +657,6 @@ namespace Cut
         FOUR_C_THROW(
             "Wrong template combination: ProbDim must be equal"
             " element Dim for the standard case.");
-        exit(EXIT_FAILURE);
       }
     };
 
@@ -771,8 +759,6 @@ namespace Cut
             "The element dimension is larger than the problem dimension! \n"
             "dim = {}, probdim = {}",
             dim, probdim);
-
-      exit(EXIT_FAILURE);
     }
 
     /// concrete create variant #1
@@ -795,10 +781,7 @@ namespace Cut
           return build_position<3, eletype>(element, point, floattype);
         default:
           FOUR_C_THROW("Unsupported problem dimension! (probdim = {})", probdim_);
-          exit(EXIT_FAILURE);
       }
-
-      exit(EXIT_FAILURE);
     }
 
     /// @}
@@ -837,8 +820,6 @@ namespace Cut
             "The element dimension is larger than the problem dimension! \n"
             "dim = {}, probdim = {}",
             dim, probdim);
-
-      exit(EXIT_FAILURE);
     }
 
    private:
@@ -868,10 +849,7 @@ namespace Cut
         }
         default:
           FOUR_C_THROW("Unsupported problem dimension! (probdim = {})", probdim_);
-          exit(EXIT_FAILURE);
       }
-
-      exit(EXIT_FAILURE);
     }
 
     /// @}
@@ -907,8 +885,6 @@ namespace Cut
             "The element dimension is larger than the problem dimension! \n"
             "dim = {}, probdim = {}",
             dim, probdim);
-
-      exit(EXIT_FAILURE);
     }
 
    private:
@@ -934,10 +910,7 @@ namespace Cut
         }
         default:
           FOUR_C_THROW("Unsupported problem dimension! (probdim = {})", probdim_);
-          exit(EXIT_FAILURE);
       }
-
-      exit(EXIT_FAILURE);
     }
 
     /// @}
@@ -985,8 +958,6 @@ namespace Cut
             "The element dimension is larger than the problem dimension! \n"
             "dim = {}, probdim = {}",
             dim, probdim);
-
-      exit(EXIT_FAILURE);
     }
 
    private:
@@ -1009,10 +980,7 @@ namespace Cut
         }
         default:
           FOUR_C_THROW("Unsupported problem dimension! (probdim = {})", probdim_);
-          exit(EXIT_FAILURE);
       }
-
-      exit(EXIT_FAILURE);
     }
 
     /// @}

--- a/src/cut/4C_cut_side.cpp
+++ b/src/cut/4C_cut_side.cpp
@@ -152,7 +152,6 @@ bool Cut::Side::find_cut_lines(Mesh& mesh, Element* element, Side& other)
   }
 
   FOUR_C_THROW("How did you get here?");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -1382,10 +1381,8 @@ unsigned Cut::Side::uncut_facet_number_per_side() const
       return 2;
     default:
       FOUR_C_THROW("Unsupported parent element dimension! (ele->Dim() = {} )", ele_dim);
-      exit(EXIT_FAILURE);
   }
   // can never be reached
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -1798,7 +1795,6 @@ bool Cut::ConcreteSide<probdim, sidetype, num_nodes_side, dim>::local_coordinate
       FOUR_C_THROW(
           "Unsupported dim / probdim combination. I think this can't happen "
           "for side elements. If I'm wrong, just ask me. -- hiermeier");
-      exit(EXIT_FAILURE);
     }
     /* For a 1-D and a 2-D problem, the side dimension is equal to the problem
      * dimension */

--- a/src/cut/4C_cut_side.hpp
+++ b/src/cut/4C_cut_side.hpp
@@ -699,7 +699,6 @@ namespace Cut
           FOUR_C_THROW("Unknown sidetype! ({})\n", Core::FE::cell_type_to_string(sidetype));
           break;
       }
-      exit(EXIT_FAILURE);
     }
 
     /// Calculates the points at which the side is cut by this edge
@@ -812,7 +811,6 @@ namespace Cut
         default:
         {
           FOUR_C_THROW("Unknown/unsupported side type!");
-          exit(EXIT_FAILURE);
         }
       }
     }

--- a/src/cut/4C_cut_utils.hpp
+++ b/src/cut/4C_cut_utils.hpp
@@ -454,7 +454,6 @@ namespace Cut
       default:
         FOUR_C_THROW("Currently unsupported discretization type: {}",
             Core::FE::cell_type_to_string(distype));
-        exit(EXIT_FAILURE);
     }
   }
 }  // namespace Cut

--- a/src/cut/4C_cut_volume_integration.cpp
+++ b/src/cut/4C_cut_volume_integration.cpp
@@ -93,7 +93,6 @@ Core::LinAlg::SerialDenseVector Cut::VolumeIntegration::compute_rhs_moment()
     default:
       FOUR_C_THROW("unsupported integration cell type ( cell type = {} )",
           Core::FE::cell_type_to_string(elem1_->shape()));
-      exit(EXIT_FAILURE);
   }
   volcell_->set_volume(volGlobal);
 

--- a/src/cut/4C_cut_volumecell.cpp
+++ b/src/cut/4C_cut_volumecell.cpp
@@ -420,7 +420,6 @@ void Cut::VolumeCell::new_boundary_cell(
       break;
     default:
       FOUR_C_THROW("Unsupported shape ( shape = {} )", Core::FE::cell_type_to_string(shape));
-      exit(EXIT_FAILURE);
   }
 }
 
@@ -538,7 +537,6 @@ void Cut::VolumeCell::new_integration_cell(
       break;
     default:
       FOUR_C_THROW("Unsupported shape ( shape = {} )", Core::FE::cell_type_to_string(shape));
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/fluid/4C_fluid_coupling_red_models.cpp
+++ b/src/fluid/4C_fluid_coupling_red_models.cpp
@@ -521,7 +521,6 @@ void FLD::Utils::FluidCouplingWrapperBase::apply_boundary_conditions(
       FOUR_C_THROW(
           "Reduced-dimensional problem, returned a value of type [{}] at the condition ({})",
           ReturnedVariable.c_str(), ID);
-      exit(0);
     }
   }
   return;
@@ -1212,7 +1211,6 @@ void FLD::Utils::FluidCouplingBc::evaluate_dirichlet(
           if ((velnp)[lid] > 1.0)
           {
             FOUR_C_THROW("coupled 3D/Reduced-D must have Dirichlet BC = 1");
-            exit(1);
           }
           std::cout << "[" << dof_gid << "]\t|" << val << "\t<-<" << (velnp)[lid] << "|\t";
           velnp.replace_global_values(1, &val, &dof_gid);
@@ -1221,7 +1219,6 @@ void FLD::Utils::FluidCouplingBc::evaluate_dirichlet(
     }
     std::cout << std::endl;
   }
-  //  exit(1);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -46,7 +46,6 @@ FLD::Utils::FluidVolumetricSurfaceFlowWrapper::FluidVolumetricSurfaceFlowWrapper
   if (num_of_wom_conds != num_of_borders)
   {
     FOUR_C_THROW("Each Womersley surface condition must have one and only one border condition");
-    exit(0);
   }
   // Check if each surface has it's corresponding border
   for (unsigned int i = 0; i < womersleycond.size(); i++)
@@ -72,7 +71,6 @@ FLD::Utils::FluidVolumetricSurfaceFlowWrapper::FluidVolumetricSurfaceFlowWrapper
           FOUR_C_THROW(
               "There are more than one Womersley condition lines with the same ID. This can not "
               "yet be handled.");
-          exit(0);
         }
         ConditionIsWrong = false;
         break;
@@ -83,7 +81,6 @@ FLD::Utils::FluidVolumetricSurfaceFlowWrapper::FluidVolumetricSurfaceFlowWrapper
     if (ConditionIsWrong)
     {
       FOUR_C_THROW("Each Womersley surface condition must have one and only one border condition");
-      exit(1);
     }
   }
 
@@ -237,7 +234,6 @@ FLD::Utils::FluidVolumetricSurfaceFlowBc::FluidVolumetricSurfaceFlowBc(
   else
   {
     FOUR_C_THROW("[{}]: is not a defined normal evaluation type", normal_info);
-    exit(1);
   }
 
   // get the center of mass
@@ -265,7 +261,6 @@ FLD::Utils::FluidVolumetricSurfaceFlowBc::FluidVolumetricSurfaceFlowBc(
   else
   {
     FOUR_C_THROW("[{}]: is not a defined center-of-mass evaluation type", normal_info);
-    exit(1);
   }
 
 
@@ -282,7 +277,6 @@ FLD::Utils::FluidVolumetricSurfaceFlowBc::FluidVolumetricSurfaceFlowBc(
   else
   {
     FOUR_C_THROW("[{}]: is not a defined flow-direction-type", normal_info);
-    exit(1);
   }
 
   // check if the flow is with correction
@@ -456,7 +450,6 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::eval_local_normalized_radii(
     if (!inserted)
     {
       FOUR_C_THROW("There are more than one node of the same number. something went wrong");
-      exit(0);
     }
   }
 
@@ -1799,7 +1792,6 @@ FLD::Utils::TotalTractionCorrector::TotalTractionCorrector(
   if (num_of_tr_conds != num_of_borders)
   {
     FOUR_C_THROW("Each Womersley surface condition must have one and only one border condition");
-    exit(0);
   }
   // Check if each surface has it's corresponding border
   for (unsigned int i = 0; i < tractioncond.size(); i++)
@@ -1826,7 +1818,6 @@ FLD::Utils::TotalTractionCorrector::TotalTractionCorrector(
           FOUR_C_THROW(
               "There are more than one impedance condition lines with the same ID. This can not "
               "yet be handled.");
-          exit(0);
         }
 
         ConditionIsWrong = false;
@@ -1840,7 +1831,6 @@ FLD::Utils::TotalTractionCorrector::TotalTractionCorrector(
       FOUR_C_THROW(
           "Each Total traction correction surface condition must have one and only one border "
           "condition");
-      exit(1);
     }
   }
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -41,7 +41,6 @@ namespace Inpar
           return "ConstDisVelAccPres";
         default:
           FOUR_C_THROW("Cannot make std::string for predictor {}", name);
-          exit(EXIT_FAILURE);
       }
     }
 

--- a/src/levelset/4C_levelset_algorithm_reinit.cpp
+++ b/src/levelset/4C_levelset_algorithm_reinit.cpp
@@ -382,7 +382,6 @@ void ScaTra::LevelSetAlgorithm::calc_node_based_reinit_vel()
         default:
         {
           FOUR_C_THROW("Unknown reinitialization method for projection!");
-          exit(EXIT_FAILURE);
         }
       }
       // call loop over elements

--- a/src/levelset/4C_levelset_intersection_utils.cpp
+++ b/src/levelset/4C_levelset_intersection_utils.cpp
@@ -317,7 +317,6 @@ void ScaTra::LevelSet::Intersection::prepare_cut(const Core::Elements::Element* 
           break;
         default:
           FOUR_C_THROW("Unsupported problem dimension! (probdim = {})", probdim);
-          exit(EXIT_FAILURE);
       }
       break;
     default:

--- a/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
+++ b/src/mat/elast/4C_mat_elast_couptransverselyisotropic.cpp
@@ -101,7 +101,6 @@ void Mat::Elastic::CoupTransverselyIsotropic::setup(
     default:
     {
       FOUR_C_THROW("INIT mode not implemented");
-      exit(EXIT_FAILURE);
     }
   }
 }

--- a/src/mixture/4C_mixture_constituent_remodelfiber_lib.cpp
+++ b/src/mixture/4C_mixture_constituent_remodelfiber_lib.cpp
@@ -50,8 +50,5 @@ Mixture::PAR::fiber_material_factory(int matid)
           "The referenced material with id {} is not registered as a remodel fiber material!",
           matid);
   }
-
-  // we will not end up here, so make the compiler happy
-  std::exit(1);
 }
 FOUR_C_NAMESPACE_CLOSE

--- a/src/mixture/4C_mixture_constituent_remodelfiber_material.hpp
+++ b/src/mixture/4C_mixture_constituent_remodelfiber_material.hpp
@@ -34,7 +34,6 @@ namespace Mixture
       std::shared_ptr<Core::Mat::Material> create_material() override
       {
         FOUR_C_THROW("This type of material is not created with create_material()");
-        std::exit(1);
       }
 
       [[nodiscard]] virtual std::unique_ptr<Mixture::RemodelFiberMaterial<T>>

--- a/src/mortar/4C_mortar_calc_utils.hpp
+++ b/src/mortar/4C_mortar_calc_utils.hpp
@@ -109,7 +109,6 @@ namespace Mortar
             default:
             {
               FOUR_C_THROW("Wrong Dimension");
-              exit(EXIT_FAILURE);
             }
           }
 
@@ -261,7 +260,6 @@ namespace Mortar
             default:
             {
               FOUR_C_THROW("Wrong Dimension");
-              exit(EXIT_FAILURE);
             }
           }
 
@@ -286,7 +284,6 @@ namespace Mortar
         default:
         {
           FOUR_C_THROW("ERROR: Invalid interpolation type requested, only 0,1,2!");
-          exit(EXIT_FAILURE);
         }
       }
       return true;

--- a/src/mortar/4C_mortar_element.cpp
+++ b/src/mortar/4C_mortar_element.cpp
@@ -558,7 +558,6 @@ bool Mortar::Element::local_coordinates_of_node(int lid, double* xi) const
     // unknown case
     default:
       FOUR_C_THROW("local_coordinates_of_node called for unknown element type");
-      exit(EXIT_FAILURE);
   }
   return true;
 }
@@ -909,7 +908,6 @@ void Mortar::Element::metrics(const double* xi, double* gxi, double* geta) const
     }
     default:
       FOUR_C_THROW("Metrics called for unknown element type");
-      exit(EXIT_FAILURE);
   }
 
   Core::LinAlg::SerialDenseVector val(nnodes);
@@ -1065,7 +1063,6 @@ void Mortar::Element::deriv_jacobian(
     }
     default:
       FOUR_C_THROW("Jac. derivative not implemented for this type of Element");
-      exit(EXIT_FAILURE);
   }
 
   // *********************************************************************

--- a/src/mortar/4C_mortar_interface.hpp
+++ b/src/mortar/4C_mortar_interface.hpp
@@ -784,7 +784,6 @@ namespace Mortar
         return oldnodecolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -796,7 +795,6 @@ namespace Mortar
         return oldelecolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -808,7 +806,6 @@ namespace Mortar
         return snoderowmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -832,7 +829,6 @@ namespace Mortar
         return mnoderowmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -856,7 +852,6 @@ namespace Mortar
         return snodecolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -868,7 +863,6 @@ namespace Mortar
         return mnodecolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -880,7 +874,6 @@ namespace Mortar
         return snoderowmapbound_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -892,7 +885,6 @@ namespace Mortar
         return snodecolmapbound_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -904,7 +896,6 @@ namespace Mortar
         return mnoderowmapnobound_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -916,7 +907,6 @@ namespace Mortar
         return mnodecolmapnobound_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -928,7 +918,6 @@ namespace Mortar
         return selerowmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -940,7 +929,6 @@ namespace Mortar
         return melerowmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -952,7 +940,6 @@ namespace Mortar
         return selecolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -964,7 +951,6 @@ namespace Mortar
         return melecolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -976,7 +962,6 @@ namespace Mortar
         return sdofrowmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -988,7 +973,6 @@ namespace Mortar
         return sdofcolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -1012,7 +996,6 @@ namespace Mortar
         return mdofrowmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -1024,7 +1007,6 @@ namespace Mortar
         return mdofcolmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!
@@ -1048,7 +1030,6 @@ namespace Mortar
         return lmdofmap_;
       else
         FOUR_C_THROW("Mortar::Interface::fill_complete was not called");
-      exit(EXIT_FAILURE);  // calm down the compiler
     }
 
     /*!

--- a/src/post/4C_post_common.cpp
+++ b/src/post/4C_post_common.cpp
@@ -79,13 +79,13 @@ PostProblem::PostProblem(Teuchos::CommandLineProcessor& CLP, int argc, char** ar
 
   if (parseReturn != Teuchos::CommandLineProcessor::PARSE_SUCCESSFUL)
   {
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 
   if (file == "")
   {
     CLP.printHelpMessage(argv[0], std::cout);
-    exit(1);
+    exit(EXIT_FAILURE);
   }
 
   if (file.length() <= 8 or file.substr(file.length() - 8, 8) != ".control")

--- a/src/post/4C_post_vtk_vtu_writer.cpp
+++ b/src/post/4C_post_vtk_vtu_writer.cpp
@@ -568,7 +568,6 @@ void PostVtuWriter::write_geo_nurbs_ele(const Core::Elements::Element* ele,
     }
     default:
       FOUR_C_THROW("VTK output not yet implemented for given NURBS element");
-      exit(EXIT_FAILURE);
   }
 
   return;
@@ -658,7 +657,6 @@ Core::FE::CellType PostVtuWriter::map_nurbs_dis_type_to_lagrange_dis_type(
       return Core::FE::CellType::hex27;
     default:
       FOUR_C_THROW("No known mapping from NURBS to Lagrange.");
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -108,7 +108,6 @@ void sysmat(Discret::Elements::RedAcinus* ele, Core::LinAlg::SerialDenseVector& 
   else
   {
     FOUR_C_THROW("Material law is not a valid reduced dimensional lung acinus material.");
-    exit(1);
   }
 }
 
@@ -338,7 +337,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           else
           {
             FOUR_C_THROW("no boundary condition defined!");
-            exit(1);
           }
 
           // Get factor of FUNCT
@@ -367,7 +365,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
         }
         /**
@@ -388,7 +385,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             FOUR_C_THROW(
                 "Cannot prescribe a boundary condition from 3D to reduced D, if the parameters "
                 "passed don't exist");
-            exit(1);
           }
 
           // -----------------------------------------------------------------
@@ -474,7 +470,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           else
           {
             FOUR_C_THROW("no boundary condition defined!");
-            exit(1);
           }
 
           // Get the local id of the node to whom the bc is prescribed
@@ -483,7 +478,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
         }
         else
@@ -625,7 +619,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
         else
         {
           FOUR_C_THROW("prescribed [{}] is not defined for reduced acinuss", Bc);
-          exit(1);
         }
       }
       /**
@@ -642,7 +635,6 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
 
           Discret::ReducedLung::EvaluationData& evaluation_data =
@@ -847,7 +839,6 @@ void Discret::Elements::AcinusImpl<distype>::get_coupled_values(RedAcinus* ele,
           FOUR_C_THROW(
               "Cannot prescribe a boundary condition from 3D to reduced D, if the parameters "
               "passed don't exist");
-          exit(1);
         }
 
 
@@ -892,7 +883,6 @@ void Discret::Elements::AcinusImpl<distype>::get_coupled_values(RedAcinus* ele,
         {
           std::string str = (condition->parameters().get<std::string>("ReturnedVariable"));
           FOUR_C_THROW("{}, is an unimplemented type of coupling", str);
-          exit(1);
         }
         std::stringstream returnedBCwithId;
         returnedBCwithId << returnedBC << "_" << ID;
@@ -913,7 +903,6 @@ void Discret::Elements::AcinusImpl<distype>::get_coupled_values(RedAcinus* ele,
         {
           FOUR_C_THROW(
               "The 3D map for (1D - 3D coupling) has no variable ({}) for ID [{}]", returnedBC, ID);
-          exit(1);
         }
 
         // update the 1D map

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -166,7 +166,6 @@ namespace
     else
     {
       FOUR_C_THROW("Material law is not a Newtonian fluid");
-      exit(1);
     }
 
     rhs.putScalar(0.0);
@@ -504,7 +503,6 @@ namespace
     else
     {
       FOUR_C_THROW("[{}] is not an implemented element yet", (ele->type()));
-      exit(1);
     }
 
     double Ainv = -0.5 * C / (dt + Rvis * C);
@@ -929,7 +927,6 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
                   "FUNCTION {} has to take either value 0.0 or 1.0. Not clear if flow or pressure "
                   "boundary condition should be active.",
                   (funct_id_switch - 1));
-              exit(1);
             }
 
             BCin = Global::Problem::instance()
@@ -992,7 +989,6 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
         }
         else if (ele->nodes()[i]->get_condition("Art_redD_3D_CouplingCond"))
@@ -1010,7 +1006,6 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
             FOUR_C_THROW(
                 "Cannot prescribe a boundary condition from 3D to reduced D, if the parameters "
                 "passed don't exist");
-            exit(1);
           }
 
           // -----------------------------------------------------------------
@@ -1094,7 +1089,6 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
         else
         {
           FOUR_C_THROW("precribed [{}] is not defined for reduced airways", Bc);
-          exit(1);
         }
       }
       else
@@ -1114,7 +1108,6 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
 
           // set pressure at node i
@@ -1370,7 +1363,6 @@ void Discret::Elements::AirwayImpl<distype>::get_coupled_values(RedAirway* ele,
           FOUR_C_THROW(
               "Cannot prescribe a boundary condition from 3D to reduced D, if the parameters "
               "passed don't exist");
-          exit(1);
         }
 
 
@@ -1415,7 +1407,6 @@ void Discret::Elements::AirwayImpl<distype>::get_coupled_values(RedAirway* ele,
         {
           std::string str = (condition->parameters().get<std::string>("ReturnedVariable"));
           FOUR_C_THROW("{}, is an unimplemented type of coupling", str);
-          exit(1);
         }
         std::stringstream returnedBCwithId;
         returnedBCwithId << returnedBC << "_" << ID;
@@ -1434,7 +1425,6 @@ void Discret::Elements::AirwayImpl<distype>::get_coupled_values(RedAirway* ele,
         {
           FOUR_C_THROW(
               "The 3D map for (1D - 3D coupling) has no variable ({}) for ID [{}]", returnedBC, ID);
-          exit(1);
         }
 
         // update the 1D map

--- a/src/red_airways/4C_red_airways_interacinardep.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep.cpp
@@ -206,7 +206,6 @@ void Discret::Elements::RedInterAcinarDep::get_params(std::string name, double& 
   if (it == elem_params_.end())
   {
     FOUR_C_THROW("[{}] is not found with in the element variables", name);
-    exit(1);
   }
   var = elem_params_[name];
 }
@@ -224,7 +223,6 @@ void Discret::Elements::RedInterAcinarDep::get_params(std::string name, int& var
   else
   {
     FOUR_C_THROW("[{}] is not found with in the element INT variables", name);
-    exit(1);
   }
 }
 

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -216,7 +216,6 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           else
           {
             FOUR_C_THROW("no boundary condition defined!");
-            exit(1);
           }
           // Get factor of FUNCT
           double functionfac = 0.0;
@@ -244,7 +243,6 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
         }
         else
@@ -370,7 +368,6 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
         else
         {
           FOUR_C_THROW("Prescribed [{}] is not defined for reduced-inter-acinar linkers", Bc);
-          exit(1);
         }
       }
       /**
@@ -387,7 +384,6 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
           {
             FOUR_C_THROW("node ({}) doesn't exist on proc({})", ele->nodes()[i]->id(),
                 Core::Communication::my_mpi_rank(discretization.get_comm()));
-            exit(1);
           }
 
           Discret::ReducedLung::EvaluationData& evaluation_data =

--- a/src/scatra_ele/4C_scatra_ele_calc_lsreinit.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_lsreinit.cpp
@@ -201,13 +201,11 @@ void Discret::Elements::ScaTraEleCalcLsReinit<distype, prob_dim>::eval_reinitial
         }
         default:
           FOUR_C_THROW("Unsupported action!");
-          exit(EXIT_FAILURE);
       }
       break;
     }
     default:
       FOUR_C_THROW("Unsupported reinitialization equation for the embedded case!");
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -178,7 +178,6 @@ Core::LinAlg::SerialDenseMatrix Discret::Elements::SolidType::compute_null_space
           "The null space computation of a solid element of dimension {} is not yet implemented",
           numdof);
   }
-  exit(1);
 }
 
 Discret::Elements::Solid::Solid(int id, int owner) : Core::Elements::Element(id, owner) {}

--- a/src/solid_3D_ele/4C_solid_3D_ele_surface_evaluate.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_surface_evaluate.cpp
@@ -1398,7 +1398,6 @@ void Discret::Elements::SolidSurface::compute_area_deriv(const Core::LinAlg::Ser
         else
         {
           FOUR_C_THROW("calculation of second derivatives of interfacial area failed");
-          exit(1);
         }
 
         for (int j = 0; j < ndof; ++j)

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
@@ -102,7 +102,6 @@ NOX::Nln::LinSystem::LinearSystemType NOX::Nln::Aux::get_linear_system_type(
       FOUR_C_THROW(
           "There is no capable linear system type for the given linear "
           "solver combination! ( 1 linear solver )");
-      exit(EXIT_FAILURE);
     }
     case 2:
     {
@@ -153,7 +152,6 @@ NOX::Nln::LinSystem::LinearSystemType NOX::Nln::Aux::get_linear_system_type(
       FOUR_C_THROW(
           "There is no capable linear system type for the given linear "
           "solver combination!");
-      exit(EXIT_FAILURE);
     }
   }
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_enum_lists.hpp
@@ -53,7 +53,6 @@ namespace NOX
         default:
           return "Unknown Solution Type";
       }
-      exit(EXIT_FAILURE);
     };
 
     //! Map quantity std::string to enum
@@ -109,7 +108,6 @@ namespace NOX
         default:
           return "Unknown second order correction Type";
       }
-      exit(EXIT_FAILURE);
     };
 
     namespace LinSystem
@@ -173,7 +171,6 @@ namespace NOX
           default:
             return "unknown operator type";
         }
-        exit(EXIT_FAILURE);
       };
     }  // namespace LinSystem
 
@@ -302,7 +299,6 @@ namespace NOX
           default:
             return "unknown quantity type";
         }
-        exit(EXIT_FAILURE);
       };
 
       /// Map std::string to quantity type

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_interface_required.hpp
@@ -76,7 +76,6 @@ namespace NOX
             const enum NOX::Nln::MeritFunction::LinType lintype) const
         {
           FOUR_C_THROW("Not implemented!");
-          exit(EXIT_FAILURE);
         }
 
         //! calculate characteristic/reference norms for forces

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -695,7 +695,6 @@ const Core::LinAlg::SparseMatrix& NOX::Nln::LinearSystem::get_jacobian_block(
     {
       FOUR_C_THROW("Unsupported LinSystem::OperatorType: {}",
           NOX::Nln::LinSystem::operator_type_to_string(jacType_));
-      exit(EXIT_FAILURE);
     }
   }
 }
@@ -767,7 +766,6 @@ double NOX::Nln::LinearSystem::compute_serial_condition_number_of_jacobian(
       break;
     default:
       FOUR_C_THROW("Unsupported");
-      exit(EXIT_FAILURE);
   }
   double rcond = 0.0;
 
@@ -881,7 +879,6 @@ void NOX::Nln::LinearSystem::convert_jacobian_to_dense_matrix(
     default:
     {
       FOUR_C_THROW("Unsupported jacobian operator type!");
-      exit(EXIT_FAILURE);
     }
   }
 }

--- a/src/ssti/4C_ssti_utils.cpp
+++ b/src/ssti/4C_ssti_utils.cpp
@@ -478,7 +478,7 @@ SSTI::ConvCheckMono::ConvCheckMono(Teuchos::ParameterList params)
  *---------------------------------------------------------------------------------*/
 bool SSTI::ConvCheckMono::converged(const SSTI::SSTIMono& ssti_mono)
 {
-  bool exit(false);
+  bool is_converged(false);
 
   // compute L2 norm of concentration state vector
   double concdofnorm(0.0);
@@ -649,18 +649,18 @@ bool SSTI::ConvCheckMono::converged(const SSTI::SSTIMono& ssti_mono)
         potincnorm / potdofnorm <= itertol_ and structureincnorm / structuredofnorm <= itertol_ and
         thermoincnorm / thermodofnorm <= itertol_)
       // exit Newton-Raphson iteration upon convergence
-      exit = true;
+      is_converged = true;
   }
 
   // exit Newton-Raphson iteration when residuals are small enough to prevent unnecessary additional
   // solver calls
   if (concresnorm < restol_ and potresnorm < restol_ and structureresnorm < restol_ and
       thermoresnorm < restol_)
-    exit = true;
+    is_converged = true;
 
   // print warning to screen if maximum number of Newton-Raphson iterations is reached without
   // convergence
-  if (ssti_mono.newton_iteration() == itermax_ and !exit)
+  if (ssti_mono.newton_iteration() == itermax_ and !is_converged)
   {
     if (Core::Communication::my_mpi_rank(ssti_mono.get_comm()) == 0)
     {
@@ -674,10 +674,10 @@ bool SSTI::ConvCheckMono::converged(const SSTI::SSTIMono& ssti_mono)
     }
 
     // proceed to next time step
-    exit = true;
+    is_converged = true;
   }
 
-  return exit;
+  return is_converged;
 }
 
 /*---------------------------------------------------------------------------------*

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -1326,8 +1326,7 @@ const std::shared_ptr<const Core::LinAlg::Map>& STI::Monolithic::dof_row_map() c
  *--------------------------------------------------------------------------------*/
 bool STI::Monolithic::exit_newton_raphson()
 {
-  // initialize exit flag
-  bool exit(false);
+  bool is_converged(false);
 
   // perform Newton-Raphson convergence check depending on type of scalar transport
   switch (
@@ -1457,16 +1456,17 @@ bool STI::Monolithic::exit_newton_raphson()
             concincnorm / concdofnorm <= itertol_ and potincnorm / potdofnorm <= itertol_ and
             thermoincnorm / thermodofnorm <= itertol_)
           // exit Newton-Raphson iteration upon convergence
-          exit = true;
+          is_converged = true;
       }
 
       // exit Newton-Raphson iteration when residuals are small enough to prevent unnecessary
       // additional solver calls
-      if (concresnorm < restol_ and potresnorm < restol_ and thermoresnorm < restol_) exit = true;
+      if (concresnorm < restol_ and potresnorm < restol_ and thermoresnorm < restol_)
+        is_converged = true;
 
       // print warning to screen if maximum number of Newton-Raphson iterations is reached without
       // convergence
-      if (iter_ == itermax_ and !exit)
+      if (iter_ == itermax_ and !is_converged)
       {
         if (Core::Communication::my_mpi_rank(get_comm()) == 0)
         {
@@ -1480,11 +1480,11 @@ bool STI::Monolithic::exit_newton_raphson()
         }
 
         // proceed to next time step
-        exit = true;
+        is_converged = true;
       }
 
       // print finish line of convergence table to screen
-      if (exit and Core::Communication::my_mpi_rank(get_comm()) == 0)
+      if (is_converged and Core::Communication::my_mpi_rank(get_comm()) == 0)
       {
         std::cout << "+------------+-------------------+--------------+--------------+-------------"
                      "-+--------------+--------------+--------------+"
@@ -1502,7 +1502,7 @@ bool STI::Monolithic::exit_newton_raphson()
     }
   }
 
-  return exit;
+  return is_converged;
 }  // STI::Monolithic::exit_newton_raphson()
 
 /*--------------------------------------------------------------------------------*

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -917,7 +917,6 @@ namespace Solid
     Solid::ModelEvaluator::Generic& model_evaluator(Inpar::Solid::ModelType mtype) override
     {
       FOUR_C_THROW("new time integration only");
-      exit(EXIT_FAILURE);
     }
 
     /*!

--- a/src/structure_new/src/4C_structure_new_enum_lists.hpp
+++ b/src/structure_new/src/4C_structure_new_enum_lists.hpp
@@ -55,7 +55,6 @@ namespace Solid
       default:
         return "unknown_type_of_energy";
     }
-    exit(EXIT_FAILURE);
   };
 
   //! Map std::string to energy type
@@ -79,7 +78,6 @@ namespace Solid
       return beam_to_sphere_link_kinetic_energy;
     else
       FOUR_C_THROW("Unknown type of energy {}", type);
-    exit(EXIT_FAILURE);
   };
 
 

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -367,7 +367,6 @@ double Solid::Integrator::get_model_value(const Core::LinAlg::Vector<double>& x)
   FOUR_C_THROW(
       "This routine is not supported in the currently active time "
       "integration scheme.");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -780,7 +779,6 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Solid::Integrator::MidTimeEn
     }
     default:
       FOUR_C_THROW("Don't know what to do for the given MidAvg type.");
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -929,7 +929,6 @@ Solid::TimeInt::BaseDataGlobalState::extract_model_block(Core::LinAlg::SparseOpe
   FOUR_C_THROW(
       "The jacobian has the wrong type! (no Core::LinAlg::SparseMatrix "
       "and no Core::LinAlg::BlockSparseMatrix)");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -985,7 +984,6 @@ Solid::TimeInt::BaseDataGlobalState::extract_row_of_blocks(
   FOUR_C_THROW(
       "The jacobian has the wrong type! (no Core::LinAlg::SparseMatrix "
       "and no Core::LinAlg::BlockSparseMatrix)");
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -1077,7 +1075,6 @@ int Solid::TimeInt::BaseDataGlobalState::get_nln_iteration_number(const unsigned
   }
 
   FOUR_C_THROW("There is no nonlinear iteration number for the given step {}.", step);
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -177,7 +177,6 @@ bool Solid::IMPLICIT::Generic::apply_correction_system(const enum NOX::Nln::Corr
           "No action defined for the given second order correction type: "
           "\"{}\"",
           NOX::Nln::correction_type_to_string(type).c_str());
-      exit(EXIT_FAILURE);
     }
   }
 

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -526,7 +526,6 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
     {
       FOUR_C_THROW("Unsupported NOX::Nln::LinSystem::OperatorType: \"{}\"",
           NOX::Nln::LinSystem::operator_type_to_string(jac_type));
-      exit(EXIT_FAILURE);
     }
   }
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -595,7 +595,6 @@ std::shared_ptr<Core::LinAlg::Vector<double>> Solid::ModelEvaluator::Structure::
       break;
     default:
       FOUR_C_THROW("Unknown mass linearization type!");
-      exit(EXIT_FAILURE);
   }
 
   return nullptr;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -451,7 +451,6 @@ double Solid::TimeInt::NoxInterface::get_model_value(const Epetra_Vector& x, con
     {
       FOUR_C_THROW("There is no objective model value for {}.",
           NOX::Nln::MeritFunction::merit_func_name_to_string(merit_func_type));
-      exit(EXIT_FAILURE);
     }
   }
 
@@ -474,7 +473,6 @@ double Solid::TimeInt::NoxInterface::get_linearized_model_terms(const ::NOX::Abs
     {
       FOUR_C_THROW("There is no linearization for the objective model {}.",
           NOX::Nln::MeritFunction::merit_func_name_to_string(mf_type));
-      exit(EXIT_FAILURE);
     }
   }
 }

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -100,7 +100,6 @@ int Solid::MonitorDbc::get_unique_id(int tagged_id, Core::Conditions::GeometryTy
       return tagged_id + 10000;
     default:
       FOUR_C_THROW("Unsupported geometry type! (enum={})", gtype);
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
@@ -541,7 +541,6 @@ void Solid::ResultTest::test_special(const Core::IO::InputParameterContainer& co
     {
       FOUR_C_THROW(
           "Solid::ResultTest::test_special: Undefined status type (enum={})!", special_status);
-      exit(EXIT_FAILURE);
     }
   }
 }
@@ -578,8 +577,6 @@ std::optional<double> Solid::ResultTest::get_special_result(
         "Quantity '{}' not supported by special result testing functionality "
         "for structure field!",
         quantity.c_str());
-
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*
@@ -686,7 +683,6 @@ int Solid::get_integer_number_at_last_position_of_name(const std::string& quanti
         "The correct format is:\n"
         "\"<prefix_name>_<number>\"");
   }
-  exit(EXIT_FAILURE);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -48,7 +48,6 @@ NOX::Nln::LinSystem::ConditionNumber Solid::Nln::convert2_nox_condition_number_t
       return NOX::Nln::LinSystem::ConditionNumber::inf_norm;
     default:
       FOUR_C_THROW("No known conversion.");
-      exit(EXIT_FAILURE);
   }
 }
 

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -1080,10 +1080,7 @@ std::shared_ptr<const Core::LinAlg::Map> XFEM::MultiFieldMapExtractor::node_row_
     }
     default:
       FOUR_C_THROW("Unknown block type!");
-      exit(EXIT_FAILURE);
   }
-  // hoops, shouldn't happen ...
-  exit(EXIT_FAILURE);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -233,7 +233,6 @@ void XFEM::XFieldField::Coupling::build_dof_maps(const Core::FE::Discretization&
           "per node is unknown or cannot be identified, since it \n"
           "changes from node to node. This case needs extra \n"
           "communication effort and is currently unsupported.");
-      exit(EXIT_FAILURE);
     }
   }
 }


### PR DESCRIPTION
Most calls to `exit()` were introduced to help the compiler back when `dserror` was not `[[noreturn]]`. This is nowadays unnecessary. 