### PR TITLE
Refactor the preconditioner reuse logic

### DIFF
--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -44,12 +44,9 @@ std::shared_ptr<Epetra_Operator> Core::LinearSolver::AmGnxnPreconditioner::prec_
 /*------------------------------------------------------------------------------*/
 /*------------------------------------------------------------------------------*/
 
-void Core::LinearSolver::AmGnxnPreconditioner::setup(bool create, Epetra_Operator* matrix,
+void Core::LinearSolver::AmGnxnPreconditioner::setup(Epetra_Operator* matrix,
     Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
 {
-  // Decide if the setup has to be done
-  if (!create) return;
-
   // Check whether this is a block sparse matrix
   Core::LinAlg::BlockSparseMatrixBase* A_bl =
       dynamic_cast<Core::LinAlg::BlockSparseMatrixBase*>(matrix);
@@ -59,8 +56,6 @@ void Core::LinearSolver::AmGnxnPreconditioner::setup(bool create, Epetra_Operato
 
   // Do all the setup
   setup(Core::Utils::shared_ptr_from_ref(*A_bl));
-
-  return;
 }
 
 /*------------------------------------------------------------------------------*/

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.hpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.hpp
@@ -35,7 +35,7 @@ namespace Core::LinearSolver
    public:
     AmGnxnPreconditioner(Teuchos::ParameterList& params);
 
-    void setup(bool create, Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
+    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
         Core::LinAlg::MultiVector<double>* b) override;
 
     virtual void setup(std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> A);

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
@@ -62,7 +62,7 @@ void Core::LinearSolver::IterativeSolver<MatrixType, VectorType>::setup(
   x_ = x;
   b_ = b;
 
-  preconditioner_->setup(create, a_.get(), x_.get(), b_.get());
+  if (create) preconditioner_->setup(a_.get(), x_.get(), b_.get());
 }
 
 //----------------------------------------------------------------------------------

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.cpp
@@ -18,50 +18,42 @@ Core::LinearSolver::IFPACKPreconditioner::IFPACKPreconditioner(
     Teuchos::ParameterList& ifpacklist, Teuchos::ParameterList& solverlist)
     : ifpacklist_(ifpacklist), solverlist_(solverlist)
 {
-  return;
 }
 
 //------------------------------------------------------------------------------
 //------------------------------------------------------------------------------
-void Core::LinearSolver::IFPACKPreconditioner::setup(bool create, Epetra_Operator* matrix,
+void Core::LinearSolver::IFPACKPreconditioner::setup(Epetra_Operator* matrix,
     Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
 {
-  if (create)
+  std::shared_ptr<Epetra_CrsMatrix> A_crs =
+      std::dynamic_pointer_cast<Epetra_CrsMatrix>(Core::Utils::shared_ptr_from_ref(*matrix));
+
+  if (!A_crs)
   {
-    std::shared_ptr<Epetra_CrsMatrix> A_crs =
-        std::dynamic_pointer_cast<Epetra_CrsMatrix>(Core::Utils::shared_ptr_from_ref(*matrix));
+    std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> A =
+        std::dynamic_pointer_cast<Core::LinAlg::BlockSparseMatrixBase>(
+            Core::Utils::shared_ptr_from_ref(*matrix));
 
-    if (!A_crs)
-    {
-      std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> A =
-          std::dynamic_pointer_cast<Core::LinAlg::BlockSparseMatrixBase>(
-              Core::Utils::shared_ptr_from_ref(*matrix));
-
-      std::cout
-          << "\n WARNING: IFPACK preconditioner is merging matrix, this is very expensive! \n";
-      A_crs = A->merge()->epetra_matrix();
-    }
-
-    pmatrix_ = std::make_shared<Epetra_CrsMatrix>(*A_crs);
-
-    // get the type of ifpack preconditioner from solver parameter list
-    std::string prectype = solverlist_.get("Preconditioner Type", "ILU");
-    const int overlap = ifpacklist_.get("IFPACKOVERLAP", 0);
-
-    // create the preconditioner
-    Ifpack Factory;
-    prec_ =
-        std::shared_ptr<Ifpack_Preconditioner>(Factory.Create(prectype, pmatrix_.get(), overlap));
-
-    if (!prec_) FOUR_C_THROW("Creation of IFPACK preconditioner of type '{}' failed.", prectype);
-
-    // setup
-    prec_->SetParameters(ifpacklist_);
-    prec_->Initialize();
-    prec_->Compute();
-
-    return;
+    std::cout << "\n WARNING: IFPACK preconditioner is merging matrix, this is very expensive! \n";
+    A_crs = A->merge()->epetra_matrix();
   }
+
+  pmatrix_ = std::make_shared<Epetra_CrsMatrix>(*A_crs);
+
+  // get the type of ifpack preconditioner from solver parameter list
+  std::string prectype = solverlist_.get("Preconditioner Type", "ILU");
+  const int overlap = ifpacklist_.get("IFPACKOVERLAP", 0);
+
+  // create the preconditioner
+  Ifpack Factory;
+  prec_ = std::shared_ptr<Ifpack_Preconditioner>(Factory.Create(prectype, pmatrix_.get(), overlap));
+
+  if (!prec_) FOUR_C_THROW("Creation of IFPACK preconditioner of type '{}' failed.", prectype);
+
+  // setup
+  prec_->SetParameters(ifpacklist_);
+  prec_->Initialize();
+  prec_->Compute();
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.hpp
@@ -29,7 +29,7 @@ namespace Core::LinearSolver
     IFPACKPreconditioner(Teuchos::ParameterList& ifpacklist, Teuchos::ParameterList& solverlist);
 
     //! Setup
-    void setup(bool create, Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
+    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
         Core::LinAlg::MultiVector<double>* b) override;
 
     /// linear operator used for preconditioning

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.cpp
@@ -22,13 +22,13 @@ Core::LinearSolver::KrylovProjectionPreconditioner::KrylovProjectionPrecondition
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::KrylovProjectionPreconditioner::setup(bool create, Epetra_Operator* matrix,
+void Core::LinearSolver::KrylovProjectionPreconditioner::setup(Epetra_Operator* matrix,
     Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
 {
   projector_->apply_pt(*b);
 
   // setup wrapped preconditioner
-  preconditioner_->setup(create, matrix, x, b);
+  preconditioner_->setup(matrix, x, b);
 
   // Wrap the linear operator of the contained preconditioner. This way the
   // actual preconditioner is called first and the projection is done

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.hpp
@@ -30,7 +30,7 @@ namespace Core::LinearSolver
     KrylovProjectionPreconditioner(std::shared_ptr<PreconditionerTypeBase> preconditioner,
         std::shared_ptr<Core::LinAlg::KrylovProjector> projector);
 
-    void setup(bool create, Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
+    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
         Core::LinAlg::MultiVector<double>* b) override;
 
     /// linear operator used for preconditioning

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
@@ -49,151 +49,145 @@ Core::LinearSolver::MueLuPreconditioner::MueLuPreconditioner(Teuchos::ParameterL
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::MueLuPreconditioner::setup(bool create, Epetra_Operator* matrix,
+void Core::LinearSolver::MueLuPreconditioner::setup(Epetra_Operator* matrix,
     Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
 {
-  if (create)
+  using EpetraCrsMatrix = Xpetra::EpetraCrsMatrixT<GO, NO>;
+  using EpetraMap = Xpetra::EpetraMapT<GO, NO>;
+  using EpetraMultiVector = Xpetra::EpetraMultiVectorT<GO, NO>;
+
+  Teuchos::RCP<Core::LinAlg::BlockSparseMatrixBase> A =
+      Teuchos::rcp_dynamic_cast<Core::LinAlg::BlockSparseMatrixBase>(Teuchos::rcpFromRef(*matrix));
+
+  if (A.is_null())
   {
-    using EpetraCrsMatrix = Xpetra::EpetraCrsMatrixT<GO, NO>;
-    using EpetraMap = Xpetra::EpetraMapT<GO, NO>;
-    using EpetraMultiVector = Xpetra::EpetraMultiVectorT<GO, NO>;
+    Teuchos::RCP<Epetra_CrsMatrix> crsA =
+        Teuchos::rcp_dynamic_cast<Epetra_CrsMatrix>(Teuchos::rcpFromRef(*matrix));
 
-    Teuchos::RCP<Core::LinAlg::BlockSparseMatrixBase> A =
-        Teuchos::rcp_dynamic_cast<Core::LinAlg::BlockSparseMatrixBase>(
-            Teuchos::rcpFromRef(*matrix));
+    Teuchos::RCP<Xpetra::CrsMatrix<SC, LO, GO, NO>> mueluA =
+        Teuchos::make_rcp<EpetraCrsMatrix>(crsA);
+    pmatrix_ = Xpetra::MatrixFactory<SC, LO, GO, NO>::BuildCopy(
+        Teuchos::make_rcp<Xpetra::CrsMatrixWrap<SC, LO, GO, NO>>(mueluA));
 
-    if (A.is_null())
+    const Teuchos::ParameterList& inverseList = muelulist_.sublist("MueLu Parameters");
+
+    auto xmlFileName = inverseList.get<std::string>("MUELU_XML_FILE");
+
+    auto muelu_params = Teuchos::make_rcp<Teuchos::ParameterList>();
+    auto comm = pmatrix_->getRowMap()->getComm();
+    Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, muelu_params.ptr(), *comm);
+
+    const int number_of_equations = inverseList.get<int>("PDE equations");
+    pmatrix_->SetFixedBlockSize(number_of_equations);
+
+    Teuchos::RCP<const Xpetra::Map<LO, GO, NO>> row_map = mueluA->getRowMap();
+    Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> nullspace =
+        Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist(*row_map, inverseList);
+
+    Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> coordinates =
+        Teuchos::make_rcp<EpetraMultiVector>(Teuchos::rcpFromRef(
+            *inverseList.get<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("Coordinates")
+                ->get_ptr_of_Epetra_MultiVector()));
+
+    muelu_params->set("number of equations", number_of_equations);
+    Teuchos::ParameterList& user_param_list = muelu_params->sublist("user data");
+    user_param_list.set("Nullspace", nullspace);
+    user_param_list.set("Coordinates", coordinates);
+
+    H_ = MueLu::CreateXpetraPreconditioner(pmatrix_, *muelu_params);
+    P_ = Teuchos::make_rcp<MueLu::EpetraOperator>(H_);
+  }
+  else
+  {
+    std::vector<Teuchos::RCP<const Xpetra::Map<LO, GO, NO>>> maps;
+
+    for (int block = 0; block < A->rows(); block++)
     {
-      Teuchos::RCP<Epetra_CrsMatrix> crsA =
-          Teuchos::rcp_dynamic_cast<Epetra_CrsMatrix>(Teuchos::rcpFromRef(*matrix));
+      Teuchos::RCP<Xpetra::CrsMatrix<SC, LO, GO, NO>> crsA =
+          Teuchos::make_rcp<EpetraCrsMatrix>(Teuchos::rcp(A->matrix(block, block).epetra_matrix()));
 
-      Teuchos::RCP<Xpetra::CrsMatrix<SC, LO, GO, NO>> mueluA =
-          Teuchos::make_rcp<EpetraCrsMatrix>(crsA);
-      pmatrix_ = Xpetra::MatrixFactory<SC, LO, GO, NO>::BuildCopy(
-          Teuchos::make_rcp<Xpetra::CrsMatrixWrap<SC, LO, GO, NO>>(mueluA));
-
-      const Teuchos::ParameterList& inverseList = muelulist_.sublist("MueLu Parameters");
-
-      auto xmlFileName = inverseList.get<std::string>("MUELU_XML_FILE");
-
-      auto muelu_params = Teuchos::make_rcp<Teuchos::ParameterList>();
-      auto comm = pmatrix_->getRowMap()->getComm();
-      Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, muelu_params.ptr(), *comm);
-
+      const std::string inverse = "Inverse" + std::to_string(block + 1);
+      const Teuchos::ParameterList& inverseList =
+          muelulist_.sublist(inverse).sublist("MueLu Parameters");
       const int number_of_equations = inverseList.get<int>("PDE equations");
-      pmatrix_->SetFixedBlockSize(number_of_equations);
 
-      Teuchos::RCP<const Xpetra::Map<LO, GO, NO>> row_map = mueluA->getRowMap();
-      Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> nullspace =
-          Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist(
-              *row_map, inverseList);
+      std::vector<size_t> striding;
+      striding.emplace_back(number_of_equations);
 
-      Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> coordinates =
-          Teuchos::make_rcp<EpetraMultiVector>(Teuchos::rcpFromRef(
-              *inverseList.get<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("Coordinates")
-                  ->get_ptr_of_Epetra_MultiVector()));
+      Teuchos::RCP<const Xpetra::StridedMap<LO, GO, NO>> map =
+          Teuchos::make_rcp<Xpetra::StridedMap<LO, GO, NO>>(crsA->getRowMap()->lib(),
+              crsA->getRowMap()->getGlobalNumElements(), crsA->getRowMap()->getLocalElementList(),
+              crsA->getRowMap()->getIndexBase(), striding, crsA->getRowMap()->getComm(), -1);
 
-      muelu_params->set("number of equations", number_of_equations);
-      Teuchos::ParameterList& user_param_list = muelu_params->sublist("user data");
-      user_param_list.set("Nullspace", nullspace);
-      user_param_list.set("Coordinates", coordinates);
-
-      H_ = MueLu::CreateXpetraPreconditioner(pmatrix_, *muelu_params);
-      P_ = Teuchos::make_rcp<MueLu::EpetraOperator>(H_);
+      maps.emplace_back(map);
     }
-    else
-    {
-      std::vector<Teuchos::RCP<const Xpetra::Map<LO, GO, NO>>> maps;
 
-      for (int block = 0; block < A->rows(); block++)
+    Teuchos::RCP<const Xpetra::Map<LO, GO, NO>> fullrangemap =
+        Xpetra::MapUtils<LO, GO, NO>::concatenateMaps(maps);
+
+    Teuchos::RCP<const Xpetra::MapExtractor<SC, LO, GO, NO>> map_extractor =
+        Xpetra::MapExtractorFactory<SC, LO, GO, NO>::Build(fullrangemap, maps);
+
+    auto bOp = Teuchos::make_rcp<Xpetra::BlockedCrsMatrix<SC, LO, GO, NO>>(
+        map_extractor, map_extractor, 42);
+
+    for (int row = 0; row < A->rows(); row++)
+    {
+      for (int col = 0; col < A->cols(); col++)
       {
         Teuchos::RCP<Xpetra::CrsMatrix<SC, LO, GO, NO>> crsA = Teuchos::make_rcp<EpetraCrsMatrix>(
-            Teuchos::rcp(A->matrix(block, block).epetra_matrix()));
-
-        const std::string inverse = "Inverse" + std::to_string(block + 1);
-        const Teuchos::ParameterList& inverseList =
-            muelulist_.sublist(inverse).sublist("MueLu Parameters");
-        const int number_of_equations = inverseList.get<int>("PDE equations");
-
-        std::vector<size_t> striding;
-        striding.emplace_back(number_of_equations);
-
-        Teuchos::RCP<const Xpetra::StridedMap<LO, GO, NO>> map =
-            Teuchos::make_rcp<Xpetra::StridedMap<LO, GO, NO>>(crsA->getRowMap()->lib(),
-                crsA->getRowMap()->getGlobalNumElements(), crsA->getRowMap()->getLocalElementList(),
-                crsA->getRowMap()->getIndexBase(), striding, crsA->getRowMap()->getComm(), -1);
-
-        maps.emplace_back(map);
+            Teuchos::rcpFromRef(*A->matrix(row, col).epetra_matrix()));
+        Teuchos::RCP<Xpetra::Matrix<SC, LO, GO, NO>> mat =
+            Xpetra::MatrixFactory<SC, LO, GO, NO>::BuildCopy(
+                Teuchos::make_rcp<Xpetra::CrsMatrixWrap<SC, LO, GO, NO>>(crsA));
+        bOp->setMatrix(row, col, mat);
       }
-
-      Teuchos::RCP<const Xpetra::Map<LO, GO, NO>> fullrangemap =
-          Xpetra::MapUtils<LO, GO, NO>::concatenateMaps(maps);
-
-      Teuchos::RCP<const Xpetra::MapExtractor<SC, LO, GO, NO>> map_extractor =
-          Xpetra::MapExtractorFactory<SC, LO, GO, NO>::Build(fullrangemap, maps);
-
-      auto bOp = Teuchos::make_rcp<Xpetra::BlockedCrsMatrix<SC, LO, GO, NO>>(
-          map_extractor, map_extractor, 42);
-
-      for (int row = 0; row < A->rows(); row++)
-      {
-        for (int col = 0; col < A->cols(); col++)
-        {
-          Teuchos::RCP<Xpetra::CrsMatrix<SC, LO, GO, NO>> crsA = Teuchos::make_rcp<EpetraCrsMatrix>(
-              Teuchos::rcpFromRef(*A->matrix(row, col).epetra_matrix()));
-          Teuchos::RCP<Xpetra::Matrix<SC, LO, GO, NO>> mat =
-              Xpetra::MatrixFactory<SC, LO, GO, NO>::BuildCopy(
-                  Teuchos::make_rcp<Xpetra::CrsMatrixWrap<SC, LO, GO, NO>>(crsA));
-          bOp->setMatrix(row, col, mat);
-        }
-      }
-
-      bOp->fillComplete();
-      pmatrix_ = bOp;
-
-      if (!muelulist_.sublist("MueLu Parameters").isParameter("MUELU_XML_FILE"))
-        FOUR_C_THROW("MUELU_XML_FILE parameter not set!");
-
-      auto xmlFileName = muelulist_.sublist("MueLu Parameters").get<std::string>("MUELU_XML_FILE");
-      auto mueluParams = Teuchos::make_rcp<Teuchos::ParameterList>();
-      auto comm = pmatrix_->getRowMap()->getComm();
-      Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, mueluParams.ptr(), *comm);
-
-      MueLu::ParameterListInterpreter<SC, LO, GO, NO> mueLuFactory(xmlFileName, *comm);
-      H_ = mueLuFactory.CreateHierarchy();
-      H_->GetLevel(0)->Set(
-          "A", Teuchos::rcp_dynamic_cast<Xpetra::Matrix<SC, LO, GO, NO>>(pmatrix_));
-
-      for (int block = 0; block < A->rows(); block++)
-      {
-        const std::string inverse = "Inverse" + std::to_string(block + 1);
-        const Teuchos::ParameterList& inverse_list =
-            muelulist_.sublist(inverse).sublist("MueLu Parameters");
-
-        Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> nullspace =
-            Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist(
-                *maps.at(block), inverse_list);
-
-        H_->GetLevel(0)->Set("Nullspace" + std::to_string(block + 1), nullspace);
-      }
-
-      if (muelulist_.sublist("Belos Parameters").isParameter("contact slaveDofMap"))
-      {
-        Teuchos::RCP<Epetra_Map> ep_slave_dof_map =
-            muelulist_.sublist("Belos Parameters")
-                .get<Teuchos::RCP<Epetra_Map>>("contact slaveDofMap");
-
-        if (ep_slave_dof_map.is_null()) FOUR_C_THROW("Interface contact map is not available!");
-
-        Teuchos::RCP<EpetraMap> x_slave_dof_map = Teuchos::make_rcp<EpetraMap>(ep_slave_dof_map);
-
-        H_->GetLevel(0)->Set("Primal interface DOF map",
-            Teuchos::rcp_dynamic_cast<const Xpetra::Map<LO, GO, NO>>(x_slave_dof_map, true));
-      }
-
-      mueLuFactory.SetupHierarchy(*H_);
-      P_ = Teuchos::make_rcp<MueLu::EpetraOperator>(H_);
     }
+
+    bOp->fillComplete();
+    pmatrix_ = bOp;
+
+    if (!muelulist_.sublist("MueLu Parameters").isParameter("MUELU_XML_FILE"))
+      FOUR_C_THROW("MUELU_XML_FILE parameter not set!");
+
+    auto xmlFileName = muelulist_.sublist("MueLu Parameters").get<std::string>("MUELU_XML_FILE");
+    auto mueluParams = Teuchos::make_rcp<Teuchos::ParameterList>();
+    auto comm = pmatrix_->getRowMap()->getComm();
+    Teuchos::updateParametersFromXmlFileAndBroadcast(xmlFileName, mueluParams.ptr(), *comm);
+
+    MueLu::ParameterListInterpreter<SC, LO, GO, NO> mueLuFactory(xmlFileName, *comm);
+    H_ = mueLuFactory.CreateHierarchy();
+    H_->GetLevel(0)->Set("A", Teuchos::rcp_dynamic_cast<Xpetra::Matrix<SC, LO, GO, NO>>(pmatrix_));
+
+    for (int block = 0; block < A->rows(); block++)
+    {
+      const std::string inverse = "Inverse" + std::to_string(block + 1);
+      const Teuchos::ParameterList& inverse_list =
+          muelulist_.sublist(inverse).sublist("MueLu Parameters");
+
+      Teuchos::RCP<Xpetra::MultiVector<SC, LO, GO, NO>> nullspace =
+          Core::LinearSolver::Parameters::extract_nullspace_from_parameterlist(
+              *maps.at(block), inverse_list);
+
+      H_->GetLevel(0)->Set("Nullspace" + std::to_string(block + 1), nullspace);
+    }
+
+    if (muelulist_.sublist("Belos Parameters").isParameter("contact slaveDofMap"))
+    {
+      Teuchos::RCP<Epetra_Map> ep_slave_dof_map =
+          muelulist_.sublist("Belos Parameters")
+              .get<Teuchos::RCP<Epetra_Map>>("contact slaveDofMap");
+
+      if (ep_slave_dof_map.is_null()) FOUR_C_THROW("Interface contact map is not available!");
+
+      Teuchos::RCP<EpetraMap> x_slave_dof_map = Teuchos::make_rcp<EpetraMap>(ep_slave_dof_map);
+
+      H_->GetLevel(0)->Set("Primal interface DOF map",
+          Teuchos::rcp_dynamic_cast<const Xpetra::Map<LO, GO, NO>>(x_slave_dof_map, true));
+    }
+
+    mueLuFactory.SetupHierarchy(*H_);
+    P_ = Teuchos::make_rcp<MueLu::EpetraOperator>(H_);
   }
 }
 

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
@@ -52,12 +52,11 @@ namespace Core::LinearSolver
      * it re-uses the existing preconditioner and only updates the fine level matrix
      * for the Krylov solver.
      *
-     * @param create Boolean flag to enforce (re-)creation of the preconditioner
      * @param matrix Epetra_Operator to be used as input for the preconditioner
      * @param x Solution of the linear system
      * @param b Right-hand side of the linear system
      */
-    void setup(bool create, Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
+    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
         Core::LinAlg::MultiVector<double>* b) override;
 
     //! linear operator used for preconditioning

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.hpp
@@ -33,7 +33,7 @@ namespace Core::LinearSolver
    public:
     TekoPreconditioner(Teuchos::ParameterList& tekolist);
 
-    void setup(bool create, Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
+    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
         Core::LinAlg::MultiVector<double>* b) override;
 
     /// linear operator used for preconditioning

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
@@ -39,7 +39,7 @@ namespace Core::LinearSolver
     virtual ~PreconditionerTypeBase() = default;
 
     /// Setup preconditioner with a given linear system.
-    virtual void setup(bool create, Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
+    virtual void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
         Core::LinAlg::MultiVector<double>* b) = 0;
 
     /// linear operator used for preconditioning


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title states. Removing the `create` boolean from the preconditioner setup call and letting the iterative solver directly decide.
