### PR TITLE
Simplify ConditionSelector classes into a function

### DIFF
--- a/src/ale/4C_ale_utils_mapextractor.cpp
+++ b/src/ale/4C_ale_utils_mapextractor.cpp
@@ -19,25 +19,18 @@ FOUR_C_NAMESPACE_OPEN
 void ALE::Utils::MapExtractor::setup(const Core::FE::Discretization& dis, bool overlapping)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.set_overlapping(overlapping);
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "FSICoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "FREESURFCoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "StructAleCoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "AleWear", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "BioGrCoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "ALEUPDATECoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "fpsi_coupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "Mortar", 0, ndim));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(dis, *this,
+      {
+          Core::Conditions::Selector("FSICoupling", 0, ndim),
+          Core::Conditions::Selector("FREESURFCoupling", 0, ndim),
+          Core::Conditions::Selector("StructAleCoupling", 0, ndim),
+          Core::Conditions::Selector("AleWear", 0, ndim),
+          Core::Conditions::Selector("BioGrCoupling", 0, ndim),
+          Core::Conditions::Selector("ALEUPDATECoupling", 0, ndim),
+          Core::Conditions::Selector("fpsi_coupling", 0, ndim),
+          Core::Conditions::Selector("Mortar", 0, ndim),
+      },
+      overlapping);
 }
 
 
@@ -84,10 +77,8 @@ std::shared_ptr<std::set<int>> ALE::Utils::MapExtractor::conditioned_element_map
 void ALE::Utils::FsiMapExtractor::setup(const Core::FE::Discretization& dis)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "FSICoupling", 0, ndim));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(
+      dis, *this, {Core::Conditions::Selector("FSICoupling", 0, ndim)});
 }
 
 /*----------------------------------------------------------------------------*/
@@ -95,10 +86,8 @@ void ALE::Utils::FsiMapExtractor::setup(const Core::FE::Discretization& dis)
 void ALE::Utils::XFluidFluidMapExtractor::setup(const Core::FE::Discretization& dis)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "FluidFluidCoupling", 0, ndim));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(
+      dis, *this, {Core::Conditions::Selector("FluidFluidCoupling", 0, ndim)});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/condition/4C_fem_condition_utils.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_utils.hpp
@@ -42,7 +42,7 @@ namespace Core::Elements
 namespace Core::Conditions
 {
   // forward declaration
-  class ConditionSelector;
+  class Selector;
 
   /**
    * A functor that returns true if the given global id is owned by the emap.

--- a/src/fluid/4C_fluid_utils_mapextractor.cpp
+++ b/src/fluid/4C_fluid_utils_mapextractor.cpp
@@ -21,19 +21,15 @@ void FLD::Utils::MapExtractor::setup(
     const Core::FE::Discretization& dis, bool withpressure, bool overlapping, const int nds_master)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.set_overlapping(overlapping);  // defines if maps can overlap
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "FSICoupling", 0, ndim + withpressure));
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "FREESURFCoupling", 0, ndim + withpressure));
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "StructAleCoupling", 0, ndim + withpressure));
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "Mortar", 0, ndim + withpressure));
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "ALEUPDATECoupling", 0, ndim + withpressure));
-  mcs.setup_extractor(dis, *dis.dof_row_map(nds_master), *this);
+  Core::Conditions::setup_extractor(dis, *dis.dof_row_map(nds_master), *this,
+      {
+          Core::Conditions::Selector("FSICoupling", 0, ndim + withpressure),
+          Core::Conditions::Selector("FREESURFCoupling", 0, ndim + withpressure),
+          Core::Conditions::Selector("StructAleCoupling", 0, ndim + withpressure),
+          Core::Conditions::Selector("Mortar", 0, ndim + withpressure),
+          Core::Conditions::Selector("ALEUPDATECoupling", 0, ndim + withpressure),
+      },
+      overlapping);
 }
 
 /*----------------------------------------------------------------------*/
@@ -97,21 +93,16 @@ std::shared_ptr<std::set<int>> FLD::Utils::MapExtractor::conditioned_element_map
 void FLD::Utils::VolumetricFlowMapExtractor::setup(const Core::FE::Discretization& dis)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.set_overlapping(true);  // defines if maps can overlap
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "VolumetricSurfaceFlowCond", 0, ndim));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(
+      dis, *this, {Core::Conditions::Selector("VolumetricSurfaceFlowCond", 0, ndim)}, true);
 }
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 void FLD::Utils::KSPMapExtractor::setup(const Core::FE::Discretization& dis)
 {
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::ConditionSelector>(dis, "KrylovSpaceProjection"));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(
+      dis, *this, {Core::Conditions::Selector("KrylovSpaceProjection")});
 }
 
 
@@ -139,10 +130,8 @@ void FLD::Utils::VelPressExtractor::setup(const Core::FE::Discretization& dis)
 void FLD::Utils::FsiMapExtractor::setup(const Core::FE::Discretization& dis)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "FSICoupling", 0, ndim));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(
+      dis, *this, {Core::Conditions::Selector("FSICoupling", 0, ndim)});
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/fpsi/4C_fpsi_coupling.cpp
+++ b/src/fpsi/4C_fpsi_coupling.cpp
@@ -110,44 +110,35 @@ void FPSI::FpsiCoupling::setup_interface_coupling()
 
   {
     porofluid_extractor_ = std::make_shared<Core::LinAlg::MapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *porofluiddis, "fpsi_coupling", 0, ndim + 1));
-    mcs.setup_extractor(*porofluiddis, *(porofluiddis->dof_row_map()), *porofluid_extractor_);
+    Core::Conditions::setup_extractor(*porofluiddis, *porofluid_extractor_,
+        {Core::Conditions::Selector("fpsi_coupling", 0, ndim + 1)});
   }
 
   {
     porostruct_extractor_ = std::make_shared<Core::LinAlg::MapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *porostructdis, "fpsi_coupling", 0, ndim));
-    mcs.setup_extractor(*porostructdis, *(porostructdis->dof_row_map()), *porostruct_extractor_);
+    Core::Conditions::setup_extractor(*porostructdis, *porostruct_extractor_,
+        {Core::Conditions::Selector("fpsi_coupling", 0, ndim)});
   }
 
   {
     fluidvelpres_extractor_ = std::make_shared<Core::LinAlg::MapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *fluiddis, "fpsi_coupling", 0, ndim + 1));
-    mcs.setup_extractor(*fluiddis, *(fluiddis->dof_row_map()), *fluidvelpres_extractor_);
+    Core::Conditions::setup_extractor(*fluiddis, *fluidvelpres_extractor_,
+        {Core::Conditions::Selector("fpsi_coupling", 0, ndim + 1)});
   }
 
   {
     fluidvel_extractor_ = std::make_shared<Core::LinAlg::MapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *fluiddis, "fpsi_coupling", 0, ndim));
-    mcs.setup_extractor(*fluiddis, *(fluiddis->dof_row_map()), *fluidvel_extractor_);
+    Core::Conditions::setup_extractor(
+        *fluiddis, *fluidvel_extractor_, {Core::Conditions::Selector("fpsi_coupling", 0, ndim)});
   }
 
   {
     fluid_fsifpsi_extractor_ = std::make_shared<FPSI::Utils::MapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *fluiddis, "FSICoupling", 0, ndim));
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *fluiddis, "fpsi_coupling", 0, ndim));
-    mcs.setup_extractor(*fluiddis, *(fluiddis->dof_row_map()), *fluid_fsifpsi_extractor_);
+    Core::Conditions::setup_extractor(*fluiddis, *fluid_fsifpsi_extractor_,
+        {
+            Core::Conditions::Selector("FSICoupling", 0, ndim),
+            Core::Conditions::Selector("fpsi_coupling", 0, ndim),
+        });
   }
 
   {

--- a/src/fpsi/4C_fpsi_utils.cpp
+++ b/src/fpsi/4C_fpsi_utils.cpp
@@ -626,13 +626,12 @@ void FPSI::Utils::MapExtractor::setup(
     const Core::FE::Discretization& dis, bool withpressure, bool overlapping)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.set_overlapping(overlapping);  // defines if maps can overlap
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "FSICoupling", 0, ndim + withpressure));
-  mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-      dis, "fpsi_coupling", 0, ndim + withpressure));
-  mcs.setup_extractor(dis, *dis.dof_row_map(), *this);
+  Core::Conditions::setup_extractor(dis, *this,
+      {
+          Core::Conditions::Selector("FSICoupling", 0, ndim + withpressure),
+          Core::Conditions::Selector("fpsi_coupling", 0, ndim + withpressure),
+      },
+      overlapping);
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned.cpp
@@ -421,10 +421,8 @@ void FS3I::PartFPS3I::setup_system()
         currscatra->scatra_field()->discretization();
     std::shared_ptr<Core::LinAlg::MultiMapExtractor> mapex =
         std::make_shared<Core::LinAlg::MultiMapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *currdis, "ScaTraCoupling", 0, numscal));
-    mcs.setup_extractor(*currdis, *currdis->dof_row_map(), *mapex);
+    Core::Conditions::setup_extractor(
+        *currdis, *mapex, {Core::Conditions::Selector("ScaTraCoupling", 0, numscal)});
     scatrafieldexvec_.push_back(mapex);
   }
 

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -486,10 +486,8 @@ void FS3I::PartFS3I::setup_system()
     const int numscal = currscatra->scatra_field()->num_scal();
     std::shared_ptr<Core::LinAlg::MultiMapExtractor> mapex =
         std::make_shared<Core::LinAlg::MultiMapExtractor>();
-    Core::Conditions::MultiConditionSelector mcs;
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *currdis, "ScaTraCoupling", 0, numscal));
-    mcs.setup_extractor(*currdis, *currdis->dof_row_map(), *mapex);
+    Core::Conditions::setup_extractor(
+        *currdis, *mapex, {Core::Conditions::Selector("ScaTraCoupling", 0, numscal)});
     scatrafieldexvec_.push_back(mapex);
   }
 

--- a/src/fsi_xfem/4C_fsi_xfem_coupling_comm_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_coupling_comm_manager.cpp
@@ -231,11 +231,10 @@ void XFEM::CouplingCommManager::setup_multi_map_extractors(
   for (std::map<int, std::shared_ptr<const Core::FE::Discretization>>::iterator dit = dis.begin();
       dit != dis.end(); ++dit)
   {
-    Core::Conditions::MultiConditionSelector mcs;
     mme_[dit->first] = std::make_shared<Core::LinAlg::MultiMapExtractor>();
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        *dit->second, cond_name_, startdim_, enddim_));
-    mcs.setup_extractor(*dit->second, *dit->second->dof_row_map(), *mme_[dit->first]);
+    Core::Conditions::setup_extractor(*dit->second, *mme_[dit->first],
+        std::vector<Core::Conditions::Selector>{
+            Core::Conditions::Selector(cond_name_, startdim_, enddim_)});
   }
 }
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodebased.cpp
@@ -129,12 +129,9 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNodeBased::setup_map_extract
   // build coupled maps for all coupled dofs
   for (int idof = 0; idof < num_coupled_dofs_; idof++)
   {
-    Core::Conditions::MultiConditionSelector mcs;
     Core::LinAlg::MultiMapExtractor dummy;
-    // selector for coupleddofs[idof]
-    mcs.add_selector(std::make_shared<Core::Conditions::NDimConditionSelector>(
-        dis, condname_, coupleddofs[idof], coupleddofs[idof] + 1));
-    mcs.setup_extractor(dis, *dis.dof_row_map(), dummy);
+    Core::Conditions::setup_extractor(dis, dummy,
+        {Core::Conditions::Selector(condname_, coupleddofs[idof], coupleddofs[idof] + 1)});
 
     partialmaps_coupled.push_back(dummy.map(1));
   }

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -494,18 +494,15 @@ void ScaTra::ScaTraTimIntImpl::setup()
     // initialize map extractor associated with boundary segments for flux calculation
     if (calcflux_boundary_ != Inpar::ScaTra::flux_none)
     {
-      // extract conditions for boundary flux calculation
       std::vector<Core::Conditions::Condition*> conditions;
       discret_->get_condition("ScaTraFluxCalc", conditions);
-
       // set up map extractor
       flux_boundary_maps_ = std::make_shared<Core::LinAlg::MultiMapExtractor>();
-      Core::Conditions::MultiConditionSelector mcs;
-      mcs.set_overlapping(true);
-      for (auto& condition : conditions)
-        mcs.add_selector(std::make_shared<Core::Conditions::ConditionSelector>(
-            *discret_, std::vector<Core::Conditions::Condition*>(1, condition)));
-      mcs.setup_extractor(*discret_, *discret_->dof_row_map(), *flux_boundary_maps_);
+      std::vector<Core::Conditions::Selector> selectors;
+      for (const auto& c : conditions)
+        selectors.emplace_back(
+            Core::Conditions::Selector(std::vector<Core::Conditions::Condition*>{c}));
+      Core::Conditions::setup_extractor(*discret_, *flux_boundary_maps_, selectors, true);
     }
   }
 

--- a/src/structure/4C_structure_aux.cpp
+++ b/src/structure/4C_structure_aux.cpp
@@ -60,24 +60,17 @@ void Solid::MapExtractor::setup(
     const Core::FE::Discretization& dis, const Core::LinAlg::Map& fullmap, bool overlapping)
 {
   const int ndim = Global::Problem::instance()->n_dim();
-  Core::Conditions::MultiConditionSelector mcs;
-  mcs.set_overlapping(overlapping);
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "FSICoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "StructAleCoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "BioGrCoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "AleWear", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "fpsi_coupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "IMMERSEDCoupling", 0, ndim));
-  mcs.add_selector(
-      std::make_shared<Core::Conditions::NDimConditionSelector>(dis, "ParticleWall", 0, ndim));
-
-  mcs.setup_extractor(dis, fullmap, *this);
+  Core::Conditions::setup_extractor(dis, fullmap, *this,
+      {
+          Core::Conditions::Selector("FSICoupling", 0, ndim),
+          Core::Conditions::Selector("StructAleCoupling", 0, ndim),
+          Core::Conditions::Selector("BioGrCoupling", 0, ndim),
+          Core::Conditions::Selector("AleWear", 0, ndim),
+          Core::Conditions::Selector("fpsi_coupling", 0, ndim),
+          Core::Conditions::Selector("IMMERSEDCoupling", 0, ndim),
+          Core::Conditions::Selector("ParticleWall", 0, ndim),
+      },
+      overlapping);
 }
 
 


### PR DESCRIPTION
The `ConditionSelector` classes are heavily over-engineered OOP-style. This functionality can be condensed into a function.
