### PR TITLE
Minor improvement to LinAlg::View

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
@@ -234,20 +234,20 @@ namespace Core::LinAlg
     /**
      * View a given Epetra_MultiVector under our own MultiVector wrapper.
      */
-    [[nodiscard]] static std::shared_ptr<MultiVector<T>> create_view(Epetra_MultiVector& view)
+    [[nodiscard]] static std::unique_ptr<MultiVector<T>> create_view(Epetra_MultiVector& view)
     {
-      std::shared_ptr<MultiVector<T>> ret(new MultiVector<T>);
+      std::unique_ptr<MultiVector<T>> ret(new MultiVector<T>);
       ret->vector_ =
-          std::make_shared<Epetra_MultiVector>(Epetra_DataAccess::View, view, 0, view.NumVectors());
+          std::make_unique<Epetra_MultiVector>(Epetra_DataAccess::View, view, 0, view.NumVectors());
       return ret;
     }
 
-    [[nodiscard]] static std::shared_ptr<const MultiVector<T>> create_view(
+    [[nodiscard]] static std::unique_ptr<const MultiVector<T>> create_view(
         const Epetra_MultiVector& view)
     {
-      std::shared_ptr<MultiVector<T>> ret(new MultiVector<T>);
+      std::unique_ptr<MultiVector<T>> ret(new MultiVector<T>);
       ret->vector_ =
-          std::make_shared<Epetra_MultiVector>(Epetra_DataAccess::View, view, 0, view.NumVectors());
+          std::make_unique<Epetra_MultiVector>(Epetra_DataAccess::View, view, 0, view.NumVectors());
       return ret;
     }
 
@@ -267,7 +267,7 @@ namespace Core::LinAlg
 
     //! Vector view of the single columns stored inside the vector. This is used to allow
     //! access to the single columns of the MultiVector.
-    mutable std::vector<std::shared_ptr<Vector<T>>> column_vector_view_;
+    mutable std::vector<std::unique_ptr<Vector<T>>> column_vector_view_;
 
     friend class Vector<T>;
   };

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -313,17 +313,17 @@ namespace Core::LinAlg
     /**
      * View a given Epetra_Vector object under our own Vector wrapper.
      */
-    [[nodiscard]] static std::shared_ptr<Vector<T>> create_view(Epetra_Vector& view)
+    [[nodiscard]] static std::unique_ptr<Vector<T>> create_view(Epetra_Vector& view)
     {
-      std::shared_ptr<Vector<T>> ret(new Vector<T>);
-      ret->vector_ = std::make_shared<Epetra_Vector>(Epetra_DataAccess::View, view, 0);
+      std::unique_ptr<Vector<T>> ret(new Vector<T>);
+      ret->vector_ = std::make_unique<Epetra_Vector>(Epetra_DataAccess::View, view, 0);
       return ret;
     }
 
-    [[nodiscard]] static std::shared_ptr<const Vector<T>> create_view(const Epetra_Vector& view)
+    [[nodiscard]] static std::unique_ptr<const Vector<T>> create_view(const Epetra_Vector& view)
     {
-      std::shared_ptr<Vector<T>> ret(new Vector<T>);
-      ret->vector_ = std::make_shared<Epetra_Vector>(Epetra_DataAccess::View, view, 0);
+      std::unique_ptr<Vector<T>> ret(new Vector<T>);
+      ret->vector_ = std::make_unique<Epetra_Vector>(Epetra_DataAccess::View, view, 0);
       return ret;
     }
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -132,7 +132,8 @@ bool NOX::FSI::LinearSystem::applyJacobianInverse(
   Core::LinAlg::SolverParams solver_params;
   solver_params.refactor = true;
   solver_params.reset = callcount_ == 0;
-  solver_->solve(jac_ptr_, disi.get_non_owning_shared_ptr_ref(), fres, solver_params);
+  solver_->solve(
+      jac_ptr_, Core::Utils::shared_ptr_from_ref(disi.underlying()), fres, solver_params);
 
   callcount_ += 1;
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -334,8 +334,9 @@ bool NOX::Nln::LinearSystem::applyJacobianInverse(Teuchos::ParameterList& linear
     Core::LinAlg::View x(*linProblem.GetLHS());
     Core::LinAlg::View b(*linProblem.GetRHS());
 
-    linsol_status = currSolver->solve_with_multi_vector(matrix, x.get_non_owning_shared_ptr_ref(),
-        b.get_non_owning_shared_ptr_ref(), solver_params);
+    linsol_status = currSolver->solve_with_multi_vector(matrix,
+        Core::Utils::shared_ptr_from_ref(x.underlying()),
+        Core::Utils::shared_ptr_from_ref(b.underlying()), solver_params);
 
     if (linsol_status)
     {

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -144,8 +144,8 @@ bool NOX::Solid::LinearSystem::applyJacobianInverse(
     Core::LinAlg::SolverParams solver_params;
     solver_params.refactor = true;
     solver_params.reset = callcount_ == 0;
-    structureSolver_->solve(
-        J->epetra_operator(), result_view.get_non_owning_shared_ptr_ref(), fres, solver_params);
+    structureSolver_->solve(J->epetra_operator(),
+        Core::Utils::shared_ptr_from_ref(result_view.underlying()), fres, solver_params);
     callcount_ += 1;
   }
   else


### PR DESCRIPTION
- Use `unique_ptr`
- Add an example to docs
- Remove the `shared_ptr` accessor. No need to propagate these further than necessary. We can use `shared_ptr_from_ref` instead.