### PR TITLE
[LinAlg] Add FE_Graph capability to `Core::LinAlg::Graph`

### DIFF
--- a/src/core/fem/src/dofset/4C_fem_dofset.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset.cpp
@@ -12,8 +12,6 @@
 #include "4C_fem_discretization_hdg.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 
-#include <Epetra_FECrsGraph.h>
-
 #include <algorithm>
 #include <format>
 


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR proposes a way to include the `Epetra_FECrsGraph` into our `Core::LinAlg::Graph` wrapper. For clarification, I tried to replace the internal `Epetra_CrsGraph` member with `Epetra_FECrsGraph`, which did not work out. Thus, I replicated what is done in `SparseMatrix`, which is not the prettiest thing, but it works and is consistent to what is already done.

I would be happy about some other opinions though. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
* Closes #404 