### PR TITLE
Remove unnecessary particle output

### DIFF
--- a/src/particle_engine/4C_particle_engine_particlereader.cpp
+++ b/src/particle_engine/4C_particle_engine_particlereader.cpp
@@ -35,7 +35,6 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
     if (!any_particles_read) Core::IO::cout << "Read and create particles\n" << Core::IO::flush;
     any_particles_read = true;
 
-    double t1 = time.totalElapsedTime(true);
     {
       PARTICLEENGINE::TypeEnum particletype;
       PARTICLEENGINE::ParticleStates particlestates;
@@ -112,13 +111,6 @@ void PARTICLEENGINE::read_particles(Core::IO::InputFile& input, const std::strin
       // construct and store read in particle object
       particles.emplace_back(
           std::make_shared<PARTICLEENGINE::ParticleObject>(particletype, -1, particlestates));
-    }
-
-    double t2 = time.totalElapsedTime(true);
-    if (!myrank)
-    {
-      printf("reading %10.5e secs\n", t2 - t1);
-      fflush(stdout);
     }
   }
 


### PR DESCRIPTION
Follow up of cce0df77b512952df408dead231c82ecc95bc8af. Before this commit, the timing of reading a block of particles was printed. After the refactoring the printing was done after each read particle.