### PR TITLE
Implement dot product between rank 1 tensors

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor.hpp
@@ -460,6 +460,22 @@ namespace Core::LinAlg
   constexpr auto transpose(const Rank2TensorConcept auto& A);
 
   /*!
+   * @brief Computes the dot product of two rank-1 tensors
+   *
+   * This function performs the inner product between two vectors a * b. Both sizes need to match.
+   *
+   * @tparam TensorLeft The type of the rank-1 tensor (vector).
+   * @tparam TensorRight The type of the rank-1 tensor (vector).
+   * @param a The rank-1 tensor (vector).
+   * @param b The rank-1 tensor (vector).
+   * @return scalar resulting from the dot product.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank1TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
+             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& a, const TensorRight& b);
+
+  /*!
    * @brief Computes the dot product of a rank-2 tensor and a rank-1 tensor.
    *
    * This function performs the matrix-vector multiplication A * b, where A is a rank-2 tensor
@@ -742,6 +758,18 @@ namespace Core::LinAlg
   }
 
   constexpr auto transpose(const Rank2TensorConcept auto& A) { return reorder_axis<1, 0>(A); }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(Rank1TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
+             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
+  constexpr auto dot(const TensorLeft& a, const TensorRight& b)
+  {
+    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
+                                std::declval<typename TensorRight::value_type>());
+    constexpr std::size_t m = TensorLeft::template extent<0>();
+
+    return DenseFunctions::dot<value_type, m, 1>(a.data(), b.data());
+  }
 
   template <typename TensorLeft, typename TensorRight>
     requires(Rank2TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&

--- a/src/core/linalg/tests/4C_linalg_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_operations_test.cpp
@@ -124,6 +124,21 @@ namespace
     EXPECT_EQ(t_t.at(1, 2), 6.0);
   }
 
+  TYPED_TEST(TensorOperationsTest, Vec_dot_Vec)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2> a = math::Tensor<double, 2>{{2.0, 3.0}};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2> b = math::Tensor<double, 2>{{1.0, 2.0}};
+
+    double axb = math::dot(a.get_tensor(), b.get_tensor());
+
+    EXPECT_EQ(axb, 8.0);
+
+
+    double axb2 = a.get_tensor() * b.get_tensor();
+
+    EXPECT_EQ(axb2, 8.0);
+  }
+
   TYPED_TEST(TensorOperationsTest, Mat_dot_Vec)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{


### PR DESCRIPTION
This combination is missing in the current implementation.