### PR TITLE
Disable metadata generation in lnm cluster presets

### DIFF
--- a/presets/lnm/cluster/CMakePresets.json
+++ b/presets/lnm/cluster/CMakePresets.json
@@ -12,7 +12,8 @@
         "FOUR_C_BUILD_DOXYGEN": "OFF",
         "FOUR_C_CLN_ROOT": "/lnm/packages/cln/1-3-4",
         "FOUR_C_QHULL_ROOT": "/lnm/packages/qhull/2012-1",
-        "FOUR_C_TRILINOS_ROOT": "/lnm/packages/trilinos/16-1-0_v2/release"
+        "FOUR_C_TRILINOS_ROOT": "/lnm/packages/trilinos/16-1-0_v2/release",
+        "FOUR_C_ENABLE_METADATA_GENERATION": "OFF"
       }
     },
     {


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This pull request disables the metadata generation in the LNM cluster presets. If enabled, the automated build of 4C on a cluster node in the [Queens](https://github.com/queens-py/queens) cluster test fails due to an MPI error (see https://github.com/queens-py/queens/pull/146#issuecomment-2848493756).  Of course it is also possible to add this build option as an additional variable in the queens pipeline setup (see https://github.com/queens-py/queens/pull/146#discussion_r2088429776), but we think it would make sense to disable the metadata generation on the clusters by default (this is also the default at the IMCS cluster).

Tagging @davidrudlstorfer @sbrandstaeter @knarfnitram 