### PR TITLE
Enable LinAlg::View for Map

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -8,10 +8,11 @@
 #ifndef FOUR_C_LINALG_MAP_HPP
 #define FOUR_C_LINALG_MAP_HPP
 
-
 #include "4C_config.hpp"
 
 #include "4C_comm_mpi_utils.hpp"
+#include "4C_linalg_view.hpp"
+#include "4C_utils_owner_or_view.hpp"
 
 #include <Epetra_Comm.h>
 #include <Epetra_Map.h>
@@ -146,9 +147,15 @@ namespace Core::LinAlg
     //! Returns a pointer to the BlockMapData instance this BlockMap uses.
     const Epetra_BlockMapData* DataPtr() const { return map_->DataPtr(); }
 
+    [[nodiscard]] static std::unique_ptr<Map> create_view(Epetra_Map& view);
+
+    [[nodiscard]] static std::unique_ptr<const Map> create_view(const Epetra_Map& view);
+
    private:
+    Map() = default;
+
     //! The actual Epetra_Map object.
-    std::shared_ptr<Epetra_Map> map_;
+    Utils::OwnerOrView<Epetra_Map> map_;
   };
 
   inline std::ostream& operator<<(std::ostream& os, const Map& m)
@@ -156,6 +163,12 @@ namespace Core::LinAlg
     os << m.get_epetra_map();
     return os;
   }
+
+  template <>
+  struct EnableViewFor<Epetra_Map>
+  {
+    using type = Map;
+  };
 
 }  // namespace Core::LinAlg
 

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
@@ -273,13 +273,13 @@ namespace Core::LinAlg
   };
 
   template <>
-  struct WrapperFor<Epetra_MultiVector>
+  struct EnableViewFor<Epetra_MultiVector>
   {
     using type = MultiVector<double>;
   };
 
   template <>
-  struct WrapperFor<Epetra_FEVector>
+  struct EnableViewFor<Epetra_FEVector>
   {
     using type = MultiVector<double>;
   };

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrixbase.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrixbase.hpp
@@ -134,46 +134,18 @@ namespace Core::LinAlg
     int global_row_index(int local_row_index) const { return sysmat_->GRID(local_row_index); }
 
     /// Returns the Epetra_Map object associated with the rows of this matrix.
-    const Core::LinAlg::Map& row_map() const
-    {
-      if (!row_map_)
-      {  // check if view is uninitialized
-        row_map_ = Core::LinAlg::Map(sysmat_->RowMap());
-      }
-      return *row_map_;
-    }
+    const Core::LinAlg::Map& row_map() const { return row_map_.sync(sysmat_->RowMap()); }
 
     /// Returns the  Epetra_Mapobject that describes the set of column-indices that appear in
     /// each processor's locally owned matrix rows.
-    const Core::LinAlg::Map& col_map() const
-    {
-      if (!column_map_)
-      {  // check if view is uninitialized
-        column_map_ = Core::LinAlg::Map(sysmat_->ColMap());
-      }
-      return *column_map_;
-    }
+    const Core::LinAlg::Map& col_map() const { return column_map_.sync(sysmat_->ColMap()); }
 
     /// Returns the Epetra_Map object associated with the domain of this matrix operator.
-    const Map& domain_map() const override
-    {
-      if (!domain_map_)
-      {  // check if view is uninitialized
-        domain_map_ = Core::LinAlg::Map(sysmat_->DomainMap());
-      }
-      return *domain_map_;
-    }
+    const Map& domain_map() const override { return domain_map_.sync(sysmat_->DomainMap()); }
 
 
     /// Returns the Epetra_Map object associated with the range of this matrix operator.
-    const Core::LinAlg::Map& range_map() const
-    {
-      if (!range_map_)
-      {  // check if view is uninitialized
-        range_map_ = Core::LinAlg::Map(sysmat_->RangeMap());
-      }
-      return *range_map_;
-    }
+    const Core::LinAlg::Map& range_map() const { return range_map_.sync(sysmat_->RangeMap()); }
 
 
     /// Returns the current UseTranspose setting.
@@ -302,10 +274,10 @@ namespace Core::LinAlg
     /// internal epetra matrix (Epetra_CrsMatrix or Epetra_FECrsMatrix)
     std::shared_ptr<Epetra_CrsMatrix> sysmat_;
 
-    mutable std::optional<Core::LinAlg::Map> range_map_;
-    mutable std::optional<Core::LinAlg::Map> row_map_;
-    mutable std::optional<Core::LinAlg::Map> domain_map_;
-    mutable std::optional<Core::LinAlg::Map> column_map_;
+    mutable View<const Map> range_map_;
+    mutable View<const Map> row_map_;
+    mutable View<const Map> domain_map_;
+    mutable View<const Map> column_map_;
   };
 
 }  // namespace Core::LinAlg

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -426,7 +426,7 @@ namespace Core::LinAlg
 
 
   template <>
-  struct WrapperFor<Epetra_Vector>
+  struct EnableViewFor<Epetra_Vector>
   {
     using type = Vector<double>;
   };

--- a/src/core/utils/src/stl_extension/4C_utils_owner_or_view.hpp
+++ b/src/core/utils/src/stl_extension/4C_utils_owner_or_view.hpp
@@ -1,0 +1,101 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_UTILS_OWNER_OR_VIEW_HPP
+#define FOUR_C_UTILS_OWNER_OR_VIEW_HPP
+
+#include "4C_config.hpp"
+
+#include <functional>
+#include <memory>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::Utils
+{
+  /**
+   * This class holds a pointer to an object of type T. It can either own the object or
+   * views it.
+   * This type is useful to hold wrapped objects in wrappers in combination with the LinAlg::View
+   * mechanism.
+   */
+  template <typename T>
+  class OwnerOrView
+  {
+   public:
+    using Deleter = std::function<void(T*)>;
+
+    /**
+     * Default constructor. The constructed OwnerOrView will not allocate any object. Accessing the
+     * content before copy or move assigning another OwnerOrView will fail at runtime.
+     */
+    OwnerOrView() = default;
+
+    /**
+     * Construct owning version from a unique_ptr.
+     */
+    template <typename D>
+    explicit OwnerOrView(std::unique_ptr<T, D>&& obj_) : obj_(std::move(obj_))
+    {
+    }
+
+    /**
+     * Construct non-owning view on @p ptr.
+     */
+    OwnerOrView(T* ptr) : obj_(ptr, [](T*) {}) {}
+
+    /**
+     * Const-propagating dereference operator.
+     */
+    const T& operator*() const { return *obj_; }
+
+    /**
+     * Non-const dereference operator.
+     */
+    T& operator*() { return *obj_; }
+
+    /**
+     * Const-propagating pointer operator.
+     */
+    const T* operator->() const { return obj_.get(); }
+
+    /**
+     * Non-const pointer operator.
+     */
+    T* operator->() { return obj_.get(); }
+
+   private:
+    /**
+     * Pointer to the object which is either owned or viewed.
+     */
+    std::unique_ptr<T, Deleter> obj_;
+  };
+
+
+  /**
+   * Construct an owning OwnerOrView.
+   */
+  template <typename T, typename... Args>
+  OwnerOrView<T> make_owner(Args&&... args)
+  {
+    return OwnerOrView<T>(std::make_unique<T>(std::forward<Args>(args)...));
+  }
+
+  /**
+   * Construct a viewing OwnerOrView.
+   */
+  template <typename T>
+  OwnerOrView<T> make_view(T* obj)
+  {
+    return OwnerOrView<T>(obj);
+  }
+}  // namespace Core::Utils
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
This PR enables the `LinAlg::View` class for _any type_, regardless of whether it has native view support. I'll point out how this works in the diff.

I apply it to `LinAlg::Map` here.