### PR TITLE
Remove LinAlg::Map constructors taking Epetra_Comm

### DIFF
--- a/src/adapter/4C_adapter_fld_fluid_fsi.cpp
+++ b/src/adapter/4C_adapter_fld_fluid_fsi.cpp
@@ -394,8 +394,8 @@ void Adapter::FluidFSI::proj_vel_to_div_zero()
   const int numallele = discretization()->num_global_elements();
   const int mapoffset =
       dbcfsimap->MaxAllGID() + discretization()->element_row_map()->MinAllGID() + 1;
-  std::shared_ptr<Core::LinAlg::Map> elemap = std::make_shared<Core::LinAlg::Map>(
-      numallele, mapoffset, Core::Communication::as_epetra_comm(discretization()->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> elemap =
+      std::make_shared<Core::LinAlg::Map>(numallele, mapoffset, discretization()->get_comm());
 
   // create the combination of dbcfsimap and elemap
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> domainmaps;

--- a/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
@@ -905,18 +905,16 @@ void CONTACT::Beam3cmanager::init_beam_contact_discret()
       esdata, erdata, (int)ertproc.size(), ertproc.data(), bt_sol_discret().get_comm());
 
   // build completely overlapping node map (on participating processors)
-  std::shared_ptr<Core::LinAlg::Map> newnodecolmap =
-      std::make_shared<Core::LinAlg::Map>(-1, (int)rdata.size(), rdata.data(), 0,
-          Core::Communication::as_epetra_comm(bt_sol_discret().get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> newnodecolmap = std::make_shared<Core::LinAlg::Map>(
+      -1, (int)rdata.size(), rdata.data(), 0, bt_sol_discret().get_comm());
   sdata.clear();
   stproc.clear();
   rdata.clear();
   allproc.clear();
 
   // build completely overlapping element map (on participating processors)
-  std::shared_ptr<Core::LinAlg::Map> newelecolmap =
-      std::make_shared<Core::LinAlg::Map>(-1, (int)erdata.size(), erdata.data(), 0,
-          Core::Communication::as_epetra_comm(bt_sol_discret().get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> newelecolmap = std::make_shared<Core::LinAlg::Map>(
+      -1, (int)erdata.size(), erdata.data(), 0, bt_sol_discret().get_comm());
   esdata.clear();
   estproc.clear();
   erdata.clear();

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -1015,10 +1015,8 @@ bool Beam3ContactOctTree::locate_all()
     std::vector<int> gids;
     for (int i = 0; i < bboxlengthglobal; i++) gids.push_back(i);
     // crosslinker column and row map
-    Core::LinAlg::Map octtreerowmap(
-        (int)gids.size(), 0, Core::Communication::as_epetra_comm(discret_.get_comm()));
-    Core::LinAlg::Map octtreemap(-1, (int)gids.size(), gids.data(), 0,
-        Core::Communication::as_epetra_comm(discret_.get_comm()));
+    Core::LinAlg::Map octtreerowmap((int)gids.size(), 0, discret_.get_comm());
+    Core::LinAlg::Map octtreemap(-1, (int)gids.size(), gids.data(), 0, discret_.get_comm());
 
     // build Core::LinAlg::MultiVector<double>s which hold the BBs of the OctreeMap; for
     // communication

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
@@ -163,22 +163,20 @@ void BeamInteraction::BeamToSolidMortarManager::setup()
   }
 
   // Rowmap for the additional GIDs used by the mortar contact discretization.
-  lambda_dof_rowmap_translations_ = std::make_shared<Core::LinAlg::Map>(-1,
-      my_lambda_gid_translational.size(), my_lambda_gid_translational.data(), 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
+  lambda_dof_rowmap_translations_ =
+      std::make_shared<Core::LinAlg::Map>(-1, my_lambda_gid_translational.size(),
+          my_lambda_gid_translational.data(), 0, discret_->get_comm());
   lambda_dof_rowmap_rotations_ = std::make_shared<Core::LinAlg::Map>(-1,
-      my_lambda_gid_rotational.size(), my_lambda_gid_rotational.data(), 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
+      my_lambda_gid_rotational.size(), my_lambda_gid_rotational.data(), 0, discret_->get_comm());
   lambda_dof_rowmap_ =
       Core::LinAlg::merge_map(lambda_dof_rowmap_translations_, lambda_dof_rowmap_rotations_, false);
 
   // We need to be able to get the global ids for a Lagrange multiplier DOF from the global id
   // of a node or element. To do so, we 'abuse' the Core::LinAlg::MultiVector<double> as map between
   // the global node / element ids and the global Lagrange multiplier DOF ids.
-  Core::LinAlg::Map node_gid_rowmap(-1, n_nodes, my_nodes_gid.data(), 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
-  Core::LinAlg::Map element_gid_rowmap(-1, n_element, my_elements_gid.data(), 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
+  Core::LinAlg::Map node_gid_rowmap(-1, n_nodes, my_nodes_gid.data(), 0, discret_->get_comm());
+  Core::LinAlg::Map element_gid_rowmap(
+      -1, n_element, my_elements_gid.data(), 0, discret_->get_comm());
 
   // Map from global node / element ids to global lagrange multiplier ids. Only create the
   // multivector if it hase one or more columns.
@@ -265,10 +263,10 @@ void BeamInteraction::BeamToSolidMortarManager::set_global_maps()
   }
 
   // Create the beam and solid maps.
-  beam_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(-1, beam_dofs.size(), beam_dofs.data(), 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
-  solid_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(-1, solid_dofs.size(), solid_dofs.data(),
-      0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  beam_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, beam_dofs.size(), beam_dofs.data(), 0, discret_->get_comm());
+  solid_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, solid_dofs.size(), solid_dofs.data(), 0, discret_->get_comm());
 
   // Reset the local maps.
   node_gid_to_lambda_gid_map_.clear();
@@ -330,10 +328,10 @@ void BeamInteraction::BeamToSolidMortarManager::set_local_maps(
   element_gid_needed.resize(std::distance(element_gid_needed.begin(), it));
 
   // Create the maps for the extraction of the values.
-  Core::LinAlg::Map node_gid_needed_rowmap(-1, node_gid_needed.size(), node_gid_needed.data(), 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
-  Core::LinAlg::Map element_gid_needed_rowmap(-1, element_gid_needed.size(),
-      element_gid_needed.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  Core::LinAlg::Map node_gid_needed_rowmap(
+      -1, node_gid_needed.size(), node_gid_needed.data(), 0, discret_->get_comm());
+  Core::LinAlg::Map element_gid_needed_rowmap(
+      -1, element_gid_needed.size(), element_gid_needed.data(), 0, discret_->get_comm());
 
   // Create the Multivectors that will be filled with all values needed on this rank.
   std::shared_ptr<Core::LinAlg::MultiVector<double>> node_gid_to_lambda_gid_copy = nullptr;
@@ -382,8 +380,8 @@ void BeamInteraction::BeamToSolidMortarManager::set_local_maps(
   }
 
   // Create the global lambda col map.
-  lambda_dof_colmap_ = std::make_shared<Core::LinAlg::Map>(-1, lambda_gid_for_col_map.size(),
-      lambda_gid_for_col_map.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  lambda_dof_colmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, lambda_gid_for_col_map.size(), lambda_gid_for_col_map.data(), 0, discret_->get_comm());
 
   // Set flags for local maps.
   is_local_maps_build_ = true;

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.cpp
@@ -45,10 +45,10 @@ void BeamInteraction::add_beam_interaction_nodal_forces(
     else
       for (unsigned int dim = 0; dim < 3; ++dim) gid_solid_dof.push_back(gid_node[dim]);
   }
-  Core::LinAlg::Map beam_dof_map(-1, gid_beam_dof.size(), gid_beam_dof.data(), 0,
-      Core::Communication::as_epetra_comm(discret_ptr->get_comm()));
-  Core::LinAlg::Map solid_dof_map(-1, gid_solid_dof.size(), gid_solid_dof.data(), 0,
-      Core::Communication::as_epetra_comm(discret_ptr->get_comm()));
+  Core::LinAlg::Map beam_dof_map(
+      -1, gid_beam_dof.size(), gid_beam_dof.data(), 0, discret_ptr->get_comm());
+  Core::LinAlg::Map solid_dof_map(
+      -1, gid_solid_dof.size(), gid_solid_dof.data(), 0, discret_ptr->get_comm());
 
   // Extract the forces and add them to the discretization.
   std::shared_ptr<Core::LinAlg::Vector<double>> force_beam =

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_visualization.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_visualization.cpp
@@ -82,8 +82,8 @@ void BeamInteraction::BeamToSolidOutputWriterVisualization::
       point_coordinates.push_back(current_node->x()[dim]);
     }
   }
-  node_gid_map_ = std::make_shared<Core::LinAlg::Map>(-1, my_global_dof_ids.size(),
-      my_global_dof_ids.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  node_gid_map_ = std::make_shared<Core::LinAlg::Map>(
+      -1, my_global_dof_ids.size(), my_global_dof_ids.data(), 0, discret_->get_comm());
 }
 
 /**

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -373,8 +373,8 @@ namespace BeamInteraction
       std::vector<int> colgids(coleleset.begin(), coleleset.end());
 
       // create new ele col map
-      Core::LinAlg::Map newelecolmap(-1, static_cast<int>(colgids.size()), colgids.data(), 0,
-          Core::Communication::as_epetra_comm(discret.get_comm()));
+      Core::LinAlg::Map newelecolmap(
+          -1, static_cast<int>(colgids.size()), colgids.data(), 0, discret.get_comm());
 
       // temporarily extend ghosting
       Core::Binstrategy::Utils::extend_discretization_ghosting(
@@ -1250,8 +1250,8 @@ namespace BeamInteraction
       {
         std::vector<int> mapvec(eletypeset[i].begin(), eletypeset[i].end());
         eletypeset[i].clear();
-        maps[i] = std::make_shared<Core::LinAlg::Map>(-1, mapvec.size(), mapvec.data(), 0,
-            Core::Communication::as_epetra_comm(discret->get_comm()));
+        maps[i] = std::make_shared<Core::LinAlg::Map>(
+            -1, mapvec.size(), mapvec.data(), 0, discret->get_comm());
       }
 
       eletypeextractor->setup(*discret->element_row_map(), maps);

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -563,9 +563,8 @@ void Solid::ModelEvaluator::BeamInteraction::extend_ghosting()
 
   // build auxiliary bin col map
   std::vector<int> auxgids(colbins.begin(), colbins.end());
-  std::shared_ptr<Core::LinAlg::Map> auxmap =
-      std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(auxgids.size()), auxgids.data(), 0,
-          Core::Communication::as_epetra_comm(bindis_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> auxmap = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(auxgids.size()), auxgids.data(), 0, bindis_->get_comm());
 
   std::shared_ptr<Core::LinAlg::Map> ia_elecolmap = binstrategy_->extend_element_col_map(
       ia_state_ptr_->get_bin_to_row_ele_map(), ia_state_ptr_->get_bin_to_row_ele_map(),

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
@@ -1464,8 +1464,8 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::read_restart(
   }
 
   // build dummy map according to read data on myrank
-  Core::LinAlg::Map dummy_cl_map(-1, read_node_ids.size(), read_node_ids.data(), 0,
-      Core::Communication::as_epetra_comm(bin_discret().get_comm()));
+  Core::LinAlg::Map dummy_cl_map(
+      -1, read_node_ids.size(), read_node_ids.data(), 0, bin_discret().get_comm());
 
   // build exporter object
   std::shared_ptr<Core::Communication::Exporter> exporter =
@@ -1515,9 +1515,8 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::read_restart(
   }
 
   // build dummy map according to read data on myrank
-  std::shared_ptr<Core::LinAlg::Map> dummy_beam_map =
-      std::make_shared<Core::LinAlg::Map>(-1, read_ele_ids.size(), read_ele_ids.data(), 0,
-          Core::Communication::as_epetra_comm(discret().get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> dummy_beam_map = std::make_shared<Core::LinAlg::Map>(
+      -1, read_ele_ids.size(), read_ele_ids.data(), 0, discret().get_comm());
 
   // build exporter object
   exporter = std::make_shared<Core::Communication::Exporter>(

--- a/src/cardiovascular0d/4C_cardiovascular0d_dofset.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_dofset.cpp
@@ -72,14 +72,14 @@ int Utils::Cardiovascular0DDofSet::assign_degrees_of_freedom(
     count = mor->get_red_dim();
 
   // dofrowmap with index base = count, which is undesired
-  Core::LinAlg::Map dofrowmap(ndofs, count, Core::Communication::as_epetra_comm(dis->get_comm()));
+  Core::LinAlg::Map dofrowmap(ndofs, count, dis->get_comm());
 
   std::vector<int> gids;
   for (int i = 0; i < dofrowmap.NumMyElements(); i++) gids.push_back(dofrowmap.GID(i));
 
   // dofrowmap with index base = 0
-  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, gids.size(), gids.data(), 0, Core::Communication::as_epetra_comm(dis->get_comm()));
+  dofrowmap_ =
+      std::make_shared<Core::LinAlg::Map>(-1, gids.size(), gids.data(), 0, dis->get_comm());
 
   return count;
 }

--- a/src/cardiovascular0d/4C_cardiovascular0d_dofset.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_dofset.hpp
@@ -66,8 +66,7 @@ namespace Utils
       int lmin = dofrowmap_->MinMyGID();
       if (dofrowmap_->NumMyElements() == 0) lmin = std::numeric_limits<int>::max();
       int gmin = std::numeric_limits<int>::max();
-      Core::Communication::min_all(
-          &lmin, &gmin, 1, Core::Communication::unpack_epetra_comm(dofrowmap_->Comm()));
+      Core::Communication::min_all(&lmin, &gmin, 1, dofrowmap_->Comm());
       return gmin;
     };
 

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
@@ -997,8 +997,7 @@ int Utils::Cardiovascular0DManager::solve(Core::LinAlg::SparseMatrix& mat_struct
     std::shared_ptr<Core::LinAlg::MultiVector<double>> rhsstruct_R = mor_->reduce_rhs(rhsstruct);
 
     // define maps of reduced standard dofs and additional pressures
-    Core::LinAlg::Map structmap_R(
-        mor_->get_red_dim(), 0, Core::Communication::as_epetra_comm(actdisc_->get_comm()));
+    Core::LinAlg::Map structmap_R(mor_->get_red_dim(), 0, actdisc_->get_comm());
     std::shared_ptr<Core::LinAlg::Map> standrowmap_R =
         std::make_shared<Core::LinAlg::Map>(structmap_R);
     std::shared_ptr<Core::LinAlg::Map> cardvasc0drowmap_R =

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -316,7 +316,7 @@ void Cardiovascular0D::ProperOrthogonalDecomposition::read_pod_basis_vectors_fro
   char* memblock = new char[mysize];
 
   // calculation of starting points in matrix for each processor
-  MPI_Comm comm(Core::Communication::unpack_epetra_comm(full_model_dof_row_map_->Comm()));
+  MPI_Comm comm(full_model_dof_row_map_->Comm());
   const int numproc(Core::Communication::num_mpi_ranks(comm));
   const int mypid(Core::Communication::my_mpi_rank(comm));
   std::vector<int> localnumbers(numproc, 0);

--- a/src/constraint/4C_constraint_dofset.cpp
+++ b/src/constraint/4C_constraint_dofset.cpp
@@ -44,14 +44,14 @@ int Constraints::ConstraintDofSet::assign_degrees_of_freedom(
   const int count = max_gid_in_list(dis->get_comm()) + 1;
 
   // dofrowmap with index base = count, which is undesired
-  Core::LinAlg::Map dofrowmap(ndofs, count, Core::Communication::as_epetra_comm(dis->get_comm()));
+  Core::LinAlg::Map dofrowmap(ndofs, count, dis->get_comm());
 
   std::vector<int> gids;
   for (int i = 0; i < dofrowmap.NumMyElements(); i++) gids.push_back(dofrowmap.GID(i));
 
   // dofrowmap with index base = 0
-  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, gids.size(), gids.data(), 0, Core::Communication::as_epetra_comm(dis->get_comm()));
+  dofrowmap_ =
+      std::make_shared<Core::LinAlg::Map>(-1, gids.size(), gids.data(), 0, dis->get_comm());
 
   return count;
 }

--- a/src/constraint/4C_constraint_dofset.hpp
+++ b/src/constraint/4C_constraint_dofset.hpp
@@ -58,8 +58,7 @@ namespace Constraints
       int lmin = dofrowmap_->MinMyGID();
       if (dofrowmap_->NumMyElements() == 0) lmin = std::numeric_limits<int>::max();
       int gmin = std::numeric_limits<int>::max();
-      Core::Communication::min_all(
-          &lmin, &gmin, 1, Core::Communication::unpack_epetra_comm(dofrowmap_->Comm()));
+      Core::Communication::min_all(&lmin, &gmin, 1, dofrowmap_->Comm());
       return gmin;
     };
 

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -188,8 +188,8 @@ void Constraints::ConstrManager::setup(
       nummyele = num_monitor_id_;
     }
     // initialize maps and importer
-    monitormap_ = std::make_shared<Core::LinAlg::Map>(
-        num_monitor_id_, nummyele, 0, Core::Communication::as_epetra_comm(actdisc_->get_comm()));
+    monitormap_ =
+        std::make_shared<Core::LinAlg::Map>(num_monitor_id_, nummyele, 0, actdisc_->get_comm());
     redmonmap_ = Core::LinAlg::allreduce_e_map(*monitormap_);
     monimpo_ = std::make_shared<Epetra_Export>(
         redmonmap_->get_epetra_map(), monitormap_->get_epetra_map());

--- a/src/constraint/4C_constraint_multipointconstraint2.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint2.cpp
@@ -210,15 +210,15 @@ Constraints::MPConstraint2::create_discretization_from_condition(
   // build unique node row map
   std::vector<int> boundarynoderowvec(rownodeset.begin(), rownodeset.end());
   rownodeset.clear();
-  Core::LinAlg::Map constraintnoderowmap(-1, boundarynoderowvec.size(), boundarynoderowvec.data(),
-      0, Core::Communication::as_epetra_comm(newdis->get_comm()));
+  Core::LinAlg::Map constraintnoderowmap(
+      -1, boundarynoderowvec.size(), boundarynoderowvec.data(), 0, newdis->get_comm());
   boundarynoderowvec.clear();
 
   // build overlapping node column map
   std::vector<int> constraintnodecolvec(colnodeset.begin(), colnodeset.end());
   colnodeset.clear();
-  Core::LinAlg::Map constraintnodecolmap(-1, constraintnodecolvec.size(),
-      constraintnodecolvec.data(), 0, Core::Communication::as_epetra_comm(newdis->get_comm()));
+  Core::LinAlg::Map constraintnodecolmap(
+      -1, constraintnodecolvec.size(), constraintnodecolvec.data(), 0, newdis->get_comm());
 
   constraintnodecolvec.clear();
 

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -308,15 +308,15 @@ Constraints::MPConstraint3::create_discretization_from_condition(
     // build unique node row map
     std::vector<int> boundarynoderowvec(rownodeset.begin(), rownodeset.end());
     rownodeset.clear();
-    Core::LinAlg::Map constraintnoderowmap(-1, boundarynoderowvec.size(), boundarynoderowvec.data(),
-        0, Core::Communication::as_epetra_comm(newdis->get_comm()));
+    Core::LinAlg::Map constraintnoderowmap(
+        -1, boundarynoderowvec.size(), boundarynoderowvec.data(), 0, newdis->get_comm());
     boundarynoderowvec.clear();
 
     // build overlapping node column map
     std::vector<int> constraintnodecolvec(colnodeset.begin(), colnodeset.end());
     colnodeset.clear();
-    Core::LinAlg::Map constraintnodecolmap(-1, constraintnodecolvec.size(),
-        constraintnodecolvec.data(), 0, Core::Communication::as_epetra_comm(newdis->get_comm()));
+    Core::LinAlg::Map constraintnodecolmap(
+        -1, constraintnodecolvec.size(), constraintnodecolvec.data(), 0, newdis->get_comm());
 
     constraintnodecolvec.clear();
     newdis->redistribute(constraintnoderowmap, constraintnodecolmap);

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -72,8 +72,7 @@ Constraints::MPConstraint3Penalty::MPConstraint3Penalty(
       nummyele = numele;
     }
     // initialize maps and importer
-    errormap_ = std::make_shared<Core::LinAlg::Map>(
-        numele, nummyele, 0, Core::Communication::as_epetra_comm(actdisc_->get_comm()));
+    errormap_ = std::make_shared<Core::LinAlg::Map>(numele, nummyele, 0, actdisc_->get_comm());
     rederrormap_ = Core::LinAlg::allreduce_e_map(*errormap_);
     errorexport_ = std::make_shared<Epetra_Export>(
         rederrormap_->get_epetra_map(), errormap_->get_epetra_map());
@@ -314,15 +313,15 @@ Constraints::MPConstraint3Penalty::create_discretization_from_condition(
     // build unique node row map
     std::vector<int> boundarynoderowvec(rownodeset.begin(), rownodeset.end());
     rownodeset.clear();
-    Core::LinAlg::Map constraintnoderowmap(-1, boundarynoderowvec.size(), boundarynoderowvec.data(),
-        0, Core::Communication::as_epetra_comm(newdis->get_comm()));
+    Core::LinAlg::Map constraintnoderowmap(
+        -1, boundarynoderowvec.size(), boundarynoderowvec.data(), 0, newdis->get_comm());
     boundarynoderowvec.clear();
 
     // build overlapping node column map
     std::vector<int> constraintnodecolvec(colnodeset.begin(), colnodeset.end());
     colnodeset.clear();
-    Core::LinAlg::Map constraintnodecolmap(-1, constraintnodecolvec.size(),
-        constraintnodecolvec.data(), 0, Core::Communication::as_epetra_comm(newdis->get_comm()));
+    Core::LinAlg::Map constraintnodecolmap(
+        -1, constraintnodecolvec.size(), constraintnodecolvec.data(), 0, newdis->get_comm());
 
     constraintnodecolvec.clear();
     newdis->redistribute(constraintnoderowmap, constraintnodecolmap);

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -44,8 +44,7 @@ Constraints::ConstraintPenalty::ConstraintPenalty(
       nummyele = numele;
     }
     // initialize maps and importer
-    errormap_ = std::make_shared<Core::LinAlg::Map>(
-        numele, nummyele, 0, Core::Communication::as_epetra_comm(actdisc_->get_comm()));
+    errormap_ = std::make_shared<Core::LinAlg::Map>(numele, nummyele, 0, actdisc_->get_comm());
     rederrormap_ = Core::LinAlg::allreduce_e_map(*errormap_);
     errorexport_ = std::make_shared<Epetra_Export>(
         rederrormap_->get_epetra_map(), errormap_->get_epetra_map());

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
@@ -138,14 +138,13 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::setup(
   }
 
   // Rowmap for the additional GIDs used by the mortar contact discretization.
-  lambda_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(-1, my_lambda_gid.size(),
-      my_lambda_gid.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  lambda_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, my_lambda_gid.size(), my_lambda_gid.data(), 0, discret_->get_comm());
 
   // We need to be able to get the global ids for a Lagrange multiplier DOF from the global id
   // of a node. To do so, we 'abuse' the Core::LinAlg::MultiVector<double> as map between the
   // global node ids and the global Lagrange multiplier DOF ids.
-  Core::LinAlg::Map node_gid_rowmap(
-      -1, n_nodes, &my_nodes_gid[0], 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  Core::LinAlg::Map node_gid_rowmap(-1, n_nodes, &my_nodes_gid[0], 0, discret_->get_comm());
 
   // Map from global node ids to global lagrange multiplier ids. Only create the
   // multivector if it has one or more columns.
@@ -210,11 +209,11 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::set_global_maps()
   }
 
   // Create the beam and solid maps.
-  boundary_layer_interface_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(-1,
-      boundary_layer_interface_dofs.size(), &boundary_layer_interface_dofs[0], 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
-  background_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(-1, background_dofs.size(),
-      &background_dofs[0], 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  boundary_layer_interface_dof_rowmap_ =
+      std::make_shared<Core::LinAlg::Map>(-1, boundary_layer_interface_dofs.size(),
+          &boundary_layer_interface_dofs[0], 0, discret_->get_comm());
+  background_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, background_dofs.size(), &background_dofs[0], 0, discret_->get_comm());
 
   // Reset the local maps.
   node_gid_to_lambda_gid_map_.clear();
@@ -267,8 +266,8 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::set_local_maps(
   node_gid_needed.resize(std::distance(node_gid_needed.begin(), it));
 
   // Create the maps for the extraction of the values.
-  Core::LinAlg::Map node_gid_needed_rowmap(-1, node_gid_needed.size(), &node_gid_needed[0], 0,
-      Core::Communication::as_epetra_comm(discret_->get_comm()));
+  Core::LinAlg::Map node_gid_needed_rowmap(
+      -1, node_gid_needed.size(), &node_gid_needed[0], 0, discret_->get_comm());
 
   // Create the Multivectors that will be filled with all values needed on this rank.
   std::shared_ptr<Core::LinAlg::MultiVector<double>> node_gid_to_lambda_gid_copy = nullptr;
@@ -298,8 +297,8 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::set_local_maps(
   }
 
   // Create the global lambda col map.
-  lambda_dof_colmap_ = std::make_shared<Core::LinAlg::Map>(-1, lambda_gid_for_col_map.size(),
-      &lambda_gid_for_col_map[0], 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  lambda_dof_colmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, lambda_gid_for_col_map.size(), &lambda_gid_for_col_map[0], 0, discret_->get_comm());
 
   // Set flags for local maps.
   is_local_maps_build_ = true;

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_base.cpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_base.cpp
@@ -62,7 +62,8 @@ void Constraints::SubmodelEvaluator::ConstraintBase::evaluate_coupling_terms(
   for (const auto& mpc : listMPCs_) ncon_ += mpc->get_number_of_mp_cs();
 
   // ToDo: Add an offset to the constraint dof map.
-  n_condition_map_ = std::make_shared<Core::LinAlg::Map>(ncon_, 0, stiff_ptr_->Comm());
+  n_condition_map_ = std::make_shared<Core::LinAlg::Map>(
+      ncon_, 0, Core::Communication::unpack_epetra_comm(stiff_ptr_->Comm()));
 
   // initialise all global coupling objects
   constraint_vector_ = std::make_shared<Core::LinAlg::Vector<double>>(*n_condition_map_, true);

--- a/src/contact/4C_contact_abstract_strategy.cpp
+++ b/src/contact/4C_contact_abstract_strategy.cpp
@@ -823,8 +823,8 @@ std::shared_ptr<Core::LinAlg::Map> CONTACT::AbstractStrategy::create_determinist
 
     my_lm_gids[slid] = interface_lmgid;
   }
-  return std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_lm_gids.size()),
-      my_lm_gids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  return std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(my_lm_gids.size()), my_lm_gids.data(), 0, get_comm());
 }
 
 
@@ -980,14 +980,10 @@ void CONTACT::AbstractStrategy::update_global_self_contact_state()
   if (not is_self_contact()) return;
 
   // reset global slave / master Epetra Maps
-  gsnoderowmap_ =
-      std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
-  gsdofrowmap_ =
-      std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
-  gmdofrowmap_ =
-      std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
-  glmdofrowmap_ =
-      std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+  gsnoderowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
+  gsdofrowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
+  gmdofrowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
+  glmdofrowmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
 
   // make numbering of LM dofs consecutive and unique across N interfaces
   int offset_if = 0;

--- a/src/contact/4C_contact_interface.cpp
+++ b/src/contact/4C_contact_interface.cpp
@@ -279,18 +279,18 @@ void CONTACT::Interface::update_master_slave_sets()
       }
     }
 
-    sdofVertexRowmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sVr.size(), sVr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    sdofVertexColmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sVc.size(), sVc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    sdofEdgeRowmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sEr.size(), sEr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    sdofEdgeColmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sEc.size(), sEc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    sdofSurfRowmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sSr.size(), sSr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    sdofSurfColmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sSc.size(), sSc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    sdofVertexRowmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sVr.size(), sVr.data(), 0, get_comm());
+    sdofVertexColmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sVc.size(), sVc.data(), 0, get_comm());
+    sdofEdgeRowmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sEr.size(), sEr.data(), 0, get_comm());
+    sdofEdgeColmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sEc.size(), sEc.data(), 0, get_comm());
+    sdofSurfRowmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sSr.size(), sSr.data(), 0, get_comm());
+    sdofSurfColmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sSc.size(), sSc.data(), 0, get_comm());
   }
 }
 
@@ -530,8 +530,7 @@ void CONTACT::Interface::extend_interface_ghosting_safely(const double meanVeloc
       Core::LinAlg::gather<int>(sdata, rdata, (int)allproc.size(), allproc.data(), get_comm());
 
       // build completely overlapping map of nodes (on ALL processors)
-      Core::LinAlg::Map newnodecolmap(
-          -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+      Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
       sdata.clear();
       rdata.clear();
 
@@ -545,8 +544,7 @@ void CONTACT::Interface::extend_interface_ghosting_safely(const double meanVeloc
       Core::LinAlg::gather<int>(sdata, rdata, (int)allproc.size(), allproc.data(), get_comm());
 
       // build complete overlapping map of elements (on ALL processors)
-      Core::LinAlg::Map newelecolmap(
-          -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+      Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
       sdata.clear();
       rdata.clear();
       allproc.clear();
@@ -598,8 +596,7 @@ void CONTACT::Interface::extend_interface_ghosting_safely(const double meanVeloc
       }
 
       // build new node column map (on ALL processors)
-      Core::LinAlg::Map newnodecolmap(
-          -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+      Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
       sdata.clear();
       rdata.clear();
 
@@ -631,8 +628,7 @@ void CONTACT::Interface::extend_interface_ghosting_safely(const double meanVeloc
       }
 
       // build new element column map (on ALL processors)
-      Core::LinAlg::Map newelecolmap(
-          -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+      Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
       sdata.clear();
       rdata.clear();
       allproc.clear();
@@ -691,8 +687,7 @@ void CONTACT::Interface::extend_interface_ghosting_safely(const double meanVeloc
       }
 
       std::vector<int> colnodes(nodes.begin(), nodes.end());
-      Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0,
-          Core::Communication::as_epetra_comm(get_comm()));
+      Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0, get_comm());
 
       discret().export_column_nodes(nodecolmap);
       break;
@@ -768,10 +763,10 @@ void CONTACT::Interface::redistribute()
   }
 
   // we need an arbitrary preliminary element row map
-  Core::LinAlg::Map slaveCloseRowEles(-1, (int)closeele.size(), closeele.data(), 0,
-      Core::Communication::as_epetra_comm(Interface::get_comm()));
-  Core::LinAlg::Map slaveNonCloseRowEles(-1, (int)noncloseele.size(), noncloseele.data(), 0,
-      Core::Communication::as_epetra_comm(Interface::get_comm()));
+  Core::LinAlg::Map slaveCloseRowEles(
+      -1, (int)closeele.size(), closeele.data(), 0, Interface::get_comm());
+  Core::LinAlg::Map slaveNonCloseRowEles(
+      -1, (int)noncloseele.size(), noncloseele.data(), 0, Interface::get_comm());
   Core::LinAlg::Map masterRowEles(*master_row_elements());
 
   // check for consistency
@@ -1039,7 +1034,7 @@ void CONTACT::Interface::redistribute()
   const Epetra_BlockMap& bcol = outgraph->col_map();
   std::shared_ptr<Core::LinAlg::Map> scolnodes =
       std::make_shared<Core::LinAlg::Map>(bcol.NumGlobalElements(), bcol.NumMyElements(),
-          bcol.MyGlobalElements(), 0, Core::Communication::as_epetra_comm(Interface::get_comm()));
+          bcol.MyGlobalElements(), 0, Interface::get_comm());
 
   // trash new graph
   outgraph = nullptr;
@@ -7347,12 +7342,9 @@ bool CONTACT::Interface::split_active_dofs()
   // get out of here if active set is empty
   if (activenodes_ == nullptr or activenodes_->NumGlobalElements() == 0)
   {
-    activen_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
-    activet_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
-    slipt_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    activen_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
+    activet_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
+    slipt_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return true;
   }
 
@@ -7401,10 +7393,8 @@ bool CONTACT::Interface::split_active_dofs()
     FOUR_C_THROW("split_active_dofs: Splitting went wrong!");
 
   // create Nmap and Tmap objects
-  activen_ = std::make_shared<Core::LinAlg::Map>(
-      gcountN, countN, myNgids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  activet_ = std::make_shared<Core::LinAlg::Map>(
-      gcountT, countT, myTgids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  activen_ = std::make_shared<Core::LinAlg::Map>(gcountN, countN, myNgids.data(), 0, get_comm());
+  activet_ = std::make_shared<Core::LinAlg::Map>(gcountT, countT, myTgids.data(), 0, get_comm());
 
   // *******************************************************************
   // FRICTION - EXTRACTING TANGENTIAL DOFS FROM SLIP DOFS
@@ -7419,15 +7409,13 @@ bool CONTACT::Interface::split_active_dofs()
   // get out of here if slip set is empty
   if (slipnodes_ == nullptr)
   {
-    slipt_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    slipt_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return true;
   }
 
   if (slipnodes_->NumGlobalElements() == 0)
   {
-    slipt_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    slipt_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return true;
   }
 
@@ -7464,8 +7452,8 @@ bool CONTACT::Interface::split_active_dofs()
   Core::Communication::sum_all(&countslipT, &gcountslipT, 1, get_comm());
 
   // create Tslipmap objects
-  slipt_ = std::make_shared<Core::LinAlg::Map>(gcountslipT, countslipT, myslipTgids.data(), 0,
-      Core::Communication::as_epetra_comm(get_comm()));
+  slipt_ = std::make_shared<Core::LinAlg::Map>(
+      gcountslipT, countslipT, myslipTgids.data(), 0, get_comm());
 
   return true;
 }
@@ -7549,8 +7537,8 @@ void CONTACT::Interface::update_self_contact_lag_mult_set(
     lmdofs.push_back(ref_lmgids[ref_lid]);
   }
 
-  lmdofmap_ = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(lmdofs.size()),
-      lmdofs.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  lmdofmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(lmdofs.size()), lmdofs.data(), 0, get_comm());
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/contact/4C_contact_interface_roundrobin.cpp
+++ b/src/contact/4C_contact_interface_roundrobin.cpp
@@ -51,10 +51,9 @@ void CONTACT::Interface::round_robin_extend_ghosting(bool firstevaluation)
 
   std::shared_ptr<Core::LinAlg::Map> currently_ghosted_elements =
       std::make_shared<Core::LinAlg::Map>(-1, (int)element_GIDs_to_be_ghosted.size(),
-          element_GIDs_to_be_ghosted.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  std::shared_ptr<Core::LinAlg::Map> currently_ghosted_nodes =
-      std::make_shared<Core::LinAlg::Map>(-1, (int)node_GIDs_to_be_ghosted.size(),
-          node_GIDs_to_be_ghosted.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+          element_GIDs_to_be_ghosted.data(), 0, get_comm());
+  std::shared_ptr<Core::LinAlg::Map> currently_ghosted_nodes = std::make_shared<Core::LinAlg::Map>(
+      -1, (int)node_GIDs_to_be_ghosted.size(), node_GIDs_to_be_ghosted.data(), 0, get_comm());
 
   if (firstevaluation)
   {
@@ -336,15 +335,15 @@ void CONTACT::Interface::round_robin_change_ownership()
   Core::Communication::barrier(comm_v);
 
   // create maps from sending
-  std::shared_ptr<Core::LinAlg::Map> noderowmap = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)nrow.size(), nrow.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  std::shared_ptr<Core::LinAlg::Map> nodecolmap = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)ncol.size(), ncol.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> noderowmap =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)nrow.size(), nrow.data(), 0, get_comm());
+  std::shared_ptr<Core::LinAlg::Map> nodecolmap =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)ncol.size(), ncol.data(), 0, get_comm());
 
-  std::shared_ptr<Core::LinAlg::Map> elerowmap = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)erow.size(), erow.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  std::shared_ptr<Core::LinAlg::Map> elecolmap = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)ecol.size(), ecol.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> elerowmap =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)erow.size(), erow.data(), 0, get_comm());
+  std::shared_ptr<Core::LinAlg::Map> elecolmap =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)ecol.size(), ecol.data(), 0, get_comm());
 
   // Merge s/m column maps for eles and nodes
   std::shared_ptr<Core::LinAlg::Map> colnodesfull = Core::LinAlg::merge_map(nodecolmap, SCN, true);

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -4967,11 +4967,8 @@ void CONTACT::LagrangeStrategy::update_active_set_semi_smooth(const bool firstSt
   }
   else
   {
-    gOldActiveSlaveNodes_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
-    if (friction_)
-      gOldslipnodes_ = std::make_shared<Core::LinAlg::Map>(
-          0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    gOldActiveSlaveNodes_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
+    if (friction_) gOldslipnodes_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
   }
 
   // also update special flag for semi-smooth Newton convergence

--- a/src/contact/4C_contact_meshtying_abstract_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_abstract_strategy.cpp
@@ -436,8 +436,8 @@ void CONTACT::MtAbstractStrategy::restrict_meshtying_zone()
     }
 
     // re-setup old slave dof row map (with restriction now)
-    non_redist_gsdofrowmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)data.size(), data.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    non_redist_gsdofrowmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)data.size(), data.data(), 0, get_comm());
   }
 
   // Step 5: re-setup internal dof row map (non-interface dofs)

--- a/src/contact/4C_contact_selfcontact_binarytree.cpp
+++ b/src/contact/4C_contact_selfcontact_binarytree.cpp
@@ -1562,8 +1562,7 @@ void CONTACT::SelfBinaryTree::search_contact()
     int gid = elements_->GID(i);
     if (contactpairs_.find(gid) != contactpairs_.end()) locdata.push_back(gid);
   }
-  Core::LinAlg::Map mymap(
-      -1, (int)locdata.size(), locdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  Core::LinAlg::Map mymap(-1, (int)locdata.size(), locdata.data(), 0, get_comm());
   std::shared_ptr<Core::LinAlg::Map> redmap = Core::LinAlg::allreduce_e_map(mymap);
   Core::Communication::Exporter ex(mymap, *redmap, get_comm());
   ex.do_export(contactpairs_);

--- a/src/contact/4C_contact_wear_interface.cpp
+++ b/src/contact/4C_contact_wear_interface.cpp
@@ -3116,10 +3116,8 @@ bool Wear::WearInterface::build_active_set_master()
 
     if (frinode->fri_data().slip()) sl.push_back(frinode->id());
   }
-  Core::LinAlg::Map auxa(
-      -1, (int)a.size(), a.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  Core::LinAlg::Map auxsl(
-      -1, (int)sl.size(), sl.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  Core::LinAlg::Map auxa(-1, (int)a.size(), a.data(), 0, get_comm());
+  Core::LinAlg::Map auxsl(-1, (int)sl.size(), sl.data(), 0, get_comm());
 
   const std::shared_ptr<Core::LinAlg::Map> ara = Core::LinAlg::allreduce_e_map((auxa));
   const std::shared_ptr<Core::LinAlg::Map> arsl = Core::LinAlg::allreduce_e_map((auxsl));
@@ -3170,8 +3168,7 @@ bool Wear::WearInterface::build_active_set_master()
       eleatt.push_back(moele->id());
   }
 
-  Core::LinAlg::Map auxe(
-      -1, (int)eleatt.size(), eleatt.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  Core::LinAlg::Map auxe(-1, (int)eleatt.size(), eleatt.data(), 0, get_comm());
   const std::shared_ptr<Core::LinAlg::Map> att = Core::LinAlg::allreduce_e_map((auxe));
 
   for (int j = 0; j < att->NumMyElements(); ++j)
@@ -3272,12 +3269,9 @@ bool Wear::WearInterface::build_active_set_master()
     mele->set_attached() = false;
   }
 
-  Core::LinAlg::Map actmn(
-      -1, (int)wa.size(), wa.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  Core::LinAlg::Map slimn(
-      -1, (int)wsl.size(), wsl.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  Core::LinAlg::Map slimd(
-      -1, (int)wsln.size(), wsln.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  Core::LinAlg::Map actmn(-1, (int)wa.size(), wa.data(), 0, get_comm());
+  Core::LinAlg::Map slimn(-1, (int)wsl.size(), wsl.data(), 0, get_comm());
+  Core::LinAlg::Map slimd(-1, (int)wsln.size(), wsln.data(), 0, get_comm());
 
   const std::shared_ptr<Core::LinAlg::Map> ARactmn =
       Core::LinAlg::allreduce_overlapping_e_map((actmn));
@@ -3329,12 +3323,11 @@ bool Wear::WearInterface::build_active_set_master()
     }
   }
 
-  activmasternodes_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)ga.size(), ga.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  slipmasternodes_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)gs.size(), gs.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  slipmn_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)gsd.size(), gsd.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  activmasternodes_ =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)ga.size(), ga.data(), 0, get_comm());
+  slipmasternodes_ =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)gs.size(), gs.data(), 0, get_comm());
+  slipmn_ = std::make_shared<Core::LinAlg::Map>(-1, (int)gsd.size(), gsd.data(), 0, get_comm());
 
   for (int j = 0; j < slave_col_nodes()->NumMyElements(); ++j)
   {
@@ -3426,10 +3419,10 @@ bool Wear::WearInterface::build_active_set(bool init)
     }
 
     // create map for all involved master nodes -- both-sided wear specific
-    involvednodes_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mymnodegids.size(),
-        mymnodegids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    involveddofs_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mymdofgids.size(),
-        mymdofgids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    involvednodes_ = std::make_shared<Core::LinAlg::Map>(
+        -1, (int)mymnodegids.size(), mymnodegids.data(), 0, get_comm());
+    involveddofs_ = std::make_shared<Core::LinAlg::Map>(
+        -1, (int)mymdofgids.size(), mymdofgids.data(), 0, get_comm());
   }
 
   return true;
@@ -4044,15 +4037,13 @@ void Wear::WearInterface::split_slave_dofs()
   // get out of here if active set is empty
   if (snoderowmap_ == nullptr)
   {
-    sndofmap_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    sndofmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return;
   }
 
   else if (snoderowmap_->NumGlobalElements() == 0)
   {
-    sndofmap_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    sndofmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return;
   }
 
@@ -4089,8 +4080,7 @@ void Wear::WearInterface::split_slave_dofs()
     FOUR_C_THROW("SplitSlaveDofs: Splitting went wrong!");
 
   // create Nmap and Tmap objects
-  sndofmap_ = std::make_shared<Core::LinAlg::Map>(
-      gcountN, countN, myNgids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  sndofmap_ = std::make_shared<Core::LinAlg::Map>(gcountN, countN, myNgids.data(), 0, get_comm());
 
   return;
 }
@@ -4104,15 +4094,13 @@ void Wear::WearInterface::split_master_dofs()
   // get out of here if active set is empty
   if (mnoderowmap_ == nullptr)
   {
-    mndofmap_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    mndofmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return;
   }
 
   else if (mnoderowmap_->NumGlobalElements() == 0)
   {
-    mndofmap_ =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+    mndofmap_ = std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     return;
   }
 
@@ -4149,8 +4137,7 @@ void Wear::WearInterface::split_master_dofs()
     FOUR_C_THROW("SplitSlaveDofs: Splitting went wrong!");
 
   // create Nmap and Tmap objects
-  mndofmap_ = std::make_shared<Core::LinAlg::Map>(
-      gcountN, countN, myNgids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  mndofmap_ = std::make_shared<Core::LinAlg::Map>(gcountN, countN, myNgids.data(), 0, get_comm());
 
   return;
 }
@@ -4223,8 +4210,8 @@ void Wear::WearInterface::update_w_sets(int offset_if, int maxdofwear, bool both
   // create interface w map
   // (if maxdofglobal_ == 0, we do not want / need this)
   if (maxdofwear > 0)
-    wdofmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)wdof.size(), wdof.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    wdofmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)wdof.size(), wdof.data(), 0, get_comm());
 
   //********************************************************************
   // For discrete both-sided wear
@@ -4256,8 +4243,8 @@ void Wear::WearInterface::update_w_sets(int offset_if, int maxdofwear, bool both
     // create interface w map
     // (if maxdofglobal_ == 0, we do not want / need this)
     if (maxdofwear > 0)
-      wmdofmap_ = std::make_shared<Core::LinAlg::Map>(
-          -1, (int)wmdof.size(), wmdof.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+      wmdofmap_ =
+          std::make_shared<Core::LinAlg::Map>(-1, (int)wmdof.size(), wmdof.data(), 0, get_comm());
   }
 
   return;

--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -45,8 +45,7 @@ namespace Core::Binstrategy::Utils
     }
 
     std::vector<int> colnodes(nodes.begin(), nodes.end());
-    Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0,
-        Core::Communication::as_epetra_comm(discret.get_comm()));
+    Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0, discret.get_comm());
 
     // now ghost the nodes
     discret.export_column_nodes(nodecolmap);

--- a/src/core/comm/src/4C_comm_exporter.cpp
+++ b/src/core/comm/src/4C_comm_exporter.cpp
@@ -16,7 +16,7 @@ FOUR_C_NAMESPACE_OPEN
 
 
 Core::Communication::Exporter::Exporter(MPI_Comm comm)
-    : dummymap_(0, 0, Core::Communication::as_epetra_comm(comm)),
+    : dummymap_(0, 0, comm),
       frommap_(dummymap_),
       tomap_(dummymap_),
       comm_(comm),
@@ -27,7 +27,7 @@ Core::Communication::Exporter::Exporter(MPI_Comm comm)
 
 Core::Communication::Exporter::Exporter(
     const Core::LinAlg::Map& frommap, const Core::LinAlg::Map& tomap, MPI_Comm comm)
-    : dummymap_(0, 0, Core::Communication::as_epetra_comm(comm)),
+    : dummymap_(0, 0, comm),
       frommap_(frommap),
       tomap_(tomap),
       comm_(comm),

--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -351,7 +351,7 @@ namespace Core::Communication
     // do stupid conversion from Epetra_BlockMap to Core::LinAlg::Map
     const Epetra_BlockMap& vecblockmap = vec.Map();
     Core::LinAlg::Map vecmap(vecblockmap.NumGlobalElements(), vecblockmap.NumMyElements(),
-        vecblockmap.MyGlobalElements(), 0, Core::Communication::as_epetra_comm(vec.Comm()));
+        vecblockmap.MyGlobalElements(), 0, vec.Comm());
 
     // gather data of vector to compare on gcomm proc 0 and last gcomm proc
     std::shared_ptr<Core::LinAlg::Map> proc0map;

--- a/src/core/comm/tests/4C_comm_utils_test.np3.cpp
+++ b/src/core/comm/tests/4C_comm_utils_test.np3.cpp
@@ -47,9 +47,8 @@ namespace
           false, false, false, Core::IO::standard, communicators_->local_comm(), 0, 0, "dummy");
 
       // create arbitrary distributed map within each group
-      std::shared_ptr<Core::LinAlg::Map> map =
-          std::make_shared<Core::LinAlg::Map>(numberOfElementsToDistribute_, 0,
-              Core::Communication::as_epetra_comm(communicators_->local_comm()));
+      std::shared_ptr<Core::LinAlg::Map> map = std::make_shared<Core::LinAlg::Map>(
+          numberOfElementsToDistribute_, 0, communicators_->local_comm());
       vector_ = std::make_shared<Core::LinAlg::Vector<double>>(*map, false);
 
       // fill test Core::LinAlg::Vector<double> with entry equals gid
@@ -89,9 +88,8 @@ namespace
           false, false, false, Core::IO::standard, communicators_->local_comm(), 0, 0, "dummy");
 
       // create arbitrary distributed map within each group
-      std::shared_ptr<Core::LinAlg::Map> rowmap =
-          std::make_shared<Core::LinAlg::Map>(numberOfElementsToDistribute_, 0,
-              Core::Communication::as_epetra_comm(communicators_->local_comm()));
+      std::shared_ptr<Core::LinAlg::Map> rowmap = std::make_shared<Core::LinAlg::Map>(
+          numberOfElementsToDistribute_, 0, communicators_->local_comm());
       int approximateNumberOfNonZeroesPerRow = 3;
       matrix_ =
           std::make_shared<Core::LinAlg::SparseMatrix>(*rowmap, approximateNumberOfNonZeroesPerRow);
@@ -160,10 +158,8 @@ namespace
           false, false, false, Core::IO::standard, communicators_->local_comm(), 0, 0, "dummy");
 
       // create arbitrary distributed map within each group
-      Core::LinAlg::Map rowmap(numberOfElementsToDistribute_, 0,
-          Core::Communication::as_epetra_comm(communicators_->local_comm()));
-      Core::LinAlg::Map colmap(2 * numberOfElementsToDistribute_, 0,
-          Core::Communication::as_epetra_comm(communicators_->local_comm()));
+      Core::LinAlg::Map rowmap(numberOfElementsToDistribute_, 0, communicators_->local_comm());
+      Core::LinAlg::Map colmap(2 * numberOfElementsToDistribute_, 0, communicators_->local_comm());
       int approximateNumberOfNonZeroesPerRow = 6;
       matrix_ =
           std::make_shared<Core::LinAlg::SparseMatrix>(rowmap, approximateNumberOfNonZeroesPerRow);

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
@@ -392,9 +392,8 @@ void Core::Conditions::LocsysManager::update(const double time,
     nummyentries = static_cast<int>(locsysdofs.size());
     myglobalentries = locsysdofs.data();
   }
-  locsysdofmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyentries, myglobalentries,
-      discret_.dof_row_map()->IndexBase(),
-      Core::Communication::as_epetra_comm(discret_.get_comm()));
+  locsysdofmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, nummyentries, myglobalentries, discret_.dof_row_map()->IndexBase(), discret_.get_comm());
   if (locsysdofmap_ == nullptr) FOUR_C_THROW("Creation failed.");
 
   // The matrix subtrafo_ is used in order to apply the Dirichlet Conditions in a more efficient

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
@@ -956,8 +956,7 @@ void Core::FE::DiscretizationFaces::build_face_row_map()
       ++count;
     }
   if (count != nummyeles) FOUR_C_THROW("Mismatch in no. of internal faces");
-  facerowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, nummyeles, eleids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  facerowmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyeles, eleids.data(), 0, get_comm());
   return;
 }
 
@@ -980,8 +979,7 @@ void Core::FE::DiscretizationFaces::build_face_col_map()
     ++count;
   }
   if (count != nummyeles) FOUR_C_THROW("Mismatch in no. of elements");
-  facecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, nummyeles, eleids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  facecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyeles, eleids.data(), 0, get_comm());
   return;
 }
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
@@ -178,8 +178,7 @@ void Core::FE::Discretization::build_node_row_map()
       ++count;
     }
   if (count != nummynodes) FOUR_C_THROW("Mismatch in no. of nodes");
-  noderowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, nummynodes, nodeids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  noderowmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummynodes, nodeids.data(), 0, get_comm());
   return;
 }
 
@@ -202,8 +201,7 @@ void Core::FE::Discretization::build_node_col_map()
     ++count;
   }
   if (count != nummynodes) FOUR_C_THROW("Mismatch in no. of nodes");
-  nodecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, nummynodes, nodeids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  nodecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummynodes, nodeids.data(), 0, get_comm());
   return;
 }
 
@@ -229,8 +227,7 @@ void Core::FE::Discretization::build_element_row_map()
       ++count;
     }
   if (count != nummyeles) FOUR_C_THROW("Mismatch in no. of elements");
-  elerowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, nummyeles, eleids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  elerowmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyeles, eleids.data(), 0, get_comm());
   return;
 }
 
@@ -252,8 +249,7 @@ void Core::FE::Discretization::build_element_col_map()
     ++count;
   }
   if (count != nummyeles) FOUR_C_THROW("Mismatch in no. of elements");
-  elecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, nummyeles, eleids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  elecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, nummyeles, eleids.data(), 0, get_comm());
   return;
 }
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -600,16 +600,16 @@ Core::FE::Discretization::build_element_row_column(const Core::LinAlg::Map& node
   // allreduced nummyele must match the total no. of elements in this
   // discretization, otherwise we lost some
   // build the rowmap of elements
-  std::shared_ptr<Core::LinAlg::Map> elerowmap = std::make_shared<Core::LinAlg::Map>(
-      -1, nummyele, myele.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> elerowmap =
+      std::make_shared<Core::LinAlg::Map>(-1, nummyele, myele.data(), 0, get_comm());
   if (!elerowmap->UniqueGIDs()) FOUR_C_THROW("Element row map is not unique");
 
   // build elecolmap
   std::vector<int> elecol(nummyele + nummyghostele);
   for (int i = 0; i < nummyele; ++i) elecol[i] = myele[i];
   for (int i = 0; i < nummyghostele; ++i) elecol[nummyele + i] = myghostele[i];
-  std::shared_ptr<Core::LinAlg::Map> elecolmap = std::make_shared<Core::LinAlg::Map>(-1,
-      nummyghostele + nummyele, elecol.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> elecolmap = std::make_shared<Core::LinAlg::Map>(
+      -1, nummyghostele + nummyele, elecol.data(), 0, get_comm());
 
   return {elerowmap, elecolmap};
 }
@@ -790,8 +790,7 @@ void Core::FE::Discretization::extended_ghosting(const Core::LinAlg::Map& elecol
   if (have_pbc) pbcdofset->set_coupled_nodes(pbcmapvec);
 
   std::vector<int> colnodes(nodes.begin(), nodes.end());
-  Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0,
-      Core::Communication::as_epetra_comm(get_comm()));
+  Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0, get_comm());
 
   // now ghost the nodes
   export_column_nodes(nodecolmap);
@@ -841,8 +840,7 @@ void Core::FE::Discretization::setup_ghosting(
     entriesperrow.push_back(localgraph[i->first].size());
   }
 
-  Core::LinAlg::Map rownodes(
-      -1, gids.size(), gids.data(), 0, Core::Communication::as_epetra_comm(comm_));
+  Core::LinAlg::Map rownodes(-1, gids.size(), gids.data(), 0, comm_);
 
   // Construct FE graph. This graph allows processor off-rows to be inserted
   // as well. The communication issue is solved.
@@ -879,10 +877,10 @@ void Core::FE::Discretization::setup_ghosting(
   // do stupid conversion from Epetra_BlockMap to Core::LinAlg::Map
   const Epetra_BlockMap& brow = graph->row_map();
   const Epetra_BlockMap& bcol = graph->col_map();
-  Core::LinAlg::Map noderowmap(brow.NumGlobalElements(), brow.NumMyElements(),
-      brow.MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm_));
-  Core::LinAlg::Map nodecolmap(bcol.NumGlobalElements(), bcol.NumMyElements(),
-      bcol.MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm_));
+  Core::LinAlg::Map noderowmap(
+      brow.NumGlobalElements(), brow.NumMyElements(), brow.MyGlobalElements(), 0, comm_);
+  Core::LinAlg::Map nodecolmap(
+      bcol.NumGlobalElements(), bcol.NumMyElements(), bcol.MyGlobalElements(), 0, comm_);
 
   graph = nullptr;
 

--- a/src/core/fem/src/dofset/4C_fem_dofset.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset.cpp
@@ -523,17 +523,17 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
     std::copy(dofs.begin(), dofs.end(), std::back_inserter(localcoldofs));
   }
 
-  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, localrowdofs.size(), localrowdofs.data(), 0,
-      Core::Communication::as_epetra_comm(dis.get_comm()));
+  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, localrowdofs.size(), localrowdofs.data(), 0, dis.get_comm());
   if (!dofrowmap_->UniqueGIDs()) FOUR_C_THROW("Dof row map is not unique");
-  dofcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, localcoldofs.size(), localcoldofs.data(), 0,
-      Core::Communication::as_epetra_comm(dis.get_comm()));
+  dofcolmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, localcoldofs.size(), localcoldofs.data(), 0, dis.get_comm());
 
   // **********************************************************************
   // **********************************************************************
   // build map of all (non-unique) column DoFs
-  dofscolnodes_ = std::make_shared<Core::LinAlg::Map>(-1, allnodelocalcoldofs.size(),
-      allnodelocalcoldofs.data(), 0, Core::Communication::as_epetra_comm(dis.get_comm()));
+  dofscolnodes_ = std::make_shared<Core::LinAlg::Map>(
+      -1, allnodelocalcoldofs.size(), allnodelocalcoldofs.data(), 0, dis.get_comm());
 
   // build shift vector
   shiftcolnodes_ = std::make_shared<Core::LinAlg::Vector<int>>(*dis.node_col_map());

--- a/src/core/fem/src/dofset/4C_fem_dofset_definedmapping_wrapper.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_definedmapping_wrapper.cpp
@@ -141,11 +141,9 @@ int Core::DOFSets::DofSetDefinedMappingWrapper::assign_degrees_of_freedom(
   }
 
   // Epetra maps
-  Core::LinAlg::Map targetnodemap(-1, patchedtargetnodes.size(), patchedtargetnodes.data(), 0,
-      Core::Communication::as_epetra_comm(com));
+  Core::LinAlg::Map targetnodemap(-1, patchedtargetnodes.size(), patchedtargetnodes.data(), 0, com);
 
-  Core::LinAlg::Map permsourcenodemap(-1, permsourcenodes.size(), permsourcenodes.data(), 0,
-      Core::Communication::as_epetra_comm(com));
+  Core::LinAlg::Map permsourcenodemap(-1, permsourcenodes.size(), permsourcenodes.data(), 0, com);
 
   // we expect to get maps of exactly the same shape
   if (not targetnodemap.PointSameAs(permsourcenodemap))

--- a/src/core/fem/src/dofset/4C_fem_dofset_transparent.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_transparent.cpp
@@ -83,8 +83,8 @@ void Core::DOFSets::TransparentDofSet::transfer_degrees_of_freedom(
     dofrowvec.push_back(*idof);
   }
 
-  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, dofrowvec.size(), dofrowvec.data(), 0,
-      Core::Communication::as_epetra_comm(newdis.get_comm()));
+  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, dofrowvec.size(), dofrowvec.data(), 0, newdis.get_comm());
 
   // build dofcolvec
   std::set<int> dofcolset;
@@ -123,8 +123,8 @@ void Core::DOFSets::TransparentDofSet::transfer_degrees_of_freedom(
     dofcolvec.push_back(*idof);
   }
 
-  dofcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, dofcolvec.size(), dofcolvec.data(), 0,
-      Core::Communication::as_epetra_comm(newdis.get_comm()));
+  dofcolmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, dofcolvec.size(), dofcolvec.data(), 0, newdis.get_comm());
 }
 
 /// Assign dof numbers for new discretization using dof numbering from source discretization.
@@ -284,8 +284,8 @@ void Core::DOFSets::TransparentDofSet::parallel_transfer_degrees_of_freedom(
     dofrowvec.push_back(*idof);
   }
 
-  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, dofrowvec.size(), dofrowvec.data(), 0,
-      Core::Communication::as_epetra_comm(newdis.get_comm()));
+  dofrowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, dofrowvec.size(), dofrowvec.data(), 0, newdis.get_comm());
 
   // build dofcolvec
   std::set<int> dofcolset;
@@ -318,8 +318,8 @@ void Core::DOFSets::TransparentDofSet::parallel_transfer_degrees_of_freedom(
     dofcolvec.push_back(*idof);
   }
 
-  dofcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, dofcolvec.size(), dofcolvec.data(), 0,
-      Core::Communication::as_epetra_comm(newdis.get_comm()));
+  dofcolmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, dofcolvec.size(), dofcolvec.data(), 0, newdis.get_comm());
 
 
   return;

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -88,9 +88,8 @@ std::shared_ptr<Core::LinAlg::Map> Core::FE::DiscretizationCreatorBase::create_m
   std::vector<int> targetgidvec(gidset.begin(), gidset.end());
   gidset.clear();
 
-  std::shared_ptr<Core::LinAlg::Map> map =
-      std::make_shared<Core::LinAlg::Map>(-1, targetgidvec.size(), targetgidvec.data(), 0,
-          Core::Communication::as_epetra_comm(targetdis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> map = std::make_shared<Core::LinAlg::Map>(
+      -1, targetgidvec.size(), targetgidvec.data(), 0, targetdis.get_comm());
   targetgidvec.clear();
 
   return map;

--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -488,8 +488,7 @@ namespace Core::IO
       const std::function<bool(const Core::Elements::Element* ele)>& element_predicate)
   {
     // Set up a multivector which will be populated with all ghosting information.
-    MPI_Comm comm =
-        Core::Communication::unpack_epetra_comm(discretization.element_col_map()->Comm());
+    MPI_Comm comm = discretization.element_col_map()->Comm();
     const int n_proc = Core::Communication::num_mpi_ranks(comm);
     const int my_proc = Core::Communication::my_mpi_rank(comm);
 

--- a/src/core/io/src/4C_io_gridgenerator.cpp
+++ b/src/core/io/src/4C_io_gridgenerator.cpp
@@ -73,8 +73,7 @@ namespace Core::IO::GridGenerator
       {
         scale = 2;
       }
-      elementRowMap = std::make_shared<Core::LinAlg::Map>(
-          scale * numnewele, 0, Core::Communication::as_epetra_comm(comm));
+      elementRowMap = std::make_shared<Core::LinAlg::Map>(scale * numnewele, 0, comm);
     }
     else  // fancy final box map
     {
@@ -150,8 +149,8 @@ namespace Core::IO::GridGenerator
           for (size_t ix = xranges[mysection[0]]; ix < xranges[mysection[0] + 1]; ++ix)
             mynewele[idx++] = (iz * inputData.interval_[1] + it) * inputData.interval_[0] + ix;
 
-      elementRowMap = std::make_shared<Core::LinAlg::Map>(
-          -1, nummynewele, mynewele.data(), 0, Core::Communication::as_epetra_comm(comm));
+      elementRowMap =
+          std::make_shared<Core::LinAlg::Map>(-1, nummynewele, mynewele.data(), 0, comm);
     }
 
     // Build an input line that matches what is expected from an input file.
@@ -231,10 +230,10 @@ namespace Core::IO::GridGenerator
     {
       std::shared_ptr<const Core::LinAlg::Graph> graph =
           Core::Rebalance::build_graph(dis, *elementRowMap);
-      nodeRowMap = std::make_shared<Core::LinAlg::Map>(-1, graph->row_map().NumMyElements(),
-          graph->row_map().MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm));
-      nodeColMap = std::make_shared<Core::LinAlg::Map>(-1, graph->col_map().NumMyElements(),
-          graph->col_map().MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm));
+      nodeRowMap = std::make_shared<Core::LinAlg::Map>(
+          -1, graph->row_map().NumMyElements(), graph->row_map().MyGlobalElements(), 0, comm);
+      nodeColMap = std::make_shared<Core::LinAlg::Map>(
+          -1, graph->col_map().NumMyElements(), graph->col_map().MyGlobalElements(), 0, comm);
     }
 
 

--- a/src/core/io/src/4C_io_hdf.cpp
+++ b/src/core/io/src/4C_io_hdf.cpp
@@ -344,8 +344,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::IO::HDFReader::read_res
   calculate_range(new_proc_num, my_id, start, end);
 
   std::shared_ptr<std::vector<int>> ids = read_int_data(id_path, start, end);
-  Core::LinAlg::Map map(
-      -1, static_cast<int>(ids->size()), ids->data(), 0, Core::Communication::as_epetra_comm(Comm));
+  Core::LinAlg::Map map(-1, static_cast<int>(ids->size()), ids->data(), 0, Comm);
 
   std::shared_ptr<Core::LinAlg::MultiVector<double>> res =
       std::make_shared<Core::LinAlg::MultiVector<double>>(map, columns, false);
@@ -392,8 +391,7 @@ std::shared_ptr<std::vector<char>> Core::IO::HDFReader::read_result_data_vec_cha
 
   std::shared_ptr<std::vector<int>> ids = read_int_data(id_path, start, end);
   // cout << "size of ids:" << (*ids).size() << endl;
-  Core::LinAlg::Map map(
-      -1, static_cast<int>(ids->size()), ids->data(), 0, Core::Communication::as_epetra_comm(Comm));
+  Core::LinAlg::Map map(-1, static_cast<int>(ids->size()), ids->data(), 0, Comm);
   elemap = std::make_shared<Core::LinAlg::Map>(map);
 
   std::shared_ptr<std::vector<char>> res = read_char_data(value_path, start, end);

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -173,8 +173,7 @@ namespace
     if (eids.empty())
     {
       // If the element section is empty, we create an empty input and return
-      roweles_ = std::make_shared<Core::LinAlg::Map>(
-          -1, 0, nullptr, 0, Core::Communication::as_epetra_comm(comm_));
+      roweles_ = std::make_shared<Core::LinAlg::Map>(-1, 0, nullptr, 0, comm_);
 
       return;
     }
@@ -193,8 +192,7 @@ namespace
       if (myrank == numproc - 1) mysize = numele - (numproc - 1) * bsize;
 
       // construct the map
-      roweles_ = std::make_shared<Core::LinAlg::Map>(
-          -1, mysize, &eids[myrank * bsize], 0, Core::Communication::as_epetra_comm(comm_));
+      roweles_ = std::make_shared<Core::LinAlg::Map>(-1, mysize, &eids[myrank * bsize], 0, comm_);
     }
 
     // define blocksizes for blocks of elements we read
@@ -559,10 +557,10 @@ namespace
 
         rebalanceParams.set("partitioning method", "RCB");
 
-        rowmap = std::make_shared<Core::LinAlg::Map>(-1, graph->row_map().NumMyElements(),
-            graph->row_map().MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm));
-        colmap = std::make_shared<Core::LinAlg::Map>(-1, graph->col_map().NumMyElements(),
-            graph->col_map().MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm));
+        rowmap = std::make_shared<Core::LinAlg::Map>(
+            -1, graph->row_map().NumMyElements(), graph->row_map().MyGlobalElements(), 0, comm);
+        colmap = std::make_shared<Core::LinAlg::Map>(
+            -1, graph->col_map().NumMyElements(), graph->col_map().MyGlobalElements(), 0, comm);
 
         discret.redistribute(*rowmap, *colmap,
             {.assign_degrees_of_freedom = false,
@@ -583,10 +581,10 @@ namespace
 
         rebalanceParams.set("partitioning method", "HYPERGRAPH");
 
-        rowmap = std::make_shared<Core::LinAlg::Map>(-1, graph->row_map().NumMyElements(),
-            graph->row_map().MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm));
-        colmap = std::make_shared<Core::LinAlg::Map>(-1, graph->col_map().NumMyElements(),
-            graph->col_map().MyGlobalElements(), 0, Core::Communication::as_epetra_comm(comm));
+        rowmap = std::make_shared<Core::LinAlg::Map>(
+            -1, graph->row_map().NumMyElements(), graph->row_map().MyGlobalElements(), 0, comm);
+        colmap = std::make_shared<Core::LinAlg::Map>(
+            -1, graph->col_map().NumMyElements(), graph->col_map().MyGlobalElements(), 0, comm);
 
         discret.redistribute(*rowmap, *colmap, {.do_boundary_conditions = false});
 
@@ -647,8 +645,7 @@ namespace
     }
     else
     {
-      rowmap = colmap = std::make_shared<Core::LinAlg::Map>(
-          -1, 0, nullptr, 0, Core::Communication::as_epetra_comm(comm));
+      rowmap = colmap = std::make_shared<Core::LinAlg::Map>(-1, 0, nullptr, 0, comm);
     }
 
     auto options_redistribution = Core::FE::OptionsRedistribution();
@@ -885,8 +882,8 @@ namespace
       int first_ele_id = ele_count_before;
       Core::Communication::broadcast(num_read_ele, 0, comm);
       Core::Communication::broadcast(first_ele_id, 0, comm);
-      linear_element_map = std::make_unique<Core::LinAlg::Map>(
-          num_read_ele, ele_count_before, Core::Communication::as_epetra_comm(comm));
+      linear_element_map =
+          std::make_unique<Core::LinAlg::Map>(num_read_ele, ele_count_before, comm);
 
       std::vector<int> gid_list(num_read_ele);
       std::iota(gid_list.begin(), gid_list.end(), ele_count_before);
@@ -908,8 +905,7 @@ namespace
       int first_ele_id;
       Core::Communication::broadcast(num_read_ele, 0, comm);
       Core::Communication::broadcast(first_ele_id, 0, comm);
-      linear_element_map = std::make_unique<Core::LinAlg::Map>(
-          num_read_ele, first_ele_id, Core::Communication::as_epetra_comm(comm));
+      linear_element_map = std::make_unique<Core::LinAlg::Map>(num_read_ele, first_ele_id, comm);
 
       std::vector<int> gid_list;
       exodus_reader.target_discretization.proc_zero_distribute_elements_to_all(

--- a/src/core/linalg/src/dense/4C_linalg_utils_densematrix_communication.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_densematrix_communication.cpp
@@ -56,8 +56,7 @@ void Core::LinAlg::allreduce_vector(
 /*----------------------------------------------------------------------*/
 void Core::LinAlg::allreduce_e_map(std::vector<int>& rredundant, const Core::LinAlg::Map& emap)
 {
-  const int mynodepos =
-      find_my_pos(emap.NumMyElements(), Core::Communication::unpack_epetra_comm(emap.Comm()));
+  const int mynodepos = find_my_pos(emap.NumMyElements(), emap.Comm());
 
   std::vector<int> sredundant(emap.NumGlobalElements(), 0);
 
@@ -65,8 +64,8 @@ void Core::LinAlg::allreduce_e_map(std::vector<int>& rredundant, const Core::Lin
   std::copy(gids, gids + emap.NumMyElements(), sredundant.data() + mynodepos);
 
   rredundant.resize(emap.NumGlobalElements());
-  Core::Communication::sum_all(sredundant.data(), rredundant.data(), emap.NumGlobalElements(),
-      Core::Communication::unpack_epetra_comm(emap.Comm()));
+  Core::Communication::sum_all(
+      sredundant.data(), rredundant.data(), emap.NumGlobalElements(), emap.Comm());
 }
 
 /*----------------------------------------------------------------------*/
@@ -101,7 +100,7 @@ std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::allreduce_e_map(
   allreduce_e_map(rv, emap);
   std::shared_ptr<Core::LinAlg::Map> rmap;
 
-  if (Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(emap.Comm())) == pid)
+  if (Core::Communication::my_mpi_rank(emap.Comm()) == pid)
   {
     rmap = std::make_shared<Core::LinAlg::Map>(-1, rv.size(), rv.data(), 0, emap.Comm());
     // check the map
@@ -161,7 +160,7 @@ std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::allreduce_overlapping_e_map(
   allreduce_e_map(rv, emap);
   std::shared_ptr<Core::LinAlg::Map> rmap;
 
-  if (Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(emap.Comm())) == pid)
+  if (Core::Communication::my_mpi_rank(emap.Comm()) == pid)
   {
     // remove duplicates only on proc pid
     std::set<int> rs(rv.begin(), rv.end());

--- a/src/core/linalg/src/dense/4C_linalg_utils_densematrix_communication.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_densematrix_communication.hpp
@@ -61,7 +61,7 @@ namespace Core::LinAlg
     std::map<int, std::vector<T>> datamap;
     datamap[myrank] = sdata;
     // build a source map
-    Core::LinAlg::Map source(numproc, 1, &myrank, 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map source(numproc, 1, &myrank, 0, comm);
     // build a target map which is redundant on all target procs and zero everywhere else
     bool iamtarget = false;
     for (int i = 0; i < ntargetprocs; ++i)
@@ -77,8 +77,7 @@ namespace Core::LinAlg
       for (int i = 0; i < numproc; ++i) targetvec[i] = i;
     }
     const int tnummyelements = (int)targetvec.size();
-    Core::LinAlg::Map target(
-        -1, tnummyelements, targetvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map target(-1, tnummyelements, targetvec.data(), 0, comm);
     // build an exporter and export data
     Core::Communication::Exporter exporter(source, target, comm);
     exporter.do_export(datamap);
@@ -137,7 +136,7 @@ namespace Core::LinAlg
     std::map<int, std::set<T>> datamap;
     datamap[myrank] = sdata;
     // build a source map
-    Core::LinAlg::Map source(numproc, 1, &myrank, 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map source(numproc, 1, &myrank, 0, comm);
     // build a target map which is redundant on all target procs and zero everywhere else
     bool iamtarget = false;
     for (int i = 0; i < ntargetprocs; ++i)
@@ -153,8 +152,7 @@ namespace Core::LinAlg
       for (int i = 0; i < numproc; ++i) targetvec[i] = i;
     }
     const int tnummyelements = (int)targetvec.size();
-    Core::LinAlg::Map target(
-        -1, tnummyelements, targetvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map target(-1, tnummyelements, targetvec.data(), 0, comm);
     // build an exporter and export data
     Core::Communication::Exporter exporter(source, target, comm);
     exporter.do_export(datamap);
@@ -213,7 +211,7 @@ namespace Core::LinAlg
     std::map<int, std::map<int, std::set<T>>> datamap;
     datamap[myrank] = sdata;
     // build a source map
-    Core::LinAlg::Map source(numproc, 1, &myrank, 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map source(numproc, 1, &myrank, 0, comm);
     // build a target map which is redundant on all target procs and zero everywhere else
     bool iamtarget = false;
     for (int i = 0; i < ntargetprocs; ++i)
@@ -229,8 +227,7 @@ namespace Core::LinAlg
       for (int i = 0; i < numproc; ++i) targetvec[i] = i;
     }
     const int tnummyelements = (int)targetvec.size();
-    Core::LinAlg::Map target(
-        -1, tnummyelements, targetvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map target(-1, tnummyelements, targetvec.data(), 0, comm);
     // build an exporter and export data
     Core::Communication::Exporter exporter(source, target, comm);
     exporter.do_export(datamap);
@@ -289,7 +286,7 @@ namespace Core::LinAlg
     std::map<int, std::map<int, std::vector<T>>> datamap;
     datamap[myrank] = sdata;
     // build a source map
-    Core::LinAlg::Map source(numproc, 1, &myrank, 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map source(numproc, 1, &myrank, 0, comm);
     // build a target map which is redundant on all target procs and zero everywhere else
     bool iamtarget = false;
     for (int i = 0; i < ntargetprocs; ++i)
@@ -305,8 +302,7 @@ namespace Core::LinAlg
       for (int i = 0; i < numproc; ++i) targetvec[i] = i;
     }
     const int tnummyelements = (int)targetvec.size();
-    Core::LinAlg::Map target(
-        -1, tnummyelements, targetvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map target(-1, tnummyelements, targetvec.data(), 0, comm);
     // build an exporter and export data
     Core::Communication::Exporter exporter(source, target, comm);
     exporter.do_export(datamap);
@@ -368,7 +364,7 @@ namespace Core::LinAlg
     datamap[myrank] = sdata;
 
     // build a source map
-    Core::LinAlg::Map source(numproc, 1, &myrank, 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map source(numproc, 1, &myrank, 0, comm);
     // build a target map which is redundant on all target procs and zero everywhere else
     bool iamtarget = false;
     for (int i = 0; i < ntargetprocs; ++i)
@@ -384,8 +380,7 @@ namespace Core::LinAlg
       for (int i = 0; i < numproc; ++i) targetvec[i] = i;
     }
     const int tnummyelements = (int)targetvec.size();
-    Core::LinAlg::Map target(
-        -1, tnummyelements, targetvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map target(-1, tnummyelements, targetvec.data(), 0, comm);
     // build an exporter and export data
     Core::Communication::Exporter exporter(source, target, comm);
     exporter.do_export(datamap);

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -150,8 +150,8 @@ void Core::LinAlg::BlockSparseMatrixBase::complete(bool enforce_complete)
     std::sort(colmapentries.begin(), colmapentries.end());
     colmapentries.erase(
         std::unique(colmapentries.begin(), colmapentries.end()), colmapentries.end());
-    fullcolmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, colmapentries.size(), colmapentries.data(), 0, Comm());
+    fullcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, colmapentries.size(),
+        colmapentries.data(), 0, Core::Communication::unpack_epetra_comm(Comm()));
   }
 }
 
@@ -407,7 +407,7 @@ bool Core::LinAlg::BlockSparseMatrixBase::HasNormInf() const { return false; }
  *----------------------------------------------------------------------*/
 const Epetra_Comm& Core::LinAlg::BlockSparseMatrixBase::Comm() const
 {
-  return full_domain_map().Comm();
+  return full_domain_map().EpetraComm();
 }
 
 
@@ -552,7 +552,7 @@ void Core::LinAlg::DefaultBlockMatrixStrategy::complete(bool enforce_complete)
       cgidlist.size(), cgidlist.data(), cpidlist.data(), nullptr);
   if (err != 0) FOUR_C_THROW("RemoteIDList failed");
 
-  MPI_Comm comm = Core::Communication::unpack_epetra_comm(mat_.full_range_map().Comm());
+  MPI_Comm comm = mat_.full_range_map().Comm();
   const int numproc = Core::Communication::num_mpi_ranks(comm);
 
   // Send the ghost gids to their respective processor to ask for the domain

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -514,7 +514,7 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
 
   // do stupid conversion into Epetra map
   Core::LinAlg::Map mv1map(mv1->Map().NumGlobalElements(), mv1->Map().NumMyElements(),
-      mv1->Map().MyGlobalElements(), 0, mv1->Map().Comm());
+      mv1->Map().MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(mv1->Map().Comm()));
   // initialization of mat with map of mv1
   std::shared_ptr<Core::LinAlg::SparseMatrix> mat =
       std::make_shared<Core::LinAlg::SparseMatrix>(mv1map, glob_numnonzero, false);
@@ -528,7 +528,7 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
 
   // do stupid conversion into Epetra map
   Core::LinAlg::Map mv2map(mv2->Map().NumGlobalElements(), mv2->Map().NumMyElements(),
-      mv2->Map().MyGlobalElements(), 0, mv2->Map().Comm());
+      mv2->Map().MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(mv2->Map().Comm()));
 
   // fully redundant/overlapping map
   std::shared_ptr<Core::LinAlg::Map> redundant_map = Core::LinAlg::allreduce_e_map(mv2map);

--- a/src/core/linalg/src/sparse/4C_linalg_map.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.cpp
@@ -19,11 +19,6 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-Core::LinAlg::Map::Map(int NumGlobalElements, int IndexBase, const Epetra_Comm& Comm)
-    : map_(std::make_shared<Epetra_Map>(NumGlobalElements, IndexBase, Comm))
-{
-}
-
 Core::LinAlg::Map::Map(int NumGlobalElements, int IndexBase, const MPI_Comm& Comm)
     : map_(std::make_shared<Epetra_Map>(
           NumGlobalElements, IndexBase, Core::Communication::as_epetra_comm(Comm)))
@@ -31,22 +26,9 @@ Core::LinAlg::Map::Map(int NumGlobalElements, int IndexBase, const MPI_Comm& Com
 }
 
 Core::LinAlg::Map::Map(
-    int NumGlobalElements, int NumMyElements, int IndexBase, const Epetra_Comm& Comm)
-    : map_(std::make_shared<Epetra_Map>(NumGlobalElements, NumMyElements, IndexBase, Comm))
-{
-}
-
-Core::LinAlg::Map::Map(
     int NumGlobalElements, int NumMyElements, int IndexBase, const MPI_Comm& Comm)
     : map_(std::make_shared<Epetra_Map>(
           NumGlobalElements, NumMyElements, IndexBase, Core::Communication::as_epetra_comm(Comm)))
-{
-}
-
-Core::LinAlg::Map::Map(int NumGlobalElements, int NumMyElements, const int* MyGlobalElements,
-    int IndexBase, const Epetra_Comm& Comm)
-    : map_(std::make_shared<Epetra_Map>(
-          NumGlobalElements, NumMyElements, MyGlobalElements, IndexBase, Comm))
 {
 }
 

--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -11,6 +11,8 @@
 
 #include "4C_config.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
+
 #include <Epetra_Comm.h>
 #include <Epetra_Map.h>
 #include <mpi.h>
@@ -30,17 +32,9 @@ namespace Core::LinAlg
   class Map
   {
    public:
-    //! Creates a Epetra_Map object based on Epetra_Comm
-    Map(int NumGlobalElements, int IndexBase, const Epetra_Comm& Comm);
-
     Map(int NumGlobalElements, int IndexBase, const MPI_Comm& Comm);
 
-    Map(int NumGlobalElements, int NumMyElements, int IndexBase, const Epetra_Comm& Comm);
-
     Map(int NumGlobalElements, int NumMyElements, int IndexBase, const MPI_Comm& Comm);
-
-    Map(int NumGlobalElements, int NumMyElements, const int* MyGlobalElements, int IndexBase,
-        const Epetra_Comm& Comm);
 
     Map(int NumGlobalElements, int NumMyElements, const int* MyGlobalElements, int IndexBase,
         const MPI_Comm& Comm);
@@ -126,7 +120,9 @@ namespace Core::LinAlg
     int MinMyGID(void) const { return map_->MinMyGID(); }
 
     //! Access function for Epetra_Comm communicator.
-    const Epetra_Comm& Comm() const { return map_->Comm(); }
+    const Epetra_Comm& EpetraComm() const { return map_->Comm(); }
+
+    MPI_Comm Comm() const { return Core::Communication::unpack_epetra_comm(map_->Comm()); }
 
     //! Returns true if map GIDs are 1-to-1.
     bool UniqueGIDs(void) const { return map_->UniqueGIDs(); }

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
@@ -89,8 +89,7 @@ std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::MultiMapExtractor::merge_maps(
     std::copy(map.MyGlobalElements(), map.MyGlobalElements() + map.NumMyElements(),
         std::inserter(mapentries, mapentries.begin()));
   }
-  return Core::LinAlg::create_map(
-      mapentries, Core::Communication::unpack_epetra_comm(maps[0]->Comm()));
+  return Core::LinAlg::create_map(mapentries, maps[0]->Comm());
 }
 
 
@@ -151,8 +150,7 @@ std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::MultiMapExtractor::intersect_ma
     }
     std::swap(mapentries, newset);
   }
-  return Core::LinAlg::create_map(
-      mapentries, Core::Communication::unpack_epetra_comm(maps[0]->Comm()));
+  return Core::LinAlg::create_map(mapentries, maps[0]->Comm());
 }
 
 
@@ -283,8 +281,7 @@ double Core::LinAlg::MultiMapExtractor::norm2(
   }
 
   double global_norm = 0;
-  Core::Communication::sum_all(
-      &local_norm, &global_norm, 1, Core::Communication::unpack_epetra_comm(fm.Comm()));
+  Core::Communication::sum_all(&local_norm, &global_norm, 1, fm.Comm());
   return std::sqrt(global_norm);
 }
 
@@ -347,8 +344,7 @@ Core::LinAlg::MapExtractor::MapExtractor(const Core::LinAlg::Map& fullmap,
   }
 
   // create (non-overlapping) othermap for non-condmap DOFs
-  std::shared_ptr<Core::LinAlg::Map> othermap =
-      Core::LinAlg::create_map(othergids, Core::Communication::unpack_epetra_comm(fullmap.Comm()));
+  std::shared_ptr<Core::LinAlg::Map> othermap = Core::LinAlg::create_map(othergids, fullmap.Comm());
 
   // create the extractor based on choice 'iscondmap'
   if (iscondmap)
@@ -385,8 +381,7 @@ void Core::LinAlg::MapExtractor::setup(
   std::vector<int> other_gids;
   std::ranges::set_difference(full_gids, cond_gids, std::back_inserter(other_gids));
 
-  auto other_map = Core::LinAlg::create_map(
-      other_gids, Core::Communication::unpack_epetra_comm(full_map.Comm()));
+  auto other_map = Core::LinAlg::create_map(other_gids, full_map.Comm());
 
   setup(full_map, cond_map, other_map);
 }

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -214,7 +214,7 @@ Core::LinAlg::SparseMatrix::SparseMatrix(const Core::LinAlg::Vector<double>& dia
 {
   int length = diag.get_block_map().NumMyElements();
   Core::LinAlg::Map map(-1, length, diag.get_block_map().MyGlobalElements(),
-      diag.get_block_map().IndexBase(), Core::Communication::as_epetra_comm(diag.get_comm()));
+      diag.get_block_map().IndexBase(), diag.get_comm());
   if (!map.UniqueGIDs()) FOUR_C_THROW("Row map is not unique");
 
   if (matrixtype_ == CRS_MATRIX)

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_assemble.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_assemble.cpp
@@ -237,9 +237,9 @@ std::shared_ptr<Core::LinAlg::MapExtractor> Core::LinAlg::convert_dirichlet_togg
   const Epetra_BlockMap& fullblockmap = dbctoggle.get_block_map();
   // this copy is needed because the constructor of Core::LinAlg::MapExtractor
   // accepts only Core::LinAlg::Map and not Epetra_BlockMap
-  const Core::LinAlg::Map fullmap =
-      Core::LinAlg::Map(fullblockmap.NumGlobalElements(), fullblockmap.NumMyElements(),
-          fullblockmap.MyGlobalElements(), fullblockmap.IndexBase(), fullblockmap.Comm());
+  const Core::LinAlg::Map fullmap = Core::LinAlg::Map(fullblockmap.NumGlobalElements(),
+      fullblockmap.NumMyElements(), fullblockmap.MyGlobalElements(), fullblockmap.IndexBase(),
+      Core::Communication::unpack_epetra_comm(fullblockmap.Comm()));
   const int mylength = dbctoggle.local_length();
   const int* fullgids = fullmap.MyGlobalElements();
   // build sets containing the DBC or free global IDs, respectively

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
@@ -177,8 +177,7 @@ std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::create_map(
     const std::vector<int>& gids, MPI_Comm comm)
 {
   const int* my_gids = (gids.size() > 0) ? gids.data() : nullptr;
-  return std::make_shared<Core::LinAlg::Map>(
-      -1, gids.size(), my_gids, 0, Core::Communication::as_epetra_comm(comm));
+  return std::make_shared<Core::LinAlg::Map>(-1, gids.size(), my_gids, 0, comm);
 }
 
 /*----------------------------------------------------------------------*
@@ -213,18 +212,16 @@ void Core::LinAlg::create_map_extractor_from_discretization(
   conddofmapvec.reserve(conddofset.size());
   conddofmapvec.assign(conddofset.begin(), conddofset.end());
   conddofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> conddofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, conddofmapvec.size(), conddofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(dis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> conddofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, conddofmapvec.size(), conddofmapvec.data(), 0, dis.get_comm());
   conddofmapvec.clear();
 
   std::vector<int> otherdofmapvec;
   otherdofmapvec.reserve(otherdofset.size());
   otherdofmapvec.assign(otherdofset.begin(), otherdofset.end());
   otherdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> otherdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, otherdofmapvec.size(), otherdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(dis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> otherdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, otherdofmapvec.size(), otherdofmapvec.data(), 0, dis.get_comm());
   otherdofmapvec.clear();
 
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps(2);
@@ -265,18 +262,16 @@ void Core::LinAlg::create_map_extractor_from_discretization(const Core::FE::Disc
   conddofmapvec.reserve(conddofset.size());
   conddofmapvec.assign(conddofset.begin(), conddofset.end());
   conddofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> conddofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, conddofmapvec.size(), conddofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(dis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> conddofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, conddofmapvec.size(), conddofmapvec.data(), 0, dis.get_comm());
   conddofmapvec.clear();
 
   std::vector<int> otherdofmapvec;
   otherdofmapvec.reserve(otherdofset.size());
   otherdofmapvec.assign(otherdofset.begin(), otherdofset.end());
   otherdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> otherdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, otherdofmapvec.size(), otherdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(dis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> otherdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, otherdofmapvec.size(), otherdofmapvec.data(), 0, dis.get_comm());
   otherdofmapvec.clear();
 
   extractor.setup(*dofset.dof_row_map(), conddofmap, otherdofmap);
@@ -322,18 +317,16 @@ void Core::LinAlg::create_map_extractor_from_discretization(const Core::FE::Disc
   conddofmapvec.reserve(conddofset.size());
   conddofmapvec.assign(conddofset.begin(), conddofset.end());
   conddofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> conddofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, conddofmapvec.size(), conddofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(dis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> conddofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, conddofmapvec.size(), conddofmapvec.data(), 0, dis.get_comm());
   conddofmapvec.clear();
 
   std::vector<int> otherdofmapvec;
   otherdofmapvec.reserve(otherdofset.size());
   otherdofmapvec.assign(otherdofset.begin(), otherdofset.end());
   otherdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> otherdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, otherdofmapvec.size(), otherdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(dis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> otherdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, otherdofmapvec.size(), otherdofmapvec.data(), 0, dis.get_comm());
   otherdofmapvec.clear();
 
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps(2);

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -601,7 +601,7 @@ int Core::LinAlg::insert_my_row_diagonal_into_unfilled_matrix(
 std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::split_map(
     const Core::LinAlg::Map& Amap, const Core::LinAlg::Map& Agiven)
 {
-  MPI_Comm Comm = Core::Communication::unpack_epetra_comm(Amap.Comm());
+  MPI_Comm Comm = Amap.Comm();
   const Core::LinAlg::Map& Ag = Agiven;
 
   int count = 0;
@@ -616,8 +616,8 @@ std::shared_ptr<Core::LinAlg::Map> Core::LinAlg::split_map(
   myaugids.resize(count);
   int gcount;
   Core::Communication::sum_all(&count, &gcount, 1, Comm);
-  std::shared_ptr<Core::LinAlg::Map> Aunknown = std::make_shared<Core::LinAlg::Map>(
-      gcount, count, myaugids.data(), 0, Core::Communication::as_epetra_comm(Comm));
+  std::shared_ptr<Core::LinAlg::Map> Aunknown =
+      std::make_shared<Core::LinAlg::Map>(gcount, count, myaugids.data(), 0, Comm);
 
   return Aunknown;
 }

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
@@ -173,7 +173,7 @@ void Core::LinAlg::print_vector_in_matlab_format(
 void Core::LinAlg::print_map_in_matlab_format(
     const std::string& filename, const Core::LinAlg::Map& map, const bool newfile)
 {
-  const auto& comm = Core::Communication::unpack_epetra_comm(map.Comm());
+  const auto& comm = map.Comm();
 
   const int my_PID = Core::Communication::my_mpi_rank(comm);
   const int num_proc = Core::Communication::num_mpi_ranks(comm);

--- a/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_manipulation_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_manipulation_test.np2.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 #include "4C_unittest_utils_support_files_test.hpp"
 

--- a/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_math_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_sparse_algebra_math_test.np2.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
 
+#include "4C_comm_mpi_utils.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_unittest_utils_support_files_test.hpp"
 

--- a/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
@@ -36,8 +36,7 @@ namespace
       comm_ = MPI_COMM_WORLD;
 
       // set up a map
-      map_ = std::make_shared<Core::LinAlg::Map>(
-          NumGlobalElements, 0, Core::Communication::as_epetra_comm(comm_));
+      map_ = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 0, comm_);
     }
   };
 
@@ -290,8 +289,7 @@ namespace
       my_elements = {0, 2, 4, 6, 8};
     else
       my_elements = {1, 3, 5, 7, 9};
-    Core::LinAlg::Map new_map(
-        10, my_elements.size(), my_elements.data(), 0, Core::Communication::as_epetra_comm(comm_));
+    Core::LinAlg::Map new_map(10, my_elements.size(), my_elements.data(), 0, comm_);
 
     const Core::LinAlg::MultiVector<double>& b = a;
     const Core::LinAlg::Vector<double>& c = b(0);

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -107,7 +107,7 @@ void Core::LinearSolver::Parameters::fix_null_space(std::string field,
     const Core::LinAlg::Map& oldmap, const Core::LinAlg::Map& newmap,
     Teuchos::ParameterList& solveparams)
 {
-  if (!Core::Communication::my_mpi_rank(Core::Communication::unpack_epetra_comm(oldmap.Comm())))
+  if (!Core::Communication::my_mpi_rank(oldmap.Comm()))
     printf("Fixing %s Nullspace\n", field.c_str());
 
   // find the ML or MueLu list

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -120,8 +120,7 @@ void Core::Rebalance::ghost_discretization_on_all_procs(Core::FE::Discretization
   Core::LinAlg::gather<int>(sdata, rdata, (int)allproc.size(), allproc.data(), com);
 
   // build new node column map (on ALL processors)
-  Core::LinAlg::Map newnodecolmap(
-      -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(com));
+  Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0, com);
   sdata.clear();
   rdata.clear();
 
@@ -139,8 +138,7 @@ void Core::Rebalance::ghost_discretization_on_all_procs(Core::FE::Discretization
   Core::LinAlg::gather<int>(sdata, rdata, (int)allproc.size(), allproc.data(), com);
 
   // build new element column map (on ALL processors)
-  Core::LinAlg::Map newelecolmap(
-      -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(com));
+  Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0, com);
   sdata.clear();
   rdata.clear();
   allproc.clear();
@@ -203,12 +201,12 @@ void Core::Rebalance::match_element_distribution_of_matching_discretizations(
         dis_template, dis_to_rebalance, rebalance_rowelegid_vec, rebalance_colelegid_vec);
 
     // construct rebalanced element row map
-    Core::LinAlg::Map rebalanced_elerowmap(-1, rebalance_rowelegid_vec.size(),
-        rebalance_rowelegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_elerowmap(
+        -1, rebalance_rowelegid_vec.size(), rebalance_rowelegid_vec.data(), 0, com);
 
     // construct rebalanced element col map
-    Core::LinAlg::Map rebalanced_elecolmap(-1, rebalance_colelegid_vec.size(),
-        rebalance_colelegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_elecolmap(
+        -1, rebalance_colelegid_vec.size(), rebalance_colelegid_vec.data(), 0, com);
 
     ////////////////////////////////////////
     // MATCH NODES
@@ -222,12 +220,12 @@ void Core::Rebalance::match_element_distribution_of_matching_discretizations(
         dis_template, dis_to_rebalance, rebalance_nodegid_vec, rebalance_colnodegid_vec);
 
     // construct rebalanced node row map
-    Core::LinAlg::Map rebalanced_noderowmap(-1, rebalance_nodegid_vec.size(),
-        rebalance_nodegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_noderowmap(
+        -1, rebalance_nodegid_vec.size(), rebalance_nodegid_vec.data(), 0, com);
 
     // construct rebalanced node col map
-    Core::LinAlg::Map rebalanced_nodecolmap(-1, rebalance_colnodegid_vec.size(),
-        rebalance_colnodegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_nodecolmap(
+        -1, rebalance_colnodegid_vec.size(), rebalance_colnodegid_vec.data(), 0, com);
 
     ////////////////////////////////////////
     // REBALANCE
@@ -407,12 +405,12 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
 
 
     // construct rebalanced element row map
-    Core::LinAlg::Map rebalanced_elerowmap(-1, rebalance_rowelegid_vec.size(),
-        rebalance_rowelegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_elerowmap(
+        -1, rebalance_rowelegid_vec.size(), rebalance_rowelegid_vec.data(), 0, com);
 
     // construct rebalanced element col map
-    Core::LinAlg::Map rebalanced_elecolmap(-1, rebalance_colelegid_vec.size(),
-        rebalance_colelegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_elecolmap(
+        -1, rebalance_colelegid_vec.size(), rebalance_colelegid_vec.data(), 0, com);
 
 
     ////////////////////////////////////////
@@ -505,12 +503,12 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
     }
 
     // construct rebalanced node row map
-    Core::LinAlg::Map rebalanced_noderowmap(-1, rebalance_rownodegid_vec.size(),
-        rebalance_rownodegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_noderowmap(
+        -1, rebalance_rownodegid_vec.size(), rebalance_rownodegid_vec.data(), 0, com);
 
     // construct rebalanced node col map
-    Core::LinAlg::Map rebalanced_nodecolmap(-1, rebalance_colnodegid_vec.size(),
-        rebalance_colnodegid_vec.data(), 0, Core::Communication::as_epetra_comm(com));
+    Core::LinAlg::Map rebalanced_nodecolmap(
+        -1, rebalance_colnodegid_vec.size(), rebalance_colnodegid_vec.data(), 0, com);
 
 
     ////////////////////////////////////////
@@ -591,9 +589,8 @@ std::shared_ptr<Core::LinAlg::Map> Core::Rebalance::compute_node_col_map(
   }
 
   // now reconstruct the extended colmap
-  std::shared_ptr<Core::LinAlg::Map> newcolnodemap =
-      std::make_shared<Core::LinAlg::Map>(-1, mycolnodes.size(), mycolnodes.data(), 0,
-          Core::Communication::as_epetra_comm(sourcedis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> newcolnodemap = std::make_shared<Core::LinAlg::Map>(
+      -1, mycolnodes.size(), mycolnodes.data(), 0, sourcedis.get_comm());
   return newcolnodemap;
 }  // Core::Rebalance::ComputeNodeColMap
 

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -43,12 +43,12 @@ Core::Rebalance::rebalance_node_maps(const Core::LinAlg::Graph& initialGraph,
       initialNodeWeights, initialEdgeWeights, initialNodeCoordinates);
 
   // extract repartitioned maps
-  std::shared_ptr<Core::LinAlg::Map> rownodes =
-      std::make_shared<Core::LinAlg::Map>(-1, balanced_graph->row_map().NumMyElements(),
-          balanced_graph->row_map().MyGlobalElements(), 0, initialGraph.get_comm());
-  std::shared_ptr<Core::LinAlg::Map> colnodes =
-      std::make_shared<Core::LinAlg::Map>(-1, balanced_graph->col_map().NumMyElements(),
-          balanced_graph->col_map().MyGlobalElements(), 0, initialGraph.get_comm());
+  std::shared_ptr<Core::LinAlg::Map> rownodes = std::make_shared<Core::LinAlg::Map>(-1,
+      balanced_graph->row_map().NumMyElements(), balanced_graph->row_map().MyGlobalElements(), 0,
+      Core::Communication::unpack_epetra_comm(initialGraph.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> colnodes = std::make_shared<Core::LinAlg::Map>(-1,
+      balanced_graph->col_map().NumMyElements(), balanced_graph->col_map().MyGlobalElements(), 0,
+      Core::Communication::unpack_epetra_comm(initialGraph.get_comm()));
 
   return {rownodes, colnodes};
 }
@@ -209,8 +209,8 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_graph(
     for (fool = mynodes.begin(); fool != mynodes.end(); ++fool) nodes.push_back(*fool);
     mynodes.clear();
     // create a non-overlapping row map
-    rownodes = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)nodes.size(), &nodes[0], 0, Core::Communication::as_epetra_comm(dis.get_comm()));
+    rownodes =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)nodes.size(), &nodes[0], 0, dis.get_comm());
   }
 
   // start building the graph object
@@ -382,7 +382,7 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_monolithic_nod
   std::vector<int> my_colliding_primitives_vec(
       my_colliding_primitives.begin(), my_colliding_primitives.end());
   Core::LinAlg::Map my_colliding_primitives_map(-1, my_colliding_primitives_vec.size(),
-      my_colliding_primitives_vec.data(), 0, Core::Communication::as_epetra_comm(dis.get_comm()));
+      my_colliding_primitives_vec.data(), 0, dis.get_comm());
   Epetra_Import importer(
       my_colliding_primitives_map.get_epetra_map(), dis.element_row_map()->get_epetra_map());
   Core::LinAlg::Graph my_colliding_primitives_connectivity(

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -130,17 +130,14 @@ void Coupling::Adapter::Coupling::setup_coupling(const Core::FE::Discretization&
 
   // maps in original distribution
 
-  std::shared_ptr<Core::LinAlg::Map> masternodemap =
-      std::make_shared<Core::LinAlg::Map>(-1, patchedmasternodes.size(), patchedmasternodes.data(),
-          0, Core::Communication::as_epetra_comm(masterdis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> masternodemap = std::make_shared<Core::LinAlg::Map>(
+      -1, patchedmasternodes.size(), patchedmasternodes.data(), 0, masterdis.get_comm());
 
-  std::shared_ptr<Core::LinAlg::Map> slavenodemap =
-      std::make_shared<Core::LinAlg::Map>(-1, slavenodes.size(), slavenodes.data(), 0,
-          Core::Communication::as_epetra_comm(slavedis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> slavenodemap = std::make_shared<Core::LinAlg::Map>(
+      -1, slavenodes.size(), slavenodes.data(), 0, slavedis.get_comm());
 
-  std::shared_ptr<Core::LinAlg::Map> permslavenodemap =
-      std::make_shared<Core::LinAlg::Map>(-1, permslavenodes.size(), permslavenodes.data(), 0,
-          Core::Communication::as_epetra_comm(slavedis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> permslavenodemap = std::make_shared<Core::LinAlg::Map>(
+      -1, permslavenodes.size(), permslavenodes.data(), 0, slavedis.get_comm());
 
   finish_coupling(masterdis, slavedis, masternodemap, slavenodemap, permslavenodemap, masterdofs,
       slavedofs, nds_master, nds_slave);
@@ -199,15 +196,13 @@ void Coupling::Adapter::Coupling::setup_coupling(const Core::FE::Discretization&
 
   // maps in original distribution
 
-  std::shared_ptr<Core::LinAlg::Map> masternodemap =
-      std::make_shared<Core::LinAlg::Map>(-1, mastervect.size(), mastervect.data(), 0,
-          Core::Communication::as_epetra_comm(masterdis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> masternodemap = std::make_shared<Core::LinAlg::Map>(
+      -1, mastervect.size(), mastervect.data(), 0, masterdis.get_comm());
 
   std::shared_ptr<Core::LinAlg::Map> slavenodemap = std::make_shared<Core::LinAlg::Map>(slavenodes);
 
-  std::shared_ptr<Core::LinAlg::Map> permslavenodemap =
-      std::make_shared<Core::LinAlg::Map>(-1, permslavenodes.size(), permslavenodes.data(), 0,
-          Core::Communication::as_epetra_comm(slavedis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> permslavenodemap = std::make_shared<Core::LinAlg::Map>(
+      -1, permslavenodes.size(), permslavenodes.data(), 0, slavedis.get_comm());
 
   finish_coupling(masterdis, slavedis, masternodemap, slavenodemap, permslavenodemap,
       build_dof_vector_from_num_dof(numdof), build_dof_vector_from_num_dof(numdof), nds_master,
@@ -287,12 +282,12 @@ void Coupling::Adapter::Coupling::setup_coupling(const Core::FE::Discretization&
 
     match_nodes(masterdis, slavedis, masternodes, permslavenodes, slavenodes, matchall, tolerance);
 
-    masternodemap_cond.push_back(std::make_shared<Core::LinAlg::Map>(-1, masternodes.size(),
-        masternodes.data(), 0, Core::Communication::as_epetra_comm(masterdis.get_comm())));
-    slavenodemap_cond.push_back(std::make_shared<Core::LinAlg::Map>(-1, slavenodes.size(),
-        slavenodes.data(), 0, Core::Communication::as_epetra_comm(slavedis.get_comm())));
-    permslavenodemap_cond.push_back(std::make_shared<Core::LinAlg::Map>(-1, permslavenodes.size(),
-        permslavenodes.data(), 0, Core::Communication::as_epetra_comm(slavedis.get_comm())));
+    masternodemap_cond.push_back(std::make_shared<Core::LinAlg::Map>(
+        -1, masternodes.size(), masternodes.data(), 0, masterdis.get_comm()));
+    slavenodemap_cond.push_back(std::make_shared<Core::LinAlg::Map>(
+        -1, slavenodes.size(), slavenodes.data(), 0, slavedis.get_comm()));
+    permslavenodemap_cond.push_back(std::make_shared<Core::LinAlg::Map>(
+        -1, permslavenodes.size(), permslavenodes.data(), 0, slavedis.get_comm()));
   }
 
   // merge maps for all conditions, but keep order (= keep assignment of permuted slave node map and
@@ -380,9 +375,9 @@ void Coupling::Adapter::Coupling::finish_coupling(const Core::FE::Discretization
   const int err = permmasternodevec->export_to(*masternodevec, masternodeexport, Insert);
   if (err) FOUR_C_THROW("failed to export master nodes");
 
-  std::shared_ptr<const Core::LinAlg::Map> permmasternodemap = std::make_shared<Core::LinAlg::Map>(
-      -1, permmasternodevec->local_length(), permmasternodevec->get_values(), 0,
-      Core::Communication::as_epetra_comm(masterdis.get_comm()));
+  std::shared_ptr<const Core::LinAlg::Map> permmasternodemap =
+      std::make_shared<Core::LinAlg::Map>(-1, permmasternodevec->local_length(),
+          permmasternodevec->get_values(), 0, masterdis.get_comm());
 
   if (not slavenodemap->PointSameAs(*permmasternodemap))
     FOUR_C_THROW("slave and permuted master node maps do not match");
@@ -500,8 +495,8 @@ void Coupling::Adapter::Coupling::build_dof_maps(const Core::FE::Discretization&
   if (pos != dofmapvec.end() and *pos < 0) FOUR_C_THROW("illegal dof number {}", *pos);
 
   // dof map is the original, unpermuted distribution of dofs
-  dofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(dis.get_comm()));
+  dofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec.size(), dofmapvec.data(), 0, dis.get_comm());
 
   dofmapvec.clear();
 
@@ -520,8 +515,8 @@ void Coupling::Adapter::Coupling::build_dof_maps(const Core::FE::Discretization&
   dofs.clear();
 
   // permuted dof map according to a given permuted node map
-  permdofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(dis.get_comm()));
+  permdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec.size(), dofmapvec.data(), 0, dis.get_comm());
 
   // prepare communication plan to create a dofmap out of a permuted
   // dof map

--- a/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
@@ -130,8 +130,7 @@ bool Coupling::Adapter::MatrixLogicalSplitAndTransform::operator()(
       }
 
     int gsubset = 0;
-    Core::Communication::min_all(
-        &subset, &gsubset, 1, Core::Communication::unpack_epetra_comm(logical_range_map.Comm()));
+    Core::Communication::min_all(&subset, &gsubset, 1, logical_range_map.Comm());
 
     // need communication -> call import on permuted map
     if (!gsubset)

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -164,8 +164,7 @@ void Coupling::VolMortar::VolMortarCoupl::build_maps(std::shared_ptr<Core::FE::D
     }
   }
   // dof map is the original, unpermuted distribution of dofs
-  dofmap = std::make_shared<Core::LinAlg::Map>(
-      -1, dofmapvec.size(), dofmapvec.data(), 0, Core::Communication::as_epetra_comm(comm_));
+  dofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0, comm_);
 
   return;
 }

--- a/src/deal_ii/src/4C_deal_ii_vector_conversion.cpp
+++ b/src/deal_ii/src/4C_deal_ii_vector_conversion.cpp
@@ -99,7 +99,7 @@ Core::LinAlg::Map DealiiWrappers::create_dealii_to_four_c_map(
   }
 
   Core::LinAlg::Map dealii_to_four_c_map(dof_handler.n_dofs(), locally_owned_dofs.n_elements(),
-      my_gids.data(), 0, Core::Communication::as_epetra_comm(discretization.get_comm()));
+      my_gids.data(), 0, discretization.get_comm());
 
   return dealii_to_four_c_map;
 }

--- a/src/deal_ii/tests/4C_deal_ii_create_discretization_helper_test.hpp
+++ b/src/deal_ii/tests/4C_deal_ii_create_discretization_helper_test.hpp
@@ -158,8 +158,8 @@ namespace TESTING
     { return i * (subdivisions + 1) * (subdivisions + 1) + j * (subdivisions + 1) + k; };
 
     // Create a map for all elements with some initial distribution
-    auto row_elements = std::make_shared<Core::LinAlg::Map>(
-        total_elements, 0, Core::Communication::as_epetra_comm(discretization.get_comm()));
+    auto row_elements =
+        std::make_shared<Core::LinAlg::Map>(total_elements, 0, discretization.get_comm());
 
     // Connect the nodes into elements on the owning ranks
     for (int i = 0; i < subdivisions; ++i)
@@ -250,8 +250,8 @@ namespace TESTING
     const int n_total_elements = std::pow(2, levels) - 1;
 
     // Create a map for all elements with some initial distribution
-    auto row_elements = std::make_shared<Core::LinAlg::Map>(
-        n_total_elements, 0, Core::Communication::as_epetra_comm(discretization.get_comm()));
+    auto row_elements =
+        std::make_shared<Core::LinAlg::Map>(n_total_elements, 0, discretization.get_comm());
 
     const auto leaf_on_level = [&](unsigned level, unsigned ele_on_level) -> int
     { return std::pow(2, level) + ele_on_level; };

--- a/src/fbi/4C_fbi_beam_to_fluid_meshtying_output_writer.cpp
+++ b/src/fbi/4C_fbi_beam_to_fluid_meshtying_output_writer.cpp
@@ -127,8 +127,8 @@ void BeamInteraction::BeamToFluidMeshtyingVtkOutputWriter::write_output_beam_to_
         for (unsigned int dim = 0; dim < 3; ++dim) gid_beam_dof.push_back(gid_node[dim]);
     }
     Core::LinAlg::Map beam_dof_map(-1, gid_beam_dof.size(), gid_beam_dof.data(), 0,
-        Core::Communication::as_epetra_comm(
-            couplingenforcer.get_structure()->get_discretization()->get_comm()));
+
+        couplingenforcer.get_structure()->get_discretization()->get_comm());
 
     // Extract the forces and add them to the discretization.
     std::shared_ptr<Core::LinAlg::Vector<double>> force_beam =

--- a/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.cpp
+++ b/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.cpp
@@ -124,18 +124,17 @@ void BeamInteraction::BeamToFluidMortarManager::setup()
     my_lambda_gid[my_lid] = my_lambda_gid_start_value + my_lid;
 
   // Rowmap for the additional GIDs used by the mortar contact discretization.
-  lambda_dof_rowmap_ =
-      std::make_shared<Core::LinAlg::Map>(-1, my_lambda_gid.size(), my_lambda_gid.data(), 0,
-          Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
+  lambda_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, my_lambda_gid.size(), my_lambda_gid.data(), 0, discretization_structure_->get_comm());
 
 
   // We need to be able to get the global ids for a Lagrange multiplier DOF from the global id
   // of a node or element. To do so, we 'abuse' the Core::LinAlg::MultiVector<double> as map between
   // the global node / element ids and the global Lagrange multiplier DOF ids.
-  Core::LinAlg::Map node_gid_rowmap(-1, n_nodes, my_nodes_gid.data(), 0,
-      Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
-  Core::LinAlg::Map element_gid_rowmap(-1, n_element, my_elements_gid.data(), 0,
-      Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
+  Core::LinAlg::Map node_gid_rowmap(
+      -1, n_nodes, my_nodes_gid.data(), 0, discretization_structure_->get_comm());
+  Core::LinAlg::Map element_gid_rowmap(
+      -1, n_element, my_elements_gid.data(), 0, discretization_structure_->get_comm());
 
   // Map from global node / element ids to global lagrange multiplier ids. Only create the
   // multivector if it hase one or more columns.
@@ -219,12 +218,10 @@ void BeamInteraction::BeamToFluidMortarManager::set_global_maps()
   }
 
   // Create the beam and fluid maps.
-  beam_dof_rowmap_ =
-      std::make_shared<Core::LinAlg::Map>(-1, field_dofs[0].size(), field_dofs[0].data(), 0,
-          Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
-  fluid_dof_rowmap_ =
-      std::make_shared<Core::LinAlg::Map>(-1, field_dofs[1].size(), field_dofs[1].data(), 0,
-          Core::Communication::as_epetra_comm(discretization_fluid_->get_comm()));
+  beam_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, field_dofs[0].size(), field_dofs[0].data(), 0, discretization_structure_->get_comm());
+  fluid_dof_rowmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, field_dofs[1].size(), field_dofs[1].data(), 0, discretization_fluid_->get_comm());
 
   // Reset the local maps.
   node_gid_to_lambda_gid_map_.clear();
@@ -285,11 +282,10 @@ void BeamInteraction::BeamToFluidMortarManager::set_local_maps(
   element_gid_needed.resize(std::distance(element_gid_needed.begin(), it));
 
   // Create the maps for the extraction of the values.
-  Core::LinAlg::Map node_gid_needed_rowmap(-1, node_gid_needed.size(), node_gid_needed.data(), 0,
-      Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
+  Core::LinAlg::Map node_gid_needed_rowmap(
+      -1, node_gid_needed.size(), node_gid_needed.data(), 0, discretization_structure_->get_comm());
   Core::LinAlg::Map element_gid_needed_rowmap(-1, element_gid_needed.size(),
-      element_gid_needed.data(), 0,
-      Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
+      element_gid_needed.data(), 0, discretization_structure_->get_comm());
 
   // Create the Multivectors that will be filled with all values needed on this rank.
   std::shared_ptr<Core::LinAlg::MultiVector<double>> node_gid_to_lambda_gid_copy = nullptr;
@@ -339,8 +335,7 @@ void BeamInteraction::BeamToFluidMortarManager::set_local_maps(
 
   // Create the global lambda col map.
   lambda_dof_colmap_ = std::make_shared<Core::LinAlg::Map>(-1, lambda_gid_for_col_map.size(),
-      lambda_gid_for_col_map.data(), 0,
-      Core::Communication::as_epetra_comm(discretization_structure_->get_comm()));
+      lambda_gid_for_col_map.data(), 0, discretization_structure_->get_comm());
 
   // Set flags for local maps.
   is_local_maps_build_ = true;

--- a/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
+++ b/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
@@ -146,8 +146,8 @@ void FBI::FBIGeometryCoupler::extend_beam_ghosting(Core::FE::Discretization& dis
       sdata, rdata, (int)allproc.size(), allproc.data(), discretization.get_comm());
 
   // build completely overlapping map of nodes (on ALL processors)
-  Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0,
-      Core::Communication::as_epetra_comm(discretization.get_comm()));
+  Core::LinAlg::Map newnodecolmap(
+      -1, (int)rdata.size(), rdata.data(), 0, discretization.get_comm());
   sdata.clear();
   rdata.clear();
 
@@ -162,8 +162,7 @@ void FBI::FBIGeometryCoupler::extend_beam_ghosting(Core::FE::Discretization& dis
       sdata, rdata, (int)allproc.size(), allproc.data(), discretization.get_comm());
 
   // build complete overlapping map of elements (on ALL processors)
-  Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0,
-      Core::Communication::as_epetra_comm(discretization.get_comm()));
+  Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0, discretization.get_comm());
   sdata.clear();
   rdata.clear();
   allproc.clear();
@@ -252,8 +251,8 @@ void FBI::FBIGeometryCoupler::prepare_pair_creation(
   }
 
   // build overlapping column map of the elements
-  Core::LinAlg::Map newelecolmap(-1, (int)element_recvdata.size(), element_recvdata.data(), 0,
-      Core::Communication::as_epetra_comm(discretizations[1]->get_comm()));
+  Core::LinAlg::Map newelecolmap(
+      -1, (int)element_recvdata.size(), element_recvdata.data(), 0, discretizations[1]->get_comm());
 
 
   if (!newelecolmap.SameAs(*elecolmap))
@@ -288,8 +287,8 @@ void FBI::FBIGeometryCoupler::prepare_pair_creation(
     }
 
     // build complete overlapping map of elements (on ALL processors)
-    Core::LinAlg::Map newnodecolmap(-1, (int)node_recvdata.size(), node_recvdata.data(), 0,
-        Core::Communication::as_epetra_comm(discretizations[1]->get_comm()));
+    Core::LinAlg::Map newnodecolmap(
+        -1, (int)node_recvdata.size(), node_recvdata.data(), 0, discretizations[1]->get_comm());
 
     // export nodes and elements
     discretizations[1]->export_column_nodes(newnodecolmap);

--- a/src/fluid/4C_fluid_coupling_red_models.cpp
+++ b/src/fluid/4C_fluid_coupling_red_models.cpp
@@ -953,8 +953,7 @@ double FLD::Utils::FluidCouplingBc::flow_rate_calculation(double time, double dt
   }
 
   double flowrate = 0.0;
-  Core::Communication::sum_all(
-      &local_flowrate, &flowrate, 1, Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+  Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
   return flowrate;
 }  // FluidImplicitTimeInt::flow_rate_calculation

--- a/src/fluid/4C_fluid_discret_extractor.cpp
+++ b/src/fluid/4C_fluid_discret_extractor.cpp
@@ -234,8 +234,8 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
       }
 
       // build noderowmap for new distribution of nodes
-      newrownodemap = std::make_shared<Core::LinAlg::Map>(-1, rownodes.size(), rownodes.data(), 0,
-          Core::Communication::as_epetra_comm(childdiscret_->get_comm()));
+      newrownodemap = std::make_shared<Core::LinAlg::Map>(
+          -1, rownodes.size(), rownodes.data(), 0, childdiscret_->get_comm());
 
       std::vector<int> colnodes;
 
@@ -245,8 +245,8 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
         colnodes.push_back(*id);
       }
       // build nodecolmap for new distribution of nodes
-      newcolnodemap = std::make_shared<Core::LinAlg::Map>(-1, colnodes.size(), colnodes.data(), 0,
-          Core::Communication::as_epetra_comm(childdiscret_->get_comm()));
+      newcolnodemap = std::make_shared<Core::LinAlg::Map>(
+          -1, colnodes.size(), colnodes.data(), 0, childdiscret_->get_comm());
     }
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)

--- a/src/fluid/4C_fluid_impedancecondition.cpp
+++ b/src/fluid/4C_fluid_impedancecondition.cpp
@@ -311,8 +311,7 @@ void FLD::Utils::FluidImpedanceBc::flow_rate_calculation(const int condid)
   }
 
   double flowrate = 0.0;
-  Core::Communication::sum_all(
-      &local_flowrate, &flowrate, 1, Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+  Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
   q_np_ = flowrate;
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1458,8 +1458,7 @@ void FLD::FluidImplicitTimeInt::apply_nonlinear_boundary_conditions()
 
       // sum up global flow rate over all processors and set to global value
       double flowrate = 0.0;
-      Core::Communication::sum_all(&local_flowrate, &flowrate, 1,
-          Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+      Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
       // set current flow rate
       flowratenp_[fdpcondid] = flowrate;
@@ -2777,12 +2776,12 @@ void FLD::FluidImplicitTimeInt::ale_update(std::string condName)
 
         // Sum variables over all processors to obtain global value
         double globalSumVelnpDotNodeTangent = 0.0;
-        Core::Communication::sum_all(&localSumVelnpDotNodeTangent, &globalSumVelnpDotNodeTangent, 1,
-            Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+        Core::Communication::sum_all(
+            &localSumVelnpDotNodeTangent, &globalSumVelnpDotNodeTangent, 1, dofrowmap->Comm());
 
         int globalNumOfCondNodes = 0;
-        Core::Communication::sum_all(&localNumOfCondNodes, &globalNumOfCondNodes, 1,
-            Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+        Core::Communication::sum_all(
+            &localNumOfCondNodes, &globalNumOfCondNodes, 1, dofrowmap->Comm());
 
         // Finalize calculation of mean tangent velocity
         double lambda = 0.0;

--- a/src/fluid/4C_fluid_timint_genalpha.cpp
+++ b/src/fluid/4C_fluid_timint_genalpha.cpp
@@ -289,7 +289,7 @@ void FLD::TimIntGenAlpha::gen_alpha_intermediate_values(
   // do stupid conversion into map
   Core::LinAlg::Map vecmap(vecnp->get_block_map().NumGlobalElements(),
       vecnp->get_block_map().NumMyElements(), vecnp->get_block_map().MyGlobalElements(), 0,
-      vecnp->get_block_map().Comm());
+      Core::Communication::unpack_epetra_comm(vecnp->get_block_map().Comm()));
 
   std::shared_ptr<Core::LinAlg::Vector<double>> vecam = Core::LinAlg::create_vector(vecmap, true);
   vecam->update((alphaM_), *vecnp, (1.0 - alphaM_), *vecn, 0.0);

--- a/src/fluid/4C_fluid_timint_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_hdg.cpp
@@ -76,16 +76,14 @@ void FLD::TimIntHDG::init()
   conddofmapvec.reserve(conddofset.size());
   conddofmapvec.assign(conddofset.begin(), conddofset.end());
   conddofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> conddofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, conddofmapvec.size(), conddofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(hdgdis->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> conddofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, conddofmapvec.size(), conddofmapvec.data(), 0, hdgdis->get_comm());
   std::vector<int> otherdofmapvec;
   otherdofmapvec.reserve(otherdofset.size());
   otherdofmapvec.assign(otherdofset.begin(), otherdofset.end());
   otherdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> otherdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, otherdofmapvec.size(), otherdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(hdgdis->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> otherdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, otherdofmapvec.size(), otherdofmapvec.data(), 0, hdgdis->get_comm());
   velpressplitter_->setup(*hdgdis->dof_row_map(), conddofmap, otherdofmap);
 
   // implement ost and bdf2 through gen-alpha facilities

--- a/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
+++ b/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
@@ -70,18 +70,16 @@ void FLD::TimIntHDGWeakComp::init()
   dofmapvec_r.reserve(dofset_r.size());
   dofmapvec_r.assign(dofset_r.begin(), dofset_r.end());
   dofset_r.clear();
-  std::shared_ptr<Core::LinAlg::Map> dofmap_r =
-      std::make_shared<Core::LinAlg::Map>(-1, dofmapvec_r.size(), dofmapvec_r.data(), 0,
-          Core::Communication::as_epetra_comm(hdgdis->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> dofmap_r = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec_r.size(), dofmapvec_r.data(), 0, hdgdis->get_comm());
 
   // define momentum dof map
   std::vector<int> dofmapvec_w;
   dofmapvec_w.reserve(dofset_w.size());
   dofmapvec_w.assign(dofset_w.begin(), dofset_w.end());
   dofset_w.clear();
-  std::shared_ptr<Core::LinAlg::Map> dofmap_w =
-      std::make_shared<Core::LinAlg::Map>(-1, dofmapvec_w.size(), dofmapvec_w.data(), 0,
-          Core::Communication::as_epetra_comm(hdgdis->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> dofmap_w = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec_w.size(), dofmapvec_w.data(), 0, hdgdis->get_comm());
 
   // build density/momentum (actually velocity/pressure) splitter
   velpressplitter_->setup(*hdgdis->dof_row_map(), dofmap_r, dofmap_w);

--- a/src/fluid/4C_fluid_timint_stat_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_stat_hdg.cpp
@@ -79,16 +79,14 @@ void FLD::TimIntStationaryHDG::init()
   conddofmapvec.reserve(conddofset.size());
   conddofmapvec.assign(conddofset.begin(), conddofset.end());
   conddofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> conddofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, conddofmapvec.size(), conddofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(hdgdis->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> conddofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, conddofmapvec.size(), conddofmapvec.data(), 0, hdgdis->get_comm());
   std::vector<int> otherdofmapvec;
   otherdofmapvec.reserve(otherdofset.size());
   otherdofmapvec.assign(otherdofset.begin(), otherdofset.end());
   otherdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> otherdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, otherdofmapvec.size(), otherdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(hdgdis->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> otherdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, otherdofmapvec.size(), otherdofmapvec.data(), 0, hdgdis->get_comm());
   velpressplitter_->setup(*hdgdis->dof_row_map(), conddofmap, otherdofmap);
 
   // call init()-functions of base classes

--- a/src/fluid/4C_fluid_utils.cpp
+++ b/src/fluid/4C_fluid_utils.cpp
@@ -517,18 +517,16 @@ void FLD::Utils::setup_fluid_fluid_vel_pres_split(const Core::FE::Discretization
   veldofmapvec.reserve(veldofset.size());
   veldofmapvec.assign(veldofset.begin(), veldofset.end());
   veldofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> velrowmap =
-      std::make_shared<Core::LinAlg::Map>(-1, veldofmapvec.size(), veldofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(fluiddis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> velrowmap = std::make_shared<Core::LinAlg::Map>(
+      -1, veldofmapvec.size(), veldofmapvec.data(), 0, fluiddis.get_comm());
   veldofmapvec.clear();
 
   std::vector<int> presdofmapvec;
   presdofmapvec.reserve(presdofset.size());
   presdofmapvec.assign(presdofset.begin(), presdofset.end());
   presdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> presrowmap =
-      std::make_shared<Core::LinAlg::Map>(-1, presdofmapvec.size(), presdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(alefluiddis.get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> presrowmap = std::make_shared<Core::LinAlg::Map>(
+      -1, presdofmapvec.size(), presdofmapvec.data(), 0, alefluiddis.get_comm());
   extractor.setup(*fullmap, presrowmap, velrowmap);
 }
 
@@ -860,8 +858,7 @@ std::map<int, double> FLD::Utils::compute_flow_rates(Core::FE::Discretization& d
     }
 
     double flowrate = 0.0;
-    Core::Communication::sum_all(
-        &local_flowrate, &flowrate, 1, Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+    Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
     // if(dofrowmap->Comm().MyPID()==0)
     // std::cout << "global flow rate = " << flowrate << "\t condition ID = " << condID <<

--- a/src/fluid/4C_fluid_utils_infnormscaling.cpp
+++ b/src/fluid/4C_fluid_utils_infnormscaling.cpp
@@ -21,8 +21,7 @@ FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 FLD::Utils::FluidInfNormScaling::FluidInfNormScaling(Core::LinAlg::MapExtractor& mapextractor)
-    : myrank_(Core::Communication::my_mpi_rank(
-          Core::Communication::unpack_epetra_comm(mapextractor.map(0)->Comm()))),
+    : myrank_(Core::Communication::my_mpi_rank(mapextractor.map(0)->Comm())),
       velpressplitter_(mapextractor),
       leftscale_momentum_(true),
       leftscale_continuity_(false)

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -715,8 +715,8 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::build_condition_node_row_map(
   //--------------------------------------------------------------------
   // create the node row map of the nodes on the current proc
   //--------------------------------------------------------------------
-  cond_noderowmap = std::make_shared<Core::LinAlg::Map>(
-      -1, nodeids.size(), nodeids.data(), 0, Core::Communication::as_epetra_comm(dis->get_comm()));
+  cond_noderowmap =
+      std::make_shared<Core::LinAlg::Map>(-1, nodeids.size(), nodeids.data(), 0, dis->get_comm());
 
 }  // build_condition_node_row_map
 
@@ -769,8 +769,8 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::build_condition_dof_row_map(
   //--------------------------------------------------------------------
   // create the node row map of the nodes on the current proc
   //--------------------------------------------------------------------
-  cond_dofrowmap = std::make_shared<Core::LinAlg::Map>(
-      -1, dofids.size(), dofids.data(), 0, Core::Communication::as_epetra_comm(dis->get_comm()));
+  cond_dofrowmap =
+      std::make_shared<Core::LinAlg::Map>(-1, dofids.size(), dofids.data(), 0, dis->get_comm());
 
 }  // FluidVolumetricSurfaceFlowBc::build_condition_dof_row_map
 
@@ -1347,8 +1347,7 @@ double FLD::Utils::FluidVolumetricSurfaceFlowBc::flow_rate_calculation(
   }
 
   double flowrate = 0.0;
-  Core::Communication::sum_all(
-      &local_flowrate, &flowrate, 1, Core::Communication::unpack_epetra_comm(dofrowmap->Comm()));
+  Core::Communication::sum_all(&local_flowrate, &flowrate, 1, dofrowmap->Comm());
 
   return flowrate;
 

--- a/src/fluid/4C_fluid_xwall.cpp
+++ b/src/fluid/4C_fluid_xwall.cpp
@@ -311,8 +311,8 @@ void FLD::XWall::init_x_wall_maps()
       if (enriched) rowvec.push_back(xwallgid);
     }
 
-    xwallrownodemap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)rowvec.size(), rowvec.data(), 0,
-        Core::Communication::as_epetra_comm(discret_->get_comm()));
+    xwallrownodemap_ = std::make_shared<Core::LinAlg::Map>(
+        -1, (int)rowvec.size(), rowvec.data(), 0, discret_->get_comm());
   }
 
   // get Dirichlet conditions
@@ -337,8 +337,8 @@ void FLD::XWall::init_x_wall_maps()
 
     int gcount;
     Core::Communication::sum_all(&count, &gcount, 1, (discret_->get_comm()));
-    dircolnodemap_ = std::make_shared<Core::LinAlg::Map>(gcount, count, testcollect.data(), 0,
-        Core::Communication::as_epetra_comm(discret_->get_comm()));
+    dircolnodemap_ = std::make_shared<Core::LinAlg::Map>(
+        gcount, count, testcollect.data(), 0, discret_->get_comm());
   }  // end loop this conditions
   else
     FOUR_C_THROW("You need DESIGN FLUID STRESS CALC SURF CONDITIONS for xwall");
@@ -424,8 +424,8 @@ void FLD::XWall::init_wall_dist()
   }
   int count = (int)colvec.size();
 
-  xwallcolnodemap_ = std::make_shared<Core::LinAlg::Map>(
-      count, count, colvec.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  xwallcolnodemap_ =
+      std::make_shared<Core::LinAlg::Map>(count, count, colvec.data(), 0, discret_->get_comm());
 
   for (int j = 0; j < xwallcolnodemap_->NumMyElements(); ++j)
   {
@@ -710,8 +710,8 @@ void FLD::XWall::setup_l2_projection()
       }
     }
 
-    enrdofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)enrdf.size(), enrdf.data(), 0,
-        Core::Communication::as_epetra_comm(xwdiscret_->get_comm()));
+    enrdofrowmap_ = std::make_shared<Core::LinAlg::Map>(
+        -1, (int)enrdf.size(), enrdf.data(), 0, xwdiscret_->get_comm());
 
     massmatrix_ = std::make_shared<Core::LinAlg::SparseMatrix>(*enrdofrowmap_, 108, false, true);
 

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_mean_general.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_mean_general.cpp
@@ -158,9 +158,7 @@ void FLD::TurbulenceStatisticsGeneralMean::add_to_current_time_average(const dou
     {
       // any XFEM problem with scatra will crash here, it could probably be removed     henke 12/11
       MPI_Comm comm =
-          (discret_ != nullptr)
-              ? (discret_->get_comm())
-              : (Core::Communication::unpack_epetra_comm(standarddofset_->dof_row_map()->Comm()));
+          (discret_ != nullptr) ? (discret_->get_comm()) : (standarddofset_->dof_row_map()->Comm());
       if (Core::Communication::my_mpi_rank(comm) == 0)
         std::cout << "curr_avg_sca_ or scavec is nullptr" << std::endl;
     }

--- a/src/fpsi/4C_fpsi_utils.cpp
+++ b/src/fpsi/4C_fpsi_utils.cpp
@@ -552,8 +552,8 @@ void FPSI::InterfaceUtils::redistribute_interface(Core::FE::Discretization& mast
 
       int globalsize;
       Core::Communication::sum_all(&myglobalelementsize, &globalsize, 1, comm);
-      Core::LinAlg::Map newelecolmap(globalsize, myglobalelementsize, myglobalelements.data(), 0,
-          Core::Communication::as_epetra_comm(comm));
+      Core::LinAlg::Map newelecolmap(
+          globalsize, myglobalelementsize, myglobalelements.data(), 0, comm);
 
       if (mastereleid == printid)
       {

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
@@ -281,8 +281,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::create_lagrange_multiplier_dof_
   const int num_loc_elem_fluid_interface =
       fluid_field()->interface()->fsi_cond_map()->NumMyElements();
   const int max_gid_ale = ale_field()->dof_row_map()->MaxAllGID();
-  lag_mult_dof_map_ = std::make_shared<Core::LinAlg::Map>(num_glob_elem_fluid_interface,
-      num_loc_elem_fluid_interface, max_gid_ale + 1, Core::Communication::as_epetra_comm(comm_));
+  lag_mult_dof_map_ = std::make_shared<Core::LinAlg::Map>(
+      num_glob_elem_fluid_interface, num_loc_elem_fluid_interface, max_gid_ale + 1, comm_);
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
@@ -109,8 +109,7 @@ Solid::ModelEvaluator::PartitionedFSI::solve_relaxation_linear(
     std::shared_ptr<Adapter::Structure> structure)
 {
   // print to screen
-  if (Core::Communication::my_mpi_rank(
-          Core::Communication::unpack_epetra_comm(global_state().dof_row_map()->Comm())) == 0)
+  if (Core::Communication::my_mpi_rank(global_state().dof_row_map()->Comm()) == 0)
     std::cout << "\n DO SRUCTURAL RELAXATION SOLVE ..." << std::endl;
 
   // cast adapter structure to implicit time integrator

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -622,8 +622,8 @@ void FSI::Utils::SlideAleUtils::redundant_elements(
 
     Core::Communication::sum_all(&partsum, &globsum, 1, comm);
     // map with ele ids
-    Core::LinAlg::Map mstruslideleids(globsum, vstruslideleids.size(), vstruslideleids.data(), 0,
-        Core::Communication::as_epetra_comm(comm));
+    Core::LinAlg::Map mstruslideleids(
+        globsum, vstruslideleids.size(), vstruslideleids.data(), 0, comm);
     // redundant version of it
     Core::LinAlg::Map redmstruslideleids(*Core::LinAlg::allreduce_e_map(mstruslideleids));
 

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
@@ -669,7 +669,7 @@ void FSI::MonolithicXFEM::create_combined_dof_row_map()
   {
     vecSpaces.push_back(structure_poro()->fluid_field()->dof_row_map());
     std::shared_ptr<const Core::LinAlg::Map> empty_map =
-        std::make_shared<Core::LinAlg::Map>(0, 0, Core::Communication::as_epetra_comm(get_comm()));
+        std::make_shared<Core::LinAlg::Map>(0, 0, get_comm());
     vecSpaces_mergedporo.push_back(empty_map);
     // porofluid maps empty??
     if (vecSpaces[fluidp_block_]->NumGlobalElements() == 0)

--- a/src/mat/4C_mat_aaaneohooke.cpp
+++ b/src/mat/4C_mat_aaaneohooke.cpp
@@ -25,8 +25,8 @@ Mat::PAR::AAAneohooke::AAAneohooke(const Core::Mat::PAR::Parameter::Data& matdat
     : Parameter(matdata)
 {
   Core::LinAlg::Map dummy_map(1, 1, 0,
-      Core::Communication::as_epetra_comm(
-          (Global::Problem::instance()->get_communicators()->local_comm())));
+
+      Global::Problem::instance()->get_communicators()->local_comm());
   for (int i = first; i <= last; i++)
   {
     matparams_.push_back(std::make_shared<Core::LinAlg::Vector<double>>(dummy_map, true));

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -66,9 +66,8 @@ Mat::PAR::ConstraintMixture::ConstraintMixture(const Core::Mat::PAR::Parameter::
       storehistory_(matdata.parameters.get<bool>("STOREHISTORY")),
       degtol_(1.0e-6)
 {
-  Core::LinAlg::Map dummy_map(1, 1, 0,
-      Core::Communication::as_epetra_comm(
-          Global::Problem::instance()->get_communicators()->local_comm()));
+  Core::LinAlg::Map dummy_map(
+      1, 1, 0, Global::Problem::instance()->get_communicators()->local_comm());
   for (int i = first; i <= last; i++)
   {
     matparams_.push_back(std::make_shared<Core::LinAlg::Vector<double>>(dummy_map, true));

--- a/src/mat/4C_mat_micromaterial_evaluate.cpp
+++ b/src/mat/4C_mat_micromaterial_evaluate.cpp
@@ -128,8 +128,8 @@ void Mat::MicroMaterial::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
 
   // maps are created and data is broadcast to the supporting procs
   int tag = 0;
-  Core::LinAlg::Map oldmap(1, 1, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
-  Core::LinAlg::Map newmap(1, 1, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
+  Core::LinAlg::Map oldmap(1, 1, &tag, 0, subcomm);
+  Core::LinAlg::Map newmap(1, 1, &tag, 0, subcomm);
   Core::Communication::Exporter exporter(oldmap, newmap, subcomm);
   exporter.do_export<MultiScale::MicroStaticParObject>(condnamemap);
 
@@ -315,8 +315,8 @@ void Mat::MicroMaterial::read_restart(const int gp, const int eleID, const bool 
 
   // maps are created and data is broadcast to the supporting procs
   int tag = 0;
-  Core::LinAlg::Map oldmap(1, 1, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
-  Core::LinAlg::Map newmap(1, 1, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
+  Core::LinAlg::Map oldmap(1, 1, &tag, 0, subcomm);
+  Core::LinAlg::Map newmap(1, 1, &tag, 0, subcomm);
   Core::Communication::Exporter exporter(oldmap, newmap, subcomm);
   exporter.do_export<MultiScale::MicroStaticParObject>(condnamemap);
 

--- a/src/mat/4C_mat_scatra.cpp
+++ b/src/mat/4C_mat_scatra.cpp
@@ -27,7 +27,7 @@ Mat::PAR::ScatraMat::ScatraMat(const Core::Mat::PAR::Parameter::Data& matdata) :
                       ? Global::Problem::instance()->get_communicators()->local_comm()
                       : Global::Problem::instance()->get_communicators()->sub_comm();
 
-  Core::LinAlg::Map dummy_map(1, 1, 0, Core::Communication::as_epetra_comm(comm));
+  Core::LinAlg::Map dummy_map(1, 1, 0, comm);
   for (int i = first; i <= last; i++)
   {
     matparams_.push_back(std::make_shared<Core::LinAlg::Vector<double>>(dummy_map, true));

--- a/src/mortar/4C_mortar_interface.cpp
+++ b/src/mortar/4C_mortar_interface.cpp
@@ -1298,8 +1298,7 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
     Core::LinAlg::gather<int>(sdata, rdata, (int)allproc.size(), allproc.data(), get_comm());
 
     // build completely overlapping map of nodes (on ALL processors)
-    Core::LinAlg::Map newnodecolmap(
-        -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
     sdata.clear();
     rdata.clear();
 
@@ -1313,8 +1312,7 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
     Core::LinAlg::gather<int>(sdata, rdata, (int)allproc.size(), allproc.data(), get_comm());
 
     // build complete overlapping map of elements (on ALL processors)
-    Core::LinAlg::Map newelecolmap(
-        -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
     sdata.clear();
     rdata.clear();
     allproc.clear();
@@ -1385,8 +1383,7 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
     }
 
     // build new node column map (on ALL processors)
-    Core::LinAlg::Map newnodecolmap(
-        -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
     sdata.clear();
     rdata.clear();
 
@@ -1418,8 +1415,7 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
     }
 
     // build new element column map (on ALL processors)
-    Core::LinAlg::Map newelecolmap(
-        -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
     sdata.clear();
     rdata.clear();
     allproc.clear();
@@ -1470,8 +1466,7 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
     }
 
     // re-build node column map (now formally on ALL processors)
-    Core::LinAlg::Map newnodecolmap(
-        -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    Core::LinAlg::Map newnodecolmap(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
     rdata.clear();
 
     // fill my own slave and master column element ids (non-redundant)
@@ -1483,8 +1478,8 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
     }
 
     // re-build element column map (now formally on ALL processors)
-    std::shared_ptr<Core::LinAlg::Map> newelecolmap = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)rdata.size(), rdata.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    std::shared_ptr<Core::LinAlg::Map> newelecolmap =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)rdata.size(), rdata.data(), 0, get_comm());
     rdata.clear();
 
     // redistribute the discretization of the interface according to the
@@ -1547,8 +1542,7 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
       }
 
       std::vector<int> colnodes(nodes.begin(), nodes.end());
-      Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0,
-          Core::Communication::as_epetra_comm(get_comm()));
+      Core::LinAlg::Map nodecolmap(-1, (int)colnodes.size(), colnodes.data(), 0, get_comm());
 
       // now ghost the nodes
       discret().export_column_nodes(nodecolmap);
@@ -1654,14 +1648,10 @@ void Mortar::Interface::update_master_slave_dof_maps()
     }
   }
 
-  sdofrowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)sr.size(), sr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  sdofcolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)sc.size(), sc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  mdofrowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mr.size(), mr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  mdofcolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mc.size(), mc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  sdofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sr.size(), sr.data(), 0, get_comm());
+  sdofcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sc.size(), sc.data(), 0, get_comm());
+  mdofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mr.size(), mr.data(), 0, get_comm());
+  mdofcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mc.size(), mc.data(), 0, get_comm());
 }
 
 /*----------------------------------------------------------------------*
@@ -1702,14 +1692,10 @@ void Mortar::Interface::update_master_slave_element_maps(
     }
   }
 
-  selerowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)sr.size(), sr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  selecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)sc.size(), sc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  melerowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mr.size(), mr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  melecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mc.size(), mc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  selerowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sr.size(), sr.data(), 0, get_comm());
+  selecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sc.size(), sc.data(), 0, get_comm());
+  melerowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mr.size(), mr.data(), 0, get_comm());
+  melecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mc.size(), mc.data(), 0, get_comm());
 }
 
 /*----------------------------------------------------------------------*
@@ -1763,23 +1749,19 @@ void Mortar::Interface::update_master_slave_node_maps(
     }
   }
 
-  snoderowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)sr.size(), sr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  snodecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)sc.size(), sc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  mnoderowmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mr.size(), mr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  mnodecolmap_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mc.size(), mc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  snoderowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sr.size(), sr.data(), 0, get_comm());
+  snodecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sc.size(), sc.data(), 0, get_comm());
+  mnoderowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mr.size(), mr.data(), 0, get_comm());
+  mnodecolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)mc.size(), mc.data(), 0, get_comm());
 
-  snoderowmapbound_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)srb.size(), srb.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  snodecolmapbound_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)scb.size(), scb.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  mnoderowmapnobound_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mrb.size(), mrb.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-  mnodecolmapnobound_ = std::make_shared<Core::LinAlg::Map>(
-      -1, (int)mcb.size(), mcb.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  snoderowmapbound_ =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)srb.size(), srb.data(), 0, get_comm());
+  snodecolmapbound_ =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)scb.size(), scb.data(), 0, get_comm());
+  mnoderowmapnobound_ =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)mrb.size(), mrb.data(), 0, get_comm());
+  mnodecolmapnobound_ =
+      std::make_shared<Core::LinAlg::Map>(-1, (int)mcb.size(), mcb.data(), 0, get_comm());
 
   // build exporter
   interface_data_->sl_exporter_ptr() = std::make_shared<Core::Communication::Exporter>(
@@ -1811,10 +1793,10 @@ void Mortar::Interface::restrict_slave_sets()
       if (istied && snoderowmap_->MyGID(gid)) sr.push_back(gid);
     }
 
-    snoderowmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sr.size(), sr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    snodecolmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sc.size(), sc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    snoderowmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sr.size(), sr.data(), 0, get_comm());
+    snodecolmap_ =
+        std::make_shared<Core::LinAlg::Map>(-1, (int)sc.size(), sc.data(), 0, get_comm());
   }
 
   //********************************************************************
@@ -1849,10 +1831,8 @@ void Mortar::Interface::restrict_slave_sets()
         for (int j = 0; j < numdof; ++j) sr.push_back(mrtrnode->dofs()[j]);
     }
 
-    sdofrowmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sr.size(), sr.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
-    sdofcolmap_ = std::make_shared<Core::LinAlg::Map>(
-        -1, (int)sc.size(), sc.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    sdofrowmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sr.size(), sr.data(), 0, get_comm());
+    sdofcolmap_ = std::make_shared<Core::LinAlg::Map>(-1, (int)sc.size(), sc.data(), 0, get_comm());
   }
 }
 
@@ -1903,8 +1883,7 @@ std::shared_ptr<Core::LinAlg::Map> Mortar::Interface::update_lag_mult_sets(
   // create interface LM map
   // (if maxdofglobal_ == 0, we do not want / need this)
   if (max_dof_global() > 0)
-    return std::make_shared<Core::LinAlg::Map>(
-        -1, (int)lmdof.size(), lmdof.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    return std::make_shared<Core::LinAlg::Map>(-1, (int)lmdof.size(), lmdof.data(), 0, get_comm());
 
   return nullptr;
 }
@@ -1979,8 +1958,7 @@ std::shared_ptr<Core::LinAlg::Map> Mortar::Interface::redistribute_lag_mult_sets
   }
 
   // create deterministic interface LM map
-  return std::make_shared<Core::LinAlg::Map>(
-      -1, (int)lmdof.size(), lmdof.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+  return std::make_shared<Core::LinAlg::Map>(-1, (int)lmdof.size(), lmdof.data(), 0, get_comm());
 }
 
 /*----------------------------------------------------------------------*

--- a/src/mortar/4C_mortar_utils.cpp
+++ b/src/mortar/4C_mortar_utils.cpp
@@ -278,7 +278,8 @@ void Mortar::create_new_col_map(const Core::LinAlg::SparseMatrix& mat,
   }
 
   newcolmap = std::make_shared<Core::LinAlg::Map>(mat.col_map().NumGlobalElements(),
-      static_cast<int>(my_col_gids.size()), my_col_gids.data(), 0, mat.Comm());
+      static_cast<int>(my_col_gids.size()), my_col_gids.data(), 0,
+      Core::Communication::unpack_epetra_comm(mat.Comm()));
 }
 
 /*----------------------------------------------------------------------*
@@ -742,8 +743,8 @@ void Mortar::Utils::create_volume_ghosting(const Core::FE::Discretization& dis_s
     }
 
     // re-build element column map
-    Core::LinAlg::Map newelecolmap(-1, (int)rdata.size(), rdata.data(), 0,
-        Core::Communication::as_epetra_comm(voldis[disidx]->get_comm()));
+    Core::LinAlg::Map newelecolmap(
+        -1, (int)rdata.size(), rdata.data(), 0, voldis[disidx]->get_comm());
     rdata.clear();
 
     // redistribute the volume discretization according to the

--- a/src/particle_engine/4C_particle_engine.cpp
+++ b/src/particle_engine/4C_particle_engine.cpp
@@ -998,8 +998,8 @@ void PARTICLEENGINE::ParticleEngine::setup_bin_ghosting()
 
   // copy bin gids to a vector and create bincolmap
   std::vector<int> bincolmapvec(bins.begin(), bins.end());
-  bincolmap_ = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(bincolmapvec.size()),
-      bincolmapvec.data(), 0, Core::Communication::as_epetra_comm(comm_));
+  bincolmap_ = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(bincolmapvec.size()), bincolmapvec.data(), 0, comm_);
 
   if (bincolmap_->NumGlobalElements() == 1 && Core::Communication::num_mpi_ranks(comm_) > 1)
     FOUR_C_THROW("one bin cannot be run in parallel -> reduce BIN_SIZE_LOWER_BOUND");

--- a/src/particle_wall/4C_particle_wall.cpp
+++ b/src/particle_wall/4C_particle_wall.cpp
@@ -737,17 +737,15 @@ void PARTICLEWALL::WallHandlerBoundingBox::init_wall_discretization()
   }
 
   // node row map of wall elements
-  std::shared_ptr<Core::LinAlg::Map> noderowmap =
-      std::make_shared<Core::LinAlg::Map>(-1, nodeids.size(), nodeids.data(), 0,
-          Core::Communication::as_epetra_comm(walldiscretization_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> noderowmap = std::make_shared<Core::LinAlg::Map>(
+      -1, nodeids.size(), nodeids.data(), 0, walldiscretization_->get_comm());
 
   // fully overlapping node column map
   std::shared_ptr<Core::LinAlg::Map> nodecolmap = Core::LinAlg::allreduce_e_map(*noderowmap);
 
   // element row map of wall elements
-  std::shared_ptr<Core::LinAlg::Map> elerowmap =
-      std::make_shared<Core::LinAlg::Map>(-1, eleids.size(), eleids.data(), 0,
-          Core::Communication::as_epetra_comm(walldiscretization_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> elerowmap = std::make_shared<Core::LinAlg::Map>(
+      -1, eleids.size(), eleids.data(), 0, walldiscretization_->get_comm());
 
   // fully overlapping element column map
   std::shared_ptr<Core::LinAlg::Map> elecolmap = Core::LinAlg::allreduce_e_map(*elerowmap);

--- a/src/poroelast/4C_poroelast_base.cpp
+++ b/src/poroelast/4C_poroelast_base.cpp
@@ -572,8 +572,8 @@ void PoroElast::NoPenetrationConditionHandle::build_no_penetration_map(
   {
     condIDs.push_back(*it);
   }
-  std::shared_ptr<Core::LinAlg::Map> nopendofmap = std::make_shared<Core::LinAlg::Map>(
-      -1, int(condIDs.size()), condIDs.data(), 0, Core::Communication::as_epetra_comm(comm));
+  std::shared_ptr<Core::LinAlg::Map> nopendofmap =
+      std::make_shared<Core::LinAlg::Map>(-1, int(condIDs.size()), condIDs.data(), 0, comm);
 
   nopenetration_ = std::make_shared<Core::LinAlg::MapExtractor>(*dofRowMap, nopendofmap);
 }

--- a/src/poroelast/4C_poroelast_monolithicsplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit.cpp
@@ -167,9 +167,8 @@ std::shared_ptr<Core::LinAlg::Map> PoroElast::MonolithicSplit::fsidbc_map()
     if (val == 1.0) structfsidbcvector.push_back(fluidmap[i]);
   }
 
-  std::shared_ptr<Core::LinAlg::Map> structfsidbcmap =
-      std::make_shared<Core::LinAlg::Map>(-1, structfsidbcvector.size(), structfsidbcvector.data(),
-          0, Core::Communication::as_epetra_comm(get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> structfsidbcmap = std::make_shared<Core::LinAlg::Map>(
+      -1, structfsidbcvector.size(), structfsidbcvector.data(), 0, get_comm());
   // FOUR_C_ASSERT(fluidfsidbcmap->UniqueGIDs(),"fsidbcmap is not unique!");
 
   return structfsidbcmap;

--- a/src/poroelast/4C_poroelast_utils.cpp
+++ b/src/poroelast/4C_poroelast_utils.cpp
@@ -228,8 +228,8 @@ void PoroElast::Utils::create_volume_ghosting(Core::FE::Discretization& idiscret
     }
 
     // re-build element column map
-    Core::LinAlg::Map newelecolmap(-1, static_cast<int>(rdata.size()), rdata.data(), 0,
-        Core::Communication::as_epetra_comm(voldi->get_comm()));
+    Core::LinAlg::Map newelecolmap(
+        -1, static_cast<int>(rdata.size()), rdata.data(), 0, voldi->get_comm());
     rdata.clear();
 
     // redistribute the volume discretization according to the

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
@@ -182,8 +182,8 @@ void PoroElastScaTra::Utils::create_volume_ghosting(Core::FE::Discretization& id
     }
 
     // re-build element column map
-    Core::LinAlg::Map newelecolmap(-1, static_cast<int>(rdata.size()), rdata.data(), 0,
-        Core::Communication::as_epetra_comm(voldi->get_comm()));
+    Core::LinAlg::Map newelecolmap(
+        -1, static_cast<int>(rdata.size()), rdata.data(), 0, voldi->get_comm());
     rdata.clear();
 
     // redistribute the volume discretization according to the

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -984,9 +984,8 @@ void PoroPressureBased::PorofluidAlgorithm::apply_additional_dbc_for_vol_frac_pr
 
   // build map
   int nummydirichvals = mydirichdofs.size();
-  std::shared_ptr<Core::LinAlg::Map> dirichmap =
-      std::make_shared<Core::LinAlg::Map>(-1, nummydirichvals, mydirichdofs.data(), 0,
-          Core::Communication::as_epetra_comm(discret_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> dirichmap = std::make_shared<Core::LinAlg::Map>(
+      -1, nummydirichvals, mydirichdofs.data(), 0, discret_->get_comm());
 
   // build vector of maps
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> condmaps;
@@ -1044,9 +1043,8 @@ void PoroPressureBased::PorofluidAlgorithm::apply_starting_dbc()
   }
 
   // build combined DBC map
-  std::shared_ptr<Core::LinAlg::Map> additional_map =
-      std::make_shared<Core::LinAlg::Map>(-1, dirichlet_dofs.size(), dirichlet_dofs.data(), 0,
-          Core::Communication::as_epetra_comm(discret_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> additional_map = std::make_shared<Core::LinAlg::Map>(
+      -1, dirichlet_dofs.size(), dirichlet_dofs.data(), 0, discret_->get_comm());
 
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> condition_maps;
   condition_maps.emplace_back(additional_map);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -256,15 +256,15 @@ std::map<int, std::set<int>> PoroPressureBased::extended_ghosting_artery_discret
 
   // extended ghosting for elements
   std::vector<int> coleles(elecolset.begin(), elecolset.end());
-  const Core::LinAlg::Map extendedelecolmap(-1, coleles.size(), coleles.data(), 0,
-      Core::Communication::as_epetra_comm(contdis.get_comm()));
+  const Core::LinAlg::Map extendedelecolmap(
+      -1, coleles.size(), coleles.data(), 0, contdis.get_comm());
 
   artdis->export_column_elements(extendedelecolmap);
 
   // extended ghosting for nodes
   std::vector<int> colnodes(nodecolset.begin(), nodecolset.end());
-  const Core::LinAlg::Map extendednodecolmap(-1, colnodes.size(), colnodes.data(), 0,
-      Core::Communication::as_epetra_comm(contdis.get_comm()));
+  const Core::LinAlg::Map extendednodecolmap(
+      -1, colnodes.size(), colnodes.data(), 0, contdis.get_comm());
 
   artdis->export_column_nodes(extendednodecolmap);
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -153,9 +153,8 @@ PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::get_additional_dbc_for
 
   // build map
   int nummydirichvals = mydirichdofs.size();
-  std::shared_ptr<Core::LinAlg::Map> dirichmap =
-      std::make_shared<Core::LinAlg::Map>(-1, nummydirichvals, mydirichdofs.data(), 0,
-          Core::Communication::as_epetra_comm(arterydis_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> dirichmap = std::make_shared<Core::LinAlg::Map>(
+      -1, nummydirichvals, mydirichdofs.data(), 0, arterydis_->get_comm());
 
   // build vector of maps
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> condmaps;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_base.cpp
@@ -152,8 +152,8 @@ void PoroPressureBased::PoroMultiPhaseScaTraBase::init(
 
   std::vector<int> mydirichdofs;
   add_dirichmaps_volfrac_spec_ = std::make_shared<Core::LinAlg::Map>(-1, 0, mydirichdofs.data(), 0,
-      Core::Communication::as_epetra_comm(
-          scatra_algo()->scatra_field()->discretization()->get_comm()));
+
+      scatra_algo()->scatra_field()->discretization()->get_comm());
 
   // done.
 }
@@ -412,10 +412,8 @@ void PoroPressureBased::PoroMultiPhaseScaTraBase::apply_additional_dbc_for_vol_f
 
   // build map
   int nummydirichvals = mydirichdofs.size();
-  add_dirichmaps_volfrac_spec_ =
-      std::make_shared<Core::LinAlg::Map>(-1, nummydirichvals, mydirichdofs.data(), 0,
-          Core::Communication::as_epetra_comm(
-              scatra_algo()->scatra_field()->discretization()->get_comm()));
+  add_dirichmaps_volfrac_spec_ = std::make_shared<Core::LinAlg::Map>(-1, nummydirichvals,
+      mydirichdofs.data(), 0, scatra_algo()->scatra_field()->discretization()->get_comm());
 
   // add the condition
   scatra_algo()->scatra_field()->add_dirich_cond(add_dirichmaps_volfrac_spec_);

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -1509,8 +1509,8 @@ void EnsightWriter::write_dof_result_step(std::ofstream& file, PostResult& resul
 
   // do stupid conversion into map
   std::shared_ptr<Core::LinAlg::Map> datamap;
-  datamap = std::make_shared<Core::LinAlg::Map>(
-      map.NumGlobalElements(), map.NumMyElements(), map.MyGlobalElements(), 0, map.Comm());
+  datamap = std::make_shared<Core::LinAlg::Map>(map.NumGlobalElements(), map.NumMyElements(),
+      map.MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(map.Comm()));
 
   // determine offset of dofs in case of multiple discretizations in
   // separate files (e.g. multi-scale problems). during calculation,
@@ -1818,8 +1818,8 @@ void EnsightWriter::write_element_dof_result_step(std::ofstream& file, PostResul
 
   // do stupid conversion into map
   std::shared_ptr<Core::LinAlg::Map> datamap;
-  datamap = std::make_shared<Core::LinAlg::Map>(
-      map.NumGlobalElements(), map.NumMyElements(), map.MyGlobalElements(), 0, map.Comm());
+  datamap = std::make_shared<Core::LinAlg::Map>(map.NumGlobalElements(), map.NumMyElements(),
+      map.MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(map.Comm()));
 
   //------------------------------------------------------
   // each processor provides its result values for proc 0
@@ -1984,8 +1984,8 @@ void EnsightWriter::write_element_result_step(std::ofstream& file,
 
   // do stupid conversion into map
   std::shared_ptr<Core::LinAlg::Map> datamap;
-  datamap = std::make_shared<Core::LinAlg::Map>(
-      map.NumGlobalElements(), map.NumMyElements(), map.MyGlobalElements(), 0, map.Comm());
+  datamap = std::make_shared<Core::LinAlg::Map>(map.NumGlobalElements(), map.NumMyElements(),
+      map.MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(map.Comm()));
 
   //------------------------------------------------------
   // each processor provides its result values for proc 0

--- a/src/post/4C_post_ensight_writer_nurbs.cpp
+++ b/src/post/4C_post_ensight_writer_nurbs.cpp
@@ -1341,7 +1341,7 @@ void EnsightWriter::write_coordinates_for_nurbs_shapefunctions(std::ofstream& ge
   }
 
   vispointmap_ = std::make_shared<Core::LinAlg::Map>(numvispoints, local_vis_point_ids.size(),
-      local_vis_point_ids.data(), 0, Core::Communication::as_epetra_comm(nurbsdis->get_comm()));
+      local_vis_point_ids.data(), 0, nurbsdis->get_comm());
 
   // allocate the coordinates of the visualisation points
   nodecoords = std::make_shared<Core::LinAlg::MultiVector<double>>(*vispointmap_, 3);
@@ -1900,8 +1900,8 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
   coldofmapvec.reserve(coldofset.size());
   coldofmapvec.assign(coldofset.begin(), coldofset.end());
   coldofset.clear();
-  Core::LinAlg::Map coldofmap(-1, coldofmapvec.size(), coldofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(nurbsdis->get_comm()));
+  Core::LinAlg::Map coldofmap(
+      -1, coldofmapvec.size(), coldofmapvec.data(), 0, nurbsdis->get_comm());
   coldofmapvec.clear();
 
   const Core::LinAlg::Map* fulldofmap = &(coldofmap);
@@ -3426,8 +3426,8 @@ void EnsightWriter::write_nodal_result_step_for_nurbs(std::ofstream& file, const
   colnodemapvec.reserve(colnodeset.size());
   colnodemapvec.assign(colnodeset.begin(), colnodeset.end());
   colnodeset.clear();
-  Core::LinAlg::Map colnodemap(-1, colnodemapvec.size(), colnodemapvec.data(), 0,
-      Core::Communication::as_epetra_comm(nurbsdis->get_comm()));
+  Core::LinAlg::Map colnodemap(
+      -1, colnodemapvec.size(), colnodemapvec.data(), 0, nurbsdis->get_comm());
   colnodemapvec.clear();
 
   const Core::LinAlg::Map* fullnodemap = &(colnodemap);

--- a/src/post/4C_post_vtk_vtu_writer.cpp
+++ b/src/post/4C_post_vtk_vtu_writer.cpp
@@ -263,8 +263,8 @@ void PostVtuWriter::write_dof_result_step(std::ofstream& file,
     std::vector<int> gids(vecmap.NumMyElements());
     for (int i = 0; i < vecmap.NumMyElements(); ++i)
       gids[i] = vecmap.MyGlobalElements()[i] - offset;
-    Core::LinAlg::Map rowmap(
-        vecmap.NumGlobalElements(), vecmap.NumMyElements(), gids.data(), 0, vecmap.Comm());
+    Core::LinAlg::Map rowmap(vecmap.NumGlobalElements(), vecmap.NumMyElements(), gids.data(), 0,
+        Core::Communication::unpack_epetra_comm(vecmap.Comm()));
     std::shared_ptr<Core::LinAlg::Vector<double>> dofvec =
         Core::LinAlg::create_vector(rowmap, false);
     for (int i = 0; i < vecmap.NumMyElements(); ++i) (*dofvec)[i] = (*data)[i];

--- a/src/post/4C_post_vtk_vtu_writer_node_based.cpp
+++ b/src/post/4C_post_vtk_vtu_writer_node_based.cpp
@@ -276,8 +276,8 @@ void PostVtuWriterNode::write_dof_result_step(std::ofstream& file,
     std::vector<int> gids(vecmap.NumMyElements());
     for (int i = 0; i < vecmap.NumMyElements(); ++i)
       gids[i] = vecmap.MyGlobalElements()[i] - offset;
-    Core::LinAlg::Map rowmap(
-        vecmap.NumGlobalElements(), vecmap.NumMyElements(), gids.data(), 0, vecmap.Comm());
+    Core::LinAlg::Map rowmap(vecmap.NumGlobalElements(), vecmap.NumMyElements(), gids.data(), 0,
+        Core::Communication::unpack_epetra_comm(vecmap.Comm()));
     std::shared_ptr<Core::LinAlg::Vector<double>> dofvec =
         Core::LinAlg::create_vector(rowmap, false);
     for (int i = 0; i < vecmap.NumMyElements(); ++i) (*dofvec)[i] = (*data)[i];

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -116,15 +116,15 @@ Airway::RedAirwayImplicitTimeInt::RedAirwayImplicitTimeInt(
 
     // extended ghosting for elements (also revert fully overlapping here)
     std::vector<int> coleles(elecolset.begin(), elecolset.end());
-    const Core::LinAlg::Map extendedelecolmap(-1, coleles.size(), coleles.data(), 0,
-        Core::Communication::as_epetra_comm(discret_->get_comm()));
+    const Core::LinAlg::Map extendedelecolmap(
+        -1, coleles.size(), coleles.data(), 0, discret_->get_comm());
 
     discret_->export_column_elements(extendedelecolmap);
 
     // extended ghosting for nodes
     std::vector<int> colnodes(nodecolset.begin(), nodecolset.end());
-    const Core::LinAlg::Map extendednodecolmap(-1, colnodes.size(), colnodes.data(), 0,
-        Core::Communication::as_epetra_comm(discret_->get_comm()));
+    const Core::LinAlg::Map extendednodecolmap(
+        -1, colnodes.size(), colnodes.data(), 0, discret_->get_comm());
 
     discret_->export_column_nodes(extendednodecolmap);
 

--- a/src/reduced_lung/4C_reduced_lung_helpers.cpp
+++ b/src/reduced_lung/4C_reduced_lung_helpers.cpp
@@ -20,7 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 namespace ReducedLung
 {
 
-  Core::LinAlg::Map create_domain_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
+  Core::LinAlg::Map create_domain_map(const MPI_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units)
   {
     std::vector<int> locally_owned_dof_indices;
@@ -40,7 +40,7 @@ namespace ReducedLung
     return domain_map;
   }
 
-  Core::LinAlg::Map create_row_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
+  Core::LinAlg::Map create_row_map(const MPI_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units, const std::vector<Connection>& connections,
       const std::vector<Bifurcation>& bifurcations,
       const std::vector<BoundaryCondition>& boundary_conditions)
@@ -78,7 +78,7 @@ namespace ReducedLung
     return row_map;
   }
 
-  Core::LinAlg::Map create_column_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
+  Core::LinAlg::Map create_column_map(const MPI_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units, const std::map<int, int>& global_dof_per_ele,
       const std::map<int, int>& first_global_dof_of_ele, const std::vector<Connection>& connections,
       const std::vector<Bifurcation>& bifurcations,

--- a/src/reduced_lung/4C_reduced_lung_helpers.hpp
+++ b/src/reduced_lung/4C_reduced_lung_helpers.hpp
@@ -10,10 +10,10 @@
 
 #include "4C_config.hpp"
 
-#include "4C_comm_mpi_utils.hpp"
-#include "4C_global_data.hpp"
 #include "4C_io_discretization_visualization_writer_mesh.hpp"
 #include "4C_linalg_map.hpp"
+
+#include <mpi.h>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -146,7 +146,7 @@ namespace ReducedLung
    * @param terminal_units Vector of locally owned terminal units.
    * @return map specifying the dof-distribution over all ranks.
    */
-  Core::LinAlg::Map create_domain_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
+  Core::LinAlg::Map create_domain_map(const MPI_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units);
 
   /*!
@@ -174,7 +174,7 @@ namespace ReducedLung
    * element ids are needed.
    * @return map with locally owned rows.
    */
-  Core::LinAlg::Map create_row_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
+  Core::LinAlg::Map create_row_map(const MPI_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units, const std::vector<Connection>& connections,
       const std::vector<Bifurcation>& bifurcations,
       const std::vector<BoundaryCondition>& boundary_conditions);
@@ -201,7 +201,7 @@ namespace ReducedLung
    * element ids are needed.
    * @return map with distribution of column indices for the system matrix.
    */
-  Core::LinAlg::Map create_column_map(const Epetra_Comm& comm, const std::vector<Airway>& airways,
+  Core::LinAlg::Map create_column_map(const MPI_Comm& comm, const std::vector<Airway>& airways,
       const std::vector<TerminalUnit>& terminal_units, const std::map<int, int>& global_dof_per_ele,
       const std::map<int, int>& first_global_dof_of_ele, const std::vector<Connection>& connections,
       const std::vector<Bifurcation>& bifurcations,

--- a/src/reduced_lung/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/4C_reduced_lung_main.cpp
@@ -361,17 +361,16 @@ namespace ReducedLung
     }
 
     // Create all necessary maps for matrix, rhs, and dof-vector.
-    const auto& epetra_comm = Core::Communication::as_epetra_comm(comm);
     // Map with all dof ids belonging to the local elements (airways and terminal units).
     const Core::LinAlg::Map locally_owned_dof_map =
-        create_domain_map(epetra_comm, airways, terminal_units);
+        create_domain_map(comm, airways, terminal_units);
     // Map with row ids for the equations of local elements, connections, bifurcations, and boundary
     // conditions.
     const Core::LinAlg::Map row_map = create_row_map(
-        epetra_comm, airways, terminal_units, connections, bifurcations, boundary_conditions);
+        comm, airways, terminal_units, connections, bifurcations, boundary_conditions);
     // Map with all relevant dof ids for the local equations.
     const Core::LinAlg::Map locally_relevant_dof_map =
-        create_column_map(epetra_comm, airways, terminal_units, global_dof_per_ele,
+        create_column_map(comm, airways, terminal_units, global_dof_per_ele,
             first_global_dof_of_ele, connections, bifurcations, boundary_conditions);
 
     // Assign global equation ids to connections, bifurcations, and boundary conditions based on the

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -361,10 +361,10 @@ void ScaTra::ScaTraTimIntElch::setup_conc_pot_split()
     }
   }
 
-  auto concdofmap = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(conc_dofs.size()),
-      conc_dofs.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
-  auto potdofmap = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(pot_dofs.size()),
-      pot_dofs.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  auto concdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(conc_dofs.size()), conc_dofs.data(), 0, discret_->get_comm());
+  auto potdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(pot_dofs.size()), pot_dofs.data(), 0, discret_->get_comm());
 
   // set up concentration-potential splitter
   splitter_ =
@@ -398,12 +398,12 @@ void ScaTra::ScaTraTimIntElch::setup_conc_pot_pot_split()
 
   // transform sets to maps
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps(3, nullptr);
-  maps[0] = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(conc_dofs.size()),
-      conc_dofs.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
-  maps[1] = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(pot_el_dofs.size()),
-      pot_el_dofs.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
-  maps[2] = std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(pot_ed_dofs.size()),
-      pot_ed_dofs.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  maps[0] = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(conc_dofs.size()), conc_dofs.data(), 0, discret_->get_comm());
+  maps[1] = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(pot_el_dofs.size()), pot_el_dofs.data(), 0, discret_->get_comm());
+  maps[2] = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(pot_ed_dofs.size()), pot_ed_dofs.data(), 0, discret_->get_comm());
 
   // set up concentration-potential-potential splitter
   splitter_macro_ =
@@ -3198,9 +3198,8 @@ void ScaTra::ScaTraTimIntElch::build_block_maps(
         std::unordered_set<int> dof_set(dofs.begin(), dofs.end());
         FOUR_C_ASSERT(dof_set.size() == dofs.size(), "The dofs are not unique");
 #endif
-        blockmaps.emplace_back(
-            std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(dofs.size()), dofs.data(), 0,
-                Core::Communication::as_epetra_comm(discret_->get_comm())));
+        blockmaps.emplace_back(std::make_shared<Core::LinAlg::Map>(
+            -1, static_cast<int>(dofs.size()), dofs.data(), 0, discret_->get_comm()));
       }
     }
   }

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -744,12 +744,12 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
         glob_macro_micro_coupled_node_gids, glob_macro_slave_node_master_node_gids);
 
   // setup maps for coupled nodes
-  Core::LinAlg::Map master_node_map(-1, static_cast<int>(my_macro_node_gids.size()),
-      &my_macro_node_gids[0], 0, Core::Communication::as_epetra_comm(comm));
-  Core::LinAlg::Map slave_node_map(-1, static_cast<int>(my_micro_node_gids.size()),
-      &my_micro_node_gids[0], 0, Core::Communication::as_epetra_comm(comm));
+  Core::LinAlg::Map master_node_map(
+      -1, static_cast<int>(my_macro_node_gids.size()), &my_macro_node_gids[0], 0, comm);
+  Core::LinAlg::Map slave_node_map(
+      -1, static_cast<int>(my_micro_node_gids.size()), &my_micro_node_gids[0], 0, comm);
   Core::LinAlg::Map perm_slave_node_map(-1, static_cast<int>(my_micro_permuted_node_gids.size()),
-      &my_micro_permuted_node_gids[0], 0, Core::Communication::as_epetra_comm(comm));
+      &my_micro_permuted_node_gids[0], 0, comm);
 
   // setup coupling adapter between micro (slave) and macro (master) for all dof of the nodes
   FourC::Coupling::Adapter::Coupling macro_micro_coupling_adapter_temp;
@@ -796,18 +796,14 @@ void ScaTra::ScaTraTimIntElchSCL::setup_coupling()
     }
   }
 
-  auto slave_dof_map =
-      std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_slave_dofs.size()),
-          &my_slave_dofs[0], 0, Core::Communication::as_epetra_comm(comm));
-  auto perm_slave_dof_map =
-      std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_perm_slave_dofs.size()),
-          &my_perm_slave_dofs[0], 0, Core::Communication::as_epetra_comm(comm));
-  auto master_dof_map =
-      std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_master_dofs.size()),
-          &my_master_dofs[0], 0, Core::Communication::as_epetra_comm(comm));
-  auto perm_master_dof_map =
-      std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_perm_master_dofs.size()),
-          &my_perm_master_dofs[0], 0, Core::Communication::as_epetra_comm(comm));
+  auto slave_dof_map = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(my_slave_dofs.size()), &my_slave_dofs[0], 0, comm);
+  auto perm_slave_dof_map = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(my_perm_slave_dofs.size()), &my_perm_slave_dofs[0], 0, comm);
+  auto master_dof_map = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(my_master_dofs.size()), &my_master_dofs[0], 0, comm);
+  auto perm_master_dof_map = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(my_perm_master_dofs.size()), &my_perm_master_dofs[0], 0, comm);
 
 
   macro_micro_coupling_adapter_ = std::make_shared<Coupling::Adapter::Coupling>();
@@ -1071,11 +1067,11 @@ void ScaTra::ScaTraTimIntElchSCL::redistribute_micro_discretization()
   if (myPID > 0) my_col_nodes.emplace_back(my_row_nodes[0] - 1);
   if (myPID < num_proc - 1) my_col_nodes.emplace_back(my_row_nodes.back() + 1);
 
-  Core::LinAlg::Map new_node_row_map(num_nodes, static_cast<int>(my_row_nodes.size()),
-      &my_row_nodes[0], 0, Core::Communication::as_epetra_comm(micro_dis->get_comm()));
+  Core::LinAlg::Map new_node_row_map(
+      num_nodes, static_cast<int>(my_row_nodes.size()), &my_row_nodes[0], 0, micro_dis->get_comm());
 
-  Core::LinAlg::Map new_node_col_map(-1, static_cast<int>(my_col_nodes.size()), &my_col_nodes[0], 0,
-      Core::Communication::as_epetra_comm(micro_dis->get_comm()));
+  Core::LinAlg::Map new_node_col_map(
+      -1, static_cast<int>(my_col_nodes.size()), &my_col_nodes[0], 0, micro_dis->get_comm());
 
   micro_dis->redistribute(new_node_row_map, new_node_col_map);
 }

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -3660,8 +3660,8 @@ void ScaTra::ScaTraTimIntImpl::build_block_maps(
       FOUR_C_ASSERT(dof_set.size() == dofs.size(), "The dofs are not unique");
 #endif
 
-      blockmaps.emplace_back(std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(dofs.size()),
-          dofs.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm())));
+      blockmaps.emplace_back(std::make_shared<Core::LinAlg::Map>(
+          -1, static_cast<int>(dofs.size()), dofs.data(), 0, discret_->get_comm()));
     }
   }
   else

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -2195,18 +2195,18 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
       }
 
       // initialize empty interface maps
-      std::shared_ptr<Core::LinAlg::Map> imastermap = std::make_shared<Core::LinAlg::Map>(
-          0, 0, Core::Communication::as_epetra_comm(scatratimint_->discretization()->get_comm()));
-      std::shared_ptr<Core::LinAlg::Map> islavemap = std::make_shared<Core::LinAlg::Map>(
-          0, 0, Core::Communication::as_epetra_comm(scatratimint_->discretization()->get_comm()));
-      std::shared_ptr<Core::LinAlg::Map> ifullmap = std::make_shared<Core::LinAlg::Map>(
-          0, 0, Core::Communication::as_epetra_comm(scatratimint_->discretization()->get_comm()));
+      std::shared_ptr<Core::LinAlg::Map> imastermap =
+          std::make_shared<Core::LinAlg::Map>(0, 0, scatratimint_->discretization()->get_comm());
+      std::shared_ptr<Core::LinAlg::Map> islavemap =
+          std::make_shared<Core::LinAlg::Map>(0, 0, scatratimint_->discretization()->get_comm());
+      std::shared_ptr<Core::LinAlg::Map> ifullmap =
+          std::make_shared<Core::LinAlg::Map>(0, 0, scatratimint_->discretization()->get_comm());
       if (imortarredistribution_)
       {
-        imastermap_ = std::make_shared<Core::LinAlg::Map>(
-            0, 0, Core::Communication::as_epetra_comm(scatratimint_->discretization()->get_comm()));
-        islavemap_ = std::make_shared<Core::LinAlg::Map>(
-            0, 0, Core::Communication::as_epetra_comm(scatratimint_->discretization()->get_comm()));
+        imastermap_ =
+            std::make_shared<Core::LinAlg::Map>(0, 0, scatratimint_->discretization()->get_comm());
+        islavemap_ =
+            std::make_shared<Core::LinAlg::Map>(0, 0, scatratimint_->discretization()->get_comm());
       }
 
       // loop over all slave-side scatra-scatra interface coupling conditions
@@ -2677,8 +2677,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
 
               // build Lagrange multiplier dofrowmap
               const std::shared_ptr<Core::LinAlg::Map> lmdofrowmap =
-                  std::make_shared<Core::LinAlg::Map>(-1, (int)lmdofgids.size(), lmdofgids.data(),
-                      0, Core::Communication::as_epetra_comm(comm));
+                  std::make_shared<Core::LinAlg::Map>(
+                      -1, (int)lmdofgids.size(), lmdofgids.data(), 0, comm);
 
               // initialize vectors associated with Lagrange multiplier dofs
               lm_ = std::make_shared<Core::LinAlg::Vector<double>>(*lmdofrowmap);

--- a/src/ssi/4C_ssi_manifold_utils.cpp
+++ b/src/ssi/4C_ssi_manifold_utils.cpp
@@ -953,13 +953,12 @@ SSI::ManifoldMeshTyingStrategyBlock::intersect_coupling_maps_block_map(
     }
   }
 
-  auto intersected_map =
-      std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(intersecting_map_vec.size()),
-          intersecting_map_vec.data(), 0, Core::Communication::as_epetra_comm(comm));
+  auto intersected_map = std::make_shared<Core::LinAlg::Map>(
+      -1, static_cast<int>(intersecting_map_vec.size()), intersecting_map_vec.data(), 0, comm);
 
   auto permuted_intersected_map = std::make_shared<Core::LinAlg::Map>(-1,
       static_cast<int>(permuted_intersecting_map_vec.size()), permuted_intersecting_map_vec.data(),
-      0, Core::Communication::as_epetra_comm(comm));
+      0, comm);
 
   return {intersected_map, permuted_intersected_map};
 }

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -564,8 +564,8 @@ void STI::Monolithic::output_matrix_to_file(
   if (Core::Communication::my_mpi_rank(comm)) rowgids.clear();
 
   // create full row map on processor with ID 0
-  const Core::LinAlg::Map fullrowmap(-1, static_cast<int>(rowgids.size()),
-      rowgids.size() ? rowgids.data() : nullptr, 0, Core::Communication::as_epetra_comm(comm));
+  const Core::LinAlg::Map fullrowmap(
+      -1, static_cast<int>(rowgids.size()), rowgids.size() ? rowgids.data() : nullptr, 0, comm);
 
   // import matrix to processor with ID 0
   Core::LinAlg::SparseMatrix crsmatrix(fullrowmap, 0);
@@ -675,8 +675,8 @@ void STI::Monolithic::output_vector_to_file(
   if (Core::Communication::my_mpi_rank(comm)) gids.clear();
 
   // create full vector map on processor with ID 0
-  const Core::LinAlg::Map fullmap(-1, static_cast<int>(gids.size()),
-      gids.size() ? gids.data() : nullptr, 0, Core::Communication::as_epetra_comm(comm));
+  const Core::LinAlg::Map fullmap(
+      -1, static_cast<int>(gids.size()), gids.size() ? gids.data() : nullptr, 0, comm);
 
   // export vector to processor with ID 0
   Core::LinAlg::MultiVector<double> fullvector(fullmap, vector.NumVectors(), true);

--- a/src/stru_multi/4C_stru_multi_microstatic_npsupport.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic_npsupport.cpp
@@ -77,8 +77,8 @@ void MultiScale::np_support_drt()
       {
         // receive data from the master proc
         int tag = 0;
-        Core::LinAlg::Map oldmap(1, 0, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
-        Core::LinAlg::Map newmap(1, 1, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
+        Core::LinAlg::Map oldmap(1, 0, &tag, 0, subcomm);
+        Core::LinAlg::Map newmap(1, 1, &tag, 0, subcomm);
         // create an exporter object that will figure out the communication pattern
         Core::Communication::Exporter exporter(oldmap, newmap, subcomm);
         std::map<int, std::shared_ptr<MultiScale::MicroStaticParObject>> condnamemap;
@@ -133,8 +133,8 @@ void MultiScale::np_support_drt()
       {
         // receive data from the master proc for restart
         int tag = 0;
-        Core::LinAlg::Map oldmap(1, 0, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
-        Core::LinAlg::Map newmap(1, 1, &tag, 0, Core::Communication::as_epetra_comm(subcomm));
+        Core::LinAlg::Map oldmap(1, 0, &tag, 0, subcomm);
+        Core::LinAlg::Map newmap(1, 1, &tag, 0, subcomm);
         // create an exporter object that will figure out the communication pattern
         Core::Communication::Exporter exporter(oldmap, newmap, subcomm);
         std::map<int, std::shared_ptr<MultiScale::MicroStaticParObject>> condnamemap;

--- a/src/stru_multi/4C_stru_multi_microstatic_service.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic_service.cpp
@@ -89,10 +89,9 @@ void MultiScale::MicroStatic::set_up_homogenization()
   }
 
   // create map based on the determined dofs of prescribed and free nodes
-  pdof_ = std::make_shared<Core::LinAlg::Map>(
-      -1, np_, pdof.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
-  fdof_ = std::make_shared<Core::LinAlg::Map>(
-      -1, ndof_ - np_, fdof.data(), 0, Core::Communication::as_epetra_comm(discret_->get_comm()));
+  pdof_ = std::make_shared<Core::LinAlg::Map>(-1, np_, pdof.data(), 0, discret_->get_comm());
+  fdof_ =
+      std::make_shared<Core::LinAlg::Map>(-1, ndof_ - np_, fdof.data(), 0, discret_->get_comm());
 
   // create importer
   importp_ = std::make_shared<Epetra_Import>(

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -545,18 +545,16 @@ void Solid::TimeInt::BaseDataGlobalState::setup_rot_vec_map_extractor(
   additdofmapvec.reserve(additdofset.size());
   additdofmapvec.assign(additdofset.begin(), additdofset.end());
   additdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> additdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, additdofmapvec.size(), additdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(discret_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> additdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, additdofmapvec.size(), additdofmapvec.data(), 0, discret_->get_comm());
   additdofmapvec.clear();
 
   std::vector<int> rotvecdofmapvec;
   rotvecdofmapvec.reserve(rotvecdofset.size());
   rotvecdofmapvec.assign(rotvecdofset.begin(), rotvecdofset.end());
   rotvecdofset.clear();
-  std::shared_ptr<Core::LinAlg::Map> rotvecdofmap =
-      std::make_shared<Core::LinAlg::Map>(-1, rotvecdofmapvec.size(), rotvecdofmapvec.data(), 0,
-          Core::Communication::as_epetra_comm(discret_->get_comm()));
+  std::shared_ptr<Core::LinAlg::Map> rotvecdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, rotvecdofmapvec.size(), rotvecdofmapvec.data(), 0, discret_->get_comm());
   rotvecdofmapvec.clear();
 
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps(2);

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -137,10 +137,10 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_structure_li
           actdis.dof(node, solidDofs);
       }
 
-      std::shared_ptr<Core::LinAlg::Map> rowmap1(new Core::LinAlg::Map(-1, solidDofs.size(),
-          solidDofs.data(), 0, Core::Communication::as_epetra_comm(actdis.get_comm())));
-      std::shared_ptr<Core::LinAlg::Map> rowmap2(new Core::LinAlg::Map(-1, beamDofs.size(),
-          beamDofs.data(), 0, Core::Communication::as_epetra_comm(actdis.get_comm())));
+      std::shared_ptr<Core::LinAlg::Map> rowmap1(
+          new Core::LinAlg::Map(-1, solidDofs.size(), solidDofs.data(), 0, actdis.get_comm()));
+      std::shared_ptr<Core::LinAlg::Map> rowmap2(
+          new Core::LinAlg::Map(-1, beamDofs.size(), beamDofs.data(), 0, actdis.get_comm()));
 
       std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps;
       maps.emplace_back(rowmap1);

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -208,8 +208,8 @@ void Solid::MonitorDbc::create_reaction_maps(const Core::FE::Discretization& dis
   }
 
   for (unsigned i = 0; i < DIM; ++i)
-    react_maps[i] = std::make_shared<Core::LinAlg::Map>(
-        -1, my_dofs[i].size(), my_dofs[i].data(), 0, Core::Communication::as_epetra_comm(comm));
+    react_maps[i] =
+        std::make_shared<Core::LinAlg::Map>(-1, my_dofs[i].size(), my_dofs[i].data(), 0, comm);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/tsi/4C_tsi_monolithic.cpp
+++ b/src/tsi/4C_tsi_monolithic.cpp
@@ -2376,8 +2376,8 @@ void TSI::Monolithic::calculate_necking_tsi_results()
   }  // loop over all STRUCTURAL DBC conditions
 
   // map containing all z-displacement DOFs which have a DBC
-  Core::LinAlg::Map newdofmap(-1, (int)sdata.size(), sdata.data(), 0,
-      Core::Communication::as_epetra_comm(structure_field()->discretization()->get_comm()));
+  Core::LinAlg::Map newdofmap(
+      -1, (int)sdata.size(), sdata.data(), 0, structure_field()->discretization()->get_comm());
 
   //---------------------------------------------------------------------------
   // ------------------------------------ initialise STRUCTURAL output variables

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -421,10 +421,10 @@ void XFEM::MeshVolCoupling::redistribute_embedded_discretization()
     std::vector<int> full_nodes(full_ele_nodes_col.begin(), full_ele_nodes_col.end());
     std::vector<int> full_eles(full_eles_col.begin(), full_eles_col.end());
 
-    const Core::LinAlg::Map full_nodecolmap(-1, full_nodes.size(), full_nodes.data(), 0,
-        Core::Communication::as_epetra_comm(cond_dis_->get_comm()));
-    const Core::LinAlg::Map full_elecolmap(-1, full_eles.size(), full_eles.data(), 0,
-        Core::Communication::as_epetra_comm(cond_dis_->get_comm()));
+    const Core::LinAlg::Map full_nodecolmap(
+        -1, full_nodes.size(), full_nodes.data(), 0, cond_dis_->get_comm());
+    const Core::LinAlg::Map full_elecolmap(
+        -1, full_eles.size(), full_eles.data(), 0, cond_dis_->get_comm());
 
     // redistribute nodes and elements to column (ghost) map
     cond_dis_->export_column_nodes(full_nodecolmap);
@@ -581,14 +581,14 @@ void XFEM::MeshVolCoupling::create_auxiliary_discretization()
     // (expected by Core::LinAlg::Map ctor)
     std::vector<int> rownodes(adjacent_row.begin(), adjacent_row.end());
     // build noderowmap for new distribution of nodes
-    newnoderowmap = std::make_shared<Core::LinAlg::Map>(-1, rownodes.size(), rownodes.data(), 0,
-        Core::Communication::as_epetra_comm(aux_coup_dis_->get_comm()));
+    newnoderowmap = std::make_shared<Core::LinAlg::Map>(
+        -1, rownodes.size(), rownodes.data(), 0, aux_coup_dis_->get_comm());
 
     std::vector<int> colnodes(adjacent_col.begin(), adjacent_col.end());
 
     // build nodecolmap for new distribution of nodes
-    newnodecolmap = std::make_shared<Core::LinAlg::Map>(-1, colnodes.size(), colnodes.data(), 0,
-        Core::Communication::as_epetra_comm(aux_coup_dis_->get_comm()));
+    newnodecolmap = std::make_shared<Core::LinAlg::Map>(
+        -1, colnodes.size(), colnodes.data(), 0, aux_coup_dis_->get_comm());
 
     aux_coup_dis_->redistribute(*newnoderowmap, *newnodecolmap,
         {.assign_degrees_of_freedom = false,

--- a/src/xfem/4C_xfem_discretization_utils.cpp
+++ b/src/xfem/4C_xfem_discretization_utils.cpp
@@ -418,11 +418,11 @@ void XFEM::Utils::XFEMDiscretizationBuilder::redistribute(
 
   MPI_Comm comm(dis.get_comm());
 
-  std::shared_ptr<Core::LinAlg::Map> noderowmap = std::make_shared<Core::LinAlg::Map>(
-      -1, noderowvec.size(), noderowvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+  std::shared_ptr<Core::LinAlg::Map> noderowmap =
+      std::make_shared<Core::LinAlg::Map>(-1, noderowvec.size(), noderowvec.data(), 0, comm);
 
-  std::shared_ptr<Core::LinAlg::Map> nodecolmap = std::make_shared<Core::LinAlg::Map>(
-      -1, nodecolvec.size(), nodecolvec.data(), 0, Core::Communication::as_epetra_comm(comm));
+  std::shared_ptr<Core::LinAlg::Map> nodecolmap =
+      std::make_shared<Core::LinAlg::Map>(-1, nodecolvec.size(), nodecolvec.data(), 0, comm);
   if (!dis.filled()) dis.redistribute(*noderowmap, *nodecolmap);
 
   Core::LinAlg::Map elerowmap(*dis.element_row_map());

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -437,13 +437,13 @@ void XFEM::MultiFieldMapExtractor::build_slave_node_map_extractors()
     partial_maps[MultiField::block_interface] = nullptr;
     partial_maps[MultiField::block_interface] =
         std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_interface_row_node_gids.size()),
-            my_interface_row_node_gids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+            my_interface_row_node_gids.data(), 0, get_comm());
 
     // slave sided non-interface node maps
     partial_maps[MultiField::block_non_interface] = nullptr;
     partial_maps[MultiField::block_non_interface] = std::make_shared<Core::LinAlg::Map>(-1,
         static_cast<int>(my_non_interface_row_node_gids.size()),
-        my_non_interface_row_node_gids.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+        my_non_interface_row_node_gids.data(), 0, get_comm());
 
     // setup node map extractor
     slave_map_extractors_[dis_count++][map_nodes]->setup(
@@ -496,15 +496,14 @@ void XFEM::MultiFieldMapExtractor::build_slave_dof_map_extractors()
     }
     // create slave interface dof row map
     partial_maps[MultiField::block_interface] = nullptr;
-    partial_maps[MultiField::block_interface] =
-        std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_sl_interface_dofs.size()),
-            my_sl_interface_dofs.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+    partial_maps[MultiField::block_interface] = std::make_shared<Core::LinAlg::Map>(-1,
+        static_cast<int>(my_sl_interface_dofs.size()), my_sl_interface_dofs.data(), 0, get_comm());
 
     // create slave non-interface dof row map
     partial_maps[MultiField::block_non_interface] = nullptr;
     partial_maps[MultiField::block_non_interface] =
         std::make_shared<Core::LinAlg::Map>(-1, static_cast<int>(my_sl_non_interface_dofs.size()),
-            my_sl_non_interface_dofs.data(), 0, Core::Communication::as_epetra_comm(get_comm()));
+            my_sl_non_interface_dofs.data(), 0, get_comm());
 
     // setup dof map extractor
     slave_map_extractors_[dis_count++][map_dofs]->setup(*((*cit_dis)->dof_row_map()), partial_maps);
@@ -656,9 +655,8 @@ void XFEM::MultiFieldMapExtractor::build_master_dof_map_extractor()
       for (unsigned j = 0; j < numdof; ++j)
         my_ma_interface_dofs.push_back(i_discret().dof(inode, j));
     }
-    partial_maps.at(i) = std::shared_ptr<const Core::LinAlg::Map>(
-        new Core::LinAlg::Map(-1, static_cast<int>(my_ma_interface_dofs.size()),
-            my_ma_interface_dofs.data(), 0, Core::Communication::as_epetra_comm(get_comm())));
+    partial_maps.at(i) = std::shared_ptr<const Core::LinAlg::Map>(new Core::LinAlg::Map(-1,
+        static_cast<int>(my_ma_interface_dofs.size()), my_ma_interface_dofs.data(), 0, get_comm()));
   }
 
   // --------------------------------------------------------------------------
@@ -1054,8 +1052,7 @@ void XFEM::MultiFieldMapExtractor::build_master_interface_node_maps(
   {
     master_interface_node_maps_.push_back(std::make_shared<Core::LinAlg::Map>(-1,
         static_cast<int>(my_master_interface_node_gids[i].size()),
-        my_master_interface_node_gids[i].data(), 0,
-        Core::Communication::as_epetra_comm(get_comm())));
+        my_master_interface_node_gids[i].data(), 0, get_comm()));
   }
 }
 

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -285,8 +285,8 @@ void XFEM::XFieldField::Coupling::build_min_dof_maps(const Core::FE::Discretizat
   if (pos != dofmapvec.end() and *pos < 0) FOUR_C_THROW("Illegal DoF number {}", *pos);
 
   // dof map is the original, unpermuted distribution of dofs
-  min_dofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(min_dis.get_comm()));
+  min_dofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec.size(), dofmapvec.data(), 0, min_dis.get_comm());
 
   dofmapvec.clear();
 
@@ -316,8 +316,8 @@ void XFEM::XFieldField::Coupling::build_min_dof_maps(const Core::FE::Discretizat
   dofs.clear();
 
   // permuted dof map according to a given permuted node map
-  min_permdofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(min_dis.get_comm()));
+  min_permdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec.size(), dofmapvec.data(), 0, min_dis.get_comm());
 
   /* prepare communication plan to create a dofmap out of a permuted
    * dof map */
@@ -365,8 +365,8 @@ void XFEM::XFieldField::Coupling::build_max_dof_maps(const Core::FE::Discretizat
   if (pos != dofmapvec.end() and *pos < 0) FOUR_C_THROW("Illegal DoF number {}", *pos);
 
   // dof map is the original, unpermuted distribution of dofs
-  max_dofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(max_dis.get_comm()));
+  max_dofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec.size(), dofmapvec.data(), 0, max_dis.get_comm());
 
   dofmapvec.clear();
 
@@ -385,8 +385,8 @@ void XFEM::XFieldField::Coupling::build_max_dof_maps(const Core::FE::Discretizat
   dofs.clear();
 
   // permuted dof map according to a given permuted node map
-  max_permdofmap = std::make_shared<Core::LinAlg::Map>(-1, dofmapvec.size(), dofmapvec.data(), 0,
-      Core::Communication::as_epetra_comm(max_dis.get_comm()));
+  max_permdofmap = std::make_shared<Core::LinAlg::Map>(
+      -1, dofmapvec.size(), dofmapvec.data(), 0, max_dis.get_comm());
 
   /* prepare communication plan to create a dofmap out of a permuted
    * dof map */

--- a/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
+++ b/src/xfem/4C_xfem_xfluid_contact_communicator.cpp
@@ -1327,8 +1327,8 @@ void XFEM::XFluidContactComm::fill_complete_sele_map()
     }
   }
   std::vector<int> my_sele_ids(my_sele_ids_.begin(), my_sele_ids_.end());
-  contact_ele_rowmap_fluidownerbased_ = std::make_shared<Core::LinAlg::Map>(-1, my_sele_ids.size(),
-      my_sele_ids.data(), 0, Core::Communication::as_epetra_comm(fluiddis_->get_comm()));
+  contact_ele_rowmap_fluidownerbased_ = std::make_shared<Core::LinAlg::Map>(
+      -1, my_sele_ids.size(), my_sele_ids.data(), 0, fluiddis_->get_comm());
 }
 
 void XFEM::XFluidContactComm::prepare_time_step()

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_surface_patch_averaged_normals_test.cpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_surface_patch_averaged_normals_test.cpp
@@ -147,7 +147,7 @@ namespace
 
     // Set the state in the face element, here also the FAD variables for each patch are set.
     Core::LinAlg::Map gid_map(discret_->num_global_nodes() * 3, discret_->num_global_nodes() * 3, 0,
-        Core::Communication::as_epetra_comm(discret_->get_comm()));
+        discret_->get_comm());
     auto displacement_vector = std::make_shared<Core::LinAlg::Vector<double>>(gid_map);
     for (int i = 0; i < displacement_vector->global_length(); i++)
       (*displacement_vector)[i] = i * 0.01;

--- a/unittests/io/4C_discretization_nodal_coordinates_test.cpp
+++ b/unittests/io/4C_discretization_nodal_coordinates_test.cpp
@@ -100,8 +100,8 @@ namespace
     // build node coordinates based on the node row map of first partial discretization
     {
       std::array<int, 4> nodeList{0, 2, 4, 10};  // GID list of first 4 elements
-      std::shared_ptr<Core::LinAlg::Map> node_row_map = std::make_shared<Core::LinAlg::Map>(
-          -1, nodeList.size(), nodeList.data(), 0, Core::Communication::as_epetra_comm(comm_));
+      std::shared_ptr<Core::LinAlg::Map> node_row_map =
+          std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
       std::shared_ptr<Core::LinAlg::MultiVector<double>> nodal_test_coordinates =
           test_discretization_->build_node_coordinates(node_row_map);
 
@@ -125,8 +125,8 @@ namespace
     // build node coordinates based on the node row map of second partial discretization
     {
       std::array<int, 3> nodeList{50, 62, 114};  // random GIDs
-      std::shared_ptr<Core::LinAlg::Map> node_row_map = std::make_shared<Core::LinAlg::Map>(
-          -1, nodeList.size(), nodeList.data(), 0, Core::Communication::as_epetra_comm(comm_));
+      std::shared_ptr<Core::LinAlg::Map> node_row_map =
+          std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
       std::shared_ptr<Core::LinAlg::MultiVector<double>> nodal_test_coordinates =
           test_discretization_->build_node_coordinates(node_row_map);
 

--- a/unittests/io/4C_discretization_nodal_coordinates_test.np3.cpp
+++ b/unittests/io/4C_discretization_nodal_coordinates_test.np3.cpp
@@ -139,8 +139,8 @@ namespace
     // build node coordinates based on the node row map of first partial discretization
     {
       std::array<int, 4> nodeList{0, 2, 4, 10};  // GID list of first 4 elements
-      std::shared_ptr<Core::LinAlg::Map> node_row_map = std::make_shared<Core::LinAlg::Map>(
-          -1, nodeList.size(), nodeList.data(), 0, Core::Communication::as_epetra_comm(comm_));
+      std::shared_ptr<Core::LinAlg::Map> node_row_map =
+          std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
       std::shared_ptr<Core::LinAlg::MultiVector<double>> nodal_test_coordinates =
           test_discretization_->build_node_coordinates(node_row_map);
 
@@ -170,20 +170,20 @@ namespace
       if (Core::Communication::my_mpi_rank(comm_) == 0)
       {
         std::array<int, 2> nodeList{50, 62};
-        node_row_map = std::make_shared<Core::LinAlg::Map>(
-            -1, nodeList.size(), nodeList.data(), 0, Core::Communication::as_epetra_comm(comm_));
+        node_row_map =
+            std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
       }
       else if (Core::Communication::my_mpi_rank(comm_) == 1)
       {
         std::array<int, 1> nodeList{114};
-        node_row_map = std::make_shared<Core::LinAlg::Map>(
-            -1, nodeList.size(), nodeList.data(), 0, Core::Communication::as_epetra_comm(comm_));
+        node_row_map =
+            std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
       }
       else if (Core::Communication::my_mpi_rank(comm_) == 2)
       {
         std::array<int, 1> nodeList{212};
-        node_row_map = std::make_shared<Core::LinAlg::Map>(
-            -1, nodeList.size(), nodeList.data(), 0, Core::Communication::as_epetra_comm(comm_));
+        node_row_map =
+            std::make_shared<Core::LinAlg::Map>(-1, nodeList.size(), nodeList.data(), 0, comm_);
       }
 
       std::shared_ptr<Core::LinAlg::MultiVector<double>> nodal_test_coordinates =


### PR DESCRIPTION
This reduces the use of `as_epetra_comm()` to convert the `MPI_Comm` to `Epetra_Comm` when using the LinAlg::Map wrapper.

LinAlg::Map::Comm() was renamed to EpetraComm(). A new function LinAlg::Map::Comm() now returns the MPI_Comm.

Closes #763 
