### PR TITLE
Remove calls to replace_map

### DIFF
--- a/src/mortar/4C_mortar_utils.cpp
+++ b/src/mortar/4C_mortar_utils.cpp
@@ -281,30 +281,6 @@ void Mortar::create_new_col_map(const Core::LinAlg::SparseMatrix& mat,
       static_cast<int>(my_col_gids.size()), my_col_gids.data(), 0, mat.Comm());
 }
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void Mortar::replace_column_and_domain_map(Core::LinAlg::SparseMatrix& mat,
-    const Core::LinAlg::Map& newdomainmap, std::shared_ptr<Core::LinAlg::Map>* const newcolmap_ptr)
-{
-  if (not mat.filled()) FOUR_C_THROW("Matrix must be filled!");
-
-  std::shared_ptr<Core::LinAlg::Map> newcolmap = nullptr;
-  if (newcolmap_ptr)
-  {
-    create_new_col_map(mat, newdomainmap, *newcolmap_ptr);
-    newcolmap = *newcolmap_ptr;
-  }
-  else
-    create_new_col_map(mat, newdomainmap, newcolmap);
-
-  int err = mat.epetra_matrix()->ReplaceColMap(newcolmap->get_epetra_map());
-  if (err) FOUR_C_THROW("ReplaceColMap failed! ( err = {} )", err);
-
-  Epetra_Import importer(newcolmap->get_epetra_map(), newdomainmap.get_epetra_map());
-
-  err = mat.epetra_matrix()->ReplaceDomainMapAndImporter(newdomainmap.get_epetra_map(), &importer);
-  if (err) FOUR_C_THROW("ReplaceDomainMapAndImporter failed! ( err = {} )", err);
-}
 
 /*----------------------------------------------------------------------*
  | transform the row and column maps of a matrix (GIDs)       popp 08/10|

--- a/src/mortar/4C_mortar_utils.hpp
+++ b/src/mortar/4C_mortar_utils.hpp
@@ -74,28 +74,6 @@ namespace Mortar
   std::shared_ptr<Core::LinAlg::SparseMatrix> matrix_col_transform_gids(
       const Core::LinAlg::SparseMatrix& inmat, const Core::LinAlg::Map& newdomainmap);
 
-  /*! \brief Replace the column and domain map of a filled matrix
-   *
-   *  This method changes the domain map of an input matrix to a new domain
-   *  map with different GID numbering (and the corresponding column map, accordingly).
-   *  However, the parallel distribution of the new domain map is exactly
-   *  the same as in the old domain map. Thus, this is simply a processor-local
-   *  1:1 matching of old and new GIDs. But the creation of the column map can
-   *  afford some effort. This effort can be avoided, if a suitable column map
-   *  is provided by the user (e.g. if it doesn't change during one step to another).
-   *
-   *  \param mat           (in)     : Filled matrix, which has already a column and domain map
-   *  \param newdomainmap  (in)     : new domain map which is supposed to replace the
-   *                                  old domain map
-   *  \param newcolmap_ptr (in/out) : This is optional and can be used to store the newly
-   *                                  created column map for later use or to provide an already
-   *                                  capable column map. In the latter case some communication
-   *                                  effort can be avoided.
-   *
-   *  */
-  void replace_column_and_domain_map(Core::LinAlg::SparseMatrix& mat,
-      const Core::LinAlg::Map& newdomainmap,
-      std::shared_ptr<Core::LinAlg::Map>* const newcolmap_ptr = nullptr);
 
   /*! \brief Create a new column map
    *

--- a/src/ssi/4C_ssi_partitioned_1wc.cpp
+++ b/src/ssi/4C_ssi_partitioned_1wc.cpp
@@ -95,12 +95,12 @@ void SSI::SSIPart1WC::do_scatra_step()
         // read phinp from restart file
         std::shared_ptr<Core::LinAlg::MultiVector<double>> phinptemp = reader.read_vector("phinp");
 
-        // replace old scatra map with new map since ssi map has more dofs
-        int err = phinptemp->ReplaceMap(scatra_field()->dof_row_map()->get_epetra_map());
-        if (err) FOUR_C_THROW("Replacing old scatra map with new scatra map in ssi failed!");
+        Core::LinAlg::MultiVector<double> tmp(
+            *scatra_field()->dof_row_map(), phinptemp->NumVectors());
+        std::copy_n(phinptemp->Values(), phinptemp->MyLength(), tmp.Values());
 
         // update phinp
-        scatra_field()->phinp()->update(1.0, *phinptemp, 0.0);
+        scatra_field()->phinp()->update(1.0, tmp, 0.0);
       }
       else
       {
@@ -111,12 +111,11 @@ void SSI::SSIPart1WC::do_scatra_step()
         // read phinp from restart file
         reader.read_vector(phinptemp, "phinp");
 
-        // replace old scatra map with new map since ssi map has more dofs
-        int err = phinptemp->replace_map(*scatra_field()->dof_row_map());
-        if (err) FOUR_C_THROW("Replacing old scatra map with new scatra map in ssi failed!");
+        Core::LinAlg::Vector<double> tmp(*scatra_field()->dof_row_map());
+        std::copy_n(phinptemp->get_values(), phinptemp->local_length(), tmp.get_values());
 
         // update phinp
-        scatra_field()->phinp()->update(1.0, *phinptemp, 0.0);
+        scatra_field()->phinp()->update(1.0, tmp, 0.0);
       }
     }
   }

--- a/src/timestepping/4C_timestepping_mstep.hpp
+++ b/src/timestepping/4C_timestepping_mstep.hpp
@@ -337,24 +337,6 @@ namespace TimeStepping
       return;
     }
 
-    /*! \brief Replace maps and initialize to zero
-     *
-     *  State vectors cleared and rebuild with given map
-     *  take care that underlying discret_ contains the same maps
-     */
-    void replace_maps(const Core::LinAlg::Map* dofrowmap  //!< new vector layout
-    )
-    {
-      state_.clear();
-      // allocate the vectors themselves
-      for (int index = 0; index < steps_; ++index)
-      {
-        state_.push_back(Core::LinAlg::Vector<double>(*dofrowmap, true));
-      }
-
-      return;
-    }
-
     //@}
 
     //! @name Actions


### PR DESCRIPTION
In #783, we realized that this function is confusing and causes issue when viewing data. In case you want to combine an existing Map and existing data, it seems more logical to create an object with the intended map and copy over the data from another object.

I'll see if I can replace more occurrences.