### PR TITLE
Rework of ssi monolithic meshtying strategy

### DIFF
--- a/src/ssi/4C_ssi_dyn.cpp
+++ b/src/ssi/4C_ssi_dyn.cpp
@@ -11,6 +11,7 @@
 #include "4C_io_control.hpp"
 #include "4C_rebalance_print.hpp"
 #include "4C_ssi_monolithic.hpp"
+#include "4C_ssi_monolithic_meshtying_strategy.hpp"
 #include "4C_ssi_partitioned_1wc.hpp"
 #include "4C_ssi_partitioned_2wc.hpp"
 #include "4C_ssi_utils.hpp"
@@ -88,7 +89,6 @@ void ssi_drt()
         break;
       default:
         FOUR_C_THROW("unknown coupling algorithm for SSI!");
-        break;
     }
 
     // 3.1.1 initial fill_complete

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -138,18 +138,21 @@ void SSI::SsiMono::apply_meshtying_to_sub_problems() const
       ssi_matrices_->complete_scatra_structure_matrix();
 
     strategy_meshtying_->apply_meshtying_to_scatra_structure(
-        ssi_matrices_->scatra_structure_matrix(),
+        ssi_matrices_->scatra_structure_matrix(), *ssi_maps(), *ssi_structure_mesh_tying(),
         is_uncomplete_of_matrices_necessary_for_mesh_tying());
 
     strategy_meshtying_->apply_meshtying_to_structure_matrix(*ssi_matrices_->structure_matrix(),
-        structure_field()->system_matrix(), is_uncomplete_of_matrices_necessary_for_mesh_tying());
-
-    strategy_meshtying_->apply_meshtying_to_structure_scatra(
-        ssi_matrices_->structure_scatra_matrix(),
+        *structure_field()->system_matrix(), *ssi_structure_mesh_tying(),
         is_uncomplete_of_matrices_necessary_for_mesh_tying());
 
-    ssi_vectors_->structure_residual()->update(
-        1.0, strategy_meshtying_->apply_meshtying_to_structure_rhs(*structure_field()->rhs()), 1.0);
+    strategy_meshtying_->apply_meshtying_to_structure_scatra(
+        ssi_matrices_->structure_scatra_matrix(), *ssi_maps(), *ssi_structure_mesh_tying(),
+        is_uncomplete_of_matrices_necessary_for_mesh_tying());
+
+    ssi_vectors_->structure_residual()->update(1.0,
+        strategy_meshtying_->apply_meshtying_to_structure_rhs(
+            *structure_field()->rhs(), *ssi_maps(), *ssi_structure_mesh_tying()),
+        1.0);
 
     if (is_scatra_manifold())
     {
@@ -161,15 +164,15 @@ void SSI::SsiMono::apply_meshtying_to_sub_problems() const
         manifoldscatraflux_->complete_matrix_scatra_structure();
 
       strategy_meshtying_->apply_meshtying_to_scatra_manifold_structure(
-          ssi_matrices_->scatra_manifold_structure_matrix(),
-          is_uncomplete_of_matrices_necessary_for_mesh_tying());
+          ssi_matrices_->scatra_manifold_structure_matrix(), *ssi_maps(),
+          *ssi_structure_mesh_tying(), is_uncomplete_of_matrices_necessary_for_mesh_tying());
 
       strategy_meshtying_->apply_meshtying_to_scatra_manifold_structure(
-          manifoldscatraflux_->matrix_manifold_structure(),
-          is_uncomplete_of_matrices_necessary_for_mesh_tying());
+          manifoldscatraflux_->matrix_manifold_structure(), *ssi_maps(),
+          *ssi_structure_mesh_tying(), is_uncomplete_of_matrices_necessary_for_mesh_tying());
 
       strategy_meshtying_->apply_meshtying_to_scatra_structure(
-          manifoldscatraflux_->matrix_scatra_structure(),
+          manifoldscatraflux_->matrix_scatra_structure(), *ssi_maps(), *ssi_structure_mesh_tying(),
           is_uncomplete_of_matrices_necessary_for_mesh_tying());
     }
   }
@@ -783,12 +786,12 @@ void SSI::SsiMono::setup_system()
       build_contact_strategy(nitsche_strategy_ssi(), ssi_maps_, scatra_field()->matrix_type());
 
   // instantiate appropriate mesh tying class
-  strategy_meshtying_ = build_meshtying_strategy(
-      is_scatra_manifold(), scatra_field()->matrix_type(), ssi_maps_, ssi_structure_mesh_tying());
+  strategy_meshtying_ =
+      build_meshtying_strategy(is_scatra_manifold(), scatra_field()->matrix_type(), *ssi_maps());
 
   // instantiate Dirichlet boundary condition handler class
   dbc_handler_ = build_dbc_handler(is_scatra_manifold(), matrixtype_, scatra_field(),
-      is_scatra_manifold() ? scatra_manifold() : nullptr, ssi_maps_, structure_field());
+      is_scatra_manifold() ? scatra_manifold() : nullptr, ssi_maps(), structure_field());
 }
 
 /*---------------------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_monolithic.hpp
+++ b/src/ssi/4C_ssi_monolithic.hpp
@@ -71,29 +71,32 @@ namespace SSI
     );
 
     //! return global map of degrees of freedom
-    const std::shared_ptr<const Core::LinAlg::Map>& dof_row_map() const;
+    [[nodiscard]] const std::shared_ptr<const Core::LinAlg::Map>& dof_row_map() const;
 
     void init(MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams,
         const Teuchos::ParameterList& scatraparams, const Teuchos::ParameterList& structparams,
         const std::string& struct_disname, const std::string& scatra_disname, bool isAle) override;
 
     //! return global map extractor (0: scalar transport, 1: structure, [2: scatra manifold])
-    std::shared_ptr<const Core::LinAlg::MultiMapExtractor> maps_sub_problems() const;
+    [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> maps_sub_problems() const;
 
-    //! return map extractor associated with all degrees of freedom inside scatra field
-    std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra() const;
+    //! return map extractor associated with all degrees of freedom inside the scatra field
+    [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra() const;
 
-    //! return map extractor associated with all degrees of freedom inside scatra manifold field
-    std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra_manifold() const;
+    //! return map extractor associated with all degrees of freedom inside the scatra manifold field
+    [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_scatra_manifold()
+        const;
 
-    //! return map extractor associated with all degrees of freedom inside structural field
-    std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_structure() const;
+    //! return map extractor associated with all degrees of freedom inside the structural field
+    [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_structure()
+        const;
 
     //! return map extractor associated with blocks of global system matrix
-    std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_system_matrix() const;
+    [[nodiscard]] std::shared_ptr<const Core::LinAlg::MultiMapExtractor> block_map_system_matrix()
+        const;
 
     //! Return matrix type of global system matrix
-    Core::LinAlg::MatrixType matrix_type() const { return matrixtype_; };
+    [[nodiscard]] Core::LinAlg::MatrixType matrix_type() const { return matrixtype_; };
 
     void read_restart(int restart) override;
 
@@ -104,16 +107,16 @@ namespace SSI
     /*!
      * @brief solves the linear system
      *
-     * @note in case an equilibration method (scaling of rows and columns) is defined this is also
+     * @note in case an equilibration method (scaling of rows and columns) is defined, this is also
      * performed within this call
      */
     void solve_linear_system() const;
 
     //! this object holds all maps relevant to monolithic scalar transport - structure interaction
-    std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps() const { return ssi_maps_; }
+    [[nodiscard]] std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps() const { return ssi_maps_; }
 
-    //! return algebraic solver for global system of equations
-    const Core::LinAlg::Solver& solver() const { return *solver_; };
+    //! return algebraic solver for the global system of equations
+    [[nodiscard]] const Core::LinAlg::Solver& solver() const { return *solver_; };
 
     void timeloop() override;
 
@@ -124,19 +127,19 @@ namespace SSI
     class ConvCheckStrategyElchScaTraManifold;
     class ConvCheckStrategyStd;
 
-    //! apply the contact contributions to matrices and residuals of the sub problems
+    //! apply the contact contributions to matrices and residuals of the subproblems
     void apply_contact_to_sub_problems() const;
 
-    //! apply the Dirichlet boundary conditions to the ssi system, i.e. matrices and residuals
+    //! apply the Dirichlet boundary conditions to the ssi system, i.e., matrices and residuals
     void apply_dbc_to_system() const;
 
     //! apply mesh tying between manifold domains on matrices and residuals
     void apply_manifold_meshtying() const;
 
-    //! perform mesh tying on matrices and residuals as obtained from sub problems
+    //! perform mesh tying on matrices and residuals as obtained from subproblems
     void apply_meshtying_to_sub_problems() const;
 
-    //! assemble global system of equations
+    //! assemble the global system of equations
     void assemble_mat_and_rhs() const;
 
     //! assemble linearization of scatra residuals to system matrix
@@ -151,18 +154,18 @@ namespace SSI
     //! build null spaces associated with blocks of global system matrix
     void build_null_spaces() const;
 
-    //! calc initial potential field for monolithic SSI problem including scatra and scatra manifold
-    //! fields
+    //! calc initial potential field for the monolithic SSI problem including scatra and scatra
+    //! manifold fields
     void calc_initial_potential_field();
 
-    //! calc initial time derivative of transported scalars for monolithic SSI problem including
+    //! calc initial time derivative of transported scalars for the monolithic SSI problem including
     //! scatra and scatra manifold fields
     void calc_initial_time_derivative();
 
     //! call complete on the sub problem matrices
     void complete_subproblem_matrices() const;
 
-    //! distribute solution to all other fields
+    //! distribute the solution to all other fields
     //! \param restore_velocity   restore velocity when structure_field()->set_state() is called
     void distribute_solution_all_fields(bool restore_velocity = false);
 
@@ -179,7 +182,7 @@ namespace SSI
     void evaluate_subproblems();
 
     //! build and return vector of equilibration methods for each block of system matrix
-    std::vector<Core::LinAlg::EquilibrationMethod> get_block_equilibration() const;
+    [[nodiscard]] std::vector<Core::LinAlg::EquilibrationMethod> get_block_equilibration() const;
 
     /*!
      * @note This is only necessary in the first iteration of the simulation, since only there the
@@ -188,11 +191,11 @@ namespace SSI
      * @return flag indicating if we need to uncomplete the matrices before adding the mesh tying
      * contributions.
      */
-    bool is_uncomplete_of_matrices_necessary_for_mesh_tying() const;
+    [[nodiscard]] bool is_uncomplete_of_matrices_necessary_for_mesh_tying() const;
 
     void output() override;
 
-    //! do everything, that has to be done once before first time step
+    //! do everything that has to be done once before the first time step
     void prepare_time_loop();
 
     void prepare_time_step() override;
@@ -203,13 +206,13 @@ namespace SSI
     //! print system matrix, rhs, and map of system matrix to file
     void print_system_matrix_rhs_to_mat_lab_format() const;
 
-    //! print time step size, time, and number of time step
+    //! print time step size, time, and number of the time step
     void print_time_step_info() const;
 
     //! set scatra manifold solution on scatra field
     void set_scatra_manifold_solution(const Core::LinAlg::Vector<double>& phi) const;
 
-    //! evaluate time step using Newton-Raphson iteration
+    //! evaluate the current time step using Newton-Raphson iteration
     void newton_loop();
 
     void update() override;
@@ -217,7 +220,7 @@ namespace SSI
     //! update ScaTra state within Newton iteration
     void update_iter_scatra() const;
 
-    //! update structure state within Newton iteration
+    //! update structure state within the Newton iteration
     void update_iter_structure() const;
 
     //! Dirichlet boundary condition handler
@@ -257,7 +260,7 @@ namespace SSI
     //! this object holds all maps relevant to monolithic scalar transport - structure interaction
     std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps_;
 
-    //! this object holds the system matrix and all sub blocks
+    //! this object holds the system matrix and all subblocks
     std::shared_ptr<SSI::Utils::SSIMatrices> ssi_matrices_;
 
     //! this object holds the system residuals and increment
@@ -279,7 +282,7 @@ namespace SSI
     std::shared_ptr<SSI::ManifoldMeshTyingStrategyBase> strategy_manifold_meshtying_;
 
     //! strategy how to apply mesh tying to system matrix and rhs
-    std::shared_ptr<SSI::MeshtyingStrategyBase> strategy_meshtying_;
+    std::unique_ptr<SSI::MeshtyingStrategyBase> strategy_meshtying_;
 
     //! timer for Newton-Raphson iteration
     std::shared_ptr<Teuchos::Time> timer_;

--- a/src/ssi/4C_ssi_monolithic_meshtying_strategy.hpp
+++ b/src/ssi/4C_ssi_monolithic_meshtying_strategy.hpp
@@ -42,68 +42,84 @@ namespace SSI
   class MeshtyingStrategyBase
   {
    public:
-    /**
-     * Virtual destructor.
-     */
-    virtual ~MeshtyingStrategyBase() = default;
-
     //! constructor
-    explicit MeshtyingStrategyBase(bool is_scatra_manifold,
-        std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps,
-        std::shared_ptr<const SSI::Utils::SSIMeshTying> ssi_structure_meshtying);
+    MeshtyingStrategyBase() = default;
+
+    //! virtual destructor
+    virtual ~MeshtyingStrategyBase() = default;
 
     /*!
      * @brief apply mesh tying to structure matrix
      *
-     * @param[out] ssi_structure_matrix  structure matrix including mesh tying constraints
-     * @param[in] structure_matrix       structure matrix from structure problem
-     * @param[in] do_uncomplete          flag indicating if we need to uncomplete the matrix before
-     *                                   adding something
+     * @param[out] ssi_structure_matrix    structure matrix including mesh tying constraints
+     * @param[in] structure_matrix         structure matrix from the structure problem
+     * @param[in] ssi_structure_meshtying  ssi mesh tying object providing the relevant maps and
+     *                                     converters for mesh tying
+     * @param[in] do_uncomplete            flag indicating if we need to uncomplete the matrix
+     *                                     before adding something
      */
     void apply_meshtying_to_structure_matrix(Core::LinAlg::SparseMatrix& ssi_structure_matrix,
-        std::shared_ptr<const Core::LinAlg::SparseMatrix> structure_matrix, bool do_uncomplete);
+        const Core::LinAlg::SparseMatrix& structure_matrix,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete);
 
     /*!
      * @brief apply mesh tying to scatra manifold structure matrix
      *
      * @param[in,out] manifold_structure_matrix  scalar transport on manifold structure matrix
+     * @param[in] ssi_maps                       ssi maps object
+     * @param[in] ssi_structure_meshtying        ssi mesh tying object providing the relevant maps
+     *                                           and converters for mesh tying converters for mesh
+     *                                           tying
      * @param[in]     do_uncomplete              flag indicating if we need to uncomplete the matrix
      *                                           before adding something
      */
     virtual void apply_meshtying_to_scatra_manifold_structure(
         std::shared_ptr<Core::LinAlg::SparseOperator> manifold_structure_matrix,
-        bool do_uncomplete) = 0;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) = 0;
 
     /*!
      * @brief apply mesh tying to scatra structure matrix
      *
      * @param[in,out] scatra_structure_matrix  scatra structure matrix
+     * @param[in] ssi_maps                     ssi maps object
+     * @param[in] ssi_structure_meshtying      ssi mesh tying object providing the relevant maps and
+     *                                         converters for mesh tying converters for mesh tying
      * @param[in]     do_uncomplete            flag indicating if we need to uncomplete the matrix
      *                                         before adding something
      */
     virtual void apply_meshtying_to_scatra_structure(
         std::shared_ptr<Core::LinAlg::SparseOperator> scatra_structure_matrix,
-        bool do_uncomplete) = 0;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) = 0;
 
     /*!
      * @brief apply mesh tying to structure right hand side vector
      *
      * @param[in] structure_rhs  structure right hand side vector without mesh tying contributions
+     * @param[in] ssi_maps                 ssi maps object
+     * @param[in] ssi_structure_meshtying  ssi mesh tying object providing the relevant maps and
+     *                                     converters for mesh tying converters for mesh tying
      * @return structure right hand side vector including mesh tying contributions
      */
     Core::LinAlg::Vector<double> apply_meshtying_to_structure_rhs(
-        const Core::LinAlg::Vector<double>& structure_rhs);
+        const Core::LinAlg::Vector<double>& structure_rhs, const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying);
 
     /*!
      * @brief apply mesh tying to the structure scatra matrix
      *
      * @param[in,out] structure_scatra_matrix  structure scatra matrix
+     * @param[in] ssi_maps                     ssi maps object
+     * @param[in] ssi_structure_meshtying      ssi mesh tying object providing the relevant maps and
+     *                                         converters for mesh tying converters for mesh tying
      * @param[in]     do_uncomplete            flag indicating if we need to uncomplete the matrix
      *                                         before adding something
      */
     virtual void apply_meshtying_to_structure_scatra(
         std::shared_ptr<Core::LinAlg::SparseOperator> structure_scatra_matrix,
-        bool do_uncomplete) = 0;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) = 0;
 
    protected:
     /*!
@@ -112,9 +128,12 @@ namespace SSI
      * @param[out] ssi_structure_xxx_matrix  structure xxx matrix block including mesh tying
      *                                       constraints
      * @param[in] structure_xxx_matrix       structure xxx matrix block
+     * @param[in] ssi_structure_meshtying    ssi mesh tying object providing the relevant maps and
+     *                                       converters for mesh tying converters for mesh tying
      */
     void apply_meshtying_to_structure_xxx(Core::LinAlg::SparseMatrix& ssi_structure_xxx_matrix,
-        const Core::LinAlg::SparseMatrix& structure_xxx_matrix);
+        const Core::LinAlg::SparseMatrix& structure_xxx_matrix,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying);
 
     /*!
      * @brief apply mesh tying to xxx-structure block
@@ -122,21 +141,12 @@ namespace SSI
      * @param[out] ssi_xxx_structure_matrix  xxx structure matrix block including mesh tying
      *                                       constraints
      * @param[in] xxx_structure_matrix       xxx structure matrix block
+     * @param[in] ssi_structure_meshtying    ssi mesh tying object providing the relevant maps and
+     *                                       converters for mesh tying converters for mesh tying
      */
     void apply_meshtying_to_xxx_structure(Core::LinAlg::SparseMatrix& ssi_xxx_structure_matrix,
-        const Core::LinAlg::SparseMatrix& xxx_structure_matrix);
-
-    //! solve additional scatra field on manifolds
-    bool is_scatra_manifold() const { return is_scatra_manifold_; }
-
-    //! this object holds all maps relevant to monolithic scalar transport - structure interaction
-    std::shared_ptr<const SSI::Utils::SSIMaps> ssi_maps() const { return ssi_maps_; }
-
-    //! SSI structure meshtying object containing coupling adapters, converters and maps
-    std::shared_ptr<const SSI::Utils::SSIMeshTying> ssi_structure_meshtying() const
-    {
-      return ssi_structure_meshtying_;
-    }
+        const Core::LinAlg::SparseMatrix& xxx_structure_matrix,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying);
 
     //! scatra structure contribution matrix
     std::shared_ptr<Core::LinAlg::SparseOperator> temp_scatra_struct_mat_;
@@ -153,17 +163,11 @@ namespace SSI
      * write 1.0 on main diagonal of slave side dofs
      *
      * @param[in,out] ssi_structure_matrix  structure matrix with mesh tying constraints
+     * @param[in] ssi_structure_meshtying   ssi mesh tying object providing the relevant maps and
+     *                                      converters for mesh tying converters for mesh tying
      */
-    void finalize_meshtying_structure_matrix(Core::LinAlg::SparseMatrix& ssi_structure_matrix);
-
-    //! solve additional scatra field on manifolds
-    const bool is_scatra_manifold_;
-
-    //! this object holds all maps relevant to monolithic scalar transport - structure interaction
-    std::shared_ptr<const SSI::Utils::SSIMaps> ssi_maps_;
-
-    //! SSI structure meshtying object containing coupling adapters, converters and maps
-    std::shared_ptr<const SSI::Utils::SSIMeshTying> ssi_structure_meshtying_;
+    void finalize_meshtying_structure_matrix(Core::LinAlg::SparseMatrix& ssi_structure_matrix,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying);
   };
 
   //! SSI problem is represented by one sparse matrix
@@ -171,21 +175,22 @@ namespace SSI
   {
    public:
     //! constructor
-    explicit MeshtyingStrategySparse(bool is_scatra_manifold,
-        std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps,
-        std::shared_ptr<const SSI::Utils::SSIMeshTying> ssi_structure_meshtying);
+    explicit MeshtyingStrategySparse(bool is_scatra_manifold, const SSI::Utils::SSIMaps& ssi_maps);
 
     void apply_meshtying_to_scatra_manifold_structure(
         std::shared_ptr<Core::LinAlg::SparseOperator> manifold_structure_matrix,
-        bool do_uncomplete) override;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) override;
 
     void apply_meshtying_to_scatra_structure(
         std::shared_ptr<Core::LinAlg::SparseOperator> scatra_structure_matrix,
-        bool do_uncomplete) override;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) override;
 
     void apply_meshtying_to_structure_scatra(
         std::shared_ptr<Core::LinAlg::SparseOperator> structure_scatra_matrix,
-        bool do_uncomplete) override;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) override;
   };
 
   //! SSI problem is composed of sub matrices
@@ -193,34 +198,38 @@ namespace SSI
   {
    public:
     //! constructor
-    explicit MeshtyingStrategyBlock(bool is_scatra_manifold,
-        std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps,
-        std::shared_ptr<const SSI::Utils::SSIMeshTying> ssi_structure_meshtying);
+    explicit MeshtyingStrategyBlock(bool is_scatra_manifold, const SSI::Utils::SSIMaps& ssi_maps);
 
     void apply_meshtying_to_scatra_manifold_structure(
         std::shared_ptr<Core::LinAlg::SparseOperator> manifold_structure_matrix,
-        bool do_uncomplete) override;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) override;
 
     void apply_meshtying_to_scatra_structure(
         std::shared_ptr<Core::LinAlg::SparseOperator> scatra_structure_matrix,
-        bool do_uncomplete) override;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) override;
 
     void apply_meshtying_to_structure_scatra(
         std::shared_ptr<Core::LinAlg::SparseOperator> structure_scatra_matrix,
-        bool do_uncomplete) override;
+        const SSI::Utils::SSIMaps& ssi_maps,
+        const SSI::Utils::SSIMeshTying& ssi_structure_meshtying, bool do_uncomplete) override;
 
    protected:
     //! position of scatra blocks in system matrix
-    const std::vector<int>& block_position_scatra() const { return block_position_scatra_; }
+    [[nodiscard]] const std::vector<int>& block_position_scatra() const
+    {
+      return block_position_scatra_;
+    }
 
     //! position of scatra manifold blocks in system matrix
-    const std::vector<int>& block_position_scatra_manifold() const
+    [[nodiscard]] const std::vector<int>& block_position_scatra_manifold() const
     {
       return block_position_scatra_manifold_;
     }
 
     //! position of structure block in system matrix
-    int position_structure() const { return position_structure_; };
+    [[nodiscard]] int position_structure() const { return position_structure_; };
 
    private:
     //! position of scatra blocks in system matrix
@@ -234,9 +243,8 @@ namespace SSI
   };
 
   //! build specific mesh tying strategy
-  std::shared_ptr<SSI::MeshtyingStrategyBase> build_meshtying_strategy(bool is_scatra_manifold,
-      Core::LinAlg::MatrixType matrixtype_scatra, std::shared_ptr<SSI::Utils::SSIMaps> ssi_maps,
-      std::shared_ptr<const SSI::Utils::SSIMeshTying> ssi_structure_meshtying);
+  std::unique_ptr<SSI::MeshtyingStrategyBase> build_meshtying_strategy(bool is_scatra_manifold,
+      Core::LinAlg::MatrixType matrixtype_scatra, const SSI::Utils::SSIMaps& ssi_maps);
 }  // namespace SSI
 FOUR_C_NAMESPACE_CLOSE
 


### PR DESCRIPTION
## Description and Context
The SSI MeshtyingStrategy stored pointers to other objects within SSI, namely the SSIMaps and SSIMeshTying. This is now changed such that those objects are handed in to the respective method as a const reference whenever required
Further changes:
- added [[nodiscard]] where reasonable
- changed to std::unique_ptr as return type of the factory

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
