### PR TITLE
NOX move solution vector nullification to the explicit integrator

### DIFF
--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
@@ -242,6 +242,11 @@ int Solid::TimeInt::Explicit::integrate_step()
   throw_if_state_not_in_sync_with_nox_group();
   // reset the non-linear solver
   nln_solver().reset();
+
+  // reset x vector of the group
+  auto& group = nln_solver().get_solution_group();
+  group.computeX(group, group.getX(), -1.0);
+
   // solve the non-linear problem
   nln_solver().solve();
   return 0;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
@@ -108,8 +108,6 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::SingleStep::solve()
   auto& nln_group = dynamic_cast<NOX::Nln::Group&>(*group_ptr());
 #endif
 
-  const auto& x_epetra = dynamic_cast<const ::NOX::Epetra::Vector&>(group_ptr()->getX());
-
 #if !(FOUR_C_TRILINOS_INTERNAL_VERSION_GE(2025, 4))
   nln_group.set_is_valid_newton(true);  // to circumvent the check in ::NOX::Solver::SingleStep
   nln_group.set_is_valid_rhs(false);    // force to compute the RHS
@@ -121,8 +119,6 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::SingleStep::solve()
 
   //// do one non-linear step using solve
   ::NOX::StatusTest::StatusType stepstatus = nlnsolver_->solve();
-
-  integrator().set_state(Core::LinAlg::Vector<double>(x_epetra.getEpetraVector()));
 
   return convert_final_status(stepstatus);
 }

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_singlestep.cpp
@@ -106,15 +106,10 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::SingleStep::solve()
 
 #if !(FOUR_C_TRILINOS_INTERNAL_VERSION_GE(2025, 4))
   auto& nln_group = dynamic_cast<NOX::Nln::Group&>(*group_ptr());
-#endif
 
-#if !(FOUR_C_TRILINOS_INTERNAL_VERSION_GE(2025, 4))
   nln_group.set_is_valid_newton(true);  // to circumvent the check in ::NOX::Solver::SingleStep
   nln_group.set_is_valid_rhs(false);    // force to compute the RHS
   nln_group.reset_x();                  // to initialize the solution vector to zero
-#else
-  // This nullifies the solution vector in the group
-  group_ptr()->computeX(*group_ptr(), group_ptr()->getX(), -1.0);
 #endif
 
   //// do one non-linear step using solve


### PR DESCRIPTION
## Description and Context
The final small preliminary refactoring prior to removing some solver classes. Unfortunately, the next PR will break backwards compatibility with the old versions of Trilinos, for this reason I decided to keep these small changes as a separate PR to have this intermediate state reflected in history.

## Related Issues and Pull Requests
#359, #379, #779
