### PR TITLE
Remove more `get_condition` from Node class

### DIFF
--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
@@ -109,7 +109,8 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::setup(
   for (int i_node = 0; i_node < discret_->node_row_map()->num_my_elements(); i_node++)
   {
     Core::Nodes::Node const& node = *(discret_->l_row_node(i_node));
-    if (Constraints::EmbeddedMesh::is_interface_node(node)) my_nodes_gid.push_back(node.id());
+    if (Constraints::EmbeddedMesh::is_interface_node(*discret_, node))
+      my_nodes_gid.push_back(node.id());
   }
 
   // Calculate the local number of interface nodes
@@ -206,7 +207,7 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::set_global_maps()
     const Core::Nodes::Node* node = discret_->l_row_node(i_node);
     if (is_cut_node(*node))
       discret_->dof(node, background_dofs);
-    else if (Constraints::EmbeddedMesh::is_interface_node(*node))
+    else if (Constraints::EmbeddedMesh::is_interface_node(*discret_, *node))
       discret_->dof(node, boundary_layer_interface_dofs);
   }
 

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_utils.hpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_utils.hpp
@@ -165,9 +165,11 @@ namespace Constraints::EmbeddedMesh
       const Constraints::EmbeddedMesh::SolidInteractionPair* interaction_pair,
       const unsigned int n_mortar_pos, std::vector<int>* lambda_gid_pos);
 
-  bool is_interface_node(Core::Nodes::Node const& node);
+  bool is_interface_node(
+      const Core::FE::Discretization& discretization, const Core::Nodes::Node& node);
 
-  bool is_interface_element_surface(Core::Elements::Element& ele);
+  bool is_interface_element_surface(
+      const Core::FE::Discretization& discretization, const Core::Elements::Element& ele);
 
   void get_current_element_displacement(Core::FE::Discretization const& discret,
       Core::Elements::Element const* ele, const Core::LinAlg::Vector<double>& displacement_vector,

--- a/src/core/fem/src/condition/4C_fem_condition_utils.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_utils.cpp
@@ -105,12 +105,34 @@ std::set<int> Core::Conditions::find_conditioned_node_ids(
     const Core::FE::Discretization& dis, std::span<const Condition*> conditions, LookFor look_for)
 {
   std::set<int> node_set;
-  auto node_range =
+  const auto node_range =
       (look_for == LookFor::locally_owned) ? dis.my_row_node_range() : dis.my_col_node_range();
 
   for (const auto& cond : conditions)
   {
     fill_conditioned_node_set(node_range, cond, node_set);
+  }
+
+  return node_set;
+}
+
+
+std::multimap<int, const Core::Conditions::Condition*>
+Core::Conditions::find_conditioned_node_ids_and_conditions(
+    const Core::FE::Discretization& dis, std::span<const Condition*> conditions, LookFor look_for)
+{
+  std::multimap<int, const Condition*> node_set;
+  const auto node_range =
+      (look_for == LookFor::locally_owned) ? dis.my_row_node_range() : dis.my_col_node_range();
+
+  for (const auto& cond : conditions)
+  {
+    std::set<int> nodes_of_current_condition;
+    fill_conditioned_node_set(node_range, cond, nodes_of_current_condition);
+    for (const auto& node_id : nodes_of_current_condition)
+    {
+      node_set.emplace(node_id, cond);
+    }
   }
 
   return node_set;

--- a/src/core/fem/src/condition/4C_fem_condition_utils.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_utils.hpp
@@ -55,35 +55,47 @@ namespace Core::Conditions
   };
 
   /**
-   * Loop all conditions of the given Discretization @p dis, find the ones with the
-   * specified name @p condname and collect the locally owned node ids in the supplied
-   * set @p nodes. The @p nodes vector is unique and ordered on output.
+   * An enum to specify whether to look for locally owned nodes or locally owned and ghosted
+   * nodes in the various finder functions below.
    */
-  void find_conditioned_nodes(
-      const Core::FE::Discretization& dis, const std::string& condname, std::vector<int>& nodes);
+  enum class LookFor
+  {
+    locally_owned,
+    locally_owned_and_ghosted,
+  };
 
   /**
-   * Loop over all conditions @p conds and extract their node IDs, if they are locally owned by the
-   * discretization @p dis. The node IDs are stored in the supplied vector @p nodes. The @p nodes
-   * vector is unique and ordered on output.
+   * Loop all conditions of the given Discretization @p dis and find the ones with the
+   * specified name @p condition_name. Depending on @p look_for, return a set of node IDs
+   * that are locally owned or locally owned and ghosted.
    */
-  void find_conditioned_nodes(const Core::FE::Discretization& dis,
-      std::span<const Condition*> conds, std::vector<int>& nodes);
+  std::set<int> find_conditioned_node_ids(
+      const Core::FE::Discretization& dis, const std::string& condition_name, LookFor look_for);
 
-  /// find all local nodes from discretization marked with condition
-  void find_conditioned_nodes(const Core::FE::Discretization& dis,
-      std::span<const Condition*> conds, std::map<int, Core::Nodes::Node*>& nodes);
+  /**
+   * Loop over all @p conditions and extract their node IDs, if they are locally owned by the
+   * discretization @p dis. Depending on @p look_for, return a set of node IDs
+   * that are locally owned or locally owned and ghosted.
+   */
+  std::set<int> find_conditioned_node_ids(const Core::FE::Discretization& dis,
+      std::span<const Condition*> conditions, LookFor look_for);
 
-  /// find all local nodes from discretization marked with condition and
-  /// put them into a map indexed by Id of the condition
-  void find_conditioned_nodes(const Core::FE::Discretization& dis,
-      std::span<const Condition*> conds, std::map<int, std::map<int, Core::Nodes::Node*>>& nodes);
+  /**
+   * Loop all conditions of the given Discretization @p dis, find the ones with the given name
+   * and return a map of all conditioned node IDs and their corresponding conditions. A node
+   * may be subject to multiple conditions. Depending on @p look_for, return node IDs
+   * that are locally owned or locally owned and ghosted.
+   */
+  std::multimap<int, const Condition*> find_conditioned_node_ids_and_conditions(
+      const Core::FE::Discretization& dis, std::span<const Condition*> conditions,
+      LookFor look_for);
+
 
   /// find all local nodes from discretization marked with condition and
   /// put them into a vector indexed by Id of the condition
   void find_conditioned_nodes(const Core::FE::Discretization& dis,
-      std::span<const Condition*> conds, std::map<int, std::shared_ptr<std::vector<int>>>& nodes,
-      bool use_coupling_id = true);
+      std::span<const Condition*> conditions,
+      std::map<int, std::shared_ptr<std::vector<int>>>& nodes, bool use_coupling_id = true);
 
 
   /// collect all nodes (in- and excluding 'ghosts') and
@@ -93,12 +105,12 @@ namespace Core::Conditions
     \param nodes unique map of nodes
     \param ghostnodes overlapping map of nodes
     \param elements overlapping map of elements
-    \param condname name of condition
+    \param condition_name name of condition
    */
   void find_condition_objects(const Core::FE::Discretization& dis,
       std::map<int, Core::Nodes::Node*>& nodes, std::map<int, Core::Nodes::Node*>& gnodes,
       std::map<int, std::shared_ptr<Core::Elements::Element>>& elements,
-      std::span<const Condition*> conds);
+      std::span<const Condition*> conditions);
 
   /// collect all nodes (in- and excluding 'ghosts') and
   /// elements (including ghosts) in a condition
@@ -107,12 +119,12 @@ namespace Core::Conditions
     \param nodes unique map of nodes
     \param ghostnodes overlapping map of nodes
     \param elements overlapping map of elements
-    \param condname name of condition
+    \param condition_name name of condition
    */
   void find_condition_objects(const Core::FE::Discretization& dis,
       std::map<int, Core::Nodes::Node*>& nodes, std::map<int, Core::Nodes::Node*>& gnodes,
       std::map<int, std::shared_ptr<Core::Elements::Element>>& elements,
-      const std::string& condname);
+      const std::string& condition_name);
 
   /// collect all nodes (in- and excluding 'ghosts') and
   /// elements (including ghosts) in a condition
@@ -121,40 +133,40 @@ namespace Core::Conditions
     \param nodes unique map of nodes
     \param ghostnodes overlapping map of nodes
     \param elements overlapping map of elements
-    \param condname name of condition
+    \param condition_name name of condition
    */
   void find_condition_objects(const Core::FE::Discretization& dis,
       std::map<int, std::map<int, Core::Nodes::Node*>>& nodes,
       std::map<int, std::map<int, Core::Nodes::Node*>>& gnodes,
       std::map<int, std::map<int, std::shared_ptr<Core::Elements::Element>>>& elements,
-      const std::string& condname);
+      const std::string& condition_name);
 
   /// collect all elements in a condition including ghosts
   /*!
     \param dis discretization
     \param elements overlapping map of elements
-    \param condname name of condition
+    \param condition_name name of condition
    */
   void find_condition_objects(const Core::FE::Discretization& dis,
       std::map<int, std::shared_ptr<Core::Elements::Element>>& elements,
-      const std::string& condname, const int label = -1);
+      const std::string& condition_name, const int label = -1);
 
   /// Find all conditions with given name that all nodes of the element have in common
   /*!
     \param ele (in) the element
-    \param condname (in) name of the condition to look for
+    \param condition_name (in) name of the condition to look for
     \param condition (out) all conditions that cover all element nodes
   */
-  void find_element_conditions(const Core::Elements::Element* ele, const std::string& condname,
-      std::vector<Core::Conditions::Condition*>& condition);
+  void find_element_conditions(const Core::Elements::Element* ele,
+      const std::string& condition_name, std::vector<Core::Conditions::Condition*>& condition);
 
   /// row map with nodes from condition
   std::shared_ptr<Core::LinAlg::Map> condition_node_row_map(
-      const Core::FE::Discretization& dis, const std::string& condname);
+      const Core::FE::Discretization& dis, const std::string& condition_name);
 
   /// col map with nodes from condition
   std::shared_ptr<Core::LinAlg::Map> condition_node_col_map(
-      const Core::FE::Discretization& dis, const std::string& condname);
+      const Core::FE::Discretization& dis, const std::string& condition_name);
 
   /// create the set of column element gids that have conditioned nodes
   /*!
@@ -162,7 +174,7 @@ namespace Core::Conditions
     gids of actual discretization elements are listed.
    */
   std::shared_ptr<std::set<int>> conditioned_element_map(
-      const Core::FE::Discretization& dis, const std::string& condname);
+      const Core::FE::Discretization& dis, const std::string& condition_name);
 
 }  // namespace Core::Conditions
 

--- a/src/core/fem/src/condition/4C_fem_condition_utils.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_utils.hpp
@@ -69,7 +69,7 @@ namespace Core::Conditions
    * specified name @p condition_name. Depending on @p look_for, return a set of node IDs
    * that are locally owned or locally owned and ghosted.
    */
-  std::set<int> find_conditioned_node_ids(
+  [[nodiscard]] std::set<int> find_conditioned_node_ids(
       const Core::FE::Discretization& dis, const std::string& condition_name, LookFor look_for);
 
   /**
@@ -77,7 +77,7 @@ namespace Core::Conditions
    * discretization @p dis. Depending on @p look_for, return a set of node IDs
    * that are locally owned or locally owned and ghosted.
    */
-  std::set<int> find_conditioned_node_ids(const Core::FE::Discretization& dis,
+  [[nodiscard]] std::set<int> find_conditioned_node_ids(const Core::FE::Discretization& dis,
       std::span<const Condition*> conditions, LookFor look_for);
 
   /**
@@ -86,7 +86,7 @@ namespace Core::Conditions
    * may be subject to multiple conditions. Depending on @p look_for, return node IDs
    * that are locally owned or locally owned and ghosted.
    */
-  std::multimap<int, const Condition*> find_conditioned_node_ids_and_conditions(
+  [[nodiscard]] std::multimap<int, const Condition*> find_conditioned_node_ids_and_conditions(
       const Core::FE::Discretization& dis, std::span<const Condition*> conditions,
       LookFor look_for);
 

--- a/src/core/fem/src/dofset/4C_fem_dofset_merged_wrapper.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset_merged_wrapper.cpp
@@ -70,10 +70,13 @@ int Core::DOFSets::DofSetMergedWrapper::assign_degrees_of_freedom(
   if (sourcedis_ == nullptr) FOUR_C_THROW("No source discretization assigned to mapping dof set!");
 
   // get nodes to be coupled
-  std::vector<int> masternodes;
-  Core::Conditions::find_conditioned_nodes(*sourcedis_, couplingcond_master_, masternodes);
-  std::vector<int> slavenodes;
-  Core::Conditions::find_conditioned_nodes(dis, couplingcond_slave_, slavenodes);
+  auto masternodes_set = Core::Conditions::find_conditioned_node_ids(
+      *sourcedis_, couplingcond_master_, Core::Conditions::LookFor::locally_owned);
+  std::vector<int> masternodes(masternodes_set.begin(), masternodes_set.end());
+  std::set<int> slavenodes_set = Core::Conditions::find_conditioned_node_ids(
+      dis, couplingcond_slave_, Core::Conditions::LookFor::locally_owned);
+  std::vector<int> slavenodes(slavenodes_set.begin(), slavenodes_set.end());
+
 
   // initialize search tree
   auto tree = Core::GeometricSearch::NodeMatchingOctree();
@@ -128,10 +131,13 @@ int Core::DOFSets::DofSetMergedWrapper::assign_degrees_of_freedom(
   ////////////////////////////////////////////////////
 
   // get nodes to be coupled
-  masternodes.clear();
-  Core::Conditions::find_conditioned_nodes(*sourcedis_, couplingcond_slave_, masternodes);
-  slavenodes.clear();
-  Core::Conditions::find_conditioned_nodes(dis, couplingcond_slave_, slavenodes);
+  masternodes_set = Core::Conditions::find_conditioned_node_ids(
+      dis, couplingcond_slave_, Core::Conditions::LookFor::locally_owned);
+  masternodes = std::vector<int>(masternodes_set.begin(), masternodes_set.end());
+  slavenodes_set = Core::Conditions::find_conditioned_node_ids(
+      *sourcedis_, couplingcond_slave_, Core::Conditions::LookFor::locally_owned);
+  slavenodes = std::vector<int>(slavenodes_set.begin(), slavenodes_set.end());
+
 
   // initialize search tree
   tree.init(*sourcedis_, masternodes, 150);

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -374,7 +374,10 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
     ////////////////////////////////////////
     // ALSO APPEND UNCONDITIONED ELEMENTS
     ////////////////////////////////////////
-    // add row elements
+
+    auto conditioned_node_ids = Conditions::find_conditioned_node_ids(
+        dis_to_rebalance, condname_rebalance, Conditions::LookFor::locally_owned_and_ghosted);
+
     for (int lid = 0; lid < dis_to_rebalance.element_col_map()->num_my_elements(); lid++)
     {
       bool conditionedele = false;
@@ -383,8 +386,7 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
       Core::Nodes::Node** nodes = ele->nodes();
       for (int node = 0; node < ele->num_node(); node++)
       {
-        Core::Conditions::Condition* nodal_cond = nodes[node]->get_condition(condname_rebalance);
-        if (nodal_cond != nullptr)
+        if (conditioned_node_ids.contains(nodes[node]->id()))
         {
           conditionedele = true;
           break;

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -52,10 +52,12 @@ void Coupling::Adapter::Coupling::setup_condition_coupling(
   if (numdof != numdof_slave)
     FOUR_C_THROW("Received {} master DOFs, but {} slave DOFs", numdof, numdof_slave);
 
-  std::vector<int> masternodes;
-  Core::Conditions::find_conditioned_nodes(masterdis, condname, masternodes);
-  std::vector<int> slavenodes;
-  Core::Conditions::find_conditioned_nodes(slavedis, condname, slavenodes);
+  auto masternodes_set = Core::Conditions::find_conditioned_node_ids(
+      masterdis, condname, Core::Conditions::LookFor::locally_owned);
+  std::vector<int> masternodes(masternodes_set.begin(), masternodes_set.end());
+  auto slavenodes_set = Core::Conditions::find_conditioned_node_ids(
+      slavedis, condname, Core::Conditions::LookFor::locally_owned);
+  std::vector<int> slavenodes(slavenodes_set.begin(), slavenodes_set.end());
 
   int localmastercount = static_cast<int>(masternodes.size());
   int mastercount;

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -2525,8 +2525,8 @@ void FLD::FluidImplicitTimeInt::ale_update(std::string condName)
     const Core::LinAlg::Map* dofrowmap = discret_->dof_row_map();
 
     // Obtain the global IDs of the condition's nodes for the current processor
-    std::vector<int> gIdNodes;
-    Core::Conditions::find_conditioned_nodes(*discret_, selectedCond, gIdNodes);
+    auto gIdNodes = Core::Conditions::find_conditioned_node_ids(
+        *discret_, selectedCond, Core::Conditions::LookFor::locally_owned);
 
     // Obtain fluid and ale state variables for nodes in the condition
     // **************************************************************************

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -3547,17 +3547,18 @@ void ScaTra::MeshtyingStrategyS2I::init_meshtying()
 
     // provide scalar transport discretization with additional dofset for scatra-scatra interface
     // layer thickness
+    const auto& col_map = *scatratimint_->discretization()->node_col_map();
     const std::shared_ptr<Core::LinAlg::Vector<int>> numdofpernode =
         std::make_shared<Core::LinAlg::Vector<int>>(col_map);
     auto conditioned_node_ids =
         Core::Conditions::find_conditioned_node_ids(*scatratimint_->discretization(),
             "S2IKineticsGrowth", Core::Conditions::LookFor::locally_owned_and_ghosted);
-    const std::span<const int> my_col_nodes(col_map.MyGlobalElements(), col_map.NumMyElements());
+    const std::span<const int> my_col_nodes(
+        col_map.my_global_elements(), col_map.num_my_elements());
     for (const int& inode : my_col_nodes)
     {
-      // add one degree of freedom for scatra-scatra interface layer growth to current node if
-      // applicable
-      if (scatratimint_->discretization()->l_col_node(inode)->get_condition("S2IKineticsGrowth"))
+      if (conditioned_node_ids.contains(inode))
+        // add one degree of freedom for scatra-scatra interface layer thickness to current node
         (*numdofpernode)[inode] = 1;
     }
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -3548,9 +3548,12 @@ void ScaTra::MeshtyingStrategyS2I::init_meshtying()
     // provide scalar transport discretization with additional dofset for scatra-scatra interface
     // layer thickness
     const std::shared_ptr<Core::LinAlg::Vector<int>> numdofpernode =
-        std::make_shared<Core::LinAlg::Vector<int>>(
-            *scatratimint_->discretization()->node_col_map());
-    for (int inode = 0; inode < scatratimint_->discretization()->num_my_col_nodes(); ++inode)
+        std::make_shared<Core::LinAlg::Vector<int>>(col_map);
+    auto conditioned_node_ids =
+        Core::Conditions::find_conditioned_node_ids(*scatratimint_->discretization(),
+            "S2IKineticsGrowth", Core::Conditions::LookFor::locally_owned_and_ghosted);
+    const std::span<const int> my_col_nodes(col_map.MyGlobalElements(), col_map.NumMyElements());
+    for (const int& inode : my_col_nodes)
     {
       // add one degree of freedom for scatra-scatra interface layer growth to current node if
       // applicable

--- a/src/scatra/4C_scatra_utils.cpp
+++ b/src/scatra/4C_scatra_utils.cpp
@@ -94,11 +94,10 @@ void ScaTra::ScaTraUtils::check_consistency_of_s2_i_conditions(
   s2iphysics_conditions.insert(s2iphysics_conditions.end(), s2isclcoupling_condition.begin(),
       s2isclcoupling_condition.end());
 
-  std::vector<int> s2ievaluation_nodes, s2iphysics_nodes;
-  Core::Conditions::find_conditioned_nodes(
-      *discretization, s2ievaluation_conditions, s2ievaluation_nodes);
-  Core::Conditions::find_conditioned_nodes(
-      *discretization, s2iphysics_conditions, s2iphysics_nodes);
+  auto s2ievaluation_nodes = Core::Conditions::find_conditioned_node_ids(
+      *discretization, s2ievaluation_conditions, Core::Conditions::LookFor::locally_owned);
+  auto s2iphysics_nodes = Core::Conditions::find_conditioned_node_ids(
+      *discretization, s2iphysics_conditions, Core::Conditions::LookFor::locally_owned);
 
   if (s2iphysics_nodes != s2ievaluation_nodes)
   {

--- a/src/ssi/4C_ssi_utils.cpp
+++ b/src/ssi/4C_ssi_utils.cpp
@@ -830,10 +830,10 @@ void SSI::Utils::check_consistency_of_ssi_interface_contact_condition(
           "Did not find 'S2ICoupling' condition as defined in 'SSIInterfaceContact' condition!");
 
     // now get the nodes
-    std::vector<int> InterfaceS2INodes;
-    std::vector<int> InterfaceContactNodes;
-    find_conditioned_nodes(structdis, InterfaceS2IConditions, InterfaceS2INodes);
-    find_conditioned_nodes(structdis, InterfaceContactConditions, InterfaceContactNodes);
+    auto InterfaceS2INodes = find_conditioned_node_ids(
+        structdis, InterfaceS2IConditions, Core::Conditions::LookFor::locally_owned);
+    auto InterfaceContactNodes = find_conditioned_node_ids(
+        structdis, InterfaceContactConditions, Core::Conditions::LookFor::locally_owned);
 
     // and compare whether same nodes are defined
     for (const auto InterfaceS2INode : InterfaceS2INodes)

--- a/src/xfem/4C_xfem_coupling_mesh.hpp
+++ b/src/xfem/4C_xfem_coupling_mesh.hpp
@@ -328,16 +328,17 @@ namespace XFEM
 
    private:
     void evaluate_interface_displacement(std::vector<double>& final_values, Core::Nodes::Node* node,
-        Core::Conditions::Condition* cond, const double time);
+        const Core::Conditions::Condition* cond, const double time);
 
     void evaluate_interface_velocity(std::vector<double>& final_values, Core::Nodes::Node* node,
-        Core::Conditions::Condition* cond, const double time, const double dt);
+        const Core::Conditions::Condition* cond, const double time, const double dt);
 
     void compute_interface_velocity_from_displacement(std::vector<double>& final_values,
         Core::Nodes::Node* node, const double dt, const std::string* evaltype);
 
     void evaluate_implementation(std::vector<double>& final_values, const double* x,
-        Core::Conditions::Condition* cond, const double time, const std::string& function_name);
+        const Core::Conditions::Condition* cond, const double time,
+        const std::string& function_name);
 
    protected:
     void do_condition_specific_setup() override;


### PR DESCRIPTION
I am trying to remove the `Condition*` from the `Node` object.  This PR improves a few utility functions to find nodes carrying conditions. I then use these functions to find these node IDs instead of asking the node object directly. There are still some places left where the old functions are used, but I would like to get this merged as a first step.