### PR TITLE
Replace Epetra_BlockMap with Map

### DIFF
--- a/apps/post_monitor/4C_post_monitor.cpp
+++ b/apps/post_monitor/4C_post_monitor.cpp
@@ -523,7 +523,7 @@ void FluidMonWriter::write_result(
 {
   // get actual result vector
   auto resvec = result.read_result("velnp");
-  const Epetra_BlockMap& velmap = resvec->get_block_map();
+  const Core::LinAlg::Map& velmap = resvec->get_map();
   // do output of general time step data
   outfile << std::right << std::setw(20) << result.step();
   outfile << std::right << std::setw(20) << std::scientific << result.time();
@@ -576,7 +576,7 @@ void RedAirwayMonWriter::write_result(
 {
   // get actual result vector
   auto resvec = result.read_result("PO2");
-  const Epetra_BlockMap& pmap = resvec->get_block_map();
+  const Core::LinAlg::Map& pmap = resvec->get_map();
   // do output of general time step data
   outfile << std::right << std::setw(20) << result.step();
   outfile << std::right << std::setw(20) << std::scientific << result.time();
@@ -674,7 +674,7 @@ void StructMonWriter::write_result(
 
   // get actual result vector displacement
   auto resvec = result.read_result("displacement");
-  const Epetra_BlockMap& dispmap = resvec->get_block_map();
+  const Core::LinAlg::Map& dispmap = resvec->get_map();
 
   // compute second part of offset
   int offset2 = dispmap.MinAllGID();
@@ -692,7 +692,7 @@ void StructMonWriter::write_result(
   {
     // get actual result vector displacement/pressure
     resvec = result.read_result("displacement");
-    const Epetra_BlockMap& pressmap = resvec->get_block_map();
+    const Core::LinAlg::Map& pressmap = resvec->get_map();
 
     // compute second part of offset
     offset2 = pressmap.MinAllGID();
@@ -892,7 +892,7 @@ void AleMonWriter::write_result(
 {
   // get actual result vector for displacement
   auto resvec = result.read_result("displacement");
-  const Epetra_BlockMap& dispmap = resvec->get_block_map();
+  const Core::LinAlg::Map& dispmap = resvec->get_map();
   // do output of general time step data
   outfile << std::right << std::setw(10) << result.step();
   outfile << std::right << std::setw(16) << std::scientific << result.time();
@@ -968,7 +968,7 @@ void FsiFluidMonWriter::write_result(
 {
   // get actual result vector for displacement
   std::shared_ptr<Core::LinAlg::Vector<double>> resvec = result.read_result("dispnp");
-  const Epetra_BlockMap& dispmap = resvec->get_block_map();
+  const Core::LinAlg::Map& dispmap = resvec->get_map();
   // do output of general time step data
   outfile << std::right << std::setw(10) << result.step();
   outfile << std::right << std::setw(16) << std::scientific << result.time();
@@ -985,7 +985,7 @@ void FsiFluidMonWriter::write_result(
 
   // get actual result vector for velocity
   resvec = result.read_result("velnp");
-  const Epetra_BlockMap& velmap = resvec->get_block_map();
+  const Core::LinAlg::Map& velmap = resvec->get_map();
 
   // compute second part of offset
   offset2 = velmap.MinAllGID();
@@ -1003,7 +1003,7 @@ void FsiFluidMonWriter::write_result(
   {
     // get actual result vector for fsilambda
     resvec = result.read_result("fsilambda");
-    const Epetra_BlockMap& lambdamap = resvec->get_block_map();
+    const Core::LinAlg::Map& lambdamap = resvec->get_map();
 
     // compute second part of offset
     offset2 = lambdamap.MinAllGID();
@@ -1102,7 +1102,7 @@ void FsiStructMonWriter::write_result(
 
   // get actual result vector displacement
   std::shared_ptr<Core::LinAlg::Vector<double>> resvec = result.read_result("displacement");
-  const Epetra_BlockMap& dispmap = resvec->get_block_map();
+  const Core::LinAlg::Map& dispmap = resvec->get_map();
 
   // compute second part of offset
   int offset2 = dispmap.MinAllGID();
@@ -1121,7 +1121,7 @@ void FsiStructMonWriter::write_result(
   {
     // get actual result vector displacement/pressure
     resvec = result.read_result("displacement");
-    const Epetra_BlockMap& pressmap = resvec->get_block_map();
+    const Core::LinAlg::Map& pressmap = resvec->get_map();
 
     // compute second part of offset
     offset2 = pressmap.MinAllGID();
@@ -1144,7 +1144,7 @@ void FsiStructMonWriter::write_result(
   {
     // get actual result vector for fsilambda
     resvec = result.read_result("fsilambda");
-    const Epetra_BlockMap& lambdamap = resvec->get_block_map();
+    const Core::LinAlg::Map& lambdamap = resvec->get_map();
 
     // compute second part of offset
     offset2 = lambdamap.MinAllGID();
@@ -1239,7 +1239,7 @@ void ScatraMonWriter::write_result(
   // get actual result vector for displacement
   std::shared_ptr<Core::LinAlg::Vector<double>> resvec = result.read_result("phinp");
 
-  const Epetra_BlockMap& dispmap = resvec->get_block_map();
+  const Core::LinAlg::Map& dispmap = resvec->get_map();
   // do output of general time step data
   outfile << std::right << std::setw(10) << result.step();
   outfile << std::right << std::setw(20) << std::scientific << result.time();
@@ -1301,7 +1301,7 @@ void ThermoMonWriter::write_result(
 
   // get actual result vector temperature
   std::shared_ptr<Core::LinAlg::Vector<double>> resvec = result.read_result("temperature");
-  const Epetra_BlockMap& dispmap = resvec->get_block_map();
+  const Core::LinAlg::Map& dispmap = resvec->get_map();
 
   // compute second part of offset
   int offset2 = dispmap.MinAllGID();
@@ -1318,7 +1318,7 @@ void ThermoMonWriter::write_result(
 
   // get actual result vector temperature rate
   resvec = result.read_result("rate");
-  const Epetra_BlockMap& ratemap = resvec->get_block_map();
+  const Core::LinAlg::Map& ratemap = resvec->get_map();
 
   // compute second part of offset
   offset2 = ratemap.MinAllGID();
@@ -1577,9 +1577,9 @@ void PoroFluidMultiMonWriter::write_result(
   std::shared_ptr<Core::LinAlg::Vector<double>> resvec_sat = result.read_result("saturation");
   std::shared_ptr<Core::LinAlg::Vector<double>> resvec_press = result.read_result("pressure");
 
-  const Epetra_BlockMap& phimap = resvec->get_block_map();
-  const Epetra_BlockMap& satmap = resvec_sat->get_block_map();
-  const Epetra_BlockMap& pressmap = resvec_press->get_block_map();
+  const Core::LinAlg::Map& phimap = resvec->get_map();
+  const Core::LinAlg::Map& satmap = resvec_sat->get_map();
+  const Core::LinAlg::Map& pressmap = resvec_press->get_map();
 
   // do output of general time step data
   outfile << std::right << std::setw(10) << result.step();

--- a/apps/post_processor/4C_post_processor_structure_stress.cpp
+++ b/apps/post_processor/4C_post_processor_structure_stress.cpp
@@ -198,7 +198,7 @@ struct WriteElementCenterRotation : public SpecialFieldInterface
         {
           const Core::LinAlg::SerialDenseMatrix& elecenterrot = *data->at(ele.id());
 
-          const Epetra_BlockMap& elemap = elerotation.Map();
+          const Core::LinAlg::Map& elemap = elerotation.get_map();
           int lid = elemap.LID(ele.id());
           if (lid != -1)
             for (int i = 0; i < elecenterrot.numRows(); ++i)

--- a/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
+++ b/src/adapter/4C_adapter_coupling_ehl_mortar.cpp
@@ -643,7 +643,7 @@ void Adapter::CouplingEhlMortar::recover_coupled(std::shared_ptr<Core::LinAlg::V
   {
     CONTACT::Node* cnode = dynamic_cast<CONTACT::Node*>(interface_->discret().l_row_node(i));
     for (int dof = 0; dof < interface_->n_dim(); ++dof)
-      cnode->mo_data().lm()[dof] = z_->operator[](z_->get_block_map().LID(cnode->dofs()[dof]));
+      cnode->mo_data().lm()[dof] = z_->operator[](z_->get_map().LID(cnode->dofs()[dof]));
   }
 
   return;
@@ -809,7 +809,7 @@ void Adapter::CouplingEhlMortar::assemble_real_gap()
 
   static const double offset =
       Global::Problem::instance()->lubrication_dynamic_params().get<double>("GAP_OFFSET");
-  for (int i = 0; i < nodal_gap_->get_block_map().NumMyElements(); ++i)
+  for (int i = 0; i < nodal_gap_->get_map().NumMyElements(); ++i)
     nodal_gap_->operator[](i) += offset;
 }
 
@@ -1033,7 +1033,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Adapter::CouplingEhlMortar::assemble
       const int col = p->first;
       for (auto q = p->second.begin(); q != p->second.end(); ++q)
       {
-        const int lid = x.get_block_map().LID(q->first);
+        const int lid = x.get_map().LID(q->first);
         if (lid < 0) FOUR_C_THROW("not my gid");
         const double x_val = x.operator[](lid);
         for (int d = 0; d < interface()->n_dim(); ++d)
@@ -1056,7 +1056,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Adapter::CouplingEhlMortar::assemble
           {
             const int row = cnode->dofs()[d];
             const int x_gid = q->first;
-            const int x_lid = x.get_block_map().LID(x_gid);
+            const int x_lid = x.get_map().LID(x_gid);
             if (x_lid < 0) FOUR_C_THROW("not my gid");
             double x_val = x.operator[](x_lid);
             const double val = -x_val * q->second(d) / (dval * dval) * p->second;
@@ -1088,8 +1088,8 @@ void Adapter::CouplingEhlMortar::create_force_vec(std::shared_ptr<Core::LinAlg::
     lmt.update(-1., lmn, 1.);
     for (int d = 0; d < 3; ++d)
     {
-      n->operator[](n->get_block_map().LID(cnode->dofs()[d])) = lmn(d);
-      t->operator[](t->get_block_map().LID(cnode->dofs()[d])) = lmt(d);
+      n->operator[](n->get_map().LID(cnode->dofs()[d])) = lmn(d);
+      t->operator[](t->get_map().LID(cnode->dofs()[d])) = lmt(d);
     }
   }
 }
@@ -1166,7 +1166,7 @@ void Adapter::CouplingEhlMortar::read_restart(Core::IO::DiscretizationReader& re
     cnode->fri_data().slip() = slip_toggle->operator[](i);
     cnode->data().active_old() = active_old_toggle->operator[](i);
     for (int d = 0; d < interface_->n_dim(); ++d)
-      cnode->mo_data().lm()[d] = z_->operator[](z_->get_block_map().LID(cnode->dofs()[d]));
+      cnode->mo_data().lm()[d] = z_->operator[](z_->get_map().LID(cnode->dofs()[d]));
   }
 }
 

--- a/src/adapter/4C_adapter_fld_fluid_fsi.cpp
+++ b/src/adapter/4C_adapter_fld_fluid_fsi.cpp
@@ -304,7 +304,7 @@ void Adapter::FluidFSI::displacement_to_velocity(std::shared_ptr<Core::LinAlg::V
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   // check, whether maps are the same
-  if (!fcx->get_block_map().PointSameAs(veln_vector->get_block_map()))
+  if (!fcx->get_map().PointSameAs(veln_vector->get_map()))
   {
     FOUR_C_THROW("Maps do not match, but they have to.");
   }
@@ -331,7 +331,7 @@ void Adapter::FluidFSI::velocity_to_displacement(std::shared_ptr<Core::LinAlg::V
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   // check, whether maps are the same
-  if (!fcx->get_block_map().PointSameAs(veln_vector->get_block_map()))
+  if (!fcx->get_map().PointSameAs(veln_vector->get_map()))
   {
     FOUR_C_THROW("Maps do not match, but they have to.");
   }
@@ -516,7 +516,7 @@ void Adapter::FluidFSI::proj_vel_to_div_zero()
   solver->solve(BTB->epetra_operator(), x, BTvR, solver_params);
 
   std::shared_ptr<Core::LinAlg::Vector<double>> vmod =
-      std::make_shared<Core::LinAlg::Vector<double>>(velnp()->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(velnp()->get_map(), true);
   B->Apply(*x, *vmod);
   write_access_velnp()->update(-1.0, *vmod, 1.0);
 }
@@ -640,13 +640,13 @@ void Adapter::FluidFSI::indicate_error_norms(double& err, double& errcond, doubl
   }
 
   // set '0' on all pressure DOFs
-  auto zeros = std::make_shared<Core::LinAlg::Vector<double>>(locerrvelnp_->get_block_map(), true);
+  auto zeros = std::make_shared<Core::LinAlg::Vector<double>>(locerrvelnp_->get_map(), true);
   Core::LinAlg::apply_dirichlet_to_system(*locerrvelnp_, *zeros, *pressure_row_map());
   // TODO: Do not misuse apply_dirichlet_to_system()...works for this purpose here: writes zeros
   // into all pressure DoFs
 
   // set '0' on Dirichlet DOFs
-  zeros = std::make_shared<Core::LinAlg::Vector<double>>(locerrvelnp_->get_block_map(), true);
+  zeros = std::make_shared<Core::LinAlg::Vector<double>>(locerrvelnp_->get_map(), true);
   Core::LinAlg::apply_dirichlet_to_system(
       *locerrvelnp_, *zeros, *(get_dbc_map_extractor()->cond_map()));
 

--- a/src/adapter/4C_adapter_fld_fluid_xfsi.cpp
+++ b/src/adapter/4C_adapter_fld_fluid_xfsi.cpp
@@ -187,7 +187,7 @@ void Adapter::XFluidFSI::displacement_to_velocity(
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   // check, whether maps are the same
-  if (!fcx->get_block_map().PointSameAs(veln->get_block_map()))
+  if (!fcx->get_map().PointSameAs(veln->get_map()))
   {
     FOUR_C_THROW("Maps do not match, but they have to.");
   }

--- a/src/adapter/4C_adapter_fld_poro.cpp
+++ b/src/adapter/4C_adapter_fld_poro.cpp
@@ -67,7 +67,7 @@ void Adapter::FluidPoro::evaluate_no_penetration_cond(
       const int ndof = ndim + 1;
       const int length = condVector->local_length();
       const int nnod = length / ndof;
-      const Epetra_BlockMap& map = condVector->get_block_map();
+      const Core::LinAlg::Map& map = condVector->get_map();
       bool isset = false;
       for (int i = 0; i < nnod; i++)
       {

--- a/src/adapter/4C_adapter_str_constr_merged.cpp
+++ b/src/adapter/4C_adapter_str_constr_merged.cpp
@@ -139,7 +139,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Adapter::StructureConstrMerg
   // get last converged state from structure and constraintmanager
   std::shared_ptr<const Core::LinAlg::Vector<double>> strudis = structure_->veln();
   const Core::LinAlg::Vector<double> lagrmult(
-      structure_->get_constraint_manager()->get_lagr_mult_vector_old()->get_block_map(), true);
+      structure_->get_constraint_manager()->get_lagr_mult_vector_old()->get_map(), true);
 
   // merge stuff together
   std::shared_ptr<Core::LinAlg::Vector<double>> mergedstat =
@@ -157,7 +157,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Adapter::StructureConstrMerg
   // get last converged state from structure and constraintmanager
   std::shared_ptr<const Core::LinAlg::Vector<double>> strudis = structure_->accn();
   const Core::LinAlg::Vector<double> lagrmult(
-      structure_->get_constraint_manager()->get_lagr_mult_vector_old()->get_block_map(), true);
+      structure_->get_constraint_manager()->get_lagr_mult_vector_old()->get_map(), true);
 
   // merge stuff together
   std::shared_ptr<Core::LinAlg::Vector<double>> mergedstat =

--- a/src/adapter/4C_adapter_str_fbiwrapper.cpp
+++ b/src/adapter/4C_adapter_str_fbiwrapper.cpp
@@ -39,7 +39,7 @@ Adapter::FBIStructureWrapper::FBIStructureWrapper(std::shared_ptr<Structure> str
 std::shared_ptr<Core::LinAlg::Vector<double>> Adapter::FBIStructureWrapper::extract_interface_veln()
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> veli =
-      std::make_shared<Core::LinAlg::Vector<double>>(veln()->get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(veln()->get_map());
   veli->update(1.0, *veln(), 0.0);
   return veli;
 }
@@ -51,7 +51,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FBIStructureWrapper::extract_interface_velnp()
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> veli =
-      std::make_shared<Core::LinAlg::Vector<double>>(velnp()->get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(velnp()->get_map());
   veli->update(1.0, *velnp(), 0.0);
   return veli;
 }
@@ -61,7 +61,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FBIStructureWrapper::predict_interface_velnp()
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> veli =
-      std::make_shared<Core::LinAlg::Vector<double>>(veln()->get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(veln()->get_map());
   veli->update(1.0, *veln(), 0.0);
   return veli;
 }
@@ -83,7 +83,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FBIStructureWrapper::predict_interface_dispnp()
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> disi =
-      std::make_shared<Core::LinAlg::Vector<double>>(dispn()->get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(dispn()->get_map());
   disi->update(1.0, *dispnp(), 0.0);
   return disi;
 }
@@ -94,7 +94,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FBIStructureWrapper::extract_interface_dispnp()
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> disi =
-      std::make_shared<Core::LinAlg::Vector<double>>(dispnp()->get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(dispnp()->get_map());
   disi->update(1.0, *dispnp(), 0.0);
   return disi;
 }
@@ -104,7 +104,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FBIStructureWrapper::extract_interface_dispn()
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> disi =
-      std::make_shared<Core::LinAlg::Vector<double>>(dispn()->get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(dispn()->get_map());
   disi->update(1.0, *dispn(), 0.0);
   return disi;
 }

--- a/src/adapter/4C_adapter_str_fsiwrapper.cpp
+++ b/src/adapter/4C_adapter_str_fsiwrapper.cpp
@@ -151,7 +151,7 @@ Adapter::FSIStructureWrapper::predict_interface_dispnp()
 std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FSIStructureWrapper::extract_interface_dispn()
 {
-  FOUR_C_ASSERT(interface_->full_map()->PointSameAs(dispn()->get_block_map()),
+  FOUR_C_ASSERT(interface_->full_map()->PointSameAs(dispn()->get_map()),
       "Full map of map extractor and Dispn() do not match.");
 
   // prestressing business
@@ -171,7 +171,7 @@ Adapter::FSIStructureWrapper::extract_interface_dispn()
 std::shared_ptr<Core::LinAlg::Vector<double>>
 Adapter::FSIStructureWrapper::extract_interface_dispnp()
 {
-  FOUR_C_ASSERT(interface_->full_map()->PointSameAs(dispnp()->get_block_map()),
+  FOUR_C_ASSERT(interface_->full_map()->PointSameAs(dispnp()->get_map()),
       "Full map of map extractor and Dispnp() do not match.");
 
   // prestressing business

--- a/src/ale/4C_ale_resulttest.cpp
+++ b/src/ale/4C_ale_resulttest.cpp
@@ -53,7 +53,7 @@ void ALE::AleResultTest::test_node(
 
       double result = 0.;
 
-      const Epetra_BlockMap& dispnpmap = dispnp_->get_block_map();
+      const Core::LinAlg::Map& dispnpmap = dispnp_->get_map();
 
       std::string position = container.get<std::string>("QUANTITY");
       if (position == "dispx")

--- a/src/art_net/4C_art_net_artery_resulttest.cpp
+++ b/src/art_net/4C_art_net_artery_resulttest.cpp
@@ -68,7 +68,7 @@ void Arteries::ArteryResultTest::test_node(
       if (actnode->owner() != Core::Communication::my_mpi_rank(dis_->get_comm())) return;
 
       double result = 0.;
-      const Epetra_BlockMap& pnpmap = mysol_->get_block_map();
+      const Core::LinAlg::Map& pnpmap = mysol_->get_map();
       std::string position = container.get<std::string>("QUANTITY");
 
       // test result value of single scalar field

--- a/src/beam3/4C_beam3_discretization_runtime_vtu_writer.cpp
+++ b/src/beam3/4C_beam3_discretization_runtime_vtu_writer.cpp
@@ -1363,10 +1363,10 @@ void BeamDiscretizationRuntimeOutputWriter::append_element_orientation_parameter
     for (int dim = 0; dim < 3; ++dim)
     {
       pos[0] = ele->nodes()[0]->x()[dim] +
-               (displacement_state_vector)[displacement_state_vector.get_block_map().LID(
+               (displacement_state_vector)[displacement_state_vector.get_map().LID(
                    discretization_->dof(ele->nodes()[0])[dim])];
       pos[1] = ele->nodes()[1]->x()[dim] +
-               (displacement_state_vector)[displacement_state_vector.get_block_map().LID(
+               (displacement_state_vector)[displacement_state_vector.get_map().LID(
                    discretization_->dof(ele->nodes()[1])[dim])];
       dirvec(dim) = pos[1] - pos[0];
     }

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -1810,8 +1810,8 @@ void Beam3ContactOctTree::communicate_vector(Core::LinAlg::Vector<double>& InVec
    * on all processors. */
 
   // first, export the values of OutVec on Proc 0 to InVecs of all participating processors
-  Epetra_Export exporter(OutVec.get_block_map(), InVec.get_block_map());
-  Epetra_Import importer(OutVec.get_block_map(), InVec.get_block_map());
+  Epetra_Export exporter(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
+  Epetra_Import importer(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
   if (doexport)
   {
     // zero out all vectors which are not Proc 0. Then, export Proc 0 data to InVec map.
@@ -1830,8 +1830,8 @@ void Beam3ContactOctTree::communicate_multi_vector(Core::LinAlg::MultiVector<dou
     Core::LinAlg::MultiVector<double>& OutVec, bool zerofy, bool doexport, bool doimport)
 {
   // first, export the values of OutVec on Proc 0 to InVecs of all participating processors
-  Epetra_Export exporter(OutVec.Map(), InVec.Map());
-  Epetra_Import importer(OutVec.Map(), InVec.Map());
+  Epetra_Export exporter(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
+  Epetra_Import importer(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
   if (doexport)
   {
     // zero out all vectors which are not Proc 0. Then, export Proc 0 data to InVec map.

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -1810,8 +1810,10 @@ void Beam3ContactOctTree::communicate_vector(Core::LinAlg::Vector<double>& InVec
    * on all processors. */
 
   // first, export the values of OutVec on Proc 0 to InVecs of all participating processors
-  Epetra_Export exporter(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
-  Epetra_Import importer(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
+  Epetra_Export exporter(
+      OutVec.get_map().get_epetra_block_map(), InVec.get_map().get_epetra_block_map());
+  Epetra_Import importer(
+      OutVec.get_map().get_epetra_block_map(), InVec.get_map().get_epetra_block_map());
   if (doexport)
   {
     // zero out all vectors which are not Proc 0. Then, export Proc 0 data to InVec map.
@@ -1830,8 +1832,10 @@ void Beam3ContactOctTree::communicate_multi_vector(Core::LinAlg::MultiVector<dou
     Core::LinAlg::MultiVector<double>& OutVec, bool zerofy, bool doexport, bool doimport)
 {
   // first, export the values of OutVec on Proc 0 to InVecs of all participating processors
-  Epetra_Export exporter(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
-  Epetra_Import importer(OutVec.get_map().get_epetra_map(), InVec.get_map().get_epetra_map());
+  Epetra_Export exporter(
+      OutVec.get_map().get_epetra_block_map(), InVec.get_map().get_epetra_block_map());
+  Epetra_Import importer(
+      OutVec.get_map().get_epetra_block_map(), InVec.get_map().get_epetra_block_map());
   if (doexport)
   {
     // zero out all vectors which are not Proc 0. Then, export Proc 0 data to InVec map.

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_mortar_manager.cpp
@@ -224,7 +224,7 @@ void BeamInteraction::BeamToSolidMortarManager::setup()
   set_global_maps();
 
   // Create the global coupling matrices.
-  constraint_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
+  constraint_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
   constraint_lin_beam_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *lambda_dof_rowmap_, 30, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   constraint_lin_solid_ = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -233,12 +233,12 @@ void BeamInteraction::BeamToSolidMortarManager::setup()
       *beam_dof_rowmap_, 30, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   force_solid_lin_lambda_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *solid_dof_rowmap_, 100, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  kappa_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
+  kappa_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
   kappa_lin_beam_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *lambda_dof_rowmap_, 30, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   kappa_lin_solid_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *lambda_dof_rowmap_, 100, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  lambda_active_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
+  lambda_active_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
 
   // Set flag for successful setup.
   is_setup_ = true;

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -144,7 +144,7 @@ namespace BeamInteraction
 
         for (int dim = 0; dim < 3; ++dim)
         {
-          doflid[dim] = dis.get_block_map().LID(dofnode[dim]);
+          doflid[dim] = dis.get_map().LID(dofnode[dim]);
           d(dim) = (dis)[doflid[dim]];
           X(dim) = node->x()[dim];
         }

--- a/src/beaminteraction/src/4C_beaminteraction_crosslinker_handler.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_crosslinker_handler.cpp
@@ -195,7 +195,7 @@ BeamInteraction::BeamCrosslinkerHandler::fill_linker_into_bins_remote_id_list(
     std::vector<int> unique_pidlist(uniquesize);
     int err = binstrategy_->bin_discret()->element_row_map()->RemoteIDList(
         uniquesize, uniquevec_targetbinIdlist.data(), unique_pidlist.data(), nullptr);
-    if (err < 0) FOUR_C_THROW("Epetra_BlockMap::RemoteIDList returned err={}", err);
+    if (err < 0) FOUR_C_THROW("Core::LinAlg::Map::RemoteIDList returned err={}", err);
 
     // 3) build full pid list via lookup table
     std::map<int, int> lookuptable;

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -978,7 +978,7 @@ bool Solid::ModelEvaluator::BeamInteraction::check_if_beam_discret_redistributio
       // ( this one also does not get shifted, therefore we do not need to worry
       // about a periodic boundary shift of a node between dis_at_last_redistr_ and the current
       // disp)
-      doflid[dim] = dis_at_last_redistr_->get_block_map().LID(dofnode[dim]);
+      doflid[dim] = dis_at_last_redistr_->get_map().LID(dofnode[dim]);
       (dis_increment)[doflid[dim]] =
           (*global_state().get_dis_np())[doflid[dim]] - (*dis_at_last_redistr_)[doflid[dim]];
     }

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -1187,7 +1187,7 @@ void Solid::ModelEvaluator::BeamInteraction::update_maps()
   ia_force_beaminteraction_ =
       std::make_shared<Core::LinAlg::Vector<double>>(*ia_discret_->dof_row_map(), true);
   ia_state_ptr_->get_force_np() =
-      std::make_shared<Epetra_FEVector>(ia_discret_->dof_row_map()->get_epetra_map(), true);
+      std::make_shared<Epetra_FEVector>(ia_discret_->dof_row_map()->get_epetra_block_map(), true);
 
   // stiff
   ia_state_ptr_->get_stiff() = std::make_shared<Core::LinAlg::SparseMatrix>(

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator_datastate.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator_datastate.cpp
@@ -72,8 +72,8 @@ void Solid::ModelEvaluator::BeamInteractionDataState::setup(
   discolnp_ = std::make_shared<Core::LinAlg::Vector<double>>(*ia_discret->dof_col_map());
 
   // force
-  forcen_ = std::make_shared<Epetra_FEVector>(ia_discret->dof_row_map()->get_epetra_map());
-  forcenp_ = std::make_shared<Epetra_FEVector>(ia_discret->dof_row_map()->get_epetra_map());
+  forcen_ = std::make_shared<Epetra_FEVector>(ia_discret->dof_row_map()->get_epetra_block_map());
+  forcenp_ = std::make_shared<Epetra_FEVector>(ia_discret->dof_row_map()->get_epetra_block_map());
 
   stiff_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *ia_discret->dof_row_map(), 81, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
@@ -218,7 +218,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::post_setup()
       // loop over all dofs
       for (unsigned int dim = 0; dim < 3; ++dim)
       {
-        int doflid = dis_at_last_redistr_->get_block_map().LID(dofnode[dim]);
+        int doflid = dis_at_last_redistr_->get_map().LID(dofnode[dim]);
         (*dis_at_last_redistr_)[doflid] = crosslinker_i->x()[dim];
       }
     }
@@ -1024,7 +1024,7 @@ bool BeamInteraction::SubmodelEvaluator::Crosslinking::pre_update_step_element(b
 
     for (int dim = 0; dim < 3; ++dim)
     {
-      doflid[dim] = dis_at_last_redistr_->get_block_map().LID(dofnode[dim]);
+      doflid[dim] = dis_at_last_redistr_->get_map().LID(dofnode[dim]);
       d(dim) = (*dis_at_last_redistr_)[doflid[dim]];
       (*linker_disnp_)[doflid[dim]] = ref(dim) = node->x()[dim];
     }
@@ -1307,7 +1307,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::fill_state_data_vectors_f
     // loop over all dofs
     for (unsigned int dim = 0; dim < num_spatial_dim; ++dim)
     {
-      int doflid = displacement.get_block_map().LID(dofnode[dim]);
+      int doflid = displacement.get_map().LID(dofnode[dim]);
       (displacement)[doflid] = crosslinker_i->x()[dim];
 
       if (numbonds == 2)
@@ -1561,7 +1561,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::post_read_restart()
     // loop over all dofs
     for (unsigned int dim = 0; dim < 3; ++dim)
     {
-      int doflid = dis_at_last_redistr_->get_block_map().LID(dofnode[dim]);
+      int doflid = dis_at_last_redistr_->get_map().LID(dofnode[dim]);
       (*dis_at_last_redistr_)[doflid] = crosslinker_i->x()[dim];
     }
   }
@@ -3487,7 +3487,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::update_my_double_bonds_re
   // find new host procs for double bonded crosslinker by communication
   int err = bin_discret_ptr()->node_row_map()->RemoteIDList(
       size, unique_clgidlist.data(), unique_pidlist.data(), nullptr);
-  if (err < 0) FOUR_C_THROW("Epetra_BlockMap::RemoteIDList returned err={}", err);
+  if (err < 0) FOUR_C_THROW("Core::LinAlg::Map::RemoteIDList returned err={}", err);
 
   std::map<int, std::vector<std::shared_ptr<BeamInteraction::BeamLink>>> dbcltosend;
   for (unsigned int i = 0; i < static_cast<unsigned int>(unique_clgidlist.size()); ++i)

--- a/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_manager.cpp
@@ -210,8 +210,9 @@ Utils::Cardiovascular0DManager::Cardiovascular0DManager(
     cardiovascular0dmap_ =
         std::make_shared<Core::LinAlg::Map>(*(cardiovascular0ddofset_->dof_row_map()));
     redcardiovascular0dmap_ = Core::LinAlg::allreduce_e_map(*cardiovascular0dmap_);
-    cardvasc0dimpo_ = std::make_shared<Epetra_Export>(
-        redcardiovascular0dmap_->get_epetra_map(), cardiovascular0dmap_->get_epetra_map());
+    cardvasc0dimpo_ =
+        std::make_shared<Epetra_Export>(redcardiovascular0dmap_->get_epetra_block_map(),
+            cardiovascular0dmap_->get_epetra_block_map());
     cv0ddofincrement_ = std::make_shared<Core::LinAlg::Vector<double>>(*cardiovascular0dmap_);
     cv0ddof_n_ = std::make_shared<Core::LinAlg::Vector<double>>(*cardiovascular0dmap_);
     cv0ddof_np_ = std::make_shared<Core::LinAlg::Vector<double>>(*cardiovascular0dmap_);

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -57,10 +57,10 @@ Cardiovascular0D::ProperOrthogonalDecomposition::ProperOrthogonalDecomposition(
   }
 
   // build an importer
-  Epetra_Import dofrowimporter(
-      full_model_dof_row_map_->get_epetra_map(), reduced_basis->get_map().get_epetra_map());
+  Epetra_Import dofrowimporter(full_model_dof_row_map_->get_epetra_block_map(),
+      reduced_basis->get_map().get_epetra_block_map());
   projmatrix_ = std::make_shared<Core::LinAlg::MultiVector<double>>(
-      full_model_dof_row_map_->get_epetra_map(), reduced_basis->NumVectors(), true);
+      full_model_dof_row_map_->get_epetra_block_map(), reduced_basis->NumVectors(), true);
   int err = projmatrix_->Import(*reduced_basis, dofrowimporter, Insert, nullptr);
   if (err != 0) FOUR_C_THROW("POD projection matrix could not be mapped onto the dof map");
 
@@ -82,9 +82,9 @@ Cardiovascular0D::ProperOrthogonalDecomposition::ProperOrthogonalDecomposition(
 
   // importers for reduced system
   structrimpo_ = std::make_shared<Epetra_Import>(
-      structmapr_->get_epetra_map(), redstructmapr_->get_epetra_map());
+      structmapr_->get_epetra_block_map(), redstructmapr_->get_epetra_block_map());
   structrinvimpo_ = std::make_shared<Epetra_Import>(
-      redstructmapr_->get_epetra_map(), structmapr_->get_epetra_map());
+      redstructmapr_->get_epetra_block_map(), structmapr_->get_epetra_block_map());
 
   return;
 }

--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -57,7 +57,8 @@ Cardiovascular0D::ProperOrthogonalDecomposition::ProperOrthogonalDecomposition(
   }
 
   // build an importer
-  Epetra_Import dofrowimporter(full_model_dof_row_map_->get_epetra_map(), (reduced_basis->Map()));
+  Epetra_Import dofrowimporter(
+      full_model_dof_row_map_->get_epetra_map(), reduced_basis->get_map().get_epetra_map());
   projmatrix_ = std::make_shared<Core::LinAlg::MultiVector<double>>(
       full_model_dof_row_map_->get_epetra_map(), reduced_basis->NumVectors(), true);
   int err = projmatrix_->Import(*reduced_basis, dofrowimporter, Insert, nullptr);

--- a/src/cardiovascular0d/4C_cardiovascular0d_resulttest.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_resulttest.cpp
@@ -47,7 +47,7 @@ void Cardiovascular0DResultTest::test_special(
   double result = 0.0;          // will hold the actual result of run
 
 
-  const Epetra_BlockMap& cardvasc0dmap = cardvasc0d_dof_->get_block_map();
+  const Core::LinAlg::Map& cardvasc0dmap = cardvasc0d_dof_->get_map();
   const int offset = cardvasc0dmap.MinAllGID();
 
   bool havegid = false;

--- a/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
@@ -158,7 +158,7 @@ bool Solid::ModelEvaluator::Cardiovascular0D::assemble_force(
         "the structural part indicates, that 0D cardiovascular model contributions \n"
         "are present!");
 
-  const int elements_f = f.get_block_map().NumGlobalElements();
+  const int elements_f = f.get_map().NumGlobalElements();
   const int max_gid = get_block_dof_row_map_ptr()->MaxAllGID();
   // only call when f is the full rhs of the coupled problem (not for structural
   // equilibriate initial state call)

--- a/src/constraint/4C_constraint.cpp
+++ b/src/constraint/4C_constraint.cpp
@@ -253,7 +253,7 @@ void Constraints::Constraint::evaluate_constraint(Teuchos::ParameterList& params
       // global and local ID of this bc in the redundant vectors
       const int offsetID = params.get<int>("OffsetID");
       int gindex = condID - offsetID;
-      const int lindex = (systemvector3->get_block_map()).LID(gindex);
+      const int lindex = (systemvector3->get_map()).LID(gindex);
 
       // store loadcurve values
       std::shared_ptr<Core::LinAlg::Vector<double>> timefact =

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -124,7 +124,7 @@ void Constraints::ConstrManager::setup(
     redconstrmap_ = Core::LinAlg::allreduce_e_map(*constrmap_);
     // importer
     conimpo_ = std::make_shared<Epetra_Export>(
-        redconstrmap_->get_epetra_map(), constrmap_->get_epetra_map());
+        redconstrmap_->get_epetra_block_map(), constrmap_->get_epetra_block_map());
     // sum up initial values
     refbasevalues_ = std::make_shared<Core::LinAlg::Vector<double>>(*constrmap_);
     std::shared_ptr<Core::LinAlg::Vector<double>> refbaseredundant =
@@ -192,7 +192,7 @@ void Constraints::ConstrManager::setup(
         std::make_shared<Core::LinAlg::Map>(num_monitor_id_, nummyele, 0, actdisc_->get_comm());
     redmonmap_ = Core::LinAlg::allreduce_e_map(*monitormap_);
     monimpo_ = std::make_shared<Epetra_Export>(
-        redmonmap_->get_epetra_map(), monitormap_->get_epetra_map());
+        redmonmap_->get_epetra_block_map(), monitormap_->get_epetra_block_map());
     monitorvalues_ = std::make_shared<Core::LinAlg::Vector<double>>(*monitormap_);
     initialmonvalues_ = std::make_shared<Core::LinAlg::Vector<double>>(*monitormap_);
 
@@ -415,7 +415,7 @@ void Constraints::ConstrManager::compute_monitor_values(
   areamonitor3d_->evaluate(p, actmonredundant);
   areamonitor2d_->evaluate(p, actmonredundant);
 
-  Epetra_Import monimpo(monitormap_->get_epetra_map(), redmonmap_->get_epetra_map());
+  Epetra_Import monimpo(monitormap_->get_epetra_block_map(), redmonmap_->get_epetra_block_map());
   monitorvalues_->export_to(actmonredundant, *monimpo_, Add);
 }
 
@@ -448,7 +448,7 @@ void Constraints::ConstrManager::compute_monitor_values(
   areamonitor3d_->evaluate(p, actmonredundant);
   areamonitor2d_->evaluate(p, actmonredundant);
 
-  Epetra_Import monimpo(monitormap_->get_epetra_map(), redmonmap_->get_epetra_map());
+  Epetra_Import monimpo(monitormap_->get_epetra_block_map(), redmonmap_->get_epetra_block_map());
   monitorvalues_->export_to(actmonredundant, *monimpo_, Add);
 }
 

--- a/src/constraint/4C_constraint_manager.cpp
+++ b/src/constraint/4C_constraint_manager.cpp
@@ -427,7 +427,7 @@ void Constraints::ConstrManager::compute_monitor_values(
   std::vector<const Core::Conditions::Condition*> monitcond;
   monitorvalues_->put_scalar(0.0);
   Teuchos::ParameterList p;
-  if (not actdisc_->dof_row_map()->SameAs(disp->get_block_map()))
+  if (not actdisc_->dof_row_map()->SameAs(disp->get_map()))
   {
     // build merged dof row map
     std::shared_ptr<Core::LinAlg::Map> largemap =

--- a/src/constraint/4C_constraint_multipointconstraint2.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint2.cpp
@@ -308,7 +308,7 @@ void Constraints::MPConstraint2::evaluate_constraint(std::shared_ptr<Core::FE::D
       // define global and local index of this bc in redundant vectors
       const int offsetID = params.get<int>("OffsetID");
       int gindex = condID - offsetID;
-      const int lindex = (systemvector3->get_block_map()).LID(gindex);
+      const int lindex = (systemvector3->get_map()).LID(gindex);
 
       // Get the current lagrange multiplier value for this condition
       const std::shared_ptr<Core::LinAlg::Vector<double>> lagramul =

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -398,7 +398,7 @@ void Constraints::MPConstraint3::evaluate_constraint(std::shared_ptr<Core::FE::D
       // define global and local index of this bc in redundant vectors
       const int offsetID = params.get<int>("OffsetID");
       int gindex = eid - offsetID;
-      const int lindex = (systemvector3->get_block_map()).LID(gindex);
+      const int lindex = (systemvector3->get_map()).LID(gindex);
 
       // Get the current lagrange multiplier value for this condition
       const std::shared_ptr<Core::LinAlg::Vector<double>> lagramul =

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -75,9 +75,9 @@ Constraints::MPConstraint3Penalty::MPConstraint3Penalty(
     errormap_ = std::make_shared<Core::LinAlg::Map>(numele, nummyele, 0, actdisc_->get_comm());
     rederrormap_ = Core::LinAlg::allreduce_e_map(*errormap_);
     errorexport_ = std::make_shared<Epetra_Export>(
-        rederrormap_->get_epetra_map(), errormap_->get_epetra_map());
+        rederrormap_->get_epetra_block_map(), errormap_->get_epetra_block_map());
     errorimport_ = std::make_shared<Epetra_Import>(
-        rederrormap_->get_epetra_map(), errormap_->get_epetra_map());
+        rederrormap_->get_epetra_block_map(), errormap_->get_epetra_block_map());
     acterror_ = std::make_shared<Core::LinAlg::Vector<double>>(*rederrormap_);
     initerror_ = std::make_shared<Core::LinAlg::Vector<double>>(*rederrormap_);
   }

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -47,9 +47,9 @@ Constraints::ConstraintPenalty::ConstraintPenalty(
     errormap_ = std::make_shared<Core::LinAlg::Map>(numele, nummyele, 0, actdisc_->get_comm());
     rederrormap_ = Core::LinAlg::allreduce_e_map(*errormap_);
     errorexport_ = std::make_shared<Epetra_Export>(
-        rederrormap_->get_epetra_map(), errormap_->get_epetra_map());
+        rederrormap_->get_epetra_block_map(), errormap_->get_epetra_block_map());
     errorimport_ = std::make_shared<Epetra_Import>(
-        rederrormap_->get_epetra_map(), errormap_->get_epetra_map());
+        rederrormap_->get_epetra_block_map(), errormap_->get_epetra_block_map());
     acterror_ = std::make_shared<Core::LinAlg::Vector<double>>(*rederrormap_);
     initerror_ = std::make_shared<Core::LinAlg::Vector<double>>(*rederrormap_);
     lagrvalues_ = std::make_shared<Core::LinAlg::Vector<double>>(*rederrormap_);

--- a/src/constraint/4C_constraint_solver.cpp
+++ b/src/constraint/4C_constraint_solver.cpp
@@ -115,8 +115,8 @@ void Constraints::ConstraintSolver::solve_uzawa(Core::LinAlg::SparseMatrix& stif
 
   const double computol = 1E-8;
 
-  Core::LinAlg::Vector<double> constrTLagrInc(rhsstand.get_block_map());
-  Core::LinAlg::Vector<double> constrTDispInc(rhsconstr.get_block_map());
+  Core::LinAlg::Vector<double> constrTLagrInc(rhsstand.get_map());
+  Core::LinAlg::Vector<double> constrTDispInc(rhsconstr.get_map());
   // Core::LinAlg::SparseMatrix constrT =
   // *(std::dynamic_pointer_cast<Core::LinAlg::SparseMatrix>(constr));
 
@@ -125,7 +125,7 @@ void Constraints::ConstraintSolver::solve_uzawa(Core::LinAlg::SparseMatrix& stif
   if (dirichtoggle_ != nullptr)
     dbcmaps_ = Core::LinAlg::convert_dirichlet_toggle_vector_to_maps(*dirichtoggle_);
 
-  Core::LinAlg::Vector<double> zeros(rhsstand.get_block_map(), true);
+  Core::LinAlg::Vector<double> zeros(rhsstand.get_map(), true);
   std::shared_ptr<Core::LinAlg::Vector<double>> dirichzeros = dbcmaps_->extract_cond_vector(zeros);
 
   // Compute residual of the uzawa algorithm
@@ -139,7 +139,7 @@ void Constraints::ConstraintSolver::solve_uzawa(Core::LinAlg::SparseMatrix& stif
   dbcmaps_->insert_cond_vector(*dirichzeros, uzawa_res);
 
   uzawa_res.norm_2(&norm_uzawa);
-  Core::LinAlg::Vector<double> constr_res(lagrinc.get_block_map());
+  Core::LinAlg::Vector<double> constr_res(lagrinc.get_map());
 
   constr_res.update(1.0, (rhsconstr), 0.0);
   constr_res.norm_2(&norm_constr_uzawa);
@@ -182,7 +182,7 @@ void Constraints::ConstraintSolver::solve_uzawa(Core::LinAlg::SparseMatrix& stif
     dbcmaps_->insert_cond_vector(*dirichzeros, uzawa_res);
     norm_uzawa_old = norm_uzawa;
     uzawa_res.norm_2(&norm_uzawa);
-    Core::LinAlg::Vector<double> constr_res(lagrinc.get_block_map());
+    Core::LinAlg::Vector<double> constr_res(lagrinc.get_map());
 
     constr_res.update(1.0, constrTDispInc, 1.0, rhsconstr, 0.0);
     constr_res.norm_2(&norm_constr_uzawa);
@@ -331,7 +331,7 @@ void Constraints::ConstraintSolver::solve_simple(Core::LinAlg::SparseMatrix& sti
     dbcmaps_ = Core::LinAlg::convert_dirichlet_toggle_vector_to_maps(*dirichtoggle_);
 
   // stuff needed for Dirichlet BCs
-  Core::LinAlg::Vector<double> zeros(rhsstand.get_block_map(), true);
+  Core::LinAlg::Vector<double> zeros(rhsstand.get_map(), true);
   std::shared_ptr<Core::LinAlg::Vector<double>> dirichzeros = dbcmaps_->extract_cond_vector(zeros);
   Core::LinAlg::Vector<double> rhscopy(rhsstand);
 

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -977,7 +977,7 @@ void Constraints::SpringDashpot::set_restart_old(Core::LinAlg::MultiVector<doubl
         for (auto& i : offset_prestr_)
         {
           // global id -> local id
-          const int lid = vec.Map().LID(i.first);
+          const int lid = vec.get_map().LID(i.first);
           // local id on processor
           if (lid >= 0)
           {
@@ -1003,7 +1003,7 @@ void Constraints::SpringDashpot::output_gap_normal(Core::LinAlg::Vector<double>&
   for (const auto& i : gap_)
   {
     // global id -> local id
-    const int lid = gap.get_block_map().LID(i.first);
+    const int lid = gap.get_map().LID(i.first);
     // local id on processor
     if (lid >= 0) (gap)[lid] += i.second;
   }
@@ -1012,7 +1012,7 @@ void Constraints::SpringDashpot::output_gap_normal(Core::LinAlg::Vector<double>&
   for (const auto& normal : normals_)
   {
     // global id -> local id
-    const int lid = normals.Map().LID(normal.first);
+    const int lid = normals.get_map().LID(normal.first);
     // local id on processor
     if (lid >= 0)
     {
@@ -1027,7 +1027,7 @@ void Constraints::SpringDashpot::output_gap_normal(Core::LinAlg::Vector<double>&
   for (const auto& i : springstress_)
   {
     // global id -> local id
-    const int lid = stress.Map().LID(i.first);
+    const int lid = stress.get_map().LID(i.first);
     // local id on processor
     if (lid >= 0)
     {
@@ -1058,7 +1058,7 @@ void Constraints::SpringDashpot::output_prestr_offset_old(
   for (const auto& i : offset_prestr_)
   {
     // global id -> local id
-    const int lid = springprestroffset.Map().LID(i.first);
+    const int lid = springprestroffset.get_map().LID(i.first);
     // local id on processor
     if (lid >= 0)
     {

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
@@ -174,7 +174,8 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::setup(
   set_global_maps();
 
   // Create the global coupling matrices.
-  global_constraint_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
+  global_constraint_ =
+      std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
   global_g_bl_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *lambda_dof_rowmap_, 30, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   global_g_bg_ = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -183,8 +184,9 @@ void Constraints::EmbeddedMesh::SolidToSolidMortarManager::setup(
       *boundary_layer_interface_dof_rowmap_, 30, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   global_fbg_l_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *background_dof_rowmap_, 100, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  global_kappa_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
-  global_active_lambda_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
+  global_kappa_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
+  global_active_lambda_ =
+      std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
 
   // Set flag for successful setup.
   is_setup_ = true;

--- a/src/contact/4C_contact_abstract_strategy.cpp
+++ b/src/contact/4C_contact_abstract_strategy.cpp
@@ -1013,8 +1013,8 @@ void CONTACT::AbstractStrategy::update_global_self_contact_state()
       std::make_shared<Core::LinAlg::Vector<double>>(*gsdofrowmap_, true);
 
   {
-    const int* oldgids = zincr_->get_block_map().MyGlobalElements();
-    for (int i = 0; i < zincr_->get_block_map().NumMyElements(); ++i)
+    const int* oldgids = zincr_->get_map().MyGlobalElements();
+    for (int i = 0; i < zincr_->get_map().NumMyElements(); ++i)
     {
       if (std::abs((*zincr_)[i]) > std::numeric_limits<double>::epsilon())
       {
@@ -1032,8 +1032,8 @@ void CONTACT::AbstractStrategy::update_global_self_contact_state()
 
   tmp_ptr->put_scalar(0.0);
   {
-    const int* oldgids = z_->get_block_map().MyGlobalElements();
-    for (int i = 0; i < z_->get_block_map().NumMyElements(); ++i)
+    const int* oldgids = z_->get_map().MyGlobalElements();
+    for (int i = 0; i < z_->get_map().NumMyElements(); ++i)
     {
       if (std::abs((*z_)[i]) > std::numeric_limits<double>::epsilon())
       {
@@ -1625,7 +1625,7 @@ void CONTACT::AbstractStrategy::store_nodal_quantities(Mortar::StrategyBase::Qua
 
       for (int dof = 0; dof < n_dim(); ++dof)
       {
-        locindex[dof] = (vectorinterface->get_block_map()).LID(cnode->dofs()[dof]);
+        locindex[dof] = (vectorinterface->get_map()).LID(cnode->dofs()[dof]);
         if (locindex[dof] < 0) FOUR_C_THROW("StoreNodalQuantities: Did not find dof in map");
 
         switch (type)
@@ -1728,14 +1728,14 @@ void CONTACT::AbstractStrategy::compute_contact_stresses()
       // normal stress components
       for (int dof = 0; dof < n_dim(); ++dof)
       {
-        locindex[dof] = (stressnormal_->get_block_map()).LID(cnode->dofs()[dof]);
+        locindex[dof] = (stressnormal_->get_map()).LID(cnode->dofs()[dof]);
         (*stressnormal_)[locindex[dof]] = -lmn * nn[dof];
       }
 
       // tangential stress components
       for (int dof = 0; dof < n_dim(); ++dof)
       {
-        locindex[dof] = (stresstangential_->get_block_map()).LID(cnode->dofs()[dof]);
+        locindex[dof] = (stresstangential_->get_map()).LID(cnode->dofs()[dof]);
         (*stresstangential_)[locindex[dof]] = -lmt1 * nt1[dof] - lmt2 * nt2[dof];
       }
     }
@@ -1912,7 +1912,7 @@ void CONTACT::AbstractStrategy::do_write_restart(
       Core::Nodes::Node* node = interfaces()[i]->discret().g_node(gid);
       if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
       Node* cnode = dynamic_cast<Node*>(node);
-      int dof = (activetoggle->get_block_map()).LID(gid);
+      int dof = (activetoggle->get_map()).LID(gid);
 
       if (forcedrestart)
       {
@@ -2004,7 +2004,7 @@ void CONTACT::AbstractStrategy::do_read_restart(Core::IO::DiscretizationReader& 
     for (int j = 0; j < (interfaces()[i]->slave_row_nodes())->NumMyElements(); ++j)
     {
       int gid = (interfaces()[i]->slave_row_nodes())->GID(j);
-      int dof = (activetoggle->get_block_map()).LID(gid);
+      int dof = (activetoggle->get_map()).LID(gid);
 
       if ((*activetoggle)[dof] == 1)
       {

--- a/src/contact/4C_contact_interface.cpp
+++ b/src/contact/4C_contact_interface.cpp
@@ -1017,7 +1017,8 @@ void CONTACT::Interface::redistribute()
   // create the output graph (with new slave node row map) and export to it
   std::shared_ptr<Core::LinAlg::Graph> outgraph =
       std::make_shared<Core::LinAlg::Graph>(Copy, *srownodes, 108, false);
-  Epetra_Export exporter(graph->row_map().get_epetra_map(), srownodes->get_epetra_map());
+  Epetra_Export exporter(
+      graph->row_map().get_epetra_block_map(), srownodes->get_epetra_block_map());
   int err = outgraph->export_to(graph->get_epetra_crs_graph(), exporter, Add);
   if (err < 0) FOUR_C_THROW("Graph export returned err={}", err);
 

--- a/src/contact/4C_contact_interface_assemble.cpp
+++ b/src/contact/4C_contact_interface_assemble.cpp
@@ -1779,8 +1779,8 @@ void CONTACT::Interface::assemble_lin_stick(Core::LinAlg::SparseMatrix& linstick
     // in case of TSI, the nodal temperature influences the local friction coefficient
     frcoeff = cnode->fr_coeff(frcoeff_in);
 
-    double cn_input = get_cn_ref()[get_cn_ref().get_block_map().LID(cnode->id())];
-    double ct_input = get_ct_ref()[get_ct_ref().get_block_map().LID(cnode->id())];
+    double cn_input = get_cn_ref()[get_cn_ref().get_map().LID(cnode->id())];
+    double ct_input = get_ct_ref()[get_ct_ref().get_map().LID(cnode->id())];
 
     // more information from node
     double* n = cnode->mo_data().n();
@@ -2599,8 +2599,8 @@ void CONTACT::Interface::assemble_lin_slip(Core::LinAlg::SparseMatrix& linslipLM
       // in case of TSI, the nodal temperature influences the local friction coefficient
       frcoeff = cnode->fr_coeff(frcoeff_in);
 
-      double cn_input = get_cn_ref()[get_cn_ref().get_block_map().LID(cnode->id())];
-      double ct_input = get_ct_ref()[get_ct_ref().get_block_map().LID(cnode->id())];
+      double cn_input = get_cn_ref()[get_cn_ref().get_map().LID(cnode->id())];
+      double ct_input = get_ct_ref()[get_ct_ref().get_map().LID(cnode->id())];
 
       // prepare assembly, get information from node
       std::vector<Core::Gen::Pairedvector<int, double>> dnmap = cnode->data().get_deriv_n();
@@ -3627,7 +3627,7 @@ void CONTACT::Interface::assemble_lin_slip(Core::LinAlg::SparseMatrix& linslipLM
       if (cnode->owner() != Core::Communication::my_mpi_rank(get_comm()))
         FOUR_C_THROW("AssembleLinSlip: Node ownership inconsistency!");
 
-      double ct = get_ct_ref()[get_ct_ref().get_block_map().LID(cnode->id())];
+      double ct = get_ct_ref()[get_ct_ref().get_map().LID(cnode->id())];
 
       // preparation of assembly
       // get Deriv N and calculate DerivD form DerivN
@@ -4275,9 +4275,9 @@ void CONTACT::Interface::assemble_normal_contact_regularization(Core::LinAlg::Sp
     double dval = cnode->mo_data().get_d().at(cnode->id());
 
     if (constr_direction == CONTACT::ConstraintDirection::xyz)
-      for (int d = 0; d < dim; ++d) f[f.get_block_map().LID(cnode->dofs()[d])] += n(d) * dval * gLM;
+      for (int d = 0; d < dim; ++d) f[f.get_map().LID(cnode->dofs()[d])] += n(d) * dval * gLM;
     else
-      f[f.get_block_map().LID(cnode->dofs()[0])] += dval * gLM;
+      f[f.get_map().LID(cnode->dofs()[0])] += dval * gLM;
 
     for (int l = 0; l < dim; ++l)
     {
@@ -4357,8 +4357,8 @@ void CONTACT::Interface::assemble_lin_slip_normal_regularization(
       // in case of TSI, the nodal temperature influences the local friction coefficient
       frcoeff = cnode->fr_coeff(frcoeff_in);
 
-      double cn = get_cn_ref()[get_cn_ref().get_block_map().LID(cnode->id())];
-      double ct = get_ct_ref()[get_ct_ref().get_block_map().LID(cnode->id())];
+      double cn = get_cn_ref()[get_cn_ref().get_map().LID(cnode->id())];
+      double ct = get_ct_ref()[get_ct_ref().get_map().LID(cnode->id())];
 
       // prepare assembly, get information from node
       std::vector<Core::Gen::Pairedvector<int, double>> dnmap = cnode->data().get_deriv_n();
@@ -5288,7 +5288,7 @@ void CONTACT::Interface::assemble_coup_lin_d(
           int col = scolcurr->first;
           int slavedofgid = cnode->dofs()[prodj];
 
-          int slavedoflid = x->get_block_map().LID(slavedofgid);
+          int slavedoflid = x->get_map().LID(slavedofgid);
           if (slavedoflid < 0) FOUR_C_THROW("invalid slave dof lid");
           double val = (*x)[slavedoflid] * (scolcurr->second);
 
@@ -5367,7 +5367,7 @@ void CONTACT::Interface::assemble_coup_lin_m(
           int col = mcolcurr->first;
           int slavedofgid = cnode->dofs()[prodj];
 
-          int slavedoflid = x->get_block_map().LID(slavedofgid);
+          int slavedoflid = x->get_map().LID(slavedofgid);
           double val = (*x)[slavedoflid] * (mcolcurr->second);
 
           ++mcolcurr;

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -1706,7 +1706,7 @@ void CONTACT::LagrangeStrategy::add_master_contributions(Core::LinAlg::SparseOpe
     Core::LinAlg::Vector<double>& feff, bool add_time_integration)
 {
   // create new contact force vector for LTL contact
-  auto fc = std::make_shared<Epetra_FEVector>(feff.get_map().get_epetra_map());
+  auto fc = std::make_shared<Epetra_FEVector>(feff.get_map().get_epetra_block_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -1760,9 +1760,10 @@ void CONTACT::LagrangeStrategy::add_line_to_lin_contributions(Core::LinAlg::Spar
     std::shared_ptr<Core::LinAlg::Vector<double>>& feff, bool add_time_integration)
 {
   // create new contact force vector for LTL contact
-  auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_map());
+  auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_block_map());
 
-  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_map());
+  fconservation_ =
+      std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_block_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -1815,9 +1816,10 @@ void CONTACT::LagrangeStrategy::add_line_to_lin_contributions_friction(
     bool add_time_integration)
 {
   // create new contact force vector for LTL contact
-  auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_map());
+  auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_block_map());
 
-  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_map());
+  fconservation_ =
+      std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_block_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -1453,7 +1453,7 @@ void CONTACT::LagrangeStrategy::compute_contact_stresses()
 
         for (int dof = 0; dof < n_dim(); ++dof)
         {
-          locindex[dof] = (forcenormal.get_block_map()).LID(cnode->dofs()[dof]);
+          locindex[dof] = (forcenormal.get_map()).LID(cnode->dofs()[dof]);
 
           if (cnode->mo_data().get_dscale() < 1e-8 and cnode->active())
           {
@@ -1706,7 +1706,7 @@ void CONTACT::LagrangeStrategy::add_master_contributions(Core::LinAlg::SparseOpe
     Core::LinAlg::Vector<double>& feff, bool add_time_integration)
 {
   // create new contact force vector for LTL contact
-  auto fc = std::make_shared<Epetra_FEVector>(feff.get_block_map());
+  auto fc = std::make_shared<Epetra_FEVector>(feff.get_map().get_epetra_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -1760,9 +1760,9 @@ void CONTACT::LagrangeStrategy::add_line_to_lin_contributions(Core::LinAlg::Spar
     std::shared_ptr<Core::LinAlg::Vector<double>>& feff, bool add_time_integration)
 {
   // create new contact force vector for LTL contact
-  auto fc = std::make_shared<Epetra_FEVector>(feff->get_block_map());
+  auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_map());
 
-  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_block_map());
+  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -1815,9 +1815,9 @@ void CONTACT::LagrangeStrategy::add_line_to_lin_contributions_friction(
     bool add_time_integration)
 {
   // create new contact force vector for LTL contact
-  auto fc = std::make_shared<Epetra_FEVector>(feff->get_block_map());
+  auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_map());
 
-  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_block_map());
+  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -4320,7 +4320,7 @@ void CONTACT::LagrangeStrategy::run_post_compute_x(const CONTACT::ParamsInterfac
       // store the SCALED Lagrange multiplier increment in the contact
       // strategy
       // ---------------------------------------------------------------------
-      zdir_ptr.replace_map(zincr_->get_block_map());
+      zdir_ptr.replace_map(zincr_->get_map());
       zincr_->scale(stepLength, zdir_ptr);
     }
   }
@@ -4408,7 +4408,7 @@ void CONTACT::LagrangeStrategy::reset_lagrange_multipliers(
     // ---------------------------------------------------------------------
     // Update the current lagrange multiplier
     // ---------------------------------------------------------------------
-    znew_ptr.replace_map(z_->get_block_map());
+    znew_ptr.replace_map(z_->get_map());
 
     z_->scale(1.0, znew_ptr);
 
@@ -4605,7 +4605,7 @@ void CONTACT::LagrangeStrategy::update_active_set()
       Node* cnode = dynamic_cast<Node*>(node);
 
       // compute weighted gap
-      double wgap = (*wgap_)[wgap_->get_block_map().LID(gid)];
+      double wgap = (*wgap_)[wgap_->get_map().LID(gid)];
 
       // compute normal part of Lagrange multiplier
       double nz = 0.0;
@@ -4671,7 +4671,7 @@ void CONTACT::LagrangeStrategy::update_active_set()
           {
             FriNode* frinode = dynamic_cast<FriNode*>(cnode);
             const Core::LinAlg::Vector<double>& ct_ref = interface_[i]->ct_ref();
-            double ct = ct_ref[ct_ref.get_block_map().LID(frinode->id())];
+            double ct = ct_ref[ct_ref.get_map().LID(frinode->id())];
 
             // CAREFUL: friction bound is now interface-local (popp 08/2012)
             double frbound = interface_[i]->interface_params().get<double>("FRBOUND");
@@ -4709,7 +4709,7 @@ void CONTACT::LagrangeStrategy::update_active_set()
           {
             FriNode* frinode = dynamic_cast<FriNode*>(cnode);
             const Core::LinAlg::Vector<double>& ct_ref = interface_[i]->ct_ref();
-            double ct = ct_ref[ct_ref.get_block_map().LID(frinode->id())];
+            double ct = ct_ref[ct_ref.get_map().LID(frinode->id())];
 
             // CAREFUL: friction coefficient is now interface-local (popp 08/2012)
             double frcoeff = interface_[i]->interface_params().get<double>("FRCOEFF");
@@ -5107,7 +5107,7 @@ void CONTACT::LagrangeStrategy::update(std::shared_ptr<const Core::LinAlg::Vecto
   if (fLTL_ != nullptr)
   {
     // store fLTL values for time integration
-    fLTLOld_ = std::make_shared<Core::LinAlg::Vector<double>>(fLTL_->get_block_map());
+    fLTLOld_ = std::make_shared<Core::LinAlg::Vector<double>>(fLTL_->get_map());
     if (fLTLOld_->update(1.0, *fLTL_, 0.0)) FOUR_C_THROW("Update went wrong");
   }
 
@@ -6639,8 +6639,8 @@ void CONTACT::LagrangeStrategy::run_pre_apply_jacobian_inverse(
     Core::LinAlg::Vector<double> rhs_str2(*problem_dofs());
     Core::LinAlg::export_to(rhs, rhs_str);
     if (systrafo_->multiply(true, rhs_str, rhs_str2)) FOUR_C_THROW("multiply failed");
-    for (int i = 0; i < rhs_str2.get_block_map().NumMyElements(); ++i)
-      rhs[rhs.get_block_map().LID(rhs_str2.get_block_map().GID(i))] = rhs_str2[i];
+    for (int i = 0; i < rhs_str2.get_map().NumMyElements(); ++i)
+      rhs[rhs.get_map().LID(rhs_str2.get_map().GID(i))] = rhs_str2[i];
   }
 
 

--- a/src/contact/4C_contact_lagrange_strategy_poro.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_poro.cpp
@@ -1361,7 +1361,7 @@ void CONTACT::LagrangeStrategyPoro::set_state(
 
               fpres = node->dofs()[0];  // here get ids of first component of node
 
-              myfpres = global.get_values()[global.get_block_map().LID(fpres)];
+              myfpres = global.get_values()[global.get_map().LID(fpres)];
 
               *node->poro_data().fpres() = myfpres;
             }

--- a/src/contact/4C_contact_lagrange_strategy_tsi.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_tsi.cpp
@@ -809,12 +809,12 @@ void CONTACT::Utils::add_vector(
   if (src.global_length() == 0) return;
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  for (int i = 0; i < src.get_block_map().NumMyElements(); ++i)
-    if ((dst.get_block_map().LID(src.get_block_map().GID(i))) < 0)
+  for (int i = 0; i < src.get_map().NumMyElements(); ++i)
+    if ((dst.get_map().LID(src.get_map().GID(i))) < 0)
       FOUR_C_THROW("src is not a vector on a sub-map of dst");
 #endif
 
-  Core::LinAlg::Vector<double> tmp = Core::LinAlg::Vector<double>(dst.get_block_map(), true);
+  Core::LinAlg::Vector<double> tmp = Core::LinAlg::Vector<double>(dst.get_map(), true);
   Core::LinAlg::export_to(src, tmp);
   if (dst.update(1., tmp, 1.)) FOUR_C_THROW("vector update went wrong");
   return;
@@ -926,7 +926,7 @@ void CONTACT::LagrangeStrategyTsi::store_nodal_quantities(
           Node* cnode = dynamic_cast<Node*>(node);
 
           cnode->tsi_data().thermo_lm() =
-              (*vectorinterface)[(vectorinterface->get_block_map()).LID(cnode->dofs()[0])];
+              (*vectorinterface)[(vectorinterface->get_map()).LID(cnode->dofs()[0])];
         }
       }
       break;

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -4127,7 +4127,7 @@ void Wear::LagrangeStrategyWear::output_wear()
 
         for (int dof = 0; dof < dim; ++dof)
         {
-          locindex[dof] = (wear_vector.get_block_map()).LID(frinode->dofs()[dof]);
+          locindex[dof] = (wear_vector.get_map()).LID(frinode->dofs()[dof]);
           (wear_vector)[locindex[dof]] = wear * nn[dof];
         }
       }
@@ -4190,8 +4190,8 @@ void Wear::LagrangeStrategyWear::output_wear()
     for (int i = 0; i < (int)gsdofrowmap_->NumMyElements(); ++i)
     {
       const int gid = gsdofrowmap_->MyGlobalElements()[i];
-      const double tmp = (real_wear)[real_wear.get_block_map().LID(gid)];
-      (*wearoutput_)[wearoutput_->get_block_map().LID(gid)] = tmp * fac;
+      const double tmp = (real_wear)[real_wear.get_map().LID(gid)];
+      (*wearoutput_)[wearoutput_->get_map().LID(gid)] = tmp * fac;
     }
 
     /**********************************************************************
@@ -4261,8 +4261,8 @@ void Wear::LagrangeStrategyWear::output_wear()
       for (int i = 0; i < (int)gmdofrowmap_->NumMyElements(); ++i)
       {
         int gid = gmdofrowmap_->MyGlobalElements()[i];
-        double tmp = (real_wear2)[real_wear2.get_block_map().LID(gid)];
-        (*wearoutput2_)[wearoutput2_->get_block_map().LID(gid)] =
+        double tmp = (real_wear2)[real_wear2.get_map().LID(gid)];
+        (*wearoutput2_)[wearoutput2_->get_map().LID(gid)] =
             -(tmp * fac);  // negative sign because on other interface side
         //--> this Wear-vector (defined on master side) is along slave-side normal field!
       }
@@ -4313,7 +4313,7 @@ void Wear::LagrangeStrategyWear::do_write_restart(
       Core::Nodes::Node* node = interface_[i]->discret().g_node(gid);
       if (!node) FOUR_C_THROW("Cannot find node with gid %", gid);
       CONTACT::Node* cnode = dynamic_cast<CONTACT::Node*>(node);
-      int dof = (activetoggle->get_block_map()).LID(gid);
+      int dof = (activetoggle->get_map()).LID(gid);
 
       // set value active / inactive in toggle vector
       if (cnode->active()) (*activetoggle)[dof] = 1;
@@ -4814,7 +4814,7 @@ void Wear::LagrangeStrategyWear::do_read_restart(
     for (int j = 0; j < (interface_[i]->slave_row_nodes())->NumMyElements(); ++j)
     {
       int gid = (interface_[i]->slave_row_nodes())->GID(j);
-      int dof = (activetoggle->get_block_map()).LID(gid);
+      int dof = (activetoggle->get_map()).LID(gid);
 
       if ((*activetoggle)[dof] == 1)
       {
@@ -5146,7 +5146,7 @@ void Wear::LagrangeStrategyWear::store_nodal_quantities(Mortar::StrategyBase::Qu
 
         // store updated wcurr into node
         fnode->wear_data().wcurr()[0] =
-            (*vectorinterface)[vectorinterface->get_block_map().LID(fnode->dofs()[0])];
+            (*vectorinterface)[vectorinterface->get_map().LID(fnode->dofs()[0])];
       }
     }
     else if (type == Mortar::StrategyBase::wmold)
@@ -5160,7 +5160,7 @@ void Wear::LagrangeStrategyWear::store_nodal_quantities(Mortar::StrategyBase::Qu
 
         // store updated wcurr into node
         fnode->wear_data().wold()[0] +=
-            (*vectorinterface)[vectorinterface->get_block_map().LID(fnode->dofs()[0])];
+            (*vectorinterface)[vectorinterface->get_map().LID(fnode->dofs()[0])];
       }
     }
     else
@@ -5184,7 +5184,7 @@ void Wear::LagrangeStrategyWear::store_nodal_quantities(Mortar::StrategyBase::Qu
 
         for (int dof = 0; dof < dim; ++dof)
         {
-          locindex[dof] = (vectorinterface->get_block_map()).LID(cnode->dofs()[dof]);
+          locindex[dof] = (vectorinterface->get_map()).LID(cnode->dofs()[dof]);
           if (locindex[dof] < 0) FOUR_C_THROW("StoreNodalQuantities: Did not find dof in map");
 
           switch (type)
@@ -5231,7 +5231,7 @@ void Wear::LagrangeStrategyWear::store_nodal_quantities(Mortar::StrategyBase::Qu
               // store updated wcurr into node
               CONTACT::FriNode* fnode = dynamic_cast<CONTACT::FriNode*>(cnode);
               fnode->wear_data().wold()[0] +=
-                  (*vectorinterface)[vectorinterface->get_block_map().LID(fnode->dofs()[0])];
+                  (*vectorinterface)[vectorinterface->get_map().LID(fnode->dofs()[0])];
               dof = dof + n_dim() - 1;
 
               break;

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -547,8 +547,8 @@ void Wear::LagrangeStrategyWear::initialize()
           *gmslipn_, 100, true, false, Core::LinAlg::SparseMatrix::FE_MATRIX);
 
       // w - rhs
-      inactive_wear_rhs_m_ = std::make_shared<Epetra_FEVector>(gwminact_->get_epetra_map());
-      wear_cond_rhs_m_ = std::make_shared<Epetra_FEVector>(gmslipn_->get_epetra_map());
+      inactive_wear_rhs_m_ = std::make_shared<Epetra_FEVector>(gwminact_->get_epetra_block_map());
+      wear_cond_rhs_m_ = std::make_shared<Epetra_FEVector>(gmslipn_->get_epetra_block_map());
     }
   }
 

--- a/src/contact/4C_contact_meshtying_abstract_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_abstract_strategy.cpp
@@ -523,7 +523,7 @@ void CONTACT::MtAbstractStrategy::mesh_initialization(
 
       for (int dof = 0; dof < numdof; ++dof)
       {
-        locindex[dof] = (Xslavemodcol.get_block_map()).LID(mtnode->dofs()[dof]);
+        locindex[dof] = (Xslavemodcol.get_map()).LID(mtnode->dofs()[dof]);
         if (locindex[dof] < 0) FOUR_C_THROW("Did not find dof in map");
         Xnew[dof] = Xslavemodcol[locindex[dof]];
       }
@@ -663,7 +663,7 @@ void CONTACT::MtAbstractStrategy::store_nodal_quantities(Mortar::StrategyBase::Q
 
       for (int dof = 0; dof < n_dim(); ++dof)
       {
-        locindex[dof] = (vectorinterface.get_block_map()).LID(mtnode->dofs()[dof]);
+        locindex[dof] = (vectorinterface.get_map()).LID(mtnode->dofs()[dof]);
         if (locindex[dof] < 0) FOUR_C_THROW("StoreNodalQuantities: Did not find dof in map");
 
         switch (type)

--- a/src/contact/4C_contact_meshtying_manager.cpp
+++ b/src/contact/4C_contact_meshtying_manager.cpp
@@ -669,7 +669,7 @@ void CONTACT::MtManager::postprocess_quantities(Core::IO::DiscretizationWriter& 
   // evaluate slave and master forces
   std::shared_ptr<Core::LinAlg::Vector<double>> fcslave =
       std::make_shared<Core::LinAlg::Vector<double>>(
-          get_strategy().d_matrix()->row_map().get_epetra_map());
+          get_strategy().d_matrix()->row_map().get_epetra_block_map());
   std::shared_ptr<Core::LinAlg::Vector<double>> fcmaster =
       std::make_shared<Core::LinAlg::Vector<double>>(get_strategy().m_matrix()->domain_map());
   std::shared_ptr<Core::LinAlg::Vector<double>> fcslaveexp =

--- a/src/contact/4C_contact_meshtying_poro_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_meshtying_poro_lagrange_strategy.cpp
@@ -164,7 +164,7 @@ void CONTACT::PoroMtLagrangeStrategy::recover_coupling_matrix_partof_lmp(
     Core::LinAlg::Vector<double>& veli)
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> zfluid =
-      std::make_shared<Core::LinAlg::Vector<double>>(z_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(z_->get_map(), true);
 
   Core::LinAlg::Vector<double> mod(*gsdofrowmap_);
 

--- a/src/contact/4C_contact_monocoupled_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_monocoupled_lagrange_strategy.cpp
@@ -374,7 +374,7 @@ void CONTACT::MonoCoupledLagrangeStrategy::recover_coupled(
       }
       else
       {
-        Core::LinAlg::Vector<double> zfluid(z_->get_block_map(), true);
+        Core::LinAlg::Vector<double> zfluid(z_->get_map(), true);
 
         Core::LinAlg::Vector<double> mod(*gsdofrowmap_);
         matiter->second->multiply(false, *inciter->second, mod);

--- a/src/contact/4C_contact_nitsche_strategy.cpp
+++ b/src/contact/4C_contact_nitsche_strategy.cpp
@@ -33,7 +33,8 @@ void CONTACT::NitscheStrategy::apply_force_stiff_cmt(
   set_state(Mortar::state_new_displacement, *dis);
 
   // just a Nitsche-version
-  std::shared_ptr<Epetra_FEVector> fc = std::make_shared<Epetra_FEVector>(f->get_block_map());
+  std::shared_ptr<Epetra_FEVector> fc =
+      std::make_shared<Epetra_FEVector>(f->get_map().get_epetra_map());
   std::shared_ptr<Core::LinAlg::SparseMatrix> kc = std::make_shared<Core::LinAlg::SparseMatrix>(
       Core::LinAlg::Map(dynamic_cast<Core::LinAlg::SparseMatrix*>(&(*kt))->row_map()), 100, true,
       false, Core::LinAlg::SparseMatrix::FE_MATRIX);

--- a/src/contact/4C_contact_nitsche_strategy.cpp
+++ b/src/contact/4C_contact_nitsche_strategy.cpp
@@ -34,7 +34,7 @@ void CONTACT::NitscheStrategy::apply_force_stiff_cmt(
 
   // just a Nitsche-version
   std::shared_ptr<Epetra_FEVector> fc =
-      std::make_shared<Epetra_FEVector>(f->get_map().get_epetra_map());
+      std::make_shared<Epetra_FEVector>(f->get_map().get_epetra_block_map());
   std::shared_ptr<Core::LinAlg::SparseMatrix> kc = std::make_shared<Core::LinAlg::SparseMatrix>(
       Core::LinAlg::Map(dynamic_cast<Core::LinAlg::SparseMatrix*>(&(*kt))->row_map()), 100, true,
       false, Core::LinAlg::SparseMatrix::FE_MATRIX);
@@ -250,7 +250,7 @@ std::shared_ptr<Epetra_FEVector> CONTACT::NitscheStrategy::setup_rhs_block_vec(
   {
     case CONTACT::VecBlockType::displ:
       return std::make_shared<Epetra_FEVector>(
-          Global::Problem::instance()->get_dis("structure")->dof_row_map()->get_epetra_map());
+          Global::Problem::instance()->get_dis("structure")->dof_row_map()->get_epetra_block_map());
     default:
       FOUR_C_THROW("you should not be here");
       break;

--- a/src/contact/4C_contact_nitsche_strategy_poro.cpp
+++ b/src/contact/4C_contact_nitsche_strategy_poro.cpp
@@ -133,7 +133,7 @@ std::shared_ptr<Epetra_FEVector> CONTACT::NitscheStrategyPoro::setup_rhs_block_v
   {
     case CONTACT::VecBlockType::porofluid:
       return std::make_shared<Epetra_FEVector>(
-          Global::Problem::instance()->get_dis("porofluid")->dof_row_map()->get_epetra_map());
+          Global::Problem::instance()->get_dis("porofluid")->dof_row_map()->get_epetra_block_map());
     default:
       return CONTACT::NitscheStrategy::setup_rhs_block_vec(bt);
   }

--- a/src/contact/4C_contact_nitsche_strategy_ssi.cpp
+++ b/src/contact/4C_contact_nitsche_strategy_ssi.cpp
@@ -150,7 +150,7 @@ std::shared_ptr<Epetra_FEVector> CONTACT::NitscheStrategySsi::setup_rhs_block_ve
     case CONTACT::VecBlockType::elch:
     case CONTACT::VecBlockType::scatra:
       return std::make_shared<Epetra_FEVector>(
-          Global::Problem::instance()->get_dis("scatra")->dof_row_map()->get_epetra_map());
+          Global::Problem::instance()->get_dis("scatra")->dof_row_map()->get_epetra_block_map());
     default:
       return CONTACT::NitscheStrategy::setup_rhs_block_vec(bt);
   }

--- a/src/contact/4C_contact_noxinterface.cpp
+++ b/src/contact/4C_contact_noxinterface.cpp
@@ -71,7 +71,7 @@ double CONTACT::NoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vecto
   std::shared_ptr<Core::LinAlg::Vector<double>> constrRhs_red = nullptr;
   // Note: PointSameAs is faster than SameAs and should do the job right here,
   // since we replace the map afterwards anyway.               hiermeier 08/17
-  if (not constrRhs->get_block_map().PointSameAs(strategy().lm_dof_row_map(true).get_epetra_map()))
+  if (not constrRhs->get_map().PointSameAs(strategy().lm_dof_row_map(true).get_epetra_map()))
   {
     constrRhs_red = std::make_shared<Core::LinAlg::Vector<double>>(strategy().lm_dof_row_map(true));
     Core::LinAlg::export_to(*constrRhs, *constrRhs_red);

--- a/src/contact/4C_contact_noxinterface.cpp
+++ b/src/contact/4C_contact_noxinterface.cpp
@@ -71,7 +71,7 @@ double CONTACT::NoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vecto
   std::shared_ptr<Core::LinAlg::Vector<double>> constrRhs_red = nullptr;
   // Note: PointSameAs is faster than SameAs and should do the job right here,
   // since we replace the map afterwards anyway.               hiermeier 08/17
-  if (not constrRhs->get_map().PointSameAs(strategy().lm_dof_row_map(true).get_epetra_map()))
+  if (not constrRhs->get_map().PointSameAs(strategy().lm_dof_row_map(true).get_epetra_block_map()))
   {
     constrRhs_red = std::make_shared<Core::LinAlg::Vector<double>>(strategy().lm_dof_row_map(true));
     Core::LinAlg::export_to(*constrRhs, *constrRhs_red);

--- a/src/contact/4C_contact_wear_interface.cpp
+++ b/src/contact/4C_contact_wear_interface.cpp
@@ -3595,7 +3595,7 @@ void Wear::WearInterface::assemble_inactive_wear_rhs_master(Epetra_FEVector& ina
     }
   }
 
-  Epetra_Export exp(allredi->get_epetra_map(), inactivedofs->get_epetra_map());
+  Epetra_Export exp(allredi->get_epetra_block_map(), inactivedofs->get_epetra_block_map());
   inactiverhs.Export(*rhs, exp, Add);
 
 
@@ -3794,7 +3794,7 @@ void Wear::WearInterface::assemble_wear_cond_rhs_master(Epetra_FEVector& RHS)
     }
   }
 
-  Epetra_Export exp(slmastern->get_epetra_map(), slipmn_->get_epetra_map());
+  Epetra_Export exp(slmastern->get_epetra_block_map(), slipmn_->get_epetra_block_map());
   RHS.Export(*rhs, exp, Add);
 
   return;

--- a/src/contact/4C_contact_wear_interface.cpp
+++ b/src/contact/4C_contact_wear_interface.cpp
@@ -1285,8 +1285,8 @@ void Wear::WearInterface::assemble_lin_stick(Core::LinAlg::SparseMatrix& linstic
       if (cnode->owner() != Core::Communication::my_mpi_rank(get_comm()))
         FOUR_C_THROW("AssembleLinStick: Node ownership inconsistency!");
 
-      cn = cn_ref()[cn_ref().get_block_map().LID(cnode->id())];
-      ct = ct_ref()[ct_ref().get_block_map().LID(cnode->id())];
+      cn = cn_ref()[cn_ref().get_map().LID(cnode->id())];
+      ct = ct_ref()[ct_ref().get_map().LID(cnode->id())];
 
       // prepare assembly, get information from node
       std::vector<Core::Gen::Pairedvector<int, double>> dnmap = cnode->data().get_deriv_n();
@@ -1795,8 +1795,8 @@ void Wear::WearInterface::assemble_lin_slip_w(Core::LinAlg::SparseMatrix& linsli
       if (cnode->owner() != Core::Communication::my_mpi_rank(get_comm()))
         FOUR_C_THROW("AssembleLinSlip: Node ownership inconsistency!");
 
-      cn = cn_ref()[cn_ref().get_block_map().LID(cnode->id())];
-      ct = ct_ref()[ct_ref().get_block_map().LID(cnode->id())];
+      cn = cn_ref()[cn_ref().get_map().LID(cnode->id())];
+      ct = ct_ref()[ct_ref().get_map().LID(cnode->id())];
 
       // prepare assembly, get information from node
       std::vector<Core::Gen::Pairedvector<int, double>> dnmap = cnode->data().get_deriv_n();
@@ -1980,8 +1980,8 @@ void Wear::WearInterface::assemble_lin_slip(Core::LinAlg::SparseMatrix& linslipL
       if (cnode->owner() != Core::Communication::my_mpi_rank(get_comm()))
         FOUR_C_THROW("AssembleLinSlip: Node ownership inconsistency!");
 
-      cn = cn_ref()[cn_ref().get_block_map().LID(cnode->id())];
-      ct = ct_ref()[ct_ref().get_block_map().LID(cnode->id())];
+      cn = cn_ref()[cn_ref().get_map().LID(cnode->id())];
+      ct = ct_ref()[ct_ref().get_map().LID(cnode->id())];
 
       // prepare assembly, get information from node
       std::vector<Core::Gen::Pairedvector<int, double>> dnmap = cnode->data().get_deriv_n();
@@ -2813,8 +2813,8 @@ void Wear::WearInterface::assemble_lin_w_lm_st(Core::LinAlg::SparseMatrix& sglob
     if (cnode->owner() != Core::Communication::my_mpi_rank(get_comm()))
       FOUR_C_THROW("Node ownership inconsistency!");
 
-    cn = cn_ref()[cn_ref().get_block_map().LID(cnode->id())];
-    ct = ct_ref()[ct_ref().get_block_map().LID(cnode->id())];
+    cn = cn_ref()[cn_ref().get_map().LID(cnode->id())];
+    ct = ct_ref()[ct_ref().get_map().LID(cnode->id())];
 
     // prepare assembly, get information from node
     std::map<int, double>& dwmap = cnode->data().get_deriv_wlm();
@@ -2898,8 +2898,8 @@ void Wear::WearInterface::assemble_lin_w_lm_sl(Core::LinAlg::SparseMatrix& sglob
     if (cnode->owner() != Core::Communication::my_mpi_rank(get_comm()))
       FOUR_C_THROW("AssembleLinSlip: Node ownership inconsistency!");
 
-    cn = cn_ref()[cn_ref().get_block_map().LID(cnode->id())];
-    ct = ct_ref()[ct_ref().get_block_map().LID(cnode->id())];
+    cn = cn_ref()[cn_ref().get_map().LID(cnode->id())];
+    ct = ct_ref()[ct_ref().get_map().LID(cnode->id())];
 
     // prepare assembly, get information from node
     std::map<int, double>& dwmap = cnode->data().get_deriv_wlm();

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -1436,7 +1436,8 @@ void Core::Binstrategy::BinningStrategy::standard_discretization_ghosting(
   std::shared_ptr<Core::LinAlg::Graph> newnodegraph;
 
   newnodegraph = std::make_shared<Core::LinAlg::Graph>(Copy, *newnoderowmap, 108, false);
-  Epetra_Export exporter(initgraph->row_map().get_epetra_map(), newnoderowmap->get_epetra_map());
+  Epetra_Export exporter(
+      initgraph->row_map().get_epetra_block_map(), newnoderowmap->get_epetra_block_map());
   int err = newnodegraph->export_to(initgraph->get_epetra_crs_graph(), exporter, Add);
   if (err < 0) FOUR_C_THROW("Graph export returned err={}", err);
   newnodegraph->fill_complete();

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -832,8 +832,8 @@ void Core::Binstrategy::BinningStrategy::distribute_bins_recurs_coord_bisection(
       Core::Rebalance::rebalance_coordinates(*bincenters, params, *binweights);
 
   // create bin row map
-  binrowmap = std::make_shared<Core::LinAlg::Map>(-1, bincenters->Map().NumMyElements(),
-      bincenters->Map().MyGlobalElements(), 0, bin_discret()->get_comm());
+  binrowmap = std::make_shared<Core::LinAlg::Map>(-1, bincenters->get_map().NumMyElements(),
+      bincenters->get_map().MyGlobalElements(), 0, bin_discret()->get_comm());
 }
 
 void Core::Binstrategy::BinningStrategy::fill_bins_into_bin_discretization(
@@ -1247,7 +1247,7 @@ Core::Binstrategy::BinningStrategy::weighted_distribution_of_bins_to_procs(
   auto balanced_bingraph = Core::Rebalance::rebalance_graph(*bingraph, paramlist, vweights);
 
   // extract repartitioned bin row map
-  const Epetra_BlockMap& rbinstmp = balanced_bingraph->row_map();
+  const Core::LinAlg::Map& rbinstmp = balanced_bingraph->row_map();
   std::shared_ptr<Core::LinAlg::Map> newrowbins = std::make_shared<Core::LinAlg::Map>(
       -1, rbinstmp.NumMyElements(), rbinstmp.MyGlobalElements(), 0, discret[0]->get_comm());
 
@@ -1436,14 +1436,14 @@ void Core::Binstrategy::BinningStrategy::standard_discretization_ghosting(
   std::shared_ptr<Core::LinAlg::Graph> newnodegraph;
 
   newnodegraph = std::make_shared<Core::LinAlg::Graph>(Copy, *newnoderowmap, 108, false);
-  Epetra_Export exporter(initgraph->row_map(), newnoderowmap->get_epetra_map());
+  Epetra_Export exporter(initgraph->row_map().get_epetra_map(), newnoderowmap->get_epetra_map());
   int err = newnodegraph->export_to(initgraph->get_epetra_crs_graph(), exporter, Add);
   if (err < 0) FOUR_C_THROW("Graph export returned err={}", err);
   newnodegraph->fill_complete();
   newnodegraph->optimize_storage();
 
   // the column map will become the new ghosted distribution of nodes (standard ghosting)
-  const Epetra_BlockMap cntmp = newnodegraph->col_map();
+  const Core::LinAlg::Map cntmp = newnodegraph->col_map();
   stdnodecolmap = std::make_shared<Core::LinAlg::Map>(
       -1, cntmp.NumMyElements(), cntmp.MyGlobalElements(), 0, discret->get_comm());
 

--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -248,7 +248,7 @@ namespace Core::Binstrategy::Utils
     if (disnp != nullptr)
     {
       const int gid = discret.dof(node, 0);
-      const int lid = disnp->get_block_map().LID(gid);
+      const int lid = disnp->get_map().LID(gid);
       if (lid < 0)
         FOUR_C_THROW(
             "Your displacement is incomplete (need to be based on a column map"

--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -361,7 +361,8 @@ namespace Core::Communication
           vecmap, Core::Communication::num_mpi_ranks(lcomm) - 1);
 
     // export full vectors to the two desired processors
-    Core::LinAlg::MultiVector<double> fullvec(proc0map->get_epetra_map(), vec.NumVectors(), true);
+    Core::LinAlg::MultiVector<double> fullvec(
+        proc0map->get_epetra_block_map(), vec.NumVectors(), true);
     Core::LinAlg::export_to(vec, fullvec);
 
     const int myglobalrank = Core::Communication::my_mpi_rank(gcomm);
@@ -509,7 +510,8 @@ namespace Core::Communication
           domainmap, Core::Communication::num_mpi_ranks(lcomm) - 1);
 
     // export full matrices to the two desired processors
-    Epetra_Import serialimporter(serialrowmap->get_epetra_map(), rowmap.get_epetra_map());
+    Epetra_Import serialimporter(
+        serialrowmap->get_epetra_block_map(), rowmap.get_epetra_block_map());
     Core::LinAlg::SparseMatrix serialCrsMatrix(*serialrowmap, 0);
     serialCrsMatrix.import(matrix, serialimporter, Insert);
     serialCrsMatrix.complete(*serialdomainmap, *serialrowmap);

--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -14,7 +14,6 @@
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 
 #include <Epetra_Import.h>
-#include <Epetra_Map.h>
 
 #include <iomanip>
 #include <sstream>
@@ -348,8 +347,8 @@ namespace Core::Communication
       return false;
     }
 
-    // do stupid conversion from Epetra_BlockMap to Core::LinAlg::Map
-    const Epetra_BlockMap& vecblockmap = vec.Map();
+    // do stupid conversion from Core::LinAlg::Map to Core::LinAlg::Map
+    const Core::LinAlg::Map& vecblockmap = vec.get_map();
     Core::LinAlg::Map vecmap(vecblockmap.NumGlobalElements(), vecblockmap.NumMyElements(),
         vecblockmap.MyGlobalElements(), 0, vec.Comm());
 
@@ -423,7 +422,7 @@ namespace Core::Communication
           std::stringstream diff;
           diff << std::scientific << std::setprecision(16) << maxdiff;
           std::cout << "vectors " << name << " do not match, difference in row "
-                    << fullvec.Map().GID(i) << " between entries is: " << diff.str().c_str()
+                    << fullvec.get_map().GID(i) << " between entries is: " << diff.str().c_str()
                     << std::endl;
         }
         maxdiff = std::max(maxdiff, difference);

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
@@ -618,7 +618,7 @@ void Core::Conditions::LocsysManager::calc_rotation_vector_for_normal_system(
     double length = 0.0;
     for (int jdim = 0; jdim < dim_; jdim++)
     {
-      const int localId = massConsistentNodeNormals->get_block_map().LID(nodeGIDs[jdim]);
+      const int localId = massConsistentNodeNormals->get_map().LID(nodeGIDs[jdim]);
       nodeNormal(jdim, 0) = (*massConsistentNodeNormals)[localId];
       length += nodeNormal(jdim, 0) * nodeNormal(jdim, 0);
     }

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -1134,7 +1134,7 @@ void Core::Conditions::PeriodicBoundaryConditions::redistribute_and_create_dof_c
     nodegraph.optimize_storage();
 
     // build nodecolmap for new distribution of nodes
-    const Epetra_BlockMap cntmp = nodegraph.col_map();
+    const Core::LinAlg::Map cntmp = nodegraph.col_map();
 
     std::shared_ptr<Core::LinAlg::Map> newcolnodemap;
 
@@ -1499,7 +1499,7 @@ void Core::Conditions::PeriodicBoundaryConditions::balance_load()
     if (numproc > 1)
     {
       // get rowmap of the graph  (from blockmap -> map)
-      const Epetra_BlockMap& graph_row_map = nodegraph->row_map();
+      const Core::LinAlg::Map& graph_row_map = nodegraph->row_map();
       const Core::LinAlg::Map graph_rowmap(graph_row_map.NumGlobalElements(),
           graph_row_map.NumMyElements(), graph_row_map.MyGlobalElements(), 0,
           Core::Communication::unpack_epetra_comm(nodegraph->get_comm()));

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -1126,7 +1126,7 @@ void Core::Conditions::PeriodicBoundaryConditions::redistribute_and_create_dof_c
 
     {
       Epetra_Export exporter(
-          discret_->node_row_map()->get_epetra_map(), newrownodemap->get_epetra_map());
+          discret_->node_row_map()->get_epetra_block_map(), newrownodemap->get_epetra_block_map());
       int err = nodegraph.export_to(oldnodegraph->get_epetra_crs_graph(), exporter, Add);
       if (err < 0) FOUR_C_THROW("Graph export returned err={}", err);
     }
@@ -1505,8 +1505,7 @@ void Core::Conditions::PeriodicBoundaryConditions::balance_load()
           Core::Communication::unpack_epetra_comm(nodegraph->get_comm()));
 
       // set standard value of edge weight to 1.0
-      auto edge_weights =
-          std::make_shared<Core::LinAlg::SparseMatrix>(graph_rowmap.get_epetra_map(), 15);
+      auto edge_weights = std::make_shared<Core::LinAlg::SparseMatrix>(graph_rowmap, 15);
       for (int i = 0; i < nodegraph->num_local_rows(); ++i)
       {
         const int grow = nodegraph->row_map().GID(i);

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -515,7 +515,7 @@ void Core::FE::Discretization::set_state(
   // This is a rough test, but it might be ok at this place. It is an
   // error anyway to hand in a vector that is not related to our dof
   // maps.
-  if (vecmap.PointSameAs(colmap->get_epetra_map()))
+  if (vecmap.PointSameAs(colmap->get_epetra_block_map()))
   {
     FOUR_C_ASSERT(colmap->SameAs(vecmap),
         "col map of discretization {} and state vector {} are different. This is a fatal bug!",
@@ -540,11 +540,11 @@ void Core::FE::Discretization::set_state(
     }
     // (re)build importer if necessary
     if (stateimporter_[nds] == nullptr or
-        not stateimporter_[nds]->SourceMap().SameAs(state.get_map().get_epetra_map()) or
-        not stateimporter_[nds]->TargetMap().SameAs(colmap->get_epetra_map()))
+        not stateimporter_[nds]->SourceMap().SameAs(state.get_map().get_epetra_block_map()) or
+        not stateimporter_[nds]->TargetMap().SameAs(colmap->get_epetra_block_map()))
     {
       stateimporter_[nds] = std::make_shared<Epetra_Import>(
-          colmap->get_epetra_map(), state.get_map().get_epetra_map());
+          colmap->get_epetra_block_map(), state.get_map().get_epetra_block_map());
     }
 
     // transfer data
@@ -785,7 +785,7 @@ void Core::FE::Discretization::add_multi_vector_to_parameter_list(Teuchos::Param
 
     // if it's already in column map just copy it
     // This is a rough test, but it might be ok at this place.
-    if (vec->get_map().PointSameAs(nodecolmap->get_epetra_map()))
+    if (vec->get_map().PointSameAs(nodecolmap->get_epetra_block_map()))
     {
       // make a copy as in parallel such that no additional RCP points to the state vector
       std::shared_ptr<Core::LinAlg::MultiVector<double>> tmp =

--- a/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
@@ -226,7 +226,7 @@ void Core::FE::Discretization::evaluate_neumann(Teuchos::ParameterList& params,
             });
 
         value *= functfac;
-        const int lid = systemvector.get_block_map().LID(gid);
+        const int lid = systemvector.get_map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Global id {} not on this proc in system vector", gid);
         systemvector[lid] += value;
       }
@@ -626,7 +626,7 @@ void Core::FE::Discretization::evaluate_scalars(
     // pointer to current element
     Core::Elements::Element* actele = l_row_element(i);
 
-    if (!scalars.Map().MyGID(actele->id()))
+    if (!scalars.get_map().MyGID(actele->id()))
       FOUR_C_THROW("Proc does not have global element {}", actele->id());
 
     // get element location vector

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
@@ -374,7 +374,7 @@ void Core::FE::Utils::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterL
         // get global id
         const int gid = dofs[j];
         // get corresponding local id
-        const int lid = info.toggle.get_block_map().LID(gid);
+        const int lid = info.toggle.get_map().LID(gid);
         if (lid < 0)
           FOUR_C_THROW("Global id {} not on this proc {} in system vector", dofs[j],
               Core::Communication::my_mpi_rank(discret.get_comm()));
@@ -572,7 +572,7 @@ void Core::FE::Utils::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterLis
         // get global id
         const int gid = dofs[j];
         // get corresponding local id
-        const int lid = toggle.get_block_map().LID(gid);
+        const int lid = toggle.get_map().LID(gid);
         if (lid < 0)
           FOUR_C_THROW("Global id {} not on this proc {} in system vector", dofs[j],
               Core::Communication::my_mpi_rank(discret.get_comm()));

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -98,7 +98,7 @@ void Core::FE::Discretization::proc_zero_distribute_elements_to_all(
   int size = (int)gidlist.size();
   std::vector<int> pidlist(size);  // gids on proc 0
   int err = target.RemoteIDList(size, gidlist.data(), pidlist.data(), nullptr);
-  if (err < 0) FOUR_C_THROW("Epetra_BlockMap::RemoteIDList returned err={}", err);
+  if (err < 0) FOUR_C_THROW("Core::LinAlg::Map::RemoteIDList returned err={}", err);
 
   std::map<int, std::vector<char>> sendmap;  // proc to send a set of elements to
   if (!myrank)
@@ -198,7 +198,7 @@ void Core::FE::Discretization::proc_zero_distribute_nodes_to_all(Core::LinAlg::M
   std::vector<int> pidlist(size, -1);
   {
     int err = target.RemoteIDList(size, oldmap.MyGlobalElements(), pidlist.data(), nullptr);
-    if (err) FOUR_C_THROW("Epetra_BlockMap::RemoteIDLis returned err={}", err);
+    if (err) FOUR_C_THROW("Core::LinAlg::Map::RemoteIDLis returned err={}", err);
   }
 
   std::map<int, std::vector<char>> sendmap;
@@ -443,7 +443,7 @@ Core::FE::Discretization::build_element_row_column(const Core::LinAlg::Map& node
   std::vector<int> cnodeowner(ncnode);
   int err =
       noderowmap.RemoteIDList(ncnode, nodecolmap.MyGlobalElements(), cnodeowner.data(), nullptr);
-  if (err) FOUR_C_THROW("Epetra_BlockMap::RemoteIDLis returned err={}", err);
+  if (err) FOUR_C_THROW("Core::LinAlg::Map::RemoteIDLis returned err={}", err);
 
   // build connectivity of elements
   // storing :  element gid
@@ -874,9 +874,8 @@ void Core::FE::Discretization::setup_ghosting(
   if (err) FOUR_C_THROW("graph->GlobalAssemble returned {}", err);
 
   // replace rownodes, colnodes with row and column maps from the graph
-  // do stupid conversion from Epetra_BlockMap to Core::LinAlg::Map
-  const Epetra_BlockMap& brow = graph->row_map();
-  const Epetra_BlockMap& bcol = graph->col_map();
+  const Core::LinAlg::Map& brow = graph->row_map();
+  const Core::LinAlg::Map& bcol = graph->col_map();
   Core::LinAlg::Map noderowmap(
       brow.NumGlobalElements(), brow.NumMyElements(), brow.MyGlobalElements(), 0, comm_);
   Core::LinAlg::Map nodecolmap(

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -845,7 +845,7 @@ void Core::FE::Discretization::setup_ghosting(
   // Construct FE graph. This graph allows processor off-rows to be inserted
   // as well. The communication issue is solved.
 
-  auto graph = std::make_shared<Core::LinAlg::Graph>(Copy, rownodes.get_epetra_map(),
+  auto graph = std::make_shared<Core::LinAlg::Graph>(Copy, rownodes.get_epetra_block_map(),
       entriesperrow.data(), false, Core::LinAlg::Graph::GraphType::FE_GRAPH);
 
   gids.clear();

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
@@ -111,7 +111,7 @@ void Core::FE::Utils::do_initial_field(const Core::Utils::FunctionManager& funct
 
           // assign value
           const int gid = node_dofs[j];
-          const int lid = fieldvector.get_block_map().LID(gid);
+          const int lid = fieldvector.get_map().LID(gid);
           if (lid < 0) FOUR_C_THROW("Global id {} not on this proc in system vector", gid);
           fieldvector[lid] = functfac;
         }

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
@@ -164,9 +164,9 @@ namespace Core::FE
          */
         DbcInfo(const Core::LinAlg::Vector<int>& toggle_input)
             : toggle(toggle_input),
-              hierarchy(Core::LinAlg::Vector<int>(toggle_input.get_block_map())),
-              condition(Core::LinAlg::Vector<int>(toggle_input.get_block_map())),
-              values(Core::LinAlg::Vector<double>(toggle_input.get_block_map(), true))
+              hierarchy(Core::LinAlg::Vector<int>(toggle_input.get_map())),
+              condition(Core::LinAlg::Vector<int>(toggle_input.get_map())),
+              values(Core::LinAlg::Vector<double>(toggle_input.get_map(), true))
         {
           hierarchy.put_value(std::numeric_limits<int>::max());
           condition.put_value(-1);
@@ -176,7 +176,7 @@ namespace Core::FE
          * \brief constructor using the vector map as input
          * \note all the vectors use the same map
          */
-        DbcInfo(const Epetra_BlockMap& toggle_map)
+        DbcInfo(const Core::LinAlg::Map& toggle_map)
             : toggle(Core::LinAlg::Vector<int>(toggle_map)),
               hierarchy(Core::LinAlg::Vector<int>(toggle_map)),
               condition(Core::LinAlg::Vector<int>(toggle_map)),

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
@@ -117,15 +117,15 @@ std::shared_ptr<Core::LinAlg::Vector<int>> Core::FE::Utils::Dbc::create_toggle_v
   {
     if (systemvectors[0])
     {
-      toggleaux = std::make_shared<Core::LinAlg::Vector<int>>(systemvectors[0]->get_block_map());
+      toggleaux = std::make_shared<Core::LinAlg::Vector<int>>(systemvectors[0]->get_map());
     }
     else if (systemvectors[1])
     {
-      toggleaux = std::make_shared<Core::LinAlg::Vector<int>>(systemvectors[1]->get_block_map());
+      toggleaux = std::make_shared<Core::LinAlg::Vector<int>>(systemvectors[1]->get_map());
     }
     else if (systemvectors[2])
     {
-      toggleaux = std::make_shared<Core::LinAlg::Vector<int>>(systemvectors[2]->get_block_map());
+      toggleaux = std::make_shared<Core::LinAlg::Vector<int>>(systemvectors[2]->get_map());
     }
     else if (systemvectors[0] == nullptr and systemvectors[1] == nullptr and
              systemvectors[2] == nullptr)
@@ -299,7 +299,7 @@ void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList
       const int gid = dofs[j];
 
       // get corresponding lid
-      const int lid = info.toggle.get_block_map().LID(gid);
+      const int lid = info.toggle.get_map().LID(gid);
       if (lid < 0)
         FOUR_C_THROW("Global id {} not on this proc {} in system vector", dofs[j],
             Core::Communication::my_mpi_rank(discret.get_comm()));
@@ -514,7 +514,7 @@ void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& 
       // get dof gid
       const int gid = dofs[j];
       // get corresponding lid
-      const int lid = toggle.get_block_map().LID(gid);
+      const int lid = toggle.get_map().LID(gid);
       if (lid < 0)
         FOUR_C_THROW("Global id {} not on this proc {} in system vector", dofs[j],
             Core::Communication::my_mpi_rank(discret.get_comm()));

--- a/src/core/fem/src/dofset/4C_fem_dofset.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset.cpp
@@ -357,8 +357,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
       // **********************************************************************
     }
 
-    Epetra_Import nodeimporter(
-        numdfcolnodes_->get_map().get_epetra_map(), num_dof_rownodes.get_map().get_epetra_map());
+    Epetra_Import nodeimporter(numdfcolnodes_->get_map().get_epetra_block_map(),
+        num_dof_rownodes.get_map().get_epetra_block_map());
     int err = numdfcolnodes_->import(num_dof_rownodes, nodeimporter, Insert);
     if (err) FOUR_C_THROW("Import using importer returned err={}", err);
     err = idxcolnodes_->import(idxrownodes, nodeimporter, Insert);
@@ -417,8 +417,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
           }
       }
 
-      Epetra_Import faceimporter(
-          numdfcolfaces_->get_map().get_epetra_map(), numdfrowfaces.get_map().get_epetra_map());
+      Epetra_Import faceimporter(numdfcolfaces_->get_map().get_epetra_block_map(),
+          numdfrowfaces.get_map().get_epetra_block_map());
       err = numdfcolfaces_->import(numdfrowfaces, faceimporter, Insert);
       if (err) FOUR_C_THROW("Import using importer returned err={}", err);
       err = idxcolfaces_->import(idxrowfaces, faceimporter, Insert);
@@ -460,8 +460,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
       }
     }
 
-    Epetra_Import elementimporter(
-        numdfcolelements_->get_map().get_epetra_map(), numdfrowelements.get_map().get_epetra_map());
+    Epetra_Import elementimporter(numdfcolelements_->get_map().get_epetra_block_map(),
+        numdfrowelements.get_map().get_epetra_block_map());
     err = numdfcolelements_->import(numdfrowelements, elementimporter, Insert);
     if (err) FOUR_C_THROW("Import using importer returned err={}", err);
     err = idxcolelements_->import(idxrowelements, elementimporter, Insert);

--- a/src/core/fem/src/dofset/4C_fem_dofset.cpp
+++ b/src/core/fem/src/dofset/4C_fem_dofset.cpp
@@ -357,7 +357,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
       // **********************************************************************
     }
 
-    Epetra_Import nodeimporter(numdfcolnodes_->get_block_map(), num_dof_rownodes.get_block_map());
+    Epetra_Import nodeimporter(
+        numdfcolnodes_->get_map().get_epetra_map(), num_dof_rownodes.get_map().get_epetra_map());
     int err = numdfcolnodes_->import(num_dof_rownodes, nodeimporter, Insert);
     if (err) FOUR_C_THROW("Import using importer returned err={}", err);
     err = idxcolnodes_->import(idxrownodes, nodeimporter, Insert);
@@ -416,7 +417,8 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
           }
       }
 
-      Epetra_Import faceimporter(numdfcolfaces_->get_block_map(), numdfrowfaces.get_block_map());
+      Epetra_Import faceimporter(
+          numdfcolfaces_->get_map().get_epetra_map(), numdfrowfaces.get_map().get_epetra_map());
       err = numdfcolfaces_->import(numdfrowfaces, faceimporter, Insert);
       if (err) FOUR_C_THROW("Import using importer returned err={}", err);
       err = idxcolfaces_->import(idxrowfaces, faceimporter, Insert);
@@ -459,7 +461,7 @@ int Core::DOFSets::DofSet::assign_degrees_of_freedom(
     }
 
     Epetra_Import elementimporter(
-        numdfcolelements_->get_block_map(), numdfrowelements.get_block_map());
+        numdfcolelements_->get_map().get_epetra_map(), numdfrowelements.get_map().get_epetra_map());
     err = numdfcolelements_->import(numdfrowelements, elementimporter, Insert);
     if (err) FOUR_C_THROW("Import using importer returned err={}", err);
     err = idxcolelements_->import(idxrowelements, elementimporter, Insert);

--- a/src/core/fem/src/general/element/4C_fem_general_element.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.cpp
@@ -799,7 +799,7 @@ Core::GeometricSearch::BoundingVolume Core::Elements::Element::get_bounding_volu
 
     for (unsigned int i_dir = 0; i_dir < 3; ++i_dir)
     {
-      const int lid = result_data_dofbased.get_block_map().LID(nodedofs[i_dir]);
+      const int lid = result_data_dofbased.get_map().LID(nodedofs[i_dir]);
 
       if (lid > -1)
         point(i_dir) = node->x()[i_dir] + result_data_dofbased[lid];

--- a/src/core/fem/src/general/element/4C_fem_general_utils_gauss_point_postprocess.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_utils_gauss_point_postprocess.cpp
@@ -40,7 +40,7 @@ void Core::FE::assemble_gauss_point_values(
 {
   for (int gp = 0; gp < gp_data.numRows(); ++gp)
   {
-    const Epetra_BlockMap& elemap = global_data[gp]->Map();
+    const Core::LinAlg::Map& elemap = global_data[gp]->get_map();
     int lid = elemap.LID(ele.id());
     if (lid != -1)
     {
@@ -57,7 +57,7 @@ void Core::FE::assemble_nodal_element_count(
 {
   for (int n = 0; n < ele.num_node(); ++n)
   {
-    const int lid = global_count.get_block_map().LID(ele.node_ids()[n]);
+    const int lid = global_count.get_map().LID(ele.node_ids()[n]);
 
     if (lid != -1)
     {

--- a/src/core/fem/src/general/element/4C_fem_general_utils_gauss_point_postprocess.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_utils_gauss_point_postprocess.hpp
@@ -89,7 +89,8 @@ namespace Core::FE
   void assemble_averaged_element_values(Core::LinAlg::MultiVector<double>& global_data,
       const T& gp_data, const Core::Elements::Element& ele)
   {
-    const Epetra_BlockMap& elemap = global_data.Map();
+    const Core::LinAlg::Map& elemap = global_data.get_map();
+
     int lid = elemap.LID(ele.id());
     if (lid != -1)
     {

--- a/src/core/fem/src/general/utils/4C_fem_general_extract_values.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_extract_values.cpp
@@ -26,7 +26,7 @@ void Core::FE::extract_my_values(const Core::LinAlg::Vector<double>& global,
   local.size(ldim);
   for (size_t i = 0; i < ldim; ++i)
   {
-    const int lid = global.get_block_map().LID(lm[i]);
+    const int lid = global.get_map().LID(lm[i]);
     if (lid < 0)
       FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
           Core::Communication::my_mpi_rank(global.get_comm()), lm[i]);
@@ -49,7 +49,7 @@ void Core::FE::extract_my_node_based_values(const Core::Elements::Element* ele,
   for (int i = 0; i < numnode; ++i)
   {
     const int nodegid = (ele->nodes()[i])->id();
-    const int lid = global.Map().LID(nodegid);
+    const int lid = global.get_map().LID(nodegid);
     if (lid < 0)
       FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
           Core::Communication::my_mpi_rank(global.Comm()), nodegid);
@@ -82,7 +82,7 @@ void Core::FE::extract_my_node_based_values(const Core::Elements::Element* ele,
     for (int j = 0; j < iel; j++)
     {
       const int nodegid = (ele->nodes()[j])->id();
-      const int lid = global.Map().LID(nodegid);
+      const int lid = global.get_map().LID(nodegid);
       if (lid < 0)
         FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::MultiVector<double>",
             Core::Communication::my_mpi_rank(global.Comm()), nodegid);

--- a/src/core/fem/src/general/utils/4C_fem_general_extract_values.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_extract_values.hpp
@@ -33,7 +33,7 @@ namespace Core::FE
     {
       return [&](int global_id)
       {
-        const int local_id = global.get_block_map().LID(global_id);
+        const int local_id = global.get_map().LID(global_id);
         FOUR_C_ASSERT_ALWAYS(local_id >= 0,
             "Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
             Core::Communication::my_mpi_rank(global.get_comm()), global_id);
@@ -106,7 +106,7 @@ namespace Core::FE
     std::vector<T> local(ldim * numcol);
     for (size_t i = 0; i < ldim; ++i)
     {
-      const int lid = global.Map().LID(global_ids[i]);
+      const int lid = global.get_map().LID(global_ids[i]);
       FOUR_C_ASSERT_ALWAYS(lid >= 0,
           "Proc {}: Cannot find gid={} in Core::LinAlg::MultiVector<double>",
           Core::Communication::my_mpi_rank(global.Comm()), global_ids[i]);
@@ -139,7 +139,7 @@ namespace Core::FE
       for (unsigned idof = 0; idof < local.size(); ++idof)
       {
         // extract local ID of current dof
-        const int lid = global.get_block_map().LID(lm[inode * local.size() + idof]);
+        const int lid = global.get_map().LID(lm[inode * local.size() + idof]);
 
         // safety check
         if (lid < 0)
@@ -170,7 +170,7 @@ namespace Core::FE
       {
         // extract local ID of current dof
         const unsigned index = icol * local.num_rows() + irow;
-        const int lid = global.get_block_map().LID(lm[index]);
+        const int lid = global.get_map().LID(lm[index]);
 
         // safety check
         if (lid < 0)
@@ -227,7 +227,7 @@ namespace Core::FE
       for (int j = 0; j < iel; j++)
       {
         const int nodegid = (ele->nodes()[j])->id();
-        const int lid = global.Map().LID(nodegid);
+        const int lid = global.get_map().LID(nodegid);
         if (lid < 0)
           FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
               Core::Communication::my_mpi_rank((global).Comm()), nodegid);
@@ -255,7 +255,7 @@ namespace Core::FE
     for (int i = 0; i < numnode; ++i)
     {
       const int nodegid = (ele->nodes()[i])->id();
-      const int lid = global.Map().LID(nodegid);
+      const int lid = global.get_map().LID(nodegid);
       if (lid < 0)
         FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
             Core::Communication::my_mpi_rank(global.Comm()), nodegid);

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_gauss_point_extrapolation.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_gauss_point_extrapolation.cpp
@@ -270,7 +270,7 @@ namespace
   {
     for (decltype(nodal_data.numRows()) i = 0; i < nodal_data.numRows(); ++i)
     {
-      const int lid = global_data.Map().LID(ele.node_ids()[i]);
+      const int lid = global_data.get_map().LID(ele.node_ids()[i]);
       if (lid >= 0)  // rownode
       {
         const double invmyadjele = (nodal_average) ? 1.0 / ele.nodes()[i]->num_element() : 1.0;

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
     FOUR_C_THROW("action type for element is missing");
 
   // decide whether a dof or an element based map is given
-  FOUR_C_ASSERT(state.get_map().PointSameAs(dis.dof_row_map()->get_epetra_map()),
+  FOUR_C_ASSERT(state.get_map().PointSameAs(dis.dof_row_map()->get_epetra_block_map()),
       "Only works for same maps.");
 
   // handle pbcs if existing
@@ -153,7 +153,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
 
   // step 2: use precalculated (velocity) gradient for patch-recovery of gradient
   // solution vector based on reduced node row map
-  Epetra_FEVector nodevec(noderowmap.get_epetra_map(), numvec);
+  Epetra_FEVector nodevec(noderowmap.get_epetra_block_map(), numvec);
 
   std::vector<const Core::Conditions::Condition*> conds;
   dis.get_condition("SPRboundary", conds);

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -36,7 +36,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
     FOUR_C_THROW("action type for element is missing");
 
   // decide whether a dof or an element based map is given
-  FOUR_C_ASSERT(state.get_block_map().PointSameAs(dis.dof_row_map()->get_epetra_map()),
+  FOUR_C_ASSERT(state.get_map().PointSameAs(dis.dof_row_map()->get_epetra_map()),
       "Only works for same maps.");
 
   // handle pbcs if existing
@@ -204,7 +204,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
           // loop over all surrounding elements
           for (int k = 0; k < numadjacent; ++k)
           {
-            const int elelid = elevec_toberecovered_col.Map().LID(adjacentele[k]->id());
+            const int elelid = elevec_toberecovered_col.get_map().LID(adjacentele[k]->id());
             for (int d = 0; d < dim; ++d)
               p(d + 1) = centercoords_col(d)[elelid] - node->x()[d] /* + ALE_DISP*/;
 
@@ -273,7 +273,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
           {
             for (int k = 0; k < numadjacenteles[s]; ++k)
             {
-              const int elelid = elevec_toberecovered_col.Map().LID(adjacenteles[s][k]->id());
+              const int elelid = elevec_toberecovered_col.get_map().LID(adjacenteles[s][k]->id());
               for (int d = 0; d < dim; ++d)
                 p(d + 1) =
                     (centercoords_col(d))[elelid] + eleoffsets[s][d] - node->x()[d] /* + ALE_DISP*/;
@@ -364,7 +364,8 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
           // loop over all surrounding elements
           for (int k = 0; k < numadjacent; ++k)
           {
-            const int elelid = elevec_toberecovered_col.Map().LID(closestnodeadjacentele[k]->id());
+            const int elelid =
+                elevec_toberecovered_col.get_map().LID(closestnodeadjacentele[k]->id());
             for (int d = 0; d < dim; ++d)
               p(d + 1) = (centercoords_col(d))[elelid] - closestnode->x()[d]; /* + ALE_DISP*/
 
@@ -504,7 +505,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
             for (int k = 0; k < numadjacenteles[s]; ++k)
             {
               const int elelid =
-                  elevec_toberecovered_col.Map().LID(closestnodeadjacenteles[s][k]->id());
+                  elevec_toberecovered_col.get_map().LID(closestnodeadjacenteles[s][k]->id());
               for (int d = 0; d < dim; ++d)
                 p(d + 1) = (centercoords_col(d))[elelid] + eleoffsets[s][d] -
                            closestnode->x()[d]; /* + ALE_DISP*/

--- a/src/core/fem/src/geometry/4C_fem_geometry_periodic_boundingbox.cpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_periodic_boundingbox.cpp
@@ -674,7 +674,7 @@ Core::LinAlg::Matrix<3, 1> Core::Geo::MeshFree::BoundingBox::current_position_of
     std::vector<int> dofnode = boxdiscret_->dof(node_i);
 
     for (int dim = 0; dim < 3; ++dim)
-      x(dim) = node_i->x()[dim] + (*disn_col_)[disn_col_->get_block_map().LID(dofnode[dim])];
+      x(dim) = node_i->x()[dim] + (*disn_col_)[disn_col_->get_map().LID(dofnode[dim])];
   }
   else
   {

--- a/src/core/fem/src/geometry/4C_fem_geometry_update_reference_config.cpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_update_reference_config.cpp
@@ -29,12 +29,12 @@ void Core::Geo::update_reference_config_with_disp(
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     FOUR_C_ASSERT(static_cast<int>(ndim * dis.node_row_map()->NumGlobalElements()) ==
-                      disp.get_block_map().NumGlobalElements(),
+                      disp.get_map().NumGlobalElements(),
         "Number of space dimensions does not fit to displacement vector.");
 
-    for (int disp_lid = 0; disp_lid < disp.get_block_map().NumMyElements(); ++disp_lid)
+    for (int disp_lid = 0; disp_lid < disp.get_map().NumMyElements(); ++disp_lid)
     {
-      const int disp_gid = disp.get_block_map().GID(disp_lid);
+      const int disp_gid = disp.get_map().GID(disp_lid);
       FOUR_C_ASSERT(
           dis.dof_row_map()->LID(disp_gid) >= 0, "Displacement dofs not part of dof_row_map()");
     }
@@ -47,7 +47,7 @@ void Core::Geo::update_reference_config_with_disp(
     for (unsigned int i = 0; i < ndim; ++i)
     {
       const int gid = globaldofs[0] + static_cast<int>(i);
-      const int lid = coldisp.get_block_map().LID(gid);
+      const int lid = coldisp.get_map().LID(gid);
 
       FOUR_C_ASSERT(lid >= 0, "Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
           Core::Communication::my_mpi_rank(coldisp.get_comm()), globaldofs[i]);

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
@@ -119,7 +119,7 @@ void Core::FE::Utils::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
     std::copy(curr_conds.begin(), curr_conds.end(), std::back_inserter(conds));
   }
 
-  Core::FE::Utils::Dbc::DbcInfo info2(info.toggle.get_block_map());
+  Core::FE::Utils::Dbc::DbcInfo info2(info.toggle.get_map());
   read_dirichlet_condition(params, discret, conds, time, info2, dbcgids);
 
   // --------------------------- Step 3 ---------------------------------------
@@ -136,7 +136,7 @@ void Core::FE::Utils::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
   if (not discret_nurbs) FOUR_C_THROW("Dynamic cast failed!");
 
   // build dummy column toggle vector and auxiliary vectors
-  Core::FE::Utils::Dbc::DbcInfo info_col(discret_nurbs->dof_col_map()->get_epetra_map());
+  Core::FE::Utils::Dbc::DbcInfo info_col(*discret_nurbs->dof_col_map());
   read_dirichlet_condition(params, discret, conds, time, info_col, dbcgids_nurbs);
 
   // --------------------------- Step 4 ---------------------------------------

--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -862,7 +862,7 @@ void Core::IO::DiscretizationWriter::write_multi_vector(
 
     valuename = groupname.str() + valuename;
 
-    const Epetra_BlockMapData* mapdata = vec.Map().DataPtr();
+    const Epetra_BlockMapData* mapdata = vec.get_map().DataPtr();
     std::map<const Epetra_BlockMapData*, std::string>::const_iterator m = mapcache_.find(mapdata);
     if (m != mapcache_.end())
     {
@@ -873,7 +873,7 @@ void Core::IO::DiscretizationWriter::write_multi_vector(
     {
       const hsize_t mapsize = vec.MyLength();
       idname = name + ".ids";
-      int* ids = vec.Map().MyGlobalElements();
+      int* ids = vec.get_map().MyGlobalElements();
       if (size != 0)
       {
         const herr_t make_status =
@@ -895,7 +895,7 @@ void Core::IO::DiscretizationWriter::write_multi_vector(
       /* Make a copy of the map. This is a std::shared_ptr copy internally. We
        * just make sure here the map stays alive as long as we keep our cache.
        * Otherwise subtle errors could occur. */
-      mapstack_.push_back(vec.Map());
+      mapstack_.push_back(vec.get_map());
       /* BUT: If a problem relies on fill_complete()-calls in every time step,
        * new maps are created in every time step. Storing all old maps in
        * mapstack_ leads to an unbounded increase in memory consumption which
@@ -1009,7 +1009,7 @@ void Core::IO::DiscretizationWriter::write_vector(const std::string name,
       /* Make a copy of the map. This is a std::shared_ptr copy internally. We
        * just make sure here the map stays alive as long as we keep our cache.
        * Otherwise subtle errors could occur. */
-      mapstack_.push_back(elemap.get_epetra_map());
+      mapstack_.push_back(elemap);
       /* BUT: If a problem relies on fill_complete()-calls in every time step,
        * new maps are created in every time step. Storing all old maps in
        * mapstack_ leads to an unbounded increase in memory consumption which

--- a/src/core/io/src/4C_io.hpp
+++ b/src/core/io/src/4C_io.hpp
@@ -21,15 +21,13 @@
 #include <string>
 #include <vector>
 
-class Map;
-class Epetra_BlockMap;
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace LinAlg
 {
   class SerialDenseMatrix;
-}
+  class Map;
+}  // namespace LinAlg
 namespace Core::FE
 {
   class Discretization;
@@ -417,7 +415,7 @@ namespace Core::IO
     std::map<const Epetra_BlockMapData*, std::string> mapcache_;
 
     /// dummy stack to really save the maps we cache
-    std::vector<Epetra_BlockMap> mapstack_;
+    std::vector<Core::LinAlg::Map> mapstack_;
 
     int resultfile_changed_;
     int meshfile_changed_;

--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -203,11 +203,11 @@ namespace Core::IO
 
     auto convert_to_col_map_if_necessary = [&](const Core::LinAlg::Vector<double>& vector)
     {
-      if (discretization_->dof_col_map()->SameAs(vector.get_block_map()))
+      if (discretization_->dof_col_map()->SameAs(vector.get_map()))
       {
         return vector;
       }
-      else if (discretization_->dof_row_map()->SameAs(vector.get_block_map()))
+      else if (discretization_->dof_row_map()->SameAs(vector.get_map()))
       {
         auto vector_col_map = Core::LinAlg::Vector<double>(*discretization_->dof_col_map(), true);
         Core::LinAlg::export_to(vector, vector_col_map);
@@ -219,8 +219,7 @@ namespace Core::IO
     auto result_data_dofbased_col_map = convert_to_col_map_if_necessary(result_data_dofbased);
 
     // safety checks
-    FOUR_C_ASSERT(
-        discretization_->dof_col_map()->SameAs(result_data_dofbased_col_map.get_block_map()),
+    FOUR_C_ASSERT(discretization_->dof_col_map()->SameAs(result_data_dofbased_col_map.get_map()),
         "Received map of dof-based result data vector does not match the discretization's dof "
         "col map.");
 
@@ -267,11 +266,11 @@ namespace Core::IO
 
     auto convert_to_col_map_if_necessary = [&](const Core::LinAlg::MultiVector<double>& vector)
     {
-      if (discretization_->node_col_map()->SameAs(vector.Map()))
+      if (discretization_->node_col_map()->SameAs(vector.get_map()))
       {
         return vector;
       }
-      else if (discretization_->node_row_map()->SameAs(vector.Map()))
+      else if (discretization_->node_row_map()->SameAs(vector.get_map()))
       {
         auto vector_col_map = Core::LinAlg::MultiVector<double>(
             *discretization_->node_col_map(), result_num_components_per_node, true);
@@ -289,7 +288,7 @@ namespace Core::IO
         "Expected Core::LinAlg::MultiVector<double> with {} columns but got {}.",
         result_num_components_per_node, result_data_nodebased_col_map.NumVectors());
 
-    FOUR_C_ASSERT(discretization_->node_col_map()->SameAs(result_data_nodebased_col_map.Map()),
+    FOUR_C_ASSERT(discretization_->node_col_map()->SameAs(result_data_nodebased_col_map.get_map()),
         "Received map of node-based result data vector does not match the discretization's node "
         "col map.");
 
@@ -339,7 +338,7 @@ namespace Core::IO
         "Expected Core::LinAlg::MultiVector<double> with {} columns but got {}.",
         result_num_components_per_element, result_data_elementbased.NumVectors());
 
-    FOUR_C_ASSERT(discretization_->element_row_map()->SameAs(result_data_elementbased.Map()),
+    FOUR_C_ASSERT(discretization_->element_row_map()->SameAs(result_data_elementbased.get_map()),
         "Received map of element-based result data vector does not match the discretization's "
         "element row map.");
 

--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -493,7 +493,7 @@ namespace Core::IO
 
     // Create Vectors to store the ghosting information.
     Epetra_FEVector ghosting_information(
-        discretization.element_row_map()->get_epetra_map(), n_proc);
+        discretization.element_row_map()->get_epetra_block_map(), n_proc);
 
     // Get elements ghosted by this rank.
     std::vector<int> my_ghost_elements;

--- a/src/core/io/src/4C_io_discretization_visualization_writer_nodes.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_nodes.cpp
@@ -99,7 +99,8 @@ namespace Core::IO
      */
 
     // count number of nodes for each processor
-    const unsigned int num_row_nodes = (unsigned int)result_data_nodebased.Map().NumMyElements();
+    const unsigned int num_row_nodes =
+        (unsigned int)result_data_nodebased.get_map().NumMyElements();
 
     // safety check
     if ((unsigned int)result_data_nodebased.NumVectors() != result_num_components_per_node)

--- a/src/core/io/src/4C_io_element_append_visualization.hpp
+++ b/src/core/io/src/4C_io_element_append_visualization.hpp
@@ -205,8 +205,8 @@ namespace Core::IO
         // Since this is not supported by vtu, we add a NaN in this case, see else branch
         if (nodedofs.size() > read_result_data_from_dofindex + idof)
         {
-          const int lid = result_data_dofbased.get_block_map().LID(
-              nodedofs[idof + read_result_data_from_dofindex]);
+          const int lid =
+              result_data_dofbased.get_map().LID(nodedofs[idof + read_result_data_from_dofindex]);
           vtu_point_result_data.push_back((result_data_dofbased)[lid]);
         }
         else

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -407,7 +407,7 @@ bool Core::LinAlg::BlockSparseMatrixBase::HasNormInf() const { return false; }
  *----------------------------------------------------------------------*/
 const Epetra_Comm& Core::LinAlg::BlockSparseMatrixBase::Comm() const
 {
-  return full_domain_map().EpetraComm();
+  return full_domain_map().get_epetra_map().Comm();
 }
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_equilibrate.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_equilibrate.cpp
@@ -105,7 +105,7 @@ void Core::LinAlg::Equilibration::compute_inv_symmetry(
       Core::LinAlg::create_vector(matrix.range_map(), true);
   matrix.extract_diagonal_copy(*diag);
 
-  for (int my_row = 0; my_row < diag->get_block_map().NumMyElements(); ++my_row)
+  for (int my_row = 0; my_row < diag->get_map().NumMyElements(); ++my_row)
   {
     (invsymmetry)[my_row] = 1.0 / std::sqrt((*diag)[my_row]);
   }

--- a/src/core/linalg/src/sparse/4C_linalg_graph.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.cpp
@@ -39,10 +39,10 @@ Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Map& RowMap, const int* N
 {
   if (graphtype_ == CRS_GRAPH)
     graph_ = std::make_unique<Epetra_CrsGraph>(
-        CV, RowMap.get_epetra_map(), NumIndicesPerRow, StaticProfile);
+        CV, RowMap.get_epetra_block_map(), NumIndicesPerRow, StaticProfile);
   else if (graphtype_ == FE_GRAPH)
     graph_ = std::make_unique<Epetra_FECrsGraph>(
-        CV, RowMap.get_epetra_map(), const_cast<int*>(NumIndicesPerRow), StaticProfile);
+        CV, RowMap.get_epetra_block_map(), const_cast<int*>(NumIndicesPerRow), StaticProfile);
 }
 
 Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Epetra_BlockMap& RowMap,
@@ -61,10 +61,10 @@ Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Map& RowMap, int NumIndic
 {
   if (graphtype_ == CRS_GRAPH)
     graph_ = std::make_unique<Epetra_CrsGraph>(
-        CV, RowMap.get_epetra_map(), NumIndicesPerRow, StaticProfile);
+        CV, RowMap.get_epetra_block_map(), NumIndicesPerRow, StaticProfile);
   else if (graphtype_ == FE_GRAPH)
     graph_ = std::make_unique<Epetra_FECrsGraph>(
-        CV, RowMap.get_epetra_map(), NumIndicesPerRow, StaticProfile);
+        CV, RowMap.get_epetra_block_map(), NumIndicesPerRow, StaticProfile);
 }
 
 Core::LinAlg::Graph::Graph(const Graph& other)

--- a/src/core/linalg/src/sparse/4C_linalg_graph.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.hpp
@@ -114,7 +114,8 @@ namespace Core::LinAlg
       int err = 0;
 
       if (graphtype_ == CRS_GRAPH)
-        err = graph_->FillComplete(domain_map.get_epetra_map(), range_map.get_epetra_map());
+        err = graph_->FillComplete(
+            domain_map.get_epetra_block_map(), range_map.get_epetra_block_map());
       else if (graphtype_ == FE_GRAPH)
         err = static_cast<Epetra_FECrsGraph*>(graph_.get())
                   ->GlobalAssemble(domain_map.get_epetra_map(), range_map.get_epetra_map());

--- a/src/core/linalg/src/sparse/4C_linalg_graph.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.hpp
@@ -18,7 +18,7 @@
 #include <Epetra_FECrsGraph.h>
 
 #include <memory>
-
+#include <optional>
 
 
 FOUR_C_NAMESPACE_OPEN
@@ -65,9 +65,6 @@ namespace Core::LinAlg
     const Epetra_CrsGraph& get_epetra_crs_graph() const { return *graph_; }
 
     Epetra_CrsGraph& get_epetra_crs_graph() { return *graph_; }
-
-    //! Returns the Column Map associated with this graph.
-    const Epetra_BlockMap& col_map() const { return (graph_->ColMap()); }
 
     //! Returns a pointer to the Epetra_Comm communicator associated with this graph.
     const Epetra_Comm& get_comm() const { return (graph_->Comm()); }
@@ -168,13 +165,34 @@ namespace Core::LinAlg
     //! Remove a list of elements from a specified global row of the graph.
     int remove_global_indices(int GlobalRow, int NumIndices, int* Indices);
 
-    const Epetra_BlockMap& row_map() const { return graph_->RowMap(); }
+    //! Returns the Row Map associated with this graph.
+    const Map& row_map() const
+    {
+      if (!row_map_)
+      {  // check if view is uninitialized
+        row_map_ = Core::LinAlg::Map(graph_->RowMap());
+      }
+      return *row_map_;
+    }
+
+    //! Returns the Column Map associated with this graph.
+    const Map& col_map() const
+    {
+      if (!col_map_)
+      {  // check if view is uninitialized
+        col_map_ = Core::LinAlg::Map(graph_->ColMap());
+      }
+      return *col_map_;
+    }
 
    private:
     GraphType graphtype_;
 
     //! The actual Epetra_CrsGraph object.
     std::unique_ptr<Epetra_CrsGraph> graph_;
+
+    mutable std::optional<Map> row_map_;
+    mutable std::optional<Map> col_map_;
   };
 }  // namespace Core::LinAlg
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -535,7 +535,8 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
   // initialize global mv2 without setting to 0
   Core::LinAlg::MultiVector<double> mv2glob(*redundant_map, nsdim_);
   // create importer with redundant target map and distributed source map
-  Epetra_Import importer(redundant_map->get_epetra_map(), mv2->get_map().get_epetra_map());
+  Epetra_Import importer(
+      redundant_map->get_epetra_block_map(), mv2->get_map().get_epetra_block_map());
   // import values to global mv2
   mv2glob.Import(*mv2, importer, Insert);
 

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -30,7 +30,7 @@ FOUR_C_NAMESPACE_OPEN
                           Constructor
    -------------------------------------------------------------------- */
 Core::LinAlg::KrylovProjector::KrylovProjector(
-    const std::vector<int> modeids, const std::string* weighttype, const Epetra_BlockMap* map)
+    const std::vector<int> modeids, const std::string* weighttype, const Core::LinAlg::Map* map)
     : complete_(false), modeids_(modeids), weighttype_(weighttype), p_(nullptr), pt_(nullptr)
 {
   nsdim_ = modeids_.size();
@@ -84,7 +84,7 @@ Core::LinAlg::KrylovProjector::get_non_const_weights()
 }
 
 void Core::LinAlg::KrylovProjector::set_cw(Core::LinAlg::MultiVector<double>& c0,
-    Core::LinAlg::MultiVector<double>& w0, const Epetra_BlockMap* newmap)
+    Core::LinAlg::MultiVector<double>& w0, const Core::LinAlg::Map* newmap)
 {
   c_ = nullptr;
   w_ = nullptr;
@@ -302,7 +302,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::KrylovProjector::proje
 
   // here: matvec = A c_;
   std::shared_ptr<Core::LinAlg::MultiVector<double>> matvec =
-      std::make_shared<Core::LinAlg::MultiVector<double>>(c_->Map(), nsdim_, false);
+      std::make_shared<Core::LinAlg::MultiVector<double>>(c_->get_map(), nsdim_, false);
   A.epetra_matrix()->Multiply(false, *c_, *matvec);
 
   // compute serial dense matrix c^T A c
@@ -463,7 +463,7 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_dense_matrix(
 
   // create empty multivector mvout
   std::shared_ptr<Core::LinAlg::MultiVector<double>> mvout =
-      std::make_shared<Core::LinAlg::MultiVector<double>>(mv->Map(), nsdim_);
+      std::make_shared<Core::LinAlg::MultiVector<double>>(mv->get_map(), nsdim_);
 
   // loop over all vectors of mvout
   for (int rr = 0; rr < nsdim_; ++rr)
@@ -513,8 +513,8 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
   Core::Communication::sum_all(&numnonzero, &glob_numnonzero, 1, prod.get_comm());
 
   // do stupid conversion into Epetra map
-  Core::LinAlg::Map mv1map(mv1->Map().NumGlobalElements(), mv1->Map().NumMyElements(),
-      mv1->Map().MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(mv1->Map().Comm()));
+  Core::LinAlg::Map mv1map(mv1->get_map().NumGlobalElements(), mv1->get_map().NumMyElements(),
+      mv1->get_map().MyGlobalElements(), 0, mv1->get_map().Comm());
   // initialization of mat with map of mv1
   std::shared_ptr<Core::LinAlg::SparseMatrix> mat =
       std::make_shared<Core::LinAlg::SparseMatrix>(mv1map, glob_numnonzero, false);
@@ -527,15 +527,15 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
   const int numvals = mv2->GlobalLength();
 
   // do stupid conversion into Epetra map
-  Core::LinAlg::Map mv2map(mv2->Map().NumGlobalElements(), mv2->Map().NumMyElements(),
-      mv2->Map().MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(mv2->Map().Comm()));
+  Core::LinAlg::Map mv2map(mv2->get_map().NumGlobalElements(), mv2->get_map().NumMyElements(),
+      mv2->get_map().MyGlobalElements(), 0, mv2->get_map().Comm());
 
   // fully redundant/overlapping map
   std::shared_ptr<Core::LinAlg::Map> redundant_map = Core::LinAlg::allreduce_e_map(mv2map);
   // initialize global mv2 without setting to 0
   Core::LinAlg::MultiVector<double> mv2glob(*redundant_map, nsdim_);
   // create importer with redundant target map and distributed source map
-  Epetra_Import importer(redundant_map->get_epetra_map(), mv2->Map());
+  Epetra_Import importer(redundant_map->get_epetra_map(), mv2->get_map().get_epetra_map());
   // import values to global mv2
   mv2glob.Import(*mv2, importer, Insert);
 

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.hpp
@@ -22,6 +22,7 @@ namespace Core::LinAlg
   class SerialDenseMatrix;
   class SerialDenseVector;
   class SparseMatrix;
+  class Map;
 
   /*!
   A class providing a Krylov projectors. Used for projected preconditioner,
@@ -42,7 +43,7 @@ namespace Core::LinAlg
     KrylovProjector(const std::vector<int>
                         modeids,        //! ids of to-be-projected modes according element nullspace
         const std::string* weighttype,  //! type of weights: integration or pointvalues
-        const Epetra_BlockMap* map      //! map for kernel and weight vectors
+        const Core::LinAlg::Map* map    //! map for kernel and weight vectors
     );
 
     //! give out std::shared_ptr to c_ for change
@@ -52,7 +53,7 @@ namespace Core::LinAlg
     std::shared_ptr<Core::LinAlg::MultiVector<double>> get_non_const_weights();
     // set c_ and w_ from outside
     void set_cw(Core::LinAlg::MultiVector<double>& c0, Core::LinAlg::MultiVector<double>& w0,
-        const Epetra_BlockMap* newmap);
+        const Core::LinAlg::Map* newmap);
     void set_cw(Core::LinAlg::MultiVector<double>& c0, Core::LinAlg::MultiVector<double>& w0);
     //! compute (w^T c)^(-1) and completes projector for use
     void fill_complete();

--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -73,6 +73,9 @@ namespace Core::LinAlg
     //! Index base for this map.
     int IndexBase() const { return map_->IndexBase(); }
 
+    //! Same as FirstPointInElementList() except it fills the user array that is passed in.
+    int FirstPointInElementList(int* LID) const { return map_->FirstPointInElementList(LID); }
+
     //! Returns true if map is defined across more than one processor.
     bool DistributedGlobal() const { return map_->DistributedGlobal(); }
 
@@ -151,6 +154,10 @@ namespace Core::LinAlg
 
     [[nodiscard]] static std::unique_ptr<const Map> create_view(const Epetra_Map& view);
 
+    [[nodiscard]] static std::unique_ptr<Map> create_view(Epetra_BlockMap& view);
+
+    [[nodiscard]] static std::unique_ptr<const Map> create_view(const Epetra_BlockMap& view);
+
    private:
     Map() = default;
 
@@ -166,6 +173,12 @@ namespace Core::LinAlg
 
   template <>
   struct EnableViewFor<Epetra_Map>
+  {
+    using type = Map;
+  };
+
+  template <>
+  struct EnableViewFor<Epetra_BlockMap>
   {
     using type = Map;
   };

--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -10,15 +10,15 @@
 
 #include "4C_config.hpp"
 
-#include "4C_comm_mpi_utils.hpp"
 #include "4C_linalg_view.hpp"
+#include "4C_utils_exceptions.hpp"
 #include "4C_utils_owner_or_view.hpp"
 
-#include <Epetra_Comm.h>
 #include <Epetra_Map.h>
 #include <mpi.h>
 
 #include <memory>
+#include <variant>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -27,11 +27,29 @@ FOUR_C_NAMESPACE_OPEN
 
 // NOLINTBEGIN(readability-identifier-naming)
 
+
+
 namespace Core::LinAlg
 {
-
   class Map
   {
+    // This wrapper may have two different variants
+    // Either it holds an Epetra_Map or Epetra_BlockMap
+    using MapVariant =
+        std::variant<Utils::OwnerOrView<Epetra_Map>, Utils::OwnerOrView<Epetra_BlockMap>>;
+
+    // helper function to access each variant safely
+    template <typename Func>
+    decltype(auto) visit_variant(Func&& func) const
+    {
+      return std::visit(
+          [&](const auto& wrapped) -> decltype(auto)
+          {
+            return func(*wrapped);  // Unwrap OwnerOrView
+          },
+          map_);
+    }
+
    public:
     Map(int NumGlobalElements, int IndexBase, const MPI_Comm& Comm);
 
@@ -45,129 +63,272 @@ namespace Core::LinAlg
     /// Copy constructor from Epetra_Map
     explicit Map(const Epetra_Map& Source);
 
-    /// Copy constructor from Epetra_Map
+    /// Copy constructor from Epetra_BlockMap
     explicit Map(const Epetra_BlockMap& Source);
 
     ~Map() = default;
 
-
     Map& operator=(const Map& other);
-    void Print(std::ostream& os) const { map_->Print(os); }
 
-    //! return the reference to the Epetra_Map
-    const Epetra_Map& get_epetra_map() const { return *map_; }
-    Epetra_Map& get_epetra_map() { return *map_; }
-
-    //! Returns true if this and Map are identical maps
-    bool SameAs(const Map& other) const { return map_->SameAs(*(other.map_)); }
-
-    //! Returns true if this and Map have identical point-wise structure
-    bool PointSameAs(const Map& Map) const { return map_->PointSameAs(Map.get_epetra_map()); }
-
-    //! Number of elements across all processors.
-    int NumGlobalElements() const { return map_->NumGlobalElements(); }
-
-    //! Number of elements on the calling processor.
-    int NumMyElements() const { return map_->NumMyElements(); }
-
-    //! Index base for this map.
-    int IndexBase() const { return map_->IndexBase(); }
-
-    //! Same as FirstPointInElementList() except it fills the user array that is passed in.
-    int FirstPointInElementList(int* LID) const { return map_->FirstPointInElementList(LID); }
-
-    //! Returns true if map is defined across more than one processor.
-    bool DistributedGlobal() const { return map_->DistributedGlobal(); }
-
-    //! Returns true if this and Map are identical maps
-    bool SameAs(const Epetra_Map& other) const { return map_->SameAs(other); }
-    bool SameAs(const Epetra_BlockMap& other) const { return map_->SameAs(other); }
-
-    //! Returns true if the GID passed in belongs to the calling processor in this map,
-    //! otherwise returns false.
-    bool MyGID(int GID_in) const { return map_->MyGID(GID_in); }
-
-    //! Returns global ID of local ID, return IndexBase-1 if not found on this processor.
-    int GID(int LID) const { return map_->GID(LID); }
-
-    //! Returns the size of elements in the map; only valid if map has constant element size.
-    int ElementSize() const { return map_->ElementSize(); }
-
-    //! Size of element for specified LID.
-    int ElementSize(int LID) const { return map_->ElementSize(LID); }
-
-    //! Returns the maximum global ID across the entire map
-    int MaxAllGID() const { return map_->MaxAllGID(); }
-
-    //! Returns the minimum global ID across the entire map.
-    int MinAllGID() const { return map_->MinAllGID(); }
-
-    //! Returns local ID of global ID, return -1 if not found on this processor.
-    int LID(int GID) const { return map_->LID(GID); }
-
-    //! Returns true if this and Map have identical point-wise structure
-    bool PointSameAs(const Epetra_Map& Map) const { return map_->PointSameAs(Map); }
-    bool PointSameAs(const Epetra_BlockMap& Map) const { return map_->PointSameAs(Map); }
-
-    //! Returns the processor IDs and corresponding local index value for a given list of global
-    //! indices.
-    int RemoteIDList(int NumIDs, int* GIDList, int* PIDList, int* LIDList) const
+    //! Print object to the output stream
+    void Print(std::ostream& os) const
     {
-      return map_->RemoteIDList(NumIDs, GIDList, PIDList, LIDList);
+      visit_variant([&](const auto& map) -> void { map.Print(os); });
     }
 
+    //! Returns a reference of the Epetra_Map if available.
+    const Epetra_Map& get_epetra_map() const
+    {
+      auto* map = std::get_if<Utils::OwnerOrView<Epetra_Map>>(&map_);
+      if (map == nullptr)
+      {
+        FOUR_C_THROW(
+            "This Map is based on an Epetra_BlockMap, not an Epetra_Map. This cast is not "
+            "possible.");
+      }
+      return **map;
+    }
+
+    //! Returns a reference of the Epetra_Map if available.
+    Epetra_Map& get_epetra_map()
+    {
+      auto* map = std::get_if<Utils::OwnerOrView<Epetra_Map>>(&map_);
+      if (map == nullptr)
+      {
+        FOUR_C_THROW(
+            "This Map is based on an Epetra_BlockMap, not an Epetra_Map. This cast is not "
+            "possible.");
+      }
+      return **map;
+    }
+
+
+    //! Returns a const reference to the underlying Epetra_BlockMap.
+    const Epetra_BlockMap& get_epetra_block_map() const
+    {
+      // If the map_ holds directly the Epetra_BlockMap, just return it.
+      if (auto map = std::get_if<Utils::OwnerOrView<Epetra_BlockMap>>(&map_))
+      {
+        return **map;
+      }
+
+      // If the Epetra_Map is stored try to cast it.
+      const auto& map = *std::get<Utils::OwnerOrView<Epetra_Map>>(map_);
+
+      return map;
+    }
+
+
+    //! Returns a reference to the underlying Epetra_BlockMap.
+    Epetra_BlockMap& get_epetra_block_map()
+    {
+      // If the map_ holds directly the Epetra_BlockMap, just return it.
+      if (auto map = std::get_if<Utils::OwnerOrView<Epetra_BlockMap>>(&map_))
+      {
+        return **map;
+      }
+
+      // If the Epetra_Map is stored try to cast it.
+      auto& map = *std::get<Utils::OwnerOrView<Epetra_Map>>(map_);
+      return map;
+    }
+
+    //! Returns true if this and Map are identical maps
+    bool SameAs(const Map& other) const
+    {
+      return std::visit(
+          [&](const auto& this_wrapped)
+          {
+            return std::visit([&](const auto& other_wrapped)
+                { return (*this_wrapped).SameAs(*other_wrapped); }, other.map_);
+          },
+          map_);
+    }
+
+    //! Returns true if this and Map have identical point-wise structure
+    bool PointSameAs(const Map& Map) const
+    {
+      return visit_variant(
+          [&](const auto& map) { return map.PointSameAs(Map.get_epetra_block_map()); });
+    }
+
+    //! Number of elements across all processors.
+    int NumGlobalElements() const
+    {
+      return visit_variant([](const auto& map) { return map.NumGlobalElements(); });
+    }
+
+    //! Number of elements on the calling processor.
+    int NumMyElements() const
+    {
+      return visit_variant([](const auto& map) { return map.NumMyElements(); });
+    }
+
+    //! returns the index base for this map.
+    int IndexBase() const
+    {
+      return visit_variant([](const auto& map) { return map.IndexBase(); });
+    }
+
+    //! Pointer to internal array containing a mapping between the local elements and the first
+    //! local point number in each element.
+    int FirstPointInElementList(int* LID) const
+    {
+      return visit_variant([&](const auto& map) { return map.FirstPointInElementList(LID); });
+    }
+
+    //! Returns true if map is defined across more than one processor.
+    bool DistributedGlobal() const
+    {
+      return visit_variant([](const auto& map) { return map.DistributedGlobal(); });
+    }
+
+    //! Returns true if this and Map are identical maps
+    bool SameAs(const Epetra_Map& other) const
+    {
+      return visit_variant([&](const auto& map) { return map.SameAs(other); });
+    }
+
+    //! Returns true if this and Map are identical maps
+    bool SameAs(const Epetra_BlockMap& other) const
+    {
+      return visit_variant([&](const auto& map) { return map.SameAs(other); });
+    }
+
+    //! Returns true if the GID passed in belongs to the calling processor in this map, otherwise
+    //! returns false.
+    bool MyGID(int GID_in) const
+    {
+      return visit_variant([&](const auto& map) { return map.MyGID(GID_in); });
+    }
+
+    //! Returns global ID of local ID, return IndexBase-1 if not found on this processor.
+    int GID(int LID) const
+    {
+      return visit_variant([&](const auto& map) { return map.GID(LID); });
+    }
+
+    //! Returns the size of elements in the map; only valid if map has constant element size.
+    int ElementSize() const
+    {
+      return visit_variant([](const auto& map) { return map.ElementSize(); });
+    }
+
+    //! Returns the size of elements in the map; only valid if map has constant element size.
+    int ElementSize(int LID) const
+    {
+      return visit_variant([&](const auto& map) { return map.ElementSize(LID); });
+    }
+
+    //! Returns the maximum global ID across the entire map.
+    int MaxAllGID() const
+    {
+      return visit_variant([](const auto& map) { return map.MaxAllGID(); });
+    }
+
+    //! Returns the minimum global ID across the entire map.
+    int MinAllGID() const
+    {
+      return visit_variant([](const auto& map) { return map.MinAllGID(); });
+    }
+
+    //! Returns local ID of global ID, return -1 if not found on this processor.
+    int LID(int GID) const
+    {
+      return visit_variant([&](const auto& map) { return map.LID(GID); });
+    }
+
+    //! Returns true if this and Map have identical point-wise structure
+    bool PointSameAs(const Epetra_Map& Map) const
+    {
+      return visit_variant([&](const auto& map) { return map.PointSameAs(Map); });
+    }
+
+    //! Returns true if this and Map have identical point-wise structure
+    bool PointSameAs(const Epetra_BlockMap& Map) const
+    {
+      return visit_variant([&](const auto& map) { return map.PointSameAs(Map); });
+    }
+
+    //! Returns the processor IDs and corresponding local index value for a given list of global
+    //! indices
+    int RemoteIDList(int NumIDs, int* GIDList, int* PIDList, int* LIDList) const
+    {
+      return visit_variant(
+          [&](const auto& map) { return map.RemoteIDList(NumIDs, GIDList, PIDList, LIDList); });
+    }
+
+    //! Returns the processor IDs and corresponding local index value for a given list of global
+    //! indices
     int RemoteIDList(
         int NumIDs, const int* GIDList, int* PIDList, int* LIDList, int* SizeList) const
     {
-      return map_->RemoteIDList(NumIDs, GIDList, PIDList, LIDList, SizeList);
+      return visit_variant([&](const auto& map)
+          { return map.RemoteIDList(NumIDs, GIDList, PIDList, LIDList, SizeList); });
     }
-    int MinMyGID(void) const { return map_->MinMyGID(); }
+
+    //! Returns the minimum global ID owned by this processor.
+    int MinMyGID(void) const
+    {
+      return visit_variant([](const auto& map) { return map.MinMyGID(); });
+    }
 
     //! Access function for Epetra_Comm communicator.
-    const Epetra_Comm& EpetraComm() const { return map_->Comm(); }
-
-    MPI_Comm Comm() const { return Core::Communication::unpack_epetra_comm(map_->Comm()); }
+    MPI_Comm Comm() const;
 
     //! Returns true if map GIDs are 1-to-1.
-    bool UniqueGIDs(void) const { return map_->UniqueGIDs(); }
+    bool UniqueGIDs(void) const
+    {
+      return visit_variant([](const auto& map) { return map.UniqueGIDs(); });
+    }
 
     //! Pointer to internal array containing list of global IDs assigned to the calling processor.
-    int* MyGlobalElements(void) const { return map_->MyGlobalElements(); }
+    int* MyGlobalElements(void) const
+    {
+      return visit_variant([](const auto& map) { return map.MyGlobalElements(); });
+    }
 
     //! Maximum element size across all processors.
-    int MaxElementSize(void) const { return map_->MaxElementSize(); }
+    int MaxElementSize(void) const
+    {
+      return visit_variant([](const auto& map) { return map.MaxElementSize(); });
+    }
 
     //! Puts list of global elements on this processor into the user-provided array.
     int MyGlobalElements(int* MyGlobalElementList) const
     {
-      return map_->MyGlobalElements(MyGlobalElementList);
+      return visit_variant(
+          [&](const auto& map) { return map.MyGlobalElements(MyGlobalElementList); });
     }
-
     //! Number of local points for this map; equals the sum of all element sizes on the calling
     //! processor.
-    int NumMyPoints() const { return map_->NumMyPoints(); }
+    int NumMyPoints() const
+    {
+      return visit_variant([](const auto& map) { return map.NumMyPoints(); });
+    }
 
     //! Returns a pointer to the BlockMapData instance this BlockMap uses.
-    const Epetra_BlockMapData* DataPtr() const { return map_->DataPtr(); }
+    const Epetra_BlockMapData* DataPtr() const
+    {
+      return visit_variant([](const auto& map) { return map.DataPtr(); });
+    }
+
 
     [[nodiscard]] static std::unique_ptr<Map> create_view(Epetra_Map& view);
-
     [[nodiscard]] static std::unique_ptr<const Map> create_view(const Epetra_Map& view);
-
     [[nodiscard]] static std::unique_ptr<Map> create_view(Epetra_BlockMap& view);
-
     [[nodiscard]] static std::unique_ptr<const Map> create_view(const Epetra_BlockMap& view);
 
    private:
     Map() = default;
 
-    //! The actual Epetra_Map object.
-    Utils::OwnerOrView<Epetra_Map> map_;
+    //! stores an Epetra_BlockMap or Epetra_Map
+    MapVariant map_;
   };
 
   inline std::ostream& operator<<(std::ostream& os, const Map& m)
   {
-    os << m.get_epetra_map();
+    os << m.get_epetra_block_map();
     return os;
   }
 
@@ -185,10 +346,8 @@ namespace Core::LinAlg
 
 }  // namespace Core::LinAlg
 
-
 // NOLINTEND(readability-identifier-naming)
 
 FOUR_C_NAMESPACE_CLOSE
-
 
 #endif

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
@@ -38,8 +38,8 @@ void Core::LinAlg::MultiMapExtractor::setup(const Core::LinAlg::Map& fullmap,
   {
     if (maps_[i] != nullptr)
     {
-      importer_[i] =
-          std::make_shared<Epetra_Import>(maps_[i]->get_epetra_map(), fullmap_->get_epetra_map());
+      importer_[i] = std::make_shared<Epetra_Import>(
+          maps_[i]->get_epetra_block_map(), fullmap_->get_epetra_block_map());
     }
   }
 }

--- a/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_mapextractor.cpp
@@ -233,7 +233,8 @@ void Core::LinAlg::MultiMapExtractor::add_vector(const Core::LinAlg::MultiVector
     int block, Core::LinAlg::MultiVector<double>& full, double scale) const
 {
   std::shared_ptr<Core::LinAlg::MultiVector<double>> v = extract_vector(full, block);
-  if (not v->Map().SameAs(partial.Map())) FOUR_C_THROW("The maps of the vectors must be the same!");
+  if (not v->get_map().SameAs(partial.get_map()))
+    FOUR_C_THROW("The maps of the vectors must be the same!");
   v->Update(scale, partial, 1.0);
   insert_vector(*v, block, full);
 }

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
@@ -26,7 +26,8 @@ Core::LinAlg::MultiVector<T>::MultiVector(const Epetra_BlockMap& Map, int num_co
 template <typename T>
 Core::LinAlg::MultiVector<T>::MultiVector(
     const Core::LinAlg::Map& Map, int num_columns, bool zeroOut)
-    : vector_(std::make_shared<Epetra_MultiVector>(Map.get_epetra_map(), num_columns, zeroOut))
+    : vector_(
+          std::make_shared<Epetra_MultiVector>(Map.get_epetra_block_map(), num_columns, zeroOut))
 {
 }
 
@@ -127,7 +128,7 @@ template <typename T>
 int Core::LinAlg::MultiVector<T>::ReplaceMap(const Core::LinAlg::Map& map)
 {
   for (auto& view : column_vector_view_) view->replace_map(map);
-  return vector_->ReplaceMap(map.get_epetra_map());
+  return vector_->ReplaceMap(map.get_epetra_block_map());
 }
 
 template <typename T>

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.cpp
@@ -124,10 +124,10 @@ int Core::LinAlg::MultiVector<T>::PutScalar(double ScalarConstant)
 }
 
 template <typename T>
-int Core::LinAlg::MultiVector<T>::ReplaceMap(const Epetra_BlockMap& map)
+int Core::LinAlg::MultiVector<T>::ReplaceMap(const Core::LinAlg::Map& map)
 {
   for (auto& view : column_vector_view_) view->replace_map(map);
-  return vector_->ReplaceMap(map);
+  return vector_->ReplaceMap(map.get_epetra_map());
 }
 
 template <typename T>

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
@@ -19,6 +19,7 @@
 #include <mpi.h>
 
 #include <memory>
+#include <optional>
 
 // Do not lint the file for identifier names, since the naming of the Wrapper functions follow the
 // naming of the Core::LinAlg::MultiVector<double>
@@ -107,8 +108,8 @@ namespace Core::LinAlg
     //! Initialize all values in a multi-vector with const value.
     int PutScalar(double ScalarConstant);
 
-    //! Returns the address of the Epetra_BlockMap for this multi-vector.
-    const Epetra_BlockMap& Map() const { return (vector_->Map()); };
+    //! Returns a view of the EpetraMap as type Map for this multi-vector.
+    const Map& get_map() const { return map_.sync(vector_->Map()); };
 
     //! Returns the MPI_Comm for this multi-vector.
     [[nodiscard]] MPI_Comm Comm() const;
@@ -138,7 +139,7 @@ namespace Core::LinAlg
     /** Replace map, only if new map has same point-structure as current map.
         return 0 if map is replaced, -1 if not.
      */
-    int ReplaceMap(const Epetra_BlockMap& map);
+    int ReplaceMap(const Map& map);
 
     int ReplaceGlobalValue(int GlobalRow, int VectorIndex, double ScalarValue)
     {
@@ -268,6 +269,8 @@ namespace Core::LinAlg
     //! Vector view of the single columns stored inside the vector. This is used to allow
     //! access to the single columns of the MultiVector.
     mutable std::vector<std::unique_ptr<Vector<T>>> column_vector_view_;
+
+    mutable View<const Map> map_;
 
     friend class Vector<T>;
   };

--- a/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_multi_vector.hpp
@@ -19,7 +19,6 @@
 #include <mpi.h>
 
 #include <memory>
-#include <optional>
 
 // Do not lint the file for identifier names, since the naming of the Wrapper functions follow the
 // naming of the Core::LinAlg::MultiVector<double>

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -212,9 +212,9 @@ Core::LinAlg::SparseMatrix::SparseMatrix(const Core::LinAlg::Vector<double>& dia
       savegraph_(savegraph),
       matrixtype_(matrixtype)
 {
-  int length = diag.get_block_map().NumMyElements();
-  Core::LinAlg::Map map(-1, length, diag.get_block_map().MyGlobalElements(),
-      diag.get_block_map().IndexBase(), diag.get_comm());
+  int length = diag.get_map().NumMyElements();
+  Core::LinAlg::Map map(
+      -1, length, diag.get_map().MyGlobalElements(), diag.get_map().IndexBase(), diag.get_comm());
   if (!map.UniqueGIDs()) FOUR_C_THROW("Row map is not unique");
 
   if (matrixtype_ == CRS_MATRIX)

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_assemble.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_assemble.cpp
@@ -84,9 +84,8 @@ void Core::LinAlg::assemble(Core::LinAlg::Vector<double>& V,
   {
     if (lmowner[lrow] != myrank) continue;
     int rgid = lm[lrow];
-    if (!V.get_block_map().MyGID(rgid))
-      FOUR_C_THROW("Sparse vector V does not have global row {}", rgid);
-    int rlid = V.get_block_map().LID(rgid);
+    if (!V.get_map().MyGID(rgid)) FOUR_C_THROW("Sparse vector V does not have global row {}", rgid);
+    int rlid = V.get_map().LID(rgid);
     V[rlid] += Vele[lrow];
   }  // for (int lrow=0; lrow<ldim; ++lrow)
 }
@@ -96,10 +95,10 @@ void Core::LinAlg::assemble(Core::LinAlg::Vector<double>& V,
 void Core::LinAlg::assemble_my_vector(double scalar_target, Core::LinAlg::Vector<double>& target,
     double scalar_source, const Core::LinAlg::Vector<double>& source)
 {
-  for (int slid = 0; slid < source.get_block_map().NumMyElements(); ++slid)
+  for (int slid = 0; slid < source.get_map().NumMyElements(); ++slid)
   {
-    const int sgid = source.get_block_map().GID(slid);
-    const int tlid = target.get_block_map().LID(sgid);
+    const int sgid = source.get_map().GID(slid);
+    const int tlid = target.get_map().LID(sgid);
     if (tlid == -1)
       FOUR_C_THROW(
           "The target vector has no global row {}"
@@ -149,8 +148,8 @@ void Core::LinAlg::apply_dirichlet_to_system(Core::LinAlg::Vector<double>& x,
 
   // We use two maps since we want to allow dbcv and X to be independent of
   // each other. So we are slow and flexible...
-  const Epetra_BlockMap& xmap = x.get_block_map();
-  const Epetra_BlockMap& dbcvmap = dbcval.get_block_map();
+  const Core::LinAlg::Map& xmap = x.get_map();
+  const Core::LinAlg::Map& dbcvmap = dbcval.get_map();
 
   const int mylength = dbcmap.NumMyElements();
   const int* mygids = dbcmap.MyGlobalElements();
@@ -182,9 +181,9 @@ void Core::LinAlg::apply_dirichlet_to_system(Core::LinAlg::Vector<double>& b,
   {
     const int gid = mygids[i];
 
-    const int dbcvlid = dbcval.get_block_map().LID(gid);
+    const int dbcvlid = dbcval.get_map().LID(gid);
 
-    const int blid = b.get_block_map().LID(gid);
+    const int blid = b.get_map().LID(gid);
     // Note:
     // if gid is not found in vector b, just continue
     // b might only be a subset of a larger field vector
@@ -234,12 +233,12 @@ void Core::LinAlg::apply_dirichlet_to_system(Core::LinAlg::SparseMatrix& A,
 std::shared_ptr<Core::LinAlg::MapExtractor> Core::LinAlg::convert_dirichlet_toggle_vector_to_maps(
     const Core::LinAlg::Vector<double>& dbctoggle)
 {
-  const Epetra_BlockMap& fullblockmap = dbctoggle.get_block_map();
+  const Core::LinAlg::Map& fullblockmap = dbctoggle.get_map();
   // this copy is needed because the constructor of Core::LinAlg::MapExtractor
-  // accepts only Core::LinAlg::Map and not Epetra_BlockMap
-  const Core::LinAlg::Map fullmap = Core::LinAlg::Map(fullblockmap.NumGlobalElements(),
-      fullblockmap.NumMyElements(), fullblockmap.MyGlobalElements(), fullblockmap.IndexBase(),
-      Core::Communication::unpack_epetra_comm(fullblockmap.Comm()));
+  // accepts only Core::LinAlg::Map and not Core::LinAlg::Map
+  const Core::LinAlg::Map fullmap =
+      Core::LinAlg::Map(fullblockmap.NumGlobalElements(), fullblockmap.NumMyElements(),
+          fullblockmap.MyGlobalElements(), fullblockmap.IndexBase(), fullblockmap.Comm());
   const int mylength = dbctoggle.local_length();
   const int* fullgids = fullmap.MyGlobalElements();
   // build sets containing the DBC or free global IDs, respectively

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.cpp
@@ -139,16 +139,6 @@ Core::LinAlg::SparseMatrix Core::LinAlg::create_interpolation_matrix(const Spars
 }
 
 
-/*----------------------------------------------------------------------*
- |  create a Core::LinAlg::Vector<double>                                   mwgee 12/06|
- *----------------------------------------------------------------------*/
-std::shared_ptr<Core::LinAlg::Vector<double>> Core::LinAlg::create_vector(
-    const Epetra_BlockMap& rowmap, const bool init)
-{
-  return std::make_shared<Core::LinAlg::Vector<double>>(rowmap, init);
-}
-
-
 std::shared_ptr<Core::LinAlg::Vector<double>> Core::LinAlg::create_vector(
     const Map& rowmap, const bool init)
 {

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_create.hpp
@@ -56,21 +56,13 @@ namespace Core::LinAlg
       const Core::LinAlg::MultiVector<double>& nullspace, Teuchos::ParameterList& params);
 
   /*!
-   \brief Create a new Core::LinAlg::Vector<double> and return RefcountPtr to it
-
-   \param rowmap (in): row map of vector
-   \param init (in): initialize vector to zero upon construction
-   */
-  std::shared_ptr<Core::LinAlg::Vector<double>> create_vector(
-      const Epetra_BlockMap& rowmap, const bool init = true);
-  /*!
  \brief Create a new Core::LinAlg::Vector<double> and return RefcountPtr to it
 
  \param rowmap (in): row map of vector
  \param init (in): initialize vector to zero upon construction
  */
   std::shared_ptr<Core::LinAlg::Vector<double>> create_vector(
-      const Map& rowmap, const bool init = true);
+      const Core::LinAlg::Map& rowmap, const bool init = true);
 
   /*!
   \brief Create a new Core::LinAlg::MultiVector<double> and return RefcountPtr to it
@@ -80,7 +72,7 @@ namespace Core::LinAlg
   \param init (in): initialize vector to zero upon construction
   */
   std::shared_ptr<Core::LinAlg::MultiVector<double>> create_multi_vector(
-      const Map& rowmap, const int numrows, const bool init = true);
+      const Core::LinAlg::Map& rowmap, const int numrows, const bool init = true);
 
   /*!
    \brief Create an Core::LinAlg::Map from a set of gids

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -47,14 +47,16 @@ void Core::LinAlg::export_to(
     }
     else if (sourceunique && targetunique)
     {
-      Epetra_Export exporter(source.get_map().get_epetra_map(), target.get_map().get_epetra_map());
+      Epetra_Export exporter(
+          source.get_map().get_epetra_block_map(), target.get_map().get_epetra_block_map());
       int err = target.Export(source, exporter, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
     }
     else if (sourceunique && !targetunique)
     {
-      Epetra_Import importer(target.get_map().get_epetra_map(), source.get_map().get_epetra_map());
+      Epetra_Import importer(
+          target.get_map().get_epetra_block_map(), source.get_map().get_epetra_block_map());
       int err = target.Import(source, importer, Insert);
       if (err) FOUR_C_THROW("Export using importer returned err={}", err);
       return;
@@ -123,21 +125,24 @@ void Core::LinAlg::export_to(
     }
     else if (sourceunique && targetunique)
     {
-      Epetra_Export exporter(source.get_map().get_epetra_map(), target.get_map().get_epetra_map());
+      Epetra_Export exporter(
+          source.get_map().get_epetra_block_map(), target.get_map().get_epetra_block_map());
       int err = target.export_to(source, exporter, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
     }
     else if (sourceunique && !targetunique)
     {
-      Epetra_Import importer(target.get_map().get_epetra_map(), source.get_map().get_epetra_map());
+      Epetra_Import importer(
+          target.get_map().get_epetra_block_map(), source.get_map().get_epetra_block_map());
       int err = target.import(source, importer, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
     }
     else if (!sourceunique && targetunique)
     {
-      Epetra_Export exporter(source.get_map().get_epetra_map(), target.get_map().get_epetra_map());
+      Epetra_Export exporter(
+          source.get_map().get_epetra_block_map(), target.get_map().get_epetra_block_map());
       int err = target.export_to(source, exporter, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
@@ -256,7 +261,7 @@ std::shared_ptr<Core::LinAlg::Graph> Core::LinAlg::threshold_matrix_graph(
 
   Core::LinAlg::Vector<double> ghosted_diagonal(A.col_map(), true);
   const Epetra_Import importer =
-      Epetra_Import(A.col_map().get_epetra_map(), A.row_map().get_epetra_map());
+      Epetra_Import(A.col_map().get_epetra_block_map(), A.row_map().get_epetra_block_map());
   ghosted_diagonal.import(
       diagonal.get_ref_of_epetra_vector(), importer, Epetra_CombineMode::Insert);
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -24,8 +24,8 @@ void Core::LinAlg::export_to(
 {
   try
   {
-    const bool sourceunique = source.Map().UniqueGIDs();
-    const bool targetunique = target.Map().UniqueGIDs();
+    const bool sourceunique = source.get_map().UniqueGIDs();
+    const bool targetunique = target.get_map().UniqueGIDs();
 
     // both are unique, does not matter whether ex- or import
     if (sourceunique && targetunique && Core::Communication::num_mpi_ranks(source.Comm()) == 1 &&
@@ -34,11 +34,11 @@ void Core::LinAlg::export_to(
       if (source.NumVectors() != target.NumVectors())
         FOUR_C_THROW("number of vectors in source and target not the same!");
       for (int k = 0; k < source.NumVectors(); ++k)
-        for (int i = 0; i < target.Map().NumMyElements(); ++i)
+        for (int i = 0; i < target.get_map().NumMyElements(); ++i)
         {
-          const int gid = target.Map().GID(i);
+          const int gid = target.get_map().GID(i);
           if (gid < 0) FOUR_C_THROW("No gid for i");
-          const int lid = source.Map().LID(gid);
+          const int lid = source.get_map().LID(gid);
           if (lid < 0) continue;
           // FOUR_C_THROW("No source for target");
           target(k)[i] = source(k)[lid];
@@ -47,14 +47,14 @@ void Core::LinAlg::export_to(
     }
     else if (sourceunique && targetunique)
     {
-      Epetra_Export exporter(source.Map(), target.Map());
+      Epetra_Export exporter(source.get_map().get_epetra_map(), target.get_map().get_epetra_map());
       int err = target.Export(source, exporter, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
     }
     else if (sourceunique && !targetunique)
     {
-      Epetra_Import importer(target.Map(), source.Map());
+      Epetra_Import importer(target.get_map().get_epetra_map(), source.get_map().get_epetra_map());
       int err = target.Import(source, importer, Insert);
       if (err) FOUR_C_THROW("Export using importer returned err={}", err);
       return;
@@ -64,8 +64,8 @@ void Core::LinAlg::export_to(
       // copy locally data from source to target
       // do not allow for inter-processor communication to obtain source
       // as this may give a non-unique answer depending on the proc which is asked
-      const Epetra_BlockMap& sourcemap = source.Map();
-      const Epetra_BlockMap& targetmap = target.Map();
+      const Core::LinAlg::Map& sourcemap = source.get_map();
+      const Core::LinAlg::Map& targetmap = target.get_map();
       for (int targetlid = 0; targetlid < targetmap.NumMyElements(); ++targetlid)
       {
         const int sourcelid = sourcemap.LID(targetmap.GID(targetlid));
@@ -103,19 +103,19 @@ void Core::LinAlg::export_to(
 {
   try
   {
-    const bool sourceunique = source.get_block_map().UniqueGIDs();
-    const bool targetunique = target.get_block_map().UniqueGIDs();
+    const bool sourceunique = source.get_map().UniqueGIDs();
+    const bool targetunique = target.get_map().UniqueGIDs();
 
     // both are unique, does not matter whether ex- or import
     if (sourceunique && targetunique &&
         Core::Communication::num_mpi_ranks(source.get_comm()) == 1 &&
         Core::Communication::num_mpi_ranks(target.get_comm()) == 1)
     {
-      for (int i = 0; i < target.get_block_map().NumMyElements(); ++i)
+      for (int i = 0; i < target.get_map().NumMyElements(); ++i)
       {
-        const int gid = target.get_block_map().GID(i);
+        const int gid = target.get_map().GID(i);
         if (gid < 0) FOUR_C_THROW("No gid for i");
-        const int lid = source.get_block_map().LID(gid);
+        const int lid = source.get_map().LID(gid);
         if (lid < 0) continue;
         target[i] = source[lid];
       }
@@ -123,21 +123,21 @@ void Core::LinAlg::export_to(
     }
     else if (sourceunique && targetunique)
     {
-      Epetra_Export exporter(source.get_block_map(), target.get_block_map());
+      Epetra_Export exporter(source.get_map().get_epetra_map(), target.get_map().get_epetra_map());
       int err = target.export_to(source, exporter, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
     }
     else if (sourceunique && !targetunique)
     {
-      Epetra_Import importer(target.get_block_map(), source.get_block_map());
+      Epetra_Import importer(target.get_map().get_epetra_map(), source.get_map().get_epetra_map());
       int err = target.import(source, importer, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
     }
     else if (!sourceunique && targetunique)
     {
-      Epetra_Export exporter(source.get_block_map(), target.get_block_map());
+      Epetra_Export exporter(source.get_map().get_epetra_map(), target.get_map().get_epetra_map());
       int err = target.export_to(source, exporter, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       return;
@@ -179,8 +179,8 @@ std::unique_ptr<Core::LinAlg::Vector<double>> Core::LinAlg::extract_my_vector(
 void Core::LinAlg::extract_my_vector(
     const Core::LinAlg::Vector<double>& source, Core::LinAlg::Vector<double>& target)
 {
-  const int my_num_target_gids = target.get_block_map().NumMyElements();
-  const int* my_target_gids = target.get_block_map().MyGlobalElements();
+  const int my_num_target_gids = target.get_map().NumMyElements();
+  const int* my_target_gids = target.get_map().MyGlobalElements();
 
   double* target_values = target.get_values();
 
@@ -190,7 +190,7 @@ void Core::LinAlg::extract_my_vector(
   {
     const int target_gid = my_target_gids[tar_lid];
 
-    const int src_lid = source.get_block_map().LID(target_gid);
+    const int src_lid = source.get_map().LID(target_gid);
     // check if the target_map is a local sub-set of the source map on each proc
     if (src_lid == -1)
       FOUR_C_THROW("Couldn't find the target GID {} in the source map on proc {}.", target_gid,
@@ -385,7 +385,7 @@ void Core::LinAlg::split_matrix2x2(
   // find out about how the column map is linked to the individual processors.
   // this is done by filling the information about the rowmap into a vector that
   // is then exported to the column map
-  Core::LinAlg::Vector<double> dselector(ASparse.domain_map());
+  Core::LinAlg::Vector<double> dselector(Map(ASparse.domain_map()));
   for (int i = 0; i < dselector.local_length(); ++i)
   {
     const int gid = ASparse.domain_map().GID(i);
@@ -396,7 +396,7 @@ void Core::LinAlg::split_matrix2x2(
     else
       dselector[i] = -1.;
   }
-  Core::LinAlg::Vector<double> selector(ASparse.col_map());
+  Core::LinAlg::Vector<double> selector(Map(ASparse.col_map()));
   Core::LinAlg::export_to(dselector, selector);
 
   std::vector<int> gcindices1(ASparse.max_num_entries());
@@ -474,7 +474,7 @@ void Core::LinAlg::split_matrixmxn(
   // associate each global column ID of SparseMatrix with corresponding block ID of
   // BlockSparseMatrixBase this is done via an Core::LinAlg::Vector<double> which is filled using
   // domain map information and then exported to column map
-  Core::LinAlg::Vector<double> dselector(ASparse.domain_map());
+  Core::LinAlg::Vector<double> dselector(Core::LinAlg::Map(ASparse.domain_map()));
   for (int collid = 0; collid < dselector.local_length(); ++collid)
   {
     const int colgid = ASparse.domain_map().GID(collid);
@@ -489,7 +489,7 @@ void Core::LinAlg::split_matrixmxn(
       }
     }
   }
-  Core::LinAlg::Vector<double> selector(ASparse.col_map());
+  Core::LinAlg::Vector<double> selector(Map(ASparse.col_map()));
   Core::LinAlg::export_to(dselector, selector);
 
   // allocate vectors storing global column indexes and values of matrix entries in a given row,
@@ -548,8 +548,8 @@ int Core::LinAlg::insert_my_row_diagonal_into_unfilled_matrix(
 {
   if (mat.filled()) return -1;
 
-  const int my_num_entries = diag.get_block_map().NumMyElements();
-  const int* my_gids = diag.get_block_map().MyGlobalElements();
+  const int my_num_entries = diag.get_map().NumMyElements();
+  const int* my_gids = diag.get_map().MyGlobalElements();
 
   double* diag_values = diag.get_values();
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -345,7 +345,8 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::matrix_sparse_inverse(
       std::make_shared<SparseMatrix>(sparsity_pattern, dbc_map);
 
   // gather missing rows from other procs to generate an overlapping map
-  Epetra_Import rowImport = Epetra_Import(sparsity_pattern->col_map(), sparsity_pattern->row_map());
+  Epetra_Import rowImport = Epetra_Import(
+      sparsity_pattern->col_map().get_epetra_map(), sparsity_pattern->row_map().get_epetra_map());
   Epetra_CrsMatrix A_overlap = Epetra_CrsMatrix(*A.epetra_matrix(), rowImport);
 
   // loop over all rows of the inverse sparsity pattern (this can be done in parallel)

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -345,8 +345,8 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::matrix_sparse_inverse(
       std::make_shared<SparseMatrix>(sparsity_pattern, dbc_map);
 
   // gather missing rows from other procs to generate an overlapping map
-  Epetra_Import rowImport = Epetra_Import(
-      sparsity_pattern->col_map().get_epetra_map(), sparsity_pattern->row_map().get_epetra_map());
+  Epetra_Import rowImport = Epetra_Import(sparsity_pattern->col_map().get_epetra_block_map(),
+      sparsity_pattern->row_map().get_epetra_block_map());
   Epetra_CrsMatrix A_overlap = Epetra_CrsMatrix(*A.epetra_matrix(), rowImport);
 
   // loop over all rows of the inverse sparsity pattern (this can be done in parallel)

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
@@ -124,7 +124,7 @@ void Core::LinAlg::print_vector_in_matlab_format(
         global_elements_iproc[i] = vector.get_map().MyGlobalElements()[i];
         values_iproc[i] = vector.get_values()[i];
         first_point_in_element_list_iproc[i] =
-            vector.get_map().get_epetra_map().FirstPointInElementList()[i];
+            vector.get_map().get_epetra_block_map().FirstPointInElementList()[i];
       }
     }
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_print.cpp
@@ -107,8 +107,8 @@ void Core::LinAlg::print_vector_in_matlab_format(
   // loop over all procs and send data to proc 0
   for (int iproc = 0; iproc < num_proc; iproc++)
   {
-    int num_elements_iproc = vector.get_block_map().NumMyElements();
-    int max_element_size_iproc = vector.get_block_map().MaxElementSize();
+    int num_elements_iproc = vector.get_map().NumMyElements();
+    int max_element_size_iproc = vector.get_map().MaxElementSize();
 
     Core::Communication::broadcast(&num_elements_iproc, 1, iproc, comm);
     Core::Communication::broadcast(&max_element_size_iproc, 1, iproc, comm);
@@ -121,9 +121,10 @@ void Core::LinAlg::print_vector_in_matlab_format(
     {
       for (int i = 0; i < num_elements_iproc; ++i)
       {
-        global_elements_iproc[i] = vector.get_block_map().MyGlobalElements()[i];
+        global_elements_iproc[i] = vector.get_map().MyGlobalElements()[i];
         values_iproc[i] = vector.get_values()[i];
-        first_point_in_element_list_iproc[i] = vector.get_block_map().FirstPointInElementList()[i];
+        first_point_in_element_list_iproc[i] =
+            vector.get_map().get_epetra_map().FirstPointInElementList()[i];
       }
     }
 
@@ -151,7 +152,7 @@ void Core::LinAlg::print_vector_in_matlab_format(
         }
         else
         {
-          for (int ele_lid = 0; ele_lid < vector.get_block_map().ElementSize(lid); ele_lid++)
+          for (int ele_lid = 0; ele_lid < vector.get_map().ElementSize(lid); ele_lid++)
           {
             os << std::setw(10) << global_elements_iproc[lid] << "/" << std::setw(10) << ele_lid;
 

--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -20,7 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 
 template <typename T>
 Core::LinAlg::Vector<T>::Vector(const Map& Map, bool zeroOut)
-    : vector_(std::make_shared<Epetra_Vector>(Map.get_epetra_map(), zeroOut))
+    : vector_(std::make_shared<Epetra_Vector>(Map.get_epetra_block_map(), zeroOut))
 {
 }
 
@@ -187,7 +187,7 @@ template <typename T>
 int Core::LinAlg::Vector<T>::replace_map(const Map& map)
 {
   if (multi_vector_view_) multi_vector_view_->ReplaceMap(map);
-  auto rv = vector_->ReplaceMap(map.get_epetra_map());
+  auto rv = vector_->ReplaceMap(map.get_epetra_block_map());
   return rv;
 }
 
@@ -216,14 +216,14 @@ template class Core::LinAlg::Vector<double>;
 
 
 Core::LinAlg::Vector<int>::Vector(const Map& map, bool zeroOut)
-    : vector_(std::make_shared<Epetra_IntVector>(map.get_epetra_map(), zeroOut))
+    : vector_(std::make_shared<Epetra_IntVector>(map.get_epetra_block_map(), zeroOut))
 {
 }
 
 
 Core::LinAlg::Vector<int>::Vector(const Map& map, int* values)
-    : vector_(
-          std::make_shared<Epetra_IntVector>(Epetra_DataAccess::Copy, map.get_epetra_map(), values))
+    : vector_(std::make_shared<Epetra_IntVector>(
+          Epetra_DataAccess::Copy, map.get_epetra_block_map(), values))
 {
 }
 

--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -16,15 +16,17 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-template <typename T>
-Core::LinAlg::Vector<T>::Vector(const Epetra_BlockMap& Map, bool zeroOut)
-    : vector_(std::make_shared<Epetra_Vector>(Map, zeroOut))
-{
-}
+
 
 template <typename T>
 Core::LinAlg::Vector<T>::Vector(const Map& Map, bool zeroOut)
     : vector_(std::make_shared<Epetra_Vector>(Map.get_epetra_map(), zeroOut))
+{
+}
+
+template <typename T>
+Core::LinAlg::Vector<T>::Vector(const Epetra_BlockMap& Map, bool zeroOut)
+    : vector_(std::make_shared<Epetra_Vector>(Map, zeroOut))
 {
 }
 
@@ -180,24 +182,25 @@ int Core::LinAlg::Vector<T>::put_scalar(double ScalarConstant)
 }
 
 
-template <typename T>
-int Core::LinAlg::Vector<T>::replace_map(const Epetra_BlockMap& map)
-{
-  if (multi_vector_view_) multi_vector_view_->ReplaceMap(map);
-  return vector_->ReplaceMap(map);
-}
 
 template <typename T>
 int Core::LinAlg::Vector<T>::replace_map(const Map& map)
 {
-  if (multi_vector_view_) multi_vector_view_->ReplaceMap(map.get_epetra_map());
-  return vector_->ReplaceMap(map.get_epetra_map());
+  if (multi_vector_view_) multi_vector_view_->ReplaceMap(map);
+  auto rv = vector_->ReplaceMap(map.get_epetra_map());
+  return rv;
 }
 
 template <typename T>
 MPI_Comm Core::LinAlg::Vector<T>::get_comm() const
 {
   return Core::Communication::unpack_epetra_comm(vector_->Comm());
+}
+
+template <typename T>
+const Core::LinAlg::Map& Core::LinAlg::Vector<T>::get_map() const
+{
+  return map_.sync(vector_->Map());
 }
 
 template <typename T>
@@ -212,20 +215,12 @@ template class Core::LinAlg::Vector<double>;
 
 
 
-Core::LinAlg::Vector<int>::Vector(const Epetra_BlockMap& map, bool zeroOut)
-    : vector_(std::make_shared<Epetra_IntVector>(map, zeroOut))
-{
-}
-
 Core::LinAlg::Vector<int>::Vector(const Map& map, bool zeroOut)
     : vector_(std::make_shared<Epetra_IntVector>(map.get_epetra_map(), zeroOut))
 {
 }
 
-Core::LinAlg::Vector<int>::Vector(const Epetra_BlockMap& map, int* values)
-    : vector_(std::make_shared<Epetra_IntVector>(Epetra_DataAccess::Copy, map, values))
-{
-}
+
 Core::LinAlg::Vector<int>::Vector(const Map& map, int* values)
     : vector_(
           std::make_shared<Epetra_IntVector>(Epetra_DataAccess::Copy, map.get_epetra_map(), values))

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -149,11 +149,8 @@ namespace Core::LinAlg
 
     double operator[](int const index) const { return (*vector_)[index]; }
 
-    //! Returns the address of the Epetra_BlockMap for this multi-vector.
-    const Epetra_BlockMap& get_block_map() const { return (vector_->Map()); };
-
-    //! Returns the address of the Map for this multi-vector.
-    Map get_map() const { return Map(vector_->Map()); };
+    //! Returns the address of the Core::LinAlg::Map for this multi-vector.
+    const Map& get_map() const;
 
     //! Returns the MPI_Comm for this multi-vector.
     MPI_Comm get_comm() const;
@@ -199,7 +196,7 @@ namespace Core::LinAlg
     /** Replace map, only if new map has same point-structure as current map.
         return 0 if map is replaced, -1 if not.
      */
-    int replace_map(const Epetra_BlockMap& map);
+    // int replace_map(const Epetra_BlockMap& map);
 
     int replace_map(const Map& map);
 
@@ -342,6 +339,10 @@ namespace Core::LinAlg
 
     //! The actual Epetra_Vector object.
     std::shared_ptr<Epetra_Vector> vector_;
+
+    //! Map from Epetra_Vector
+    mutable View<const Map> map_;
+
     //! MultiVector view of the Vector. This is used to allow implicit conversion to MultiVector.
     mutable std::shared_ptr<MultiVector<T>> multi_vector_view_;
 
@@ -362,7 +363,7 @@ namespace Core::LinAlg
 
     explicit Vector(const Map& map, bool zeroOut = true);
 
-    Vector(const Epetra_BlockMap& map, int* values);
+    // Vector(const Epetra_BlockMap& map, int* values);
 
     Vector(const Map& map, int* values);
 
@@ -389,8 +390,9 @@ namespace Core::LinAlg
 
     void print(std::ostream& os) const;
 
-    Map get_map() { return Map(vector_->Map()); };
-    const Epetra_BlockMap& get_block_map() const { return vector_->Map(); };
+    //! Returns the address of the Map for this multi-vector.
+    const Map& get_map() const { return map_.sync(vector_->Map()); };
+
 
     //! Imports an Epetra_DistObject using the Epetra_Import object.
     int import(const Vector& A, const Epetra_Import& Importer, Epetra_CombineMode CombineMode,
@@ -422,6 +424,9 @@ namespace Core::LinAlg
 
    private:
     std::shared_ptr<Epetra_IntVector> vector_;
+
+    //! Map from Epetra_Vector
+    mutable View<const Map> map_;
   };
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -196,8 +196,6 @@ namespace Core::LinAlg
     /** Replace map, only if new map has same point-structure as current map.
         return 0 if map is replaced, -1 if not.
      */
-    // int replace_map(const Epetra_BlockMap& map);
-
     int replace_map(const Map& map);
 
     int replace_global_value(int GlobalRow, int VectorIndex, double ScalarValue)
@@ -362,8 +360,6 @@ namespace Core::LinAlg
     explicit Vector(const Epetra_BlockMap& map, bool zeroOut = true);
 
     explicit Vector(const Map& map, bool zeroOut = true);
-
-    // Vector(const Epetra_BlockMap& map, int* values);
 
     Vector(const Map& map, int* values);
 

--- a/src/core/linalg/src/sparse/4C_linalg_view.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_view.hpp
@@ -11,6 +11,8 @@
 
 #include "4C_config.hpp"
 
+#include "4C_utils_exceptions.hpp"
+
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN

--- a/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
@@ -1,0 +1,101 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_linalg_map.hpp"
+
+#include "4C_comm_mpi_utils.hpp"
+#include "4C_linalg_multi_vector.hpp"
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_vector.hpp"
+
+#include <memory>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+
+  TEST(ExchangeMapTest, Vector)
+  {
+    // initialize a communicator and the number of elements
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int NumGlobalElements = 10;
+
+    // set up a map
+    std::shared_ptr<Core::LinAlg::Map> starting_map =
+        std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 0, comm);
+
+    // create a vector
+    auto vector = Core::LinAlg::Vector<double>(starting_map->get_epetra_map(), true);
+
+    const Epetra_Map& expected_map = starting_map->get_epetra_map();
+    const Epetra_Map& actual_map = vector.get_map().get_epetra_map();
+
+    // check if underlying maps are identical.
+    EXPECT_TRUE(actual_map.SameAs(expected_map));
+
+    // create a new map with different index base
+    auto new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 1, comm);
+
+    // replace map with vector function
+    vector.replace_map(*new_map);
+
+    // Ensure that the underlying epetra maps are identical
+    EXPECT_EQ(vector.get_map().get_epetra_map().SameAs(new_map->get_epetra_map()), true);
+
+    // create a new map with index base 2
+    new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 2, comm);
+
+    // replace the map based on the map of epetra vector
+    EXPECT_EQ(vector.get_ptr_of_epetra_vector()->ReplaceMap(new_map->get_epetra_map()), 0);
+
+    // compare result with our map wrapper
+    EXPECT_TRUE(vector.get_map().SameAs(*new_map));
+  }
+
+  TEST(ExchangeMapTest, MultiVector)
+  {
+    // initialize a communicator and the number of elements
+    MPI_Comm comm = MPI_COMM_WORLD;
+    int NumGlobalElements = 10;
+
+    std::shared_ptr<Core::LinAlg::Map> starting_map =
+        std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 0, comm);
+
+    // create a multi vector
+    auto vector = Core::LinAlg::MultiVector<double>(starting_map->get_epetra_map(), true);
+
+    // check that the vector has the same epetra map
+    EXPECT_TRUE(vector.get_map().get_epetra_map().SameAs(starting_map->get_epetra_map()));
+
+    // create a new map with different index base
+    auto new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 1, comm);
+
+    // check if map replacement is successfully
+    EXPECT_EQ(vector.ReplaceMap(*new_map), 0);
+
+    // compare if the wrapper returns the correct map
+    EXPECT_TRUE(vector.get_map().SameAs(*new_map));
+
+    // check that the epetra maps are same
+    EXPECT_TRUE(vector.get_map().get_epetra_map().SameAs(new_map->get_epetra_map()));
+
+    // create a new map with index base 2
+    new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 2, comm);
+
+    // replace the map based on the epetra vector
+    EXPECT_EQ(vector.get_ptr_of_Epetra_MultiVector()->ReplaceMap(new_map->get_epetra_map()), 0);
+
+    // compare result with our map wrapper
+    EXPECT_TRUE(vector.get_map().SameAs(*new_map));
+  }
+
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
@@ -14,8 +14,6 @@
 #include "4C_linalg_multi_vector.hpp"
 #include "4C_linalg_sparsematrix.hpp"
 
-#include <Epetra_Map.h>
-
 #include <memory>
 
 FOUR_C_NAMESPACE_OPEN
@@ -297,8 +295,8 @@ namespace
     // A change of the map is reflected to all views
     a.replace_map(new_map);
 
-    EXPECT_TRUE(a.get_block_map().SameAs(b.Map()));
-    EXPECT_TRUE(a.get_block_map().SameAs(c.get_block_map()));
+    EXPECT_TRUE(a.get_map().SameAs(b.get_map()));
+    EXPECT_TRUE(a.get_map().SameAs(c.get_map()));
   }
 
 }  // namespace

--- a/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
@@ -41,7 +41,7 @@ namespace
   TEST_F(VectorTest, ConstructorsAndNorms)
   {
     // create an epetra vector
-    Epetra_Vector my_epetra_vector = Epetra_Vector(map_->get_epetra_map(), true);
+    Epetra_Vector my_epetra_vector = Epetra_Vector(map_->get_epetra_block_map(), true);
 
     // try to copy zero vector into wrapper
     Core::LinAlg::Vector<double> epetra_based_test_vector =
@@ -151,7 +151,7 @@ namespace
 
   TEST_F(VectorTest, View)
   {
-    Epetra_Vector a(map_->get_epetra_map(), true);
+    Epetra_Vector a(map_->get_epetra_block_map(), true);
     a.PutScalar(1.0);
     // Scope in which a is modified by the view
     {

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_objects.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_objects.cpp
@@ -63,7 +63,6 @@ Core::LinearSolver::AMGNxN::BlockedVector::new_rcp(bool ZeroIt) const
   Teuchos::RCP<BlockedVector> out = Teuchos::make_rcp<BlockedVector>(this->get_num_blocks());
   for (int i = 0; i < get_num_blocks(); i++)
   {
-    // const Core::LinAlg::Map&  Map = this->GetVector(i)->Map();
     // int NV = this->GetNumBlocks();
     // out->SetVector(Teuchos::rcp( new Core::LinAlg::MultiVector<double>(Map,NV,ZeroIt)),i); //This
     // is buggy

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_objects.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_objects.cpp
@@ -63,7 +63,7 @@ Core::LinearSolver::AMGNxN::BlockedVector::new_rcp(bool ZeroIt) const
   Teuchos::RCP<BlockedVector> out = Teuchos::make_rcp<BlockedVector>(this->get_num_blocks());
   for (int i = 0; i < get_num_blocks(); i++)
   {
-    // const Epetra_BlockMap&  Map = this->GetVector(i)->Map();
+    // const Core::LinAlg::Map&  Map = this->GetVector(i)->Map();
     // int NV = this->GetNumBlocks();
     // out->SetVector(Teuchos::rcp( new Core::LinAlg::MultiVector<double>(Map,NV,ZeroIt)),i); //This
     // is buggy
@@ -149,7 +149,7 @@ void Core::LinearSolver::AMGNxN::BlockedMatrix::apply(
 
     Teuchos::RCP<Core::LinAlg::MultiVector<double>> Yi = out.get_vector(i);
     Yi->PutScalar(0.0);
-    Core::LinAlg::MultiVector<double> Yitmp(Yi->Map(), Yi->NumVectors(), true);
+    Core::LinAlg::MultiVector<double> Yitmp(Yi->get_map(), Yi->NumVectors(), true);
 
     for (int j = 0; j < get_num_cols(); j++)
     {

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_smoothers.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_smoothers.cpp
@@ -745,10 +745,10 @@ void Core::LinearSolver::AMGNxN::IfpackWrapper::apply(const Core::LinAlg::MultiV
   }
   else
   {
-    Core::LinAlg::MultiVector<double> DX(X.Map(), X.NumVectors(), false);
+    Core::LinAlg::MultiVector<double> DX(X.get_map(), X.NumVectors(), false);
     a_->Apply(Y, DX);
     DX.Update(1.0, X, -1.0);
-    Core::LinAlg::MultiVector<double> DY(Y.Map(), X.NumVectors(), false);
+    Core::LinAlg::MultiVector<double> DY(Y.get_map(), X.NumVectors(), false);
     prec_->ApplyInverse(DX, DY);
     Y.Update(1.0, DY, 1.0);
   }

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_vcycle.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_vcycle.cpp
@@ -302,7 +302,7 @@ void Core::LinearSolver::AMGNxN::VcycleSingle::do_vcycle(const Core::LinAlg::Mul
 
     // Compute residual
     int NV = X.NumVectors();
-    Core::LinAlg::MultiVector<double> DX(X.Map(), NV, false);
+    Core::LinAlg::MultiVector<double> DX(X.get_map(), NV, false);
     avec_[level]->Apply(Y, DX);
     DX.Update(1.0, X, -1.0);
 
@@ -317,7 +317,7 @@ void Core::LinearSolver::AMGNxN::VcycleSingle::do_vcycle(const Core::LinAlg::Mul
     do_vcycle(DXcoarse, DYcoarse, level + 1, true);
 
     // Compute correction
-    Core::LinAlg::MultiVector<double> DY(Y.Map(), NV, false);
+    Core::LinAlg::MultiVector<double> DY(Y.get_map(), NV, false);
     pvec_[level]->Apply(DYcoarse, DY);
     Y.Update(1.0, DY, 1.0);
 

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -554,7 +554,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Core::Rebalance::get_col_ver
   // This is a rought test, but it might be ok at this place. It is an
   // error anyway to hand in a vector that is not related to our dof
   // maps.
-  if (vecmap.PointSameAs(colmap->get_epetra_map())) return state;
+  if (vecmap.PointSameAs(colmap->get_epetra_block_map())) return state;
   // if it's not in column map export and allocate
   else
   {

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -548,7 +548,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Core::Rebalance::get_col_ver
 
   if (!dis.have_dofs()) FOUR_C_THROW("fill_complete() was not called");
   const Core::LinAlg::Map* colmap = dis.dof_col_map(nds);
-  const Epetra_BlockMap& vecmap = state->get_block_map();
+  const Core::LinAlg::Map& vecmap = state->get_map();
 
   // if it's already in column map just set a reference
   // This is a rought test, but it might be ok at this place. It is an

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -383,8 +383,8 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_monolithic_nod
       my_colliding_primitives.begin(), my_colliding_primitives.end());
   Core::LinAlg::Map my_colliding_primitives_map(-1, my_colliding_primitives_vec.size(),
       my_colliding_primitives_vec.data(), 0, dis.get_comm());
-  Epetra_Import importer(
-      my_colliding_primitives_map.get_epetra_map(), dis.element_row_map()->get_epetra_map());
+  Epetra_Import importer(my_colliding_primitives_map.get_epetra_block_map(),
+      dis.element_row_map()->get_epetra_block_map());
   Core::LinAlg::Graph my_colliding_primitives_connectivity(
       Copy, my_colliding_primitives_map, n_nodes_per_element_max, false);
   err = my_colliding_primitives_connectivity.import_from(

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -619,9 +619,9 @@ void Coupling::Adapter::Coupling::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.Map().PointSameAs(masterdofmap_->get_epetra_map()))
+  if (not mv.get_map().PointSameAs(masterdofmap_->get_epetra_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.Map().PointSameAs(slavedofmap_->get_epetra_map()))
+  if (not sv.get_map().PointSameAs(slavedofmap_->get_epetra_map()))
     FOUR_C_THROW("slave dof map vector expected");
   if (sv.NumVectors() != mv.NumVectors())
     FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
@@ -654,14 +654,14 @@ void Coupling::Adapter::Coupling::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.Map().PointSameAs(masterdofmap_->get_epetra_map()))
+  if (not mv.get_map().PointSameAs(masterdofmap_->get_epetra_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.Map().PointSameAs(slavedofmap_->get_epetra_map()))
+  if (not sv.get_map().PointSameAs(slavedofmap_->get_epetra_map()))
   {
     std::cout << "slavedofmap_" << std::endl;
     std::cout << *slavedofmap_ << std::endl;
     std::cout << "sv" << std::endl;
-    std::cout << sv.Map() << std::endl;
+    std::cout << sv.get_map() << std::endl;
     FOUR_C_THROW("slave dof map vector expected");
   }
   if (sv.NumVectors() != mv.NumVectors())

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -94,11 +94,11 @@ void Coupling::Adapter::Coupling::setup_condition_coupling(
 
   masterdofmap_ = mastercondmap;
   masterexport_ = std::make_shared<Epetra_Export>(
-      permmasterdofmap_->get_epetra_map(), masterdofmap_->get_epetra_map());
+      permmasterdofmap_->get_epetra_block_map(), masterdofmap_->get_epetra_block_map());
 
   slavedofmap_ = slavecondmap;
   slaveexport_ = std::make_shared<Epetra_Export>(
-      permslavedofmap_->get_epetra_map(), slavedofmap_->get_epetra_map());
+      permslavedofmap_->get_epetra_block_map(), slavedofmap_->get_epetra_block_map());
 }
 
 /*----------------------------------------------------------------------*/
@@ -169,9 +169,9 @@ void Coupling::Adapter::Coupling::setup_coupling(
   permslavedofmap_ = permslavedofmap;
 
   masterexport_ = std::make_shared<Epetra_Export>(
-      permmasterdofmap_->get_epetra_map(), masterdofmap_->get_epetra_map());
+      permmasterdofmap_->get_epetra_block_map(), masterdofmap_->get_epetra_block_map());
   slaveexport_ = std::make_shared<Epetra_Export>(
-      permslavedofmap_->get_epetra_map(), slavedofmap_->get_epetra_map());
+      permslavedofmap_->get_epetra_block_map(), slavedofmap_->get_epetra_block_map());
 }
 
 
@@ -251,13 +251,13 @@ void Coupling::Adapter::Coupling::setup_coupling(
   permmasterdofmap_ = std::make_shared<Core::LinAlg::Map>(*slavedis.dof_row_map());
   masterdofmap_ = std::make_shared<Core::LinAlg::Map>(*masterdis.dof_row_map());
   masterexport_ = std::make_shared<Epetra_Export>(
-      permmasterdofmap_->get_epetra_map(), masterdofmap_->get_epetra_map());
+      permmasterdofmap_->get_epetra_block_map(), masterdofmap_->get_epetra_block_map());
 
   // get slave dof maps and build exporter
   permslavedofmap_ = std::make_shared<Core::LinAlg::Map>(*masterdis.dof_row_map());
   slavedofmap_ = std::make_shared<Core::LinAlg::Map>(*slavedis.dof_row_map());
   slaveexport_ = std::make_shared<Epetra_Export>(
-      permslavedofmap_->get_epetra_map(), slavedofmap_->get_epetra_map());
+      permslavedofmap_->get_epetra_block_map(), slavedofmap_->get_epetra_block_map());
 }
 
 /*----------------------------------------------------------------------*/
@@ -371,7 +371,7 @@ void Coupling::Adapter::Coupling::finish_coupling(const Core::FE::Discretization
       std::make_shared<Core::LinAlg::Vector<int>>(*slavenodemap);
 
   Epetra_Export masternodeexport(
-      permslavenodemap->get_epetra_map(), slavenodemap->get_epetra_map());
+      permslavenodemap->get_epetra_block_map(), slavenodemap->get_epetra_block_map());
   const int err = permmasternodevec->export_to(*masternodevec, masternodeexport, Insert);
   if (err) FOUR_C_THROW("failed to export master nodes");
 
@@ -520,8 +520,8 @@ void Coupling::Adapter::Coupling::build_dof_maps(const Core::FE::Discretization&
 
   // prepare communication plan to create a dofmap out of a permuted
   // dof map
-  exporter =
-      std::make_shared<Epetra_Export>(permdofmap->get_epetra_map(), dofmap->get_epetra_map());
+  exporter = std::make_shared<Epetra_Export>(
+      permdofmap->get_epetra_block_map(), dofmap->get_epetra_block_map());
 }
 
 
@@ -559,7 +559,7 @@ std::shared_ptr<Epetra_FEVector> Coupling::Adapter::Coupling::master_to_slave(
     const Epetra_FEVector& mv) const
 {
   std::shared_ptr<Epetra_FEVector> sv =
-      std::make_shared<Epetra_FEVector>(slavedofmap_->get_epetra_map(), mv.NumVectors());
+      std::make_shared<Epetra_FEVector>(slavedofmap_->get_epetra_block_map(), mv.NumVectors());
 
   Core::LinAlg::View sv_view(*sv);
   Core::LinAlg::View mv_view(mv);
@@ -575,7 +575,7 @@ std::shared_ptr<Epetra_FEVector> Coupling::Adapter::Coupling::slave_to_master(
     const Epetra_FEVector& sv) const
 {
   std::shared_ptr<Epetra_FEVector> mv =
-      std::make_shared<Epetra_FEVector>(masterdofmap_->get_epetra_map(), sv.NumVectors());
+      std::make_shared<Epetra_FEVector>(masterdofmap_->get_epetra_block_map(), sv.NumVectors());
 
   Core::LinAlg::View sv_view(sv);
   Core::LinAlg::View mv_view(*mv);
@@ -619,9 +619,9 @@ void Coupling::Adapter::Coupling::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().PointSameAs(masterdofmap_->get_epetra_map()))
+  if (not mv.get_map().PointSameAs(masterdofmap_->get_epetra_block_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().PointSameAs(slavedofmap_->get_epetra_map()))
+  if (not sv.get_map().PointSameAs(slavedofmap_->get_epetra_block_map()))
     FOUR_C_THROW("slave dof map vector expected");
   if (sv.NumVectors() != mv.NumVectors())
     FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
@@ -654,9 +654,9 @@ void Coupling::Adapter::Coupling::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().PointSameAs(masterdofmap_->get_epetra_map()))
+  if (not mv.get_map().PointSameAs(masterdofmap_->get_epetra_block_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().PointSameAs(slavedofmap_->get_epetra_map()))
+  if (not sv.get_map().PointSameAs(slavedofmap_->get_epetra_block_map()))
   {
     std::cout << "slavedofmap_" << std::endl;
     std::cout << *slavedofmap_ << std::endl;
@@ -763,7 +763,8 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::master_
 
   // OK. You cannot use the same exporter for different matrices. So we
   // recreate one all the time... This has to be optimized later on.
-  Epetra_Export exporter(permmasterdofmap_->get_epetra_map(), masterdofmap_->get_epetra_map());
+  Epetra_Export exporter(
+      permmasterdofmap_->get_epetra_block_map(), masterdofmap_->get_epetra_block_map());
   int err = permsm->import(sm, exporter, Insert);
 
   if (err) FOUR_C_THROW("Import failed with err={}", err);
@@ -789,7 +790,8 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::slave_t
 
   // OK. You cannot use the same exporter for different matrices. So we
   // recreate one all the time... This has to be optimized later on.
-  Epetra_Export exporter(permslavedofmap_->get_epetra_map(), slavedofmap_->get_epetra_map());
+  Epetra_Export exporter(
+      permslavedofmap_->get_epetra_block_map(), slavedofmap_->get_epetra_block_map());
   int err = permsm->import(sm, exporter, Insert);
 
   if (err) FOUR_C_THROW("Import failed with err={}", err);
@@ -848,7 +850,8 @@ void Coupling::Adapter::Coupling::setup_coupling_matrices(const Core::LinAlg::Ma
   // communicate slave to master matrix
   auto tmp = std::make_shared<Core::LinAlg::SparseMatrix>(slavedomainmap, 1);
 
-  Epetra_Import exporter(slavedomainmap.get_epetra_map(), perm_slave_dof_map()->get_epetra_map());
+  Epetra_Import exporter(
+      slavedomainmap.get_epetra_block_map(), perm_slave_dof_map()->get_epetra_block_map());
   int err = tmp->import(*matsm_trans_, exporter, Insert);
   if (err) FOUR_C_THROW("Import failed with err={}", err);
 

--- a/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
@@ -123,7 +123,7 @@ bool Coupling::Adapter::MatrixLogicalSplitAndTransform::operator()(
     // check if the permuted map is simply a subset of the current rowmap (no communication)
     int subset = 1;
     for (int i = 0; i < permsrcmap.NumMyElements(); ++i)
-      if (!src.row_map().MyGID(permsrcmap.get_epetra_map().GID(i)))
+      if (!src.row_map().MyGID(permsrcmap.get_epetra_block_map().GID(i)))
       {
         subset = 0;
         break;
@@ -138,7 +138,7 @@ bool Coupling::Adapter::MatrixLogicalSplitAndTransform::operator()(
       if (exporter_ == nullptr)
       {
         exporter_ = std::make_shared<Epetra_Export>(
-            permsrcmap.get_epetra_map(), src.row_map().get_epetra_map());
+            permsrcmap.get_epetra_block_map(), src.row_map().get_epetra_block_map());
       }
 
       std::shared_ptr<Epetra_CrsMatrix> permsrc =

--- a/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
@@ -1101,8 +1101,10 @@ void Coupling::Adapter::CouplingMortar::evaluate(
 
   std::shared_ptr<Core::LinAlg::Map> dofrowmap =
       Core::LinAlg::merge_map(*pmasterdofrowmap_, *pslavedofrowmap_, false);
-  Epetra_Import master_importer(dofrowmap->get_epetra_map(), pmasterdofrowmap_->get_epetra_map());
-  Epetra_Import slaveImporter(dofrowmap->get_epetra_map(), pslavedofrowmap_->get_epetra_map());
+  Epetra_Import master_importer(
+      dofrowmap->get_epetra_block_map(), pmasterdofrowmap_->get_epetra_block_map());
+  Epetra_Import slaveImporter(
+      dofrowmap->get_epetra_block_map(), pslavedofrowmap_->get_epetra_block_map());
 
   // Import master and slave displacements into a single vector
   int err = 0;
@@ -1330,9 +1332,9 @@ void Coupling::Adapter::CouplingMortar::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().PointSameAs(P_->col_map().get_epetra_map()))
+  if (not mv.get_map().PointSameAs(P_->col_map().get_epetra_block_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().PointSameAs(D_->col_map().get_epetra_map()))
+  if (not sv.get_map().PointSameAs(D_->col_map().get_epetra_block_map()))
     FOUR_C_THROW("slave dof map vector expected");
 #endif
 
@@ -1361,9 +1363,9 @@ void Coupling::Adapter::CouplingMortar::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().PointSameAs(P_->col_map().get_epetra_map()))
+  if (not mv.get_map().PointSameAs(P_->col_map().get_epetra_block_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().PointSameAs(D_->col_map().get_epetra_map()))
+  if (not sv.get_map().PointSameAs(D_->col_map().get_epetra_block_map()))
     FOUR_C_THROW("slave dof map vector expected");
 #endif
 

--- a/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
@@ -559,7 +559,7 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
 
       for (int k = 0; k < dim; ++k)
       {
-        val[k] += (*idisp)[(idisp->get_block_map()).LID(gdofs[k])];
+        val[k] += (*idisp)[(idisp->get_map()).LID(gdofs[k])];
       }
     }
 
@@ -598,7 +598,7 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
 
       for (int k = 0; k < dim; ++k)
       {
-        val[k] += (*idisp)[(idisp->get_block_map()).LID(gdofs[k])];
+        val[k] += (*idisp)[(idisp->get_map()).LID(gdofs[k])];
       }
     }
 
@@ -693,12 +693,11 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
     for (int k = 0; k < dim; ++k)
     {
       int dof = mtnode->dofs()[k];
-      (*Xmaster)[(Xmaster->get_block_map()).LID(dof)] = mtnode->x()[k];
+      (*Xmaster)[(Xmaster->get_map()).LID(dof)] = mtnode->x()[k];
 
       // add ALE displacements, if required
       if (idisp != nullptr)
-        (*Xmaster)[(Xmaster->get_block_map()).LID(dof)] +=
-            (*idisp)[(idisp->get_block_map()).LID(dof)];
+        (*Xmaster)[(Xmaster->get_map()).LID(dof)] += (*idisp)[(idisp->get_map()).LID(dof)];
     }
   }
 
@@ -793,12 +792,12 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
 
         for (int k = 0; k < numdim; ++k)
         {
-          locindex[k] = (Xslavemodcol.get_block_map()).LID(mtnode->dofs()[k]);
+          locindex[k] = (Xslavemodcol.get_map()).LID(mtnode->dofs()[k]);
           if (locindex[k] < 0) FOUR_C_THROW("Did not find dof in map");
           Xnew[k] = Xslavemodcol[locindex[k]];
           Xold[k] = mtnode->x()[k];
           if (idisp != nullptr)
-            Xold[k] += (*idisp)[(idisp->get_block_map()).LID(interface_->discret().dof(node)[k])];
+            Xold[k] += (*idisp)[(idisp->get_map()).LID(interface_->discret().dof(node)[k])];
         }
 
         // check is mesh distortion is still OK
@@ -873,7 +872,7 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
           for (int k = 0; k < dim; ++k)
           {
             // get global ID of degree of freedom for this spatial direction
-            int dofgid = (idisp->get_block_map()).LID(gdofs[k]);
+            int dofgid = (idisp->get_map()).LID(gdofs[k]);
             // get new coordinate value for this spatial direction
             const double value = Xnewglobal[k] - node->x()[k];
             // replace respective value in displacement vector
@@ -924,7 +923,7 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
 
       for (int k = 0; k < dim; ++k)
       {
-        val[k] += (*idisp)[(idisp->get_block_map()).LID(gdofs[k])];
+        val[k] += (*idisp)[(idisp->get_map()).LID(gdofs[k])];
       }
     }
 
@@ -960,7 +959,7 @@ void Coupling::Adapter::CouplingMortar::mesh_relocation(Core::FE::Discretization
 
       for (int k = 0; k < dim; ++k)
       {
-        val[k] += (*idisp)[(idisp->get_block_map()).LID(gdofs[k])];
+        val[k] += (*idisp)[(idisp->get_map()).LID(gdofs[k])];
       }
     }
 
@@ -1097,7 +1096,7 @@ void Coupling::Adapter::CouplingMortar::evaluate(
   FOUR_C_ASSERT(idispsl->get_map().PointSameAs(*pslavedofrowmap_),
       "Map of incoming slave vector does not match the stored slave dof row map.");
 
-  const Epetra_BlockMap stdmap = idispsl->get_block_map();
+  const Core::LinAlg::Map stdmap = idispsl->get_map();
   idispsl->replace_map(*slavedofrowmap_);
 
   std::shared_ptr<Core::LinAlg::Map> dofrowmap =
@@ -1287,8 +1286,7 @@ Coupling::Adapter::CouplingMortar::master_to_slave(
   // safety check
   check_setup();
 
-  FOUR_C_ASSERT(
-      masterdofrowmap_->SameAs(Core::LinAlg::Map(mv.Map())), "Vector with master dof map expected");
+  FOUR_C_ASSERT(masterdofrowmap_->SameAs(mv.get_map()), "Vector with master dof map expected");
 
   Core::LinAlg::MultiVector<double> tmp =
       Core::LinAlg::MultiVector<double>(M_->row_map(), mv.NumVectors());
@@ -1311,8 +1309,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> Coupling::Adapter::CouplingMortar:
   // safety check
   check_setup();
 
-  FOUR_C_ASSERT(
-      masterdofrowmap_->SameAs(mv.get_block_map()), "Vector with master dof map expected");
+  FOUR_C_ASSERT(masterdofrowmap_->SameAs(mv.get_map()), "Vector with master dof map expected");
 
   Core::LinAlg::Vector<double> tmp = Core::LinAlg::Vector<double>(M_->row_map());
 
@@ -1333,9 +1330,9 @@ void Coupling::Adapter::CouplingMortar::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.Map().PointSameAs(P_->col_map().get_epetra_map()))
+  if (not mv.get_map().PointSameAs(P_->col_map().get_epetra_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.Map().PointSameAs(D_->col_map().get_epetra_map()))
+  if (not sv.get_map().PointSameAs(D_->col_map().get_epetra_map()))
     FOUR_C_THROW("slave dof map vector expected");
 #endif
 
@@ -1364,9 +1361,9 @@ void Coupling::Adapter::CouplingMortar::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.Map().PointSameAs(P_->col_map().get_epetra_map()))
+  if (not mv.get_map().PointSameAs(P_->col_map().get_epetra_map()))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.Map().PointSameAs(D_->col_map().get_epetra_map()))
+  if (not sv.get_map().PointSameAs(D_->col_map().get_epetra_map()))
     FOUR_C_THROW("slave dof map vector expected");
 #endif
 

--- a/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
@@ -297,10 +297,10 @@ void Coupling::Adapter::MortarVolCoupl::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  FOUR_C_ASSERT(mv.get_map().PointSameAs(p21_->domain_map().get_epetra_map()),
+  FOUR_C_ASSERT(mv.get_map().PointSameAs(p21_->domain_map().get_epetra_block_map()),
       "master dof map vector expected");
-  FOUR_C_ASSERT(
-      sv.get_map().PointSameAs(p21_->row_map().get_epetra_map()), "slave dof map vector expected");
+  FOUR_C_ASSERT(sv.get_map().PointSameAs(p21_->row_map().get_epetra_block_map()),
+      "slave dof map vector expected");
   FOUR_C_ASSERT(sv.NumVectors() == mv.NumVectors(), "column number mismatch {}!={}",
       sv.NumVectors(), mv.NumVectors());
 #endif
@@ -390,10 +390,10 @@ void Coupling::Adapter::MortarVolCoupl::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  FOUR_C_ASSERT(
-      mv.get_map().PointSameAs(p12_->row_map().get_epetra_map()), "master dof map vector expected");
-  FOUR_C_ASSERT(
-      sv.get_map().PointSameAs(p21_->row_map().get_epetra_map()), "slave dof map vector expected");
+  FOUR_C_ASSERT(mv.get_map().PointSameAs(p12_->row_map().get_epetra_block_map()),
+      "master dof map vector expected");
+  FOUR_C_ASSERT(sv.get_map().PointSameAs(p21_->row_map().get_epetra_block_map()),
+      "slave dof map vector expected");
   FOUR_C_ASSERT(sv.NumVectors() == mv.NumVectors(), "column number mismatch {}!={}",
       sv.NumVectors(), mv.NumVectors());
 #endif

--- a/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
@@ -297,10 +297,10 @@ void Coupling::Adapter::MortarVolCoupl::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
+  FOUR_C_ASSERT(mv.get_map().PointSameAs(p21_->domain_map().get_epetra_map()),
+      "master dof map vector expected");
   FOUR_C_ASSERT(
-      mv.Map().PointSameAs(p21_->domain_map().get_epetra_map()), "master dof map vector expected");
-  FOUR_C_ASSERT(
-      sv.Map().PointSameAs(p21_->row_map().get_epetra_map()), "slave dof map vector expected");
+      sv.get_map().PointSameAs(p21_->row_map().get_epetra_map()), "slave dof map vector expected");
   FOUR_C_ASSERT(sv.NumVectors() == mv.NumVectors(), "column number mismatch {}!={}",
       sv.NumVectors(), mv.NumVectors());
 #endif
@@ -391,9 +391,9 @@ void Coupling::Adapter::MortarVolCoupl::slave_to_master(
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
   FOUR_C_ASSERT(
-      mv.Map().PointSameAs(p12_->row_map().get_epetra_map()), "master dof map vector expected");
+      mv.get_map().PointSameAs(p12_->row_map().get_epetra_map()), "master dof map vector expected");
   FOUR_C_ASSERT(
-      sv.Map().PointSameAs(p21_->row_map().get_epetra_map()), "slave dof map vector expected");
+      sv.get_map().PointSameAs(p21_->row_map().get_epetra_map()), "slave dof map vector expected");
   FOUR_C_ASSERT(sv.NumVectors() == mv.NumVectors(), "column number mismatch {}!={}",
       sv.NumVectors(), mv.NumVectors());
 #endif

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -1422,7 +1422,7 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
         // loop over slave dofs
         for (int jdof = 0; jdof < nsdof; ++jdof)
         {
-          const int lid = sola->get_block_map().LID(discret1()->dof(dofseta, cnode, jdof));
+          const int lid = sola->get_map().LID(discret1()->dof(dofseta, cnode, jdof));
           nvector[jdof] = (*sola)[lid] - cnode->x()[jdof];
         }
         cnode->change_pos(nvector);
@@ -1441,7 +1441,7 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
         // loop over slave dofs
         for (int jdof = 0; jdof < nsdof; ++jdof)
         {
-          const int lid = solb->get_block_map().LID(discret2()->dof(dofsetb, cnode, jdof));
+          const int lid = solb->get_map().LID(discret2()->dof(dofsetb, cnode, jdof));
           nvector[jdof] = (*solb)[lid] - cnode->x()[jdof];
         }
         cnode->change_pos(nvector);

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -234,11 +234,10 @@ std::shared_ptr<Core::LinAlg::Vector<double>> EHL::Base::evaluate_fluid_force(
 {
   // safety: unprojectable nodes to zero pressure
   if (inf_gap_toggle_lub_ != nullptr)
-    for (int i = 0; i < lubrication_->lubrication_field()->prenp()->get_block_map().NumMyElements();
-        ++i)
+    for (int i = 0; i < lubrication_->lubrication_field()->prenp()->get_map().NumMyElements(); ++i)
     {
-      if (abs(inf_gap_toggle_lub_->operator[](inf_gap_toggle_lub_->get_block_map().LID(
-                  lubrication_->lubrication_field()->prenp()->get_block_map().GID(i))) -
+      if (abs(inf_gap_toggle_lub_->operator[](inf_gap_toggle_lub_->get_map().LID(
+                  lubrication_->lubrication_field()->prenp()->get_map().GID(i))) -
               1) < 1.e-2)
         lubrication_->lubrication_field()->prenp()->operator[](i) = 0.;
     }
@@ -375,7 +374,7 @@ void EHL::Base::add_couette_force(
     Core::Nodes::Node* lnode = lub_dis.l_row_node(i);
     if (!lnode) FOUR_C_THROW("node not found");
     const double p = lubrication_->lubrication_field()->prenp()->operator[](
-        lubrication_->lubrication_field()->prenp()->get_block_map().LID(lub_dis.dof(0, lnode, 0)));
+        lubrication_->lubrication_field()->prenp()->get_map().LID(lub_dis.dof(0, lnode, 0)));
 
     std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
     if (!mat) FOUR_C_THROW("null pointer");
@@ -541,7 +540,7 @@ void EHL::Base::setup_unprojectable_dbc()
   static std::shared_ptr<Core::LinAlg::Vector<double>> old_toggle = nullptr;
   if (old_toggle != nullptr)
   {
-    for (int i = 0; i < inf_gap_toggle_lub_->get_block_map().NumMyElements(); ++i)
+    for (int i = 0; i < inf_gap_toggle_lub_->get_map().NumMyElements(); ++i)
       if (abs(inf_gap_toggle_lub_->operator[](i) - old_toggle->operator[](i)) > 1.e-12)
       {
         if (!Core::Communication::my_mpi_rank(get_comm()))
@@ -723,7 +722,7 @@ void EHL::Base::output(bool forced_writerestart)
   {
     std::shared_ptr<Core::LinAlg::Vector<double>> active_toggle, slip_toggle;
     mortaradapter_->create_active_slip_toggle(&active_toggle, &slip_toggle);
-    for (int i = 0; i < active_toggle->get_block_map().NumMyElements(); ++i)
+    for (int i = 0; i < active_toggle->get_map().NumMyElements(); ++i)
       slip_toggle->operator[](i) += active_toggle->operator[](i);
     std::shared_ptr<Core::LinAlg::Vector<double>> active =
         std::make_shared<Core::LinAlg::Vector<double>>(
@@ -799,7 +798,7 @@ void EHL::Base::output(bool forced_writerestart)
       Core::Nodes::Node* lnode = lubrication_->lubrication_field()->discretization()->l_row_node(i);
       if (!lnode) FOUR_C_THROW("node not found");
       const double p = lubrication_->lubrication_field()->prenp()->operator[](
-          lubrication_->lubrication_field()->prenp()->get_block_map().LID(
+          lubrication_->lubrication_field()->prenp()->get_map().LID(
               lubrication_->lubrication_field()->discretization()->dof(0, lnode, 0)));
       std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
       if (!mat) FOUR_C_THROW("null pointer");

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -499,7 +499,7 @@ void EHL::Base::setup_unprojectable_dbc()
   if (not Global::Problem::instance()->elasto_hydro_dynamic_params().get<bool>("UNPROJ_ZERO_DBC"))
     return;
 
-  Epetra_FEVector inf_gap_toggle(mortaradapter_->slave_dof_map()->get_epetra_map(), true);
+  Epetra_FEVector inf_gap_toggle(mortaradapter_->slave_dof_map()->get_epetra_block_map(), true);
   for (int i = 0; i < mortaradapter_->interface()->slave_row_nodes()->NumMyElements(); ++i)
   {
     Core::Nodes::Node* node = mortaradapter_->interface()->discret().g_node(

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -1677,7 +1677,7 @@ void EHL::Monolithic::lin_couette_force_disp(
     Core::Nodes::Node* lnode = lub_dis.l_row_node(i);
     if (!lnode) FOUR_C_THROW("node not found");
     const double p = lubrication_->lubrication_field()->prenp()->operator[](
-        lubrication_->lubrication_field()->prenp()->get_block_map().LID(lub_dis.dof(0, lnode, 0)));
+        lubrication_->lubrication_field()->prenp()->get_map().LID(lub_dis.dof(0, lnode, 0)));
 
     std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
     if (!mat) FOUR_C_THROW("null pointer");
@@ -1827,7 +1827,7 @@ void EHL::Monolithic::lin_couette_force_pres(
     Core::Nodes::Node* lnode = lub_dis.l_row_node(i);
     if (!lnode) FOUR_C_THROW("node not found");
     const double p = lubrication_->lubrication_field()->prenp()->operator[](
-        lubrication_->lubrication_field()->prenp()->get_block_map().LID(lub_dis.dof(0, lnode, 0)));
+        lubrication_->lubrication_field()->prenp()->get_map().LID(lub_dis.dof(0, lnode, 0)));
 
     std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
     if (!mat) FOUR_C_THROW("null pointer");
@@ -1913,7 +1913,7 @@ void EHL::Monolithic::apply_dbc()
   if (inf_gap_toggle_lub_ != nullptr)
     for (int i = 0; i < inf_gap_toggle_lub_->local_length(); ++i)
       if (abs(inf_gap_toggle_lub_->operator[](i)) > 1.e-12)
-        rhs_->replace_global_value(inf_gap_toggle_lub_->get_block_map().GID(i), 0, 0.);
+        rhs_->replace_global_value(inf_gap_toggle_lub_->get_map().GID(i), 0, 0.);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/elch/4C_elch_moving_boundary_algorithm.cpp
+++ b/src/elch/4C_elch_moving_boundary_algorithm.cpp
@@ -334,7 +334,7 @@ void ElCh::MovingBoundaryAlgorithm::compute_interface_vectors(
   // id of the reacting species
   int reactingspeciesid = 0;
 
-  const Epetra_BlockMap& ivelmap = iveln.get_block_map();
+  const Core::LinAlg::Map& ivelmap = iveln.get_map();
 
   // loop over all local nodes of fluid discretization
   for (int lnodeid = 0; lnodeid < fluiddis->num_my_row_nodes(); lnodeid++)

--- a/src/fbi/4C_fbi_adapter_constraintbridge_penalty.cpp
+++ b/src/fbi/4C_fbi_adapter_constraintbridge_penalty.cpp
@@ -26,8 +26,8 @@ void Adapter::FBIConstraintBridgePenalty::setup(const Core::LinAlg::Map* beam_ma
 {
   // Initialize all necessary vectors and matrices
   FBIConstraintBridge::setup(beam_map, fluid_map, fluidmatrix, fluidmeshtying);
-  fs_ = std::make_shared<Epetra_FEVector>(beam_map->get_epetra_map());
-  ff_ = std::make_shared<Epetra_FEVector>(fluid_map->get_epetra_map());
+  fs_ = std::make_shared<Epetra_FEVector>(beam_map->get_epetra_block_map());
+  ff_ = std::make_shared<Epetra_FEVector>(fluid_map->get_epetra_block_map());
   cff_ = fluidmatrix;
 }
 /*----------------------------------------------------------------------*/

--- a/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.cpp
+++ b/src/fbi/4C_fbi_beam_to_fluid_mortar_manager.cpp
@@ -183,8 +183,9 @@ void BeamInteraction::BeamToFluidMortarManager::setup()
       *lambda_dof_rowmap_, 30, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   global_m_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *lambda_dof_rowmap_, 100, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  global_kappa_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
-  global_active_lambda_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_map());
+  global_kappa_ = std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
+  global_active_lambda_ =
+      std::make_shared<Epetra_FEVector>(lambda_dof_rowmap_->get_epetra_block_map());
 
   // Create the maps for beam and solid DOFs.
   set_global_maps();

--- a/src/fbi/4C_fbi_constraintenforcer_penalty.cpp
+++ b/src/fbi/4C_fbi_constraintenforcer_penalty.cpp
@@ -116,7 +116,7 @@ void Adapter::FBIPenaltyConstraintenforcer::print_violation(double time, int ste
     double penalty_parameter = bridge()->get_params()->get_penalty_parameter();
 
     std::shared_ptr<Core::LinAlg::Vector<double>> violation = Core::LinAlg::create_vector(
-        std::dynamic_pointer_cast<Adapter::FBIFluidMB>(get_fluid())->velnp()->get_block_map());
+        std::dynamic_pointer_cast<Adapter::FBIFluidMB>(get_fluid())->velnp()->get_map());
 
     int err = std::dynamic_pointer_cast<const Adapter::FBIConstraintBridgePenalty>(get_bridge())
                   ->get_cff()

--- a/src/fluid/4C_fluid_DbcHDG.cpp
+++ b/src/fluid/4C_fluid_DbcHDG.cpp
@@ -107,7 +107,7 @@ void FLD::Utils::DbcHdgFluid::read_dirichlet_condition(const Teuchos::ParameterL
         // get global id
         const int gid = dofs[j];
         // get corresponding local id
-        const int lid = info.toggle.get_block_map().LID(gid);
+        const int lid = info.toggle.get_map().LID(gid);
         if (lid < 0)
           FOUR_C_THROW("Global id {} not on this proc {} in system vector", dofs[j],
               Core::Communication::my_mpi_rank(discret.get_comm()));
@@ -355,7 +355,7 @@ void FLD::Utils::DbcHdgFluid::do_dirichlet_condition(const Teuchos::ParameterLis
         // get global id
         const int gid = dofs[j];
         // get corresponding local id
-        const int lid = toggle.get_block_map().LID(gid);
+        const int lid = toggle.get_map().LID(gid);
         if (lid < 0)
           FOUR_C_THROW("Global id {} not on this proc {} in system vector", dofs[j],
               Core::Communication::my_mpi_rank(discret.get_comm()));

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1189,7 +1189,7 @@ void FLD::FluidImplicitTimeInt::evaluate_mat_and_rhs(Teuchos::ParameterList& ele
         Core::LinAlg::create_vector(*discret_->dof_row_map(), true);
 
     Epetra_Export exporter(
-        residual_col->get_map().get_epetra_map(), tmp->get_map().get_epetra_map());
+        residual_col->get_map().get_epetra_block_map(), tmp->get_map().get_epetra_block_map());
     int err = tmp->export_to(*residual_col, exporter, Add);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
     residual_->update(1.0, *tmp, 1.0);
@@ -2012,7 +2012,7 @@ void FLD::FluidImplicitTimeInt::evaluate_fluid_edge_based(
   // need to export residual_col to systemvector1 (residual_)
   Core::LinAlg::Vector<double> res_tmp(systemvector1.get_map(), false);
   Epetra_Export exporter(
-      residual_col->get_map().get_epetra_map(), res_tmp.get_map().get_epetra_map());
+      residual_col->get_map().get_epetra_block_map(), res_tmp.get_map().get_epetra_block_map());
   int err2 = res_tmp.export_to(*residual_col, exporter, Add);
   if (err2) FOUR_C_THROW("Export using exporter returned err={}", err2);
   systemvector1.update(1.0, res_tmp, 1.0);

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -1188,7 +1188,8 @@ void FLD::FluidImplicitTimeInt::evaluate_mat_and_rhs(Teuchos::ParameterList& ele
     std::shared_ptr<Core::LinAlg::Vector<double>> tmp =
         Core::LinAlg::create_vector(*discret_->dof_row_map(), true);
 
-    Epetra_Export exporter(residual_col->get_block_map(), tmp->get_block_map());
+    Epetra_Export exporter(
+        residual_col->get_map().get_epetra_map(), tmp->get_map().get_epetra_map());
     int err = tmp->export_to(*residual_col, exporter, Add);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
     residual_->update(1.0, *tmp, 1.0);
@@ -2009,8 +2010,9 @@ void FLD::FluidImplicitTimeInt::evaluate_fluid_edge_based(
 
   //------------------------------------------------------------
   // need to export residual_col to systemvector1 (residual_)
-  Core::LinAlg::Vector<double> res_tmp(systemvector1.get_block_map(), false);
-  Epetra_Export exporter(residual_col->get_block_map(), res_tmp.get_block_map());
+  Core::LinAlg::Vector<double> res_tmp(systemvector1.get_map(), false);
+  Epetra_Export exporter(
+      residual_col->get_map().get_epetra_map(), res_tmp.get_map().get_epetra_map());
   int err2 = res_tmp.export_to(*residual_col, exporter, Add);
   if (err2) FOUR_C_THROW("Export using exporter returned err={}", err2);
   systemvector1.update(1.0, res_tmp, 1.0);
@@ -2123,8 +2125,8 @@ void FLD::FluidImplicitTimeInt::setup_krylov_space_projection(
   // set flag for projection update true only if ALE and integral weights
   if (alefluid_ and (*weighttype == "integration")) updateprojection_ = true;
 
-  auto map = discret_->dof_row_map()->get_epetra_map();
-  projector_ = std::make_shared<Core::LinAlg::KrylovProjector>(activemodeids, weighttype, &map);
+  auto map = discret_->dof_row_map();
+  projector_ = std::make_shared<Core::LinAlg::KrylovProjector>(activemodeids, weighttype, map);
 
   // update the projector
   update_krylov_space_projection();
@@ -2228,8 +2230,7 @@ void FLD::FluidImplicitTimeInt::update_krylov_space_projection()
       c0_update = meshtying_->adapt_krylov_projector(Core::Utils::shared_ptr_from_ref(c0));
       if (msht_ == Inpar::FLUID::condensed_bmat || msht_ == Inpar::FLUID::condensed_bmat_merged)
       {
-        auto mergedmap = meshtying_->get_merged_map()->get_epetra_map();
-        projector_->set_cw(*c0_update, *w0_update, &mergedmap);
+        projector_->set_cw(*c0_update, *w0_update, meshtying_->get_merged_map());
       }
       else
       {
@@ -2257,7 +2258,7 @@ void FLD::FluidImplicitTimeInt::check_matrix_nullspace()
     int nsdim = c->NumVectors();
     if (nsdim != 1) FOUR_C_THROW("Only one mode, namely the constant pressure mode, expected.");
 
-    Core::LinAlg::Vector<double> result(c->Map(), false);
+    Core::LinAlg::Vector<double> result(c->get_map(), false);
 
     sysmat_->Apply(*c, result);
 
@@ -2977,9 +2978,9 @@ void FLD::FluidImplicitTimeInt::get_dofs_vector_local_indicesfor_node(int nodeGi
   for (int i = 0; i < dim; i++)
   {
     int dofGid = dofsGid[i];
-    if (!vec.get_block_map().MyGID(dofGid))
+    if (!vec.get_map().MyGID(dofGid))
       FOUR_C_THROW("Sparse vector does not have global row  {} or vectors don't match", dofGid);
-    (*dofsLocalInd)[i] = vec.get_block_map().LID(dofGid);
+    (*dofsLocalInd)[i] = vec.get_map().LID(dofGid);
   }
 }
 
@@ -3853,11 +3854,11 @@ void FLD::FluidImplicitTimeInt::read_restart(int step)
   // that was used when the restart data was written. Especially
   // in case of multiphysics problems & periodic boundary conditions
   // it is better to check the consistency of the maps here:
-  if (not(discret_->dof_row_map())->SameAs(velnp_->get_block_map()))
+  if (not(discret_->dof_row_map())->SameAs(velnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(discret_->dof_row_map())->SameAs(veln_->get_block_map()))
+  if (not(discret_->dof_row_map())->SameAs(veln_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(discret_->dof_row_map())->SameAs(accn_->get_block_map()))
+  if (not(discret_->dof_row_map())->SameAs(accn_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
 }
 
@@ -4560,7 +4561,7 @@ void FLD::FluidImplicitTimeInt::set_iter_scalar_fields(
       // find out the global dof id of the last(!) dof at the scatra node
       const int numscatradof = scatradis->num_dof(dofset, lscatranode);
       const int globalscatradofid = scatradis->dof(dofset, lscatranode, numscatradof - 1);
-      const int localscatradofid = scalaraf->get_block_map().LID(globalscatradofid);
+      const int localscatradofid = scalaraf->get_map().LID(globalscatradofid);
       if (localscatradofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
       // get the processor's local fluid node
@@ -4568,7 +4569,7 @@ void FLD::FluidImplicitTimeInt::set_iter_scalar_fields(
       // get global and processor's local pressure dof id (using the map!)
       const int numdof = discret_->num_dof(0, lnode);
       const int globaldofid = discret_->dof(0, lnode, numdof - 1);
-      const int localdofid = scaam_->get_block_map().LID(globaldofid);
+      const int localdofid = scaam_->get_map().LID(globaldofid);
       if (localdofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
       // now copy the values
@@ -4596,8 +4597,8 @@ void FLD::FluidImplicitTimeInt::set_iter_scalar_fields(
   {
     // given vectors are already in dofrowmap layout of fluid and values can
     // be copied directly
-    if (not scalaraf->get_block_map().SameAs(scaaf_->get_block_map()) or
-        not scalaram->get_block_map().SameAs(scaam_->get_block_map()))
+    if (not scalaraf->get_map().SameAs(scaaf_->get_map()) or
+        not scalaram->get_map().SameAs(scaam_->get_map()))
       FOUR_C_THROW("fluid dofrowmap layout expected");
 
     // loop all nodes on the processor
@@ -4608,7 +4609,7 @@ void FLD::FluidImplicitTimeInt::set_iter_scalar_fields(
       // get global and processor's local pressure dof id (using the map!)
       const int numdof = discret_->num_dof(0, lnode);
       const int globaldofid = discret_->dof(0, lnode, numdof - 1);
-      const int localdofid = scaam_->get_block_map().LID(globaldofid);
+      const int localdofid = scaam_->get_map().LID(globaldofid);
       if (localdofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
       // now copy the values
@@ -4673,7 +4674,7 @@ void FLD::FluidImplicitTimeInt::set_scalar_fields(
       // respect the explicit wish of the user
       globalscatradofid = scatradis->dof(0, lscatranode, whichscalar);
     }
-    const int localscatradofid = scalarnp->get_block_map().LID(globalscatradofid);
+    const int localscatradofid = scalarnp->get_map().LID(globalscatradofid);
     if (localscatradofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
     // get the processor's local fluid node
@@ -4682,7 +4683,7 @@ void FLD::FluidImplicitTimeInt::set_scalar_fields(
     nodedofs = discret_->dof(0, lnode);
     // get global and processor's local pressure dof id (using the map!)
     const int globaldofid = nodedofs[numdim_];
-    const int localdofid = scaam_->get_block_map().LID(globaldofid);
+    const int localdofid = scaam_->get_map().LID(globaldofid);
     if (localdofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
     value = (*scalarnp)[localscatradofid];
@@ -6155,7 +6156,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FLD::FluidImplicitTimeInt::calc_di
 
   // integrated divergence operator B in vector form
   std::shared_ptr<Core::LinAlg::Vector<double>> divop =
-      std::make_shared<Core::LinAlg::Vector<double>>(velnp_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(velnp_->get_map(), true);
 
   // copy row map of mesh displacement to column map (only if ALE is used)
   discret_->clear_state();

--- a/src/fluid/4C_fluid_result_test.cpp
+++ b/src/fluid/4C_fluid_result_test.cpp
@@ -66,7 +66,7 @@ void FLD::FluidResultTest::test_node(
 
       double result = 0.;
 
-      const Epetra_BlockMap& velnpmap = mysol_->get_block_map();
+      const Core::LinAlg::Map& velnpmap = mysol_->get_map();
 
       const int numdim = Global::Problem::instance()->n_dim();
 
@@ -87,22 +87,22 @@ void FLD::FluidResultTest::test_node(
         result = (*mysol_)[velnpmap.LID(fluiddis_->dof(0, actnode, numdim))];
       }
       else if (position == "tractionx")
-        result = (*mytraction_)[(mytraction_->get_block_map()).LID(fluiddis_->dof(0, actnode, 0))];
+        result = (*mytraction_)[(mytraction_->get_map()).LID(fluiddis_->dof(0, actnode, 0))];
       else if (position == "tractiony")
-        result = (*mytraction_)[(mytraction_->get_block_map()).LID(fluiddis_->dof(0, actnode, 1))];
+        result = (*mytraction_)[(mytraction_->get_map()).LID(fluiddis_->dof(0, actnode, 1))];
       else if (position == "tractionz")
       {
         if (numdim == 2) FOUR_C_THROW("Cannot test result for tractionz in 2D case.");
-        result = (*mytraction_)[(mytraction_->get_block_map()).LID(fluiddis_->dof(0, actnode, 2))];
+        result = (*mytraction_)[(mytraction_->get_map()).LID(fluiddis_->dof(0, actnode, 2))];
       }
       else if (position == "wssx")
-        result = (*mywss_)[(mywss_->get_block_map()).LID(fluiddis_->dof(0, actnode, 0))];
+        result = (*mywss_)[(mywss_->get_map()).LID(fluiddis_->dof(0, actnode, 0))];
       else if (position == "wssy")
-        result = (*mywss_)[(mywss_->get_block_map()).LID(fluiddis_->dof(0, actnode, 1))];
+        result = (*mywss_)[(mywss_->get_map()).LID(fluiddis_->dof(0, actnode, 1))];
       else if (position == "wssz")
       {
         if (numdim == 2) FOUR_C_THROW("Cannot test result for wssz in 2D case.");
-        result = (*mywss_)[(mywss_->get_block_map()).LID(fluiddis_->dof(0, actnode, 2))];
+        result = (*mywss_)[(mywss_->get_map()).LID(fluiddis_->dof(0, actnode, 2))];
       }
       else if (position == "L2errvel")
         result = (*myerror_)[0];

--- a/src/fluid/4C_fluid_timint_genalpha.cpp
+++ b/src/fluid/4C_fluid_timint_genalpha.cpp
@@ -201,7 +201,7 @@ void FLD::TimIntGenAlpha::gen_alpha_update_acceleration()
     std::shared_ptr<Core::LinAlg::Vector<double>> onlyvelnp =
         velpressplitter_->extract_other_vector(*velnp_);
 
-    Core::LinAlg::Vector<double> onlyaccnp(onlyaccn->get_block_map());
+    Core::LinAlg::Vector<double> onlyaccnp(onlyaccn->get_map());
 
     onlyaccnp.update(fact2, *onlyaccn, 0.0);
     onlyaccnp.update(fact1, *onlyvelnp, -fact1, *onlyveln, 1.0);
@@ -243,7 +243,7 @@ void FLD::TimIntGenAlpha::gen_alpha_intermediate_values()
     std::shared_ptr<Core::LinAlg::Vector<double>> onlyaccnp =
         velpressplitter_->extract_other_vector(*accnp_);
 
-    Core::LinAlg::Vector<double> onlyaccam(onlyaccnp->get_block_map());
+    Core::LinAlg::Vector<double> onlyaccam(onlyaccnp->get_map());
 
     onlyaccam.update((alphaM_), *onlyaccnp, (1.0 - alphaM_), *onlyaccn, 0.0);
 
@@ -287,9 +287,8 @@ void FLD::TimIntGenAlpha::gen_alpha_intermediate_values(
   //    vec         = alpha_F * vecnp     + (1-alpha_F) *  vecn
 
   // do stupid conversion into map
-  Core::LinAlg::Map vecmap(vecnp->get_block_map().NumGlobalElements(),
-      vecnp->get_block_map().NumMyElements(), vecnp->get_block_map().MyGlobalElements(), 0,
-      Core::Communication::unpack_epetra_comm(vecnp->get_block_map().Comm()));
+  Core::LinAlg::Map vecmap(vecnp->get_map().NumGlobalElements(), vecnp->get_map().NumMyElements(),
+      vecnp->get_map().MyGlobalElements(), 0, vecnp->get_map().Comm());
 
   std::shared_ptr<Core::LinAlg::Vector<double>> vecam = Core::LinAlg::create_vector(vecmap, true);
   vecam->update((alphaM_), *vecnp, (1.0 - alphaM_), *vecn, 0.0);

--- a/src/fluid/4C_fluid_timint_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_hdg.cpp
@@ -300,8 +300,7 @@ void FLD::TimIntHDG::clear_state_assemble_mat_and_rhs()
     // data back before it disappears when clearing the state (at least for nproc>1)
     const Core::LinAlg::Vector<double>& intvelnpGhosted = *discret_->get_state(1, "intvelnp");
     for (int i = 0; i < intvelnp_->local_length(); ++i)
-      (*intvelnp_)[i] =
-          intvelnpGhosted[intvelnpGhosted.get_block_map().LID(intvelnp_->get_block_map().GID(i))];
+      (*intvelnp_)[i] = intvelnpGhosted[intvelnpGhosted.get_map().LID(intvelnp_->get_map().GID(i))];
   }
   first_assembly_ = false;
   FluidImplicitTimeInt::clear_state_assemble_mat_and_rhs();
@@ -473,7 +472,7 @@ namespace
       velocity = std::make_shared<Core::LinAlg::MultiVector<double>>(*dis.node_row_map(), ndim);
       pressure = std::make_shared<Core::LinAlg::Vector<double>>(*dis.node_row_map());
     }
-    tracevel = std::make_shared<Core::LinAlg::MultiVector<double>>(velocity->Map(), ndim);
+    tracevel = std::make_shared<Core::LinAlg::MultiVector<double>>(velocity->get_map(), ndim);
     cellPres = std::make_shared<Core::LinAlg::Vector<double>>(*dis.element_row_map());
 
     // call element routine for interpolate HDG to elements

--- a/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
+++ b/src/fluid/4C_fluid_timint_hdg_weak_comp.cpp
@@ -301,8 +301,7 @@ void FLD::TimIntHDGWeakComp::clear_state_assemble_mat_and_rhs()
     // data back before it disappears when clearing the state (at least for nproc>1)
     const Core::LinAlg::Vector<double>& intvelnpGhosted = *discret_->get_state(1, "intvelnp");
     for (int i = 0; i < intvelnp_->local_length(); ++i)
-      (*intvelnp_)[i] =
-          intvelnpGhosted[intvelnpGhosted.get_block_map().LID(intvelnp_->get_block_map().GID(i))];
+      (*intvelnp_)[i] = intvelnpGhosted[intvelnpGhosted.get_map().LID(intvelnp_->get_map().GID(i))];
   }
   first_assembly_ = false;
   FluidImplicitTimeInt::clear_state_assemble_mat_and_rhs();
@@ -667,7 +666,7 @@ namespace
       mixedvar = std::make_shared<Core::LinAlg::MultiVector<double>>(*dis.node_row_map(), msd);
       density = std::make_shared<Core::LinAlg::Vector<double>>(*dis.node_row_map());
     }
-    traceden = std::make_shared<Core::LinAlg::Vector<double>>(density->get_block_map());
+    traceden = std::make_shared<Core::LinAlg::Vector<double>>(density->get_map());
 
     // call element routine for interpolate HDG to elements
     Teuchos::ParameterList params;
@@ -750,7 +749,7 @@ void FLD::TimIntHDGWeakComp::output()
     std::shared_ptr<Core::LinAlg::MultiVector<double>> interpolatedVelocity;
     std::shared_ptr<Core::LinAlg::Vector<double>> interpolatedPressure;
     interpolatedPressure =
-        std::make_shared<Core::LinAlg::Vector<double>>(interpolatedDensity_->get_block_map());
+        std::make_shared<Core::LinAlg::Vector<double>>(interpolatedDensity_->get_map());
     for (int i = 0; i < interpolatedDensity_->local_length(); ++i)
     {
       (*interpolatedPressure)[i] =

--- a/src/fluid/4C_fluid_timint_loma.cpp
+++ b/src/fluid/4C_fluid_timint_loma.cpp
@@ -114,7 +114,7 @@ void FLD::TimIntLoma::set_loma_iter_scalar_fields(
     // find out the global dof id of the last(!) dof at the scatra node
     const int numscatradof = scatradis->num_dof(0, lscatranode);
     const int globalscatradofid = scatradis->dof(0, lscatranode, numscatradof - 1);
-    const int localscatradofid = scalaraf->get_block_map().LID(globalscatradofid);
+    const int localscatradofid = scalaraf->get_map().LID(globalscatradofid);
     if (localscatradofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
     // get the processor's local fluid node
@@ -124,7 +124,7 @@ void FLD::TimIntLoma::set_loma_iter_scalar_fields(
     // get global and processor's local pressure dof id (using the map!)
     const int numdof = discret_->num_dof(0, lnode);
     const int globaldofid = discret_->dof(0, lnode, numdof - 1);
-    const int localdofid = scaam_->get_block_map().LID(globaldofid);
+    const int localdofid = scaam_->get_map().LID(globaldofid);
     if (localdofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
 
     // now copy the values

--- a/src/fluid/4C_fluid_timint_stat_hdg.cpp
+++ b/src/fluid/4C_fluid_timint_stat_hdg.cpp
@@ -160,8 +160,7 @@ void FLD::TimIntStationaryHDG::clear_state_assemble_mat_and_rhs()
     // data back before it disappears when clearing the state (at least for nproc>1)
     const Core::LinAlg::Vector<double>& intvelnpGhosted = *discret_->get_state(1, "intvelnp");
     for (int i = 0; i < intvelnp_->local_length(); ++i)
-      (*intvelnp_)[i] =
-          intvelnpGhosted[intvelnpGhosted.get_block_map().LID(intvelnp_->get_block_map().GID(i))];
+      (*intvelnp_)[i] = intvelnpGhosted[intvelnpGhosted.get_map().LID(intvelnp_->get_map().GID(i))];
   }
   first_assembly_ = false;
   FluidImplicitTimeInt::clear_state_assemble_mat_and_rhs();

--- a/src/fluid/4C_fluid_utils.cpp
+++ b/src/fluid/4C_fluid_utils.cpp
@@ -646,7 +646,7 @@ void FLD::Utils::lift_drag(const std::shared_ptr<const Core::FE::Discretization>
       {
         const Core::LinAlg::Matrix<3, 1> x(
             (*actnode)->x().data(), false);  // pointer to nodal coordinates
-        const Epetra_BlockMap& rowdofmap = trueresidual.get_block_map();
+        const Core::LinAlg::Map& rowdofmap = trueresidual.get_map();
         const std::vector<int> dof = dis->dof(*actnode);
 
         // get nodal forces

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -1262,10 +1262,10 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::correct_flow_rate(
     double correction = 0.0;
     for (int lid = 0; lid < correction_velnp->local_length(); lid++)
     {
-      int gid = correction_velnp->get_block_map().GID(lid);
+      int gid = correction_velnp->get_map().GID(lid);
       correction = correction_factor * (*correction_velnp)[lid];
 
-      int bc_lid = cond_velocities_->get_block_map().LID(gid);
+      int bc_lid = cond_velocities_->get_map().LID(gid);
       (*cond_velocities_)[bc_lid] += correction;
     }
   }
@@ -1276,10 +1276,10 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::correct_flow_rate(
     double correction = 0.0;
     for (int lid = 0; lid < correction_velnp->local_length(); lid++)
     {
-      int gid = correction_velnp->get_block_map().GID(lid);
+      int gid = correction_velnp->get_map().GID(lid);
       correction = correction_factor * (*correction_velnp)[lid];
 
-      int bc_lid = cond_velocities_->get_block_map().LID(gid);
+      int bc_lid = cond_velocities_->get_map().LID(gid);
       (*cond_velocities_)[bc_lid] = correction;
     }
   }
@@ -1294,7 +1294,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::set_velocities(
 {
   for (int lid = 0; lid < cond_velocities_->local_length(); lid++)
   {
-    int gid = cond_velocities_->get_block_map().GID(lid);
+    int gid = cond_velocities_->get_map().GID(lid);
     double val = (*cond_velocities_)[lid];
 
     velocities.replace_global_values(1, &val, &gid);
@@ -1935,7 +1935,7 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::export_and_set_boundary_values(
     std::string name)
 {
   // define the exporter
-  Epetra_Export exporter(source.get_block_map(), target->get_block_map());
+  Epetra_Export exporter(source.get_map().get_epetra_map(), target->get_map().get_epetra_map());
   // Export source vector to target vector
   int err = target->export_to(source, exporter, Zero);
   // check if the exporting was successful
@@ -1952,7 +1952,7 @@ void FLD::Utils::TotalTractionCorrector::export_and_set_boundary_values(
     std::string name)
 {
   // define the exporter
-  Epetra_Export exporter(source.get_block_map(), target->get_block_map());
+  Epetra_Export exporter(source.get_map().get_epetra_map(), target->get_map().get_epetra_map());
   // Export source vector to target vector
   int err = target->export_to(source, exporter, Zero);
   // check if the exporting was successful

--- a/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
+++ b/src/fluid/4C_fluid_volumetric_surfaceFlow_condition.cpp
@@ -1935,7 +1935,8 @@ void FLD::Utils::FluidVolumetricSurfaceFlowBc::export_and_set_boundary_values(
     std::string name)
 {
   // define the exporter
-  Epetra_Export exporter(source.get_map().get_epetra_map(), target->get_map().get_epetra_map());
+  Epetra_Export exporter(
+      source.get_map().get_epetra_block_map(), target->get_map().get_epetra_block_map());
   // Export source vector to target vector
   int err = target->export_to(source, exporter, Zero);
   // check if the exporting was successful
@@ -1952,7 +1953,8 @@ void FLD::Utils::TotalTractionCorrector::export_and_set_boundary_values(
     std::string name)
 {
   // define the exporter
-  Epetra_Export exporter(source.get_map().get_epetra_map(), target->get_map().get_epetra_map());
+  Epetra_Export exporter(
+      source.get_map().get_epetra_block_map(), target->get_map().get_epetra_block_map());
   // Export source vector to target vector
   int err = target->export_to(source, exporter, Zero);
   // check if the exporting was successful

--- a/src/fluid/4C_fluid_xwall.cpp
+++ b/src/fluid/4C_fluid_xwall.cpp
@@ -985,7 +985,7 @@ void FLD::XWall::calc_tau_w(
         if (!node) FOUR_C_THROW("ERROR: Cannot find off wall node with gid %", gid);
 
         int firstglobaldofid = discret_->dof(0, node, 0);
-        int firstlocaldofid = wss.get_block_map().LID(firstglobaldofid);
+        int firstlocaldofid = wss.get_map().LID(firstglobaldofid);
 
         if (firstlocaldofid < 0) FOUR_C_THROW("localdofid not found in map for given globaldofid");
         double forcex = (wss)[firstlocaldofid];

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
@@ -332,7 +332,7 @@ int Discret::Elements::FluidEleCalcHDG<distype>::compute_error(Discret::Elements
 
   for (unsigned int i = 0; i < localDofs.size(); ++i)
   {
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     vecValues[i] = (*matrix_state)[lid];
   }
 
@@ -700,7 +700,7 @@ int Discret::Elements::FluidEleCalcHDG<distype>::interpolate_solution_to_nodes(
   for (unsigned int i = 0; i < solvalues.size(); ++i)
   {
     // Finding the local id of the current "localDofs"
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     // Saving the value of the "localDofs[i]" in the "solvalues" vector
     solvalues[i] = (*matrix_state)[lid];
   }
@@ -770,7 +770,7 @@ int Discret::Elements::FluidEleCalcHDG<distype>::interpolate_solution_to_nodes(
 
   for (unsigned int i = 0; i < solvalues.size(); ++i)
   {
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     solvalues[i] = (*matrix_state)[lid];
   }
 
@@ -890,7 +890,7 @@ int Discret::Elements::FluidEleCalcHDG<distype>::interpolate_solution_for_hit(
 
   for (unsigned int i = 0; i < solvalues.size(); ++i)
   {
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     solvalues[i] = (*matrix_state)[lid];
   }
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
@@ -343,7 +343,7 @@ int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::compute_error(
   std::vector<double> vecValues(localDofs.size());
   for (unsigned int i = 0; i < localDofs.size(); ++i)
   {
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     vecValues[i] = (*matrix_state)[lid];
   }
 
@@ -685,7 +685,7 @@ int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::interpolate_solution_to
   for (unsigned int i = 0; i < solvalues.size(); ++i)
   {
     // Finding the local id of the current "localDofs"
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     // Saving the value of the "localDofs[i]" in the "solvalues" vector
     solvalues[i] = (*matrix_state)[lid];
   }
@@ -749,7 +749,7 @@ int Discret::Elements::FluidEleCalcHDGWeakComp<distype>::interpolate_solution_to
 
   for (unsigned int i = 0; i < solvalues.size(); ++i)
   {
-    const int lid = matrix_state->get_block_map().LID(localDofs[i]);
+    const int lid = matrix_state->get_map().LID(localDofs[i]);
     solvalues[i] = (*matrix_state)[lid];
   }
   for (int i = (msd_ + 1 + nsd_) * nen_; i < elevec1.numRows(); ++i) elevec1(i) = 0.0;

--- a/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
@@ -687,7 +687,7 @@ int Discret::Elements::FluidInternalSurfaceStab<distype, pdistype,
 
   for (int i = 0; i < ndofinpatch; ++i)
   {
-    int lid = velaf->get_block_map().LID(patchlm[i]);
+    int lid = velaf->get_map().LID(patchlm[i]);
     if (lid == -1) FOUR_C_THROW("Cannot find degree of freedom on this proc");
     patch_velaf[i] = (*velaf)[lid];
   }
@@ -720,7 +720,7 @@ int Discret::Elements::FluidInternalSurfaceStab<distype, pdistype,
     std::vector<double> patch_velnp(ndofinpatch);
     for (int i = 0; i < ndofinpatch; ++i)
     {
-      int lid = velnp->get_block_map().LID(patchlm[i]);
+      int lid = velnp->get_map().LID(patchlm[i]);
       if (lid == -1) FOUR_C_THROW("Cannot find degree of freedom on this proc");
       patch_velnp[i] = (*velnp)[lid];
     }
@@ -775,11 +775,11 @@ int Discret::Elements::FluidInternalSurfaceStab<distype, pdistype,
 
     for (int i = 0; i < ndofinpatch; ++i)
     {
-      int lid_1 = dispnp->get_block_map().LID(patchlm[i]);
+      int lid_1 = dispnp->get_map().LID(patchlm[i]);
       if (lid_1 == -1) FOUR_C_THROW("Cannot find degree of freedom on this proc");
       patch_dispnp[i] = (*dispnp)[lid_1];
 
-      int lid_2 = gridv->get_block_map().LID(patchlm[i]);
+      int lid_2 = gridv->get_map().LID(patchlm[i]);
       if (lid_2 == -1) FOUR_C_THROW("Cannot find degree of freedom on this proc");
       patch_gridv[i] = (*gridv)[lid_2];
     }

--- a/src/fluid_ele/4C_fluid_ele_calc_xwall.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xwall.cpp
@@ -409,7 +409,7 @@ void Discret::Elements::FluidEleCalcXWall<distype, enrtype>::get_ele_properties(
   // get element mk for stabilization
   const std::shared_ptr<Core::LinAlg::Vector<double>> mkvec =
       params.get<std::shared_ptr<Core::LinAlg::Vector<double>>>("mk");
-  mk_ = (*mkvec)[mkvec->get_block_map().LID(ele->id())];
+  mk_ = (*mkvec)[mkvec->get_map().LID(ele->id())];
 
   numgpnorm_ = params.get<int>("gpnorm");
   numgpnormow_ = params.get<int>("gpnormow");

--- a/src/fluid_turbulence/4C_fluid_turbulence_boxfilter.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_boxfilter.cpp
@@ -1362,7 +1362,7 @@ void FLD::Boxfilter::apply_box_filter_scatra(
         {
           // get global and local dof IDs
           const int gid = nodedofs[idim];
-          const int lid = convel->get_block_map().LID(gid);
+          const int lid = convel->get_map().LID(gid);
           if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
 
           double vel_i = (*convel)[lid];
@@ -1425,7 +1425,7 @@ void FLD::Boxfilter::apply_box_filter_scatra(
           {
             // get global and local dof IDs
             const int gid = nodedofs[idim];
-            const int lid = convel->get_block_map().LID(gid);
+            const int lid = convel->get_map().LID(gid);
             if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
 
             double valvel_i = (*convel)[lid];

--- a/src/fluid_turbulence/4C_fluid_turbulence_hit_forcing.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_hit_forcing.cpp
@@ -2075,7 +2075,7 @@ namespace FLD
 
       int firstgdofid = discret_->dof(0, node, 0);
 
-      int firstldofid = forcing_->get_block_map().LID(firstgdofid);
+      int firstldofid = forcing_->get_map().LID(firstgdofid);
 
       int err = forcing_->replace_local_value(firstldofid, 0, newforce);
       if (err != 0) FOUR_C_THROW("something went wrong during replacemyvalue");

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_ccy.cpp
@@ -591,10 +591,10 @@ void FLD::TurbulenceStatisticsCcy::evaluate_pointwise_mean_values_in_planes()
     else
       scatranurbsdis->set_state("phinp_for_statistics", *meanfullphinp_);
 
-    if (not(scatranurbsdis->dof_row_map())->SameAs(meanfullphinp_->get_block_map()))
+    if (not(scatranurbsdis->dof_row_map())->SameAs(meanfullphinp_->get_map()))
     {
       scatranurbsdis->dof_row_map()->Print(std::cout);
-      meanfullphinp_->get_block_map().Print(std::cout);
+      meanfullphinp_->get_map().Print(std::cout);
       FOUR_C_THROW("Global dof numbering in maps does not match");
     }
   }

--- a/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
@@ -141,7 +141,8 @@ void FLD::TurbulentFlowAlgorithm::transfer_inflow_velocity()
   velnp_ = Core::LinAlg::create_vector(*fluiddis_->dof_row_map(), true);
 
   // get exporter for transfer of dofs from inflow discretization to complete fluid discretization
-  Epetra_Export exporter(inflowvelnp->get_block_map(), velnp_->get_block_map());
+  Epetra_Export exporter(
+      inflowvelnp->get_map().get_epetra_map(), velnp_->get_map().get_epetra_map());
   // export inflow velocity
   int err = velnp_->export_to(*inflowvelnp, exporter, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
@@ -200,19 +201,22 @@ void FLD::TurbulentFlowAlgorithm::read_restart(const int restart)
 
   // export vectors to inflow discretization
   int err = 0;
-  Epetra_Export exportvelnp(fluidvelnp->get_block_map(), velnp->get_block_map());
+  Epetra_Export exportvelnp(
+      fluidvelnp->get_map().get_epetra_map(), velnp->get_map().get_epetra_map());
   err = velnp->export_to(*fluidvelnp, exportvelnp, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
-  Epetra_Export exportveln(fluidveln->get_block_map(), veln->get_block_map());
+  Epetra_Export exportveln(fluidveln->get_map().get_epetra_map(), veln->get_map().get_epetra_map());
   err = veln->export_to(*fluidveln, exportveln, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
-  Epetra_Export exportvelnm(fluidvelnm->get_block_map(), velnm->get_block_map());
+  Epetra_Export exportvelnm(
+      fluidvelnm->get_map().get_epetra_map(), velnm->get_map().get_epetra_map());
   err = velnm->export_to(*fluidvelnm, exportvelnm, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
-  Epetra_Export exportaccnp(fluidaccnp->get_block_map(), accnp->get_block_map());
+  Epetra_Export exportaccnp(
+      fluidaccnp->get_map().get_epetra_map(), accnp->get_map().get_epetra_map());
   err = accnp->export_to(*fluidaccnp, exportaccnp, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
-  Epetra_Export exportaccn(fluidaccn->get_block_map(), accn->get_block_map());
+  Epetra_Export exportaccn(fluidaccn->get_map().get_epetra_map(), accn->get_map().get_epetra_map());
   err = accn->export_to(*fluidaccn, exportaccn, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
 

--- a/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_turbulent_flow_algorithm.cpp
@@ -142,7 +142,7 @@ void FLD::TurbulentFlowAlgorithm::transfer_inflow_velocity()
 
   // get exporter for transfer of dofs from inflow discretization to complete fluid discretization
   Epetra_Export exporter(
-      inflowvelnp->get_map().get_epetra_map(), velnp_->get_map().get_epetra_map());
+      inflowvelnp->get_map().get_epetra_block_map(), velnp_->get_map().get_epetra_block_map());
   // export inflow velocity
   int err = velnp_->export_to(*inflowvelnp, exporter, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
@@ -202,21 +202,23 @@ void FLD::TurbulentFlowAlgorithm::read_restart(const int restart)
   // export vectors to inflow discretization
   int err = 0;
   Epetra_Export exportvelnp(
-      fluidvelnp->get_map().get_epetra_map(), velnp->get_map().get_epetra_map());
+      fluidvelnp->get_map().get_epetra_block_map(), velnp->get_map().get_epetra_block_map());
   err = velnp->export_to(*fluidvelnp, exportvelnp, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
-  Epetra_Export exportveln(fluidveln->get_map().get_epetra_map(), veln->get_map().get_epetra_map());
+  Epetra_Export exportveln(
+      fluidveln->get_map().get_epetra_block_map(), veln->get_map().get_epetra_block_map());
   err = veln->export_to(*fluidveln, exportveln, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
   Epetra_Export exportvelnm(
-      fluidvelnm->get_map().get_epetra_map(), velnm->get_map().get_epetra_map());
+      fluidvelnm->get_map().get_epetra_block_map(), velnm->get_map().get_epetra_block_map());
   err = velnm->export_to(*fluidvelnm, exportvelnm, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
   Epetra_Export exportaccnp(
-      fluidaccnp->get_map().get_epetra_map(), accnp->get_map().get_epetra_map());
+      fluidaccnp->get_map().get_epetra_block_map(), accnp->get_map().get_epetra_block_map());
   err = accnp->export_to(*fluidaccnp, exportaccnp, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
-  Epetra_Export exportaccn(fluidaccn->get_map().get_epetra_map(), accn->get_map().get_epetra_map());
+  Epetra_Export exportaccn(
+      fluidaccn->get_map().get_epetra_block_map(), accn->get_map().get_epetra_block_map());
   err = accn->export_to(*fluidaccn, exportaccn, Insert);
   if (err != 0) FOUR_C_THROW("Export using exporter returned err={}", err);
 

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -795,8 +795,8 @@ void FLD::XFluid::assemble_mat_and_rhs(int itnum)
     // finalize residual vector
     // need to export residual_col to state_->residual_ (row)
     Core::LinAlg::Vector<double> res_tmp(state_->residual_->get_map(), true);
-    Epetra_Export exporter(
-        state_->residual_col_->get_map().get_epetra_map(), res_tmp.get_map().get_epetra_map());
+    Epetra_Export exporter(state_->residual_col_->get_map().get_epetra_block_map(),
+        res_tmp.get_map().get_epetra_block_map());
     int err2 = res_tmp.export_to(*state_->residual_col_, exporter, Add);
     if (err2) FOUR_C_THROW("Export using exporter returned err={}", err2);
 
@@ -1507,8 +1507,8 @@ void FLD::XFluid::integrate_shape_function(Teuchos::ParameterList& eleparams,
   //-------------------------------------------------------------------------------
   // need to export residual_col to systemvector1 (residual_)
   Core::LinAlg::Vector<double> vec_tmp(vec.get_map(), false);
-  Epetra_Export exporter(
-      strategy.systemvector1()->get_map().get_epetra_map(), vec_tmp.get_map().get_epetra_map());
+  Epetra_Export exporter(strategy.systemvector1()->get_map().get_epetra_block_map(),
+      vec_tmp.get_map().get_epetra_block_map());
   int err2 = vec_tmp.export_to(*strategy.systemvector1(), exporter, Add);
   if (err2) FOUR_C_THROW("Export using exporter returned err={}", err2);
   vec.scale(1.0, vec_tmp);
@@ -1596,7 +1596,7 @@ void FLD::XFluid::assemble_mat_and_rhs_gradient_penalty(
   // need to export residual_col to systemvector1 (residual_)
   Core::LinAlg::Vector<double> res_tmp(residual_gp.get_map(), false);
   Epetra_Export exporter(
-      residual_gp_col->get_map().get_epetra_map(), res_tmp.get_map().get_epetra_map());
+      residual_gp_col->get_map().get_epetra_block_map(), res_tmp.get_map().get_epetra_block_map());
   int err2 = res_tmp.export_to(*residual_gp_col, exporter, Add);
   if (err2) FOUR_C_THROW("Export using exporter returned err={}", err2);
   residual_gp.update(1.0, res_tmp, 1.0);

--- a/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_fluid.cpp
@@ -535,7 +535,7 @@ void FLD::XFluidFluid::add_eos_pres_stab_to_emb_layer()
   {
     Core::LinAlg::Vector<double> res_tmp(embedded_fluid_->residual()->get_map(), true);
     Epetra_Export exporter(
-        residual_col->get_map().get_epetra_map(), res_tmp.get_map().get_epetra_map());
+        residual_col->get_map().get_epetra_block_map(), res_tmp.get_map().get_epetra_block_map());
     int err = res_tmp.export_to(*residual_col, exporter, Add);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
     embedded_fluid_->residual()->update(1.0, res_tmp, 1.0);

--- a/src/fluid_xfluid/4C_fluid_xfluid_outputservice.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_outputservice.cpp
@@ -176,18 +176,18 @@ void FLD::XFluidOutputService::output(int step, double time, bool write_restart_
     // write ale displacement for t^{n+1}
     std::shared_ptr<Core::LinAlg::Vector<double>> dispnprm =
         std::make_shared<Core::LinAlg::Vector<double>>(*dispnp);
-    dispnprm->replace_map(outvec_fluid_->get_block_map());  // to get dofs starting by 0 ...
+    dispnprm->replace_map(outvec_fluid_->get_map());  // to get dofs starting by 0 ...
     discret_->writer()->write_vector("dispnp", dispnprm);
 
     // write grid velocity for t^{n+1}
     std::shared_ptr<Core::LinAlg::Vector<double>> gridvnprm =
         std::make_shared<Core::LinAlg::Vector<double>>(*gridvnp);
-    gridvnprm->replace_map(outvec_fluid_->get_block_map());  // to get dofs starting by 0 ...
+    gridvnprm->replace_map(outvec_fluid_->get_map());  // to get dofs starting by 0 ...
     discret_->writer()->write_vector("gridv", gridvnprm);
 
     // write convective velocity for t^{n+1}
     std::shared_ptr<Core::LinAlg::Vector<double>> convvel =
-        std::make_shared<Core::LinAlg::Vector<double>>(outvec_fluid_->get_block_map(), true);
+        std::make_shared<Core::LinAlg::Vector<double>>(outvec_fluid_->get_map(), true);
     convvel->update(1.0, *outvec_fluid_, -1.0, *gridvnprm, 0.0);
     discret_->writer()->write_vector("convel", convvel);
   }

--- a/src/fluid_xfluid/4C_fluid_xfluid_resulttest.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_resulttest.cpp
@@ -83,7 +83,7 @@ void FLD::XFluidResultTest::test_node(const Core::IO::InputParameterContainer& c
 
       double result = 0.;
 
-      const Epetra_BlockMap& velnpmap = velnp.get_block_map();
+      const Core::LinAlg::Map& velnpmap = velnp.get_map();
 
       std::string position = container.get<std::string>("QUANTITY");
       if (position == "velx")

--- a/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
@@ -91,7 +91,7 @@ void FLD::XFluidState::CouplingState::complete_coupling_matrices_and_rhs(
   // export the rhs coupling vector to a row vector
   Core::LinAlg::Vector<double> rhC_s_tmp(rhC_s_->get_map(), true);
   Epetra_Export exporter_rhC_s_col(
-      rhC_s_col_->get_map().get_epetra_map(), rhC_s_tmp.get_map().get_epetra_map());
+      rhC_s_col_->get_map().get_epetra_block_map(), rhC_s_tmp.get_map().get_epetra_block_map());
   int err = rhC_s_tmp.export_to(*rhC_s_col_, exporter_rhC_s_col, Add);
   if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state.cpp
@@ -89,8 +89,9 @@ void FLD::XFluidState::CouplingState::complete_coupling_matrices_and_rhs(
   //  C_ss_->EpetraMatrix()->MaxNumEntries() << std::endl;
   //-------------------------------------------------------------------------------
   // export the rhs coupling vector to a row vector
-  Core::LinAlg::Vector<double> rhC_s_tmp(rhC_s_->get_block_map(), true);
-  Epetra_Export exporter_rhC_s_col(rhC_s_col_->get_block_map(), rhC_s_tmp.get_block_map());
+  Core::LinAlg::Vector<double> rhC_s_tmp(rhC_s_->get_map(), true);
+  Epetra_Export exporter_rhC_s_col(
+      rhC_s_col_->get_map().get_epetra_map(), rhC_s_tmp.get_map().get_epetra_map());
   int err = rhC_s_tmp.export_to(*rhC_s_col_, exporter_rhC_s_col, Add);
   if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
 

--- a/src/fpsi/4C_fpsi_monolithic_plain.cpp
+++ b/src/fpsi/4C_fpsi_monolithic_plain.cpp
@@ -1077,8 +1077,8 @@ void FPSI::MonolithicPlain::recover_lagrange_multiplier()
        * The inner ale displacement increment is converted to the fluid map using AleToFluid().
        * This results in a map that contains all velocity but no pressure DOFs.
        *
-       * We have to circumvent some trouble with Epetra_BlockMaps since we cannot split
-       * an Epetra_BlockMap into inner and interface DOFs.
+       * We have to circumvent some trouble with Core::LinAlg::Maps since we cannot split
+       * an Core::LinAlg::Map into inner and interface DOFs.
        *
        * We create a map extractor 'velothermap' in order to extract the inner velocity
        * DOFs after calling AleToFluid(). Afterwards, a second map extractor

--- a/src/fs3i/4C_fs3i_biofilm_fsi_utils.cpp
+++ b/src/fs3i/4C_fs3i_biofilm_fsi_utils.cpp
@@ -52,7 +52,7 @@ void FS3I::BioFilm::Utils::scatra_change_config(Core::FE::Discretization& scatra
 
     for (int i = 0; i < numdim; ++i)
     {
-      const int lid = gvector.get_block_map().LID(nodedofs[i]);
+      const int lid = gvector.get_map().LID(nodedofs[i]);
 
       if (lid < 0)
         FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",

--- a/src/fs3i/4C_fs3i_fps3i_partitioned_1wc.cpp
+++ b/src/fs3i/4C_fs3i_fps3i_partitioned_1wc.cpp
@@ -223,7 +223,7 @@ bool FS3I::PartFpS3I1Wc::scatra_convergence_check(const int itnum)
 
       double connorm(0.0);
       // set up vector of absolute concentrations
-      Core::LinAlg::Vector<double> con(scatraincrement_->get_block_map());
+      Core::LinAlg::Vector<double> con(scatraincrement_->get_map());
       std::shared_ptr<const Core::LinAlg::Vector<double>> scatra1 =
           scatravec_[0]->scatra_field()->phinp();
       std::shared_ptr<const Core::LinAlg::Vector<double>> scatra2 =

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -745,7 +745,7 @@ void FS3I::PartFS3I::extract_vel(
   vel.push_back(velocity);
   // structure ScaTra: velocity and grid velocity are identical!
   std::shared_ptr<Core::LinAlg::Vector<double>> zeros =
-      std::make_shared<Core::LinAlg::Vector<double>>(velocity->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(velocity->get_map(), true);
   convel.push_back(zeros);
 }
 

--- a/src/fs3i/4C_fs3i_partitioned_1wc.cpp
+++ b/src/fs3i/4C_fs3i_partitioned_1wc.cpp
@@ -187,7 +187,7 @@ bool FS3I::PartFS3I1Wc::scatra_convergence_check(const int itnum)
 
       double connorm(0.0);
       // set up vector of absolute concentrations
-      Core::LinAlg::Vector<double> con(scatraincrement_->get_block_map());
+      Core::LinAlg::Vector<double> con(scatraincrement_->get_map());
       std::shared_ptr<const Core::LinAlg::Vector<double>> scatra1 =
           scatravec_[0]->scatra_field()->phinp();
       std::shared_ptr<const Core::LinAlg::Vector<double>> scatra2 =

--- a/src/fsi/src/monolithic/4C_fsi_monolithic.cpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic.cpp
@@ -1026,7 +1026,7 @@ void FSI::Monolithic::setup_rhs(Core::LinAlg::Vector<double>& f, bool firstcall)
   {
     // Finally, we take care of Dirichlet boundary conditions
     Core::LinAlg::Vector<double> rhs(f);
-    const Core::LinAlg::Vector<double> zeros(f.get_block_map(), true);
+    const Core::LinAlg::Vector<double> zeros(f.get_map(), true);
     Core::LinAlg::apply_dirichlet_to_system(rhs, zeros, *(dbcmaps_->cond_map()));
     f.update(1.0, rhs, 0.0);
   }

--- a/src/fsi/src/monolithic/4C_fsi_monolithic_nonox.cpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic_nonox.cpp
@@ -317,8 +317,8 @@ void FSI::MonolithicNoNOX::evaluate(const Core::LinAlg::Vector<double>& step_inc
 
   // Save the inner fluid map that includes the background fluid DOF in order to
   // determine a change.
-  const Epetra_BlockMap fluidincrementmap =
-      extractor().extract_vector(step_increment, 1)->get_block_map();
+  const Core::LinAlg::Map fluidincrementmap =
+      extractor().extract_vector(step_increment, 1)->get_map();
 
   if (not firstcall_)
   {

--- a/src/fsi/src/monolithic/4C_fsi_monolithic_nonox.hpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic_nonox.hpp
@@ -192,7 +192,7 @@ namespace FSI
      * and inner fluid DOF map after evaluation
 
      */
-    virtual bool has_fluid_dof_map_changed(const Epetra_BlockMap& fluidincrementmap) = 0;
+    virtual bool has_fluid_dof_map_changed(const Core::LinAlg::Map& fluidincrementmap) = 0;
 
     /// access type-cast pointer to problem-specific ALE-wrapper
     const std::shared_ptr<Adapter::AleXFFsiWrapper>& ale_field() { return ale_; }

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
@@ -1175,7 +1175,7 @@ bool FSI::FluidFluidMonolithicFluidSplitNoNOX::has_fluid_dof_map_changed(
     const Core::LinAlg::Map& fluidincrementmap)
 {
   bool isoldmap =
-      fluidincrementmap.SameAs(fluid_field()->interface()->other_map()->get_epetra_map());
+      fluidincrementmap.SameAs(fluid_field()->interface()->other_map()->get_epetra_block_map());
   return !isoldmap;
 }
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
@@ -1172,7 +1172,7 @@ void FSI::FluidFluidMonolithicFluidSplitNoNOX::handle_fluid_dof_map_change_in_ne
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 bool FSI::FluidFluidMonolithicFluidSplitNoNOX::has_fluid_dof_map_changed(
-    const Epetra_BlockMap& fluidincrementmap)
+    const Core::LinAlg::Map& fluidincrementmap)
 {
   bool isoldmap =
       fluidincrementmap.SameAs(fluid_field()->interface()->other_map()->get_epetra_map());

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.hpp
@@ -112,7 +112,7 @@ namespace FSI
      * and inner fluid DOF map after evaluation
 
      */
-    bool has_fluid_dof_map_changed(const Epetra_BlockMap& fluidincrementmap) override;
+    bool has_fluid_dof_map_changed(const Core::LinAlg::Map& fluidincrementmap) override;
 
    private:
     /// build block vector from field vectors

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.cpp
@@ -985,7 +985,7 @@ void FSI::FluidFluidMonolithicStructureSplitNoNOX::handle_fluid_dof_map_change_i
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 bool FSI::FluidFluidMonolithicStructureSplitNoNOX::has_fluid_dof_map_changed(
-    const Epetra_BlockMap& fluidincrementmap)
+    const Core::LinAlg::Map& fluidincrementmap)
 {
   return !fluid_field()->dof_row_map()->SameAs(fluidincrementmap);
 }

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_structuresplit_nonox.hpp
@@ -114,7 +114,7 @@ namespace FSI
      * and inner fluid DOF map after evaluation
 
      */
-    bool has_fluid_dof_map_changed(const Epetra_BlockMap& fluidincrementmap) override;
+    bool has_fluid_dof_map_changed(const Core::LinAlg::Map& fluidincrementmap) override;
 
    private:
     /// build block vector from field vectors

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
@@ -917,7 +917,7 @@ void FSI::MonolithicFluidSplit::unscale_solution(Core::LinAlg::BlockSparseMatrix
 
   // very simple hack just to see the linear solution
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 
@@ -1440,8 +1440,8 @@ void FSI::MonolithicFluidSplit::recover_lagrange_multiplier()
      * The inner ale displacement increment is converted to the fluid map using AleToFluid().
      * This results in a map that contains all velocity but no pressure DOFs.
      *
-     * We have to circumvent some trouble with Epetra_BlockMaps since we cannot split
-     * an Epetra_BlockMap into inner and interface DOFs.
+     * We have to circumvent some trouble with Core::LinAlg::Maps since we cannot split
+     * an Core::LinAlg::Map into inner and interface DOFs.
      *
      * We create a map extractor 'velothermap' in order to extract the inner velocity
      * DOFs after calling AleToFluid(). Afterwards, a second map extractor 'velotherpressuremapext'
@@ -1507,7 +1507,7 @@ void FSI::MonolithicFluidSplit::calculate_interface_energy_increment()
 
   // interface traction weighted by time integration factors
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionfluid =
-      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_map(), true);
   tractionfluid->update(stiparam - ftiparam, *lambdaold_, ftiparam - stiparam, *lambda_, 0.0);
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionstructure = fluid_to_struct(tractionfluid);
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.hpp
@@ -210,7 +210,7 @@ namespace FSI
     virtual void set_lambda(std::shared_ptr<Core::LinAlg::Vector<double>> lambdanew)
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (lambdanew == nullptr || !lambdanew->get_block_map().PointSameAs(lambda_->get_block_map()))
+      if (lambdanew == nullptr || !lambdanew->get_map().PointSameAs(lambda_->get_map()))
         FOUR_C_THROW("Map failure! Attempting to assign invalid vector to lambda_.");
 #endif
       lambda_ = lambdanew;

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
@@ -808,7 +808,7 @@ void FSI::MonolithicStructureSplit::unscale_solution(Core::LinAlg::BlockSparseMa
 
   // very simple hack just to see the linear solution
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 
@@ -1318,7 +1318,7 @@ void FSI::MonolithicStructureSplit::calculate_interface_energy_increment()
 
   // interface traction weighted by time integration factors
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionstructure =
-      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_map(), true);
   tractionstructure->update(stiparam - ftiparam, *lambdaold_, ftiparam - stiparam, *lambda_, 0.0);
 
   // displacement increment of this time step

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
@@ -692,7 +692,7 @@ void FSI::MortarMonolithicFluidSplit::setup_rhs_firstiter(Core::LinAlg::Vector<d
 
       rhs = structure_field()->interface()->insert_fsi_cond_vector(tmprhs);
 
-      auto zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_block_map(), true);
+      auto zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_map(), true);
       Core::LinAlg::apply_dirichlet_to_system(
           *rhs, *zeros, *(structure_field()->get_dbc_map_extractor()->cond_map()));
 
@@ -711,7 +711,7 @@ void FSI::MortarMonolithicFluidSplit::setup_rhs_firstiter(Core::LinAlg::Vector<d
 
       rhs = fluid_field()->interface()->insert_other_vector(*rhs);
 
-      zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_block_map(), true);
+      zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_map(), true);
       Core::LinAlg::apply_dirichlet_to_system(
           *rhs, *zeros, *(structure_field()->get_dbc_map_extractor()->cond_map()));
 
@@ -1084,7 +1084,7 @@ void FSI::MortarMonolithicFluidSplit::unscale_solution(Core::LinAlg::BlockSparse
 
   // very simple hack just to see the linear solution
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 
@@ -1439,7 +1439,7 @@ void FSI::MortarMonolithicFluidSplit::update()
 
     std::shared_ptr<Core::LinAlg::Vector<double>> temp =
         std::make_shared<Core::LinAlg::Vector<double>>(*iprojdisp_);
-    temp->replace_map(idispale->get_block_map());
+    temp->replace_map(idispale->get_map());
     std::shared_ptr<Core::LinAlg::Vector<double>> acx = fluid_to_ale_interface(temp);
     ale_field()->apply_interface_displacements(acx);
     fluid_field()->apply_mesh_displacement(ale_to_fluid(ale_field()->dispnp()));
@@ -1688,8 +1688,8 @@ void FSI::MortarMonolithicFluidSplit::recover_lagrange_multiplier()
      * to the fluid map using AleToFluid(). This results in a map that contains
      * all velocity but no pressure DOFs.
      *
-     * We have to circumvent some trouble with Epetra_BlockMaps since we cannot
-     * split an Epetra_BlockMap into inner and interface DOFs.
+     * We have to circumvent some trouble with Core::LinAlg::Maps since we cannot
+     * split an Core::LinAlg::Map into inner and interface DOFs.
      *
      * We create a map extractor 'velothermap' in order to extract the inner
      * velocity DOFs after calling AleToFluid(). Afterwards, a second map
@@ -1764,7 +1764,7 @@ void FSI::MortarMonolithicFluidSplit::calculate_interface_energy_increment()
   const std::shared_ptr<Core::LinAlg::SparseMatrix> mortarm = coupsfm_->get_mortar_matrix_m();
 
   // interface traction weighted by time integration factors
-  Core::LinAlg::Vector<double> tractionfluid(lambda_->get_block_map(), true);
+  Core::LinAlg::Vector<double> tractionfluid(lambda_->get_map(), true);
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionstructure =
       std::make_shared<Core::LinAlg::Vector<double>>(
           *structure_field()->interface()->fsi_cond_map(), true);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
@@ -1056,7 +1056,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::unscale_solution(
       FOUR_C_THROW("ale scaling failed");
   }
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
@@ -858,7 +858,7 @@ void FSI::MortarMonolithicStructureSplit::update()
 
     std::shared_ptr<Core::LinAlg::Vector<double>> temp =
         std::make_shared<Core::LinAlg::Vector<double>>(*iprojdisp_);
-    temp->replace_map(idispale->get_block_map());
+    temp->replace_map(idispale->get_map());
     std::shared_ptr<Core::LinAlg::Vector<double>> acx = fluid_to_ale_interface(temp);
     ale_field()->apply_interface_displacements(acx);
     fluid_field()->apply_mesh_displacement(ale_to_fluid(ale_field()->dispnp()));
@@ -968,7 +968,7 @@ void FSI::MortarMonolithicStructureSplit::unscale_solution(Core::LinAlg::BlockSp
 
   // very simple hack just to see the linear solution
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 
@@ -1511,7 +1511,7 @@ void FSI::MortarMonolithicStructureSplit::calculate_interface_energy_increment()
 
   // interface traction weighted by time integration factors
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionstructure =
-      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_map(), true);
   tractionstructure->update(stiparam - ftiparam, *lambdaold_, ftiparam - stiparam, *lambda_, 0.0);
 
   // displacement increment of this time step

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
@@ -680,7 +680,7 @@ void FSI::SlidingMonolithicFluidSplit::setup_rhs_firstiter(Core::LinAlg::Vector<
 
       rhs = structure_field()->interface()->insert_fsi_cond_vector(tmprhs);
 
-      auto zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_block_map(), true);
+      auto zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_map(), true);
       Core::LinAlg::apply_dirichlet_to_system(
           *rhs, *zeros, *(structure_field()->get_dbc_map_extractor()->cond_map()));
 
@@ -699,7 +699,7 @@ void FSI::SlidingMonolithicFluidSplit::setup_rhs_firstiter(Core::LinAlg::Vector<
 
       rhs = fsi_fluid_field()->fsi_interface()->insert_other_vector(*rhs);
 
-      zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_block_map(), true);
+      zeros = std::make_shared<Core::LinAlg::Vector<double>>(rhs->get_map(), true);
       Core::LinAlg::apply_dirichlet_to_system(
           *rhs, *zeros, *(structure_field()->get_dbc_map_extractor()->cond_map()));
 
@@ -1082,7 +1082,7 @@ void FSI::SlidingMonolithicFluidSplit::unscale_solution(Core::LinAlg::BlockSpars
 
   // very simple hack just to see the linear solution
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 
@@ -1437,7 +1437,7 @@ void FSI::SlidingMonolithicFluidSplit::update()
 
     std::shared_ptr<Core::LinAlg::Vector<double>> temp =
         std::make_shared<Core::LinAlg::Vector<double>>(*iprojdisp_);
-    temp->replace_map(idispale->get_block_map());
+    temp->replace_map(idispale->get_map());
     std::shared_ptr<Core::LinAlg::Vector<double>> acx = fluid_to_ale_interface(temp);
     ale_field()->apply_interface_displacements(acx);
     fluid_field()->apply_mesh_displacement(ale_to_fluid(ale_field()->dispnp()));
@@ -1681,8 +1681,8 @@ void FSI::SlidingMonolithicFluidSplit::recover_lagrange_multiplier()
      * to the fluid map using AleToFluid(). This results in a map that contains
      * all velocity but no pressure DOFs.
      *
-     * We have to circumvent some trouble with Epetra_BlockMaps since we cannot
-     * split an Epetra_BlockMap into inner and interface DOFs.
+     * We have to circumvent some trouble with Core::LinAlg::Maps since we cannot
+     * split an Core::LinAlg::Map into inner and interface DOFs.
      *
      * We create a map extractor 'velothermap' in order to extract the inner
      * velocity DOFs after calling AleToFluid(). Afterwards, a second map
@@ -1757,7 +1757,7 @@ void FSI::SlidingMonolithicFluidSplit::calculate_interface_energy_increment()
   const std::shared_ptr<Core::LinAlg::SparseMatrix> mortarm = coupsfm_->get_mortar_matrix_m();
 
   // interface traction weighted by time integration factors
-  Core::LinAlg::Vector<double> tractionfluid(lambda_->get_block_map(), true);
+  Core::LinAlg::Vector<double> tractionfluid(lambda_->get_map(), true);
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionstructure =
       std::make_shared<Core::LinAlg::Vector<double>>(
           *structure_field()->interface()->fsi_cond_map(), true);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
@@ -824,7 +824,7 @@ void FSI::SlidingMonolithicStructureSplit::update()
 
     std::shared_ptr<Core::LinAlg::Vector<double>> temp =
         std::make_shared<Core::LinAlg::Vector<double>>(*iprojdisp_);
-    temp->replace_map(idispale->get_block_map());
+    temp->replace_map(idispale->get_map());
     std::shared_ptr<Core::LinAlg::Vector<double>> acx = fluid_to_ale_interface(temp);
     ale_field()->apply_interface_displacements(acx);
     fluid_field()->apply_mesh_displacement(ale_to_fluid(ale_field()->dispnp()));
@@ -935,7 +935,7 @@ void FSI::SlidingMonolithicStructureSplit::unscale_solution(
 
   // very simple hack just to see the linear solution
 
-  Core::LinAlg::Vector<double> r(b.get_block_map());
+  Core::LinAlg::Vector<double> r(b.get_map());
   mat.Apply(x, r);
   r.update(1., b, 1.);
 
@@ -1479,7 +1479,7 @@ void FSI::SlidingMonolithicStructureSplit::calculate_interface_energy_increment(
 
   // interface traction weighted by time integration factors
   std::shared_ptr<Core::LinAlg::Vector<double>> tractionstructure =
-      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(lambda_->get_map(), true);
   tractionstructure->update(stiparam - ftiparam, *lambdaold_, ftiparam - stiparam, *lambda_, 0.0);
 
   // displacement increment of this time step

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -895,7 +895,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FSI::Partitioned::fluid_to_struct(
     // Translate consistent nodal forces to interface loads
     const std::shared_ptr<Core::LinAlg::Vector<double>> ishape =
         mb_fluid_field()->integrate_interface_shape();
-    Core::LinAlg::Vector<double> iforce(iv->get_block_map());
+    Core::LinAlg::Vector<double> iforce(iv->get_map());
 
     if (iforce.reciprocal_multiply(1.0, *ishape, *iv, 0.0))
       FOUR_C_THROW("ReciprocalMultiply failed");

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_dirichletneumann_volcoupl.cpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_dirichletneumann_volcoupl.cpp
@@ -266,7 +266,7 @@ void FSI::VolCorrector::correct_vol_displacements_para_space(
     std::shared_ptr<Core::LinAlg::Vector<double>> disp_fluid,
     std::shared_ptr<FLD::Utils::MapExtractor> const& finterface)
 {
-  Core::LinAlg::Vector<double> correction(disp_fluid->get_block_map(), true);
+  Core::LinAlg::Vector<double> correction(disp_fluid->get_map(), true);
   Core::LinAlg::Vector<double> DofColMapDummy(
       *fluidale->fluid_field()->discretization()->dof_col_map(), true);
   Core::LinAlg::export_to(*deltadisp, DofColMapDummy);
@@ -396,7 +396,7 @@ void FSI::VolCorrector::correct_vol_displacements_phys_space(
     std::shared_ptr<Core::LinAlg::Vector<double>> disp_fluid,
     std::shared_ptr<FLD::Utils::MapExtractor> const& finterface)
 {
-  Core::LinAlg::Vector<double> correction(disp_fluid->get_block_map(), true);
+  Core::LinAlg::Vector<double> correction(disp_fluid->get_map(), true);
   Core::LinAlg::Vector<double> DofColMapDummy(
       *fluidale->fluid_field()->discretization()->dof_col_map(), true);
   Core::LinAlg::export_to(*deltadisp, DofColMapDummy);

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.cpp
@@ -34,8 +34,8 @@ NOX::FSI::FSIMatrixFree::FSIMatrixFree(Teuchos::ParameterList& printParams,
   perturbY.init(0.0);
 
   // Epetra_Operators require Epetra_Maps, so anyone using block maps
-  // (Epetra_BlockMap) won't be able to directly use the AztecOO solver.
-  // We get around this by creating an Epetra_Map from the Epetra_BlockMap.
+  // (Core::LinAlg::Map) won't be able to directly use the AztecOO solver.
+  // We get around this by creating an Epetra_Map from the Core::LinAlg::Map.
   const Epetra_Map* testMap = nullptr;
   testMap = dynamic_cast<const Epetra_Map*>(&currentX.getEpetraVector().Map());
   if (testMap != nullptr)

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_jacobian.hpp
@@ -92,10 +92,10 @@ namespace NOX
       //! Returns a reference to the Epetra_Comm communicator associated with this operator.
       const Epetra_Comm& Comm() const override;
 
-      //! Returns the Epetra_BlockMap object associated with the domain of this matrix operator.
+      //! Returns the Core::LinAlg::Map object associated with the domain of this matrix operator.
       const Epetra_Map& OperatorDomainMap() const override;
 
-      //! Returns the Epetra_BlockMap object associated with the range of this matrix operator.
+      //! Returns the Core::LinAlg::Map object associated with the range of this matrix operator.
       const Epetra_Map& OperatorRangeMap() const override;
 
       //! Compute Jacobian given the specified input vector, x.  Returns true if computation was
@@ -124,9 +124,9 @@ namespace NOX
       mutable ::NOX::Epetra::Vector perturbY;
 
       //! Core::LinAlg::Map object used in the returns of the Epetra_Operator derived methods.
-      /*! If the user is using Epetra_BlockMaps, then ::NOX::Epetra::MatrixFree must create an
-       * equivalent Core::LinAlg::Map from the Epetra_BlockMap that can be used as the return object
-       * of the OperatorDomainMap() and OperatorRangeMap() methods.
+      /*! If the user is using Core::LinAlg::Maps, then ::NOX::Epetra::MatrixFree must create an
+       * equivalent Core::LinAlg::Map from the Core::LinAlg::Map that can be used as the return
+       * object of the OperatorDomainMap() and OperatorRangeMap() methods.
        */
       std::shared_ptr<const Epetra_Map> epetraMap;
 

--- a/src/fsi/src/utils/4C_fsi_resulttest.cpp
+++ b/src/fsi/src/utils/4C_fsi_resulttest.cpp
@@ -233,7 +233,7 @@ void FSI::FSIResultTest::test_node(
       // test Lagrange multipliers
       if (fsilambda_ != nullptr)
       {
-        const Epetra_BlockMap& fsilambdamap = fsilambda_->get_block_map();
+        const Core::LinAlg::Map& fsilambdamap = fsilambda_->get_map();
         if (quantity == "lambdax")
         {
           unknownquantity = false;

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -249,8 +249,8 @@ void FSI::Utils::SlideAleUtils::remeshing(Adapter::FSIStructureWrapper& structur
 
   std::shared_ptr<Core::LinAlg::Map> dofrowmap =
       Core::LinAlg::merge_map(*structdofrowmap_, *fluiddofrowmap_, true);
-  Epetra_Import msimpo(dofrowmap->get_epetra_map(), structdofrowmap_->get_epetra_map());
-  Epetra_Import slimpo(dofrowmap->get_epetra_map(), fluiddofrowmap_->get_epetra_map());
+  Epetra_Import msimpo(dofrowmap->get_epetra_block_map(), structdofrowmap_->get_epetra_block_map());
+  Epetra_Import slimpo(dofrowmap->get_epetra_block_map(), fluiddofrowmap_->get_epetra_block_map());
 
   idispms_->import(*idisptotal, msimpo, Add);
   idispms_->import(iprojdispale, slimpo, Add);
@@ -270,8 +270,10 @@ void FSI::Utils::SlideAleUtils::evaluate_mortar(Core::LinAlg::Vector<double>& id
 
   std::shared_ptr<Core::LinAlg::Map> dofrowmap =
       Core::LinAlg::merge_map(*structdofrowmap_, *fluiddofrowmap_, true);
-  Epetra_Import master_importer(dofrowmap->get_epetra_map(), structdofrowmap_->get_epetra_map());
-  Epetra_Import slave_importer(dofrowmap->get_epetra_map(), fluiddofrowmap_->get_epetra_map());
+  Epetra_Import master_importer(
+      dofrowmap->get_epetra_block_map(), structdofrowmap_->get_epetra_block_map());
+  Epetra_Import slave_importer(
+      dofrowmap->get_epetra_block_map(), fluiddofrowmap_->get_epetra_block_map());
 
   if (idispms_->import(idispstruct, master_importer, Add)) FOUR_C_THROW("Import operation failed.");
   if (idispms_->import(idispfluid, slave_importer, Add)) FOUR_C_THROW("Import operation failed.");
@@ -444,7 +446,8 @@ void FSI::Utils::SlideAleUtils::slide_projection(
   std::shared_ptr<Core::LinAlg::Vector<double>> idispnp = structure.extract_interface_dispnp();
 
   // Redistribute displacement of structnodes on the interface to all processors.
-  Epetra_Import interimpo(structfullnodemap_->get_epetra_map(), structdofrowmap_->get_epetra_map());
+  Epetra_Import interimpo(
+      structfullnodemap_->get_epetra_block_map(), structdofrowmap_->get_epetra_block_map());
   std::shared_ptr<Core::LinAlg::Vector<double>> reddisp =
       Core::LinAlg::create_vector(*structfullnodemap_, true);
   reddisp->import(*idispnp, interimpo, Add);

--- a/src/fsi/src/utils/4C_fsi_utils.cpp
+++ b/src/fsi/src/utils/4C_fsi_utils.cpp
@@ -296,7 +296,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> FSI::Utils::SlideAleUtils::interpo
     const Core::LinAlg::Vector<double>& uold)
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> unew = coupff_->master_to_slave(uold);
-  unew->replace_map(uold.get_block_map());
+  unew->replace_map(uold.get_map());
 
   return unew;
 }

--- a/src/fsi_xfem/4C_fsi_xfem_XFFcoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFFcoupling_manager.cpp
@@ -58,7 +58,7 @@ void XFEM::XffCouplingManager::set_coupling_states()
   Core::LinAlg::export_to(*fluid_->veln(), *mcffi_->i_veln());
 
   std::shared_ptr<Core::LinAlg::Vector<double>> tmp_diff =
-      std::make_shared<Core::LinAlg::Vector<double>>((*mcffi_->i_dispnp()).get_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>((*mcffi_->i_dispnp()).get_map());
   tmp_diff->update(1.0, *mcffi_->i_dispnp(), -1.0, *mcffi_->i_dispnpi(), 0.0);
 
   double norm = 0.0;

--- a/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_XFScoupling_manager.cpp
@@ -81,7 +81,7 @@ void XFEM::XfsCouplingManager::set_coupling_states()
 
   // get interface velocity at t(n)
   std::shared_ptr<Core::LinAlg::Vector<double>> velnp =
-      std::make_shared<Core::LinAlg::Vector<double>>(mcfsi_->i_velnp()->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(mcfsi_->i_velnp()->get_map(), true);
   velnp->update(1.0, *mcfsi_->i_dispnp(), -1.0, *mcfsi_->i_dispn(), 0.0);
 
   // inverse of FSI (1st order, 2nd order) scaling
@@ -101,7 +101,7 @@ void XFEM::XfsCouplingManager::set_coupling_states()
     struct_->discretization()->set_state("dispnp", *struct_->dispnp());
     // Set Velnp (used for interface integration)
     std::shared_ptr<Core::LinAlg::Vector<double>> fullvelnp =
-        std::make_shared<Core::LinAlg::Vector<double>>(struct_->velnp()->get_block_map(), true);
+        std::make_shared<Core::LinAlg::Vector<double>>(struct_->velnp()->get_map(), true);
     fullvelnp->update(1.0, *struct_->dispnp(), -1.0, *struct_->dispn(), 0.0);
     fullvelnp->update(-(dt - 1 / scaling_FSI) * scaling_FSI, *struct_->veln(), scaling_FSI);
     struct_->discretization()->set_state("velaf", *fullvelnp);

--- a/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
+++ b/src/fsi_xfem/4C_fsi_xfem_monolithic.cpp
@@ -1908,15 +1908,15 @@ void FSI::MonolithicXFEM::permute_fluid_dofs_forward(Core::LinAlg::Vector<double
     {
       if (key + 1 != p_cycle.end())  // standard during the cycle
       {
-        tmp_value = (fx)[fx.get_block_map().LID(
-            *(key + 1))];  // save the value before it will be overwritten
-        (fx)[fx.get_block_map().LID(*(key + 1))] =
-            (fx)[fx.get_block_map().LID(*(key))];  // set current value to next position
+        tmp_value =
+            (fx)[fx.get_map().LID(*(key + 1))];  // save the value before it will be overwritten
+        (fx)[fx.get_map().LID(*(key + 1))] =
+            (fx)[fx.get_map().LID(*(key))];  // set current value to next position
         // std::cout << "copy value from gid " << *(key) << " to " << *(key+1) << std::endl;
       }
       else  // last value in cycle reached
       {
-        (fx)[fx.get_block_map().LID(*p_cycle.begin())] = tmp_value;
+        (fx)[fx.get_map().LID(*p_cycle.begin())] = tmp_value;
         // std::cout << "copy value from tmp to " << *p_cycle.begin() << std::endl;
       }
     }
@@ -1962,16 +1962,16 @@ void FSI::MonolithicXFEM::permute_fluid_dofs_backward(Core::LinAlg::Vector<doubl
     {
       if (key_reverse != p_cycle.begin())  // standard during the cycle
       {
-        tmp_value = (fx)[fx.get_block_map().LID(
+        tmp_value = (fx)[fx.get_map().LID(
             *(key_reverse - 1))];  // save the value before it will be overwritten
-        (fx)[fx.get_block_map().LID(*(key_reverse - 1))] =
-            (fx)[fx.get_block_map().LID(*(key_reverse))];  // set current value to position before
+        (fx)[fx.get_map().LID(*(key_reverse - 1))] =
+            (fx)[fx.get_map().LID(*(key_reverse))];  // set current value to position before
         // std::cout << "copy value from gid " << *(key_reverse) << " to " << *(key_reverse-1) <<
         // std::endl;
       }
       else
       {
-        (fx)[fx.get_block_map().LID(*(p_cycle.end() - 1))] = tmp_value;
+        (fx)[fx.get_map().LID(*(p_cycle.end() - 1))] = tmp_value;
         // std::cout << "copy value from tmp to " << *(p_cycle.end()-1) << std::endl;
       }
     }

--- a/src/levelset/4C_levelset_algorithm_reinit.cpp
+++ b/src/levelset/4C_levelset_algorithm_reinit.cpp
@@ -1391,7 +1391,7 @@ void ScaTra::LevelSetAlgorithm::correct_volume()
   // called after a reinitialization.
   const double thickness = -voldelta / surface;
 
-  Core::LinAlg::Vector<double> one(phin_->get_block_map());
+  Core::LinAlg::Vector<double> one(phin_->get_map());
   one.put_scalar(1.0);
 
   // update phi

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -421,7 +421,7 @@ void ScaTra::LevelSetAlgorithm::apply_contact_point_boundary_condition()
     {
       // get global and local dof IDs
       const int gid = nodedofs[index];
-      const int lid = convel_new->get_block_map().LID(gid);
+      const int lid = convel_new->get_map().LID(gid);
       if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
       const double convelocity = myvel[index];
       int err = convel_new->replace_local_value(lid, 0, convelocity);

--- a/src/lubrication/src/4C_lubrication_resulttest.cpp
+++ b/src/lubrication/src/4C_lubrication_resulttest.cpp
@@ -83,7 +83,7 @@ double Lubrication::ResultTest::result_node(
   double result(0.);
 
   // extract row map from solution vector
-  const Epetra_BlockMap& prenpmap = mysol_->get_block_map();
+  const Core::LinAlg::Map& prenpmap = mysol_->get_map();
 
   // test result value of pressure field
   if (quantity == "pre") result = (*mysol_)[prenpmap.LID(dis_->dof(0, node, 0))];

--- a/src/lubrication/src/4C_lubrication_timint_implicit.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_implicit.cpp
@@ -292,7 +292,7 @@ void Lubrication::TimIntImpl::set_height_field_pure_lub(const int nds)
 
       // get global and local dof IDs
       const int gid = nodedofs[index];
-      const int lid = height->get_block_map().LID(gid);
+      const int lid = height->get_map().LID(gid);
 
       if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
       err = height->replace_local_value(lid, 0, heightfuncvalue);
@@ -336,7 +336,7 @@ void Lubrication::TimIntImpl::set_average_velocity_field_pure_lub(const int nds)
 
       // get global and local dof IDs
       const int gid = nodedofs[index];
-      const int lid = vel->get_block_map().LID(gid);
+      const int lid = vel->get_map().LID(gid);
 
       if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
       err = vel->replace_local_value(lid, 0, velfuncvalue);
@@ -1008,7 +1008,7 @@ void Lubrication::TimIntImpl::output_state()
       Core::Nodes::Node* node = discret_->l_row_node(inode);
       for (int idim = 0; idim < nsd_; ++idim)
         (dispnp_multi)(idim)[discret_->node_row_map()->LID(node->id())] =
-            (*dispnp)[dispnp->get_block_map().LID(discret_->dof(nds_disp_, node, idim))];
+            (*dispnp)[dispnp->get_map().LID(discret_->dof(nds_disp_, node, idim))];
     }
 
     output_->write_multi_vector("dispnp", dispnp_multi, Core::IO::nodevector);

--- a/src/mat/4C_mat_aaaneohooke.hpp
+++ b/src/mat/4C_mat_aaaneohooke.hpp
@@ -68,8 +68,7 @@ namespace Mat
         else
         {
           // calculate LID here, instead of before each call
-          return (
-              *matparams_[parametername])[matparams_[parametername]->get_block_map().LID(EleId)];
+          return (*matparams_[parametername])[matparams_[parametername]->get_map().LID(EleId)];
         }
       }
 

--- a/src/mat/4C_mat_constraintmixture.hpp
+++ b/src/mat/4C_mat_constraintmixture.hpp
@@ -130,8 +130,7 @@ namespace Mat
         else
         {
           // calculate LID here, instead of before each call
-          return (
-              *matparams_[parametername])[matparams_[parametername]->get_block_map().LID(EleId)];
+          return (*matparams_[parametername])[matparams_[parametername]->get_map().LID(EleId)];
         }
       }
 

--- a/src/mat/4C_mat_scatra.hpp
+++ b/src/mat/4C_mat_scatra.hpp
@@ -66,8 +66,7 @@ namespace Mat
         else
         {
           // calculate LID here, instead of before each call
-          return (
-              *matparams_[parametername])[matparams_[parametername]->get_block_map().LID(EleId)];
+          return (*matparams_[parametername])[matparams_[parametername]->get_map().LID(EleId)];
         }
       }
 

--- a/src/membrane/4C_membrane_evaluate.cpp
+++ b/src/membrane/4C_membrane_evaluate.cpp
@@ -458,9 +458,9 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
         for (int i = 0; i < numnod_; ++i)
         {
           int gid = node_ids()[i];
-          if (postthick->Map().MyGID(node_ids()[i]))  // rownode
+          if (postthick->get_map().MyGID(node_ids()[i]))  // rownode
           {
-            int lid = postthick->Map().LID(gid);
+            int lid = postthick->get_map().LID(gid);
             int myadjele = nodes()[i]->num_element();
             (*postthick)(0)[lid] += nodalthickness(i) / myadjele;
           }

--- a/src/mortar/4C_mortar_matrix_transform.cpp
+++ b/src/mortar/4C_mortar_matrix_transform.cpp
@@ -87,12 +87,12 @@ void Mortar::MatrixRowColTransformer::setup()
     std::shared_ptr<Epetra_Export>& slave_to_master = slave_to_master_[bt];
     slave_to_master = nullptr;
     slave_to_master = std::make_shared<Epetra_Export>(
-        (**master_row_[bt]).get_epetra_map(), (**slave_row_[bt]).get_epetra_map());
+        (**master_row_[bt]).get_epetra_block_map(), (**slave_row_[bt]).get_epetra_block_map());
 
     std::shared_ptr<Epetra_Export>& master_to_slave = master_to_slave_[bt];
     master_to_slave = nullptr;
     master_to_slave = std::make_shared<Epetra_Export>(
-        (**slave_row_[bt]).get_epetra_map(), (**master_row_[bt]).get_epetra_map());
+        (**slave_row_[bt]).get_epetra_block_map(), (**master_row_[bt]).get_epetra_block_map());
   }
 
   issetup_ = true;

--- a/src/mortar/4C_mortar_utils.cpp
+++ b/src/mortar/4C_mortar_utils.cpp
@@ -929,13 +929,13 @@ void Mortar::Utils::mortar_rhs_condensation(
   Core::LinAlg::Vector<double> fs(*gsdofrowmap);
   Core::LinAlg::Vector<double> fm_cond(*gmdofrowmap);
   Core::LinAlg::export_to(rhs, fs);
-  Core::LinAlg::Vector<double> fs_full(rhs.get_block_map());
+  Core::LinAlg::Vector<double> fs_full(rhs.get_map());
   Core::LinAlg::export_to(fs, fs_full);
   if (rhs.update(-1., fs_full, 1.)) FOUR_C_THROW("update failed");
 
   if (p.multiply(true, fs, fm_cond)) FOUR_C_THROW("multiply failed");
 
-  Core::LinAlg::Vector<double> fm_cond_full(rhs.get_block_map());
+  Core::LinAlg::Vector<double> fm_cond_full(rhs.get_map());
   Core::LinAlg::export_to(fm_cond, fm_cond_full);
   if (rhs.update(1., fm_cond_full, 1.)) FOUR_C_THROW("update failed");
 
@@ -957,7 +957,7 @@ void Mortar::Utils::mortar_recover(Core::LinAlg::Vector<double>& inc, Core::LinA
 
   Core::LinAlg::Vector<double> s_inc(*gsdofrowmap);
   if (p.multiply(false, m_inc, s_inc)) FOUR_C_THROW("multiply failed");
-  Core::LinAlg::Vector<double> s_inc_full(inc.get_block_map());
+  Core::LinAlg::Vector<double> s_inc_full(inc.get_map());
   Core::LinAlg::export_to(s_inc, s_inc_full);
   if (inc.update(1., s_inc_full, 1.)) FOUR_C_THROW("update failed");
 

--- a/src/mortar/4C_mortar_utils.cpp
+++ b/src/mortar/4C_mortar_utils.cpp
@@ -383,7 +383,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Mortar::redistribute(
     const Core::LinAlg::SparseMatrix& src, const Core::LinAlg::Map& permrowmap,
     const Core::LinAlg::Map& permdomainmap)
 {
-  Epetra_Export exporter(permrowmap.get_epetra_map(), src.row_map().get_epetra_map());
+  Epetra_Export exporter(permrowmap.get_epetra_block_map(), src.row_map().get_epetra_block_map());
 
   auto permsrc = std::make_shared<Core::LinAlg::SparseMatrix>(permrowmap, src.max_num_entries());
   int err = permsrc->import(src, exporter, Insert);

--- a/src/particle_engine/4C_particle_engine.cpp
+++ b/src/particle_engine/4C_particle_engine.cpp
@@ -982,7 +982,7 @@ void PARTICLEENGINE::ParticleEngine::setup_bin_ghosting()
     const int size = static_cast<int>(ghostbins.size());
     std::vector<int> pidlist(size);
     const int err = binrowmap_->RemoteIDList(size, ghostbins_vec.data(), pidlist.data(), nullptr);
-    if (err < 0) FOUR_C_THROW("Epetra_BlockMap::RemoteIDList returned err={}", err);
+    if (err < 0) FOUR_C_THROW("Core::LinAlg::Map::RemoteIDList returned err={}", err);
 
     for (int i = 0; i < size; ++i)
     {

--- a/src/particle_wall/4C_particle_wall.cpp
+++ b/src/particle_wall/4C_particle_wall.cpp
@@ -199,8 +199,8 @@ void PARTICLEWALL::WallHandlerBase::get_max_wall_position_increment(
     if (walldatastate_->get_disp_row_last_transfer() == nullptr)
       FOUR_C_THROW("vector of wall displacements after last transfer not set!");
 
-    if (not walldatastate_->get_disp_row()->get_block_map().SameAs(
-            walldatastate_->get_disp_row_last_transfer()->get_block_map()))
+    if (not walldatastate_->get_disp_row()->get_map().SameAs(
+            walldatastate_->get_disp_row_last_transfer()->get_map()))
       FOUR_C_THROW("maps are not equal as expected!");
 #endif
 

--- a/src/particle_wall/4C_particle_wall_result_test.cpp
+++ b/src/particle_wall/4C_particle_wall_result_test.cpp
@@ -98,7 +98,7 @@ void PARTICLEWALL::WallResultTest::test_node(
 
         if (disp != nullptr)
         {
-          const Epetra_BlockMap& disnpmap = disp->get_block_map();
+          const Core::LinAlg::Map& disnpmap = disp->get_map();
           int lid = disnpmap.LID(walldiscretization_->dof(0, actnode, idx));
           if (lid < 0)
             FOUR_C_THROW("You tried to test {} on nonexistent dof {} on node {}", quantity, idx,
@@ -125,7 +125,7 @@ void PARTICLEWALL::WallResultTest::test_node(
 
       if (idx >= 0)
       {
-        const Epetra_BlockMap& disnpmap = disp->get_block_map();
+        const Core::LinAlg::Map& disnpmap = disp->get_map();
         int lid = disnpmap.LID(walldiscretization_->dof(0, actnode, idx));
         if (lid < 0)
           FOUR_C_THROW("You tried to test {} on nonexistent dof {} on node {}", quantity, idx,

--- a/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
+++ b/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
@@ -312,8 +312,8 @@ void PaSI::PasiPartTwoWayCoup::get_interface_forces()
   intfforcenp_->put_scalar(0.0);
 
   // assemble interface forces
-  Epetra_Export exporter(
-      walldatastate->get_force_col()->get_block_map(), intfforcenp_->get_block_map());
+  Epetra_Export exporter(walldatastate->get_force_col()->get_map().get_epetra_map(),
+      intfforcenp_->get_map().get_epetra_map());
   int err = intfforcenp_->export_to(*walldatastate->get_force_col(), exporter, Add);
   if (err) FOUR_C_THROW("export of interface forces failed with err={}", err);
 }

--- a/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
+++ b/src/pasi/4C_pasi_partitioned_twowaycoup.cpp
@@ -312,8 +312,8 @@ void PaSI::PasiPartTwoWayCoup::get_interface_forces()
   intfforcenp_->put_scalar(0.0);
 
   // assemble interface forces
-  Epetra_Export exporter(walldatastate->get_force_col()->get_map().get_epetra_map(),
-      intfforcenp_->get_map().get_epetra_map());
+  Epetra_Export exporter(walldatastate->get_force_col()->get_map().get_epetra_block_map(),
+      intfforcenp_->get_map().get_epetra_block_map());
   int err = intfforcenp_->export_to(*walldatastate->get_force_col(), exporter, Add);
   if (err) FOUR_C_THROW("export of interface forces failed with err={}", err);
 }

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -1821,7 +1821,7 @@ void PoroElast::Monolithic::set_poro_contact_states()
               std::make_shared<Core::LinAlg::Vector<double>>(
                   *fluid_field()->velocity_row_map(), true);
 
-          int* mygids = fpres->get_block_map().MyGlobalElements();
+          int* mygids = fpres->get_map().MyGlobalElements();
           double* val = fpres->get_values();
           const int ndim = Global::Problem::instance()->n_dim();
           for (int i = 0; i < fpres->local_length(); ++i)

--- a/src/poroelast/4C_poroelast_monolithicfluidsplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicfluidsplit.cpp
@@ -304,7 +304,7 @@ void PoroElast::MonolithicFluidSplit::extract_field_vectors(
         fluid_field()->interface()->insert_other_vector(*fox);
     fluid_field()->interface()->insert_fsi_cond_vector(*fcx, *f);
 
-    FourC::Core::LinAlg::Vector<double> zeros(f->get_block_map(), true);
+    FourC::Core::LinAlg::Vector<double> zeros(f->get_map(), true);
     Core::LinAlg::apply_dirichlet_to_system(
         *f, zeros, *(fluid_field()->get_dbc_map_extractor()->cond_map()));
 

--- a/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
+++ b/src/poroelast/4C_poroelast_monolithicmeshtying.cpp
@@ -69,7 +69,7 @@ void PoroElast::MonolithicMeshtying::evaluate(
       std::make_shared<Core::LinAlg::Vector<double>>(*fluid_field()->velocity_row_map(), true);
 
   const int ndim = Global::Problem::instance()->n_dim();
-  int* mygids = fpres->get_block_map().MyGlobalElements();
+  int* mygids = fpres->get_map().MyGlobalElements();
   double* val = fpres->get_values();
   for (int i = 0; i < fpres->local_length(); ++i)
   {

--- a/src/poroelast/4C_poroelast_monolithicsplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicsplit.cpp
@@ -160,7 +160,7 @@ std::shared_ptr<Core::LinAlg::Map> PoroElast::MonolithicSplit::fsidbc_map()
   std::vector<int> structfsidbcvector;
   const int numgids = gidmarker_fluid->local_length();  // on each processor (lids)
   double* mygids_fluid = gidmarker_fluid->get_values();
-  const int* fluidmap = gidmarker_fluid->get_block_map().MyGlobalElements();
+  const int* fluidmap = gidmarker_fluid->get_map().MyGlobalElements();
   for (int i = 0; i < numgids; ++i)
   {
     double val = mygids_fluid[i];
@@ -199,7 +199,7 @@ void PoroElast::MonolithicSplit::setup_coupling_and_matrices()
 
     std::shared_ptr<const Core::LinAlg::Vector<double>> idispnp =
         structure_field()->interface()->extract_fsi_cond_vector(*structure_field()->dispnp());
-    ddi_ = std::make_shared<Core::LinAlg::Vector<double>>(idispnp->get_block_map(), true);
+    ddi_ = std::make_shared<Core::LinAlg::Vector<double>>(idispnp->get_map(), true);
   }
 
   // initialize Poroelasticity-systemmatrix_

--- a/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
+++ b/src/poroelast/4C_poroelast_monolithicstructuresplit.cpp
@@ -262,7 +262,7 @@ void PoroElast::MonolithicStructureSplit::extract_field_vectors(
         structure_field()->interface()->insert_other_vector(*sox);
     structure_field()->interface()->insert_fsi_cond_vector(*scx, *s);
 
-    FourC::Core::LinAlg::Vector<double> zeros(s->get_block_map(), true);
+    FourC::Core::LinAlg::Vector<double> zeros(s->get_map(), true);
     Core::LinAlg::apply_dirichlet_to_system(
         *s, zeros, *(structure_field()->get_dbc_map_extractor()->cond_map()));
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -1872,7 +1872,7 @@ void PoroPressureBased::PorofluidAlgorithm::set_velocity_field(
   if (nds_vel_ >= discret_->num_dof_sets())
     FOUR_C_THROW("Too few dofsets on poro fluid discretization!");
 
-  if (not vel->get_block_map().SameAs(discret_->dof_row_map(nds_vel_)->get_epetra_map()))
+  if (not vel->get_map().SameAs(discret_->dof_row_map(nds_vel_)->get_epetra_map()))
     FOUR_C_THROW(
         "Map of given velocity and associated dof row map in poro fluid discretization"
         " do not match!");

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -1872,7 +1872,7 @@ void PoroPressureBased::PorofluidAlgorithm::set_velocity_field(
   if (nds_vel_ >= discret_->num_dof_sets())
     FOUR_C_THROW("Too few dofsets on poro fluid discretization!");
 
-  if (not vel->get_map().SameAs(discret_->dof_row_map(nds_vel_)->get_epetra_map()))
+  if (not vel->get_map().SameAs(discret_->dof_row_map(nds_vel_)->get_epetra_block_map()))
     FOUR_C_THROW(
         "Map of given velocity and associated dof row map in poro fluid discretization"
         " do not match!");

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_resulttest.cpp
@@ -135,7 +135,7 @@ double PoroPressureBased::ResultTest::result_node(
   double result(0.);
 
   // extract row map from solution vector
-  const Epetra_BlockMap& phinpmap = porofluid_algorithm_.phinp()->get_block_map();
+  const Core::LinAlg::Map& phinpmap = porofluid_algorithm_.phinp()->get_map();
 
   // test result value of phi field
   if (quantity == "phi")

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -140,7 +140,7 @@ PoroPressureBased::convert_dof_vector_to_node_based_multi_vector(
       std::make_shared<Core::LinAlg::MultiVector<double>>(*dis.node_row_map(), numdofpernode, true);
 
   // get maps
-  const Epetra_BlockMap& vectormap = vector.get_block_map();
+  const Core::LinAlg::Map& vectormap = vector.get_map();
 
   // loop over nodes of the discretization
   for (int inode = 0; inode < dis.num_my_row_nodes(); ++inode)

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -333,9 +333,9 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_a
 
   // initialize the unaffected and current lengths
   unaffected_seg_lengths_artery_ =
-      std::make_shared<Epetra_FEVector>(arterydis_->dof_row_map(1)->get_epetra_map(), true);
+      std::make_shared<Epetra_FEVector>(arterydis_->dof_row_map(1)->get_epetra_block_map(), true);
   current_seg_lengths_artery_ =
-      std::make_shared<Epetra_FEVector>(arterydis_->dof_row_map(1)->get_epetra_map());
+      std::make_shared<Epetra_FEVector>(arterydis_->dof_row_map(1)->get_epetra_block_map());
 
   // set segment ID on coupling pairs and fill the unaffected artery length
   for (int iele = 0; iele < arterydis_->element_col_map()->NumMyElements(); ++iele)
@@ -404,7 +404,7 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_a
 void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::fill_unaffected_integrated_diam()
 {
   Epetra_FEVector unaffected_diams_artery_row(
-      arterydis_->element_row_map()->get_epetra_map(), true);
+      arterydis_->element_row_map()->get_epetra_block_map(), true);
 
   for (int i = 0; i < arterydis_->element_row_map()->NumMyElements(); ++i)
   {
@@ -506,8 +506,8 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::set_varying_diam_
   // set up the required vectors
   if (has_varying_diam_)
   {
-    integrated_diams_artery_row_ =
-        std::make_shared<Epetra_FEVector>(arterydis_->element_row_map()->get_epetra_map(), true);
+    integrated_diams_artery_row_ = std::make_shared<Epetra_FEVector>(
+        arterydis_->element_row_map()->get_epetra_block_map(), true);
     unaffected_integrated_diams_artery_col_ =
         std::make_shared<Core::LinAlg::Vector<double>>(*arterydis_->element_col_map(), true);
     integrated_diams_artery_col_ =

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -869,7 +869,7 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplLineBased::depth_first_searc
     std::vector<int>& this_connected_comp)
 {
   // mark this node visited and add it to this connected component
-  const int lid = visited->get_block_map().LID(actnode->id());
+  const int lid = visited->get_map().LID(actnode->id());
   (*visited)[lid] = 1;
   this_connected_comp.push_back(actnode->id());
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
@@ -93,7 +93,8 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::init()
       *(arterydis_->dof_row_map()), 27, false, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   m_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *(arterydis_->dof_row_map()), 27, false, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  kappa_inv_ = std::make_shared<Epetra_FEVector>(arterydis_->dof_row_map()->get_epetra_map(), true);
+  kappa_inv_ =
+      std::make_shared<Epetra_FEVector>(arterydis_->dof_row_map()->get_epetra_block_map(), true);
 
   // full map of continuous and artery dofs
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps;
@@ -108,7 +109,7 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplNonConforming::init()
   FEmat_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *fullmap_, 81, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
 
-  fe_rhs_ = std::make_shared<Epetra_FEVector>(fullmap_->get_epetra_map());
+  fe_rhs_ = std::make_shared<Epetra_FEVector>(fullmap_->get_epetra_block_map());
 
   // check global map extractor
   globalex_->check_for_valid_map_extractor();

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
@@ -78,12 +78,12 @@ void PoroPressureBased::PoroMultiPhaseScaTraArtCouplSurfBased::pre_evaluate_coup
     std::vector<int> mygpvec(numgp_per_artele, 0);
     std::vector<int> sumgpvec(numgp_per_artele, 0);
     // loop over all GIDs
-    for (int gid = gp_vector->Map().MinAllGID(); gid <= gp_vector->Map().MaxAllGID(); gid++)
+    for (int gid = gp_vector->get_map().MinAllGID(); gid <= gp_vector->get_map().MaxAllGID(); gid++)
     {
       // reset
       std::fill(sumgpvec.data(), sumgpvec.data() + numgp_per_artele, 0);
 
-      const int mylid = gp_vector->Map().LID(gid);
+      const int mylid = gp_vector->get_map().LID(gid);
       // if not owned or ghosted fill with zeros
       if (mylid < 0) std::fill(mygpvec.data(), mygpvec.data() + numgp_per_artele, 0);
       // else get the GP vector

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -1505,12 +1505,12 @@ void EnsightWriter::write_dof_result_step(std::ofstream& file, PostResult& resul
   const int numnp = nodemap->NumGlobalElements();
 
   const std::shared_ptr<Core::LinAlg::Vector<double>> data = result.read_result(groupname);
-  const Epetra_BlockMap& map = data->get_block_map();
+  const Core::LinAlg::Map& map = data->get_map();
 
   // do stupid conversion into map
   std::shared_ptr<Core::LinAlg::Map> datamap;
-  datamap = std::make_shared<Core::LinAlg::Map>(map.NumGlobalElements(), map.NumMyElements(),
-      map.MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(map.Comm()));
+  datamap = std::make_shared<Core::LinAlg::Map>(
+      map.NumGlobalElements(), map.NumMyElements(), map.MyGlobalElements(), 0, map.Comm());
 
   // determine offset of dofs in case of multiple discretizations in
   // separate files (e.g. multi-scale problems). during calculation,
@@ -1565,7 +1565,7 @@ void EnsightWriter::write_dof_result_step(std::ofstream& file, PostResult& resul
     int err = proc0data.import(*data, proc0dataimporter, Insert);
     if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);
 
-    const Epetra_BlockMap& finaldatamap = proc0data.get_block_map();
+    const Core::LinAlg::Map& finaldatamap = proc0data.get_map();
 
     //------------------------------------------------------------------
     // each processor provides its dof global id information for proc 0
@@ -1717,7 +1717,7 @@ void EnsightWriter::write_nodal_result_step(std::ofstream& file,
   write(file, field_->field_pos() + 1);
   write(file, "coordinates");
 
-  const Epetra_BlockMap& datamap = data->Map();
+  const Core::LinAlg::Map& datamap = data->get_map();
 
   // switch between nurbs an others
   if (field_->problem()->spatial_approximation_type() == Core::FE::ShapeFunctionType::nurbs &&
@@ -1734,7 +1734,7 @@ void EnsightWriter::write_nodal_result_step(std::ofstream& file,
     // contract Core::LinAlg::MultiVector<double> on proc0 (proc0 gets everything, other procs
     // empty)
     Core::LinAlg::MultiVector<double> data_proc0(*proc0map_, numdf);
-    Epetra_Import proc0dofimporter(proc0map_->get_epetra_map(), datamap);
+    Epetra_Import proc0dofimporter(proc0map_->get_epetra_map(), datamap.get_epetra_map());
     int err = data_proc0.Import(*data, proc0dofimporter, Insert);
     if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);
 
@@ -1814,12 +1814,12 @@ void EnsightWriter::write_element_dof_result_step(std::ofstream& file, PostResul
   const Core::LinAlg::Map* elementmap = dis->element_row_map();  // local node row map
 
   const std::shared_ptr<Core::LinAlg::Vector<double>> data = result.read_result(groupname);
-  const Epetra_BlockMap& map = data->get_block_map();
+  const Core::LinAlg::Map& map = data->get_map();
 
   // do stupid conversion into map
   std::shared_ptr<Core::LinAlg::Map> datamap;
-  datamap = std::make_shared<Core::LinAlg::Map>(map.NumGlobalElements(), map.NumMyElements(),
-      map.MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(map.Comm()));
+  datamap = std::make_shared<Core::LinAlg::Map>(
+      map.NumGlobalElements(), map.NumMyElements(), map.MyGlobalElements(), 0, map.Comm());
 
   //------------------------------------------------------
   // each processor provides its result values for proc 0
@@ -1834,7 +1834,7 @@ void EnsightWriter::write_element_dof_result_step(std::ofstream& file, PostResul
   int err = proc0data.import(*data, proc0dataimporter, Insert);
   if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);
 
-  const Epetra_BlockMap& finaldatamap = proc0data.get_block_map();
+  const Core::LinAlg::Map& finaldatamap = proc0data.get_map();
 
   //------------------------------------------------------------------
   // each processor provides its dof global id information for proc 0
@@ -1979,13 +1979,13 @@ void EnsightWriter::write_element_result_step(std::ofstream& file,
   write(file, "part");
   write(file, field_->field_pos() + 1);
 
-  const Epetra_BlockMap& map = data->Map();
+  const Core::LinAlg::Map& map = data->get_map();
   const int numcol = data->NumVectors();
 
   // do stupid conversion into map
   std::shared_ptr<Core::LinAlg::Map> datamap;
-  datamap = std::make_shared<Core::LinAlg::Map>(map.NumGlobalElements(), map.NumMyElements(),
-      map.MyGlobalElements(), 0, Core::Communication::unpack_epetra_comm(map.Comm()));
+  datamap = std::make_shared<Core::LinAlg::Map>(
+      map.NumGlobalElements(), map.NumMyElements(), map.MyGlobalElements(), 0, map.Comm());
 
   //------------------------------------------------------
   // each processor provides its result values for proc 0
@@ -2000,7 +2000,7 @@ void EnsightWriter::write_element_result_step(std::ofstream& file,
   int err = proc0data.Import(*data, proc0dataimporter, Insert);
   if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);
 
-  const Epetra_BlockMap& finaldatamap = proc0data.Map();
+  const Core::LinAlg::Map& finaldatamap = proc0data.get_map();
 
   //-------------------------
   // specify the element type

--- a/src/post/4C_post_ensight_writer_nurbs.cpp
+++ b/src/post/4C_post_ensight_writer_nurbs.cpp
@@ -1360,7 +1360,8 @@ void EnsightWriter::write_coordinates_for_nurbs_shapefunctions(std::ofstream& ge
   proc0map = Core::LinAlg::allreduce_e_map(*vispointmap_, 0);
 
   // import my new values (proc0 gets everything, other procs empty)
-  Epetra_Import proc0importer(proc0map->get_epetra_map(), vispointmap_->get_epetra_map());
+  Epetra_Import proc0importer(
+      proc0map->get_epetra_block_map(), vispointmap_->get_epetra_block_map());
   Core::LinAlg::MultiVector<double> allnodecoords(*proc0map, 3);
   int err = allnodecoords.Import(*nodecoords, proc0importer, Insert);
   if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);
@@ -1908,7 +1909,8 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
   Core::LinAlg::Vector<double> coldata(*fulldofmap, true);
 
   // create an importer and import the data
-  Epetra_Import importer((coldata).get_map().get_epetra_map(), (data).get_map().get_epetra_map());
+  Epetra_Import importer(
+      (coldata).get_map().get_epetra_block_map(), (data).get_map().get_epetra_block_map());
   int imerr = (coldata).import((data), importer, Insert);
   if (imerr)
   {
@@ -2112,7 +2114,8 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
   }  // loop over available elements
 
   // import my new values (proc0 gets everything, other procs empty)
-  Epetra_Import proc0importer(proc0map_->get_epetra_map(), vispointmap_->get_epetra_map());
+  Epetra_Import proc0importer(
+      proc0map_->get_epetra_block_map(), vispointmap_->get_epetra_block_map());
   Core::LinAlg::MultiVector<double> allsols(*proc0map_, numdf);
   int err = allsols.Import(*idata, proc0importer, Insert);
   if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);
@@ -3430,7 +3433,8 @@ void EnsightWriter::write_nodal_result_step_for_nurbs(std::ofstream& file, const
   Core::LinAlg::MultiVector<double> coldata(*fullnodemap, numdf, true);  // numdf important!!!
 
   // create an importer and import the data
-  Epetra_Import importer((coldata).get_map().get_epetra_map(), (data).get_map().get_epetra_map());
+  Epetra_Import importer(
+      (coldata).get_map().get_epetra_block_map(), (data).get_map().get_epetra_block_map());
   int imerr = (coldata).Import((data), importer, Insert);
   if (imerr)
   {
@@ -3512,7 +3516,8 @@ void EnsightWriter::write_nodal_result_step_for_nurbs(std::ofstream& file, const
   }  // loop over available elements
 
   // import my new values (proc0 gets everything, other procs empty)
-  Epetra_Import proc0importer(proc0map_->get_epetra_map(), vispointmap_->get_epetra_map());
+  Epetra_Import proc0importer(
+      proc0map_->get_epetra_block_map(), vispointmap_->get_epetra_block_map());
   Core::LinAlg::MultiVector<double> allsols(*proc0map_, numdf);
   int err = allsols.Import(*idata, proc0importer, Insert);
   if (err > 0) FOUR_C_THROW("Importing everything to proc 0 went wrong. Import returns {}", err);

--- a/src/post/4C_post_ensight_writer_nurbs.cpp
+++ b/src/post/4C_post_ensight_writer_nurbs.cpp
@@ -1908,7 +1908,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
   Core::LinAlg::Vector<double> coldata(*fulldofmap, true);
 
   // create an importer and import the data
-  Epetra_Import importer((coldata).get_block_map(), (data).get_block_map());
+  Epetra_Import importer((coldata).get_map().get_epetra_map(), (data).get_map().get_epetra_map());
   int imerr = (coldata).import((data), importer, Insert);
   if (imerr)
   {
@@ -1989,7 +1989,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
         for (int rr = 0; rr < dim; ++rr)
         {
           my_data[dim * inode + rr] =
-              (coldata)[(coldata).get_block_map().LID(lm[inode * (dim + 1) + rr] + offset)];
+              (coldata)[(coldata).get_map().LID(lm[inode * (dim + 1) + rr] + offset)];
         }
       }
     }
@@ -2002,7 +2002,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
         for (int rr = 0; rr < dim; ++rr)
         {
           my_data[dim * inode + rr] =
-              (coldata)[(coldata).get_block_map().LID(lm[inode * dim + rr] + offset)];
+              (coldata)[(coldata).get_map().LID(lm[inode * dim + rr] + offset)];
         }
       }
     }
@@ -2014,7 +2014,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
       {
         // offset should be equal to dim for pressure case!
         my_data[inode] =
-            (coldata)[(coldata).get_block_map().LID(lm[inode * (dim + 1) + dim] + offset - dim)];
+            (coldata)[(coldata).get_map().LID(lm[inode * (dim + 1) + dim] + offset - dim)];
       }
     }
     else if (name == "averaged_scalar_field")
@@ -2024,8 +2024,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
       for (int inode = 0; inode < numnp; ++inode)
       {
         // offset should be equal to dim for pressure case!
-        my_data[inode] =
-            (coldata)[(coldata).get_block_map().LID(lm[inode * (dim + 1) + dim] + offset)];
+        my_data[inode] = (coldata)[(coldata).get_map().LID(lm[inode * (dim + 1) + dim] + offset)];
       }
     }
     else if ((name == "phi") or (name == "averaged_phi"))
@@ -2037,10 +2036,9 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
         Core::Nodes::Node* n = nurbsdis->l_row_node(inode);
         int numdofpernode = actele->num_dof_per_node(*n);
         if (numdofpernode == 1)  // one passive scalar (Scalar_Transport problem)
-          my_data[inode] =
-              (coldata)[(coldata).get_block_map().LID(lm[inode * numdofpernode] + offset)];
+          my_data[inode] = (coldata)[(coldata).get_map().LID(lm[inode * numdofpernode] + offset)];
         else  // result for electric potential (ELCH problem)
-          my_data[inode] = (coldata)[(coldata).get_block_map().LID(
+          my_data[inode] = (coldata)[(coldata).get_map().LID(
               lm[inode * numdofpernode + (numdofpernode - 1)] + offset)];
       }
     }
@@ -2065,8 +2063,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
       {
         Core::Nodes::Node* n = nurbsdis->l_row_node(inode);
         int numdofpernode = actele->num_dof_per_node(*n);
-        my_data[inode] =
-            (coldata)[(coldata).get_block_map().LID(lm[inode * numdofpernode + k] + offset)];
+        my_data[inode] = (coldata)[(coldata).get_map().LID(lm[inode * numdofpernode + k] + offset)];
       }
     }
     else if (name == "normalflux")
@@ -2077,8 +2074,7 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
       {
         // Core::Nodes::Node* n = nurbsdis->lRowNode(inode);
         int numdofpernode = 1;  // actele->NumDofPerNode(*n);
-        my_data[inode] =
-            (coldata)[(coldata).get_block_map().LID(lm[inode * numdofpernode] + offset)];
+        my_data[inode] = (coldata)[(coldata).get_map().LID(lm[inode * numdofpernode] + offset)];
       }
     }
     //---------------------------------------------------
@@ -2096,14 +2092,14 @@ void EnsightWriter::write_dof_result_step_for_nurbs(std::ofstream& file, const i
         for (int rr = 0; rr < dim; ++rr)
         {
           my_data[dim * inode + rr] =
-              (coldata)[(coldata).get_block_map().LID(lm[inode * dim + rr] + offset)];
+              (coldata)[(coldata).get_map().LID(lm[inode * dim + rr] + offset)];
         }
       }
     }
     else if (name == "temperature")
     {
       for (int inode = 0; inode < numnp; ++inode)
-        my_data[inode] = (coldata)[(coldata).get_block_map().LID(lm[inode] + offset)];
+        my_data[inode] = (coldata)[(coldata).get_map().LID(lm[inode] + offset)];
     }
     else
     {
@@ -3434,7 +3430,7 @@ void EnsightWriter::write_nodal_result_step_for_nurbs(std::ofstream& file, const
   Core::LinAlg::MultiVector<double> coldata(*fullnodemap, numdf, true);  // numdf important!!!
 
   // create an importer and import the data
-  Epetra_Import importer((coldata).Map(), (data).Map());
+  Epetra_Import importer((coldata).get_map().get_epetra_map(), (data).get_map().get_epetra_map());
   int imerr = (coldata).Import((data), importer, Insert);
   if (imerr)
   {
@@ -3505,7 +3501,7 @@ void EnsightWriter::write_nodal_result_step_for_nurbs(std::ofstream& file, const
       for (int rr = 0; rr < numdf; ++rr)
       {
         // value of nodemap-based column rr
-        my_data[numdf * inode + rr] = (((coldata)(rr)))[(coldata).Map().LID(nodeids[inode])];
+        my_data[numdf * inode + rr] = (((coldata)(rr)))[(coldata).get_map().LID(nodeids[inode])];
       }
     }
 

--- a/src/post/4C_post_vtk_vti_writer.cpp
+++ b/src/post/4C_post_vtk_vti_writer.cpp
@@ -144,7 +144,7 @@ void PostVtiWriter::write_dof_result_step(std::ofstream& file,
   // Here is the only thing we need to do for parallel computations: We need read access to all dofs
   // on the row elements, so need to get the DofColMap to have this access
   const Core::LinAlg::Map* colmap = dis->dof_col_map(0);
-  const Epetra_BlockMap& vecmap = data->get_block_map();
+  const Core::LinAlg::Map& vecmap = data->get_map();
 
   // TODO: wic, once the vtu pressure writer is fixed, apply the same solution here.
   const int offset = (fillzeros) ? 0 : vecmap.MinAllGID() - dis->dof_row_map(0)->MinAllGID();
@@ -189,7 +189,7 @@ void PostVtiWriter::write_dof_result_step(std::ofstream& file,
 
       for (int d = 0; d < numdf; ++d)
       {
-        const int lid = ghostedData->get_block_map().LID(nodedofs[d + from] + offset);
+        const int lid = ghostedData->get_map().LID(nodedofs[d + from] + offset);
         if (lid > -1)
         {
           solution[inpos + d] = (*ghostedData)[lid];
@@ -239,7 +239,7 @@ void PostVtiWriter::write_nodal_result_step(std::ofstream& file,
   // Here is the only thing we need to do for parallel computations: We need read access to all dofs
   // on the row elements, so need to get the NodeColMap to have this access
   const Core::LinAlg::Map* colmap = dis->node_col_map();
-  const Epetra_BlockMap& vecmap = data->Map();
+  const Core::LinAlg::Map& vecmap = data->get_map();
 
   FOUR_C_ASSERT(
       colmap->MaxAllGID() == vecmap.MaxAllGID() && colmap->MinAllGID() == vecmap.MinAllGID(),
@@ -274,7 +274,7 @@ void PostVtiWriter::write_nodal_result_step(std::ofstream& file,
       {
         Core::LinAlg::Vector<double> column((*ghostedData)(idf));
 
-        const int lid = ghostedData->Map().LID(gid);
+        const int lid = ghostedData->get_map().LID(gid);
 
         if (lid > -1)
         {
@@ -335,7 +335,7 @@ void PostVtiWriter::write_element_result_step(std::ofstream& file,
     FOUR_C_THROW("violated column range of Core::LinAlg::MultiVector<double>: {}", numcol);
 
   std::shared_ptr<Core::LinAlg::MultiVector<double>> importedData;
-  if (dis->element_col_map()->SameAs(data->Map()))
+  if (dis->element_col_map()->SameAs(data->get_map()))
     importedData = data;
   else
   {

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -1432,31 +1432,36 @@ void Airway::RedAirwayImplicitTimeInt::output(
     output_.write_vector("elemRadius_current", qexp_);
 
     {
-      Epetra_Export exporter(acini_e_volumenm_->get_block_map(), qexp_->get_block_map());
+      Epetra_Export exporter(
+          acini_e_volumenm_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
       int err = qexp_->export_to(*acini_e_volumenm_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_vnm", qexp_);
     }
     {
-      Epetra_Export exporter(acini_e_volumen_->get_block_map(), qexp_->get_block_map());
+      Epetra_Export exporter(
+          acini_e_volumen_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
       int err = qexp_->export_to(*acini_e_volumen_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_vn", qexp_);
     }
     {
-      Epetra_Export exporter(acini_e_volumenp_->get_block_map(), qexp_->get_block_map());
+      Epetra_Export exporter(
+          acini_e_volumenp_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
       int err = qexp_->export_to(*acini_e_volumenp_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_vnp", qexp_);
     }
     {
-      Epetra_Export exporter(acini_e_volume_strain_->get_block_map(), qexp_->get_block_map());
+      Epetra_Export exporter(
+          acini_e_volume_strain_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
       int err = qexp_->export_to(*acini_e_volume_strain_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_volumetric_strain", qexp_);
     }
     {
-      Epetra_Export exporter(acini_e_volume0_->get_block_map(), qexp_->get_block_map());
+      Epetra_Export exporter(
+          acini_e_volume0_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
       int err = qexp_->export_to(*acini_e_volume0_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_v0", qexp_);
@@ -1827,12 +1832,12 @@ bool Airway::RedAirwayImplicitTimeInt::sum_all_col_elem_val(
   // it to a RowMap and eliminate the ghosted values
   {
     // define epetra exporter
-    Epetra_Export exporter(vec.get_block_map(), qexp_->get_block_map());
+    Epetra_Export exporter(vec.get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
     // export from ColMap to RowMap
     int err = qexp_->export_to(vec, exporter, Zero);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
 
-    Epetra_Export exporter2(sumCond.get_block_map(), qexp2_->get_block_map());
+    Epetra_Export exporter2(sumCond.get_map().get_epetra_map(), qexp2_->get_map().get_epetra_map());
     // export from ColMap to RowMap
     err = qexp2_->export_to(sumCond, exporter2, Zero);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -1432,36 +1432,36 @@ void Airway::RedAirwayImplicitTimeInt::output(
     output_.write_vector("elemRadius_current", qexp_);
 
     {
-      Epetra_Export exporter(
-          acini_e_volumenm_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
+      Epetra_Export exporter(acini_e_volumenm_->get_map().get_epetra_block_map(),
+          qexp_->get_map().get_epetra_block_map());
       int err = qexp_->export_to(*acini_e_volumenm_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_vnm", qexp_);
     }
     {
-      Epetra_Export exporter(
-          acini_e_volumen_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
+      Epetra_Export exporter(acini_e_volumen_->get_map().get_epetra_block_map(),
+          qexp_->get_map().get_epetra_block_map());
       int err = qexp_->export_to(*acini_e_volumen_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_vn", qexp_);
     }
     {
-      Epetra_Export exporter(
-          acini_e_volumenp_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
+      Epetra_Export exporter(acini_e_volumenp_->get_map().get_epetra_block_map(),
+          qexp_->get_map().get_epetra_block_map());
       int err = qexp_->export_to(*acini_e_volumenp_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_vnp", qexp_);
     }
     {
-      Epetra_Export exporter(
-          acini_e_volume_strain_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
+      Epetra_Export exporter(acini_e_volume_strain_->get_map().get_epetra_block_map(),
+          qexp_->get_map().get_epetra_block_map());
       int err = qexp_->export_to(*acini_e_volume_strain_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_volumetric_strain", qexp_);
     }
     {
-      Epetra_Export exporter(
-          acini_e_volume0_->get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
+      Epetra_Export exporter(acini_e_volume0_->get_map().get_epetra_block_map(),
+          qexp_->get_map().get_epetra_block_map());
       int err = qexp_->export_to(*acini_e_volume0_, exporter, Zero);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
       output_.write_vector("acini_v0", qexp_);
@@ -1832,12 +1832,14 @@ bool Airway::RedAirwayImplicitTimeInt::sum_all_col_elem_val(
   // it to a RowMap and eliminate the ghosted values
   {
     // define epetra exporter
-    Epetra_Export exporter(vec.get_map().get_epetra_map(), qexp_->get_map().get_epetra_map());
+    Epetra_Export exporter(
+        vec.get_map().get_epetra_block_map(), qexp_->get_map().get_epetra_block_map());
     // export from ColMap to RowMap
     int err = qexp_->export_to(vec, exporter, Zero);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
 
-    Epetra_Export exporter2(sumCond.get_map().get_epetra_map(), qexp2_->get_map().get_epetra_map());
+    Epetra_Export exporter2(
+        sumCond.get_map().get_epetra_block_map(), qexp2_->get_map().get_epetra_block_map());
     // export from ColMap to RowMap
     err = qexp2_->export_to(sumCond, exporter2, Zero);
     if (err) FOUR_C_THROW("Export using exporter returned err={}", err);

--- a/src/red_airways/4C_red_airways_resulttest.cpp
+++ b/src/red_airways/4C_red_airways_resulttest.cpp
@@ -62,7 +62,7 @@ void Airway::RedAirwayResultTest::test_node(
       if (actnode->owner() != Core::Communication::my_mpi_rank(dis_->get_comm())) return;
 
       double result = 0.;
-      const Epetra_BlockMap& nodemap = mynodesol_pressure_->get_block_map();
+      const Core::LinAlg::Map& nodemap = mynodesol_pressure_->get_map();
       std::string position = container.get<std::string>("QUANTITY");
 
       // test result value of single scalar field
@@ -124,7 +124,7 @@ void Airway::RedAirwayResultTest::test_element(
       if (actelement->owner() != Core::Communication::my_mpi_rank(dis_->get_comm())) return;
 
       double result = 0.;
-      const Epetra_BlockMap& elementmap = myelemsol_acinivol_->get_block_map();
+      const Core::LinAlg::Map& elementmap = myelemsol_acinivol_->get_map();
       std::string position = container.get<std::string>("QUANTITY");
       if (position == "pressure_external")
       {

--- a/src/scatra/4C_scatra_resulttest.cpp
+++ b/src/scatra/4C_scatra_resulttest.cpp
@@ -82,7 +82,7 @@ double ScaTra::ScaTraResultTest::result_node(
   double result(0.);
 
   // extract row map from solution vector
-  const Epetra_BlockMap& phinpmap = scatratimint_->phinp()->get_block_map();
+  const Core::LinAlg::Map& phinpmap = scatratimint_->phinp()->get_map();
 
   // test result value of single scalar field
   if (quantity == "phi")

--- a/src/scatra/4C_scatra_resulttest_hdg.cpp
+++ b/src/scatra/4C_scatra_resulttest_hdg.cpp
@@ -37,7 +37,7 @@ double ScaTra::HDGResultTest::result_node(
   double result(0.);
 
   // extract row map from solution vector
-  const Epetra_BlockMap& phinpmap = scatratiminthdg_->interpolated_phinp()->get_block_map();
+  const Core::LinAlg::Map& phinpmap = scatratiminthdg_->interpolated_phinp()->get_map();
 
   // test result value of single scalar field (averaged value on element node is tested)
   if (quantity == "phi")

--- a/src/scatra/4C_scatra_timint_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_hdg.cpp
@@ -295,7 +295,7 @@ namespace
     dis.clear_state(true);
 
     // create dofsets for concentration at nodes
-    tracephi = std::make_shared<Core::LinAlg::Vector<double>>(phi->get_block_map());
+    tracephi = std::make_shared<Core::LinAlg::Vector<double>>(phi->get_map());
     gradphi = std::make_shared<Core::LinAlg::MultiVector<double>>(*dis.node_row_map(), ndim);
 
     // call element routine to interpolate HDG to elements
@@ -779,7 +779,7 @@ void ScaTra::TimIntHDG::fd_check()
       phinp_->update(1., phinp_original, 0.);
 
       // impose perturbation and update interior variables
-      if (phinp_->get_block_map().MyGID(colgid))
+      if (phinp_->get_map().MyGID(colgid))
       {
         if (phinp_->sum_into_global_value(colgid, 0, eps))
           FOUR_C_THROW(

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1260,7 +1260,7 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field_from_function()
 
           // get global and local dof IDs
           const int gid = nodedofs[index];
-          const int lid = convel->get_block_map().LID(gid);
+          const int lid = convel->get_map().LID(gid);
 
           if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
           err = convel->replace_local_value(lid, 0, value);
@@ -1331,7 +1331,7 @@ void ScaTra::ScaTraTimIntImpl::set_external_force() const
       const double force_velocity_value = external_force_value * intrinsic_mobility_value;
 
       const int gid = nodedofs[spatial_dimension];
-      const int lid = force_velocity->get_block_map().LID(gid);
+      const int lid = force_velocity->get_map().LID(gid);
 
       if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
       const int error_force_velocity =
@@ -1771,7 +1771,7 @@ void ScaTra::ScaTraTimIntImpl::collect_runtime_output_data()
       Core::Nodes::Node* node = discret_->l_row_node(inode);
       for (int idim = 0; idim < nsd_; ++idim)
         (convel_multi)(idim)[inode] =
-            (*convel)[convel->get_block_map().LID(discret_->dof(nds_vel(), node, idim))];
+            (*convel)[convel->get_map().LID(discret_->dof(nds_vel(), node, idim))];
     }
 
     std::vector<std::optional<std::string>> context(nsd_, "convec_velocity");
@@ -1792,8 +1792,8 @@ void ScaTra::ScaTraTimIntImpl::collect_runtime_output_data()
       {
         const Core::Nodes::Node* node = discret_->l_row_node(inode);
         for (int idim = 0; idim < nsd_; ++idim)
-          (multi_vector)(idim)[inode] = (*state_vector)[state_vector->get_block_map().LID(
-              discret_->dof(nds_vel(), node, idim))];
+          (multi_vector)(idim)[inode] =
+              (*state_vector)[state_vector->get_map().LID(discret_->dof(nds_vel(), node, idim))];
       }
       const std::vector<std::optional<std::string>> context(nsd_, field_name);
       visualization_writer_->append_result_data_vector_with_context(
@@ -1819,7 +1819,7 @@ void ScaTra::ScaTraTimIntImpl::collect_runtime_output_data()
       Core::Nodes::Node* node = discret_->l_row_node(inode);
       for (int idim = 0; idim < nsd_; ++idim)
         (dispnp_multi)(idim)[inode] =
-            (*dispnp)[dispnp->get_block_map().LID(discret_->dof(nds_disp(), node, idim))];
+            (*dispnp)[dispnp->get_map().LID(discret_->dof(nds_disp(), node, idim))];
     }
 
     std::vector<std::optional<std::string>> context(nsd_, "ale-displacement");
@@ -2399,7 +2399,7 @@ void ScaTra::ScaTraTimIntImpl::setup_krylov_space_projection(
 
   // create the projector
   projector_ = std::make_shared<Core::LinAlg::KrylovProjector>(
-      activemodeids, weighttype, &discret_->dof_row_map()->get_epetra_map());
+      activemodeids, weighttype, discret_->dof_row_map());
 
   // update the projector
   update_krylov_space_projection();
@@ -3185,7 +3185,7 @@ ScaTra::ScaTraTimIntImpl::convert_dof_vector_to_componentwise_node_vector(
     Core::Nodes::Node* node = discret_->l_row_node(inode);
     for (int idim = 0; idim < nsd_; ++idim)
       (*componentwise_node_vector)(idim)[inode] =
-          (dof_vector)[dof_vector.get_block_map().LID(discret_->dof(nds, node, idim))];
+          (dof_vector)[dof_vector.get_map().LID(discret_->dof(nds, node, idim))];
   }
   return componentwise_node_vector;
 }
@@ -3825,8 +3825,8 @@ void ScaTra::ScaTraTimIntImpl::calc_mean_micro_concentration()
       int dof_macro = discret_->dof(0, node)[0];
       int dof_micro = discret_->dof(nds_micro(), node)[0];
 
-      const int dof_lid_micro = phinp_micro_->get_block_map().LID(dof_micro);
-      const int dof_lid_macro = phinp_->get_block_map().LID(dof_macro);
+      const int dof_lid_micro = phinp_micro_->get_map().LID(dof_micro);
+      const int dof_lid_macro = phinp_->get_map().LID(dof_macro);
 
       // only if owned by this proc
       if (dof_lid_micro != -1 and dof_lid_macro != -1)
@@ -3849,7 +3849,7 @@ void ScaTra::ScaTraTimIntImpl::calc_mean_micro_concentration()
     if (dofs.size() != 1) FOUR_C_THROW("Only one dof expected.");
 
     const int dof_gid = dofs[0];
-    const int dof_lid = phinp_micro_->get_block_map().LID(dof_gid);
+    const int dof_lid = phinp_micro_->get_map().LID(dof_gid);
 
     // only if this dof is part of the phinp_micro_ vector/map
     if (dof_lid != -1)
@@ -3926,7 +3926,7 @@ void ScaTra::ScaTraTimIntImpl::calc_mean_micro_concentration()
   // correct values on hybrid dofs (value on node with 2 dofs is artificially set to 0.0)
   for (int hybrid_dof : hybrid_dofs)
   {
-    const int lid = phinp_micro_->get_block_map().LID(hybrid_dof);
+    const int lid = phinp_micro_->get_map().LID(hybrid_dof);
     if (lid != -1)
     {
       const double value = (*phinp_micro_)[lid];

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -1683,7 +1683,7 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_nts(
       vector1_side, systemvector2, vector2_side);
 
   // extract slave-side noderowmap
-  const Epetra_BlockMap& noderowmap_slave = islavenodestomasterelements.get_block_map();
+  const Core::LinAlg::Map& noderowmap_slave = islavenodestomasterelements.get_map();
 
   // loop over all slave-side nodes
   for (int inode = 0; inode < noderowmap_slave.NumMyElements(); ++inode)
@@ -4008,7 +4008,7 @@ void ScaTra::MeshtyingStrategyS2I::fd_check(
     statenp.update(1., statenp_original, 0.);
 
     // impose perturbation
-    if (statenp.get_block_map().MyGID(colgid))
+    if (statenp.get_map().MyGID(colgid))
       if (statenp.sum_into_global_value(colgid, 0, fdcheckeps))
         FOUR_C_THROW(
             "Perturbation could not be imposed on state vector for finite difference check!");

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -2534,7 +2534,7 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
 
         // initialize auxiliary residual vector for master side
         imasterresidual_ =
-            std::make_shared<Epetra_FEVector>(interfacemaps_->map(2)->get_epetra_map());
+            std::make_shared<Epetra_FEVector>(interfacemaps_->map(2)->get_epetra_block_map());
       }
 
       switch (couplingtype_)

--- a/src/scatra/4C_scatra_timint_poromulti.cpp
+++ b/src/scatra/4C_scatra_timint_poromulti.cpp
@@ -84,7 +84,7 @@ void ScaTra::ScaTraTimIntPoroMulti::set_l2_flux_of_multi_fluid(
       {
         // get global and local dof IDs
         const int gid = nodedofs[index];
-        const int lid = phaseflux->get_block_map().LID(gid);
+        const int lid = phaseflux->get_map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Local ID not found in map for given global ID!");
 
         const double value = ((*multiflux)(curphase * nsd_ + index))[lnodeid];
@@ -148,7 +148,7 @@ void ScaTra::ScaTraTimIntPoroMulti::collect_runtime_output_data()
       Core::Nodes::Node* node = discret_->l_row_node(inode);
       for (int idim = 0; idim < nsd_; ++idim)
         (dispnp_multi)(idim)[inode] =
-            (*dispnp)[dispnp->get_block_map().LID(discret_->dof(nds_disp(), node, idim))];
+            (*dispnp)[dispnp->get_map().LID(discret_->dof(nds_disp(), node, idim))];
     }
 
     std::vector<std::optional<std::string>> context(nsd_, "ale-displacement");

--- a/src/scatra/4C_scatra_utils.cpp
+++ b/src/scatra/4C_scatra_utils.cpp
@@ -365,7 +365,7 @@ ScaTra::ScaTraUtils::compute_gradient_at_nodes_mean_average(Core::FE::Discretiza
 
     int GID = lm[0];  // Global ID of DoF Map
     // get local processor id according to global node id
-    const int lid = (*gradphirow).Map().LID(GID);
+    const int lid = (*gradphirow).get_map().LID(GID);
     if (lid < 0)
       FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
           Core::Communication::my_mpi_rank((*gradphirow).Comm()), GID);

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
@@ -589,7 +589,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::calc_normal_vec
   for (int j = 0; j < nen_; j++)
   {
     const int nodegid = (ele->nodes()[j])->id();
-    if (normals->Map().MyGID(nodegid))
+    if (normals->get_map().MyGID(nodegid))
     {
       // scaling to a unit vector is performed on the global level after
       // assembly of nodal contributions since we have no reliable information

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
@@ -171,7 +171,7 @@ double NOX::Nln::Aux::root_mean_square_norm(const double& atol, const double& rt
   v.update(-1.0, xincr, 1.0);
 
   // new auxiliary vector
-  Core::LinAlg::Vector<double> u(xnew.get_block_map(), false);
+  Core::LinAlg::Vector<double> u(xnew.get_map(), false);
 
   // create the weighting factor u = RTOL |x^(k-1)| + ATOL
   u.put_scalar(1.0);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_forward_decl.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_forward_decl.hpp
@@ -14,7 +14,7 @@
 // and not using all identifiers will lead to clang-tidy thinking these are our own names.
 // NOLINTBEGIN(readability-identifier-naming)
 
-class Epetra_BlockMap;
+
 class Epetra_Operator;
 class Epetra_RowMatrix;
 class Epetra_LinearProblem;

--- a/src/ssi/4C_ssi_monolithic.cpp
+++ b/src/ssi/4C_ssi_monolithic.cpp
@@ -882,7 +882,7 @@ void SSI::SsiMono::newton_loop()
     // applicable
     if (scatra_field()->scatra_parameter_list()->get<bool>("OUTPUTLINSOLVERSTATS"))
       scatra_field()->output_lin_solver_stats(*solver_, dt_solve_, step(), iteration_count(),
-          ssi_vectors_->residual()->get_block_map().NumGlobalElements());
+          ssi_vectors_->residual()->get_map().NumGlobalElements());
 
     // update states for next Newton iteration
     update_iter_scatra();

--- a/src/ssi/4C_ssi_str_model_evaluator_base.cpp
+++ b/src/ssi/4C_ssi_str_model_evaluator_base.cpp
@@ -69,7 +69,7 @@ void Solid::ModelEvaluator::BaseSSI::determine_stress_strain()
 
     // extract dof lid of first degree of freedom associated with current node in second nodeset
     const int dofgid = discret().dof(2, node, 0);
-    const int doflid = mechanical_stress_state_np_->get_block_map().LID(dofgid);
+    const int doflid = mechanical_stress_state_np_->get_map().LID(dofgid);
     if (doflid < 0) FOUR_C_THROW("Local ID not found in vector!");
 
     (*mechanical_stress_state_np_)[doflid] = (nodal_stresses_source(0))[nodelid];

--- a/src/ssti/4C_ssti_monolithic_assemble_strategy.cpp
+++ b/src/ssti/4C_ssti_monolithic_assemble_strategy.cpp
@@ -1299,7 +1299,7 @@ void SSTI::AssembleStrategyBase::assemble_rhs(std::shared_ptr<Core::LinAlg::Vect
 
     // apply pseudo Dirichlet conditions to transformed slave-side part of structural right-hand
     // side vector
-    Core::LinAlg::Vector<double> zeros(residual_structure.get_block_map());
+    Core::LinAlg::Vector<double> zeros(residual_structure.get_map());
 
     if (locsysmanager_structure != nullptr)
       locsysmanager_structure->rotate_global_to_local(*rhs_structure_master);

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -573,7 +573,8 @@ void STI::Monolithic::output_matrix_to_file(
   if (sparsematrix != nullptr)
   {
     if (crsmatrix.import(*sparsematrix,
-            Epetra_Import(fullrowmap.get_epetra_map(), rowmap.get_epetra_map()), Insert))
+            Epetra_Import(fullrowmap.get_epetra_block_map(), rowmap.get_epetra_block_map()),
+            Insert))
       FOUR_C_THROW("Matrix import failed!");
   }
   else
@@ -583,8 +584,8 @@ void STI::Monolithic::output_matrix_to_file(
       for (int j = 0; j < blocksparsematrix->cols(); ++j)
       {
         if (crsmatrix.import(blocksparsematrix->matrix(i, j),
-                Epetra_Import(
-                    fullrowmap.get_epetra_map(), blocksparsematrix->range_map(i).get_epetra_map()),
+                Epetra_Import(fullrowmap.get_epetra_block_map(),
+                    blocksparsematrix->range_map(i).get_epetra_block_map()),
                 Insert))
           FOUR_C_THROW("Matrix import failed!");
       }

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -374,7 +374,7 @@ void STI::Monolithic::fd_check()
     statenp->update(1., *statenp_original, 0.);
 
     // impose perturbation
-    if (statenp->get_block_map().MyGID(colgid))
+    if (statenp->get_map().MyGID(colgid))
       if (statenp->sum_into_global_value(colgid, 0, scatra_field()->fd_check_eps()))
         FOUR_C_THROW(
             "Perturbation could not be imposed on state vector for finite difference check!");
@@ -656,7 +656,7 @@ void STI::Monolithic::output_vector_to_file(
   MPI_Comm comm = vector.Comm();
 
   // extract vector map
-  const Epetra_BlockMap& map = vector.Map();
+  const Core::LinAlg::Map& map = vector.get_map();
 
   // safety check
   if (!map.UniqueGIDs())
@@ -1575,7 +1575,7 @@ void STI::Monolithic::solve()
     // output performance statistics associated with linear solver into text file if applicable
     if (fieldparameters_->get<bool>("OUTPUTLINSOLVERSTATS"))
       scatra_field()->output_lin_solver_stats(*solver_, dtsolve_, step(), static_cast<int>(iter_),
-          residual_->get_block_map().NumGlobalElements());
+          residual_->get_map().NumGlobalElements());
 
     // update scatra field
     scatra_field()->update_iter(*maps_->extract_vector(*increment_, 0));

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -827,7 +827,7 @@ void MultiScale::MicroStatic::evaluate_micro_bc(
       {
         const int gid = dofs[l];
 
-        const int lid = disp.get_block_map().LID(gid);
+        const int lid = disp.get_map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Global id {} not on this proc in system vector", gid);
         (disp)[lid] = disp_prescribed[l];
       }
@@ -966,7 +966,7 @@ void MultiScale::MicroStatic::static_homogenization(Core::LinAlg::Matrix<6, 1>* 
     // Computer Methods in Applied Mechanics and Engineering 192: 559-591, 2003.
 
     const Core::LinAlg::Map* dofrowmap = discret_->dof_row_map();
-    Core::LinAlg::MultiVector<double> cmatpf(D_->Map(), 9);
+    Core::LinAlg::MultiVector<double> cmatpf(D_->get_map(), 9);
 
     // make a copy
     stiff_dirich_ = std::make_shared<Core::LinAlg::SparseMatrix>(*stiff_);

--- a/src/stru_multi/4C_stru_multi_microstatic_service.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic_service.cpp
@@ -95,9 +95,9 @@ void MultiScale::MicroStatic::set_up_homogenization()
 
   // create importer
   importp_ = std::make_shared<Epetra_Import>(
-      pdof_->get_epetra_map(), (discret_->dof_row_map())->get_epetra_map());
+      pdof_->get_epetra_block_map(), (discret_->dof_row_map())->get_epetra_block_map());
   importf_ = std::make_shared<Epetra_Import>(
-      fdof_->get_epetra_map(), (discret_->dof_row_map())->get_epetra_map());
+      fdof_->get_epetra_block_map(), (discret_->dof_row_map())->get_epetra_block_map());
 
   // create vector containing material coordinates of prescribed nodes
   Core::LinAlg::Vector<double> Xp_temp(*pdof_);

--- a/src/stru_multi/4C_stru_multi_microstatic_service.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic_service.cpp
@@ -42,7 +42,7 @@ void MultiScale::MicroStatic::determine_toggle()
       {
         const int gid = dofs[j];
 
-        const int lid = disn_->get_block_map().LID(gid);
+        const int lid = disn_->get_map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Global id {} not on this proc in system vector", gid);
 
         if ((*dirichtoggle_)[lid] != 1.0)  // be careful not to count dofs more
@@ -124,7 +124,7 @@ void MultiScale::MicroStatic::set_up_homogenization()
       {
         const int gid = dofs[k];
 
-        const int lid = disn_->get_block_map().LID(gid);
+        const int lid = disn_->get_map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Global id {} not on this proc in system vector", gid);
 
         for (int l = 0; l < np_; ++l)

--- a/src/structure/4C_structure_resulttest.cpp
+++ b/src/structure/4C_structure_resulttest.cpp
@@ -69,7 +69,7 @@ void StruResultTest::test_node(
       // test displacements or pressure
       if (dis_ != nullptr)
       {
-        const Epetra_BlockMap& disnpmap = dis_->get_block_map();
+        const Core::LinAlg::Map& disnpmap = dis_->get_map();
         int idx = -1;
         if (position == "dispx")
           idx = 0;
@@ -94,7 +94,7 @@ void StruResultTest::test_node(
       // test velocities
       if (vel_ != nullptr)
       {
-        const Epetra_BlockMap& velnpmap = vel_->get_block_map();
+        const Core::LinAlg::Map& velnpmap = vel_->get_map();
         int idx = -1;
         if (position == "velx")
           idx = 0;
@@ -117,7 +117,7 @@ void StruResultTest::test_node(
       // test accelerations
       if (acc_ != nullptr)
       {
-        const Epetra_BlockMap& accnpmap = acc_->get_block_map();
+        const Core::LinAlg::Map& accnpmap = acc_->get_map();
         int idx = -1;
         if (position == "accx")
           idx = 0;

--- a/src/structure/4C_structure_timada.cpp
+++ b/src/structure/4C_structure_timada.cpp
@@ -279,7 +279,7 @@ void Solid::TimAda::evaluate_local_error_dis()
 
   // blank Dirichlet DOFs since they always carry the exact solution
   std::shared_ptr<Core::LinAlg::Vector<double>> zeros =
-      std::make_shared<Core::LinAlg::Vector<double>>(locerrdisn_->get_block_map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(locerrdisn_->get_map(), true);
   Core::LinAlg::apply_dirichlet_to_system(
       *locerrdisn_, *zeros, *(sti_->get_dbc_map_extractor()->cond_map()));
 }

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -903,7 +903,7 @@ void Solid::TimInt::apply_mesh_initialization(
     // create new position vector
     for (int i = 0; i < numdim; ++i)
     {
-      const int lid = gvector.get_block_map().LID(nodedofs[i]);
+      const int lid = gvector.get_map().LID(nodedofs[i]);
 
       if (lid < 0)
         FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -769,7 +769,7 @@ void Solid::TimIntImpl::setup_krylov_space_projection(const Core::Conditions::Co
 
   // create the projector
   projector_ = std::make_shared<Core::LinAlg::KrylovProjector>(
-      activemodeids, weighttype, &discret_->dof_row_map()->get_epetra_map());
+      activemodeids, weighttype, discret_->dof_row_map());
 
   // update the projector
   update_krylov_space_projection();

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -764,13 +764,12 @@ Solid::TimeInt::BaseDataGlobalState::extract_model_entries(
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> model_ptr = nullptr;
   // extract from the full state vector
-  if (source.get_block_map().NumGlobalElements() ==
-      block_extractor().full_map()->NumGlobalElements())
+  if (source.get_map().NumGlobalElements() == block_extractor().full_map()->NumGlobalElements())
   {
     model_ptr = block_extractor().extract_vector(source, model_block_id_.at(mt));
   }
   // copy the vector
-  else if (source.get_block_map().NumGlobalElements() == model_maps_.at(mt)->NumGlobalElements())
+  else if (source.get_map().NumGlobalElements() == model_maps_.at(mt)->NumGlobalElements())
   {
     model_ptr = std::make_shared<Core::LinAlg::Vector<double>>(source);
   }
@@ -1135,14 +1134,13 @@ void NOX::Nln::GROUP::PrePostOp::TimeInt::RotVecUpdater::run_pre_compute_x(
 
   /* since parallel distribution is node-wise, the three entries belonging to
    * a rotation vector should be stored on the same processor: safety-check */
-  if (x_rotvec.get_block_map().NumMyElements() % 3 != 0 or
-      dir_rotvec.get_block_map().NumMyElements() % 3 != 0)
+  if (x_rotvec.get_map().NumMyElements() % 3 != 0 or dir_rotvec.get_map().NumMyElements() % 3 != 0)
     FOUR_C_THROW(
         "fatal error: apparently, the three DOFs of a nodal rotation vector are"
         " not stored on this processor. Can't apply multiplicative update!");
 
   // rotation vectors always consist of three consecutive DoFs
-  for (int i = 0; i < x_rotvec.get_block_map().NumMyElements(); i = i + 3)
+  for (int i = 0; i < x_rotvec.get_map().NumMyElements(); i = i + 3)
   {
     // create a Core::LinAlg::Matrix from reference to three x vector entries
     Core::LinAlg::Matrix<3, 1> theta(&x_rotvec[i], true);

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_contact.cpp
@@ -231,7 +231,7 @@ bool Solid::ModelEvaluator::Contact::assemble_force(
     // --- constr. - block --------------------------------------------------
     block_vec_ptr = strategy().get_rhs_block_ptr(CONTACT::VecBlockType::constraint);
     if (!block_vec_ptr) return true;
-    Core::LinAlg::Vector<double> tmp(f.get_block_map());
+    Core::LinAlg::Vector<double> tmp(f.get_map());
     Core::LinAlg::export_to(*block_vec_ptr, tmp);
     f.update(1., tmp, 1.);
   }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
@@ -162,7 +162,7 @@ bool Solid::ModelEvaluator::LagPenConstraint::assemble_force(
           "the structural part indicates, that constraint contributions \n"
           "are present!");
 
-    const int elements_f = f.get_block_map().NumGlobalElements();
+    const int elements_f = f.get_map().NumGlobalElements();
     const int max_gid = get_block_dof_row_map_ptr()->MaxAllGID();
     // only call when f is the rhs of the full problem (not for structural
     // equilibriate initial state call)

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -129,8 +129,8 @@ void Solid::ModelEvaluator::Meshtying::setup()
               std::make_shared<Core::LinAlg::Vector<double>>(
                   *(strategy_ptr_->non_redist_slave_row_dofs()), true);
 
-          Epetra_Export exporter(Xslavemod->get_map().get_epetra_map(),
-              strategy_ptr_->non_redist_slave_row_dofs()->get_epetra_map());
+          Epetra_Export exporter(Xslavemod->get_map().get_epetra_block_map(),
+              strategy_ptr_->non_redist_slave_row_dofs()->get_epetra_block_map());
 
           int err = original_vec->export_to(*Xslavemod, exporter, Insert);
           if (err) FOUR_C_THROW("Import failed with err={}", err);

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -129,7 +129,7 @@ void Solid::ModelEvaluator::Meshtying::setup()
               std::make_shared<Core::LinAlg::Vector<double>>(
                   *(strategy_ptr_->non_redist_slave_row_dofs()), true);
 
-          Epetra_Export exporter(Xslavemod->get_block_map(),
+          Epetra_Export exporter(Xslavemod->get_map().get_epetra_map(),
               strategy_ptr_->non_redist_slave_row_dofs()->get_epetra_map());
 
           int err = original_vec->export_to(*Xslavemod, exporter, Insert);
@@ -149,9 +149,9 @@ void Solid::ModelEvaluator::Meshtying::setup()
             int dof = gdiscret->dof(node, d);
             if (strategy_ptr_->non_redist_slave_row_dofs()->LID(dof) != -1)
             {
-              mesh_relocation_->operator[](mesh_relocation_->get_block_map().LID(dof)) =
+              mesh_relocation_->operator[](mesh_relocation_->get_map().LID(dof)) =
                   node->x()[d] -
-                  Xslavemod_noredist->operator[](Xslavemod_noredist->get_block_map().LID(dof));
+                  Xslavemod_noredist->operator[](Xslavemod_noredist->get_map().LID(dof));
             }
           }
         }
@@ -441,7 +441,7 @@ void Solid::ModelEvaluator::Meshtying::apply_mesh_initialization(
     // create new position vector
     for (int i = 0; i < numdim; ++i)
     {
-      const int lid = gvector.get_block_map().LID(nodedofs[i]);
+      const int lid = gvector.get_map().LID(nodedofs[i]);
 
       if (lid < 0)
         FOUR_C_THROW("ERROR: Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -83,7 +83,7 @@ void Solid::ModelEvaluator::Structure::setup()
   }
   // setup new variables
   {
-    dis_incr_ptr_ = std::make_shared<Core::LinAlg::Vector<double>>(dis_np().get_block_map(), true);
+    dis_incr_ptr_ = std::make_shared<Core::LinAlg::Vector<double>>(dis_np().get_map(), true);
   }
 
   // setup output writers

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
@@ -293,7 +293,7 @@ void Solid::Nln::LinSystem::StcScaling::scaleLinearSystem(Epetra_LinearProblem& 
         Core::LinAlg::matrix_multiply(*stcmat_, true, *stiff_scaled_, false, true, false, true);
 
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs_scaled =
-        Core::LinAlg::create_vector(problem.GetRHS()->Map(), true);
+        std::make_shared<Core::LinAlg::Vector<double>>(problem.GetRHS()->Map(), true);
     stcmat_->multiply(true, rhs, *rhs_scaled);
     rhs.update(1.0, *rhs_scaled, 0.0);
   }
@@ -307,7 +307,7 @@ void Solid::Nln::LinSystem::StcScaling::scaleLinearSystem(Epetra_LinearProblem& 
 void Solid::Nln::LinSystem::StcScaling::unscaleLinearSystem(Epetra_LinearProblem& problem)
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> disisdc =
-      Core::LinAlg::create_vector(problem.GetLHS()->Map(), true);
+      std::make_shared<Core::LinAlg::Vector<double>>(problem.GetLHS()->Map(), true);
   Epetra_MultiVector* disi = problem.GetLHS();
 
   Core::LinAlg::View disi_view(*disi);

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -570,7 +570,7 @@ double Solid::MonitorDbc::get_reaction_moment(Core::LinAlg::Matrix<DIM, 1>& rmom
     {
       if (onoff[i] == 1)
       {
-        const int lid = complete_freact.get_block_map().LID(node_gid[i]);
+        const int lid = complete_freact.get_map().LID(node_gid[i]);
         if (lid < 0)
           FOUR_C_THROW("Proc {}: Cannot find gid={} in Core::LinAlg::Vector<double>",
               Core::Communication::my_mpi_rank(complete_freact.get_comm()), node_gid[i]);

--- a/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_resulttest.cpp
@@ -63,7 +63,7 @@ namespace
   {
     const Core::LinAlg::MultiVector<double>& data = *all_data.at(name_and_component.name);
 
-    int local_id = data.Map().LID(node_id);
+    int local_id = data.get_map().LID(node_id);
 
     if (local_id < 0)
     {
@@ -120,7 +120,7 @@ namespace
           label.c_str(), prefix.c_str(), prefix.c_str());
     }
 
-    int local_id = nodal_data.Map().LID(node_id);
+    int local_id = nodal_data.get_map().LID(node_id);
 
     if (local_id < 0)
     {
@@ -231,7 +231,7 @@ int Solid::ResultTest::get_nodal_result(
   // test displacements or pressure
   if (disn_ != nullptr)
   {
-    const Epetra_BlockMap& disnpmap = disn_->get_block_map();
+    const Core::LinAlg::Map& disnpmap = disn_->get_map();
     int idx = -1;
     if (position == "dispx")
       idx = 0;
@@ -256,7 +256,7 @@ int Solid::ResultTest::get_nodal_result(
   // test velocities
   if (veln_ != nullptr)
   {
-    const Epetra_BlockMap& velnpmap = veln_->get_block_map();
+    const Core::LinAlg::Map& velnpmap = veln_->get_map();
     int idx = -1;
     if (position == "velx")
       idx = 0;
@@ -279,7 +279,7 @@ int Solid::ResultTest::get_nodal_result(
   // test accelerations
   if (accn_ != nullptr)
   {
-    const Epetra_BlockMap& accnpmap = accn_->get_block_map();
+    const Core::LinAlg::Map& accnpmap = accn_->get_map();
     int idx = -1;
     if (position == "accx")
       idx = 0;
@@ -344,7 +344,7 @@ int Solid::ResultTest::get_nodal_result(
   // test reaction
   if (reactn_ != nullptr)
   {
-    const Epetra_BlockMap& reactmap = reactn_->get_block_map();
+    const Core::LinAlg::Map& reactmap = reactn_->get_map();
     int idx = -1;
     if (position == "reactx")
       idx = 0;

--- a/src/thermo/src/element/4C_thermo_ele_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.cpp
@@ -496,7 +496,7 @@ int Discret::Elements::TemperImpl<distype>::evaluate(
 
       std::shared_ptr<Core::LinAlg::MultiVector<double>> eleheatflux =
           params.get<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("eleheatflux");
-      const Epetra_BlockMap& elemap = eleheatflux->Map();
+      const Core::LinAlg::Map& elemap = eleheatflux->get_map();
       int lid = elemap.LID(gid);
       if (lid != -1)
       {

--- a/src/thermo/src/utils/4C_thermo_resulttest.cpp
+++ b/src/thermo/src/utils/4C_thermo_resulttest.cpp
@@ -63,7 +63,7 @@ void Thermo::ResultTest::test_node(
       // test temperature
       if (temp_ != nullptr)
       {
-        const Epetra_BlockMap& tempmap = temp_->get_block_map();
+        const Core::LinAlg::Map& tempmap = temp_->get_map();
 
         if (position == "temp")
         {
@@ -75,7 +75,7 @@ void Thermo::ResultTest::test_node(
       // test temperature rates
       if (rate_ != nullptr)
       {
-        const Epetra_BlockMap& ratemap = rate_->get_block_map();
+        const Core::LinAlg::Map& ratemap = rate_->get_map();
 
         if (position == "rate")
         {
@@ -87,7 +87,7 @@ void Thermo::ResultTest::test_node(
       // test thermal flux
       if (flux_ != nullptr)
       {
-        const Epetra_BlockMap& fluxmap = flux_->get_block_map();
+        const Core::LinAlg::Map& fluxmap = flux_->get_map();
 
         if (position == "flux")
         {

--- a/src/xfem/4C_xfem_condition_manager.cpp
+++ b/src/xfem/4C_xfem_condition_manager.cpp
@@ -558,8 +558,7 @@ void XFEM::ConditionManager::combine_level_set_field(Core::LinAlg::Vector<double
 void XFEM::ConditionManager::check_for_equal_maps(
     Core::LinAlg::Vector<double>& vec1, Core::LinAlg::Vector<double>& vec2)
 {
-  if (not vec1.get_block_map().PointSameAs(vec2.get_block_map()))
-    FOUR_C_THROW("maps do not match!");
+  if (not vec1.get_map().PointSameAs(vec2.get_map())) FOUR_C_THROW("maps do not match!");
 }
 
 

--- a/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
@@ -130,7 +130,7 @@ void XFEM::MeshCouplingFPI::complete_state_vectors()
   // need to export the interface forces
   Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_map(), true);
   Epetra_Export exporter_iforce(
-      iforcecol_->get_map().get_epetra_map(), iforce_tmp.get_map().get_epetra_map());
+      iforcecol_->get_map().get_epetra_block_map(), iforce_tmp.get_map().get_epetra_block_map());
   int err1 = iforce_tmp.export_to(*iforcecol_, exporter_iforce, Add);
   if (err1) FOUR_C_THROW("Export using exporter returned err={}", err1);
 

--- a/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_fpi_mesh.cpp
@@ -128,8 +128,9 @@ void XFEM::MeshCouplingFPI::complete_state_vectors()
   // finalize itrueresidual vector
 
   // need to export the interface forces
-  Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_block_map(), true);
-  Epetra_Export exporter_iforce(iforcecol_->get_block_map(), iforce_tmp.get_block_map());
+  Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_map(), true);
+  Epetra_Export exporter_iforce(
+      iforcecol_->get_map().get_epetra_map(), iforce_tmp.get_map().get_epetra_map());
   int err1 = iforce_tmp.export_to(*iforcecol_, exporter_iforce, Add);
   if (err1) FOUR_C_THROW("Export using exporter returned err={}", err1);
 
@@ -594,15 +595,15 @@ void XFEM::MeshCouplingFPI::read_restart(const int step)
   boundaryreader.read_vector(idispnp_, "idispnp_res");
   boundaryreader.read_vector(idispnpi_, "idispnpi_res");
 
-  if (not(cutter_dis_->dof_row_map())->SameAs(ivelnp_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(ivelnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(iveln_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(iveln_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispnp_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispn_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispn_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispnpi_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispnpi_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
 }
 
@@ -936,8 +937,8 @@ double XFEM::MeshCouplingFPI::compute_jacobianand_pressure(
         {
           for (unsigned int idof = 0; idof < SLAVE_NUMDOF; ++idof)
           {
-            int lid = fulldispnp_->get_block_map().LID(
-                get_cond_dis()->dof(0, coupl_ele->nodes()[inode], idof));
+            int lid =
+                fulldispnp_->get_map().LID(get_cond_dis()->dof(0, coupl_ele->nodes()[inode], idof));
 
             const auto& x = nodes[inode]->x();
             xrefe(idof, inode) = x[idof];
@@ -947,7 +948,7 @@ double XFEM::MeshCouplingFPI::compute_jacobianand_pressure(
             else
               FOUR_C_THROW("Local ID for dispnp not found (lid = -1)!");
           }
-          int lidp = fullpres_->get_block_map().LID(lm_struct_x_lm_pres_.operator[](
+          int lidp = fullpres_->get_map().LID(lm_struct_x_lm_pres_.operator[](
               get_cond_dis()->dof(0, coupl_ele->nodes()[inode], 2)));
 
           if (lidp != -1)

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -377,7 +377,7 @@ bool XFEM::LevelSetCoupling::set_level_set_field(const double time)
   // make a copy of last time step
 
   std::shared_ptr<Core::LinAlg::Vector<double>> delta_phi =
-      Core::LinAlg::create_vector(cutter_phinp_->get_block_map(), true);
+      Core::LinAlg::create_vector(cutter_phinp_->get_map(), true);
   delta_phi->update(1.0, *cutter_phinp_, 0.0);
 
   // initializations
@@ -413,7 +413,7 @@ bool XFEM::LevelSetCoupling::set_level_set_field(const double time)
     if (lm.size() != 1) FOUR_C_THROW("assume 1 dof in cutterdis-Dofset for phi vector");
 
     const int gid = lm[0];
-    const int lid = cutter_phinp_->get_block_map().LID(gid);
+    const int lid = cutter_phinp_->get_map().LID(gid);
     err = cutter_phinp_->replace_local_values(1, &value, &lid);
     if (err) FOUR_C_THROW("could not replace values for phi vector");
   }
@@ -565,7 +565,7 @@ void XFEM::LevelSetCoupling::map_cutter_to_bg_vector(Core::FE::Discretization& s
       std::vector<double> val_source = Core::FE::extract_values(source_vec_dofbased, lm_source);
 
       // set to a dofrowmap based vector!
-      const int lid_target = target_vec_dofbased.get_block_map().LID(lm_target[0]);
+      const int lid_target = target_vec_dofbased.get_map().LID(lm_target[0]);
       const int err = target_vec_dofbased.replace_local_values(1, val_source.data(), &lid_target);
       if (err) FOUR_C_THROW("could not replace values for convective velocity");
     }

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -1638,7 +1638,7 @@ void XFEM::MeshCouplingFSI::complete_state_vectors()
   // need to export the interface forces
   Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_map(), true);
   Epetra_Export exporter_iforce(
-      iforcecol_->get_map().get_epetra_map(), iforce_tmp.get_map().get_epetra_map());
+      iforcecol_->get_map().get_epetra_block_map(), iforce_tmp.get_map().get_epetra_block_map());
   int err1 = iforce_tmp.export_to(*iforcecol_, exporter_iforce, Add);
   if (err1) FOUR_C_THROW("Export using exporter returned err={}", err1);
 

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -813,7 +813,7 @@ void XFEM::MeshCouplingBC::compute_interface_velocity_from_displacement(
   for (int dof = 0; dof < numdof; ++dof)
   {
     int gid = nodedofset[dof];
-    int lid = idispnp_->get_block_map().LID(gid);
+    int lid = idispnp_->get_map().LID(gid);
 
     const double dispnp = (*idispnp_)[lid];
     const double dispn = (*idispn_)[lid];
@@ -1636,8 +1636,9 @@ void XFEM::MeshCouplingFSI::complete_state_vectors()
   // finalize itrueresidual vector
 
   // need to export the interface forces
-  Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_block_map(), true);
-  Epetra_Export exporter_iforce(iforcecol_->get_block_map(), iforce_tmp.get_block_map());
+  Core::LinAlg::Vector<double> iforce_tmp(itrueresidual_->get_map(), true);
+  Epetra_Export exporter_iforce(
+      iforcecol_->get_map().get_epetra_map(), iforce_tmp.get_map().get_epetra_map());
   int err1 = iforce_tmp.export_to(*iforcecol_, exporter_iforce, Add);
   if (err1) FOUR_C_THROW("Export using exporter returned err={}", err1);
 
@@ -1682,15 +1683,15 @@ void XFEM::MeshCouplingFSI::read_restart(const int step)
   boundaryreader.read_vector(idispnp_, "idispnp_res");
   boundaryreader.read_vector(idispnpi_, "idispnpi_res");
 
-  if (not(cutter_dis_->dof_row_map())->SameAs(ivelnp_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(ivelnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(iveln_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(iveln_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispnp_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispn_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispn_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispnpi_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispnpi_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
 }
 
@@ -2664,15 +2665,15 @@ void XFEM::MeshCouplingFluidFluid::read_restart(const int step)
   boundaryreader.read_vector(idispnp_, "idispnp_res");
   boundaryreader.read_vector(idispnpi_, "idispnpi_res");
 
-  if (not(cutter_dis_->dof_row_map())->SameAs(ivelnp_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(ivelnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(iveln_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(iveln_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispnp_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispnp_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispn_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispn_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
-  if (not(cutter_dis_->dof_row_map())->SameAs(idispnpi_->get_block_map()))
+  if (not(cutter_dis_->dof_row_map())->SameAs(idispnpi_->get_map()))
     FOUR_C_THROW("Global dof numbering in maps does not match");
 }
 

--- a/src/xfem/4C_xfem_discretization.cpp
+++ b/src/xfem/4C_xfem_discretization.cpp
@@ -135,7 +135,8 @@ void XFEM::DiscretizationXFEM::export_initialto_active_vector(
     }
     else
     {
-      Epetra_Import importer(fullvec.get_block_map(), initialvec.get_block_map());
+      Epetra_Import importer(
+          fullvec.get_map().get_epetra_map(), initialvec.get_map().get_epetra_map());
       int err = fullvec.import(initialvec, importer, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
     }
@@ -215,7 +216,7 @@ void XFEM::DiscretizationXFEM::set_initial_state(unsigned nds, const std::string
 
   if (!have_dofs()) FOUR_C_THROW("fill_complete() was not called");
   const Core::LinAlg::Map* colmap = initial_dof_col_map(nds);
-  const Epetra_BlockMap& vecmap = state->get_block_map();
+  const Core::LinAlg::Map& vecmap = state->get_map();
 
   if (state_.size() <= nds) state_.resize(nds + 1);
 
@@ -230,7 +231,7 @@ void XFEM::DiscretizationXFEM::set_initial_state(unsigned nds, const std::string
   else  // if it's not in column map export and allocate
   {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-    if (not initial_dof_row_map(nds)->SameAs(state->get_block_map()))
+    if (not initial_dof_row_map(nds)->SameAs(state->get_map()))
     {
       FOUR_C_THROW(
           "row map of discretization and state vector {} are different. This is a fatal bug!",

--- a/src/xfem/4C_xfem_discretization.cpp
+++ b/src/xfem/4C_xfem_discretization.cpp
@@ -136,7 +136,7 @@ void XFEM::DiscretizationXFEM::export_initialto_active_vector(
     else
     {
       Epetra_Import importer(
-          fullvec.get_map().get_epetra_map(), initialvec.get_map().get_epetra_map());
+          fullvec.get_map().get_epetra_block_map(), initialvec.get_map().get_epetra_block_map());
       int err = fullvec.import(initialvec, importer, Insert);
       if (err) FOUR_C_THROW("Export using exporter returned err={}", err);
     }
@@ -224,7 +224,7 @@ void XFEM::DiscretizationXFEM::set_initial_state(unsigned nds, const std::string
   // This is a rough test, but it might be ok at this place. It is an
   // error anyway to hand in a vector that is not related to our dof
   // maps.
-  if (vecmap.PointSameAs(colmap->get_epetra_map()))
+  if (vecmap.PointSameAs(colmap->get_epetra_block_map()))
   {
     state_[nds][name] = state;
   }

--- a/src/xfem/4C_xfem_mesh_projector.cpp
+++ b/src/xfem/4C_xfem_mesh_projector.cpp
@@ -283,7 +283,7 @@ void XFEM::MeshProjector::project(std::map<int, std::set<int>>& projection_nodeT
 
         for (unsigned isd = 0; isd < numdofperset; ++isd)
         {
-          (*target_statevecs[iv])[target_statevecs[iv]->get_block_map().LID(dofs[isd])] =
+          (*target_statevecs[iv])[target_statevecs[iv]->get_map().LID(dofs[isd])] =
               interpolated_vecs[ni](isd + offset);
         }
         dofs.clear();

--- a/src/xfem/4C_xfem_neumann.cpp
+++ b/src/xfem/4C_xfem_neumann.cpp
@@ -137,7 +137,7 @@ void XFEM::evaluate_neumann_standard(
         const int gid = dofs[j];
         double value = val[j];
         value *= functfac;
-        const int lid = systemvector.get_block_map().LID(gid);
+        const int lid = systemvector.get_map().LID(gid);
         if (lid < 0) FOUR_C_THROW("Global id {} not on this proc in system vector", gid);
         systemvector[lid] += value;
       }

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -132,9 +132,9 @@ void XFEM::XFieldField::Coupling::master_to_slave(const Core::LinAlg::MultiVecto
     case XFEM::map_nodes:
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not mv.Map().PointSameAs(masternodemap_->get_epetra_map()))
+      if (not mv.get_map().PointSameAs(masternodemap_->get_epetra_map()))
         FOUR_C_THROW("master node map vector expected");
-      if (not sv.Map().PointSameAs(slavenodemap_->get_epetra_map()))
+      if (not sv.get_map().PointSameAs(slavenodemap_->get_epetra_map()))
         FOUR_C_THROW("slave node map vector expected");
       if (sv.NumVectors() != mv.NumVectors())
         FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
@@ -164,9 +164,9 @@ void XFEM::XFieldField::Coupling::slave_to_master(const Core::LinAlg::MultiVecto
     case XFEM::map_nodes:
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not mv.Map().PointSameAs(masternodemap_->get_epetra_map()))
+      if (not mv.get_map().PointSameAs(masternodemap_->get_epetra_map()))
         FOUR_C_THROW("master node map vector expected");
-      if (not sv.Map().PointSameAs(slavenodemap_->get_epetra_map()))
+      if (not sv.get_map().PointSameAs(slavenodemap_->get_epetra_map()))
         FOUR_C_THROW("slave node map vector expected");
       if (sv.NumVectors() != mv.NumVectors())
         FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -132,9 +132,9 @@ void XFEM::XFieldField::Coupling::master_to_slave(const Core::LinAlg::MultiVecto
     case XFEM::map_nodes:
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not mv.get_map().PointSameAs(masternodemap_->get_epetra_map()))
+      if (not mv.get_map().PointSameAs(masternodemap_->get_epetra_block_map()))
         FOUR_C_THROW("master node map vector expected");
-      if (not sv.get_map().PointSameAs(slavenodemap_->get_epetra_map()))
+      if (not sv.get_map().PointSameAs(slavenodemap_->get_epetra_block_map()))
         FOUR_C_THROW("slave node map vector expected");
       if (sv.NumVectors() != mv.NumVectors())
         FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
@@ -164,9 +164,9 @@ void XFEM::XFieldField::Coupling::slave_to_master(const Core::LinAlg::MultiVecto
     case XFEM::map_nodes:
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not mv.get_map().PointSameAs(masternodemap_->get_epetra_map()))
+      if (not mv.get_map().PointSameAs(masternodemap_->get_epetra_block_map()))
         FOUR_C_THROW("master node map vector expected");
-      if (not sv.get_map().PointSameAs(slavenodemap_->get_epetra_map()))
+      if (not sv.get_map().PointSameAs(slavenodemap_->get_epetra_block_map()))
         FOUR_C_THROW("slave node map vector expected");
       if (sv.NumVectors() != mv.NumVectors())
         FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
@@ -251,9 +251,9 @@ void XFEM::XFieldField::Coupling::save_node_maps(
   permslavenodemap_ = permslavenodemap;
 
   nodal_masterexport_ = std::make_shared<Epetra_Export>(
-      permmasternodemap->get_epetra_map(), masternodemap->get_epetra_map());
+      permmasternodemap->get_epetra_block_map(), masternodemap->get_epetra_block_map());
   nodal_slaveexport_ = std::make_shared<Epetra_Export>(
-      permslavenodemap->get_epetra_map(), slavenodemap->get_epetra_map());
+      permslavenodemap->get_epetra_block_map(), slavenodemap->get_epetra_block_map());
 }
 
 /*----------------------------------------------------------------------------*
@@ -322,7 +322,7 @@ void XFEM::XFieldField::Coupling::build_min_dof_maps(const Core::FE::Discretizat
   /* prepare communication plan to create a dofmap out of a permuted
    * dof map */
   min_exporter = std::make_shared<Epetra_Export>(
-      min_permdofmap->get_epetra_map(), min_dofmap->get_epetra_map());
+      min_permdofmap->get_epetra_block_map(), min_dofmap->get_epetra_block_map());
 }
 
 /*----------------------------------------------------------------------------*
@@ -391,7 +391,7 @@ void XFEM::XFieldField::Coupling::build_max_dof_maps(const Core::FE::Discretizat
   /* prepare communication plan to create a dofmap out of a permuted
    * dof map */
   max_exporter = std::make_shared<Epetra_Export>(
-      max_permdofmap->get_epetra_map(), max_dofmap->get_epetra_map());
+      max_permdofmap->get_epetra_block_map(), max_dofmap->get_epetra_block_map());
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/xfem/4C_xfem_xfluid_timeInt.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.cpp
@@ -1026,10 +1026,10 @@ void XFEM::XFluidTimeInt::copy_dofs(const Core::Nodes::Node* node,  /// drt node
     // copy values from old vector to new vector
     for (size_t i = 0; i < dofs_new.size(); i++)
     {
-      int dof_lid_new = vec_new->get_block_map().LID(dofs_new[i]);
+      int dof_lid_new = vec_new->get_map().LID(dofs_new[i]);
       if (dof_lid_new == -1) FOUR_C_THROW("new dof {} not local on this proc!", dofs_new[i]);
 
-      int dof_lid_old = vec_old->get_block_map().LID(dofs_old[i]);
+      int dof_lid_old = vec_old->get_map().LID(dofs_old[i]);
       if (dof_lid_old == -1) FOUR_C_THROW("old dof {} not local on this proc!", dofs_old[i]);
 
       (*vec_new)[dof_lid_new] = (*vec_old)[dof_lid_old];
@@ -1144,7 +1144,7 @@ void XFEM::XFluidTimeInt::mark_dofs(const Core::Nodes::Node* node,  /// drt node
     // set a dummy value for dofs in the vector
     for (size_t i = 0; i < dofs_new.size(); i++)
     {
-      int dof_lid_new = vec_new->get_block_map().LID(dofs_new[i]);
+      int dof_lid_new = vec_new->get_map().LID(dofs_new[i]);
       if (dof_lid_new == -1) FOUR_C_THROW("new dof {} not local on this proc!", dofs_new[i]);
 
       (*vec_new)[dof_lid_new] =

--- a/tests/input_files/beam3r_line2_genalpha_liegroup_contact_penalty_linpen_twocrossedbeams.dat
+++ b/tests/input_files/beam3r_line2_genalpha_liegroup_contact_penalty_linpen_twocrossedbeams.dat
@@ -14,7 +14,7 @@ NUMTHERMDIS                     0
 OUTPUT_BIN                      Yes
 STRUCT_DISP                     Yes
 FILESTEPS                       1000
-VERBOSITY                       standard
+VERBOSITY                       verbose
 ----------------------------------------------------------STRUCTURAL DYNAMIC
 INT_STRATEGY                    Standard
 LINEAR_SOLVER                   1


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title indicates, this MR adapts `Epetra_BlockMap` occurrences to our Wrapper `Core::LinAlg::Map`.

- Provides a unit test `4C_linalg_map_test.np2.cpp ` to ensure that the `Epetra_Map` of a `Vector` or `Multivector` may be exchanged.
- Utilizes the view introduced in #790 for the `Core::LinAlg::Vector`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Related to #552 .