### PR TITLE
Quote legacy strings when converting to YAML

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -1006,8 +1006,8 @@ namespace Core::IO
         section |= ryml::SEQ;
         for (const auto& line : pimpl_->in_section(section_name))
         {
-          section.append_child() = ryml::csubstr(
-              line.get_as_dat_style_string().data(), line.get_as_dat_style_string().size());
+          YamlNodeRef line_node{section.append_child(), file_name};
+          emit_value_as_yaml(line_node, line.get_as_dat_style_string());
         }
       }
     }


### PR DESCRIPTION
Always quote the strings in legacy sections that are written by `--to-yaml`. We expect a string, so quoting makes schema validation easier.

 This should fix one of the problems from #801. @davidrudlstorfer told me this is related to https://github.com/4C-multiphysics/fourcipp/pull/47.

@gilrrei @isteinbrecher 