### PR TITLE
NOX: remove obsolete setup() method

### DIFF
--- a/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
+++ b/src/structure_new/src/explicit/4C_structure_new_timint_explicit.cpp
@@ -56,7 +56,7 @@ void Solid::TimeInt::Explicit::setup()
   }
   nlnsolver_ptr_ = Solid::Nln::SOLVER::build_nln_solver(nlnSolverType, data_global_state_ptr(),
       data_s_dyn_ptr(), noxinterface_ptr, explint_ptr_, Core::Utils::shared_ptr_from_ref(*this));
-  nlnsolver_ptr_->setup();
+
   // set setup flag
   issetup_ = true;
 }

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -70,7 +70,6 @@ void Solid::TimeInt::Implicit::setup()
               << std::endl;
   nlnsolver_ptr_ = Solid::Nln::SOLVER::build_nln_solver(nlnSolverType, data_global_state_ptr(),
       data_s_dyn_ptr(), noxinterface_ptr, implint_ptr_, Core::Utils::shared_ptr_from_ref(*this));
-  nlnsolver_ptr_->setup();
 
   // set setup flag
   issetup_ = true;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.cpp
@@ -21,14 +21,12 @@ Solid::Nln::SOLVER::Generic::Generic(
     const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate,
     const std::shared_ptr<Solid::TimeInt::BaseDataSDyn>& sdyn,
     const std::shared_ptr<Solid::TimeInt::NoxInterface>& noxinterface,
-    const std::shared_ptr<Solid::Integrator>& integrator,
+    const std::shared_ptr<Solid::Integrator>& integr,
     const std::shared_ptr<const Solid::TimeInt::Base>& timint)
-    : isinit_(true),
-      issetup_(false),
-      gstate_ptr_(gstate),
+    : gstate_ptr_(gstate),
       sdyn_ptr_(sdyn),
       noxinterface_ptr_(noxinterface),
-      int_ptr_(integrator),
+      int_ptr_(integr),
       timint_ptr_(timint),
       group_ptr_(nullptr)
 {
@@ -39,8 +37,6 @@ Solid::Nln::SOLVER::Generic::Generic(
  *----------------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::Abstract::Group>& Solid::Nln::SOLVER::Generic::group_ptr()
 {
-  check_init();
-
   return group_ptr_;
 }
 
@@ -48,7 +44,6 @@ Teuchos::RCP<::NOX::Abstract::Group>& Solid::Nln::SOLVER::Generic::group_ptr()
  *----------------------------------------------------------------------------*/
 ::NOX::Abstract::Group& Solid::Nln::SOLVER::Generic::get_solution_group()
 {
-  check_init_setup();
   FOUR_C_ASSERT(group_ptr_, "The group pointer should be initialized beforehand!");
 
   return *group_ptr_;
@@ -58,7 +53,6 @@ Teuchos::RCP<::NOX::Abstract::Group>& Solid::Nln::SOLVER::Generic::group_ptr()
  *----------------------------------------------------------------------------*/
 const ::NOX::Abstract::Group& Solid::Nln::SOLVER::Generic::get_solution_group() const
 {
-  check_init_setup();
   FOUR_C_ASSERT(group_ptr_, "The group pointer should be initialized beforehand!");
 
   return *group_ptr_;

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_generic.hpp
@@ -53,14 +53,11 @@ namespace Solid
         Generic(const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate,
             const std::shared_ptr<Solid::TimeInt::BaseDataSDyn>& sdyn,
             const std::shared_ptr<Solid::TimeInt::NoxInterface>& noxinterface,
-            const std::shared_ptr<Solid::Integrator>& integrator,
+            const std::shared_ptr<Solid::Integrator>& integr,
             const std::shared_ptr<const Solid::TimeInt::Base>& timint);
 
         //! destructor
         virtual ~Generic() = default;
-
-        //! Setup the nonlinear solver configuration
-        virtual void setup() = 0;
 
         /*! \brief Reset internal storage before the nonlinear solution starts
          *
@@ -85,114 +82,53 @@ namespace Solid
         virtual int get_num_nln_iterations() const = 0;
 
        protected:
-        //! Returns true if init() has been called
-        inline const bool& is_init() const { return isinit_; };
-
-        //! Returns true if setup() has been called
-        inline const bool& is_setup() const { return issetup_; };
-
-        //! Check if init() and setup() have been called
-        void check_init_setup() const
-        {
-          FOUR_C_ASSERT(is_init() and is_setup(), "Call init() and setup() first!");
-        }
-
-        //! Check if init() has been called
-        void check_init() const { FOUR_C_ASSERT(is_init(), "You have to call init() first!"); }
-
         //! Returns the global state data container pointer
         std::shared_ptr<Solid::TimeInt::BaseDataGlobalState> data_global_state_ptr()
         {
-          check_init();
           return gstate_ptr_;
         }
 
         //! Returns the global state data container (read-only)
         const Solid::TimeInt::BaseDataGlobalState& data_global_state() const
         {
-          check_init();
           return *gstate_ptr_;
         }
 
         //! Returns the global state data container (read and write)
-        Solid::TimeInt::BaseDataGlobalState& data_global_state()
-        {
-          check_init();
-          return *gstate_ptr_;
-        }
+        Solid::TimeInt::BaseDataGlobalState& data_global_state() { return *gstate_ptr_; }
 
         //! Returns the structural dynamics data container pointer
-        std::shared_ptr<Solid::TimeInt::BaseDataSDyn> data_s_dyn_ptr()
-        {
-          check_init();
-          return sdyn_ptr_;
-        }
+        std::shared_ptr<Solid::TimeInt::BaseDataSDyn> data_s_dyn_ptr() { return sdyn_ptr_; }
 
         //! Returns the structural dynamics data container (read-only)
-        const Solid::TimeInt::BaseDataSDyn& data_s_dyn() const
-        {
-          check_init();
-          return *sdyn_ptr_;
-        }
+        const Solid::TimeInt::BaseDataSDyn& data_s_dyn() const { return *sdyn_ptr_; }
 
         //! Returns the structural dynamics data container (read and write)
-        Solid::TimeInt::BaseDataSDyn& data_sdyn()
-        {
-          check_init();
-          return *sdyn_ptr_;
-        }
+        Solid::TimeInt::BaseDataSDyn& data_sdyn() { return *sdyn_ptr_; }
 
         //! Returns the non-linear solver implicit time integration interface pointer
         std::shared_ptr<Solid::TimeInt::NoxInterface> nox_interface_ptr()
         {
-          check_init();
           return noxinterface_ptr_;
         }
 
         //! Returns the non-linear solver implicit time integration interface (read-only)
-        const Solid::TimeInt::NoxInterface& nox_interface() const
-        {
-          check_init();
-          return *noxinterface_ptr_;
-        }
+        const Solid::TimeInt::NoxInterface& nox_interface() const { return *noxinterface_ptr_; }
 
         //! Returns the non-linear solver implicit time integration interface (read and write)
-        Solid::TimeInt::NoxInterface& nox_interface()
-        {
-          check_init();
-          return *noxinterface_ptr_;
-        }
+        Solid::TimeInt::NoxInterface& nox_interface() { return *noxinterface_ptr_; }
 
-        Solid::Integrator& integrator()
-        {
-          check_init();
-          return *int_ptr_;
-        }
+        Solid::Integrator& integrator() { return *int_ptr_; }
 
-        const Solid::Integrator& integrator() const
-        {
-          check_init();
-          return *int_ptr_;
-        }
+        const Solid::Integrator& integrator() const { return *int_ptr_; }
 
         //! Returns the underlying time integration strategy
-        const Solid::TimeInt::Base& tim_int() const
-        {
-          check_init();
-          return *timint_ptr_;
-        }
+        const Solid::TimeInt::Base& tim_int() const { return *timint_ptr_; }
 
         /*! returns the nox group (pointer) (only for internal use)
          *
          *  The nox group has to be initialized in one of the derived setup() routines. */
         Teuchos::RCP<::NOX::Abstract::Group>& group_ptr();
-
-       protected:
-        //! init flag
-        bool isinit_;
-
-        //! setup flag
-        bool issetup_;
 
        private:
         //! global state data container of the time integrator

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
@@ -33,18 +33,10 @@ Solid::Nln::SOLVER::Nox::Nox(const Teuchos::ParameterList& default_params,
     const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate,
     const std::shared_ptr<Solid::TimeInt::BaseDataSDyn>& sdyn,
     const std::shared_ptr<Solid::TimeInt::NoxInterface>& noxinterface,
-    const std::shared_ptr<Solid::Integrator>& integrator,
+    const std::shared_ptr<Solid::Integrator>& integr,
     const std::shared_ptr<const Solid::TimeInt::Base>& timint)
-    : Generic(gstate, sdyn, noxinterface, integrator, timint), default_params_(default_params)
+    : Generic(gstate, sdyn, noxinterface, integr, timint), default_params_(default_params)
 {
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-void Solid::Nln::SOLVER::Nox::setup()
-{
-  check_init();
-
   /* Set ::NOX::Epetra::Interface::Required
    * This interface is necessary for the evaluation of basic things
    * which are evaluated outside of the non-linear solver, but
@@ -128,9 +120,6 @@ void Solid::Nln::SOLVER::Nox::setup()
   // -------------------------------------------------------------------------
   // get the stopping criteria from the nox parameter list
   problem_->create_status_tests(ostatus_, istatus_);
-
-  // set flag
-  issetup_ = true;
 }
 
 
@@ -138,9 +127,6 @@ void Solid::Nln::SOLVER::Nox::setup()
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::Nox::reset()
 {
-  // safety check
-  check_init_setup();
-
   // do a hard reset at the beginning to be on the safe side
   nlnsolver_ = Teuchos::null;
 
@@ -161,9 +147,6 @@ void Solid::Nln::SOLVER::Nox::reset()
  *----------------------------------------------------------------------------*/
 void Solid::Nln::SOLVER::Nox::reset_params()
 {
-  // safety check
-  check_init_setup();
-
   if (default_params_.isSublist("NOX"))
   {
     nlnglobaldata_->get_nln_parameter_list().setParametersNotAlreadySet(default_params_);
@@ -204,8 +187,6 @@ void Solid::Nln::SOLVER::Nox::reset_params()
  *----------------------------------------------------------------------------*/
 enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::solve()
 {
-  check_init_setup();
-
 #if !(FOUR_C_TRILINOS_INTERNAL_VERSION_GE(2025, 4))
   const auto solver_type =
       nlnglobaldata_->get_nln_parameter_list().get<std::string>("Nonlinear Solver");
@@ -237,8 +218,6 @@ enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::solve()
 enum Inpar::Solid::ConvergenceStatus Solid::Nln::SOLVER::Nox::convert_final_status(
     const ::NOX::StatusTest::StatusType& finalstatus) const
 {
-  check_init_setup();
-
   Inpar::Solid::ConvergenceStatus convstatus = Inpar::Solid::conv_success;
 
   switch (finalstatus)

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.hpp
@@ -68,11 +68,8 @@ namespace Solid
             const std::shared_ptr<Solid::TimeInt::BaseDataGlobalState>& gstate,
             const std::shared_ptr<Solid::TimeInt::BaseDataSDyn>& sdyn,
             const std::shared_ptr<Solid::TimeInt::NoxInterface>& noxinterface,
-            const std::shared_ptr<Solid::Integrator>& integrator,
+            const std::shared_ptr<Solid::Integrator>& integr,
             const std::shared_ptr<const Solid::TimeInt::Base>& timint);
-
-        //! derived from the base class
-        void setup() override;
 
         //! derived from the base class
         void reset() override;
@@ -83,16 +80,8 @@ namespace Solid
         //! returns the outer status test object pointer
         const ::NOX::StatusTest::Generic& get_outer_status_test() const
         {
-          check_init_setup();
           FOUR_C_ASSERT(ostatus_, "The outer status test object is not defined!");
           return *ostatus_;
-        }
-
-        //! returns the outer status test object pointer
-        Teuchos::RCP<const NOX::Nln::Inner::StatusTest::Generic> get_inner_status_ptr() const
-        {
-          check_init_setup();
-          return istatus_;
         }
 
         //! get number of nonlinear iterations (derived)
@@ -117,12 +106,7 @@ namespace Solid
         const Teuchos::ParameterList default_params_;
 
        private:
-        //! @name Variables which stay constant after init() and setup() call
-        //!@{
-
-        //!@}
-
-        //! @name variables which are reset in each Solve() call
+        //! @name variables which are reset in each solve() call
         //!@{
 
         /*! \brief NOX non-linear problem class


### PR DESCRIPTION
## Description and Context
Some additional clean up after #798. Mainly, the removal of unnecessary `setup()` method and the internal flags. Now ctor does everything required for initialization.

## Related Issues and Pull Requests
#359, #379, #798
