### PR TITLE
Add image for oldest supported dependencies

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -16,7 +16,7 @@ jobs:
   gcc13_assertions_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/main'
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -102,7 +102,7 @@ jobs:
   clang18_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -146,7 +146,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -172,7 +172,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -224,7 +224,7 @@ jobs:
   gcc13_no_optional_dependencies_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -248,7 +248,7 @@ jobs:
     needs: gcc13_no_optional_dependencies_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/checkcode.yml
+++ b/.github/workflows/checkcode.yml
@@ -29,7 +29,7 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -53,7 +53,7 @@ jobs:
   verify-headers:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,7 @@ jobs:
   gcc13_coverage_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -41,7 +41,7 @@ jobs:
     needs: gcc13_coverage_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       matrix:
@@ -107,7 +107,7 @@ jobs:
     needs: [gcc13_coverage_test, gcc13_coverage_build]
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,6 +63,32 @@ jobs:
             }}
           base-image: "ubuntu:24.04"
 
+  build-dependencies-oldest-supported:
+    runs-on: ubuntu-latest
+    # Sets the permissions granted to the `GITHUB_TOKEN` for the actions in this job.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      #
+    needs: check-if-build-dependencies-is-required
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.check-if-build-dependencies-is-required.outputs.build_docker_image
+      == 'true' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build and push image
+        uses: ./.github/actions/build_dependencies
+        with:
+          docker-file: docker/oldest_supported/Dockerfile
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          image-name: ${{ env.REGISTRY }}/${{ env.PROJECT_NAMESPACE }}/4c-dependencies-ubuntu24.04-oldest-supported
+          dependencies-hash: ${{ needs.check-if-build-dependencies-is-required.outputs.dependencies_hash
+            }}
+          base-image: "ubuntu:24.04"
+
   tag-images-as-main:
     runs-on: ubuntu-latest
     if: ${{ github.ref == 'refs/heads/main' && github.repository == '4C-multiphysics/4C' }}

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -18,7 +18,7 @@ jobs:
   doxygen:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -44,7 +44,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:

--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -8,7 +8,7 @@ jobs:
   gcc13_assertions_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -41,7 +41,7 @@ jobs:
     needs: gcc13_assertions_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -93,7 +93,7 @@ jobs:
   clang18_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -191,7 +191,7 @@ jobs:
     needs: clang18_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -240,10 +240,80 @@ jobs:
           junit-report-base-name: clang18_test_report
           retention-days: 2
 
+  clang18_build_oldest_supported_dependencies:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:8115e93e
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - uses: ./.github/actions/build_4C
+        with:
+          cmake-preset: docker_clang
+          build-targets: full
+          build-directory: ${{ github.workspace }}/build
+          use-ccache: "false"
+      - uses: ./.github/actions/upload_4C_build
+        with:
+          build-directory: ${{ github.workspace }}/build
+          retention-days: 1
+      - uses: ./.github/actions/chunk_test_suite
+        id: set-matrix
+        with:
+          build-directory: ${{ github.workspace }}/build
+          source-directory: ${{ github.workspace }}
+          number-of-chunks: 15
+          junit-report-artifact-name: clang18_test_oldest_supported_dependencies_report.xml
+
+  clang18_test_oldest_supported_dependencies:
+    needs: clang18_build_oldest_supported_dependencies
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04-oldest-supported:8115e93e
+      options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+    strategy:
+      fail-fast: false
+      matrix:
+        test-chunk: ${{fromJson(needs.clang18_build_oldest_supported_dependencies.outputs.test-chunks)}}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check docker hash
+        uses: ./.github/actions/compute-and-check-dependencies-hash
+      - name: Setup developer environment for testing
+        run: |
+          cd $GITHUB_WORKSPACE
+          git config --global --add safe.directory $GITHUB_WORKSPACE
+      - uses: ./.github/actions/download_4C_build
+        with:
+          build-job: clang18_build_oldest_supported_dependencies
+          destination: ${{ github.workspace }}/build
+      - name: Test
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          time ctest -I $TEST_CHUNK -j `nproc` --output-on-failure --output-junit $GITHUB_WORKSPACE/clang18_test_oldest_supported_dependencies_report-$TEST_CHUNK.xml
+        env:
+          TEST_CHUNK: ${{ matrix.test-chunk }}
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: clang18_test_oldest_supported_dependencies_report-${{ matrix.test-chunk }}.xml
+          path: |
+            ${{ github.workspace }}/clang18_test_oldest_supported_dependencies_report-${{ matrix.test-chunk }}.xml
+          retention-days: 1
+
   gcc13_no_optional_dependencies_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -276,7 +346,7 @@ jobs:
     needs: gcc13_no_optional_dependencies_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false
@@ -328,7 +398,7 @@ jobs:
   gcc13_asan_build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     defaults:
       run:
@@ -361,7 +431,7 @@ jobs:
     needs: gcc13_asan_build
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:502560ce
+      image: ghcr.io/4c-multiphysics/4c-dependencies-ubuntu24.04:8115e93e
       options: --user root --env OMPI_ALLOW_RUN_AS_ROOT=1 --env OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
     strategy:
       fail-fast: false

--- a/dependencies/oldest_supported/trilinos/install.sh
+++ b/dependencies/oldest_supported/trilinos/install.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+# Install trilinos
+# Call with
+# ./install.sh /path/to/install/dir
+
+# Exit the script at the first failure
+set -e
+
+INSTALL_DIR="$1"
+# Number of procs for building (default 4)
+NPROCS=${NPROCS:=4}
+# git sha from Trilinos repository:
+VERSION="1eab15637f2998d1e86fe127b78200f2c9687cb5"
+#CHECKSUM=""
+
+
+# Location of script to apply patches later
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+CMAKE_COMMAND=cmake
+
+git clone https://github.com/trilinos/Trilinos.git
+cd Trilinos
+git checkout $VERSION
+cd .. && mkdir trilinos_build && cd trilinos_build
+
+MPI_DIR=/usr
+MPI_BIN_DIR=$MPI_DIR/bin
+
+$CMAKE_COMMAND \
+  -D CMAKE_BUILD_TYPE:STRING="RELEASE" \
+  -D CMAKE_CXX_STANDARD:STRING="17" \
+  -D CMAKE_CXX_COMPILER:FILEPATH="$MPI_BIN_DIR/mpic++" \
+  -D CMAKE_C_COMPILER:FILEPATH="$MPI_BIN_DIR/mpicc" \
+  -D CMAKE_Fortran_COMPILER:FILEPATH="$MPI_BIN_DIR/mpif90" \
+  -D CMAKE_INSTALL_PREFIX:STRING=$INSTALL_DIR \
+  -D BUILD_SHARED_LIBS:BOOL=ON \
+  \
+  -D Trilinos_ENABLE_ALL_OPTIONAL_PACKAGES:BOOL=OFF \
+  -D Trilinos_ENABLE_EXPLICIT_INSTANTIATION:BOOL=ON \
+  -D Trilinos_ENABLE_ALL_PACKAGES:BOOL=OFF \
+  -D Trilinos_ENABLE_TESTS:BOOL=OFF \
+  -D Trilinos_ENABLE_EXAMPLES:BOOL=OFF \
+  \
+  -D Trilinos_ASSERT_MISSING_PACKAGES=OFF \
+  -D Trilinos_ENABLE_Gtest:BOOL=OFF \
+  -D Trilinos_ENABLE_Amesos:BOOL=ON \
+    -D Amesos_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Amesos2:BOOL=ON \
+  -D Trilinos_ENABLE_AztecOO:BOOL=ON \
+    -D AztecOO_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Belos:BOOL=ON \
+  -D Trilinos_ENABLE_Epetra:BOOL=ON \
+    -D Epetra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_EpetraExt:BOOL=ON \
+    -D EpetraExt_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Intrepid:BOOL=ON \
+    -D Intrepid_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Intrepid2:BOOL=ON \
+  -D Trilinos_ENABLE_Ifpack:BOOL=ON \
+    -D Ifpack_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Ifpack2:BOOL=ON \
+  -D Trilinos_ENABLE_Isorropia:BOOL=ON \
+    -D Isorropia_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Kokkos:BOOL=ON \
+  -D Trilinos_ENABLE_ML:BOOL=ON \
+    -D ML_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_MueLu:BOOL=ON \
+  -D Trilinos_ENABLE_NOX:BOOL=ON \
+  -D Trilinos_ENABLE_Sacado:BOOL=ON \
+  -D Trilinos_ENABLE_SEACASExodus:BOOL=ON \
+  -D Trilinos_ENABLE_SEACASNemesis:BOOL=OFF \
+  -D Trilinos_ENABLE_Shards:BOOL=ON \
+  -D Trilinos_ENABLE_Stratimikos:BOOL=ON \
+  -D Trilinos_ENABLE_Teko:BOOL=ON \
+  -D Trilinos_ENABLE_Teuchos:BOOL=ON \
+  -D Trilinos_ENABLE_Thyra:BOOL=ON \
+    -D Thyra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_ThyraEpetraAdapters:BOOL=ON \
+  -D Trilinos_ENABLE_ThyraEpetraExtAdapters:BOOL=ON \
+  -D Trilinos_ENABLE_Tpetra:BOOL=ON \
+    -D Tpetra_INST_INT_INT:BOOL=ON \
+  -D Trilinos_ENABLE_Xpetra:BOOL=ON \
+    -D Xpetra_ENABLE_Epetra:BOOL=ON \
+    -D Xpetra_ENABLE_EpetraExt:BOOL=ON \
+    -D Xpetra_SHOW_DEPRECATED_WARNINGS:BOOL=OFF \
+  -D Trilinos_ENABLE_Zoltan:BOOL=ON \
+  -D Trilinos_ENABLE_Zoltan2:BOOL=ON \
+  \
+  -D Trilinos_MUST_FIND_ALL_TPL_LIBS=TRUE \
+  -D TPL_ENABLE_DLlib:BOOL=OFF \
+  -D TPL_ENABLE_Netcdf:BOOL=ON \
+  -D TPL_ENABLE_MPI:BOOL=ON \
+  -D TPL_ENABLE_ParMETIS:BOOL=ON \
+    -D ParMETIS_INCLUDE_DIRS:PATH="/usr/include" \
+    -D ParMETIS_LIBRARY_DIRS:PATH="/usr/lib/libparmetis.so.4.0.3" \
+  -D TPL_ENABLE_UMFPACK:BOOL=ON \
+    -D UMFPACK_INCLUDE_DIRS:FILEPATH="$INSTALL_DIR/include" \
+    -D UMFPACK_LIBRARY_DIRS:FILEPATH="$INSTALL_DIR/lib" \
+  -D TPL_ENABLE_SuperLUDist:BOOL=ON \
+    -D SuperLUDist_INCLUDE_DIRS:PATH="$INSTALL_DIR/include" \
+    -D SuperLUDist_LIBRARY_DIRS:PATH="$INSTALL_DIR/lib" \
+  \
+  ../Trilinos
+
+make -j${NPROCS} install
+cd ..
+rm -rf Trilinos trilinos_build

--- a/docker/oldest_supported/Dockerfile
+++ b/docker/oldest_supported/Dockerfile
@@ -26,6 +26,7 @@ ENV LC_ALL en_US.UTF-8
 
 RUN apt-get update && apt-get install -y \
       build-essential \
+      flex \
       ffmpeg \
       git \
       libglu1-mesa \
@@ -82,8 +83,8 @@ RUN /dependencies/current/superlu_dist/install.sh ${INSTALL_DIR}
 # Install qhull 2012.1
 RUN /dependencies/current/qhull/install.sh ${INSTALL_DIR}
 
-# Install Trilinos 2022_Q1
-RUN /dependencies/current/trilinos/install.sh ${INSTALL_DIR}
+# Install Trilinos
+RUN /dependencies/oldest_supported/trilinos/install.sh ${INSTALL_DIR}
 
 # Install deal.II (needs to happen after Trilinos)
 RUN /dependencies/current/dealii/install.sh ${INSTALL_DIR}


### PR DESCRIPTION
This PR adds a docker image with the oldest supported dependencies. This image is updated in the same workflow as the existing image. We propose to run a nightly build on this image to catch wrong `#ifdefs` or APIs (see e.g. #806)  (unchached, so we don't overload the cache as much). Nightly should be enough since very few PRs change anything in the dependencies. We can always move it to PRs if the check fails too frequently.

Co-authored by @ppraegla 

Closes #483 
