### PR TITLE
Rename namespace Tensor to FourTensorOperations

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_derivatives.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_derivatives.cpp
@@ -11,8 +11,9 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-void Core::LinAlg::Tensor::add_derivative_of_squared_tensor(Core::LinAlg::Matrix<6, 6>& C,
-    double scalar_squared_dx, Core::LinAlg::Matrix<3, 3> X, double scalar_this)
+void Core::LinAlg::FourTensorOperations::add_derivative_of_squared_tensor(
+    Core::LinAlg::Matrix<6, 6>& C, double scalar_squared_dx, Core::LinAlg::Matrix<3, 3> X,
+    double scalar_this)
 {
   C(0, 0) = scalar_this * C(0, 0) + scalar_squared_dx * 2. * X(0, 0);  // C1111
   C(0, 1) = scalar_this * C(0, 1);                                     // C1122
@@ -57,7 +58,7 @@ void Core::LinAlg::Tensor::add_derivative_of_squared_tensor(Core::LinAlg::Matrix
   C(5, 5) = scalar_this * C(5, 5) + scalar_squared_dx * 0.5 * (X(2, 2) + X(0, 0));  // C1313
 }
 
-void Core::LinAlg::Tensor::add_derivative_of_inva_b_inva_product(double const& fac,
+void Core::LinAlg::FourTensorOperations::add_derivative_of_inva_b_inva_product(double const& fac,
     const Core::LinAlg::Matrix<6, 1>& invA, const Core::LinAlg::Matrix<6, 1>& invABinvA,
     Core::LinAlg::Matrix<6, 6>& out)
 {

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_derivatives.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_derivatives.hpp
@@ -16,7 +16,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace Core::LinAlg::Tensor
+namespace Core::LinAlg::FourTensorOperations
 {
   /*!
    * @brief Add the derivative of the square of a tensor to a 4th order symmetric material tensor in
@@ -73,7 +73,7 @@ namespace Core::LinAlg::Tensor
       const Core::LinAlg::Matrix<6, 1>& invA, const Core::LinAlg::Matrix<6, 1>& invABinvA,
       Core::LinAlg::Matrix<6, 6>& out);
 
-}  // namespace Core::LinAlg::Tensor
+}  // namespace Core::LinAlg::FourTensorOperations
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.cpp
@@ -14,8 +14,8 @@ using FAD = Sacado::Fad::DFad<double>;
 
 FOUR_C_NAMESPACE_OPEN
 
-void Core::LinAlg::Tensor::add_elasticity_tensor_product(Core::LinAlg::Matrix<6, 6>& C,
-    const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
+void Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+    Core::LinAlg::Matrix<6, 6>& C, const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
     const Core::LinAlg::Matrix<3, 3>& B, const double scalar_this)
 {
   // everything in Voigt-Notation
@@ -41,8 +41,8 @@ void Core::LinAlg::Tensor::add_elasticity_tensor_product(Core::LinAlg::Matrix<6,
   C.multiply_nt(scalar_AB, A_voigt, B_voigt, scalar_this);
 }
 
-void Core::LinAlg::Tensor::add_symmetric_elasticity_tensor_product(Core::LinAlg::Matrix<6, 6>& C,
-    const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
+void Core::LinAlg::FourTensorOperations::add_symmetric_elasticity_tensor_product(
+    Core::LinAlg::Matrix<6, 6>& C, const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
     const Core::LinAlg::Matrix<3, 3>& B, const double scalar_this)
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -80,7 +80,7 @@ void Core::LinAlg::Tensor::add_symmetric_elasticity_tensor_product(Core::LinAlg:
   C.multiply_nt(scalar_AB, B_voigt, A_voigt, 1.0);
 }
 
-void Core::LinAlg::Tensor::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 6>& C,
+void Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 6>& C,
     const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
     const Core::LinAlg::Matrix<3, 3>& B, const double scalar_this)
 {
@@ -147,7 +147,7 @@ void Core::LinAlg::Tensor::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 
 }
 
 
-void Core::LinAlg::Tensor::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 9>& C,
+void Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 9>& C,
     const double scalar_AB, const Core::LinAlg::Matrix<3, 3>& A,
     const Core::LinAlg::Matrix<3, 3>& B, const double scalar_this)
 {
@@ -261,7 +261,7 @@ void Core::LinAlg::Tensor::add_kronecker_tensor_product(Core::LinAlg::Matrix<6, 
 }
 
 template <typename T>
-void Core::LinAlg::Tensor::add_holzapfel_product(
+void Core::LinAlg::FourTensorOperations::add_holzapfel_product(
     Core::LinAlg::Matrix<6, 6, T>& cmat, const Core::LinAlg::Matrix<6, 1, T>& invc, const T scalar)
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
@@ -313,8 +313,9 @@ void Core::LinAlg::Tensor::add_holzapfel_product(
   cmat(5, 5) += scalar * 0.5 * (invc(0) * invc(2) + invc(5) * invc(5));
 }
 
-void Core::LinAlg::Tensor::add_symmetric_holzapfel_product(Core::LinAlg::Matrix<6, 6>& X,
-    const Core::LinAlg::Matrix<3, 3>& A, const Core::LinAlg::Matrix<3, 3>& B, const double fac)
+void Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
+    Core::LinAlg::Matrix<6, 6>& X, const Core::LinAlg::Matrix<3, 3>& A,
+    const Core::LinAlg::Matrix<3, 3>& B, const double fac)
 {
   X(0, 0) += 4 * fac * A(0, 0) * B(0, 0);
   X(0, 3) += fac * (2 * A(0, 0) * B(1, 0) + 2 * A(1, 0) * B(0, 0));
@@ -360,7 +361,7 @@ void Core::LinAlg::Tensor::add_symmetric_holzapfel_product(Core::LinAlg::Matrix<
 }
 
 template <typename T>
-void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+void Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
     Core::LinAlg::Matrix<6, 9, T>& out, Core::LinAlg::Matrix<3, 3, T> const& A,
     Core::LinAlg::Matrix<3, 3, T> const& B, T const fac)
 {
@@ -426,7 +427,7 @@ void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
 }
 
 template <typename T>
-void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product_strain_like(
+void Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product_strain_like(
     Core::LinAlg::Matrix<6, 9, T>& out, Core::LinAlg::Matrix<3, 3, T> const& A,
     Core::LinAlg::Matrix<3, 3, T> const& B, T const fac)
 {
@@ -491,8 +492,9 @@ void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product_strain_like
   out(5, 2) += 2 * fac * (A(0, 2) * B(2, 2) + A(2, 2) * B(0, 2));
 }
 
-void Core::LinAlg::Tensor::add_left_non_symmetric_holzapfel_product(Core::LinAlg::Matrix<9, 6>& out,
-    Core::LinAlg::Matrix<3, 3> const& A, Core::LinAlg::Matrix<3, 3> const& B, double const fac)
+void Core::LinAlg::FourTensorOperations::add_left_non_symmetric_holzapfel_product(
+    Core::LinAlg::Matrix<9, 6>& out, Core::LinAlg::Matrix<3, 3> const& A,
+    Core::LinAlg::Matrix<3, 3> const& B, double const fac)
 {
   out(0, 0) += fac * 2 * A(0, 0) * B(0, 0);
   out(0, 3) += fac * (A(0, 0) * B(0, 1) + A(0, 1) * B(0, 0));
@@ -558,7 +560,7 @@ void Core::LinAlg::Tensor::add_left_non_symmetric_holzapfel_product(Core::LinAlg
   out(2, 2) += fac * 2 * A(2, 2) * B(2, 2);
 }
 
-void Core::LinAlg::Tensor::add_adbc_tensor_product(const double fac,
+void Core::LinAlg::FourTensorOperations::add_adbc_tensor_product(const double fac,
     const Core::LinAlg::Matrix<3, 3>& A, const Core::LinAlg::Matrix<3, 3>& B,
     Core::LinAlg::Matrix<9, 9>& out)
 {
@@ -653,7 +655,7 @@ void Core::LinAlg::Tensor::add_adbc_tensor_product(const double fac,
   out(2, 2) += fac * A(2, 2) * B(2, 2);
 }
 
-void Core::LinAlg::Tensor::add_non_symmetric_product(double const& fac,
+void Core::LinAlg::FourTensorOperations::add_non_symmetric_product(double const& fac,
     Core::LinAlg::Matrix<3, 3> const& A, Core::LinAlg::Matrix<3, 3> const& B,
     Core::LinAlg::Matrix<9, 9>& out)
 {
@@ -749,7 +751,7 @@ void Core::LinAlg::Tensor::add_non_symmetric_product(double const& fac,
 }
 
 template <int dim>
-void Core::LinAlg::Tensor::multiply_four_tensor_matrix(
+void Core::LinAlg::FourTensorOperations::multiply_four_tensor_matrix(
     Core::LinAlg::FourTensor<dim>& four_tensor_result,
     const Core::LinAlg::FourTensor<dim>& four_tensor, const Core::LinAlg::Matrix<dim, dim>& matrix,
     const bool clear_result_tensor)
@@ -774,7 +776,7 @@ void Core::LinAlg::Tensor::multiply_four_tensor_matrix(
 }
 
 template <int dim>
-void Core::LinAlg::Tensor::multiply_matrix_four_tensor(
+void Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor(
     Core::LinAlg::FourTensor<dim>& four_tensor_result, const Core::LinAlg::Matrix<dim, dim>& matrix,
     const Core::LinAlg::FourTensor<dim>& four_tensor, const bool clear_result_tensor)
 {
@@ -799,7 +801,7 @@ void Core::LinAlg::Tensor::multiply_matrix_four_tensor(
 }
 
 template <int dim>
-void Core::LinAlg::Tensor::multiply_matrix_four_tensor_by_second_index(
+void Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor_by_second_index(
     Core::LinAlg::FourTensor<dim>& four_tensor_result, const Core::LinAlg::Matrix<dim, dim>& matrix,
     const Core::LinAlg::FourTensor<dim>& four_tensor, const bool clear_result_tensor)
 {
@@ -824,7 +826,7 @@ void Core::LinAlg::Tensor::multiply_matrix_four_tensor_by_second_index(
 }
 
 template <int dim>
-void Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+void Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
     Core::LinAlg::FourTensor<dim>& four_tensor_result,
     const Core::LinAlg::FourTensor<dim>& four_tensor_1,
     const Core::LinAlg::FourTensor<dim>& four_tensor_2, const bool clear_result_tensor)
@@ -849,7 +851,7 @@ void Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
   }
 }
 
-void Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+void Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
     Core::LinAlg::FourTensor<3>& four_tensor_result, const Core::LinAlg::Matrix<3, 3>& matrix_A,
     const Core::LinAlg::Matrix<3, 3>& matrix_B)
 {
@@ -860,7 +862,7 @@ void Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
           four_tensor_result(i, j, k, l) += matrix_A(i, j) * matrix_B(k, l);
 }
 
-void Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+void Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
     Core::LinAlg::FourTensor<3>& four_tensor_result, const double scale,
     const Core::LinAlg::Matrix<3, 3>& matrix_A, const Core::LinAlg::Matrix<3, 3>& matrix_B)
 {
@@ -871,7 +873,7 @@ void Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
           four_tensor_result(i, j, k, l) += scale * matrix_A(i, j) * matrix_B(k, l);
 }
 
-void Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(
+void Core::LinAlg::FourTensorOperations::add_contraction_matrix_four_tensor(
     Core::LinAlg::Matrix<3, 3>& matrix_result, const Core::LinAlg::Matrix<3, 3>& matrix,
     const Core::LinAlg::FourTensor<3>& four_tensor)
 {
@@ -882,7 +884,7 @@ void Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(
           matrix_result(k, l) += matrix(i, j) * four_tensor(i, j, k, l);
 }
 
-void Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(
+void Core::LinAlg::FourTensorOperations::add_contraction_matrix_four_tensor(
     Core::LinAlg::Matrix<3, 3>& matrix_result, const double scale,
     const Core::LinAlg::FourTensor<3>& four_tensor, const Core::LinAlg::Matrix<3, 3>& matrix)
 {
@@ -893,7 +895,7 @@ void Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(
           matrix_result(i, j) += scale * four_tensor(i, j, k, l) * matrix(k, l);
 }
 
-double Core::LinAlg::Tensor::contract_matrix_matrix(
+double Core::LinAlg::FourTensorOperations::contract_matrix_matrix(
     const Core::LinAlg::Matrix<3, 3>& matrix_A, const Core::LinAlg::Matrix<3, 3>& matrix_B)
 {
   double scalarContraction = 0.0;
@@ -904,33 +906,35 @@ double Core::LinAlg::Tensor::contract_matrix_matrix(
 }
 
 // explicit instantiation of template functions
-template void Core::LinAlg::Tensor::add_holzapfel_product<double>(
+template void Core::LinAlg::FourTensorOperations::add_holzapfel_product<double>(
     Core::LinAlg::Matrix<6, 6, double>&, const Core::LinAlg::Matrix<6, 1, double>&,
     const double scalar);
-template void Core::LinAlg::Tensor::add_holzapfel_product<FAD>(
+template void Core::LinAlg::FourTensorOperations::add_holzapfel_product<FAD>(
     Core::LinAlg::Matrix<6, 6, FAD>&, const Core::LinAlg::Matrix<6, 1, FAD>&, const FAD scalar);
-template void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product<double>(
+template void Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product<double>(
     Core::LinAlg::Matrix<6, 9, double>&, Core::LinAlg::Matrix<3, 3, double> const&,
     Core::LinAlg::Matrix<3, 3, double> const&, double const);
-template void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product<FAD>(
+template void Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product<FAD>(
     Core::LinAlg::Matrix<6, 9, FAD>&, Core::LinAlg::Matrix<3, 3, FAD> const&,
     Core::LinAlg::Matrix<3, 3, FAD> const&, FAD const);
-template void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product_strain_like<double>(
+template void
+Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product_strain_like<double>(
     Core::LinAlg::Matrix<6, 9, double>& out, Core::LinAlg::Matrix<3, 3, double> const& A,
     Core::LinAlg::Matrix<3, 3, double> const& B, double const fac);
-template void Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product_strain_like<FAD>(
+template void
+Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product_strain_like<FAD>(
     Core::LinAlg::Matrix<6, 9, FAD>& out, Core::LinAlg::Matrix<3, 3, FAD> const& A,
     Core::LinAlg::Matrix<3, 3, FAD> const& B, FAD const fac);
-template void Core::LinAlg::Tensor::multiply_four_tensor_matrix<3>(
+template void Core::LinAlg::FourTensorOperations::multiply_four_tensor_matrix<3>(
     Core::LinAlg::FourTensor<3>& four_tensor_result, const Core::LinAlg::FourTensor<3>& four_tensor,
     const Core::LinAlg::Matrix<3, 3>& matrix, const bool clear_result_tensor);
-template void Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+template void Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
     Core::LinAlg::FourTensor<3>& four_tensor_result, const Core::LinAlg::Matrix<3, 3>& matrix,
     const Core::LinAlg::FourTensor<3>& four_tensor, const bool clear_result_tensor);
-template void Core::LinAlg::Tensor::multiply_matrix_four_tensor_by_second_index<3>(
+template void Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor_by_second_index<3>(
     Core::LinAlg::FourTensor<3>& four_tensor_result, const Core::LinAlg::Matrix<3, 3>& matrix,
     const Core::LinAlg::FourTensor<3>& four_tensor, const bool clear_result_tensor);
-template void Core::LinAlg::Tensor::multiply_four_tensor_four_tensor<3>(
+template void Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor<3>(
     Core::LinAlg::FourTensor<3>& four_tensor_result,
     const Core::LinAlg::FourTensor<3>& four_tensor_1,
     const Core::LinAlg::FourTensor<3>& four_tensor_2, const bool clear_result_tensor);

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_products.hpp
@@ -22,7 +22,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace Core::LinAlg::Tensor
+namespace Core::LinAlg::FourTensorOperations
 {
   /*!
    * @brief Multiply two 2nd order tensors A x B and add the result to a 4th order symmetric
@@ -401,7 +401,7 @@ namespace Core::LinAlg::Tensor
   double contract_matrix_matrix(
       const Core::LinAlg::Matrix<3, 3>& matrix_A, const Core::LinAlg::Matrix<3, 3>& matrix_B);
 
-}  // namespace Core::LinAlg::Tensor
+}  // namespace Core::LinAlg::FourTensorOperations
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_transformation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_transformation.cpp
@@ -9,9 +9,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-template void Core::LinAlg::Tensor::tensor_rotation<3>(const Core::LinAlg::Matrix<3, 3>&,
-    const Core::LinAlg::Matrix<3, 3>&, Core::LinAlg::Matrix<3, 3>&);
-template void Core::LinAlg::Tensor::inverse_tensor_rotation<3>(const Core::LinAlg::Matrix<3, 3>&,
-    const Core::LinAlg::Matrix<3, 3>&, Core::LinAlg::Matrix<3, 3>&);
+template void Core::LinAlg::FourTensorOperations::tensor_rotation<3>(
+    const Core::LinAlg::Matrix<3, 3>&, const Core::LinAlg::Matrix<3, 3>&,
+    Core::LinAlg::Matrix<3, 3>&);
+template void Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<3>(
+    const Core::LinAlg::Matrix<3, 3>&, const Core::LinAlg::Matrix<3, 3>&,
+    Core::LinAlg::Matrix<3, 3>&);
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_transformation.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix_tensor_transformation.hpp
@@ -14,7 +14,7 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-namespace Core::LinAlg::Tensor
+namespace Core::LinAlg::FourTensorOperations
 {
   /*!
    * @brief Rotation of all basis vectors of 2-Tensor Tin by the rotation Matrix Q
@@ -122,7 +122,7 @@ namespace Core::LinAlg::Tensor
     Tout.multiply_nn(1.0, temp, Qfourth);
   }
 
-}  // namespace Core::LinAlg::Tensor
+}  // namespace Core::LinAlg::FourTensorOperations
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_utils_densematrix_funct.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_densematrix_funct.cpp
@@ -292,7 +292,7 @@ namespace
     // compose derivative of matrix exponential (non-symmetric Voigt-notation)
     for (int n = 1; n <= nmax; n++)
       for (int m = 1; m <= n; m++)
-        Core::LinAlg::Tensor::add_non_symmetric_product(
+        Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
             1. / fac[n], Xn.at(m - 1), Xn.at(n - m), output);
 
     err_status = Core::LinAlg::MatrixFunctErrorType::no_errors;
@@ -355,10 +355,10 @@ namespace
     for (int n = 1; n <= nmax; n++)
     {
       for (int m = 1; m <= n / 2; m++)
-        Core::LinAlg::Tensor::add_symmetric_holzapfel_product(
+        Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
             output, Xn.at(m - 1), Xn.at(n - m), .5 / fac[n]);
       if (n % 2 == 1)
-        Core::LinAlg::Tensor::add_symmetric_holzapfel_product(
+        Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
             output, Xn.at((n - 1) / 2), Xn.at((n - 1) / 2), .25 / fac[n]);
     }
 
@@ -466,12 +466,13 @@ namespace
       s6 = EVal(c, c) * EVal(c, c) * s3;
 
       // calculate derivative
-      Core::LinAlg::Tensor::add_derivative_of_squared_tensor(output, s1, input, 1.);
+      Core::LinAlg::FourTensorOperations::add_derivative_of_squared_tensor(output, s1, input, 1.);
       output.update(-s2, id4sharp, 1.);
-      Core::LinAlg::Tensor::add_elasticity_tensor_product(output, -1. * s3, input, input, 1.);
-      Core::LinAlg::Tensor::add_elasticity_tensor_product(output, s4, input, id2, 1.);
-      Core::LinAlg::Tensor::add_elasticity_tensor_product(output, s5, id2, input, 1.);
-      Core::LinAlg::Tensor::add_elasticity_tensor_product(output, -s6, id2, id2, 1.);
+      Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+          output, -1. * s3, input, input, 1.);
+      Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(output, s4, input, id2, 1.);
+      Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(output, s5, id2, input, 1.);
+      Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(output, -s6, id2, id2, 1.);
     }
     else if (std::abs(EVal(0, 0) - EVal(1, 1)) > EVal_tolerance &&
              std::abs(EVal(1, 1) - EVal(2, 2)) >
@@ -501,26 +502,27 @@ namespace
         double fac = std::exp(EVal(a, a)) / ((EVal(a, a) - EVal(b, b)) * (EVal(a, a) - EVal(c, c)));
 
         // + d X^2 / d X
-        Core::LinAlg::Tensor::add_derivative_of_squared_tensor(output, fac, input, 1.);
+        Core::LinAlg::FourTensorOperations::add_derivative_of_squared_tensor(
+            output, fac, input, 1.);
 
         // - (x_b + x_c) I_s
         output.update(-1. * (EVal(b, b) + EVal(c, c)) * fac, id4sharp, 1.);
 
         // - [(x_a - x_b) + (x_a - x_c)] E_a \dyad E_a
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(output,
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(output,
             -1. * fac * ((EVal(a, a) - EVal(b, b)) + (EVal(a, a) - EVal(c, c))), Ea, Ea, 1.);
 
 
         // - (x_b - x_c) (E_b \dyad E_b)
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
             output, -1. * fac * (EVal(b, b) - EVal(c, c)), Eb, Eb, 1.);
 
         // + (x_b - x_c) (E_c \dyad E_c)
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
             output, fac * (EVal(b, b) - EVal(c, c)), Ec, Ec, 1.);
 
         // dy / dx_a E_a \dyad E_a
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
             output, std::exp(EVal(a, a)), Ea, Ea, 1.);
       }  // end loop over all eigenvalues
     }
@@ -939,7 +941,7 @@ namespace
     {
       err_status = Core::LinAlg::MatrixFunctErrorType::no_errors;
       Core::LinAlg::Matrix<9, 9> id9x9{Core::LinAlg::Initialization::zero};
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, id_3x3, id9x9);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id_3x3, id_3x3, id9x9);
       return id9x9;
     }
 
@@ -984,7 +986,7 @@ namespace
       // compute \f$ \boldsymbol{I}_{AC} \boldsymbol{K}^{-1}_{DB}
       // \f$
       id_invKT.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, invK, id_invKT);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id_3x3, invK, id_invKT);
 
       // compute \f$ \boldsymbol{X}_{AI} \boldsymbol{K}^{-1}_{IB} \f$
       XinvK.multiply(1.0, X, invK, 0.0);
@@ -992,7 +994,7 @@ namespace
       // compute \f$ \boldsymbol{X}_{AI} \boldsymbol{K}^{-1}_{IC} \boldsymbol{K}^{-1}_{DB}
       // \f$
       XinvK_invKT.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, XinvK, invK, XinvK_invKT);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, XinvK, invK, XinvK_invKT);
 
       // add contribution of the Gauss point to the output matrix
       output.update(-trafo_point * trafo_weight, XinvK_invKT, trafo_weight, id_invKT, 1.0);
@@ -1021,7 +1023,7 @@ namespace
       id_3x3(i, i) = 1.0;
     }
     Core::LinAlg::Matrix<9, 9> id4(Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, id_3x3, id4);
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id_3x3, id_3x3, id4);
     Core::LinAlg::FourTensor<3> id4_FourTensor(true);
     Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(id4_FourTensor, id4);
     Core::LinAlg::Matrix<3, 3> temp3x3(Core::LinAlg::Initialization::zero);
@@ -1091,19 +1093,21 @@ namespace
 
       // update derivative dA_minus_id_m_dA
       temp9x9.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, A_minus_id_mmin1, id_3x3, temp9x9);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+          1.0, A_minus_id_mmin1, id_3x3, temp9x9);
       tempFourTensor.clear();
       Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-      Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+      Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
           leftFourTensor, tempFourTensor, id4_FourTensor, true);
       Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, leftFourTensor);
       dA_minus_id_m_dA.update(1.0, temp9x9, 0.0);
 
       temp9x9.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, A_minus_id_mmin1, temp9x9);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+          1.0, id_3x3, A_minus_id_mmin1, temp9x9);
       tempFourTensor.clear();
       Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-      Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+      Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
           rightFourTensor, tempFourTensor, dA_minus_id_mmin1_dA_FourTensor, true);
       Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, rightFourTensor);
       dA_minus_id_m_dA.update(1.0, temp9x9, 1.0);
@@ -1126,7 +1130,7 @@ namespace
       id_3x3(i, i) = 1.0;
     }
     Core::LinAlg::Matrix<9, 9> id4(Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, id_3x3, id4);
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id_3x3, id_3x3, id4);
     Core::LinAlg::FourTensor<3> id4_FourTensor(true);
     Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(id4_FourTensor, id4);
     Core::LinAlg::Matrix<3, 3> temp3x3(Core::LinAlg::Initialization::zero);
@@ -1158,7 +1162,8 @@ namespace
     // \f$ \frac{\partial  \left( \bm{I} + \bm{A} \right)^{-1}}{\partial \bm{A}}  \f$
     Core::LinAlg::Matrix<9, 9> dinv_id_plus_A_dA(Core::LinAlg::Initialization::zero);
     temp9x9.clear();
-    Core::LinAlg::Tensor::add_non_symmetric_product(1.0, inv_id_plus_A, inv_id_plus_A, temp9x9);
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+        1.0, inv_id_plus_A, inv_id_plus_A, temp9x9);
     dinv_id_plus_A_dA.multiply_nn(-1.0, temp9x9, id4, 0.0);
     Core::LinAlg::FourTensor<3> dinv_id_plus_A_dA_FourTensor(true);
     Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(
@@ -1172,17 +1177,18 @@ namespace
     // get derivative of the update matrix w.r.t. input matrix \f$ \bm{A} \f$
     Core::LinAlg::Matrix<9, 9> dupdateMat_dA(Core::LinAlg::Initialization::zero);
     temp9x9.clear();
-    Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_minus_A, id_3x3, temp9x9);
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id_minus_A, id_3x3, temp9x9);
     Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-    Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+    Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
         leftFourTensor, tempFourTensor, dinv_id_plus_A_dA_FourTensor, true);
     Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, leftFourTensor);
     dupdateMat_dA.update(1.0, temp9x9, 0.0);
 
     temp9x9.clear();
-    Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, inv_id_plus_A, temp9x9);
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+        1.0, id_3x3, inv_id_plus_A, temp9x9);
     Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-    Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+    Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
         rightFourTensor, tempFourTensor, id4_FourTensor, true);
     Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, rightFourTensor);
     dupdateMat_dA.update(-1.0, temp9x9, 1.0);
@@ -1231,17 +1237,19 @@ namespace
           dupdateMat_dA_mmin1_FourTensor, dupdateMat_dA_mmin1);
 
       temp9x9.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, updateMat_mmin1, id_3x3, temp9x9);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+          1.0, updateMat_mmin1, id_3x3, temp9x9);
       Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-      Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+      Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
           leftFourTensor, tempFourTensor, dupdateMat_dA_FourTensor, true);
       Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, leftFourTensor);
       dupdateMat_dA_m.update(1.0, temp9x9, 0.0);
 
       temp9x9.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id_3x3, updateMat, temp9x9);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+          1.0, id_3x3, updateMat, temp9x9);
       Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
-      Core::LinAlg::Tensor::multiply_four_tensor_four_tensor(
+      Core::LinAlg::FourTensorOperations::multiply_four_tensor_four_tensor(
           rightFourTensor, tempFourTensor, dupdateMat_dA_mmin1_FourTensor, true);
       Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, rightFourTensor);
       dupdateMat_dA_m.update(1.0, temp9x9, 1.0);

--- a/src/core/linalg/tests/4C_linalg_utils_tensor_products_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_tensor_products_test.cpp
@@ -78,7 +78,7 @@ namespace
     a_kron_b_ref(5, 5) = 2.4500000000;
 
     Core::LinAlg::Matrix<6, 6> a_kron_b(Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::add_kronecker_tensor_product(a_kron_b, 1.0, a, b, 0.0);
+    Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(a_kron_b, 1.0, a, b, 0.0);
 
     FOUR_C_EXPECT_NEAR(a_kron_b, a_kron_b_ref, 1.0e-10);
   }

--- a/src/core/linalg/tests/4C_linalg_utils_tensor_transformation_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_tensor_transformation_test.cpp
@@ -92,20 +92,22 @@ namespace
   TEST_F(TensorTransformationTest, TensorRotation)
   {
     Core::LinAlg::Matrix<3, 3> tmp;
-    Core::LinAlg::Tensor::tensor_rotation(rotationMatrix1_, tens1_, tmp);
+    Core::LinAlg::FourTensorOperations::tensor_rotation(rotationMatrix1_, tens1_, tmp);
     FOUR_C_EXPECT_NEAR(tmp, rotatedTens1_, 1e-9);
 
-    Core::LinAlg::Tensor::tensor_rotation(rotationMatrix2_, tens2_, tmp);
+    Core::LinAlg::FourTensorOperations::tensor_rotation(rotationMatrix2_, tens2_, tmp);
     FOUR_C_EXPECT_NEAR(tmp, rotatedTens2_, 1e-9);
   }
 
   TEST_F(TensorTransformationTest, InverseTensorRotation)
   {
     Core::LinAlg::Matrix<3, 3> tmp;
-    Core::LinAlg::Tensor::inverse_tensor_rotation(rotationMatrix1_, rotatedTens1_, tmp);
+    Core::LinAlg::FourTensorOperations::inverse_tensor_rotation(
+        rotationMatrix1_, rotatedTens1_, tmp);
     FOUR_C_EXPECT_NEAR(tmp, tens1_, 1e-9);
 
-    Core::LinAlg::Tensor::inverse_tensor_rotation(rotationMatrix2_, rotatedTens2_, tmp);
+    Core::LinAlg::FourTensorOperations::inverse_tensor_rotation(
+        rotationMatrix2_, rotatedTens2_, tmp);
     FOUR_C_EXPECT_NEAR(tmp, tens2_, 1e-9);
   }
 }  // namespace

--- a/src/mat/4C_mat_aaaneohooke.cpp
+++ b/src/mat/4C_mat_aaaneohooke.cpp
@@ -309,7 +309,7 @@ void Mat::AAAneohooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
     }
 
   // contribution: boeppel-product
-  Core::LinAlg::Tensor::add_holzapfel_product(*cmat, invc, delta7);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(*cmat, invc, delta7);
 
   // 2nd step: volumetric part
   //==========================
@@ -321,7 +321,7 @@ void Mat::AAAneohooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
     for (int j = 0; j < 6; j++) (*cmat)(i, j) += delta6 * invc(i) * invc(j);
 
   // contribution: boeppel-product
-  Core::LinAlg::Tensor::add_holzapfel_product(*cmat, invc, delta7);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(*cmat, invc, delta7);
 
   return;
 }

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -1492,7 +1492,7 @@ void Mat::ConstraintMixture::evaluate_elastin(const Core::LinAlg::Matrix<NUM_STR
   double delta6 = 2. * beta * mue * pow(I3, -beta);
   cmatiso.multiply_nt(delta6, Cisoinv, Cisoinv);
   double delta7 = 2. * mue * pow(I3, -beta);
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatiso, Cisoinv, delta7);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatiso, Cisoinv, delta7);
   cmatiso.scale(refmassdenselastin / density * prestretchelastin * prestretchelastin *
                 prestretchelastin * prestretchelastin * elastin_survival);
   *cmat = cmatiso;
@@ -1645,7 +1645,7 @@ void Mat::ConstraintMixture::evaluate_volumetric(const Core::LinAlg::Matrix<NUM_
 
   //--- do elasticity matrix -------------------------------------------------------------
   // cmatvol = J(p + J dp/dJ) Cinv x Cinv  -  2 J p Cinv o Cinv
-  Core::LinAlg::Tensor::add_holzapfel_product((*cmat), Cinv, (-2 * J * p));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product((*cmat), Cinv, (-2 * J * p));
   for (int i = 0; i < 6; i++)
   {
     for (int j = 0; j < 6; j++)

--- a/src/mat/4C_mat_elasthyper_service.cpp
+++ b/src/mat/4C_mat_elasthyper_service.cpp
@@ -209,7 +209,7 @@ void Mat::elast_hyper_add_isotropic_stress_cmat(Core::LinAlg::Matrix<6, 1>& S_st
   // contribution: Cinv \otimes Cinv
   cmat.multiply_nt(delta(5), iC_stress, iC_stress, 1.0);
   // contribution: Cinv \odot Cinv
-  Core::LinAlg::Tensor::add_holzapfel_product(cmat, iC_stress, delta(6));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmat, iC_stress, delta(6));
   // contribution: Id4^#
   cmat.update(delta(7), id4sharp, 1.0);
 }
@@ -588,15 +588,15 @@ void Mat::elast_hyper_get_derivs_of_elastic_right_cg_tensor(const Core::LinAlg::
   dCedC.clear();
   Core::LinAlg::Matrix<3, 3> iFinTM(Core::LinAlg::Initialization::zero);
   iFinTM.multiply_nt(1.0, id3x3, iFinM, 0.0);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(dCedC, 1.0, iFinTM, iFinTM, 0.0);
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(dCedC, 1.0, iFinTM, iFinTM, 0.0);
 
   // \frac{\partial C^e}{\partial F_{in}^{-1}}
   dCediFin.clear();
   Core::LinAlg::Matrix<3, 3> iFinTCM(Core::LinAlg::Initialization::zero);
   iFinTCM.multiply_tn(1.0, iFinM, CM, 0.0);
   temp9x9.clear();
-  Core::LinAlg::Tensor::add_adbc_tensor_product(1.0, id3x3, iFinTCM, temp9x9);
-  Core::LinAlg::Tensor::add_non_symmetric_product(1.0, iFinTCM, id3x3, temp9x9);
+  Core::LinAlg::FourTensorOperations::add_adbc_tensor_product(1.0, id3x3, iFinTCM, temp9x9);
+  Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, iFinTCM, id3x3, temp9x9);
   Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
   Core::LinAlg::Voigt::setup_6x9_voigt_matrix_from_four_tensor(dCediFin, tempFourTensor);
 }

--- a/src/mat/4C_mat_growthremodel_elasthyper.cpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.cpp
@@ -1318,8 +1318,8 @@ void Mat::GrowthRemodelElastHyper::evaluate_isotropic_princ_elast(
   cmatisoprinc.multiply_nt(delta(4), iCinCiCinv, iCv, 1.);
   cmatisoprinc.multiply_nt(delta(4), iCv, iCinCiCinv, 1.);
   cmatisoprinc.multiply_nt(delta(5), iCv, iCv, 1.);
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatisoprinc, iCv, delta(6));
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatisoprinc, iCinv, delta(7));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatisoprinc, iCv, delta(6));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatisoprinc, iCinv, delta(7));
 }
 
 
@@ -1342,8 +1342,10 @@ void Mat::GrowthRemodelElastHyper::evaluated_sdi_fg(Core::LinAlg::Matrix<6, 9>& 
   dSdiFin.clear();
 
   // derivative of second Piola Kirchhoff stress w.r.t. inverse growth deformation gradient
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(dSdiFin, id, iFinM, gamma(0));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(dSdiFin, iCinCM, iFinM, gamma(1));
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
+      dSdiFin, id, iFinM, gamma(0));
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
+      dSdiFin, iCinCM, iFinM, gamma(1));
   dSdiFin.multiply_nt(delta(0), iCinv, CiFin9x1, 1.);
   dSdiFin.multiply_nt(delta(1), iCinv, CiFinCe9x1, 1.);
   dSdiFin.multiply_nt(delta(1), iCinCiCinv, CiFin9x1, 1.);
@@ -1353,13 +1355,13 @@ void Mat::GrowthRemodelElastHyper::evaluated_sdi_fg(Core::LinAlg::Matrix<6, 9>& 
   dSdiFin.multiply_nt(delta(4), iCinCiCinv, CiFiniCe9x1, 1.);
   dSdiFin.multiply_nt(delta(4), iCv, CiFinCe9x1, 1.);
   dSdiFin.multiply_nt(delta(5), iCv, CiFiniCe9x1, 1.);
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dSdiFin, id, iFinCeM, 0.5 * delta(7));
 
   // diFin/diFg
   static Core::LinAlg::Matrix<9, 9> diFindiFg(Core::LinAlg::Initialization::zero);
   diFindiFg.clear();
-  Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id, gm_[gp], diFindiFg);
+  Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id, gm_[gp], diFindiFg);
 
   dSdiFg.multiply_nn(1.0, dSdiFin, diFindiFg, 0.0);
 }
@@ -1498,7 +1500,7 @@ void Mat::GrowthRemodelElastHyper::evaluate_stress_cmat_membrane(
   Core::LinAlg::Voigt::Stresses::matrix_to_vector(YM, Yv);
   static Core::LinAlg::Matrix<6, 6> dYdC(Core::LinAlg::Initialization::zero);
   dYdC.clear();
-  Core::LinAlg::Tensor::add_holzapfel_product(dYdC, Yv, -0.5);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(dYdC, Yv, -0.5);
 
   cmat.multiply_nt(0.5 * mue_el_mem * cur_rho_el_[gp] * mue_frac_[gp] / X_det.val(), Yv, Yv, 0.0);
   cmat.update(-mue_el_mem * cur_rho_el_[gp] * mue_frac_[gp] / X_det.val(), dYdC, 1.0);

--- a/src/mat/4C_mat_inelastic_defgrad_factors.cpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.cpp
@@ -67,7 +67,8 @@ namespace
           id3x3_, id6x1_);
 
       // symmetric identity four tensor
-      Core::LinAlg::Tensor::add_kronecker_tensor_product(id4_6x6_, 1.0, id3x3, id3x3, 0.0);
+      Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
+          id4_6x6_, 1.0, id3x3, id3x3, 0.0);
 
       // deviatoric operator
       Core::LinAlg::FourTensor<3> dev_op_four_tensor =
@@ -77,7 +78,7 @@ namespace
 
       // identity four tensor
       id4_9x9_.clear();
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id3x3_, id3x3_, id4_9x9_);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id3x3_, id3x3_, id4_9x9_);
 
       // 10x10 identity
       id10x10_.clear();
@@ -1828,8 +1829,9 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantities(
 
   // determine scalar quantities of invariants / pseudoinvariants needed to compute the equivalent
   // tensile stress
-  double Me_dev_sym_contract_Me_dev_sym = Core::LinAlg::Tensor::contract_matrix_matrix(
-      state_quantities.curr_Me_dev_sym_M_, state_quantities.curr_Me_dev_sym_M_);
+  double Me_dev_sym_contract_Me_dev_sym =
+      Core::LinAlg::FourTensorOperations::contract_matrix_matrix(
+          state_quantities.curr_Me_dev_sym_M_, state_quantities.curr_Me_dev_sym_M_);
   Core::LinAlg::Matrix<3, 3> Me_dev_sym_squared_M(Core::LinAlg::Initialization::zero);
   Me_dev_sym_squared_M.multiply_nn(
       1.0, state_quantities.curr_Me_dev_sym_M_, state_quantities.curr_Me_dev_sym_M_, 0.0);
@@ -2061,11 +2063,11 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   // \boldsymbol{F}^{\text{in}^{-1}}_{}} \f$ (Voigt stress-form)
   Core::LinAlg::Matrix<6, 9> dMe_sym_diFin(Core::LinAlg::Initialization::zero);
   dMe_sym_diFin.clear();
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dMe_sym_diFin, iFinTCM, const_non_mat_tensors.id3x3_, gamma(0));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dMe_sym_diFin, iFinTCM, CeM, gamma(1));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dMe_sym_diFin, CeiFinTCM, const_non_mat_tensors.id3x3_, gamma(1));
   dMe_sym_diFin.multiply_nt(delta(0), CeV, CiFinV, 1.0);
   dMe_sym_diFin.multiply_nt(delta(1), CeV, CiFinCeV, 1.0);
@@ -2080,9 +2082,12 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   // \f$ \frac{\partial \boldsymbol{M}^{\text{e}}_{\text{sym}} }{\partial
   // \boldsymbol{C}^{}_{}} \f$ (Voigt stress-stress form)
   Core::LinAlg::Matrix<6, 6> dMe_sym_dC(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(dMe_sym_dC, gamma(0), iFinTM, iFinTM, 0.0);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(dMe_sym_dC, gamma(1), iFinTM, CeiFinTM, 1.0);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(dMe_sym_dC, gamma(1), CeiFinTM, iFinTM, 1.0);
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
+      dMe_sym_dC, gamma(0), iFinTM, iFinTM, 0.0);
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
+      dMe_sym_dC, gamma(1), iFinTM, CeiFinTM, 1.0);
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
+      dMe_sym_dC, gamma(1), CeiFinTM, iFinTM, 1.0);
   dMe_sym_dC.multiply_nt(delta(0) / 2.0, CeV, iCinV, 1.0);
   dMe_sym_dC.multiply_nt(delta(1) / 2.0, CeV, iCinCiCinV, 1.0);
   dMe_sym_dC.multiply_nt(delta(1) / 2.0, CeCeV, iCinV, 1.0);
@@ -2118,7 +2123,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   if (parameter()->bool_transv_isotropy())
   {
     Core::LinAlg::FourTensor<3> CedSediFin_FourTensor(true);
-    Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+    Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
         CedSediFin_FourTensor, CeM, dSediFin_FourTensor, true);
     Core::LinAlg::FourTensor<3> CedSediFin_T12_FourTensor(true);
     CedSediFin_T12_FourTensor.transpose_12(CedSediFin_FourTensor);
@@ -2128,7 +2133,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
         temp6x9, CedSediFin_T12_FourTensor);
     dMe_sym_diFin.update(1.0 / 2.0, temp6x9, 1.0);
     Core::LinAlg::FourTensor<3> SedCediFin_FourTensor(true);
-    Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+    Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
         SedCediFin_FourTensor, SeM, dCediFin_FourTensor, true);
     Core::LinAlg::FourTensor<3> SedCediFin_T12_FourTensor(true);
     SedCediFin_T12_FourTensor.transpose_12(SedCediFin_FourTensor);
@@ -2139,7 +2144,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
     dMe_sym_diFin.update(1.0 / 2.0, temp6x9, 1.0);
 
     Core::LinAlg::FourTensor<3> CedSedC_FourTensor(true);
-    Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+    Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
         CedSedC_FourTensor, CeM, dSedC_FourTensor, true);
     Core::LinAlg::FourTensor<3> CedSedC_T12_FourTensor(true);
     CedSedC_T12_FourTensor.transpose_12(CedSedC_FourTensor);
@@ -2148,7 +2153,7 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
     Core::LinAlg::Voigt::setup_6x6_voigt_matrix_from_four_tensor(temp6x6, CedSedC_T12_FourTensor);
     dMe_sym_dC.update(1.0 / 2.0, temp6x6, 1.0);
     Core::LinAlg::FourTensor<3> SedCedC_FourTensor(true);
-    Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+    Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
         SedCedC_FourTensor, SeM, dCedC_FourTensor, true);
     Core::LinAlg::FourTensor<3> SedCedC_T12_FourTensor(true);
     SedCedC_T12_FourTensor.transpose_12(SedCedC_FourTensor);
@@ -2205,10 +2210,10 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
         const_mat_tensors_.id_dyad_mm_, 1.0);
     dNpdMe_sym_dev.update(
         1.0 / 1.0 * 1.0 / equiv_stress * (A + 2 * B), const_non_mat_tensors.id4_6x6_, 1.0);
-    Core::LinAlg::Tensor::add_kronecker_tensor_product(dNpdMe_sym_dev,
+    Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(dNpdMe_sym_dev,
         1.0 / equiv_stress * (F - A - 2 * B), const_mat_tensors_.mm_, const_non_mat_tensors.id3x3_,
         1.0);
-    Core::LinAlg::Tensor::add_kronecker_tensor_product(dNpdMe_sym_dev,
+    Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(dNpdMe_sym_dev,
         1.0 / equiv_stress * (F - A - 2 * B), const_non_mat_tensors.id3x3_, const_mat_tensors_.mm_,
         1.0);
     dNpdMe_sym_dev.update(
@@ -2263,13 +2268,13 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   Core::LinAlg::Voigt::setup_four_tensor_from_6x9_voigt_matrix(
       ddpdiFin_FourTensor, state_quantity_derivatives.curr_ddpdiFin_);
   Core::LinAlg::FourTensor<3> id_plus_mm_ddpdiFin_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       id_plus_mm_ddpdiFin_FourTensor, const_mat_tensors_.id_plus_mm_, ddpdiFin_FourTensor, true);
   Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(
       temp9x9, id_plus_mm_ddpdiFin_FourTensor);
   state_quantity_derivatives.curr_dlpdiFin_.update(1.0, temp9x9, 0.0);
   Core::LinAlg::FourTensor<3> mm_ddpdiFin_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       mm_ddpdiFin_FourTensor, const_mat_tensors_.mm_, ddpdiFin_FourTensor, true);
   Core::LinAlg::FourTensor<3> mm_ddpdiFin_T12_FourTensor(true);
   mm_ddpdiFin_T12_FourTensor.transpose_12(mm_ddpdiFin_FourTensor);
@@ -2281,13 +2286,13 @@ Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_state_quantity_deriv
   Core::LinAlg::Voigt::setup_four_tensor_from_6x6_voigt_matrix(
       ddpdC_FourTensor, state_quantity_derivatives.curr_ddpdC_);
   Core::LinAlg::FourTensor<3> id_plus_mm_ddpdC_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       id_plus_mm_ddpdC_FourTensor, const_mat_tensors_.id_plus_mm_, ddpdC_FourTensor, true);
   Core::LinAlg::Voigt::setup_9x6_voigt_matrix_from_four_tensor(
       temp9x6, id_plus_mm_ddpdC_FourTensor);
   state_quantity_derivatives.curr_dlpdC_.update(1.0, temp9x6, 0.0);
   Core::LinAlg::FourTensor<3> mm_ddpdC_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       mm_ddpdC_FourTensor, const_mat_tensors_.mm_, ddpdC_FourTensor, true);
   Core::LinAlg::FourTensor<3> mm_ddpdC_T12_FourTensor(true);
   mm_ddpdC_T12_FourTensor.transpose_12(mm_ddpdC_FourTensor);
@@ -2406,7 +2411,7 @@ void Mat::InelasticDefgradTransvIsotropElastViscoplast::evaluate_additional_cmat
       Core::LinAlg::FourTensor<3> dEpdC_FourTensor(true);
       Core::LinAlg::Voigt::setup_four_tensor_from_9x6_voigt_matrix(
           dEpdC_FourTensor, state_quantity_derivatives_.curr_dEpdC_);
-      Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(tempFourTensor,
+      Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(tempFourTensor,
           time_step_quantities_.last_plastic_defgrd_inverse_[gp_], dEpdC_FourTensor);
       Core::LinAlg::Voigt::setup_9x6_voigt_matrix_from_four_tensor(rhs_iFin_V, tempFourTensor);
 
@@ -2786,7 +2791,7 @@ Core::LinAlg::Matrix<10, 10> Mat::InelasticDefgradTransvIsotropElastViscoplast::
   {
     // compute 9x9 north-west component block of the Jacobian (derivative of residual for
     // inelastic deformation gradient w.r.t. inelastic deformation gradient)
-    Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+    Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
         tempFourTensor, last_iFinM, dEpdiFin_FourTensor, true);
     Core::LinAlg::Voigt::setup_9x9_voigt_matrix_from_four_tensor(temp9x9, tempFourTensor);
     J_iFin_iFin.update(1.0, const_non_mat_tensors.id4_9x9_, -1.0, temp9x9, 0.0);
@@ -2825,7 +2830,7 @@ Core::LinAlg::Matrix<10, 10> Mat::InelasticDefgradTransvIsotropElastViscoplast::
     FOUR_C_ASSERT_ALWAYS(log_deriv_err_status == Core::LinAlg::MatrixFunctErrorType::no_errors,
         "Matrix logarithm derivative evaluation failed!");
     Core::LinAlg::Matrix<9, 9> dTdiFin(Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::add_non_symmetric_product(
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
         1.0, last_FinM, const_non_mat_tensors.id3x3_, dTdiFin);
     Core::LinAlg::Matrix<9, 9> dlogTdiFin(Core::LinAlg::Initialization::zero);
     dlogTdiFin.multiply_nn(1.0, dlogTdT, dTdiFin, 0.0);

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper.cpp
@@ -385,11 +385,11 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_cauchy_n_dir_and_deriva
     // gradient)
     static Core::LinAlg::Matrix<6, 9> d_be_dFe(Core::LinAlg::Initialization::zero);
     d_be_dFe.clear();
-    Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product_strain_like(
+    Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product_strain_like(
         d_be_dFe, idM, FeM, 1.0);
     static Core::LinAlg::Matrix<9, 9> d_Fe_dF(Core::LinAlg::Initialization::zero);
     d_Fe_dF.clear();
-    Core::LinAlg::Tensor::add_non_symmetric_product(1.0, idM, iFinM, d_Fe_dF);
+    Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, idM, iFinM, d_Fe_dF);
     static Core::LinAlg::Matrix<6, 9> d_be_dF(Core::LinAlg::Initialization::zero);
     d_be_dF.multiply(1.0, d_be_dFe, d_Fe_dF, 0.0);
 
@@ -487,7 +487,7 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_linearization_od(
   // calculate the derivative of the deformation gradient w.r.t. the inelastic deformation gradient
   static Core::LinAlg::Matrix<9, 9> d_F_dFin(Core::LinAlg::Initialization::zero);
   d_F_dFin.clear();
-  Core::LinAlg::Tensor::add_non_symmetric_product(1.0, FeM, idM, d_F_dFin);
+  Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, FeM, idM, d_F_dFin);
 
   static Core::LinAlg::Matrix<9, 1> d_Fin_dx(Core::LinAlg::Initialization::zero);
 
@@ -538,8 +538,8 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_stress_cmat_iso(
   cmatiso.multiply_nt(delta(4), iCinCiCinV, iCV, 1.);
   cmatiso.multiply_nt(delta(4), iCV, iCinCiCinV, 1.);
   cmatiso.multiply_nt(delta(5), iCV, iCV, 1.);
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatiso, iCV, delta(6));
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatiso, iCinV, delta(7));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatiso, iCV, delta(6));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatiso, iCinV, delta(7));
   cmatiso.scale(detFin);
 }
 
@@ -670,8 +670,10 @@ Core::LinAlg::Matrix<6, 9> Mat::MultiplicativeSplitDefgradElastHyper::evaluated_
 
   // derivative of second Piola Kirchhoff stresses w.r.t. inverse growth deformation gradient
   // (contribution from iFin)
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(dSdiFin, id, iFinM, gamma(0));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(dSdiFin, iCinCM, iFinM, gamma(1));
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
+      dSdiFin, id, iFinM, gamma(0));
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
+      dSdiFin, iCinCM, iFinM, gamma(1));
   dSdiFin.multiply_nt(delta(0), iCinV, CiFin9x1, 1.);
   dSdiFin.multiply_nt(delta(1), iCinV, CiFinCe9x1, 1.);
   dSdiFin.multiply_nt(delta(1), iCinCiCinV, CiFin9x1, 1.);
@@ -681,7 +683,8 @@ Core::LinAlg::Matrix<6, 9> Mat::MultiplicativeSplitDefgradElastHyper::evaluated_
   dSdiFin.multiply_nt(delta(4), iCinCiCinV, CiFiniCe9x1, 1.);
   dSdiFin.multiply_nt(delta(4), iCV, CiFinCe9x1, 1.);
   dSdiFin.multiply_nt(delta(5), iCV, CiFiniCe9x1, 1.);
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(dSdiFin, id, iFinCeM, gamma(1));
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
+      dSdiFin, id, iFinCeM, gamma(1));
   dSdiFin.scale(detFin);
 
   // derivative of second Piola Kirchhoff stresses w.r.t. inverse growth deformation gradient
@@ -788,14 +791,14 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_transv_iso_quantities(
 
   // F_{in}^{-1} \frac{\partial S_{e}}{\partial F^{-1}_{in}}
   Core::LinAlg::FourTensor<3> iFindSediFin_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       iFindSediFin_FourTensor, iFinM, dSediFin_FourTensor, true);
   // (F_{in}^{-1} \frac{\partial S_{e}}{\partial F^{-1}_{in}})^{T_{12}}
   Core::LinAlg::FourTensor<3> iFindSediFin_FourTensor_T12(true);
   iFindSediFin_FourTensor_T12.transpose_12(iFindSediFin_FourTensor);
   // [F_{in}^{-1} (F_{in}^{-1} \frac{\partial S_{e}}{\partial F^{-1}_{in}})^T_{12}]
   Core::LinAlg::FourTensor<3> iFin_iFindSediFin_T12_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       iFin_iFindSediFin_T12_FourTensor, iFinM, iFindSediFin_FourTensor_T12, true);
   Core::LinAlg::Matrix<6, 9> iFin_iFindSediFin_T12(
       Core::LinAlg::Initialization::zero);  // Voigt stress-form
@@ -805,12 +808,12 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_transv_iso_quantities(
 
   // [F_{in}^{-1} (F_{in}^{-1} \frac{\partial S_{e}}{\partial C})^T_{12}  ]^T_{12}
   Core::LinAlg::FourTensor<3> iFindSedC_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       iFindSedC_FourTensor, iFinM, dSedC_FourTensor, true);
   Core::LinAlg::FourTensor<3> iFindSedC_FourTensor_T12(true);
   iFindSedC_FourTensor_T12.transpose_12(iFindSedC_FourTensor);
   Core::LinAlg::FourTensor<3> iFin_iFindSedC_T12_FourTensor(true);
-  Core::LinAlg::Tensor::multiply_matrix_four_tensor<3>(
+  Core::LinAlg::FourTensorOperations::multiply_matrix_four_tensor<3>(
       iFin_iFindSedC_T12_FourTensor, iFinM, iFindSedC_FourTensor_T12, true);
   Core::LinAlg::Matrix<6, 6> iFin_iFindSedC_T12(
       Core::LinAlg::Initialization::zero);  // Voigt stress-stress-form
@@ -824,8 +827,8 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_transv_iso_quantities(
   // \frac{\partial S}{\partial F^{-1}_{in}}
   dSdiFin.update(1.0, iFin_iFindSediFin_T12, 1.0);
   temp9x9.clear();
-  Core::LinAlg::Tensor::add_non_symmetric_product(1.0, id3x3, SeiFinTM, temp9x9);
-  Core::LinAlg::Tensor::add_adbc_tensor_product(1.0, iFinSeM, id3x3, temp9x9);
+  Core::LinAlg::FourTensorOperations::add_non_symmetric_product(1.0, id3x3, SeiFinTM, temp9x9);
+  Core::LinAlg::FourTensorOperations::add_adbc_tensor_product(1.0, iFinSeM, id3x3, temp9x9);
   Core::LinAlg::Voigt::setup_four_tensor_from_9x9_voigt_matrix(tempFourTensor, temp9x9);
   Core::LinAlg::Voigt::setup_6x9_voigt_matrix_from_four_tensor(temp6x9, tempFourTensor);
   dSdiFin.update(1.0, temp6x9, 1.0);
@@ -900,7 +903,8 @@ Core::LinAlg::Matrix<6, 6> Mat::MultiplicativeSplitDefgradElastHyper::evaluate_a
       }
 
       // evaluate additional contribution to C by applying chain rule
-      Core::LinAlg::Tensor::add_non_symmetric_product(1.0, producta, productb, diFindiFinj);
+      Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+          1.0, producta, productb, diFindiFinj);
       dSdiFinj.multiply(1.0, dSdiFin, diFindiFinj, 0.0);
       facdefgradin[i].second->evaluate_additional_cmat(
           defgrad, productb, iFinjM[i].second, iCV, dSdiFinj, cmatadd);
@@ -1018,7 +1022,8 @@ void Mat::MultiplicativeSplitDefgradElastHyper::evaluate_od_stiff_mat(PAR::Inela
         }
 
         // evaluate additional contribution to OD block by applying chain rule
-        Core::LinAlg::Tensor::add_non_symmetric_product(1.0, producta, productb, diFindiFinj);
+        Core::LinAlg::FourTensorOperations::add_non_symmetric_product(
+            1.0, producta, productb, diFindiFinj);
         dSdiFinj.multiply(1.0, dSdiFin, diFindiFinj, 0.0);
         facdefgradin[i].second->evaluate_od_stiff_mat(
             defgrad, iFinjM[i].second, dSdiFinj, dstressdx);

--- a/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
+++ b/src/mat/4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp
@@ -113,8 +113,8 @@ namespace Mat
     cmat.multiply_nt(delta(4), iCinCiCinv, iCv, 1.);
     cmat.multiply_nt(delta(4), iCv, iCinCiCinv, 1.);
     cmat.multiply_nt(delta(5), iCv, iCv, 1.);
-    Core::LinAlg::Tensor::add_holzapfel_product(cmat, iCv, delta(6));
-    Core::LinAlg::Tensor::add_holzapfel_product(cmat, iCinv, delta(7));
+    Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmat, iCv, delta(6));
+    Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmat, iCinv, delta(7));
   }
 
 }  // namespace Mat

--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -378,10 +378,10 @@ void Mat::MuscleCombo::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
   ccmat.multiply_nt(
       (beta * J + 1.) * J * expbeta + kappa * std::pow(detC, -kappa), invCv, invCv, 1.0);
   // adds scalar * (invC boeppel invC) to cmat, see Holzapfel2000, p. 254
-  Core::LinAlg::Tensor::add_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(
       ccmat, invCv, -(J * expbeta - std::pow(detC, -kappa)));
   // adds -expbeta*detC * dinvCLinvCdCv to cmats
-  Core::LinAlg::Tensor::add_derivative_of_inva_b_inva_product(
+  Core::LinAlg::FourTensorOperations::add_derivative_of_inva_b_inva_product(
       -expbeta * detC, invCv, invCLinvCv, ccmat);
   // additional term for corrected derivative of strain energy function
   ccmat.multiply_nt(dEta / (8 * lambdaM), Mv, Mv, 1.0);

--- a/src/mat/4C_mat_muscle_weickenmeier.cpp
+++ b/src/mat/4C_mat_muscle_weickenmeier.cpp
@@ -333,10 +333,10 @@ void Mat::MuscleWeickenmeier::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
   ccmat.multiply_nt(
       (beta * J + 1.) * J * expbeta + kappa * std::pow(detC, -kappa), invCv, invCv, 1.0);
   // adds scalar * (invC boeppel invC) to cmat, see Holzapfel2000, p. 254
-  Core::LinAlg::Tensor::add_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(
       ccmat, invCv, -(J * expbeta - std::pow(detC, -kappa)));
   // adds -expbeta*detC * dinvCLinvCdCv to cmats
-  Core::LinAlg::Tensor::add_derivative_of_inva_b_inva_product(
+  Core::LinAlg::FourTensorOperations::add_derivative_of_inva_b_inva_product(
       -expbeta * detC, invCv, invCLinvCv, ccmat);
   ccmat.scale(gamma);
 

--- a/src/mat/4C_mat_plastic_VarConstUpdate.cpp
+++ b/src/mat/4C_mat_plastic_VarConstUpdate.cpp
@@ -503,7 +503,8 @@ void Mat::PlasticElastHyperVCU::eval_dce_dlp(const Core::LinAlg::Matrix<3, 3> fp
 
   Core::LinAlg::Matrix<3, 3> tmp;
   tmp.multiply_tn(next_fpi, rcg);
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(dcedfpi, tmp, id2, 1.0);
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
+      dcedfpi, tmp, id2, 1.0);
 
   // Derivative of inverse plastic deformation gradient
   dFpiDdeltaDp.clear();
@@ -748,9 +749,9 @@ void Mat::PlasticElastHyperVCU::evaluate_plast(Core::LinAlg::Matrix<6, 9>& dPK2d
     const Core::LinAlg::Matrix<9, 1>& CFpiCe, const Core::LinAlg::Matrix<6, 1>& CpiCCpi)
 {
   // derivative of PK2 w.r.t. inverse plastic deformation gradient
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dPK2dFpinvIsoprinc, id2, Fpi, gamma(0));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dPK2dFpinvIsoprinc, CpiC, Fpi, gamma(1));
   dPK2dFpinvIsoprinc.multiply_nt(delta(0), Cpi, CFpi, 1.);
   dPK2dFpinvIsoprinc.multiply_nt(delta(1), Cpi, CFpiCe, 1.);
@@ -761,7 +762,7 @@ void Mat::PlasticElastHyperVCU::evaluate_plast(Core::LinAlg::Matrix<6, 9>& dPK2d
   dPK2dFpinvIsoprinc.multiply_nt(delta(4), CpiCCpi, CFpiCei, 1.);
   dPK2dFpinvIsoprinc.multiply_nt(delta(4), ircg, CFpiCe, 1.);
   dPK2dFpinvIsoprinc.multiply_nt(delta(5), ircg, CFpiCei, 1.);
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dPK2dFpinvIsoprinc, id2, FpiCe, 0.5 * delta(7));
 }
 

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -502,18 +502,24 @@ void Mat::PlasticElastHyper::setup_hill_plasticity(
 
     // calculate plastic anisotropy tensor
     PlAniso_full_.clear();
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(PlAniso_full_, alpha1, M0, M0, 1.);
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(PlAniso_full_, alpha2, M1, M1, 1.);
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(PlAniso_full_, alpha3, M2, M2, 1.);
-    Core::LinAlg::Tensor::add_symmetric_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+        PlAniso_full_, alpha1, M0, M0, 1.);
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+        PlAniso_full_, alpha2, M1, M1, 1.);
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+        PlAniso_full_, alpha3, M2, M2, 1.);
+    Core::LinAlg::FourTensorOperations::add_symmetric_elasticity_tensor_product(
         PlAniso_full_, 0.5 * (alpha3 - alpha1 - alpha2), M0, M1, 1.);
-    Core::LinAlg::Tensor::add_symmetric_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_symmetric_elasticity_tensor_product(
         PlAniso_full_, 0.5 * (alpha1 - alpha2 - alpha3), M1, M2, 1.);
-    Core::LinAlg::Tensor::add_symmetric_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_symmetric_elasticity_tensor_product(
         PlAniso_full_, 0.5 * (alpha2 - alpha3 - alpha1), M0, M2, 1.);
-    Core::LinAlg::Tensor::add_symmetric_holzapfel_product(PlAniso_full_, M0, M1, alpha4);
-    Core::LinAlg::Tensor::add_symmetric_holzapfel_product(PlAniso_full_, M1, M2, alpha5);
-    Core::LinAlg::Tensor::add_symmetric_holzapfel_product(PlAniso_full_, M0, M2, alpha6);
+    Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
+        PlAniso_full_, M0, M1, alpha4);
+    Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
+        PlAniso_full_, M1, M2, alpha5);
+    Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
+        PlAniso_full_, M0, M2, alpha6);
 
     // we need this matrix to get rid of the zero eigenvalue to be able to invert
     // the anisotropy tensor. After the inversion we expand the tensor again to 6x6
@@ -659,11 +665,11 @@ void Mat::PlasticElastHyper::evaluate_thermal_stress(const Core::LinAlg::Matrix<
   icg(5) = invRCG(0, 2);
 
   pk2->update(-3. * cte() * deltaT * modinv(2) * ddPmodII(2), icg, 1.);
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       *cmat, -3. * cte() * deltaT * modinv(2) * modinv(2) * dddPmodIII, invRCG, invRCG, 1.);
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       *cmat, -3. * cte() * deltaT * modinv(2) * ddPmodII(2), invRCG, invRCG, 1.);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
       *cmat, +6. * cte() * deltaT * modinv(2) * ddPmodII(2), invRCG, invRCG, 1.);
 
   return;
@@ -716,11 +722,11 @@ void Mat::PlasticElastHyper::evaluate_c_tvol(const Core::LinAlg::Matrix<3, 3>* d
   icg(5) = invRCG(0, 2);
 
   cTvol->update(-3. * cte() * modinv(2) * ddPmodII(2), icg, 1.);
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       *dCTvoldE, -3. * cte() * modinv(2) * modinv(2) * dddPmodIII, invRCG, invRCG, 1.);
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       *dCTvoldE, -3. * cte() * modinv(2) * ddPmodII(2), invRCG, invRCG, 1.);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
       *dCTvoldE, +6. * cte() * modinv(2) * ddPmodII(2), invRCG, invRCG, 1.);
 
   return;
@@ -1814,18 +1820,18 @@ void Mat::PlasticElastHyper::evaluate_cauchy_plast(const Core::LinAlg::Matrix<3,
       (.5 * dPI(1) / prinv_(2) - ddPII(3)) / sqrt(prinv_(2)), be2v_, CFpiCei_, 1.);
   d_cauchy_dFpi.scale(2.);
 
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       d_cauchy_dFpi, *defgrd, Fe_, (dPI(0) + prinv_(0) * dPI(1)) / sqrt(prinv_(2)));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       d_cauchy_dFpi, *defgrd, beFe_, -dPI(1) / sqrt(prinv_(2)));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       d_cauchy_dFpi, beF_, Fe_, -dPI(1) / sqrt(prinv_(2)));
 
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       d_cauchy_dF, id2_, FCpi_, (dPI(0) + prinv_(0) * dPI(1)) / sqrt(prinv_(2)));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       d_cauchy_dF, id2_, beFCpi_, -dPI(1) / sqrt(prinv_(2)));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       d_cauchy_dF, be_, FCpi_, -dPI(1) / sqrt(prinv_(2)));
   d_cauchy_dF.scale(2.);
   d_cauchy_dFpi.scale(2.);
@@ -2228,8 +2234,8 @@ void Mat::PlasticElastHyper::evaluate_isotropic_princ_elast(
   cmatisoprinc.multiply_nt(delta(4), CpiCCpi_, ircg_, 1.);
   cmatisoprinc.multiply_nt(delta(4), ircg_, CpiCCpi_, 1.);
   cmatisoprinc.multiply_nt(delta(5), ircg_, ircg_, 1.);
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatisoprinc, ircg_, delta(6));
-  Core::LinAlg::Tensor::add_holzapfel_product(cmatisoprinc, Cpi_, delta(7));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatisoprinc, ircg_, delta(6));
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmatisoprinc, Cpi_, delta(7));
 
   return;
 }
@@ -2243,9 +2249,9 @@ void Mat::PlasticElastHyper::evaluate_isotropic_princ_plast(
     const Core::LinAlg::Matrix<8, 1>& delta)
 {
   // derivative of PK2 w.r.t. inverse plastic deformation gradient
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dPK2dFpinvIsoprinc, id2_, invpldefgrd_, gamma(0));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dPK2dFpinvIsoprinc, CpiC_, invpldefgrd_, gamma(1));
   dPK2dFpinvIsoprinc.multiply_nt(delta(0), Cpi_, CFpi_, 1.);
   dPK2dFpinvIsoprinc.multiply_nt(delta(1), Cpi_, CFpiCe_, 1.);
@@ -2256,7 +2262,7 @@ void Mat::PlasticElastHyper::evaluate_isotropic_princ_plast(
   dPK2dFpinvIsoprinc.multiply_nt(delta(4), CpiCCpi_, CFpiCei_, 1.);
   dPK2dFpinvIsoprinc.multiply_nt(delta(4), ircg_, CFpiCe_, 1.);
   dPK2dFpinvIsoprinc.multiply_nt(delta(5), ircg_, CFpiCei_, 1.);
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dPK2dFpinvIsoprinc, id2_, FpiCe_, 0.5 * delta(7));
 
   // Mandel stress
@@ -2273,9 +2279,9 @@ void Mat::PlasticElastHyper::evaluate_isotropic_princ_plast(
   MandelStressIsoprinc(2, 0) += Mv(5);
 
   // derivative of Mandel stress w.r.t. GL
-  Core::LinAlg::Tensor::add_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
       dMdCisoprinc, invpldefgrd_, invpldefgrd_, .5 * gamma(0));
-  Core::LinAlg::Tensor::add_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(
       dMdCisoprinc, invpldefgrd_, FpiCe_, gamma(1));
   dMdCisoprinc.multiply_nt(delta(0), Ce_, Cpi_, 1.);
   dMdCisoprinc.multiply_nt(delta(1), Ce_, CpiCCpi_, 1.);
@@ -2288,11 +2294,11 @@ void Mat::PlasticElastHyper::evaluate_isotropic_princ_plast(
   dMdCisoprinc.multiply_nt(delta(5), id2V_, ircg_, 1.);
 
   // derivative of Mandel stress w.r.t. inverse plastic deformation gradient
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dMdFpinvIsoprinc, FpiTC_, id2_, gamma(0));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dMdFpinvIsoprinc, FpiTC_, CeM_, gamma(1));
-  Core::LinAlg::Tensor::add_right_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_right_non_symmetric_holzapfel_product(
       dMdFpinvIsoprinc, CeFpiTC_, id2_, gamma(1));
   dMdFpinvIsoprinc.multiply_nt(delta(0), Ce_, CFpi_, 1.);
   dMdFpinvIsoprinc.multiply_nt(delta(1), Ce_, CFpiCe_, 1.);

--- a/src/mat/4C_mat_plasticgtn.cpp
+++ b/src/mat/4C_mat_plasticgtn.cpp
@@ -243,7 +243,7 @@ void Mat::PlasticGTN::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
 
   // compute trial stress
   Core::LinAlg::Matrix<3, 3, double> stress_trial(stress_n_.at(gp));
-  Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(
+  Core::LinAlg::FourTensorOperations::add_contraction_matrix_four_tensor(
       stress_trial, 1.0, Ce, incremental_strain);
 
   const double p_trial = 1.0 / 3 * (stress_trial(0, 0) + stress_trial(1, 1) + stress_trial(2, 2));
@@ -423,21 +423,21 @@ void Mat::PlasticGTN::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
     // populate the consistent tangent operator
     Core::LinAlg::FourTensor<3> Cep = Core::LinAlg::setup_deviatoric_projection_tensor<3>(
         2 * G * (1.0 - 3 * G * dlambda / q_trial * (1.0 - f_n1) * dsigmastar_dq));
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
         Cep, 6 * G * G * dlambda / q_trial * (1.0 - f_n1) * dsigmastar_dq, nhat, nhat);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
         Cep, sqrt(6.0) * G * dlambda * dsigmastar_dq, nhat, df_de);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
         Cep, -sqrt(6.0) * G * (1.0 - f_n1) * dlambda * d2sigmastar_dq2, nhat, dq_de);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
         Cep, -sqrt(6.0) * G * (1.0 - f_n1) * dlambda * d2sigmastar_dqdp, nhat, dp_de);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(Cep,
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(Cep,
         -sqrt(6.0) * G * (1.0 - f_n1) * dlambda * d2sigmastar_dqdsigmastar, nhat, dsigmastar_de);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
         Cep, -sqrt(6.0) * G * (1.0 - f_n1) * dlambda * d2sigmastar_dqdf, nhat, df_de);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(
         Cep, -sqrt(6.0) * G * (1.0 - f_n1) * dsigmastar_dq, nhat, ddlambda_de);
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(Cep, 1.0, eye, dp_de);
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(Cep, 1.0, eye, dp_de);
 
     // transform back to matrix
     Core::LinAlg::Voigt::setup_6x6_voigt_matrix_from_four_tensor(*cmat, Cep);

--- a/src/mat/4C_mat_plasticnlnlogneohooke.cpp
+++ b/src/mat/4C_mat_plasticnlnlogneohooke.cpp
@@ -604,7 +604,7 @@ void Mat::PlasticNlnLogNeoHooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defg
     // - sum_1^3 (2 * tau N_aaaa)
     tmp1.multiply_nt(
         material_principal_directions.at(a), material_principal_directions.at(a));  // N_{aa}
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
         *cmat, -2.0 * (dev_KH(a) + pressure), tmp1, tmp1, 1.0);
 
     for (int b = 0; b < 3; b++)
@@ -615,7 +615,7 @@ void Mat::PlasticNlnLogNeoHooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defg
           material_principal_directions.at(a), material_principal_directions.at(a));  // N_{aa}
       tmp2.multiply_nt(
           material_principal_directions.at(b), material_principal_directions.at(b));  // N_{bb}
-      Core::LinAlg::Tensor::add_elasticity_tensor_product(
+      Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
           *cmat, D_ep_principal(a, b), tmp1, tmp2, 1.0);
 
       if (a != b)
@@ -634,9 +634,9 @@ void Mat::PlasticNlnLogNeoHooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defg
             material_principal_directions.at(a), material_principal_directions.at(b));  // N_{ab}
         tmp2.multiply_nt(
             material_principal_directions.at(b), material_principal_directions.at(a));  // N_{ba}
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
             *cmat, fac, tmp1, tmp1, 1.0);  // N_{abab}
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
             *cmat, fac, tmp1, tmp2, 1.0);  // N_{abba}
       }  // end if (a!=b)
     }  // end loop b

--- a/src/mat/4C_mat_service.cpp
+++ b/src/mat/4C_mat_service.cpp
@@ -113,7 +113,7 @@ void Mat::volumetrify_and_isochorify(Core::LinAlg::Matrix<6, 1>* pk2vol,
     Core::LinAlg::Matrix<6, 6> cvol_tmp(Core::LinAlg::Initialization::uninitialized);
     if (cvol != nullptr) cvol_tmp.set_view(*cvol);
     cvol_tmp.multiply_nt(2.0 / 3.0, icg, pk2lin);
-    Core::LinAlg::Tensor::add_holzapfel_product(cvol_tmp, icg, -2.0 / 3.0 * pk2rcg);
+    Core::LinAlg::FourTensorOperations::add_holzapfel_product(cvol_tmp, icg, -2.0 / 3.0 * pk2rcg);
 
     // isochoric part of constitutive tensor
     // C^{ABCD}_iso = C^{ABCD} - C^{ABCD}_vol

--- a/src/mat/4C_mat_superelastic_sma.cpp
+++ b/src/mat/4C_mat_superelastic_sma.cpp
@@ -860,13 +860,13 @@ void Mat::SuperElasticSMA::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
     cmat_eul_2.scale(2.0 * G_star);
 
     // Build up (n (x) n) and scale with M1*
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
         cmat_eul_3, M1_star, scaled_load_deviatoric_tensor, scaled_load_deviatoric_tensor, 0.0);
 
     // Build up (n (x) 1 + 1 (x) n) and scale with M2*
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
         cmat_eul_4, -M2_star, scaled_load_deviatoric_tensor, eye, 0.0);
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
         cmat_eul_4_tmp, -M2_star, eye, scaled_load_deviatoric_tensor, 0.0);
     cmat_eul_4.update(1.0, cmat_eul_4_tmp, 1.0);
 
@@ -935,7 +935,7 @@ void Mat::SuperElasticSMA::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
       // - sum_1^3 (2 * tau N_aaaa)
       tmp1.multiply_nt(
           material_principal_directions.at(a), material_principal_directions.at(a));  // N_{aa}
-      Core::LinAlg::Tensor::add_elasticity_tensor_product(
+      Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
           *cmat, -2.0 * (dev_KH(a) + pressure), tmp1, tmp1, 1.0);
 
       for (int b = 0; b < 3; b++)
@@ -946,7 +946,7 @@ void Mat::SuperElasticSMA::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
             material_principal_directions.at(a), material_principal_directions.at(a));  // N_{aa}
         tmp2.multiply_nt(
             material_principal_directions.at(b), material_principal_directions.at(b));  // N_{bb}
-        Core::LinAlg::Tensor::add_elasticity_tensor_product(
+        Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
             *cmat, D_ep_principal(a, b), tmp1, tmp2, 1.0);
 
         if (a != b)
@@ -970,9 +970,9 @@ void Mat::SuperElasticSMA::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
               material_principal_directions.at(a), material_principal_directions.at(b));  // N_{ab}
           tmp2.multiply_nt(
               material_principal_directions.at(b), material_principal_directions.at(a));  // N_{ba}
-          Core::LinAlg::Tensor::add_elasticity_tensor_product(
+          Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
               *cmat, fac, tmp1, tmp1, 1.0);  // N_{abab}
-          Core::LinAlg::Tensor::add_elasticity_tensor_product(
+          Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
               *cmat, fac, tmp1, tmp2, 1.0);  // N_{abba}
 
         }  // end if (a!=b)

--- a/src/mat/4C_mat_thermoplastichyperelast.cpp
+++ b/src/mat/4C_mat_thermoplastichyperelast.cpp
@@ -1037,12 +1037,12 @@ void Mat::ThermoPlasticHyperElast::setup_cmat_elasto_plastic(
   // with I_d = I_s - 1/3 . I \otimes I
   // pull-back of I --> invRCG
   // Cbar += Cbar_trial = 2 . mubar . pullback_I_d
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
       Cbar_trialMaterial, 2.0 * mubar, invRCG, invRCG, 1.0);
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       Cbar_trialMaterial, -2.0 / 3.0 * mubar, invRCG, invRCG, 1.0);
   // Cbar += - 2/3 qbar [N \otimes C^{-1} + C^{-1} \otimes N]
-  Core::LinAlg::Tensor::add_symmetric_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_symmetric_elasticity_tensor_product(
       Cbar_trialMaterial, -2.0 / 3.0 * q_trial, N, invRCG, 1.0);
 
   // ------------------------------------------------ volumetric part C_e
@@ -1050,8 +1050,9 @@ void Mat::ThermoPlasticHyperElast::setup_cmat_elasto_plastic(
   // with U'(J) = bulk/2 . (J^2 -1)  / J
   // C_e = bulk . J^2 [C^{-1} \otimes C^{-1}] - bulk ( J^2 -1 ) [C^{-1} \otimes C^{-1}]
   // with - bulk ( J^2 -1 ) [C^{-1} \otimes C^{-1}] = - bulk ( J^2 -1 ) [C^{-1} boeppel C^{-1}]
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(Cmat, bulk * J * J, invRCG, invRCG, 1.0);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+      Cmat, bulk * J * J, invRCG, invRCG, 1.0);
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
       Cmat, -1.0 * bulk * (J * J - 1.0), invRCG, invRCG, 1.0);
   Cmat.update(1.0, Cbar_trialMaterial, 1.0);
 
@@ -1086,8 +1087,9 @@ void Mat::ThermoPlasticHyperElast::setup_cmat_elasto_plastic(
 
     // this is nonlinear mechanics
     Cmat.update((-1.0 * beta1), Cbar_trialMaterial, 1.0);
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(Cmat, (-2.0 * mubar * beta3), N, N, 1.0);
-    Core::LinAlg::Tensor::add_elasticity_tensor_product(
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
+        Cmat, (-2.0 * mubar * beta3), N, N, 1.0);
+    Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
         Cmat, (-2.0 * mubar * beta4), N, devNsquare, 1.0);
   }  // Dgamma != 0
 
@@ -1220,9 +1222,9 @@ void Mat::ThermoPlasticHyperElast::setup_cmat_thermo(const double temperature,
   // cmat_T = 2 . dS_vol,dT/dd
   //        = (T - T_0) . m_0/2 . (J - 1/J) (C^{-1} \otimes C^{-1})
   //          - (T - T_0) . m_0 . (J + 1/J) ( Cinv boeppel Cinv )
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       cmat_T, (deltaT * m_0 / 2.0 * (J - 1 / J)), invRCG, invRCG, 1.0);
-  Core::LinAlg::Tensor::add_kronecker_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_kronecker_tensor_product(
       cmat_T, (-deltaT * m_0 * (J + 1 / J)), invRCG, invRCG, 1.0);
 
 

--- a/src/mat/4C_mat_viscoanisotropic.cpp
+++ b/src/mat/4C_mat_viscoanisotropic.cpp
@@ -457,14 +457,16 @@ void Mat::ViscoAnisotropic::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
   Core::LinAlg::Matrix<NUM_STRESS_3D, NUM_STRESS_3D> CisoEla_nh(
       Core::LinAlg::Initialization::zero);  // isochoric elastic C from NeoHooke
 
-  Core::LinAlg::Tensor::add_holzapfel_product((*cmat), Cinv, (-2 * J * p));  // -2 J p Cinv o Cinv
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(
+      (*cmat), Cinv, (-2 * J * p));  // -2 J p Cinv o Cinv
 
   const double fac = 2 * third * incJ * mue * I1;  // 2/3 J^{-2/3} Sbar:C
   // fac Psl = fac (Cinv o Cinv) - fac/3 (Cinv x Cinv)
 
   Core::LinAlg::Matrix<NUM_STRESS_3D, NUM_STRESS_3D> Psl(
       Core::LinAlg::Initialization::zero);  // Psl = Cinv o Cinv - 1/3 Cinv x Cinv
-  Core::LinAlg::Tensor::add_holzapfel_product(Psl, Cinv, 1.0);  // first part Psl = Cinv o Cinv
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(
+      Psl, Cinv, 1.0);  // first part Psl = Cinv o Cinv
 
   for (int i = 0; i < 6; ++i)
   {

--- a/src/mat/4C_mat_viscoelasthyper.cpp
+++ b/src/mat/4C_mat_viscoelasthyper.cpp
@@ -821,7 +821,7 @@ void Mat::ViscoElastHyper::evaluate_iso_visco_modified(
   // contribution: 2/3*Tr(J^(-2/3)modstress) (Cinv \odot Cinv - 1/3 Cinv \otimes Cinv)
   modcmat.clear();
   modcmat.multiply_nt(-1.0 / 3.0, icg, icg);
-  Core::LinAlg::Tensor::add_holzapfel_product(modcmat, icg, 1.0);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(modcmat, icg, 1.0);
   Core::LinAlg::Matrix<1, 1> tracemat;
   tracemat.multiply_tn(2. / 3. * std::pow(modinv(2), -2. / 3.), modstress, rcg);
   cmatisomodisovisco.update(tracemat(0, 0), modcmat, 1.0);

--- a/src/mat/4C_mat_visconeohooke.cpp
+++ b/src/mat/4C_mat_visconeohooke.cpp
@@ -369,10 +369,10 @@ void Mat::ViscoNeoHooke::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
 
   // add volumetric elastic part 1
   // add scalar2 Cinv o Cinv (see Holzapfel p. 254)
-  Core::LinAlg::Tensor::add_holzapfel_product((*cmat), Cinv, scalar2);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product((*cmat), Cinv, scalar2);
 
   // add visco-elastic deviatoric part 1
-  Core::LinAlg::Tensor::add_holzapfel_product(*cmat, Cinv, scalarvisco * scalar3);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(*cmat, Cinv, scalarvisco * scalar3);
 
   for (int i = 0; i < 6; ++i)
   {

--- a/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
+++ b/src/mat/elast/4C_mat_elast_isoanisoexpo.cpp
@@ -123,7 +123,7 @@ void Mat::Elastic::IsoAnisoExpo::add_stress_aniso_modified(const Core::LinAlg::M
 
   Core::LinAlg::Matrix<6, 6> Psl(
       Core::LinAlg::Initialization::zero);  // Psl = Cinv o Cinv - 1/3 Cinv x Cinv
-  Core::LinAlg::Tensor::add_holzapfel_product(Psl, icg, 1.0);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(Psl, icg, 1.0);
   Psl.multiply_nt(-1. / 3., icg, icg, 1.0);
 
   Core::LinAlg::Matrix<6, 1> Aiso(structural_tensor_);

--- a/src/mat/elast/4C_mat_elast_isomuscle_blemker.cpp
+++ b/src/mat/elast/4C_mat_elast_isomuscle_blemker.cpp
@@ -228,15 +228,15 @@ void Mat::Elastic::IsoMuscleBlemker::add_stress_aniso_modified(
   modcmat.update(delta8, IddI5sumdI5Id, 1.0);
   modcmat.update(delta10, dI5dI5, 1.0);
   modcmat.update(delta11, MdI5sumdI5M, 1.0);
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       modcmat, delta12, Id3, M, 1.0);  // summand 12 = ddI5/dC^2 = Id_ik*M_jl ...
-  Core::LinAlg::Tensor::add_elasticity_tensor_product(
+  Core::LinAlg::FourTensorOperations::add_elasticity_tensor_product(
       modcmat, delta12, M, Id3, 1.0);  // ... + M_ik*Id_jl
   modcmat.scale(std::pow(J, -4.0 / 3.0));
 
   // modified projection tensor Psl = Cinv o Cinv - 1/3 Cinv x Cinv
   Core::LinAlg::Matrix<6, 6> Psl(Core::LinAlg::Initialization::zero);
-  Core::LinAlg::Tensor::add_holzapfel_product(Psl, icg, 1.0);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(Psl, icg, 1.0);
   Psl.multiply_nt(-1.0 / 3.0, icg, icg, 1.0);
 
   // Right Cauchy-Green tensor in stress-like Voigt notation

--- a/src/mat/elast/4C_mat_elast_remodelfiber.cpp
+++ b/src/mat/elast/4C_mat_elast_remodelfiber.cpp
@@ -1231,7 +1231,7 @@ void Mat::Elastic::RemodelFiber::evaluated_evolution_equationd_c(Core::LinAlg::M
   static Core::LinAlg::Matrix<3, 3> iFrTFrdotTiFinTM(Core::LinAlg::Initialization::zero);
   iFinTM.update_t(1.0, iFinM, 0.0);
   iFrTFrdotTiFinTM.multiply_tt(1.0, FrdotiFrM, iFinM, 0.0);
-  Core::LinAlg::Tensor::add_left_non_symmetric_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_left_non_symmetric_holzapfel_product(
       dYdC, iFinTM, iFrTFrdotTiFinTM, 0.5);
 
   fiberdat.remodel->evaluated_funcid_c(

--- a/src/membrane/4C_membrane_evaluate.cpp
+++ b/src/membrane/4C_membrane_evaluate.cpp
@@ -375,7 +375,8 @@ int Discret::Elements::Membrane<distype>::evaluate(Teuchos::ParameterList& param
         mem_defgrd_global(dXds1, dXds2, dxds1, dxds2, lambda3, defgrd_glob);
 
         // surface deformation gradient in 3 dimensions in local coordinates
-        Core::LinAlg::Tensor::inverse_tensor_rotation<3>(Q_localToGlobal, defgrd_glob, defgrd_loc);
+        Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<3>(
+            Q_localToGlobal, defgrd_glob, defgrd_loc);
 
         /*===============================================================================*
          | right cauchygreen tensor in local coordinates                                 |
@@ -754,7 +755,8 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
     mem_defgrd_global(dXds1, dXds2, dxds1, dxds2, lambda3, defgrd_glob);
 
     // surface deformation gradient in 3 dimensions in local coordinates
-    Core::LinAlg::Tensor::inverse_tensor_rotation<3>(Q_localToGlobal, defgrd_glob, defgrd_loc);
+    Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<3>(
+        Q_localToGlobal, defgrd_glob, defgrd_loc);
 
     /*===============================================================================*
      | right cauchygreen tensor in local coordinates                                 |
@@ -800,7 +802,8 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
       mem_defgrd_global(dXds1, dXds2, dxds1, dxds2, lambda3, defgrd_glob);
 
       // update surface deformation gradient in 3 dimensions in local coordinates
-      Core::LinAlg::Tensor::inverse_tensor_rotation<3>(Q_localToGlobal, defgrd_glob, defgrd_loc);
+      Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<3>(
+          Q_localToGlobal, defgrd_glob, defgrd_loc);
 
       // update three dimensional right cauchy-green strain tensor in orthonormal base
       cauchygreen_loc.multiply_tn(1.0, defgrd_loc, defgrd_loc, 0.0);
@@ -823,11 +826,13 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
 
       // Transform stress and elasticity into the local membrane coordinate system
       Core::LinAlg::Matrix<3, 3> pk2M_loc(Core::LinAlg::Initialization::zero);
-      Core::LinAlg::Tensor::inverse_tensor_rotation<3>(Q_localToGlobal, pk2M_glob, pk2M_loc);
+      Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<3>(
+          Q_localToGlobal, pk2M_glob, pk2M_loc);
       Internal::local_plane_stress_to_stress_like_voigt(pk2M_loc, pk2red_loc);
 
       Core::LinAlg::Matrix<6, 6> cmat_loc(Core::LinAlg::Initialization::zero);
-      Core::LinAlg::Tensor::inverse_fourth_tensor_rotation(Q_localToGlobal, cmat_glob, cmat_loc);
+      Core::LinAlg::FourTensorOperations::inverse_fourth_tensor_rotation(
+          Q_localToGlobal, cmat_glob, cmat_loc);
       Internal::local_fourth_tensor_plane_stress_to_stress_like_voigt(cmat_loc, cmatred_loc);
     }
     else
@@ -969,7 +974,7 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
 
         // transform local cauchygreen to global coordinates
         Core::LinAlg::Matrix<noddof_, noddof_> cauchygreen_glob(Core::LinAlg::Initialization::zero);
-        Core::LinAlg::Tensor::tensor_rotation<3>(
+        Core::LinAlg::FourTensorOperations::tensor_rotation<3>(
             Q_localToGlobal, cauchygreen_loc, cauchygreen_glob);
 
         // green-lagrange strain tensor in global coordinates
@@ -999,7 +1004,7 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
 
         // transform local cauchygreen to global coordinates
         Core::LinAlg::Matrix<noddof_, noddof_> cauchygreen_glob(Core::LinAlg::Initialization::zero);
-        Core::LinAlg::Tensor::tensor_rotation<3>(
+        Core::LinAlg::FourTensorOperations::tensor_rotation<3>(
             Q_localToGlobal, cauchygreen_loc, cauchygreen_glob);
 
         // green-lagrange strain tensor in global coordinates
@@ -1040,7 +1045,7 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
 
         // transform local cauchygreen to global coordinates
         Core::LinAlg::Matrix<noddof_, noddof_> cauchygreen_glob(Core::LinAlg::Initialization::zero);
-        Core::LinAlg::Tensor::tensor_rotation<3>(
+        Core::LinAlg::FourTensorOperations::tensor_rotation<3>(
             Q_localToGlobal, cauchygreen_loc, cauchygreen_glob);
 
         // eigenvalue decomposition (from elasthyper.cpp)
@@ -1159,7 +1164,8 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
 
         // determine 2nd Piola-Kirchhoff stresses in global coordinates
         Core::LinAlg::Matrix<noddof_, noddof_> pkstress_glob(Core::LinAlg::Initialization::zero);
-        Core::LinAlg::Tensor::tensor_rotation<3>(Q_localToGlobal, pkstressM_local, pkstress_glob);
+        Core::LinAlg::FourTensorOperations::tensor_rotation<3>(
+            Q_localToGlobal, pkstressM_local, pkstress_glob);
 
         (*elestress)(gp, 0) = pkstress_glob(0, 0);
         (*elestress)(gp, 1) = pkstress_glob(1, 1);
@@ -1184,7 +1190,8 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
 
         // determine 2nd Piola-Kirchhoff stresses in global coordinates
         Core::LinAlg::Matrix<noddof_, noddof_> pkstress_glob(Core::LinAlg::Initialization::zero);
-        Core::LinAlg::Tensor::tensor_rotation<3>(Q_localToGlobal, pkstressM_loc, pkstress_glob);
+        Core::LinAlg::FourTensorOperations::tensor_rotation<3>(
+            Q_localToGlobal, pkstressM_loc, pkstress_glob);
 
         Core::LinAlg::Matrix<noddof_, noddof_> cauchy_glob(Core::LinAlg::Initialization::zero);
         mem_p_k2to_cauchy(pkstress_glob, defgrd_glob, cauchy_glob);
@@ -1575,7 +1582,8 @@ void Discret::Elements::Membrane<distype>::update_element(
       // surface deformation gradient in 3 dimensions in global coordinates
       mem_defgrd_global(dXds1, dXds2, dxds1, dxds2, lambda3, defgrd_glob);
 
-      Core::LinAlg::Tensor::inverse_tensor_rotation<3>(Q_localToGlobal, defgrd_glob, defgrd_loc);
+      Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<3>(
+          Q_localToGlobal, defgrd_glob, defgrd_loc);
 
       auto material_local_coordinates =
           std::dynamic_pointer_cast<Mat::MembraneMaterialLocalCoordinates>(

--- a/src/mixture/4C_mixture_constituent_elasthyper_elastin_membrane.cpp
+++ b/src/mixture/4C_mixture_constituent_elasthyper_elastin_membrane.cpp
@@ -357,7 +357,7 @@ void Mixture::MixtureConstituentElastHyperElastinMembrane::evaluate_stress_c_mat
       Core::LinAlg::Initialization::uninitialized);
   dAradgriXAradgr_symdC.clear();
 
-  Core::LinAlg::Tensor::add_holzapfel_product(
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(
       dAradgriXAradgr_symdC, iFinTAorthgrTiXTAorthgriFin_sym_stress, -2.0);
 
   cmat.multiply_nt(2.0 * mue * mue_frac_[gp] / detX, iFinTAorthgrTiXTAorthgriFin_sym_stress,

--- a/src/mixture/4C_mixture_growth_strategy_stiffness.cpp
+++ b/src/mixture/4C_mixture_growth_strategy_stiffness.cpp
@@ -74,7 +74,7 @@ void Mixture::StiffnessGrowthStrategy::evaluate_growth_stress_cmat(
   // contribution: Cinv \otimes Cinv
   cmat.multiply_nt(delta5, iC_stress, iC_stress, 0.0);
   // contribution: Cinv \odot Cinv
-  Core::LinAlg::Tensor::add_holzapfel_product(cmat, iC_stress, delta6);
+  Core::LinAlg::FourTensorOperations::add_holzapfel_product(cmat, iC_stress, delta6);
 
   cmat.multiply_nn(dgamma2DGrowthScalar, iC_stress, dCurrentReferenceGrowthScalarDC, 1.0);
 }

--- a/src/shell7p/4C_shell7p_ele_calc_lib.hpp
+++ b/src/shell7p/4C_shell7p_ele_calc_lib.hpp
@@ -943,7 +943,7 @@ namespace Discret::Elements::Shell
     // map gl strains from curvilinear system to global cartesian system
     Core::LinAlg::Matrix<Internal::num_dim, Internal::num_dim> gl_strain_tensor_cartesian(
         Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::inverse_tensor_rotation<Internal::num_dim>(
+    Core::LinAlg::FourTensorOperations::inverse_tensor_rotation<Internal::num_dim>(
         g_reference.kontravariant_, gl_strain_tensor, gl_strain_tensor_cartesian);
     // GL strain vector glstrain for solid material E={E11,E22,E33,2*E12,2*E23,2*E31}
     Core::LinAlg::Voigt::Strains::matrix_to_vector(gl_strain_tensor_cartesian, strains.gl_strain_);
@@ -976,7 +976,8 @@ namespace Discret::Elements::Shell
     Core::LinAlg::Voigt::Stresses::vector_to_matrix(stress.pk2_, stress_tensor);
     Core::LinAlg::Matrix<Internal::num_dim, Internal::num_dim> tmp(
         Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::tensor_rotation(g_reference.kontravariant_, stress_tensor, tmp);
+    Core::LinAlg::FourTensorOperations::tensor_rotation(
+        g_reference.kontravariant_, stress_tensor, tmp);
 
     // re-arrange indices for shell element formulation:
     // PK Stress=[S_{11},S_{12}, S_{13}, S_{22}, S_{23}, S_{33}]^T
@@ -994,7 +995,8 @@ namespace Discret::Elements::Shell
     Core::LinAlg::Matrix<Internal::num_dim, Internal::num_dim> g_metrics_trans(
         Core::LinAlg::Initialization::zero);
     g_metrics_trans.update_t(g_reference.kontravariant_);
-    Core::LinAlg::Tensor::inverse_fourth_tensor_rotation(g_metrics_trans, stress.cmat_, Cmat);
+    Core::LinAlg::FourTensorOperations::inverse_fourth_tensor_rotation(
+        g_metrics_trans, stress.cmat_, Cmat);
 
     // re-arrange indices for shell element formulation
     static constexpr std::array voigt_inconsistent_ = {0, 3, 5, 1, 4, 2};

--- a/src/solid_3D_ele/4C_solid_3D_ele_surface_traceestimate.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_surface_traceestimate.cpp
@@ -239,7 +239,7 @@ void Discret::Elements::SolidSurface::trace_estimate_surf_matrix(
     nn.multiply_nt(n_v, n_v);
 
     Core::LinAlg::Matrix<6, 6> cn;
-    Core::LinAlg::Tensor::add_symmetric_holzapfel_product(cn, rcg, nn, 0.25);
+    Core::LinAlg::FourTensorOperations::add_symmetric_holzapfel_product(cn, rcg, nn, 0.25);
 
     Core::LinAlg::Matrix<6, 6> tmp1, tmp2;
     tmp1.multiply(cmat, id4);

--- a/unittests/mat/4C_material_service_test.cpp
+++ b/unittests/mat/4C_material_service_test.cpp
@@ -63,7 +63,8 @@ namespace
     double scalar = 0.5;
 
     // result_ijkl = A_ik InvABInvB_jl +  A_il InvABInvB_jk + A_jk InvABInvB_il + A_jl InvABInvB_ik
-    Core::LinAlg::Tensor::add_derivative_of_inva_b_inva_product(scalar, A, InvABInvB, Result);
+    Core::LinAlg::FourTensorOperations::add_derivative_of_inva_b_inva_product(
+        scalar, A, InvABInvB, Result);
 
     Core::LinAlg::Matrix<6, 6> Result_reference(Core::LinAlg::Initialization::uninitialized);
     Result_reference(0, 0) = -0.86;
@@ -202,7 +203,7 @@ namespace
     s_ref(0, 2) = s_ref(2, 0) = 0.6;
 
     Core::LinAlg::Matrix<3, 3> s;
-    Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(s, 1.0, Id, stress);
+    Core::LinAlg::FourTensorOperations::add_contraction_matrix_four_tensor(s, 1.0, Id, stress);
 
     FOUR_C_EXPECT_NEAR(s, s_ref, 1.0e-10);
   }
@@ -318,7 +319,7 @@ namespace
     x_adbc_y_ref(8, 8) = 5.0000000000;
 
     Core::LinAlg::Matrix<9, 9> x_adbc_y(Core::LinAlg::Initialization::zero);
-    Core::LinAlg::Tensor::add_adbc_tensor_product(1.0, x, y, x_adbc_y);
+    Core::LinAlg::FourTensorOperations::add_adbc_tensor_product(1.0, x, y, x_adbc_y);
 
     FOUR_C_EXPECT_NEAR(x_adbc_y, x_adbc_y_ref, 1.0e-10);
   }
@@ -335,10 +336,10 @@ namespace
     stress(0, 2) = stress(2, 0) = 0.6;
 
     Core::LinAlg::FourTensor<3> T;
-    Core::LinAlg::Tensor::add_dyadic_product_matrix_matrix(T, 1.0, stress, stress);
+    Core::LinAlg::FourTensorOperations::add_dyadic_product_matrix_matrix(T, 1.0, stress, stress);
 
     Core::LinAlg::Matrix<3, 3> result;
-    Core::LinAlg::Tensor::add_contraction_matrix_four_tensor(result, 1.0, T, stress);
+    Core::LinAlg::FourTensorOperations::add_contraction_matrix_four_tensor(result, 1.0, T, stress);
 
     Core::LinAlg::Matrix<3, 3> result_ref = stress;
     result_ref.scale(std::pow(stress.norm2(), 2));


### PR DESCRIPTION
I realized that we have a `Core::LinAlg::Tensor` namespace containing operations for 4-tensors. I suggest to rename it to `Core::LinAlg::FourTensorOperations` to avoid any nameclashes with the Tensor-class. 