### PR TITLE
Cleanup of scatra timint implicit

### DIFF
--- a/src/adapter/4C_adapter_scatra_interface.hpp
+++ b/src/adapter/4C_adapter_scatra_interface.hpp
@@ -45,25 +45,25 @@ namespace Adapter
   {
    public:
     //! constructor
-    ScatraInterface() {};
+    ScatraInterface() = default;
 
     //! virtual to get polymorph destruction
     virtual ~ScatraInterface() = default;
 
     //! return discretization
-    virtual std::shared_ptr<Core::FE::Discretization> discretization() const = 0;
+    [[nodiscard]] virtual std::shared_ptr<Core::FE::Discretization> discretization() const = 0;
 
     //! add parameters specific for time-integration scheme
     virtual void add_time_integration_specific_vectors(bool forcedincrementalsolver = false) = 0;
 
     //! return number of dofset associated with displacement dofs
-    virtual int nds_disp() const = 0;
+    [[nodiscard]] virtual int nds_disp() const = 0;
 
     //! return rcp ptr to neumann loads vector
     virtual std::shared_ptr<Core::LinAlg::Vector<double>> get_neumann_loads_ptr() = 0;
 
     //! return meshtying strategy (includes standard case without meshtying)
-    virtual const std::shared_ptr<ScaTra::MeshtyingStrategyBase>& strategy() const = 0;
+    [[nodiscard]] virtual std::shared_ptr<ScaTra::MeshtyingStrategyBase> strategy() const = 0;
 
     //! return scalar field phi at time n
     virtual std::shared_ptr<Core::LinAlg::Vector<double>> phin() = 0;

--- a/src/adapter/4C_adapter_scatra_wrapper.hpp
+++ b/src/adapter/4C_adapter_scatra_wrapper.hpp
@@ -43,7 +43,7 @@ namespace Adapter
 
    protected:
     //! return discretization
-    std::shared_ptr<Core::FE::Discretization> discretization() const override
+    [[nodiscard]] std::shared_ptr<Core::FE::Discretization> discretization() const override
     {
       return scatra_timint_->discretization();
     };
@@ -64,10 +64,10 @@ namespace Adapter
     };
 
     //! return meshtying strategy (includes standard case without meshtying)
-    const std::shared_ptr<ScaTra::MeshtyingStrategyBase>& strategy() const override
+    [[nodiscard]] std::shared_ptr<ScaTra::MeshtyingStrategyBase> strategy() const override
     {
       return scatra_timint_->strategy();
-    };
+    }
 
     //! return scalar field phi at time n
     std::shared_ptr<Core::LinAlg::Vector<double>> phin() override { return scatra_timint_->phin(); }

--- a/src/fs3i/4C_fs3i.cpp
+++ b/src/fs3i/4C_fs3i.cpp
@@ -645,20 +645,17 @@ void FS3I::FS3IBase::setup_coupled_scatra_vector(Core::LinAlg::Vector<double>& g
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void FS3I::FS3IBase::setup_coupled_scatra_matrix()
+void FS3I::FS3IBase::setup_coupled_scatra_matrix() const
 {
-  std::shared_ptr<Core::LinAlg::SparseMatrix> scatra1 =
-      scatravec_[0]->scatra_field()->system_matrix();
-  std::shared_ptr<Core::LinAlg::SparseMatrix> scatra2 =
-      scatravec_[1]->scatra_field()->system_matrix();
+  auto scatra1 = scatravec_[0]->scatra_field()->system_matrix();
+  auto scatra2 = scatravec_[1]->scatra_field()->system_matrix();
 
   if (scatra1 == nullptr) FOUR_C_THROW("expect fluid scatra block matrix");
   if (scatra2 == nullptr) FOUR_C_THROW("expect structure scatra block matrix");
 
   if (infperm_)
   {
-    // Incomplete system matrix to be able to deal with slightly defective
-    // interface meshes.
+    // Incomplete system matrix to be able to deal with slightly defective interface meshes.
     scatra1->un_complete();
 
     // structure scatra

--- a/src/fs3i/4C_fs3i.hpp
+++ b/src/fs3i/4C_fs3i.hpp
@@ -113,7 +113,7 @@ namespace FS3I
     void setup_coupled_scatra_rhs();
 
     //! set-up of global matrix of the monolithic ScaTra problem
-    void setup_coupled_scatra_matrix();
+    void setup_coupled_scatra_matrix() const;
 
     std::shared_ptr<Core::LinAlg::Vector<double>> scatra2_to_scatra1(
         const Core::LinAlg::Vector<double>& iv) const;

--- a/src/levelset/4C_levelset_algorithm.cpp
+++ b/src/levelset/4C_levelset_algorithm.cpp
@@ -447,13 +447,4 @@ void ScaTra::LevelSetAlgorithm::test_results()
 }
 
 
-/*----------------------------------------------------------------------*
- | set time and step value                              rasthofer 04/14 |
- *----------------------------------------------------------------------*/
-void ScaTra::LevelSetAlgorithm::set_time_step(const double time, const int step)
-{
-  // call base class function
-  ScaTra::ScaTraTimIntImpl::set_time_step(time, step);
-}
-
 FOUR_C_NAMESPACE_CLOSE

--- a/src/levelset/4C_levelset_algorithm.hpp
+++ b/src/levelset/4C_levelset_algorithm.hpp
@@ -74,9 +74,6 @@ namespace ScaTra
 
     void test_results() override;
 
-    /// set time and step value
-    void set_time_step(const double time, const int step) override;
-
     // -----------------------------------------------------------------
     // general methods
     // -----------------------------------------------------------------

--- a/src/levelset/4C_levelset_algorithm_reinit.cpp
+++ b/src/levelset/4C_levelset_algorithm_reinit.cpp
@@ -484,8 +484,6 @@ void ScaTra::LevelSetAlgorithm::correction_reinit()
   system_matrix()->reset();
   // reset the solver as well
   solver_->reset();
-
-  return;
 }
 
 

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -1877,12 +1877,12 @@ void ScaTra::ScaTraTimIntElch::create_meshtying_strategy()
     strategy_ = std::make_shared<MeshtyingStrategyFluidElch>(this);
   }
   // scatra-scatra interface coupling
-  else if (s2_i_meshtying())
+  else if (s2i_meshtying())
   {
     strategy_ = std::make_shared<MeshtyingStrategyS2IElch>(this, *params_);
   }
   // ScaTra-ScaTra interface contact
-  else if (s2_i_kinetics() and !s2_i_meshtying())
+  else if (s2i_kinetics() and !s2i_meshtying())
   {
     strategy_ = std::make_shared<MeshtyingStrategyStd>(this);
   }

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -557,21 +557,18 @@ void ScaTra::ScaTraTimIntImpl::setup()
     switch (outputscalars_)
     {
       case Inpar::ScaTra::outputscalars_entiredomain:
-        outputscalarstrategy_ = std::make_shared<OutputScalarsStrategyDomain>();
+        outputscalarstrategy_ = std::make_shared<OutputScalarsStrategyDomain>(this);
         break;
       case Inpar::ScaTra::outputscalars_condition:
-        outputscalarstrategy_ = std::make_shared<OutputScalarsStrategyCondition>();
+        outputscalarstrategy_ = std::make_shared<OutputScalarsStrategyCondition>(this);
         break;
       case Inpar::ScaTra::outputscalars_entiredomain_condition:
-        outputscalarstrategy_ = std::make_shared<OutputScalarsStrategyDomainAndCondition>();
+        outputscalarstrategy_ = std::make_shared<OutputScalarsStrategyDomainAndCondition>(this);
         break;
       default:
         FOUR_C_THROW("Unknown option for output of total and mean scalars!");
         break;
     }
-
-    // initialize scalar output strategy
-    outputscalarstrategy_->init(this);
   }
   else
   {
@@ -598,8 +595,7 @@ void ScaTra::ScaTraTimIntImpl::setup()
   if (computeintegrals_ != Inpar::ScaTra::computeintegrals_none)
   {
     // initialize domain integral output strategy
-    outputdomainintegralstrategy_ = std::make_shared<OutputDomainIntegralStrategy>();
-    outputdomainintegralstrategy_->init(this);
+    outputdomainintegralstrategy_ = std::make_shared<OutputDomainIntegralStrategy>(this);
   }
   else
   {
@@ -2533,7 +2529,7 @@ void ScaTra::ScaTraTimIntImpl::create_meshtying_strategy()
   {
     strategy_ = std::make_shared<MeshtyingStrategyFluid>(this);
   }
-  else if (s2_i_meshtying())  // scatra-scatra interface mesh tying
+  else if (s2i_meshtying())  // scatra-scatra interface mesh tying
   {
     strategy_ = std::make_shared<MeshtyingStrategyS2I>(this, *params_);
   }
@@ -3670,14 +3666,14 @@ void ScaTra::ScaTraTimIntImpl::build_block_maps(
 
 /*-----------------------------------------------------------------------------*
  *-----------------------------------------------------------------------------*/
-void ScaTra::ScaTraTimIntImpl::post_setup_matrix_block_maps()
+void ScaTra::ScaTraTimIntImpl::post_setup_matrix_block_maps() const
 {
   // now build the null spaces
   build_block_null_spaces(solver(), 0);
 
   // in case of an extended solver for scatra-scatra interface meshtying including interface growth
   // we need to equip it with the null space information generated above
-  if (s2_i_meshtying()) strategy_->equip_extended_solver_with_null_space_info();
+  if (s2i_meshtying()) strategy_->equip_extended_solver_with_null_space_info();
 }
 
 /*-----------------------------------------------------------------------------*

--- a/src/ssi/4C_ssi_base.cpp
+++ b/src/ssi/4C_ssi_base.cpp
@@ -627,7 +627,7 @@ void SSI::SSIBase::set_mesh_disp(const Core::LinAlg::Vector<double>& disp)
 /*----------------------------------------------------------------------*/
 void SSI::SSIBase::check_ssi_flags() const
 {
-  if (scatra_field()->s2_i_kinetics())
+  if (scatra_field()->s2i_kinetics())
   {
     if (!(ssi_interface_contact() or ssi_interface_meshtying()))
     {
@@ -642,7 +642,7 @@ void SSI::SSIBase::check_ssi_flags() const
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSI::SSIBase::set_dt_from_scatra_to_structure()
+void SSI::SSIBase::set_dt_from_scatra_to_structure() const
 {
   structure_field()->set_dt(scatra_field()->dt());
   structure_field()->set_timen(scatra_field()->time());
@@ -651,7 +651,7 @@ void SSI::SSIBase::set_dt_from_scatra_to_structure()
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSI::SSIBase::set_dt_from_scatra_to_manifold()
+void SSI::SSIBase::set_dt_from_scatra_to_manifold() const
 {
   scatra_manifold()->set_dt(scatra_field()->dt());
   scatra_manifold()->set_time_step(scatra_field()->time(), scatra_field()->step());
@@ -672,7 +672,7 @@ void SSI::SSIBase::set_dt_from_scatra_to_ssi()
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void SSI::SSIBase::redistribute(const RedistributionType redistribution_type)
+void SSI::SSIBase::redistribute(const RedistributionType redistribution_type) const
 {
   Global::Problem* problem = Global::Problem::instance();
 

--- a/src/ssi/4C_ssi_base.hpp
+++ b/src/ssi/4C_ssi_base.hpp
@@ -256,7 +256,7 @@ namespace SSI
     [[nodiscard]] bool is_scatra_manifold_meshtying() const { return is_manifold_meshtying_; }
 
     //! Redistribute nodes and elements on processors
-    void redistribute(RedistributionType redistribution_type);
+    void redistribute(RedistributionType redistribution_type) const;
 
     //! get bool indicating if we have at least one ssi interface contact condition
     [[nodiscard]] bool ssi_interface_contact() const { return ssi_interface_contact_; }
@@ -293,13 +293,13 @@ namespace SSI
     }
 
     //! copy modified time step from scatra to scatra manifold field
-    void set_dt_from_scatra_to_manifold();
+    void set_dt_from_scatra_to_manifold() const;
 
     //! copy modified time step from scatra to this SSI algorithm
     void set_dt_from_scatra_to_ssi();
 
     //! copy modified time step from scatra to structure field
-    void set_dt_from_scatra_to_structure();
+    void set_dt_from_scatra_to_structure() const;
 
     //! set structure stress state on scatra field
     void set_mechanical_stress_state(

--- a/src/sti/4C_sti_algorithm.cpp
+++ b/src/sti/4C_sti_algorithm.cpp
@@ -73,10 +73,10 @@ STI::Algorithm::Algorithm(MPI_Comm comm, const Teuchos::ParameterList& stidyn,
     FOUR_C_THROW("Thermo field must involve exactly one transported scalar!");
 
   // perform initializations associated with scatra-scatra interface mesh tying
-  if (scatra_->scatra_field()->s2_i_meshtying())
+  if (scatra_->scatra_field()->s2i_meshtying())
   {
     // safety check
-    if (!thermo_->scatra_field()->s2_i_meshtying())
+    if (!thermo_->scatra_field()->s2i_meshtying())
     {
       FOUR_C_THROW(
           "Can't evaluate scatra-scatra interface mesh tying in scatra field, but not in thermo "
@@ -173,7 +173,7 @@ void STI::Algorithm::modify_field_parameters_for_thermo_field()
   fieldparameters_->set<int>("INITFUNCNO", stiparameters_->get<int>("THERMO_INITFUNCNO"));
 
   // perform additional manipulations associated with scatra-scatra interface mesh tying
-  if (scatra_->scatra_field()->s2_i_meshtying())
+  if (scatra_->scatra_field()->s2i_meshtying())
   {
     // set flag for matrix type associated with thermo field
     fieldparameters_->set<Core::LinAlg::MatrixType>("MATRIXTYPE", Core::LinAlg::MatrixType::sparse);
@@ -303,7 +303,7 @@ void STI::Algorithm::transfer_scatra_to_thermo(
   thermo_->scatra_field()->discretization()->set_state(2, "scatra", *scatra);
 
   // transfer state vector for evaluation of scatra-scatra interface mesh tying
-  if (thermo_->scatra_field()->s2_i_meshtying())
+  if (thermo_->scatra_field()->s2i_meshtying())
   {
     switch (strategythermo_->coupling_type())
     {
@@ -370,7 +370,7 @@ void STI::Algorithm::transfer_thermo_to_scatra(
   scatra_->scatra_field()->discretization()->set_state(2, "thermo", *thermo);
 
   // transfer state vector for evaluation of scatra-scatra interface mesh tying
-  if (scatra_->scatra_field()->s2_i_meshtying() and
+  if (scatra_->scatra_field()->s2i_meshtying() and
       strategyscatra_->coupling_type() == Inpar::S2I::coupling_mortar_standard)
   {
     // extract scatra-scatra interface mesh tying conditions

--- a/src/sti/4C_sti_monolithic.hpp
+++ b/src/sti/4C_sti_monolithic.hpp
@@ -12,15 +12,12 @@
 
 #include "4C_coupling_adapter.hpp"
 #include "4C_coupling_adapter_converter.hpp"
-#include "4C_inpar_sti.hpp"
 #include "4C_sti_algorithm.hpp"
-
-// forward declarations
-class Map;
 
 FOUR_C_NAMESPACE_OPEN
 
 
+// forward declarations
 namespace Core::LinAlg
 {
   class BlockSparseMatrixBase;
@@ -72,13 +69,13 @@ namespace STI
     );
 
     //! return algebraic solver for global system of equations
-    const Core::LinAlg::Solver& solver() const { return *solver_; };
+    [[nodiscard]] const Core::LinAlg::Solver& solver() const { return *solver_; };
 
    private:
     //! Apply Dirichlet conditions to assembled OD blocks
     void apply_dirichlet_off_diag(
-        std::shared_ptr<Core::LinAlg::SparseOperator>& scatrathermo_domain_interface,
-        std::shared_ptr<Core::LinAlg::SparseOperator>& thermoscatra_domain_interface);
+        std::shared_ptr<Core::LinAlg::SparseOperator> scatrathermo_domain_interface,
+        std::shared_ptr<Core::LinAlg::SparseOperator> thermoscatra_domain_interface) const;
 
     //! Assemble interface and domain contributions of OD blocks
     void assemble_domain_interface_off_diag(
@@ -87,12 +84,6 @@ namespace STI
 
     //! assemble global system of equations
     void assemble_mat_and_rhs();
-
-    //! assemble off-diagonal scatra-thermo block of global system matrix
-    void assemble_od_block_scatra_thermo();
-
-    //! assemble off-diagonal thermo-scatra block of global system matrix
-    void assemble_od_block_thermo_scatra();
 
     //! build null spaces associated with blocks of global system matrix
     void build_null_spaces() const;
@@ -103,7 +94,7 @@ namespace STI
     ) const;
 
     //! global map of degrees of freedom
-    const std::shared_ptr<const Core::LinAlg::Map>& dof_row_map() const;
+    [[nodiscard]] std::shared_ptr<const Core::LinAlg::Map> dof_row_map() const;
 
     //! check termination criterion for Newton-Raphson iteration
     bool exit_newton_raphson();

--- a/src/sti/4C_sti_partitioned.cpp
+++ b/src/sti/4C_sti_partitioned.cpp
@@ -50,19 +50,23 @@ STI::Partitioned::Partitioned(MPI_Comm comm,  //! communicator
     case Inpar::STI::CouplingType::twoway_thermotoscatra_aitken:
     {
       // initialize increment vectors
-      scatra_field()->phinp_inc() =
-          Core::LinAlg::create_vector(*scatra_field()->discretization()->dof_row_map(), true);
-      thermo_field()->phinp_inc() =
-          Core::LinAlg::create_vector(*thermo_field()->discretization()->dof_row_map(), true);
+      scatra_field()->set_phinp_inc(
+          Core::LinAlg::create_vector(*scatra_field()->discretization()->dof_row_map(), true));
+      thermo_field()->set_phinp_inc(
+          Core::LinAlg::create_vector(*thermo_field()->discretization()->dof_row_map(), true));
 
       // initialize old increment vectors
       if (couplingtype_ == Inpar::STI::CouplingType::twoway_scatratothermo_aitken or
           couplingtype_ == Inpar::STI::CouplingType::twoway_scatratothermo_aitken_dofsplit)
-        scatra_field()->phinp_inc_old() =
-            Core::LinAlg::create_vector(*scatra_field()->discretization()->dof_row_map(), true);
+      {
+        scatra_field()->set_phinp_inc_old(
+            Core::LinAlg::create_vector(*scatra_field()->discretization()->dof_row_map(), true));
+      }
       else if (couplingtype_ == Inpar::STI::CouplingType::twoway_thermotoscatra_aitken)
-        thermo_field()->phinp_inc_old() =
-            Core::LinAlg::create_vector(*thermo_field()->discretization()->dof_row_map(), true);
+      {
+        thermo_field()->set_phinp_inc_old(
+            Core::LinAlg::create_vector(*thermo_field()->discretization()->dof_row_map(), true));
+      }
 
       // initialize relaxation parameter
       if (couplingtype_ == Inpar::STI::CouplingType::twoway_scatratothermo)
@@ -84,11 +88,9 @@ STI::Partitioned::Partitioned(MPI_Comm comm,  //! communicator
     default:
     {
       FOUR_C_THROW("What the hell?!");
-      break;
     }
   }
 
-  return;
 }  // STI::Partitioned::Partitioned
 
 


### PR DESCRIPTION
## Description and Context
While starting to work on removing the call of the 4C-coded block preconditioning, I got annoyed by so many things in `scatra_timint_implicit`. Thus, I decided to do some cleanup first, which includes, e.g., removing init methods and moving the relevant work to the constructor, removing unused methods, fixing naming, etc.
