### PR TITLE
Simplify access into internal variant items of Map

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_map.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.cpp
@@ -80,8 +80,7 @@ Core::LinAlg::Map& Core::LinAlg::Map::operator=(const Map& other)
 
 MPI_Comm Core::LinAlg::Map::Comm() const
 {
-  return Core::Communication::unpack_epetra_comm(
-      visit_variant([](const auto& map) -> const Epetra_Comm& { return map.Comm(); }));
+  return Core::Communication::unpack_epetra_comm(wrapped().Comm());
 }
 
 std::unique_ptr<Core::LinAlg::Map> Core::LinAlg::Map::create_view(Epetra_Map& view)

--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -33,23 +33,6 @@ namespace Core::LinAlg
 {
   class Map
   {
-    // This wrapper may have two different variants
-    // Either it holds an Epetra_Map or Epetra_BlockMap
-    using MapVariant =
-        std::variant<Utils::OwnerOrView<Epetra_Map>, Utils::OwnerOrView<Epetra_BlockMap>>;
-
-    // helper function to access each variant safely
-    template <typename Func>
-    decltype(auto) visit_variant(Func&& func) const
-    {
-      return std::visit(
-          [&](const auto& wrapped) -> decltype(auto)
-          {
-            return func(*wrapped);  // Unwrap OwnerOrView
-          },
-          map_);
-    }
-
    public:
     Map(int NumGlobalElements, int IndexBase, const MPI_Comm& Comm);
 
@@ -71,10 +54,7 @@ namespace Core::LinAlg
     Map& operator=(const Map& other);
 
     //! Print object to the output stream
-    void Print(std::ostream& os) const
-    {
-      visit_variant([&](const auto& map) -> void { map.Print(os); });
-    }
+    void Print(std::ostream& os) const { wrapped().Print(os); }
 
     //! Returns a reference of the Epetra_Map if available.
     const Epetra_Map& get_epetra_map() const
@@ -104,158 +84,76 @@ namespace Core::LinAlg
 
 
     //! Returns a const reference to the underlying Epetra_BlockMap.
-    const Epetra_BlockMap& get_epetra_block_map() const
-    {
-      // If the map_ holds directly the Epetra_BlockMap, just return it.
-      if (auto map = std::get_if<Utils::OwnerOrView<Epetra_BlockMap>>(&map_))
-      {
-        return **map;
-      }
-
-      // If the Epetra_Map is stored try to cast it.
-      const auto& map = *std::get<Utils::OwnerOrView<Epetra_Map>>(map_);
-
-      return map;
-    }
+    const Epetra_BlockMap& get_epetra_block_map() const { return wrapped(); }
 
 
     //! Returns a reference to the underlying Epetra_BlockMap.
-    Epetra_BlockMap& get_epetra_block_map()
-    {
-      // If the map_ holds directly the Epetra_BlockMap, just return it.
-      if (auto map = std::get_if<Utils::OwnerOrView<Epetra_BlockMap>>(&map_))
-      {
-        return **map;
-      }
-
-      // If the Epetra_Map is stored try to cast it.
-      auto& map = *std::get<Utils::OwnerOrView<Epetra_Map>>(map_);
-      return map;
-    }
+    Epetra_BlockMap& get_epetra_block_map() { return wrapped(); }
 
     //! Returns true if this and Map are identical maps
-    bool SameAs(const Map& other) const
-    {
-      return std::visit(
-          [&](const auto& this_wrapped)
-          {
-            return std::visit([&](const auto& other_wrapped)
-                { return (*this_wrapped).SameAs(*other_wrapped); }, other.map_);
-          },
-          map_);
-    }
+    bool SameAs(const Map& other) const { return wrapped().SameAs((other.wrapped())); }
 
     //! Returns true if this and Map have identical point-wise structure
     bool PointSameAs(const Map& Map) const
     {
-      return visit_variant(
-          [&](const auto& map) { return map.PointSameAs(Map.get_epetra_block_map()); });
+      return wrapped().PointSameAs(Map.get_epetra_block_map());
     }
 
     //! Number of elements across all processors.
-    int NumGlobalElements() const
-    {
-      return visit_variant([](const auto& map) { return map.NumGlobalElements(); });
-    }
+    int NumGlobalElements() const { return wrapped().NumGlobalElements(); }
 
     //! Number of elements on the calling processor.
-    int NumMyElements() const
-    {
-      return visit_variant([](const auto& map) { return map.NumMyElements(); });
-    }
+    int NumMyElements() const { return wrapped().NumMyElements(); }
 
     //! returns the index base for this map.
-    int IndexBase() const
-    {
-      return visit_variant([](const auto& map) { return map.IndexBase(); });
-    }
+    int IndexBase() const { return wrapped().IndexBase(); }
 
     //! Pointer to internal array containing a mapping between the local elements and the first
     //! local point number in each element.
-    int FirstPointInElementList(int* LID) const
-    {
-      return visit_variant([&](const auto& map) { return map.FirstPointInElementList(LID); });
-    }
+    int FirstPointInElementList(int* LID) const { return wrapped().FirstPointInElementList(LID); }
 
     //! Returns true if map is defined across more than one processor.
-    bool DistributedGlobal() const
-    {
-      return visit_variant([](const auto& map) { return map.DistributedGlobal(); });
-    }
+    bool DistributedGlobal() const { return wrapped().DistributedGlobal(); }
 
     //! Returns true if this and Map are identical maps
-    bool SameAs(const Epetra_Map& other) const
-    {
-      return visit_variant([&](const auto& map) { return map.SameAs(other); });
-    }
+    bool SameAs(const Epetra_Map& other) const { return wrapped().SameAs(other); }
 
     //! Returns true if this and Map are identical maps
-    bool SameAs(const Epetra_BlockMap& other) const
-    {
-      return visit_variant([&](const auto& map) { return map.SameAs(other); });
-    }
+    bool SameAs(const Epetra_BlockMap& other) const { return wrapped().SameAs(other); }
 
     //! Returns true if the GID passed in belongs to the calling processor in this map, otherwise
     //! returns false.
-    bool MyGID(int GID_in) const
-    {
-      return visit_variant([&](const auto& map) { return map.MyGID(GID_in); });
-    }
+    bool MyGID(int GID_in) const { return wrapped().MyGID(GID_in); }
 
     //! Returns global ID of local ID, return IndexBase-1 if not found on this processor.
-    int GID(int LID) const
-    {
-      return visit_variant([&](const auto& map) { return map.GID(LID); });
-    }
+    int GID(int LID) const { return wrapped().GID(LID); }
 
     //! Returns the size of elements in the map; only valid if map has constant element size.
-    int ElementSize() const
-    {
-      return visit_variant([](const auto& map) { return map.ElementSize(); });
-    }
+    int ElementSize() const { return wrapped().ElementSize(); }
 
     //! Returns the size of elements in the map; only valid if map has constant element size.
-    int ElementSize(int LID) const
-    {
-      return visit_variant([&](const auto& map) { return map.ElementSize(LID); });
-    }
+    int ElementSize(int LID) const { return wrapped().ElementSize(LID); }
 
     //! Returns the maximum global ID across the entire map.
-    int MaxAllGID() const
-    {
-      return visit_variant([](const auto& map) { return map.MaxAllGID(); });
-    }
+    int MaxAllGID() const { return wrapped().MaxAllGID(); }
 
     //! Returns the minimum global ID across the entire map.
-    int MinAllGID() const
-    {
-      return visit_variant([](const auto& map) { return map.MinAllGID(); });
-    }
+    int MinAllGID() const { return wrapped().MinAllGID(); }
 
     //! Returns local ID of global ID, return -1 if not found on this processor.
-    int LID(int GID) const
-    {
-      return visit_variant([&](const auto& map) { return map.LID(GID); });
-    }
+    int LID(int GID) const { return wrapped().LID(GID); }
 
     //! Returns true if this and Map have identical point-wise structure
-    bool PointSameAs(const Epetra_Map& Map) const
-    {
-      return visit_variant([&](const auto& map) { return map.PointSameAs(Map); });
-    }
+    bool PointSameAs(const Epetra_Map& Map) const { return wrapped().PointSameAs(Map); }
 
     //! Returns true if this and Map have identical point-wise structure
-    bool PointSameAs(const Epetra_BlockMap& Map) const
-    {
-      return visit_variant([&](const auto& map) { return map.PointSameAs(Map); });
-    }
+    bool PointSameAs(const Epetra_BlockMap& Map) const { return wrapped().PointSameAs(Map); }
 
     //! Returns the processor IDs and corresponding local index value for a given list of global
     //! indices
     int RemoteIDList(int NumIDs, int* GIDList, int* PIDList, int* LIDList) const
     {
-      return visit_variant(
-          [&](const auto& map) { return map.RemoteIDList(NumIDs, GIDList, PIDList, LIDList); });
+      return wrapped().RemoteIDList(NumIDs, GIDList, PIDList, LIDList);
     }
 
     //! Returns the processor IDs and corresponding local index value for a given list of global
@@ -263,55 +161,36 @@ namespace Core::LinAlg
     int RemoteIDList(
         int NumIDs, const int* GIDList, int* PIDList, int* LIDList, int* SizeList) const
     {
-      return visit_variant([&](const auto& map)
-          { return map.RemoteIDList(NumIDs, GIDList, PIDList, LIDList, SizeList); });
+      return wrapped().RemoteIDList(NumIDs, GIDList, PIDList, LIDList, SizeList);
     }
 
     //! Returns the minimum global ID owned by this processor.
-    int MinMyGID(void) const
-    {
-      return visit_variant([](const auto& map) { return map.MinMyGID(); });
-    }
+    int MinMyGID(void) const { return wrapped().MinMyGID(); }
 
     //! Access function for Epetra_Comm communicator.
     MPI_Comm Comm() const;
 
     //! Returns true if map GIDs are 1-to-1.
-    bool UniqueGIDs(void) const
-    {
-      return visit_variant([](const auto& map) { return map.UniqueGIDs(); });
-    }
+    bool UniqueGIDs(void) const { return wrapped().UniqueGIDs(); }
 
     //! Pointer to internal array containing list of global IDs assigned to the calling processor.
-    int* MyGlobalElements(void) const
-    {
-      return visit_variant([](const auto& map) { return map.MyGlobalElements(); });
-    }
+    int* MyGlobalElements(void) const { return wrapped().MyGlobalElements(); }
 
     //! Maximum element size across all processors.
-    int MaxElementSize(void) const
-    {
-      return visit_variant([](const auto& map) { return map.MaxElementSize(); });
-    }
+    int MaxElementSize(void) const { return wrapped().MaxElementSize(); }
 
     //! Puts list of global elements on this processor into the user-provided array.
     int MyGlobalElements(int* MyGlobalElementList) const
     {
-      return visit_variant(
-          [&](const auto& map) { return map.MyGlobalElements(MyGlobalElementList); });
-    }
-    //! Number of local points for this map; equals the sum of all element sizes on the calling
-    //! processor.
-    int NumMyPoints() const
-    {
-      return visit_variant([](const auto& map) { return map.NumMyPoints(); });
+      return wrapped().MyGlobalElements(MyGlobalElementList);
     }
 
+    //! Number of local points for this map; equals the sum of all element sizes on the calling
+    //! processor.
+    int NumMyPoints() const { return wrapped().NumMyPoints(); }
+
     //! Returns a pointer to the BlockMapData instance this BlockMap uses.
-    const Epetra_BlockMapData* DataPtr() const
-    {
-      return visit_variant([](const auto& map) { return map.DataPtr(); });
-    }
+    const Epetra_BlockMapData* DataPtr() const { return wrapped().DataPtr(); }
 
 
     [[nodiscard]] static std::unique_ptr<Map> create_view(Epetra_Map& view);
@@ -321,6 +200,24 @@ namespace Core::LinAlg
 
    private:
     Map() = default;
+
+    // This wrapper may have two different variants
+    // Either it holds an Epetra_Map or Epetra_BlockMap
+    using MapVariant =
+        std::variant<Utils::OwnerOrView<Epetra_Map>, Utils::OwnerOrView<Epetra_BlockMap>>;
+
+    Epetra_BlockMap& wrapped()
+    {
+      if (auto* ptr = std::get_if<Utils::OwnerOrView<Epetra_Map>>(&map_))
+        return **ptr;
+      else
+        return *std::get<Utils::OwnerOrView<Epetra_BlockMap>>(map_);
+    }
+
+    const Epetra_BlockMap& wrapped() const
+    {
+      return const_cast<const Epetra_BlockMap&>(const_cast<Map*>(this)->wrapped());
+    }
 
     //! stores an Epetra_BlockMap or Epetra_Map
     MapVariant map_;


### PR DESCRIPTION
Instead of visting the variant, we can access the two possible options with a uniform `(const) Epetra_Map&`.

Follows #799 