### PR TITLE
Avoid include cycles

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,14 @@ repos:
         files: '\.(h|hpp)$'
         entry: utilities/python-venv/bin/check-header-guards
 
+      - id: cpp-include-cycles
+        name: C++ include cycles
+        description: 'Check that all C++ headers do not have include cycles'
+        language: python
+        always_run: true
+        pass_filenames: false
+        entry: utilities/python-venv/bin/check-includes-for-cycles
+
       - id: cpp-preprocessor
         name: C++ preprocessor directives
         description: 'Check that all C++ files only use acceptable preprocessor directives'

--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -22,13 +22,8 @@
 #include <unordered_map>
 
 
-// #define DEBUG_CUTKERNEL_OUTPUT
 #define CUT_CLN_CALC
 
-
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-#include "4C_cut_output.hpp"
-#endif
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -1159,11 +1154,6 @@ namespace Cut::Kernel
       FloatType det = A_.determinant();
       if (Kernel::close_to_zero(det))
       {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-        std::cout << " WARNING: Condition number is equal to infinity in the problem. Stopping "
-                     "the increase in precision"
-                  << std::endl;
-#endif
         return std::make_pair(false, -1.0);
       }
       A_inv.invert(A_);
@@ -1471,9 +1461,6 @@ namespace Cut::Kernel
         cond_number = cond_pair.second;
         if (not cond_pair.first)
         {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-          std::cout << "Condition number of this problem is equal to infinity" << std::endl;
-#endif
           cond_infinity_ = true;
         }
 
@@ -1946,11 +1933,6 @@ namespace Cut::Kernel
       FloatType det = A_.determinant();
       if (Kernel::close_to_zero(det))
       {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-        std::cout << " WARNING: Condition number is equal to infinity in the problem. Stopping "
-                     "the increase in precision"
-                  << std::endl;
-#endif
         return std::make_pair(false, -1.0);
       }
       A_inv.invert(A_);
@@ -2068,16 +2050,6 @@ namespace Cut::Kernel
     bool newton_failed()
     {
       tol_ = b_.norm2();
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-      std::stringstream str;
-      str << "compute_distance: Newton scheme did not converge:\n"
-          << std::setprecision(16) << (*xyze_side_) << (*px_) << xsi_;
-
-      std::string filename = Output::GenerateGmshOutputFilename(".NewtonFailed_distance.pos");
-      std::ofstream file(filename.c_str());
-      write_to_gmsh(file);
-      file.close();
-#endif
       return false;
     }
 
@@ -2591,13 +2563,6 @@ namespace Cut::Kernel
       // values back if we did not converge, by newton tolerance, but the error is small enough
       // treat as converged
       if ((not conv) && (err < CLN_LIMIT_ERROR) && (err > 0.0)) conv = true;
-
-      if (cond_infinity_)
-      {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-        std::cout << "Condition number of this problem is equal to infinity" << std::endl;
-#endif
-      }
 
       get_topology_information();
       // NOTE: Might be not needed later
@@ -3379,11 +3344,6 @@ namespace Cut::Kernel
       FloatType det = A_.determinant();
       if (Kernel::close_to_zero(det))
       {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-        std::cout << " WARNING: Condition number is equal to infinity in the problem. "
-                     "Continuing increase in precision "
-                  << std::endl;
-#endif
         return std::make_pair(false, -1.0);
       }
       A_inv.invert(A_);
@@ -3602,45 +3562,8 @@ namespace Cut::Kernel
 
     bool newton_failed()
     {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-      // If it is not edge-edge intersections we explicitly notify, that Newton's method failed
-      if (probDim == dimEdge + dimSide)
-      {
-        std::cout << "Current type is " << typeid(floatType).name() << std::endl;
-        std::cout << "Newton method failed" << std::endl;
-        std::cout << "Residual is" << residual_ << std::endl;
-        std::cout << "Tolerance is" << tol_ << std::endl;
-        std::cout << "Precision is" << Core::CLN::ClnWrapper::precision_ << "decimal points"
-                  << std::endl;
-        std::cout << "Local coordinates are " << xsi_ << std::endl;
-      }
-#endif
-
       tol_ = c_.norm2() * std::sqrt(3.0);
 
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-      if (probDim == dimEdge + dimSide)
-      {
-        std::stringstream str;
-        str << "Newton scheme did not converge:\n  "
-#ifndef CLN_CALC
-            << (*xyze_side_)
-            << (*xyze_edge_)
-#endif
-#ifndef CLN_CALC
-                   DumpDoubles(str, xyze_side_->data(), xyze_side_->m() * xyze_side_->n());
-        str << "\n";
-        DumpDoubles(str, xyze_edge_->data(), xyze_edge_->m() * xyze_edge_->n());
-#endif
-
-
-        std::stringstream f_str;
-        f_str << ".NewtonFailed_intersection.pos";
-        std::string filename(Cut::Output::GenerateGmshOutputFilename(f_str.str()));
-        std::ofstream file(filename.c_str());
-        write_to_gmsh(file);
-      }
-#endif
       return false;
     }
 
@@ -4018,18 +3941,10 @@ namespace Cut::Kernel
         conv = true;
       else if (not conv)
       {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-        if (probDim == dimSide + dimEdge)
-          std::cout << "Newton method failed and the residual is " << err << " / "
-                    << CLN_LIMIT_ERROR << std::endl;
-#endif
       }
 
       if (cond_infinity_)
       {
-#ifdef DEBUG_CUTKERNEL_OUTPUT
-        std::cout << "Condition number of this problem is equal to infinity" << std::endl;
-#endif
       }
 
       get_topology_information();

--- a/src/poroelast/4C_poroelast_utils_setup.hpp
+++ b/src/poroelast/4C_poroelast_utils_setup.hpp
@@ -16,7 +16,6 @@
 #include "4C_fem_general_utils_createdis.hpp"
 #include "4C_global_data.hpp"
 #include "4C_poroelast_utils.hpp"
-#include "4C_poroelast_utils_setup.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 

--- a/utilities/four_c_utils/pyproject.toml
+++ b/utilities/four_c_utils/pyproject.toml
@@ -21,6 +21,7 @@ include = ["four_c_utils"]
 check-file-header = "four_c_utils.check_file_header:main"
 check-filenames = "four_c_utils.check_filenames:main"
 check-includes = "four_c_utils.check_includes:main"
+check-includes-for-cycles = "four_c_utils.check_includes_for_cycles:main"
 check-header-guards = "four_c_utils.check_header_guards:main"
 check-test-files = "four_c_utils.check_test_files:main"
 check-preprocessor = "four_c_utils.check_preprocessor:main"

--- a/utilities/four_c_utils/src/four_c_utils/check_includes_for_cycles.py
+++ b/utilities/four_c_utils/src/four_c_utils/check_includes_for_cycles.py
@@ -1,0 +1,59 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+"""
+Check that our header files do not have include cycles.
+
+This script was inspired by and adapted from the one in deal.II
+https://github.com/dealii/dealii/blob/master/contrib/utilities/detect_include_cycles.py
+"""
+
+from glob import glob
+import networkx as nx
+import re
+
+match_includes = re.compile(r"# *include *\"(4C_.*.hpp)\"")
+
+
+def add_includes_for_file(header_file_path, graph):
+    """
+    Add the includes of a header file to the file's node as a directed edge.
+    """
+    with open(header_file_path) as f:
+        lines = f.readlines()
+
+    header_file_name = header_file_path.split("/")[-1]
+
+    for line in lines:
+        m = match_includes.match(line)
+        if m:
+            included_file = m.group(1)
+            graph.add_edge(header_file_name, included_file)
+
+
+def main():
+    # Create a list of all header files in the include folder.
+    filelist = glob("src/**/*.hpp", recursive=True)
+    assert filelist, "Please call the script from the top-level directory."
+
+    # For each header file, add the includes as the edges of a directed graph.
+    graph = nx.DiGraph()
+    for header_file_name in filelist:
+        add_includes_for_file(header_file_name, graph)
+
+    # Then figure out whether there are cycles and if so, print them:
+    cycles = nx.simple_cycles(graph)
+    cycles_as_list = list(cycles)
+    if len(cycles_as_list) > 0:
+        print(f"Cycles in the include graph detected! Please fix them manually.")
+        for cycle in cycles_as_list:
+            print(cycle)
+        exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/utilities/requirements.txt
+++ b/utilities/requirements.txt
@@ -1,3 +1,4 @@
 # for pre-commit:
 -e utilities/four_c_utils
 pre-commit==4.1.0
+networkx==3.4.2


### PR DESCRIPTION
This PR adds a nice modularity check based on an implementation in deal.II: https://github.com/dealii/dealii/pull/18013

The cycle in `cut` is only a thing if the `#ifdef` were turned on, but we want to remove these anyway (see #207).