### PR TITLE
Fix missing job output in nightly action

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -248,6 +248,8 @@ jobs:
     defaults:
       run:
         shell: bash
+    outputs:
+      test-chunks: ${{ steps.set-matrix.outputs.chunk-array }}
     steps:
       - uses: actions/checkout@v4
       - name: Check docker hash


### PR DESCRIPTION
Fixes failing nightly tests https://github.com/4C-multiphysics/4C/actions/runs/15220171403/job/42814245472. Follow up to #811 