### PR TITLE
Remove `shared_ptr` methods from `LinAlg::Vector` interface

### DIFF
--- a/src/adapter/4C_adapter_str_constr_merged.cpp
+++ b/src/adapter/4C_adapter_str_constr_merged.cpp
@@ -263,11 +263,9 @@ void Adapter::StructureConstrMerged::apply_interface_forces_temporary_deprecated
   conmerger_->extract_cond_vector(*fifc, (*fifcdisp)(0));
 
   // set interface forces within the structural time integrator
-  set_force_interface(fifcdisp);
+  set_force_interface(*fifcdisp);
 
   prepare_partition_step();
-
-  return;
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/adapter/4C_adapter_str_fsiwrapper.cpp
+++ b/src/adapter/4C_adapter_str_fsiwrapper.cpp
@@ -212,11 +212,9 @@ void Adapter::FSIStructureWrapper::apply_interface_forces_temporary_deprecated(
 
   interface_->add_fsi_cond_vector(*iforce, (*fifc)(0));
 
-  set_force_interface(fifc);
+  set_force_interface(*fifc);
 
   prepare_partition_step();
-
-  return;
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/adapter/4C_adapter_str_structure.hpp
+++ b/src/adapter/4C_adapter_str_structure.hpp
@@ -487,7 +487,7 @@ namespace Adapter
     ///
     /// \note This method will be deprecated as soon as new structural time integration is
     ///       completely engulfed by all algorithms using this method.
-    virtual void set_force_interface(std::shared_ptr<Core::LinAlg::MultiVector<double>> iforce) = 0;
+    virtual void set_force_interface(const Core::LinAlg::MultiVector<double>& iforce) = 0;
 
     //! specific method for iterative staggered partitioned TSI
 

--- a/src/adapter/4C_adapter_str_structure_new.hpp
+++ b/src/adapter/4C_adapter_str_structure_new.hpp
@@ -390,7 +390,7 @@ namespace Adapter
     //@{
 
     /// Set forces due to interface with fluid, the force is expected external-force-like
-    void set_force_interface(std::shared_ptr<Core::LinAlg::MultiVector<double>> iforce) override
+    void set_force_interface(const Core::LinAlg::MultiVector<double>& iforce) override
     {
       FOUR_C_THROW(
           "This method is deprecated. In the new structural time integration"

--- a/src/adapter/4C_adapter_str_wrapper.hpp
+++ b/src/adapter/4C_adapter_str_wrapper.hpp
@@ -445,7 +445,7 @@ namespace Adapter
     //@{
 
     /// set forces due to interface with fluid, the force is expected external-force-like
-    void set_force_interface(std::shared_ptr<Core::LinAlg::MultiVector<double>> iforce) override
+    void set_force_interface(const Core::LinAlg::MultiVector<double>& iforce) override
     {
       structure_->set_force_interface(iforce);
     }

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer.cpp
@@ -228,7 +228,7 @@ void BeamInteraction::BeamToSolidSurfaceVisualizationOutputWriter::
       output_writer_base_ptr_->get_visualization_writer("btss-coupling-nodal-forces");
   if (nodal_force_visualization != nullptr)
     add_beam_interaction_nodal_forces(nodal_force_visualization, beam_contact->discret_ptr(),
-        beam_contact->beam_interaction_data_state().get_dis_np()->get_ptr_of_multi_vector(),
+        beam_contact->beam_interaction_data_state().get_dis_np()->as_multi_vector(),
         Core::LinAlg::Vector<double>(*beam_contact->beam_interaction_data_state().get_force_np()),
         output_params_ptr_->get_write_unique_ids_flag());
 

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer_contact.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_surface_visualization_output_writer_contact.cpp
@@ -212,7 +212,7 @@ void BeamInteraction::BeamToSolidSurfaceVisualizationOutputWriterContact::
       output_writer_base_ptr_->get_visualization_writer("btss-contact-nodal-forces");
   if (nodal_force_visualization != nullptr)
     add_beam_interaction_nodal_forces(nodal_force_visualization, beam_contact->discret_ptr(),
-        beam_contact->beam_interaction_data_state().get_dis_np()->get_ptr_of_multi_vector(),
+        beam_contact->beam_interaction_data_state().get_dis_np()->as_multi_vector(),
         Core::LinAlg::MultiVector<double>(
             *beam_contact->beam_interaction_data_state().get_force_np()),
         output_params_ptr_->get_write_unique_ids_flag());

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.cpp
@@ -24,12 +24,12 @@ FOUR_C_NAMESPACE_OPEN
 void BeamInteraction::add_beam_interaction_nodal_forces(
     const std::shared_ptr<BeamInteraction::BeamToSolidOutputWriterVisualization>& visualization,
     const std::shared_ptr<const Core::FE::Discretization>& discret_ptr,
-    const std::shared_ptr<const Core::LinAlg::MultiVector<double>>& displacement,
+    const Core::LinAlg::MultiVector<double>& displacement,
     const Core::LinAlg::MultiVector<double>& force, const bool write_unique_ids)
 {
   // Add the reference geometry and displacement to the visualization.
   visualization->add_discretization_nodal_reference_position(discret_ptr);
-  visualization->add_discretization_nodal_data_from_multivector("displacement", *displacement);
+  visualization->add_discretization_nodal_data_from_multivector("displacement", displacement);
 
   // Create maps with the GIDs of beam and solid nodes.
   std::vector<int> gid_beam_dof;

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_visualization_output_writer_utils.hpp
@@ -53,7 +53,7 @@ namespace BeamInteraction
   void add_beam_interaction_nodal_forces(
       const std::shared_ptr<BeamInteraction::BeamToSolidOutputWriterVisualization>& visualization,
       const std::shared_ptr<const Core::FE::Discretization>& discret_ptr,
-      const std::shared_ptr<const Core::LinAlg::MultiVector<double>>& displacement,
+      const Core::LinAlg::MultiVector<double>& displacement,
       const Core::LinAlg::MultiVector<double>& force, const bool write_unique_ids = false);
 
   /**

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_visualization_output_writer.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_visualization_output_writer.cpp
@@ -179,7 +179,7 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingVisualizationOutputWriter::
       output_writer_base_ptr_->get_visualization_writer("btsv-nodal-forces");
   if (visualization != nullptr)
     add_beam_interaction_nodal_forces(visualization, beam_contact->discret_ptr(),
-        beam_contact->beam_interaction_data_state().get_dis_np()->get_ptr_of_multi_vector(),
+        beam_contact->beam_interaction_data_state().get_dis_np()->as_multi_vector(),
         Core::LinAlg::MultiVector<double>(
             *beam_contact->beam_interaction_data_state().get_force_np()),
         output_params_ptr_->get_write_unique_ids_flag());

--- a/src/constraint/4C_constraint_lagpenconstraint_noxinterface.cpp
+++ b/src/constraint/4C_constraint_lagpenconstraint_noxinterface.cpp
@@ -95,7 +95,7 @@ double LAGPENCONSTRAINT::NoxInterface::get_constraint_rhs_norms(
   if (!constrRhs) return 0.0;
 
   const ::NOX::Epetra::Vector constrRhs_nox(
-      Teuchos::rcpFromRef(*constrRhs->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(constrRhs->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
 
@@ -127,7 +127,7 @@ double LAGPENCONSTRAINT::NoxInterface::get_lagrange_multiplier_update_rms(
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
   const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(*lagincr_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   rms = NOX::Nln::Aux::root_mean_square_norm(
@@ -156,7 +156,7 @@ double LAGPENCONSTRAINT::NoxInterface::get_lagrange_multiplier_update_norms(
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
   const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(*lagincr_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   double updatenorm = -1.0;
@@ -183,7 +183,7 @@ double LAGPENCONSTRAINT::NoxInterface::get_previous_lagrange_multiplier_norms(
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_lag_pen_constraint, xOld_copy);
 
   const ::NOX::Epetra::Vector lagold_nox_ptr(
-      Teuchos::rcpFromRef(*lagold_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(lagold_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   double lagoldnorm = -1.0;

--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -4168,7 +4168,7 @@ void Wear::LagrangeStrategyWear::output_wear()
 
       // extract diagonal of data
       Core::LinAlg::Vector<double> diagD(*gactivedofs_);
-      data->epetra_matrix()->ExtractDiagonalCopy(*diagD.get_ptr_of_epetra_vector());
+      data->epetra_matrix()->ExtractDiagonalCopy(diagD.get_ref_of_epetra_vector());
 
       // solve by dividing through diagonal elements of data. Do not divide by 0.
       for (int i = 0; i < lNumActiveDOFs; ++i)
@@ -4246,7 +4246,7 @@ void Wear::LagrangeStrategyWear::output_wear()
 
         // extract diagonal of d2ii
         Core::LinAlg::Vector<double> diagD(*wear2_vectori);
-        d2ii->epetra_matrix()->ExtractDiagonalCopy(*diagD.get_ptr_of_epetra_vector());
+        d2ii->epetra_matrix()->ExtractDiagonalCopy(diagD.get_ref_of_epetra_vector());
 
         // solve by dividing through diagonal elements of data. Do not divide by 0.
         for (int i = 0; i < lNumActiveDOFs; ++i)

--- a/src/contact/4C_contact_meshtying_noxinterface.cpp
+++ b/src/contact/4C_contact_meshtying_noxinterface.cpp
@@ -59,7 +59,7 @@ double CONTACT::MtNoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vec
   if (!constrRhs) return 0.0;
 
   const ::NOX::Epetra::Vector constrRhs_nox(
-      Teuchos::rcpFromRef(*constrRhs->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(constrRhs->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   double constrNorm = -1.0;
@@ -88,7 +88,7 @@ double CONTACT::MtNoxInterface::get_lagrange_multiplier_update_rms(
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
   const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(*lagincr_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   rms = NOX::Nln::Aux::root_mean_square_norm(
@@ -114,7 +114,7 @@ double CONTACT::MtNoxInterface::get_lagrange_multiplier_update_norms(
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
   const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(*lagincr_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   double updatenorm = -1.0;
@@ -139,7 +139,7 @@ double CONTACT::MtNoxInterface::get_previous_lagrange_multiplier_norms(
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_meshtying, xOld);
 
   const ::NOX::Epetra::Vector lagold_nox_ptr(
-      Teuchos::rcpFromRef(*lagold_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(lagold_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   double lagoldnorm = -1.0;

--- a/src/contact/4C_contact_noxinterface.cpp
+++ b/src/contact/4C_contact_noxinterface.cpp
@@ -95,7 +95,8 @@ double CONTACT::NoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vecto
 
 
       constrRhs_nox = Teuchos::make_rcp<::NOX::Epetra::Vector>(
-          Teuchos::rcp(nConstrRhs->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+          Teuchos::rcpFromRef(nConstrRhs->get_ref_of_epetra_vector()),
+          ::NOX::Epetra::Vector::CreateCopy);
       break;
     }
     case NOX::Nln::StatusTest::quantity_contact_friction:
@@ -105,7 +106,8 @@ double CONTACT::NoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vecto
           Core::LinAlg::extract_my_vector(*constrRhs_red, strategy().slave_t_dof_row_map(true));
 
       constrRhs_nox = Teuchos::make_rcp<::NOX::Epetra::Vector>(
-          Teuchos::rcp(tConstrRhs->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+          Teuchos::rcpFromRef(tConstrRhs->get_ref_of_epetra_vector()),
+          ::NOX::Epetra::Vector::CreateCopy);
       break;
     }
     default:
@@ -209,7 +211,7 @@ double CONTACT::NoxInterface::get_lagrange_multiplier_update_norms(
   }
 
   const ::NOX::Epetra::Vector zincr_nox_ptr(
-      Teuchos::rcpFromRef(*zincr_ptr->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(zincr_ptr->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   updatenorm = zincr_nox_ptr.norm(type);
@@ -247,7 +249,8 @@ double CONTACT::NoxInterface::get_previous_lagrange_multiplier_norms(
           Core::LinAlg::extract_my_vector(*zold_ptr, strategy().slave_n_dof_row_map(true));
 
       zold_nox_ptr = std::make_shared<::NOX::Epetra::Vector>(
-          Teuchos::rcp(znold_ptr->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+          Teuchos::rcpFromRef(znold_ptr->get_ref_of_epetra_vector()),
+          ::NOX::Epetra::Vector::CreateCopy);
       break;
     }
     case NOX::Nln::StatusTest::quantity_contact_friction:
@@ -256,7 +259,8 @@ double CONTACT::NoxInterface::get_previous_lagrange_multiplier_norms(
           Core::LinAlg::extract_my_vector(*zold_ptr, strategy().slave_t_dof_row_map(true));
 
       zold_nox_ptr = std::make_shared<::NOX::Epetra::Vector>(
-          Teuchos::rcp(ztold_ptr->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+          Teuchos::rcpFromRef(ztold_ptr->get_ref_of_epetra_vector()),
+          ::NOX::Epetra::Vector::CreateCopy);
       break;
     }
     default:

--- a/src/core/fem/src/general/utils/4C_fem_general_l2_projection.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_l2_projection.cpp
@@ -284,8 +284,8 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::solve_nodal_l2_proj
         solver_params.refactor = true;
         solver_params.reset = true;
         solver.solve_with_multi_vector(massmatrix.epetra_operator(),
-            (*nodevec)(i).get_ptr_of_multi_vector(), rhs(i).get_ptr_of_multi_vector(),
-            solver_params);
+            Utils::shared_ptr_from_ref((*nodevec)(i).as_multi_vector()),
+            Utils::shared_ptr_from_ref(rhs(i).as_multi_vector()), solver_params);
       }
       break;
     }

--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::IO::DiscretizationReade
 void Core::IO::DiscretizationReader::read_vector(
     std::shared_ptr<Core::LinAlg::Vector<double>> vec, std::string name)
 {
-  read_vector(vec->get_ptr_of_multi_vector(), name);
+  read_vector(Utils::shared_ptr_from_ref(vec->as_multi_vector()), name);
 }
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_vector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.cpp
@@ -77,6 +77,20 @@ Core::LinAlg::Vector<T>::operator Core::LinAlg::MultiVector<T>&()
 
 
 template <typename T>
+const Core::LinAlg::MultiVector<T>& Core::LinAlg::Vector<T>::as_multi_vector() const
+{
+  return static_cast<const Core::LinAlg::MultiVector<T>&>(*this);
+}
+
+
+template <typename T>
+Core::LinAlg::MultiVector<T>& Core::LinAlg::Vector<T>::as_multi_vector()
+{
+  return static_cast<Core::LinAlg::MultiVector<T>&>(*this);
+}
+
+
+template <typename T>
 int Core::LinAlg::Vector<T>::norm_1(double* Result) const
 {
   return vector_->Norm1(Result);

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -56,6 +56,11 @@ namespace Core::LinAlg
     operator const MultiVector<T>&() const;
     operator MultiVector<T>&();
 
+    // Explicit conversion to MultiVector: the MultiVector will view the same content and only have
+    // a single column.
+    const MultiVector<T>& as_multi_vector() const;
+    MultiVector<T>& as_multi_vector();
+
     // (Implicit) conversions: they all return references or RCPs, never copies
     const Epetra_Vector& get_ref_of_epetra_vector() const { return *vector_; }
 
@@ -68,13 +73,6 @@ namespace Core::LinAlg
     operator Epetra_Vector&() { return *vector_; }
 
     operator const Epetra_Vector&() const { return *vector_; }
-
-    //! Temporary helper to ease transition from Epetra and simplify interfacing with RCP-laden code
-    std::shared_ptr<MultiVector<T>> get_ptr_of_multi_vector() const
-    {
-      sync_view();
-      return multi_vector_view_;
-    }
 
     //! Computes dot product of each corresponding pair of vectors.
     int dot(const Epetra_MultiVector& A, double* Result) const;

--- a/src/core/linalg/src/sparse/4C_linalg_vector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_vector.hpp
@@ -15,7 +15,6 @@
 #include "4C_linalg_multi_vector.hpp"
 #include "4C_linalg_view.hpp"
 
-#include <Epetra_FEVector.h>
 #include <Epetra_IntVector.h>
 #include <Epetra_Vector.h>
 
@@ -62,8 +61,6 @@ namespace Core::LinAlg
 
     Epetra_Vector& get_ref_of_epetra_vector() { return *vector_; }
 
-    std::shared_ptr<Epetra_Vector> get_ptr_of_epetra_vector() { return vector_; }
-
     operator Epetra_MultiVector&() { return *vector_; }
 
     operator const Epetra_MultiVector&() const { return *vector_; }
@@ -71,9 +68,6 @@ namespace Core::LinAlg
     operator Epetra_Vector&() { return *vector_; }
 
     operator const Epetra_Vector&() const { return *vector_; }
-
-    //! get pointer of epetra multi vector
-    std::shared_ptr<Epetra_MultiVector> get_ptr_of_epetra_multi_vector() { return vector_; }
 
     //! Temporary helper to ease transition from Epetra and simplify interfacing with RCP-laden code
     std::shared_ptr<MultiVector<T>> get_ptr_of_multi_vector() const

--- a/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
@@ -56,7 +56,7 @@ namespace
     new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 2, comm);
 
     // replace the map based on the map of epetra vector
-    EXPECT_EQ(vector.get_ptr_of_epetra_vector()->ReplaceMap(new_map->get_epetra_map()), 0);
+    EXPECT_EQ(vector.get_ref_of_epetra_vector().ReplaceMap(new_map->get_epetra_map()), 0);
 
     // compare result with our map wrapper
     EXPECT_TRUE(vector.get_map().same_as(*new_map));

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -219,7 +219,8 @@ int Core::LinAlg::Solver::solve(std::shared_ptr<Epetra_Operator> matrix,
     std::shared_ptr<Core::LinAlg::Vector<double>> x,
     std::shared_ptr<Core::LinAlg::Vector<double>> b, const SolverParams& params)
 {
-  setup(matrix, x->get_ptr_of_multi_vector(), b->get_ptr_of_multi_vector(), params);
+  setup(matrix, Utils::shared_ptr_from_ref(x->as_multi_vector()),
+      Utils::shared_ptr_from_ref(b->as_multi_vector()), params);
 
   int error_value = 0;
   {

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -65,7 +65,7 @@ std::shared_ptr<Core::LinAlg::Graph> Core::Rebalance::rebalance_graph(
 
   Isorropia::Epetra::CostDescriber costs = Isorropia::Epetra::CostDescriber();
   if (initialNodeWeights != nullptr)
-    costs.setVertexWeights(Teuchos::rcpFromRef(*initialNodeWeights->get_ptr_of_epetra_vector()));
+    costs.setVertexWeights(Teuchos::rcpFromRef(initialNodeWeights->get_ref_of_epetra_vector()));
   if (initialEdgeWeights != nullptr)
     costs.setGraphEdgeWeights(Teuchos::rcpFromRef(*initialEdgeWeights->epetra_matrix()));
 

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -279,7 +279,7 @@ void EHL::Base::set_lubrication_solution(
   // Provide the structure field with the force vector
   // Note that the mid-point values (gen-alpha) of the interface forces are evaluated in
   // Solid::TimIntGenAlpha::evaluate_force_residual()
-  structure_->set_force_interface(evaluate_fluid_force(*pressure)->get_ptr_of_multi_vector());
+  structure_->set_force_interface(evaluate_fluid_force(*pressure)->as_multi_vector());
 }
 
 void EHL::Base::add_pressure_force(

--- a/src/fs3i/4C_fs3i_biofilm_fsi.cpp
+++ b/src/fs3i/4C_fs3i_biofilm_fsi.cpp
@@ -591,17 +591,17 @@ void FS3I::BiofilmFSI::inner_timeloop()
 
       if (avgrowth)
       {
-        (*((*normtempinflux_.get_ptr_of_epetra_vector())(0)))[lnodeid] += tempflux;
-        (*((*normtemptraction_.get_ptr_of_epetra_vector())(0)))[lnodeid] += abs(tempnormtrac);
-        (*((*tangtemptractionone_.get_ptr_of_epetra_vector())(0)))[lnodeid] += abs(temptangtracone);
-        (*((*tangtemptractiontwo_.get_ptr_of_epetra_vector())(0)))[lnodeid] += abs(temptangtractwo);
+        (*((normtempinflux_.get_ref_of_epetra_vector())(0)))[lnodeid] += tempflux;
+        (*((normtemptraction_.get_ref_of_epetra_vector())(0)))[lnodeid] += abs(tempnormtrac);
+        (*((tangtemptractionone_.get_ref_of_epetra_vector())(0)))[lnodeid] += abs(temptangtracone);
+        (*((tangtemptractiontwo_.get_ref_of_epetra_vector())(0)))[lnodeid] += abs(temptangtractwo);
       }
       else
       {
-        (*((*norminflux_->get_ptr_of_epetra_vector())(0)))[lnodeid] = tempflux;
-        (*((*normtraction_->get_ptr_of_epetra_vector())(0)))[lnodeid] = abs(tempnormtrac);
-        (*((*tangtractionone_->get_ptr_of_epetra_vector())(0)))[lnodeid] = abs(temptangtracone);
-        (*((*tangtractiontwo_->get_ptr_of_epetra_vector())(0)))[lnodeid] = abs(temptangtractwo);
+        (*((norminflux_->get_ref_of_epetra_vector())(0)))[lnodeid] = tempflux;
+        (*((normtraction_->get_ref_of_epetra_vector())(0)))[lnodeid] = abs(tempnormtrac);
+        (*((tangtractionone_->get_ref_of_epetra_vector())(0)))[lnodeid] = abs(temptangtracone);
+        (*((tangtractiontwo_->get_ref_of_epetra_vector())(0)))[lnodeid] = abs(temptangtractwo);
       }
     }
   }
@@ -622,14 +622,14 @@ void FS3I::BiofilmFSI::inner_timeloop()
       int lnodeid = strudis->node_row_map()->lid(gnodeid);
 
       // Fix this.
-      (*((*norminflux_->get_ptr_of_epetra_vector())(0)))[lnodeid] =
-          (*((*normtempinflux_.get_ptr_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
-      (*((*normtraction_->get_ptr_of_epetra_vector())(0)))[lnodeid] =
-          (*((*normtemptraction_.get_ptr_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
-      (*((*tangtractionone_->get_ptr_of_epetra_vector())(0)))[lnodeid] =
-          (*((*tangtemptractionone_.get_ptr_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
-      (*((*tangtractiontwo_->get_ptr_of_epetra_vector())(0)))[lnodeid] =
-          (*((*tangtemptractiontwo_.get_ptr_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
+      (*((norminflux_->get_ref_of_epetra_vector())(0)))[lnodeid] =
+          (*((normtempinflux_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
+      (*((normtraction_->get_ref_of_epetra_vector())(0)))[lnodeid] =
+          (*((normtemptraction_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
+      (*((tangtractionone_->get_ref_of_epetra_vector())(0)))[lnodeid] =
+          (*((tangtemptractionone_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
+      (*((tangtractiontwo_->get_ref_of_epetra_vector())(0)))[lnodeid] =
+          (*((tangtemptractiontwo_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
     }
   }
 

--- a/src/fsi/src/monolithic/4C_fsi_monolithic.cpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic.cpp
@@ -626,7 +626,7 @@ void FSI::Monolithic::time_step(
       std::make_shared<Core::LinAlg::Vector<double>>(*dof_row_map(), true);
   initial_guess(initial_guess_v);
 
-  ::NOX::Epetra::Vector noxSoln(Teuchos::rcpFromRef(*initial_guess_v->get_ptr_of_epetra_vector()),
+  ::NOX::Epetra::Vector noxSoln(Teuchos::rcpFromRef(initial_guess_v->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   // Create the linear system

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -444,7 +444,7 @@ void FSI::Partitioned::timeloop(const Teuchos::RCP<::NOX::Epetra::Interface::Req
     std::shared_ptr<Core::LinAlg::Vector<double>> soln = initial_guess();
 
     ::NOX::Epetra::Vector noxSoln(
-        Teuchos::rcpFromRef(*soln->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+        Teuchos::rcpFromRef(soln->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
 
     // Create the linear system
     Teuchos::RCP<::NOX::Epetra::LinearSystem> linSys =

--- a/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
+++ b/src/fsi/src/partitioned/model_evaluator/4C_fsi_str_model_evaluator_partitioned.cpp
@@ -145,7 +145,7 @@ Solid::ModelEvaluator::PartitionedFSI::solve_relaxation_linear(
   interface_force_np_ptr_->scale(-(ti_impl->tim_int_param()));
   ti_impl->dbc_ptr()->apply_dirichlet_to_rhs(*interface_force_np_ptr_);
   Teuchos::RCP<::NOX::Epetra::Vector> nox_force = Teuchos::make_rcp<::NOX::Epetra::Vector>(
-      Teuchos::rcpFromRef(*interface_force_np_ptr_->get_ptr_of_epetra_vector()));
+      Teuchos::rcpFromRef(interface_force_np_ptr_->get_ref_of_epetra_vector()));
   grp_ptr->set_f(nox_force);
 
   // ---------------------------------------------------------------------------

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -623,7 +623,9 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               Inpar::S2I::side_master, imastermatrix_, Inpar::S2I::side_master,
               Inpar::S2I::side_slave, imastermatrix_, Inpar::S2I::side_master,
               Inpar::S2I::side_master,
-              islaveresidual_ != nullptr ? islaveresidual_->get_ptr_of_multi_vector() : nullptr,
+              islaveresidual_ != nullptr
+                  ? Core::Utils::shared_ptr_from_ref(islaveresidual_->as_multi_vector())
+                  : nullptr,
               Inpar::S2I::side_slave, imasterresidual_, Inpar::S2I::side_master);
         }
 
@@ -640,7 +642,9 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_meshtying()
               Inpar::S2I::side_master, imastermatrix_, Inpar::S2I::side_master,
               Inpar::S2I::side_slave, imastermatrix_, Inpar::S2I::side_master,
               Inpar::S2I::side_master,
-              islaveresidual_ != nullptr ? islaveresidual_->get_ptr_of_multi_vector() : nullptr,
+              islaveresidual_ != nullptr
+                  ? Core::Utils::shared_ptr_from_ref(islaveresidual_->as_multi_vector())
+                  : nullptr,
               Inpar::S2I::side_slave, imasterresidual_, Inpar::S2I::side_master);
         }
       }
@@ -2474,7 +2478,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
               Inpar::S2I::side_undefined, Inpar::S2I::side_undefined, nullptr,
               Inpar::S2I::side_undefined, Inpar::S2I::side_undefined,
               islavenodeslumpedareas_dofvector != nullptr
-                  ? islavenodeslumpedareas_dofvector->get_ptr_of_multi_vector()
+                  ? Core::Utils::shared_ptr_from_ref(
+                        islavenodeslumpedareas_dofvector->as_multi_vector())
                   : nullptr,
               Inpar::S2I::side_slave, nullptr, Inpar::S2I::side_undefined);
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -223,7 +223,7 @@ bool NOX::Nln::LinearSystem::apply_jacobian_block(const ::NOX::Epetra::Vector& i
   int status = block.Apply(*input_apply, *result_apply);
 
   result = Teuchos::make_rcp<::NOX::Epetra::Vector>(
-      Teuchos::rcpFromRef(*result_apply->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(result_apply->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateCopy);
 
   return (status == 0);
@@ -259,8 +259,8 @@ void NOX::Nln::LinearSystem::set_linear_problem_for_solve(Epetra_LinearProblem& 
     Core::LinAlg::Vector<double>& rhs) const
 {
   linear_problem.SetOperator(jac.epetra_operator().get());
-  linear_problem.SetLHS(lhs.get_ptr_of_epetra_multi_vector().get());
-  linear_problem.SetRHS(rhs.get_ptr_of_epetra_multi_vector().get());
+  linear_problem.SetLHS(&lhs.get_ref_of_epetra_vector());
+  linear_problem.SetRHS(&rhs.get_ref_of_epetra_vector());
 }
 
 /*----------------------------------------------------------------------*

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
@@ -920,7 +920,7 @@ NOX::Nln::GROUP::PrePostOp::PseudoTransient::eval_pseudo_transient_f_update(
     case NOX::Nln::Solver::PseudoTransient::scale_op_identity:
     {
       ::NOX::Epetra::Vector v = ::NOX::Epetra::Vector(
-          Teuchos::rcpFromRef(*scaling_diag_op_ptr_->get_ptr_of_epetra_vector()));
+          Teuchos::rcpFromRef(scaling_diag_op_ptr_->get_ref_of_epetra_vector()));
       v.scale(ptcsolver_.get_inverse_pseudo_time_step());
       xUpdate->scale(v);
 

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -1020,8 +1020,8 @@ void MultiScale::MicroStatic::static_homogenization(Core::LinAlg::Matrix<6, 1>* 
           solver_params.refactor = true;
           solver_params.reset = true;
           solver.solve_with_multi_vector(stiff_->epetra_operator(),
-              (*iterinc)(i).get_ptr_of_multi_vector(), (*rhs_)(i).get_ptr_of_multi_vector(),
-              solver_params);
+              Core::Utils::shared_ptr_from_ref((*iterinc)(i).as_multi_vector()),
+              Core::Utils::shared_ptr_from_ref((*rhs_)(i).as_multi_vector()), solver_params);
         }
         break;
       }

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -2835,10 +2835,10 @@ Inpar::Solid::ConvergenceStatus Solid::TimInt::perform_error_action(
 /* Set forces due to interface with fluid,
  * the force is expected external-force-like */
 void Solid::TimInt::set_force_interface(
-    std::shared_ptr<Core::LinAlg::MultiVector<double>> iforce  ///< the force on interface
+    const Core::LinAlg::MultiVector<double>& iforce  ///< the force on interface
 )
 {
-  fifc_->update(1.0, *iforce, 0.0);
+  fifc_->update(1.0, iforce, 0.0);
 }
 
 std::string Solid::TimInt::method_title() const

--- a/src/structure/4C_structure_timint.hpp
+++ b/src/structure/4C_structure_timint.hpp
@@ -538,7 +538,7 @@ namespace Solid
 
     //! Set forces due to interface with fluid, the force is expected external-force-like
     void set_force_interface(
-        std::shared_ptr<Core::LinAlg::MultiVector<double>> iforce  ///< the force on interface
+        const Core::LinAlg::MultiVector<double>& iforce  ///< the force on interface
         ) override;
 
     //! @name Attributes

--- a/src/structure/4C_structure_timint_impl_nox.cpp
+++ b/src/structure/4C_structure_timint_impl_nox.cpp
@@ -358,7 +358,7 @@ int Solid::TimIntImpl::nox_solve()
 
   // create initial guess vector of predictor result
   ::NOX::Epetra::Vector noxSoln(
-      Teuchos::rcpFromRef(*disn_->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(disn_->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
 
   // Linear system
   Teuchos::RCP<::NOX::Epetra::LinearSystem> linSys =

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -255,7 +255,7 @@ void Solid::Integrator::compute_mass_matrix_and_init_acc()
   Core::LinAlg::Vector<double> soln_ptr(*global_state().dof_row_map_view(), true);
   // wrap the soln_ptr in a nox_epetra_Vector
   Teuchos::RCP<::NOX::Epetra::Vector> nox_soln_ptr = Teuchos::make_rcp<::NOX::Epetra::Vector>(
-      Teuchos::rcpFromRef(*soln_ptr.get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(soln_ptr.get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
 
   // Check if we are using a Newton direction
   std::string dir_str = p_nox.sublist("Direction").get<std::string>("Method");

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -639,9 +639,10 @@ std::shared_ptr<::NOX::Epetra::Vector> Solid::TimeInt::BaseDataGlobalState::crea
     }
   }  // end of the switch-case statement
 
-  // wrap and return
+  // Copy the content of our vector into a vector that NOX can use
   return std::make_shared<::NOX::Epetra::Vector>(
-      Teuchos::rcp(xvec_ptr.get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::make_rcp<Epetra_Vector>(xvec_ptr.get_ref_of_epetra_vector()),
+      ::NOX::Epetra::Vector::CreateView);
 }
 
 /*----------------------------------------------------------------------------*
@@ -1161,7 +1162,7 @@ void NOX::Nln::GROUP::PrePostOp::TimeInt::RotVecUpdater::run_pre_compute_x(
 
   // now replace the rotvec entries by the correct value computed before
   Core::LinAlg::assemble_my_vector(0.0, *xnew, 1.0, x_rotvec);
-  curr_grp_mutable.setX(Teuchos::rcpFromRef(*xnew->get_ptr_of_epetra_vector()));
+  curr_grp_mutable.setX(Teuchos::rcpFromRef(xnew->get_ref_of_epetra_vector()));
 
   /* tell the NOX::Nln::Group that the x vector has already been updated in
    * this preComputeX operator call */

--- a/src/structure_new/src/implicit/4C_structure_new_impl_statics.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_statics.cpp
@@ -152,12 +152,11 @@ double Solid::IMPLICIT::Statics::calc_ref_norm_force(
 
   // switch from Core::LinAlg::Vector<double> to ::NOX::Epetra::Vector (view but read-only)
   const ::NOX::Epetra::Vector fintnp_nox_ptr(
-      Teuchos::rcpFromRef(*fintnp->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(fintnp->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
   const ::NOX::Epetra::Vector fextnp_nox_ptr(
-      Teuchos::rcpFromRef(*fextnp->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(fextnp->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
   const ::NOX::Epetra::Vector freactnp_nox_ptr(
-      Teuchos::rcpFromRef(*freactnp->get_ptr_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(freactnp->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
 
   // norm of the internal forces
   double fintnorm = fintnp_nox_ptr.norm(type);

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -81,7 +81,7 @@ void Solid::TimeInt::Implicit::set_state(const std::shared_ptr<Core::LinAlg::Vec
 {
   integrator_ptr()->set_state(*x);
   ::NOX::Epetra::Vector x_nox(
-      Teuchos::rcpFromRef(*x->get_ptr_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(x->get_ref_of_epetra_vector()), ::NOX::Epetra::Vector::CreateView);
   nln_solver().get_solution_group().setX(x_nox);
   set_state_in_sync_with_nox_group(true);
 }
@@ -168,7 +168,7 @@ void Solid::TimeInt::Implicit::update_state_incrementally(
 
   // wrap the displacement vector in a nox_epetra_Vector
   const ::NOX::Epetra::Vector nox_disiterinc_ptr(
-      Teuchos::rcpFromRef(*mutable_disiterinc->get_ptr_of_epetra_vector()),
+      Teuchos::rcpFromRef(mutable_disiterinc->get_ref_of_epetra_vector()),
       ::NOX::Epetra::Vector::CreateView);
 
   // updated the state vector in the nox group

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -203,7 +203,7 @@ double Solid::TimeInt::NoxInterface::get_primary_rhs_norms(const Epetra_Vector& 
 
       int_ptr_->remove_condensed_contributions_from_rhs(*rhs_ptr);
 
-      rhsnorm = calculate_norm(rhs_ptr->get_ptr_of_epetra_vector(), type, isscaled);
+      rhsnorm = calculate_norm(rhs_ptr->get_ref_of_epetra_vector(), type, isscaled);
 
       break;
     }
@@ -212,7 +212,7 @@ double Solid::TimeInt::NoxInterface::get_primary_rhs_norms(const Epetra_Vector& 
       // export the model specific solution if necessary
       auto rhs_ptr = gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(F));
 
-      rhsnorm = calculate_norm(rhs_ptr->get_ptr_of_epetra_vector(), type, isscaled);
+      rhsnorm = calculate_norm(rhs_ptr->get_ref_of_epetra_vector(), type, isscaled);
 
       break;
     }
@@ -311,7 +311,7 @@ double Solid::TimeInt::NoxInterface::get_primary_solution_update_norms(const Epe
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xnew));
 
       model_incr_ptr->update(1.0, *model_xnew_ptr, -1.0);
-      updatenorm = calculate_norm(model_incr_ptr->get_ptr_of_epetra_vector(), type, isscaled);
+      updatenorm = calculate_norm(model_incr_ptr->get_ref_of_epetra_vector(), type, isscaled);
 
       break;
     }
@@ -324,7 +324,7 @@ double Solid::TimeInt::NoxInterface::get_primary_solution_update_norms(const Epe
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xnew));
 
       model_incr_ptr->update(1.0, *model_xnew_ptr, -1.0);
-      updatenorm = calculate_norm(model_incr_ptr->get_ptr_of_epetra_vector(), type, isscaled);
+      updatenorm = calculate_norm(model_incr_ptr->get_ref_of_epetra_vector(), type, isscaled);
 
       break;
     }
@@ -372,7 +372,7 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(const E
       auto model_xold_ptr =
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xold));
 
-      xoldnorm = calculate_norm(model_xold_ptr->get_ptr_of_epetra_vector(), type, isscaled);
+      xoldnorm = calculate_norm(model_xold_ptr->get_ref_of_epetra_vector(), type, isscaled);
 
       break;
     }
@@ -382,7 +382,7 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(const E
       auto model_xold_ptr =
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xold));
 
-      xoldnorm = calculate_norm(model_xold_ptr->get_ptr_of_epetra_vector(), type, isscaled);
+      xoldnorm = calculate_norm(model_xold_ptr->get_ref_of_epetra_vector(), type, isscaled);
 
       break;
     }
@@ -409,11 +409,11 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(const E
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-double Solid::TimeInt::NoxInterface::calculate_norm(std::shared_ptr<Epetra_Vector> quantity,
+double Solid::TimeInt::NoxInterface::calculate_norm(Epetra_Vector& quantity,
     const ::NOX::Abstract::Vector::NormType type, const bool isscaled) const
 {
   const ::NOX::Epetra::Vector quantity_nox(
-      Teuchos::rcpFromRef(*quantity), ::NOX::Epetra::Vector::CreateView);
+      Teuchos::rcpFromRef(quantity), ::NOX::Epetra::Vector::CreateView);
 
   double norm = quantity_nox.norm(type);
   // do the scaling if desired

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
@@ -170,8 +170,8 @@ namespace Solid
           std::vector<Inpar::Solid::ModelType>& constraint_models) const;
 
       //! calculate norm in Get*Norms functions
-      double calculate_norm(std::shared_ptr<Epetra_Vector> quantity,
-          const ::NOX::Abstract::Vector::NormType type, const bool isscaled) const;
+      double calculate_norm(Epetra_Vector& quantity, const ::NOX::Abstract::Vector::NormType type,
+          const bool isscaled) const;
 
      protected:
       //! init flag

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -50,7 +50,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::XFieldField::Coupling::maste
       break;
   }
 
-  master_to_slave(*mv->get_ptr_of_multi_vector(), map_type, *sv->get_ptr_of_multi_vector());
+  master_to_slave(mv->as_multi_vector(), map_type, sv->as_multi_vector());
   return sv;
 }
 
@@ -71,7 +71,7 @@ std::shared_ptr<Core::LinAlg::Vector<double>> XFEM::XFieldField::Coupling::slave
       break;
   }
 
-  slave_to_master(*sv->get_ptr_of_multi_vector(), map_type, *mv->get_ptr_of_multi_vector());
+  slave_to_master(sv->as_multi_vector(), map_type, mv->as_multi_vector());
   return mv;
 }
 


### PR DESCRIPTION
This is a preparatory step to use `LinAlg::View` inside `LinAlg::Vector`, but it would even be useful in isolation since it cuts down on some `shared_ptr`s.