### PR TITLE
[CMake] Use FOUR_C_BUILD_SHARED_LIBS insted of BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,7 +175,7 @@ add_library(${FOUR_C_LIBRARY_NAME})
 # Remove the CMake generated prefix "lib" because we already added it manually, to have a distinct target name.
 set_target_properties(${FOUR_C_LIBRARY_NAME} PROPERTIES PREFIX "")
 target_link_libraries(${FOUR_C_LIBRARY_NAME} PRIVATE four_c_private_compile_interface)
-if(NOT BUILD_SHARED_LIBS)
+if(NOT FOUR_C_BUILD_SHARED_LIBS)
   install(
     TARGETS four_c_private_compile_interface
     EXPORT 4CTargets

--- a/cmake/functions/four_c_auto_define_module.cmake
+++ b/cmake/functions/four_c_auto_define_module.cmake
@@ -131,7 +131,7 @@ function(four_c_auto_define_module)
       EXPORT 4CTargets
       FILE_SET HEADERS
       )
-    if(NOT BUILD_SHARED_LIBS)
+    if(NOT FOUR_C_BUILD_SHARED_LIBS)
       install(
         TARGETS ${_target}_objs
         EXPORT 4CTargets

--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -33,6 +33,30 @@ function(enable_linker_flag_if_supported _flag)
   four_c_check_compiles(FOUR_C_LINKER_HAS_FLAG_${_flag_var} LINK_OPTIONS ${_flag} APPEND_ON_SUCCESS)
 endfunction()
 
+# Backwards compatibility: if BUILD_SHARED_LIBS is set but not FOUR_C_BUILD_SHARED_LIBS, set the latter to the former.
+if(NOT DEFINED FOUR_C_BUILD_SHARED_LIBS AND DEFINED BUILD_SHARED_LIBS)
+  set(FOUR_C_BUILD_SHARED_LIBS
+      ${BUILD_SHARED_LIBS}
+      CACHE BOOL "Build shared libraries instead of static ones" FORCE
+      )
+  message(
+    WARNING
+      "Set FOUR_C_BUILD_SHARED_LIBS instead of BUILD_SHARED_LIBS. "
+      "Setting FOUR_C_BUILD_SHARED_LIBS based on BUILD_SHARED_LIBS to ${FOUR_C_BUILD_SHARED_LIBS}."
+    )
+endif()
+
+four_c_process_global_option(
+  FOUR_C_BUILD_SHARED_LIBS "Build shared libraries instead of static ones" OFF
+  )
+set(BUILD_SHARED_LIBS
+    ${FOUR_C_BUILD_SHARED_LIBS}
+    CACHE
+      BOOL
+      "Build shared libraries instead of static ones. Forces to be in sync with FOUR_C_BUILD_SHARED_LIBS."
+      FORCE
+    )
+
 four_c_process_global_option(
   FOUR_C_ENABLE_DEVELOPER_MODE
   "Enable developer mode (tries to optimize setup for iterative development cycles)"
@@ -54,7 +78,7 @@ enable_linker_flag_if_supported("-rdynamic")
 
 # Enable position-independent code. This flag is necessary to build shared libraries. Since our internal targets are not
 # real libraries but object libraries, this property needs to be set explicitly.
-if(BUILD_SHARED_LIBS)
+if(FOUR_C_BUILD_SHARED_LIBS)
   message(VERBOSE "Enabling POSITION_INDEPENDENT_CODE on internal targets.")
   set_target_properties(
     four_c_private_compile_interface PROPERTIES INTERFACE_POSITION_INDEPENDENT_CODE TRUE

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -16,7 +16,7 @@
         "FOUR_C_DEAL_II_ROOT": "/opt/4C-dependencies",
         "FOUR_C_QHULL_ROOT": "/opt/4C-dependencies",
         "FOUR_C_PVPYTHON": "/opt/4C-dependencies-testing/ParaView-5.5.2-Qt5-MPI-Linux-64bit/bin/pvpython",
-        "BUILD_SHARED_LIBS": "ON",
+        "FOUR_C_BUILD_SHARED_LIBS": "ON",
         "FOUR_C_WITH_GOOGLETEST": "ON",
         "FOUR_C_BUILD_DOXYGEN": "OFF",
         "FOUR_C_BUILD_DOCUMENTATION": "ON",

--- a/presets/lnm/workstation/CMakePresets.json
+++ b/presets/lnm/workstation/CMakePresets.json
@@ -13,7 +13,7 @@
         "FOUR_C_PVPYTHON": "/lnm/programs64/ParaView-5.5.2-Qt5-MPI-Linux-64bit/bin/pvpython",
         "FOUR_C_QHULL_ROOT": "/lnm/lib/packages/qhull/2012-1",
         "FOUR_C_TRILINOS_ROOT": "/lnm/lib/packages/trilinos/16-1-0_v2/release-shared",
-        "BUILD_SHARED_LIBS": "ON",
+        "FOUR_C_BUILD_SHARED_LIBS": "ON",
         "CMAKE_BUILD_TYPE": "RELEASE",
         "CMAKE_CXX_COMPILER": "/lnm/spack_packages/linux-ubuntu20.04-ivybridge/gcc-13.2.0/bin/g++",
         "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",


### PR DESCRIPTION
This adds an entry in the docs. We internally set BUILD_SHARED_LIBS to the same value. Backwards-compatibility is provided with a warning that the new version should be used.

Might help with #809. If people don't know about this option, they can't use it.
