### PR TITLE
Use View mechanism in Vector wrappers

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_view.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_view.hpp
@@ -174,6 +174,19 @@ namespace Core::LinAlg
       return *view_;
     }
 
+    /**
+     * Invalidate the view, so that it no longer views any object. You need to call sync()  or
+     * assign a new object to the view before using it again.
+     *
+     * @note This is useful in the implementation of wrappers where we want to trigger a re-sync of
+     * the view.
+     */
+    void invalidate()
+    {
+      view_.reset();
+      viewed_object_ = nullptr;
+    }
+
    private:
     //! Source content wrapped in our own type.
     //! We need to share ownership so we can make copies of the view (which refer to the same


### PR DESCRIPTION
Use our `LinAlg::View` mechanism inside the Vector wrappers. I initially had another view implementation where we synced vectors after dangerous operations. It is easier if we just use `View::sync()` which handles this for us. 

I found another bug in `Epetra_MultiVector`: asking for a vector from a `Epetra_MultiVector` will only create the correct vector once. After a call to `Epetra_MultiVector::ReplaceMap()` this vector will not be updated; see also the test in this PR. I decided not to fix this on our side. Let's just remove `replace_map` from our interface.