### PR TITLE
Don't access an object after its lifetime ends

### DIFF
--- a/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_vector_test.np2.cpp
@@ -300,7 +300,6 @@ namespace
     EXPECT_EQ(&a.get_ref_of_epetra_vector(), &b.get_epetra_multi_vector());
     // A change of the map invalidates views, so we need to be careful.
     a.replace_map(new_map);
-    EXPECT_NE(&a.get_ref_of_epetra_vector(), &b.get_epetra_multi_vector());
 
     {
       // This highlights a bug in Trilinos: the Epetra_Vector views into a MultiVector are only


### PR DESCRIPTION
Fix a bug where a test checks that a pointer stored in a no longer existing object has some property. This is UB.

Fixes the nightly ASAN test. Introduced in #834.