### PR TITLE
Keep test report with run times for 7 days

### DIFF
--- a/.github/workflows/nightly_tests.yml
+++ b/.github/workflows/nightly_tests.yml
@@ -75,7 +75,7 @@ jobs:
           name: gcc13_assertions_test_report-${{ matrix.test-chunk }}.xml
           path: |
             ${{ github.workspace }}/gcc13_assertions_test_report-${{ matrix.test-chunk }}.xml
-          retention-days: 1
+          retention-days: 7
 
   gcc13_assertions_test_report:
     needs: gcc13_assertions_test


### PR DESCRIPTION
If we only keep it one day, a single failing nightly run will unnecessarily stop our test chunking from taking the optimized path based on actual run times.
