### PR TITLE
Clean up pressure-based porofluid-elast-scatra artery coupling schemes

### DIFF
--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.hpp
@@ -10,7 +10,6 @@
 
 #include "4C_config.hpp"
 
-#include "4C_inpar_bio.hpp"
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.hpp"
 
 
@@ -21,44 +20,45 @@ namespace PoroPressureBased
   class PoroMultiPhaseScatraArteryCouplingPairBase;
 
   //! Line-based coupling between artery network and porofluid-elasticity-scatra algorithm
-  class PorofluidElastScatraArteryCouplingLineBasedAlgorithm
+  class PorofluidElastScatraArteryCouplingLineBasedAlgorithm final
       : public PorofluidElastScatraArteryCouplingNonConformingAlgorithm
   {
    public:
     PorofluidElastScatraArteryCouplingLineBasedAlgorithm(
-        std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& couplingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname);
+        std::shared_ptr<Core::FE::Discretization> artery_dis,
+        std::shared_ptr<Core::FE::Discretization> homogenized_dis,
+        const Teuchos::ParameterList& coupling_params, const std::string& condition_name,
+        const std::string& artery_coupled_dof_name,
+        const std::string& homogenized_coupled_dof_name);
 
-    //! set-up linear system of equations of coupled problem
+    //! set up the global system of equations of the coupled problem
     void setup_system(std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
         std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_art,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_art,
-        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_cont,
-        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art) override;
+        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_homogenized,
+        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_artery,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_homogenized,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_artery,
+        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_homogenized,
+        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_artery) override;
 
-    //! setup the strategy
+    //! set up the algorithm
     void setup() override;
 
     //! apply mesh movement (on artery elements)
     void apply_mesh_movement() override;
 
-    //! access to blood vessel volume fraction
+    //! access to the blood vessel volume fraction
     std::shared_ptr<const Core::LinAlg::Vector<double>> blood_vessel_volume_fraction() override;
 
    private:
-    //! pre-evaluate the pairs and sort out duplicates
+    //! pre-evaluate the coupling pairs and delete duplicates
     void pre_evaluate_coupling_pairs();
 
-    //! fill the length not changed through deformation and initialize curr length
+    //! fill the length not changed by deformation and initialize the current length
     void fill_unaffected_artery_length();
 
-    //! fill the integrated diameter not changed through varying blood vessel diameter
-    void fill_unaffected_integrated_diam();
+    //! fill the integrated diameter not changed by varying blood vessel diameter
+    void fill_unaffected_integrated_diameter() const;
 
     //! calculate the volume fraction occupied by blood vessels
     void calculate_blood_vessel_volume_fraction();
@@ -68,11 +68,11 @@ namespace PoroPressureBased
 
     //! fill the GID to segment vector
     void fill_gid_to_segment_vector(
-        const std::vector<std::shared_ptr<
-            PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupled_ele_pairs,
-        std::map<int, std::vector<double>>& gid_to_seglength);
+        const std::vector<std::shared_ptr<PoroMultiPhaseScatraArteryCouplingPairBase>>&
+            coupled_ele_pairs,
+        std::map<int, std::vector<double>>& gid_to_segment_length) const;
 
-    //! set the artery diameter in column based vector
+    //! set the artery diameter in column-based vector
     void fill_artery_ele_diam_col();
 
     //! (re-)set the artery diameter in material to be able to use it on 1D discretization
@@ -82,54 +82,52 @@ namespace PoroPressureBased
     void reset_integrated_diameter_to_zero() override;
 
     /*!
-     * @brief Utility function for depth-first search for the connected components of the 1D artery
-     * discretization
+     * @brief Depth-first search for the connected components of the 1D artery discretization
      *
-     * @param actnode : currently checked node
-     * @param visited : vector that marks visited nodes
-     * @param artsearchdis : artery-discretization in fully-overlapping format
-     * @param ele_diams_artery_full_overlap : vector of element diameters in fully-overlapping
-     * format
-     * @param this_connected_comp : current connected component
+     * @param current_node : currently checked node
+     * @param checked_nodes : vector that marks already checked nodes
+     * @param artery_dis_fully_overlapping : artery-discretization in fully overlapping format
+     * @param artery_ele_diameters_fully_overlapping : vector of element diameters in fully
+     * overlapping format
+     * @param current_connected_component : current connected component
      */
-    void depth_first_search_util(Core::Nodes::Node* actnode,
-        std::shared_ptr<Core::LinAlg::Vector<int>> visited,
-        std::shared_ptr<Core::FE::Discretization> artconncompdis,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> ele_diams_artery_full_overlap,
-        std::vector<int>& this_connected_comp);
+    void depth_first_search(Core::Nodes::Node* current_node,
+        std::shared_ptr<Core::LinAlg::Vector<int>> checked_nodes,
+        std::shared_ptr<Core::FE::Discretization> artery_dis_fully_overlapping,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> artery_ele_diameters_fully_overlapping,
+        std::vector<int>& current_connected_component);
 
     /*!
-     * @brief find free-hanging 1D elements
+     * @brief Find free-hanging 1D elements
      *
      * Find the free hanging 1D elements which have to be taken out of simulation during blood
      * vessel collapse. This is realized by getting the connected components of the 1D graph. If no
      * node of a connected component has a DBC or if it is smaller than a user-specified
-     * threshold, all its elements are taken out
-     * @param : eles_to_be_deleted vector of free-hanging elements
+     * threshold, all its elements are deleted.
+     * @param elements_to_be_deleted : vector of free-hanging elements which should be deleted
      */
-    void find_free_hanging_1d_elements(std::vector<int>& eles_to_be_deleted);
+    void find_free_hanging_1d_elements(std::vector<int>& elements_to_be_deleted);
 
     //! evaluate additional linearization of (integrated) element diameter dependent terms
     //! (Hagen-Poiseuille)
-    void evaluate_additional_linearizationof_integrated_diam() override;
+    void evaluate_additional_linearization_of_integrated_diameter() override;
 
     /*!
-     * @brief apply additional Dirichlet boundary condition for collapsed 1D elements to avoid
-     * singular stiffness matrix
+     * @brief Apply additional Dirichlet boundary condition for collapsed 1D elements to avoid
+     * singular stiffness matrix.
      *
-     * apply additional dirichlet boundary conditions of zero pressure or mass fraction on nodes
-     * which only border collapsed 1D elements, i.e., free-hanging nodes with zero row in global
-     * stiffness matrix to avoid singularity of this matrix
-     * \note this procedure is equivalent to taking collapsed elements out of the simulation
-     * entirely
+     * Apply additional zero-pressure or zero-mass-fraction Dirichlet boundary conditions to nodes
+     * that are adjacent to collapsed 1D elements (i.e., free-hanging nodes with zero rows in the
+     * global stiffness matrix) to avoid singularity of the matrix.
+     * \note This procedure is equivalent to deleting collapsed elements from the simulation.
      *
-     * @param[in]        dbcmap_art map of nodes with DBC of 1D discretization
-     * @param[in,out]   rhs_art_with_collapsed right hand side of artery subpart
-     * @returns dbcmap, also containing additional boundary condition for collapsed eles
+     * @param[in]        dbcmap_artery map of nodes with DBC of 1D discretization
+     * @param[in,out]   rhs_artery_with_collapsed right-hand side of artery subpart
+     * @returns dbcmap, also containing additional boundary condition for collapsed elements
      */
-    std::shared_ptr<Core::LinAlg::Map> get_additional_dbc_for_collapsed_eles(
-        const Core::LinAlg::MapExtractor& dbcmap_art,
-        Core::LinAlg::Vector<double>& rhs_art_with_collapsed);
+    std::shared_ptr<Core::LinAlg::Map> get_additional_dbc_for_collapsed_elements(
+        const Core::LinAlg::MapExtractor& dbcmap_artery,
+        Core::LinAlg::Vector<double>& rhs_artery_with_collapsed) const;
 
     //! FE-assemble into global force and stiffness
     void assemble(const int& ele1_gid, const int& ele2_gid, const double& integrated_diameter,
@@ -138,64 +136,64 @@ namespace PoroPressureBased
         std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
         std::shared_ptr<Core::LinAlg::Vector<double>> rhs) override;
 
-    //! get the segment lengths of element 'artelegid'
-    std::vector<double> get_ele_segment_lengths(const int artelegid) override;
+    //! get the segment length
+    std::vector<double> get_ele_segment_length(int artery_ele_gid) override;
 
-    //! check for duplicate segment
+    //! check for duplicate segments
     bool is_duplicate_segment(
-        const std::vector<std::shared_ptr<
-            PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupled_ele_pairs,
-        PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase& possible_duplicate);
+        const std::vector<std::shared_ptr<PoroMultiPhaseScatraArteryCouplingPairBase>>&
+            coupled_ele_pairs,
+        const PoroMultiPhaseScatraArteryCouplingPairBase& possible_duplicate);
 
-    //! check for identical segment
+    //! check if segments are identical
     bool is_identical_segment(
-        const std::vector<std::shared_ptr<
-            PoroPressureBased::PoroMultiPhaseScatraArteryCouplingPairBase>>& coupled_ele_pairs,
-        const int& ele1gid, const double& etaA, const double& etaB, int& ele_pair_id);
+        const std::vector<std::shared_ptr<PoroMultiPhaseScatraArteryCouplingPairBase>>&
+            coupled_ele_pairs,
+        const int& ele1_gid, const double& etaA, const double& etaB, int& ele_pair_id);
 
     //! set flag if variable diameter has to be calculated
     void set_flag_variable_diameter() override;
 
-    //! print output of mesh tying pairs
+    //! print output of meshtying pairs
     void output_summary() const;
 
     //! print out the coupling method
     void print_coupling_method() const override;
 
     //! maximum number of segments per artery element
-    int maxnumsegperartele_;
+    int max_num_segments_per_artery_element_;
 
-    //! length of artery elements unaffected by deformation
-    std::shared_ptr<Epetra_FEVector> unaffected_seg_lengths_artery_;
+    //! lengths of artery elements unaffected by deformation
+    std::shared_ptr<Epetra_FEVector> unaffected_artery_segment_lengths_;
 
-    //! length of artery elements in current configuration
-    std::shared_ptr<Epetra_FEVector> current_seg_lengths_artery_;
+    //! lengths of artery elements in current configuration
+    std::shared_ptr<Epetra_FEVector> current_artery_segment_lengths_;
 
-    //! diameter of the artery element integrated over the length of the artery element (row format
+    //! diameters of artery elements integrated over the length of the elements (row format
     //! and FE vector due to non-local assembly)
-    std::shared_ptr<Epetra_FEVector> integrated_diams_artery_row_;
+    std::shared_ptr<Epetra_FEVector> integrated_artery_diameters_row_;
 
-    //! diameter of artery element integrated over the length of the artery element (col format)
-    std::shared_ptr<Core::LinAlg::Vector<double>> integrated_diams_artery_col_;
+    //! diameters of artery elements integrated over the length of the elements (col format)
+    std::shared_ptr<Core::LinAlg::Vector<double>> integrated_artery_diameters_col_;
 
-    //! diameter of artery element (col format)
-    std::shared_ptr<Core::LinAlg::Vector<double>> ele_diams_artery_col_;
+    //! diameters of artery elements (col format)
+    std::shared_ptr<Core::LinAlg::Vector<double>> artery_elements_diameters_col_;
 
     //! unaffected diameter integrated over the length of the artery element
     //! (protruding elements for which diameter does not change)
-    std::shared_ptr<Core::LinAlg::Vector<double>> unaffected_integrated_diams_artery_col_;
+    std::shared_ptr<Core::LinAlg::Vector<double>> unaffected_integrated_artery_diameters_col_;
 
     //! volume fraction of blood vessels (for output)
-    std::shared_ptr<Core::LinAlg::Vector<double>> bloodvesselvolfrac_;
+    std::shared_ptr<Core::LinAlg::Vector<double>> blood_vessel_volfrac_;
 
     //! gid to segment: stores [GID; [eta_a eta_b]_1, [eta_a eta_b]_2, ..., [eta_a eta_b]_n]
     //!  of artery elements in column format, i.e. fully overlapping
     std::map<int, std::vector<double>> gid_to_segment_;
 
     //! gid to segment length: stores [GID; seglength_1, seglength_2, ..., seglength_n]
-    //!  of artery elements in column format, i.e. fully overlapping (only used for
+    //!  of artery elements in column format, i.e., fully overlapping (only used for
     //!  porofluid-problems)
-    std::map<int, std::vector<double>> gid_to_seglength_;
+    std::map<int, std::vector<double>> gid_to_segment_length_;
   };
 }  // namespace PoroPressureBased
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.cpp
@@ -19,20 +19,20 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraArteryCouplingNodeToPointAlgorithm::
     PorofluidElastScatraArteryCouplingNodeToPointAlgorithm(
-        std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& couplingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname)
-    : PorofluidElastScatraArteryCouplingNonConformingAlgorithm(
-          arterydis, contdis, couplingparams, condname, artcoupleddofname, contcoupleddofname)
+        std::shared_ptr<Core::FE::Discretization> artery_dis,
+        std::shared_ptr<Core::FE::Discretization> homogenized_dis,
+        const Teuchos::ParameterList& coupling_params, const std::string& condition_name,
+        const std::string& artery_coupled_dof_name, const std::string& homogenized_coupled_dof_name)
+    : PorofluidElastScatraArteryCouplingNonConformingAlgorithm(artery_dis, homogenized_dis,
+          coupling_params, condition_name, artery_coupled_dof_name, homogenized_coupled_dof_name)
 {
   // user info
   if (my_mpi_rank_ == 0)
   {
-    std::cout << "<                                                  >" << std::endl;
+    std::cout << "<                                                  >" << '\n';
     print_coupling_method();
-    std::cout << "<                                                  >" << std::endl;
-    std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>" << std::endl;
+    std::cout << "<                                                  >" << '\n';
+    std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>" << '\n';
     std::cout << "\n";
   }
 }
@@ -55,7 +55,7 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNodeToPointAlgorithm::
 
   // error-checks
   if (has_variable_diameter_)
-    FOUR_C_THROW("Varying diameter not yet possible for node-to-point coupling");
+    FOUR_C_THROW("Variable diameter not yet possible for node-to-point coupling");
   if (!evaluate_in_ref_config_)
     FOUR_C_THROW("Evaluation in current configuration not yet possible for node-to-point coupling");
 
@@ -105,17 +105,17 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNodeToPointAlgorithm::
 void PoroPressureBased::PorofluidElastScatraArteryCouplingNodeToPointAlgorithm::setup_system(
     std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
     std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
-    std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
-    std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_art,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_art,
-    std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_cont,
-    std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art)
+    std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_homogenized,
+    std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_artery,
+    std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_homogenized,
+    std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_artery,
+    std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_homogenized,
+    std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_artery)
 {
   // call base class
-  PorofluidElastScatraArteryCouplingNonConformingAlgorithm::setup_system(*sysmat, rhs, *sysmat_cont,
-      *sysmat_art, rhs_cont, rhs_art, *dbcmap_cont, *dbcmap_art->cond_map(),
-      *dbcmap_art->cond_map());
+  PorofluidElastScatraArteryCouplingNonConformingAlgorithm::setup_system(*sysmat, rhs,
+      *sysmat_homogenized, *sysmat_artery, rhs_homogenized, rhs_artery, *dbcmap_homogenized,
+      *dbcmap_artery->cond_map(), *dbcmap_artery->cond_map());
 }
 
 /*----------------------------------------------------------------------*
@@ -159,7 +159,7 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNodeToPointAlgorithm::
     std::cout << "Proc " << std::right << std::setw(2) << my_mpi_rank_ << ": Artery-ele "
               << std::right << std::setw(5) << coupled_ele_pair->ele1_gid()
               << ": <---> continuous-ele " << std::right << std::setw(7)
-              << coupled_ele_pair->ele2_gid() << std::endl;
+              << coupled_ele_pair->ele2_gid() << '\n';
   }
   Core::Communication::barrier(get_comm());
   if (my_mpi_rank_ == 0) std::cout << "\n";

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nodetopoint.hpp
@@ -18,34 +18,35 @@ FOUR_C_NAMESPACE_OPEN
 namespace PoroPressureBased
 {
   //! Node-to-point coupling between artery network and porofluid-elasticity-scatra algorithm
-  class PorofluidElastScatraArteryCouplingNodeToPointAlgorithm
+  class PorofluidElastScatraArteryCouplingNodeToPointAlgorithm final
       : public PorofluidElastScatraArteryCouplingNonConformingAlgorithm
   {
    public:
     //! constructor
     PorofluidElastScatraArteryCouplingNodeToPointAlgorithm(
-        std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& couplingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname);
+        std::shared_ptr<Core::FE::Discretization> artery_dis,
+        std::shared_ptr<Core::FE::Discretization> homogenized_dis,
+        const Teuchos::ParameterList& coupling_params, const std::string& condition_name,
+        const std::string& artery_coupled_dof_name,
+        const std::string& homogenized_coupled_dof_name);
 
-    //! set-up of global system of equations of coupled problem
+    //! set up of the global system of equations of the coupled problem
     void setup_system(std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
         std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_art,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_art,
-        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_cont,
-        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art) override;
+        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_homogenized,
+        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_artery,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_homogenized,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_artery,
+        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_homogenized,
+        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_artery) override;
 
-    //! setup the strategy
+    //! set up the strategy
     void setup() override;
 
     //! apply mesh movement (on artery elements)
     void apply_mesh_movement() override;
 
-    //! access to blood vessel volume fraction
+    //! access to the blood vessel volume fraction
     std::shared_ptr<const Core::LinAlg::Vector<double>> blood_vessel_volume_fraction() override;
 
     //! Evaluate the 1D-3D coupling
@@ -77,27 +78,27 @@ namespace PoroPressureBased
      * (Hagen-Poiseuille)
      * \note not possible for node-to-point formulation since variable diameter not yet possible
      */
-    void evaluate_additional_linearizationof_integrated_diam() override
+    void evaluate_additional_linearization_of_integrated_diameter() override
     {
       FOUR_C_THROW(
-          "Function 'evaluate_additional_linearizationof_integrated_diam()' not possible for "
+          "Function 'evaluate_additional_linearization_of_integrated_diameter()' not possible for "
           "node-to-point coupling");
     };
 
     /*!
-     * @brief get the segment lengths of element 'artelegid'
+     * @brief get the segment lengths of element @p artery_ele_gid
      * \note segment length is set to zero since we have no segments in node-to-point coupling
      */
-    std::vector<double> get_ele_segment_lengths(const int artelegid) override { return {0.0}; };
+    std::vector<double> get_ele_segment_length(const int artery_ele_gid) override { return {0.0}; };
 
    private:
     //! print out the coupling method
     void print_coupling_method() const override;
 
-    //! preevaluate the coupling pairs
+    //! pre-evaluate the coupling pairs
     void pre_evaluate_coupling_pairs();
 
-    //! Output Coupling pairs
+    //! Output coupling pairs
     void output_coupling_pairs() const;
   };
 }  // namespace PoroPressureBased

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
@@ -17,10 +17,8 @@
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_defines.hpp"
 #include "4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp"
 #include "4C_porofluid_pressure_based_ele_parameter.hpp"
-#include "4C_porofluid_pressure_based_utils.hpp"
 #include "4C_scatra_ele_parameter_timint.hpp"
 
-#include <boost/range/numeric.hpp>
 #include <Epetra_FEVector.h>
 
 FOUR_C_NAMESPACE_OPEN
@@ -299,8 +297,8 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
       Global::Problem::instance()->poro_fluid_multi_phase_dynamic_params().sublist(
           "ARTERY COUPLING");
 
-  int num_active_pairs = boost::accumulate(nearby_ele_pairs_, 0,
-      [](const int a, const auto& b) { return a + (static_cast<int>(b.second.size())); });
+  int num_active_pairs = std::accumulate(nearby_ele_pairs_.begin(), nearby_ele_pairs_.end(), 0,
+      [](int a, auto b) { return a + (static_cast<int>(b.second.size())); });
 
   coupled_ele_pairs_.resize(num_active_pairs);
 
@@ -379,7 +377,6 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
 
   nearby_ele_pairs_.clear();
 }
-
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
@@ -470,7 +467,7 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
 
     // get the segment lengths
     const std::vector<double> segment_lengths =
-        get_ele_segment_lengths(coupled_ele_pair->ele1_gid());
+        get_ele_segment_length(coupled_ele_pair->ele1_gid());
 
     // evaluate
     const double integrated_diameter = coupled_ele_pair->evaluate(&(ele_rhs[0]), &(ele_rhs[1]),
@@ -494,7 +491,7 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
   if (homogenized_dis_->name() == "porofluid" && has_variable_diameter_)
   {
     set_artery_diameter_in_material();
-    evaluate_additional_linearizationof_integrated_diam();
+    evaluate_additional_linearization_of_integrated_diameter();
   }
 
   if (coupling_rhs_vector_->GlobalAssemble(Add, false) != 0)

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.hpp
@@ -63,7 +63,7 @@ namespace PoroPressureBased
 
     //! evaluate additional linearization of (integrated) element diameter dependent terms
     //! (Hagen-Poiseuille)
-    virtual void evaluate_additional_linearizationof_integrated_diam() = 0;
+    virtual void evaluate_additional_linearization_of_integrated_diameter() = 0;
 
     //! FE-assemble into global force and stiffness matrix
     virtual void assemble(const int& ele1_gid, const int& ele2_gid,
@@ -163,9 +163,6 @@ namespace PoroPressureBased
     //! create interaction pairs for node-to-point coupling
     void create_coupling_pairs_node_to_point();
 
-    //! calculate the volume fraction occupied by blood vessels
-    void calculate_blood_vessel_volume_fraction();
-
     //! get the node Id from 1D nodes from the input file for node-to-point coupling
     void get_coupling_nodes_from_input_node_to_point();
 
@@ -180,7 +177,7 @@ namespace PoroPressureBased
 
     //! sum D and M into global force and stiffness matrix
     void sum_mortar_matrices_into_global_matrix(Core::LinAlg::BlockSparseMatrixBase& sysmat,
-        const std::shared_ptr<Core::LinAlg::Vector<double>> rhs) const;
+        std::shared_ptr<Core::LinAlg::Vector<double>> rhs) const;
 
     //! return appropriate internal implementation class
     //! (acts as a simple factory to create single pairs)
@@ -190,8 +187,8 @@ namespace PoroPressureBased
     //! set the artery diameter in material to be able to use it on 1D discretization
     virtual void set_artery_diameter_in_material() = 0;
 
-    //! get the segment lengths of element 'artery_ele_gid'
-    virtual std::vector<double> get_ele_segment_lengths(int artery_ele_gid) = 0;
+    //! get the segment length
+    virtual std::vector<double> get_ele_segment_length(int artery_ele_gid) = 0;
 
     //! reset the integrated diameter vector to zero
     virtual void reset_integrated_diameter_to_zero() = 0;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.cpp
@@ -19,20 +19,20 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------*/
 PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm::
     PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm(
-        std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& couplingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname)
-    : PorofluidElastScatraArteryCouplingNonConformingAlgorithm(
-          arterydis, contdis, couplingparams, condname, artcoupleddofname, contcoupleddofname)
+        std::shared_ptr<Core::FE::Discretization> artery_dis,
+        std::shared_ptr<Core::FE::Discretization> homogenized_dis,
+        const Teuchos::ParameterList& coupling_params, const std::string& condition_name,
+        const std::string& artery_coupled_dof_name, const std::string& homogenized_coupled_dof_name)
+    : PorofluidElastScatraArteryCouplingNonConformingAlgorithm(artery_dis, homogenized_dis,
+          coupling_params, condition_name, artery_coupled_dof_name, homogenized_coupled_dof_name)
 {
   // user info
   if (my_mpi_rank_ == 0)
   {
-    std::cout << "<                                                  >" << std::endl;
+    std::cout << "<                                                  >" << '\n';
     print_coupling_method();
-    std::cout << "<                                                  >" << std::endl;
-    std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>" << std::endl;
+    std::cout << "<                                                  >" << '\n';
+    std::cout << "<<<<<<<<<<<<<<<<<<<<<<<<<<<>>>>>>>>>>>>>>>>>>>>>>>>>" << '\n';
     std::cout << "\n";
   }
 }
@@ -42,127 +42,126 @@ PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm::
 void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm::
     pre_evaluate_coupling_pairs()
 {
-  const int numpatch_axi = Global::Problem::instance()
-                               ->poro_fluid_multi_phase_dynamic_params()
-                               .sublist("ARTERY COUPLING")
-                               .get<int>("NUMPATCH_AXI");
-  const int numpatch_rad = Global::Problem::instance()
-                               ->poro_fluid_multi_phase_dynamic_params()
-                               .sublist("ARTERY COUPLING")
-                               .get<int>("NUMPATCH_RAD");
-  const int numartele = artery_dis_->num_global_elements();
-  const int numgp_per_artele = numpatch_axi * numpatch_rad * 25;
-  const int numgp_desired = numgp_per_artele * numartele;
+  const int num_patches_axial = Global::Problem::instance()
+                                    ->poro_fluid_multi_phase_dynamic_params()
+                                    .sublist("ARTERY COUPLING")
+                                    .get<int>("NUMPATCH_AXI");
+  const int num_patches_radial = Global::Problem::instance()
+                                     ->poro_fluid_multi_phase_dynamic_params()
+                                     .sublist("ARTERY COUPLING")
+                                     .get<int>("NUMPATCH_RAD");
+  const int num_artery_ele = artery_dis_->num_global_elements();
+  const int num_gp_per_artery_ele = num_patches_axial * num_patches_radial * 25;
+  const int num_gp_desired = num_gp_per_artery_ele * num_artery_ele;
 
-  // this vector keeps track of evaluation of GPs
-  std::shared_ptr<Core::LinAlg::MultiVector<double>> gp_vector =
-      std::make_shared<Core::LinAlg::MultiVector<double>>(
-          *artery_dis_->element_col_map(), numgp_per_artele);
+  // this vector keeps track of the Gauss point (GP) evaluation
+  const auto gp_vector = std::make_shared<Core::LinAlg::MultiVector<double>>(
+      *artery_dis_->element_col_map(), num_gp_per_artery_ele);
 
   // pre-evaluate
-  for (unsigned i = 0; i < coupled_ele_pairs_.size(); i++)
-    coupled_ele_pairs_[i]->pre_evaluate(gp_vector);
+  for (const auto& coupled_ele_pair : coupled_ele_pairs_) coupled_ele_pair->pre_evaluate(gp_vector);
 
   // delete the inactive pairs
-  coupled_ele_pairs_.erase(std::remove_if(coupled_ele_pairs_.begin(), coupled_ele_pairs_.end(),
-                               [](auto& pair) { return !pair->is_active(); }),
-      coupled_ele_pairs_.end());
+  std::erase_if(coupled_ele_pairs_, [](const auto& pair) { return !pair->is_active(); });
 
-  // the following takes care of a very special case, namely, if a GP on the lateral surface lies
-  // exactly in between two or more 3D elements owned by different procs.
-  // In that case, the GP is duplicated across all owning procs.
-  // We detect such cases and communicate them to all procs. below by adapting the
-  // "gp_vector", to contain the multiplicity of the respective GP. Later the GP weight inside the
-  // coupling pair is scaled by the inverse of the multiplicity
+  // The following takes care of a very special case, namely, if a GP on the lateral surface lies
+  // exactly in between two or more 3D elements owned by different procs. In that case, the GP is
+  // duplicated across all owning procs. We detect such cases and communicate them to all procs
+  // below by adapting the "gp_vector", to contain the multiplicity of the respective GP. Finally,
+  // the GP weight inside the coupling pair is scaled by the inverse of the multiplicity.
 
   int duplicates = 0;
   if (Core::Communication::num_mpi_ranks(get_comm()) > 1)
   {
-    std::vector<int> mygpvec(numgp_per_artele, 0);
-    std::vector<int> sumgpvec(numgp_per_artele, 0);
+    std::vector my_gp_vector(num_gp_per_artery_ele, 0);
+    std::vector sum_gp_vectors(num_gp_per_artery_ele, 0);
     // loop over all GIDs
     for (int gid = gp_vector->get_map().min_all_gid(); gid <= gp_vector->get_map().max_all_gid();
         gid++)
     {
       // reset
-      std::fill(sumgpvec.data(), sumgpvec.data() + numgp_per_artele, 0);
+      std::fill_n(sum_gp_vectors.data(), num_gp_per_artery_ele, 0);
 
-      const int mylid = gp_vector->get_map().lid(gid);
+      const int my_lid = gp_vector->get_map().lid(gid);
       // if not owned or ghosted fill with zeros
-      if (mylid < 0) std::fill(mygpvec.data(), mygpvec.data() + numgp_per_artele, 0);
+      if (my_lid < 0) std::fill_n(my_gp_vector.data(), num_gp_per_artery_ele, 0);
       // else get the GP vector
       else
-        for (int igp = 0; igp < numgp_per_artele; igp++)
-          mygpvec[igp] = static_cast<int>(((*gp_vector)(igp))[mylid]);
+        for (int igp = 0; igp < num_gp_per_artery_ele; igp++)
+          my_gp_vector[igp] = static_cast<int>(((*gp_vector)(igp))[my_lid]);
 
       // communicate to all via summation
-      Core::Communication::sum_all(mygpvec.data(), sumgpvec.data(), numgp_per_artele, get_comm());
+      Core::Communication::sum_all(
+          my_gp_vector.data(), sum_gp_vectors.data(), num_gp_per_artery_ele, get_comm());
 
-      // this is ok for now, either the GID does not exist or the entire element protrudes.
+      // This is ok for now, either the GID does not exist or the entire element protrudes.
       // Inform user and continue
-      if (*std::max_element(sumgpvec.data(), sumgpvec.data() + numgp_per_artele) < 1)
+      if (*std::max_element(sum_gp_vectors.data(), sum_gp_vectors.data() + num_gp_per_artery_ele) <
+          1)
       {
-        std::cout << "WARNING! No GP of element  " << gid + 1 << " could be projected!"
-                  << std::endl;
+        std::cout << "WARNING! No GP of element  " << gid + 1 << " could be projected!" << '\n';
         continue;
       }
 
       // if one entry is equal to zero, this GP could not be projected
-      if (*std::min_element(sumgpvec.data(), sumgpvec.data() + numgp_per_artele) < 1)
+      if (*std::min_element(sum_gp_vectors.data(), sum_gp_vectors.data() + num_gp_per_artery_ele) <
+          1)
         FOUR_C_THROW("It seems as if one GP could not be projected");
 
       // find number of duplicates
       int sum = 0;
-      sum = std::accumulate(sumgpvec.data(), sumgpvec.data() + numgp_per_artele, sum);
-      duplicates += sum - numgp_per_artele;
+      sum = std::accumulate(
+          sum_gp_vectors.data(), sum_gp_vectors.data() + num_gp_per_artery_ele, sum);
+      duplicates += sum - num_gp_per_artery_ele;
 
       // if owned or ghosted by this proc. and if duplicates have been detected, replace entry in
       // gp_vector
-      if (mylid >= 0 && sum > numgp_per_artele)
+      if (my_lid >= 0 && sum > num_gp_per_artery_ele)
       {
-        for (int igp = 0; igp < numgp_per_artele; igp++)
+        for (int igp = 0; igp < num_gp_per_artery_ele; igp++)
         {
-          int err = gp_vector->ReplaceMyValue(mylid, igp, static_cast<double>(sumgpvec[igp]));
-          if (err != 0) FOUR_C_THROW("ReplaceMyValue failed with error code {}!", err);
+          if (int err = gp_vector->ReplaceMyValue(my_lid, igp, sum_gp_vectors[igp]); err != 0)
+            FOUR_C_THROW("ReplaceMyValue failed with error code {}!", err);
         }
       }
     }
   }
 
-  for (unsigned i = 0; i < coupled_ele_pairs_.size(); i++)
-    coupled_ele_pairs_[i]->delete_unnecessary_gps(gp_vector);
+  for (const auto& coupled_ele_pair : coupled_ele_pairs_)
+    coupled_ele_pair->delete_unnecessary_gps(gp_vector);
 
   int total_num_gp = 0;
-  int numgp = 0;
+  int num_gp = 0;
 
-  for (unsigned i = 0; i < coupled_ele_pairs_.size(); i++)
+  for (const auto& coupled_ele_pair : coupled_ele_pairs_)
   {
-    // segment ID not needed in this case, just set to zero
-    coupled_ele_pairs_[i]->set_segment_id(0);
-    numgp = numgp + coupled_ele_pairs_[i]->num_gp();
+    // segment ID is not needed in this case, just set to zero
+    coupled_ele_pair->set_segment_id(0);
+    num_gp = num_gp + coupled_ele_pair->num_gp();
   }
   // safety check
-  Core::Communication::sum_all(&numgp, &total_num_gp, 1, get_comm());
-  if (numgp_desired != total_num_gp - duplicates)
+  Core::Communication::sum_all(&num_gp, &total_num_gp, 1, get_comm());
+  if (num_gp_desired != total_num_gp - duplicates)
     FOUR_C_THROW("It seems as if some GPs could not be projected");
 
   // output
-  int total_numactive_pairs = 0;
-  int numactive_pairs = static_cast<int>(coupled_ele_pairs_.size());
-  Core::Communication::sum_all(&numactive_pairs, &total_numactive_pairs, 1, get_comm());
+  int total_num_active_pairs = 0;
+  int num_active_pairs = static_cast<int>(coupled_ele_pairs_.size());
+  Core::Communication::sum_all(&num_active_pairs, &total_num_active_pairs, 1, get_comm());
   if (homogenized_dis_->name() == "porofluid" && my_mpi_rank_ == 0)
-    std::cout << "Only " << total_numactive_pairs
-              << " Artery-to-PoroMultiphaseScatra coupling pairs are active" << std::endl;
+    std::cout << "Only " << total_num_active_pairs
+              << " Artery-to-PoroMultiphaseScatra coupling pairs are active" << '\n';
 
-  // print out summary of pairs
+  // print summary of pairs
   if (homogenized_dis_->name() == "porofluid" &&
       coupling_params_.get<bool>("PRINT_OUT_SUMMARY_PAIRS"))
   {
     if (my_mpi_rank_ == 0)
-      std::cout << "In total " << numgp_desired << " GPs (" << numgp_per_artele
-                << " per artery element) required for lateral surface coupling" << std::endl;
-    std::cout << "Proc. " << my_mpi_rank_ << " evaluates " << numgp << " GPs " << "("
-              << (double)(numgp) / (double)(total_num_gp) * 100.0 << "% of all GPs)" << std::endl;
+      std::cout << "In total " << num_gp_desired << " GPs (" << num_gp_per_artery_ele
+                << " per artery element) required for lateral surface coupling" << '\n';
+    std::cout << "Proc. " << my_mpi_rank_ << " evaluates " << num_gp << " GPs " << "("
+              << static_cast<double>(num_gp) / static_cast<double>(total_num_gp) * 100.0
+              << "% of all GPs)" << '\n';
   }
 }
 
@@ -171,11 +170,11 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm:
 void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm::setup()
 {
   // call base class
-  PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm::setup();
+  PorofluidElastScatraArteryCouplingNonConformingAlgorithm::setup();
 
   // error-checks
   if (has_variable_diameter_)
-    FOUR_C_THROW("Varying diameter not yet possible for surface-based coupling");
+    FOUR_C_THROW("Variable diameter not yet possible for surface-based coupling");
   if (!evaluate_in_ref_config_)
     FOUR_C_THROW("Evaluation in current configuration not yet possible for surface-based coupling");
 
@@ -185,8 +184,8 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm:
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm::evaluate(
-    std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
-    std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
+    const std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
+    const std::shared_ptr<Core::LinAlg::Vector<double>> rhs)
 {
   if (!is_setup_) FOUR_C_THROW("setup() has not been called");
 
@@ -204,19 +203,19 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm:
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void PoroPressureBased::PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm::setup_system(
-    std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
-    std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
-    std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
-    std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_art,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
-    std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_art,
-    std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_cont,
-    std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art)
+    const std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
+    const std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
+    const std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_homogenized,
+    const std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_artery,
+    const std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_homogenized,
+    const std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_artery,
+    const std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_homogenized,
+    const std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_artery)
 {
   // call base class
-  PorofluidElastScatraArteryCouplingNonConformingAlgorithm::setup_system(*sysmat, rhs, *sysmat_cont,
-      *sysmat_art, rhs_cont, rhs_art, *dbcmap_cont, *dbcmap_art->cond_map(),
-      *dbcmap_art->cond_map());
+  PorofluidElastScatraArteryCouplingNonConformingAlgorithm::setup_system(*sysmat, rhs,
+      *sysmat_homogenized, *sysmat_artery, rhs_homogenized, rhs_artery, *dbcmap_homogenized,
+      *dbcmap_artery->cond_map(), *dbcmap_artery->cond_map());
 }
 
 /*----------------------------------------------------------------------*

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_surfbased.hpp
@@ -18,33 +18,34 @@ FOUR_C_NAMESPACE_OPEN
 namespace PoroPressureBased
 {
   //! Surface-based coupling between artery network and porofluid-elasticity-scatra algorithm
-  class PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm
+  class PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm final
       : public PorofluidElastScatraArteryCouplingNonConformingAlgorithm
   {
    public:
     PorofluidElastScatraArteryCouplingSurfaceBasedAlgorithm(
-        std::shared_ptr<Core::FE::Discretization> arterydis,
-        std::shared_ptr<Core::FE::Discretization> contdis,
-        const Teuchos::ParameterList& couplingparams, const std::string& condname,
-        const std::string& artcoupleddofname, const std::string& contcoupleddofname);
+        std::shared_ptr<Core::FE::Discretization> artery_dis,
+        std::shared_ptr<Core::FE::Discretization> homogenized_dis,
+        const Teuchos::ParameterList& coupling_params, const std::string& condition_name,
+        const std::string& artery_coupled_dof_name,
+        const std::string& homogenized_coupled_dof_name);
 
-    //! set-up of global system of equations of coupled problem
+    //! set up of the global system of equations of the coupled problem
     void setup_system(std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> sysmat,
         std::shared_ptr<Core::LinAlg::Vector<double>> rhs,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_cont,
-        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_art,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_cont,
-        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_art,
-        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_cont,
-        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_art) override;
+        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_homogenized,
+        std::shared_ptr<Core::LinAlg::SparseMatrix> sysmat_artery,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_homogenized,
+        std::shared_ptr<const Core::LinAlg::Vector<double>> rhs_artery,
+        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_homogenized,
+        std::shared_ptr<const Core::LinAlg::MapExtractor> dbcmap_artery) override;
 
-    //! setup the strategy
+    //! set up the strategy
     void setup() override;
 
     //! apply mesh movement (on artery elements)
     void apply_mesh_movement() override;
 
-    //! access to blood vessel volume fraction
+    //! access to the blood vessel volume fraction
     std::shared_ptr<const Core::LinAlg::Vector<double>> blood_vessel_volume_fraction() override;
 
     //! Evaluate the 1D-3D coupling
@@ -55,30 +56,27 @@ namespace PoroPressureBased
     //! pre-evaluate the pairs
     void pre_evaluate_coupling_pairs();
 
-    //! calculate the volume fraction occupied by blood vessels
-    void calculate_blood_vessel_volume_fraction();
-
     /*!
      * @brief et the artery diameter in material to be able to use it on 1D discretization
      * \note nothing to do for surface-based formulation since variable diameter not yet possible
      */
-    void set_artery_diameter_in_material() override {};
+    void set_artery_diameter_in_material() override {}
 
     /*!
      * @brief reset the integrated diameter vector to zero
      * \note nothing to do for surface-based formulation since variable diameter not yet possible
      */
-    void reset_integrated_diameter_to_zero() override {};
+    void reset_integrated_diameter_to_zero() override {}
 
     /*!
      * @brief evaluate additional linearization of (integrated) element diameter dependent terms
      * (Hagen-Poiseuille)
      * \note nothing to do for surface-based formulation since variable diameter not yet possible
      */
-    void evaluate_additional_linearizationof_integrated_diam() override {};
+    void evaluate_additional_linearization_of_integrated_diameter() override {};
 
     //! get the segment lengths of element 'artelegid'
-    std::vector<double> get_ele_segment_lengths(const int artelegid) override { return {2.0}; };
+    std::vector<double> get_ele_segment_length(const int artery_ele_gid) override { return {2.0}; };
 
     //! print out the coupling method
     void print_coupling_method() const override;

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
@@ -117,7 +117,7 @@ PoroPressureBased::create_and_init_artery_coupling_strategy(
     case Inpar::ArteryNetwork::ArteryPoroMultiphaseScatraCouplingMethod::nodal:
     {
       strategy =
-          std::make_shared<PoroPressureBased::PorofluidElastScatraArteryCouplingNodebasedAlgorithm>(
+          std::make_shared<PoroPressureBased::PorofluidElastScatraArteryCouplingNodeBasedAlgorithm>(
               arterydis, contdis, meshtyingparams, condname, artcoupleddofname, contcoupleddofname);
       break;
     }


### PR DESCRIPTION
This PR continues the clean-up with the various artery coupling schemes (line-based, surface-based, node-based, node-to-point).

Follow #833 
