### PR TITLE
Scalar interpolation class

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.cpp
@@ -1,0 +1,470 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_utils_scalar_interpolation.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_fixedsizematrix_solver.hpp"
+#include "4C_utils_exceptions.hpp"
+
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+Core::LinAlg::Matrix<num_cofeffcients, 1>
+Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
+    const Core::LinAlg::Matrix<loc_dim, 1>& location)
+{
+  Core::LinAlg::Matrix<num_cofeffcients, 1> polynomial(Core::LinAlg::Initialization::zero);
+
+  switch (loc_dim)
+  {
+    case 3:
+    {
+      double x = location(0, 0);
+      double y = location(1, 0);
+      double z = location(2, 0);
+
+      switch (poly_order)
+      {
+        case 1:  // [1 x y z xy xz yz xyz] tri-linear
+          if (num_cofeffcients == 8)
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+            polynomial(2) = y;
+            polynomial(3) = z;
+            polynomial(4) = x * y;
+            polynomial(5) = x * z;
+            polynomial(6) = y * z;
+            polynomial(7) = x * y * z;
+          }
+          break;
+        case 2:  // [1 x y z x^2 y^2 z^2 xy xz yz] quadratic
+          if (num_cofeffcients == 10)
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+            polynomial(2) = y;
+            polynomial(3) = z;
+            polynomial(4) = x * x;
+            polynomial(5) = y * y;
+            polynomial(6) = z * z;
+            polynomial(7) = x * y;
+            polynomial(8) = x * z;
+            polynomial(9) = y * z;
+          }
+          break;
+        default:
+          FOUR_C_THROW("Unknown 3D shape function order");
+          return polynomial;
+      }
+    }
+    break;
+    case 2:
+    {
+      double x = location(0, 0);
+      double y = location(1, 0);
+
+      switch (poly_order)
+      {
+        case 1:
+          if (num_cofeffcients == 4)  // [1 x y xy] linear
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+            polynomial(2) = y;
+            polynomial(3) = x * y;
+          }
+          break;
+        case 2:
+          if (num_cofeffcients == 8)  // [1 x y xy x^2 y^2] quadartic complete
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+            polynomial(2) = y;
+            polynomial(3) = x * y;
+            polynomial(4) = x * x;
+            polynomial(5) = y * y;
+            polynomial(6) = x * x * y;
+            polynomial(7) = x * y * y;
+          }
+          else if (num_cofeffcients == 6)  // [1 x y xy x^2 y^2] quadratic incomplete
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+            polynomial(2) = y;
+            polynomial(3) = x * y;
+            polynomial(4) = x * x;
+            polynomial(5) = y * y;
+          }
+          break;
+        default:
+          FOUR_C_THROW("Unknown 2D shape function order");
+          return polynomial;
+      }
+    }
+    break;
+    case 1:
+    {
+      double x = location(0, 0);
+
+      switch (poly_order)
+      {
+        case 1:
+          if (num_cofeffcients == 2)  // [1 x] linear
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+          }
+          break;
+        case 2:
+          if (num_cofeffcients == 3)  // [1 x x*x] quadratic
+          {
+            polynomial(0) = 1.;
+            polynomial(1) = x;
+            polynomial(2) = x * x;
+          }
+          break;
+        default:
+          FOUR_C_THROW("Unknown 1D shape function order");
+          return polynomial;
+      }
+    }
+    break;
+    default:
+      FOUR_C_THROW("Unsupported spatial dimension for shape function");
+      return polynomial;
+  }
+  return polynomial;
+}
+
+// 1D linear
+template Core::LinAlg::Matrix<2, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<1, 1,
+    2>(const Core::LinAlg::Matrix<1, 1>&);
+
+// 1D quadratic
+template Core::LinAlg::Matrix<3, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<1, 2,
+    3>(const Core::LinAlg::Matrix<1, 1>&);
+
+// 2D linear
+template Core::LinAlg::Matrix<4, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<2, 1,
+    4>(const Core::LinAlg::Matrix<2, 1>&);
+
+// 2D quadratic (incomplete)
+template Core::LinAlg::Matrix<6, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<2, 2,
+    6>(const Core::LinAlg::Matrix<2, 1>&);
+
+// 2D quadratic (complete)
+template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<2, 2,
+    8>(const Core::LinAlg::Matrix<2, 1>&);
+
+// 3D linear
+template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<3, 1,
+    8>(const Core::LinAlg::Matrix<3, 1>&);
+
+// 3D quadratic
+template Core::LinAlg::Matrix<10, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<3,
+    2, 10>(const Core::LinAlg::Matrix<3, 1>&);
+
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+    num_cofeffcients>::ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
+    const WeightingFunction weight_func, const InterpParams& interp_params)
+    : scalar_interp_type_(scalar_interp_type),
+      weight_func_(weight_func),
+      interp_params_(interp_params)
+{
+  // check for valid polynomial order
+  if (scalar_interp_type != ScalarInterpolationType::LOG and poly_order < 1)
+    FOUR_C_THROW("ScalarInterpolator: for MLS and LOGMLS polynomial order must be at least 1!");
+
+  // check for valid location dimension
+  if (loc_dim < 1 || loc_dim > 3)
+    FOUR_C_THROW("ScalarInterpolator: location dimension must be between 1 and 3!");
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+std::vector<double> Core::LinAlg::ScalarInterpolation::
+    ScalarInterpolator<loc_dim, poly_order, num_cofeffcients>::calculate_normalized_weights(
+        const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const WeightingFunction& weight_func,
+        const InterpParams& interp_params)
+{
+  std::vector<double> weights(ref_locs.size(), 0.0);
+  std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs_tmp(ref_locs);
+
+  for (auto& loc : ref_locs_tmp)
+    loc.update(-1.0, interp_loc, 1.0);  // shift locations to the interpolation point
+
+  // calculate the weight based on the chosen weighting function
+  switch (weight_func)
+  {
+    case WeightingFunction::inversedistance:
+    {
+      double exponent = loc_dim;  // default exponent for inverse distance
+      if (interp_params.inverse_distance_power.has_value())
+        exponent = interp_params.inverse_distance_power.value();  // use the provided power
+
+      for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)
+      {
+        double norm = ref_locs_tmp[i].norm2();
+        if (norm < interp_params.distance_threshold)
+          weights[i] = 1.0;
+        else
+          weights[i] = 1.0 / std::pow(norm, exponent);
+      }
+    }
+    break;
+
+    case WeightingFunction::exponential:
+    {
+      for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)
+      {
+        double norm = ref_locs_tmp[i].norm2();
+        if (norm < interp_params.distance_threshold)
+          weights[i] = 1.0;
+        else
+          weights[i] = std::exp(-1.0 * interp_params.exponential_decay_c * norm * norm);
+      }
+    }
+    break;
+
+    case WeightingFunction::unity:
+    {
+      for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)
+        weights[i] = 1.0 / static_cast<double>(ref_locs_tmp.size());
+      return weights;
+    }
+    break;
+
+    default:
+      FOUR_C_THROW("Unknown weighting function.");
+  }
+
+  for (unsigned int i = 0; i < weights.size(); ++i)
+  {
+    if (weights[i] == 1.0)
+    {
+      for (auto& w : weights) w = 0.0;
+      weights[i] = 1.0;  // set the weight to 1.0 for the closest point
+      return weights;
+    }
+  }
+
+  // normalize the weights
+  double sum_of_weights = 0.0;
+  for (const auto& weight : weights) sum_of_weights += weight;
+  for (double& weight : weights) weight /= sum_of_weights;  // normalize the weight
+
+  // check for sum of weights = 1.0
+  sum_of_weights = 0.0;
+  for (const auto& weight : weights) sum_of_weights += weight;
+  if (std::abs(sum_of_weights - 1.0) > 1e-8)
+    FOUR_C_THROW("Sum of weights is not equal to 1.0 after normalization.");
+
+  return weights;
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+    num_cofeffcients>::logarthmic(const std::vector<std::vector<double>>& scalar_data,
+    const std::vector<double>& weights)
+{
+  const size_t field_size = scalar_data[0].size();
+  std::vector<double> log_sum(field_size, 0.0);
+
+  for (size_t i = 0; i < scalar_data.size(); ++i)
+  {
+    const auto& row = scalar_data[i];
+    if (row.size() != field_size) FOUR_C_THROW("Inconsistent vector sizes in scalar_data.");
+    if (weights[i] < 0.0)
+      FOUR_C_THROW("Weights must be non-negative for logarithmic interpolation.");
+
+    for (size_t j = 0; j < field_size; ++j)
+    {
+      if (row[j] <= 0.0)
+        FOUR_C_THROW("Logarithmic interpolation requires positive scalar data values.");
+      log_sum[j] += weights[i] * std::log(row[j]);
+    }
+  }
+
+  for (auto& val : log_sum) val = std::exp(val);
+
+  return log_sum;
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+    num_cofeffcients>::moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+    const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+    const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights)
+{
+  const size_t field_size = scalar_data[0].size();
+  std::vector<double> interp_scalar(field_size, 0.0);
+
+  std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs_tmp(ref_locs);
+
+  Core::LinAlg::Matrix<num_cofeffcients, num_cofeffcients> Pinv(Core::LinAlg::Initialization::zero);
+  std::vector<Core::LinAlg::Matrix<num_cofeffcients, 1>> bj(field_size);
+  for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)  // number of reference locations
+  {
+    ref_locs_tmp[i].update(-1.0, interp_loc, 1.0);  // shift locations to the interpolation point
+
+    Core::LinAlg::Matrix<num_cofeffcients, 1> p_i =
+        Core::LinAlg::ScalarInterpolation::polynomialshapefunction<loc_dim, poly_order,
+            num_cofeffcients>(ref_locs_tmp[i]);
+
+    // bj = w * p_i * scalar_data[i][j]
+    for (unsigned int j = 0; j < field_size; ++j)  // number of scalar fields
+      bj[j].update(weights[i] * scalar_data[i][j], p_i, 1.0);
+
+    // P = P + w * p_i * p_i^T
+    Pinv.multiply_nt(weights[i], p_i, p_i, 1.0);
+  }
+
+  // now evaluate P^-1 with solver
+  Core::LinAlg::FixedSizeSerialDenseSolver<num_cofeffcients, num_cofeffcients, 1> solve_for_inverse;
+  solve_for_inverse.set_matrix(Pinv);
+  int err2 = solve_for_inverse.factor();
+  int err = solve_for_inverse.invert();
+  if ((err != 0) || (err2 != 0))
+    FOUR_C_THROW(
+        "ERROR: ScalarInterpolator::moving_least_square Inversion of P failed, check the "
+        "dimension, poly order, and number of coefficients.");
+
+  // now compute the interpolated scalar values
+  for (unsigned int j = 0; j < field_size; ++j)  // number of scalar fields
+  {
+    Core::LinAlg::Matrix<num_cofeffcients, 1> yj(Core::LinAlg::Initialization::zero);
+    yj.multiply(Pinv, bj[j]);  // compute the coeffiicents
+
+    Core::LinAlg::Matrix<loc_dim, 1> interp_loc_shifted(Core::LinAlg::Initialization::zero);
+
+    Core::LinAlg::Matrix<num_cofeffcients, 1> p_inter =
+        Core::LinAlg::ScalarInterpolation::polynomialshapefunction<loc_dim, poly_order,
+            num_cofeffcients>(interp_loc_shifted);
+
+    Core::LinAlg::Matrix<1, 1> interp_value(Core::LinAlg::Initialization::zero);
+    interp_value.multiply_tn(p_inter, yj);  // compute the interpolated value
+
+    interp_scalar[j] = interp_value(0, 0);  // store the interpolated value
+  }
+
+  return interp_scalar;
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+    num_cofeffcients>::log_moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+    const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+    const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights)
+{
+  std::vector<double> interp_scalar(scalar_data[0].size(), 0.0);
+
+  std::vector<std::vector<double>> log_scalar_data(scalar_data.size());
+
+  for (size_t i = 0; i < scalar_data.size(); ++i)
+  {
+    log_scalar_data[i].resize(scalar_data[i].size());
+    for (size_t j = 0; j < scalar_data[i].size(); ++j)
+    {
+      if (scalar_data[i][j] <= 0.0)
+        FOUR_C_THROW("Logarithmic moving least squares requires positive scalar data values.");
+      log_scalar_data[i][j] = std::log(scalar_data[i][j]);
+    }
+  }
+
+  // Use the moving least square method on the logarithmic data
+  std::vector<double> log_interp_scalar =
+      moving_least_square(log_scalar_data, ref_locs, interp_loc, weights);
+
+  // Exponentiate the result to get back to the original scale
+  for (size_t j = 0; j < log_interp_scalar.size(); ++j)
+    interp_scalar[j] = std::exp(log_interp_scalar[j]);
+
+  // check the interpolated scalar values
+  for (size_t j = 0; j < interp_scalar.size(); ++j)
+    if (interp_scalar[j] <= 0.0)
+      FOUR_C_THROW("Logarithmic moving least squares resulted in non-positive scalar values.");
+
+  // Return the interpolated scalar values
+  return interp_scalar;
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+    num_cofeffcients>::get_interpolated_scalar(const std::vector<std::vector<double>>& scalar_data,
+    const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+    const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc)
+{
+  // Check for size consistency
+  if (scalar_data.empty()) FOUR_C_THROW("Scalar data vector is empty.");
+  if (ref_locs.empty()) FOUR_C_THROW("Reference locations vector is empty.");
+  if (scalar_data.size() != ref_locs.size())
+    FOUR_C_THROW("Size mismatch: scalar_data vs ref_locs.");
+  if (ref_locs.size() < 1)
+    FOUR_C_THROW("At least one reference location is required for interpolation.");
+
+  auto weights =
+      this->calculate_normalized_weights(ref_locs, interp_loc, weight_func_, interp_params_);
+
+  // If one weight is 1.0, return the corresponding scalar data directly
+  for (size_t i = 0; i < scalar_data.size(); ++i)
+    if (weights[i] == 1.0) return scalar_data[i];
+
+  switch (scalar_interp_type_)  // Choose the interpolation method based on the type
+  {
+    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::LOG:
+      return logarthmic(scalar_data, weights);
+      break;
+    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::MLS:
+      return moving_least_square(scalar_data, ref_locs, interp_loc, weights);
+      break;
+    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::LOGMLS:
+      return log_moving_least_square(scalar_data, ref_locs, interp_loc, weights);
+      break;
+    default:
+      FOUR_C_THROW("Unknown scalar interpolation type.");
+      break;
+  }
+}
+
+// Explicit template instantiations
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<1>;
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2>;
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<3>;
+
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<1, 1, 2>;
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<1, 2, 3>;
+
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2, 1, 4>;
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2, 2, 6>;
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2, 2, 8>;
+
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<3, 1, 8>;
+template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<3, 2, 10>;
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.cpp
@@ -19,12 +19,12 @@ FOUR_C_NAMESPACE_OPEN
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
-Core::LinAlg::Matrix<num_cofeffcients, 1>
-Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
+Core::LinAlg::Matrix<num_coefficients, 1>
+Core::LinAlg::ScalarInterpolation::polynomial_shape_function(
     const Core::LinAlg::Matrix<loc_dim, 1>& location)
 {
-  Core::LinAlg::Matrix<num_cofeffcients, 1> polynomial(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<num_coefficients, 1> polynomial(Core::LinAlg::Initialization::zero);
 
   switch (loc_dim)
   {
@@ -37,7 +37,7 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
       switch (poly_order)
       {
         case 1:  // [1 x y z xy xz yz xyz] tri-linear
-          if (num_cofeffcients == 8)
+          if (num_coefficients == 8)
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
@@ -50,7 +50,7 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
           }
           break;
         case 2:  // [1 x y z x^2 y^2 z^2 xy xz yz] quadratic
-          if (num_cofeffcients == 10)
+          if (num_coefficients == 10)
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
@@ -66,7 +66,6 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
           break;
         default:
           FOUR_C_THROW("Unknown 3D shape function order");
-          return polynomial;
       }
     }
     break;
@@ -78,7 +77,7 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
       switch (poly_order)
       {
         case 1:
-          if (num_cofeffcients == 4)  // [1 x y xy] linear
+          if (num_coefficients == 4)  // [1 x y xy] linear
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
@@ -87,7 +86,7 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
           }
           break;
         case 2:
-          if (num_cofeffcients == 8)  // [1 x y xy x^2 y^2] quadartic complete
+          if (num_coefficients == 8)  // [1 x y xy x^2 y^2] quadartic complete
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
@@ -98,7 +97,7 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
             polynomial(6) = x * x * y;
             polynomial(7) = x * y * y;
           }
-          else if (num_cofeffcients == 6)  // [1 x y xy x^2 y^2] quadratic incomplete
+          else if (num_coefficients == 6)  // [1 x y xy x^2 y^2] quadratic incomplete
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
@@ -110,7 +109,6 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
           break;
         default:
           FOUR_C_THROW("Unknown 2D shape function order");
-          return polynomial;
       }
     }
     break;
@@ -121,14 +119,14 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
       switch (poly_order)
       {
         case 1:
-          if (num_cofeffcients == 2)  // [1 x] linear
+          if (num_coefficients == 2)  // [1 x] linear
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
           }
           break;
         case 2:
-          if (num_cofeffcients == 3)  // [1 x x*x] quadratic
+          if (num_coefficients == 3)  // [1 x x*x] quadratic
           {
             polynomial(0) = 1.;
             polynomial(1) = x;
@@ -137,73 +135,50 @@ Core::LinAlg::ScalarInterpolation::polynomialshapefunction(
           break;
         default:
           FOUR_C_THROW("Unknown 1D shape function order");
-          return polynomial;
       }
     }
     break;
     default:
       FOUR_C_THROW("Unsupported spatial dimension for shape function");
-      return polynomial;
   }
   return polynomial;
 }
 
 // 1D linear
-template Core::LinAlg::Matrix<2, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<1, 1,
-    2>(const Core::LinAlg::Matrix<1, 1>&);
+template Core::LinAlg::Matrix<2, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<1,
+    1, 2>(const Core::LinAlg::Matrix<1, 1>&);
 
 // 1D quadratic
-template Core::LinAlg::Matrix<3, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<1, 2,
-    3>(const Core::LinAlg::Matrix<1, 1>&);
+template Core::LinAlg::Matrix<3, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<1,
+    2, 3>(const Core::LinAlg::Matrix<1, 1>&);
 
 // 2D linear
-template Core::LinAlg::Matrix<4, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<2, 1,
-    4>(const Core::LinAlg::Matrix<2, 1>&);
+template Core::LinAlg::Matrix<4, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<2,
+    1, 4>(const Core::LinAlg::Matrix<2, 1>&);
 
 // 2D quadratic (incomplete)
-template Core::LinAlg::Matrix<6, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<2, 2,
-    6>(const Core::LinAlg::Matrix<2, 1>&);
+template Core::LinAlg::Matrix<6, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<2,
+    2, 6>(const Core::LinAlg::Matrix<2, 1>&);
 
 // 2D quadratic (complete)
-template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<2, 2,
-    8>(const Core::LinAlg::Matrix<2, 1>&);
+template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<2,
+    2, 8>(const Core::LinAlg::Matrix<2, 1>&);
 
 // 3D linear
-template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<3, 1,
-    8>(const Core::LinAlg::Matrix<3, 1>&);
+template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<3,
+    1, 8>(const Core::LinAlg::Matrix<3, 1>&);
 
 // 3D quadratic
-template Core::LinAlg::Matrix<10, 1> Core::LinAlg::ScalarInterpolation::polynomialshapefunction<3,
+template Core::LinAlg::Matrix<10, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<3,
     2, 10>(const Core::LinAlg::Matrix<3, 1>&);
 
-
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
-Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_cofeffcients>::ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
-    const WeightingFunction weight_func, const InterpParams& interp_params)
-    : scalar_interp_type_(scalar_interp_type),
-      weight_func_(weight_func),
-      interp_params_(interp_params)
-{
-  // check for valid polynomial order
-  if (scalar_interp_type != ScalarInterpolationType::LOG and poly_order < 1)
-    FOUR_C_THROW("ScalarInterpolator: for MLS and LOGMLS polynomial order must be at least 1!");
-
-  // check for valid location dimension
-  if (loc_dim < 1 || loc_dim > 3)
-    FOUR_C_THROW("ScalarInterpolator: location dimension must be between 1 and 3!");
-}
-
-/*--------------------------------------------------------------------*
- *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
-std::vector<double> Core::LinAlg::ScalarInterpolation::
-    ScalarInterpolator<loc_dim, poly_order, num_cofeffcients>::calculate_normalized_weights(
-        const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const WeightingFunction& weight_func,
-        const InterpParams& interp_params)
+template <unsigned int loc_dim>
+std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+    const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+    const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const WeightingFunction weight_func,
+    const InterpParams& interp_params)
 {
   std::vector<double> weights(ref_locs.size(), 0.0);
   std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs_tmp(ref_locs);
@@ -214,7 +189,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::
   // calculate the weight based on the chosen weighting function
   switch (weight_func)
   {
-    case WeightingFunction::inversedistance:
+    case WeightingFunction::inverse_distance:
     {
       double exponent = loc_dim;  // default exponent for inverse distance
       if (interp_params.inverse_distance_power.has_value())
@@ -256,6 +231,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::
       FOUR_C_THROW("Unknown weighting function.");
   }
 
+  // if one of the weights is 1.0: zero out all other weights and return directly
   for (unsigned int i = 0; i < weights.size(); ++i)
   {
     if (weights[i] == 1.0)
@@ -280,11 +256,46 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::
   return weights;
 }
 
+// Explicit template instantiations for calculate_normalized_weights
+template std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights<1>(
+    const std::vector<Core::LinAlg::Matrix<1, 1>>&, const Core::LinAlg::Matrix<1, 1>&,
+    const Core::LinAlg::ScalarInterpolation::WeightingFunction,
+    const Core::LinAlg::ScalarInterpolation::InterpParams&);
+template std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights<2>(
+    const std::vector<Core::LinAlg::Matrix<2, 1>>&, const Core::LinAlg::Matrix<2, 1>&,
+    const Core::LinAlg::ScalarInterpolation::WeightingFunction,
+    const Core::LinAlg::ScalarInterpolation::InterpParams&);
+template std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights<3>(
+    const std::vector<Core::LinAlg::Matrix<3, 1>>&, const Core::LinAlg::Matrix<3, 1>&,
+    const Core::LinAlg::ScalarInterpolation::WeightingFunction,
+    const Core::LinAlg::ScalarInterpolation::InterpParams&);
+
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
+Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+    num_coefficients>::ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
+    const WeightingFunction weight_func, const InterpParams& interp_params)
+    : scalar_interp_type_(scalar_interp_type),
+      weight_func_(weight_func),
+      interp_params_(interp_params)
+{
+  // check for valid polynomial order
+  if (scalar_interp_type != ScalarInterpolationType::logarithmic_weighted_average and
+      poly_order < 1)
+    FOUR_C_THROW("ScalarInterpolator: for MLS and LOGMLS polynomial order must be at least 1!");
+
+  // check for valid location dimension
+  static_assert(loc_dim >= 1 && loc_dim <= 3,
+      "ScalarInterpolator: location dimension must be between 1 and 3!");
+}
+
+/*--------------------------------------------------------------------*
+ *--------------------------------------------------------------------*/
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
 std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_cofeffcients>::logarthmic(const std::vector<std::vector<double>>& scalar_data,
+    num_coefficients>::logarithmic_weighted_average(const std::vector<std::vector<double>>&
+                                                        scalar_data,
     const std::vector<double>& weights)
 {
   const size_t field_size = scalar_data[0].size();
@@ -312,9 +323,9 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
 std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_cofeffcients>::moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+    num_coefficients>::moving_least_square(const std::vector<std::vector<double>>& scalar_data,
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
     const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights)
 {
@@ -323,15 +334,20 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
   std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs_tmp(ref_locs);
 
-  Core::LinAlg::Matrix<num_cofeffcients, num_cofeffcients> Pinv(Core::LinAlg::Initialization::zero);
-  std::vector<Core::LinAlg::Matrix<num_cofeffcients, 1>> bj(field_size);
+  Core::LinAlg::Matrix<num_coefficients, num_coefficients> Pinv(Core::LinAlg::Initialization::zero);
+  std::vector<Core::LinAlg::Matrix<num_coefficients, 1>> bj(field_size);
+
+  // Initialize polynomial shape function vectors
+  Core::LinAlg::Matrix<num_coefficients, 1> p_i(Core::LinAlg::Initialization::zero);
+
   for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)  // number of reference locations
   {
     ref_locs_tmp[i].update(-1.0, interp_loc, 1.0);  // shift locations to the interpolation point
 
-    Core::LinAlg::Matrix<num_cofeffcients, 1> p_i =
-        Core::LinAlg::ScalarInterpolation::polynomialshapefunction<loc_dim, poly_order,
-            num_cofeffcients>(ref_locs_tmp[i]);
+    // compute the polynomial shape function for the current reference location
+    p_i.put_scalar(0.0);  // reset p_i to zero
+    p_i.update(Core::LinAlg::ScalarInterpolation::polynomial_shape_function<loc_dim, poly_order,
+        num_coefficients>(ref_locs_tmp[i]));
 
     // bj = w * p_i * scalar_data[i][j]
     for (unsigned int j = 0; j < field_size; ++j)  // number of scalar fields
@@ -342,7 +358,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
   }
 
   // now evaluate P^-1 with solver
-  Core::LinAlg::FixedSizeSerialDenseSolver<num_cofeffcients, num_cofeffcients, 1> solve_for_inverse;
+  Core::LinAlg::FixedSizeSerialDenseSolver<num_coefficients, num_coefficients, 1> solve_for_inverse;
   solve_for_inverse.set_matrix(Pinv);
   int err2 = solve_for_inverse.factor();
   int err = solve_for_inverse.invert();
@@ -351,19 +367,24 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
         "ERROR: ScalarInterpolator::moving_least_square Inversion of P failed, check the "
         "dimension, poly order, and number of coefficients.");
 
+  // initialize loop variable vector and matrix
+  Core::LinAlg::Matrix<num_coefficients, 1> p_inter(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<loc_dim, 1> interp_loc_shifted(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<num_coefficients, 1> yj(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Matrix<1, 1> interp_value(Core::LinAlg::Initialization::zero);
+
   // now compute the interpolated scalar values
   for (unsigned int j = 0; j < field_size; ++j)  // number of scalar fields
   {
-    Core::LinAlg::Matrix<num_cofeffcients, 1> yj(Core::LinAlg::Initialization::zero);
+    yj.put_scalar(0.0);        // reset yj to zero
     yj.multiply(Pinv, bj[j]);  // compute the coeffiicents
 
-    Core::LinAlg::Matrix<loc_dim, 1> interp_loc_shifted(Core::LinAlg::Initialization::zero);
+    p_inter.put_scalar(0.0);  // reset p_inter to zero
+    p_inter.update(Core::LinAlg::ScalarInterpolation::polynomial_shape_function<loc_dim, poly_order,
+        num_coefficients>(interp_loc_shifted));  // compute the polynomial shape function at
+                                                 // the interpolation point
 
-    Core::LinAlg::Matrix<num_cofeffcients, 1> p_inter =
-        Core::LinAlg::ScalarInterpolation::polynomialshapefunction<loc_dim, poly_order,
-            num_cofeffcients>(interp_loc_shifted);
-
-    Core::LinAlg::Matrix<1, 1> interp_value(Core::LinAlg::Initialization::zero);
+    interp_value.put_scalar(0.0);           // reset interp_value to zero
     interp_value.multiply_tn(p_inter, yj);  // compute the interpolated value
 
     interp_scalar[j] = interp_value(0, 0);  // store the interpolated value
@@ -374,9 +395,10 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
 std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_cofeffcients>::log_moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+    num_coefficients>::logarithmic_moving_least_squares(const std::vector<std::vector<double>>&
+                                                            scalar_data,
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
     const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights)
 {
@@ -414,9 +436,9 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
-template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
 std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_cofeffcients>::get_interpolated_scalar(const std::vector<std::vector<double>>& scalar_data,
+    num_coefficients>::get_interpolated_scalar(const std::vector<std::vector<double>>& scalar_data,
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
     const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc)
 {
@@ -428,8 +450,8 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
   if (ref_locs.size() < 1)
     FOUR_C_THROW("At least one reference location is required for interpolation.");
 
-  auto weights =
-      this->calculate_normalized_weights(ref_locs, interp_loc, weight_func_, interp_params_);
+  auto weights = Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+      ref_locs, interp_loc, weight_func_, interp_params_);
 
   // If one weight is 1.0, return the corresponding scalar data directly
   for (size_t i = 0; i < scalar_data.size(); ++i)
@@ -437,14 +459,15 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
   switch (scalar_interp_type_)  // Choose the interpolation method based on the type
   {
-    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::LOG:
-      return logarthmic(scalar_data, weights);
+    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::logarithmic_weighted_average:
+      return logarithmic_weighted_average(scalar_data, weights);
       break;
-    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::MLS:
+    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::moving_least_squares:
       return moving_least_square(scalar_data, ref_locs, interp_loc, weights);
       break;
-    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::LOGMLS:
-      return log_moving_least_square(scalar_data, ref_locs, interp_loc, weights);
+    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::
+        logarithmic_moving_least_squares:
+      return logarithmic_moving_least_squares(scalar_data, ref_locs, interp_loc, weights);
       break;
     default:
       FOUR_C_THROW("Unknown scalar interpolation type.");

--- a/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.hpp
@@ -1,0 +1,222 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_UTILS_SCALAR_INTERPOLATION_HPP
+#define FOUR_C_LINALG_UTILS_SCALAR_INTERPOLATION_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  namespace ScalarInterpolation
+  {
+    /// enum class for the interpolation type
+    enum class ScalarInterpolationType
+    {
+      LOG,     ///< logarithmic weighted average,
+      MLS,     ///< moving least squares,
+      LOGMLS,  ///< logarithmic moving least squares,
+    };
+
+    /// enum class for the interpolation weighting function
+    enum class WeightingFunction
+    {
+      inversedistance,  ///< inverse distance weighting
+      exponential,      ///< exponential weighting
+      unity,            ///< equal weighting
+    };
+
+    /// struct containing parameters used for the scalar interpolation
+    struct InterpParams
+    {
+      /// exponential decay factor of the
+      double exponential_decay_c = 10.0;
+
+      /// inverse distance power
+      /// used for the inverse distance weighting function
+      /// (i.e., 1 / (distance^power))
+      std::optional<double> inverse_distance_power;
+
+      double distance_threshold = 1.0e-8;  ///< threshold for distance to avoid singularities
+    };
+
+    /**
+     * @brief Computes the polynomial shape function values at a given location.
+     *
+     * This templated function evaluates the shape function for a polynomial of specified order
+     * at a given location in the local coordinate system.
+     *
+     * @tparam loc_dim Dimension of the local coordinate system.
+     * @tparam poly_order Order of the polynomial shape function.
+     * @tparam num_cofeffcients Number of coefficients (basis functions) in the polynomial, this
+     * important in the contest of a incomplete polynomial basis. Example: An incomplete quadratic
+     * basis: [1,x,y,x^2], missing xy and y^2
+     * @param location The local coordinates where the shape function is to be evaluated.
+     * @return A column vector containing the values of the shape function basis at the given
+     * location.
+     */
+    template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_cofeffcients>
+    Core::LinAlg::Matrix<num_cofeffcients, 1> polynomialshapefunction(
+        const Core::LinAlg::Matrix<loc_dim, 1>& location);
+
+    /**
+     * @class ScalarInterpolator
+     * @brief A class template for performing scalar interpolation using various methods and
+     * weighting functions.
+     *
+     * This class provides functionality to interpolate scalar values at arbitrary locations based
+     * on reference data points and their associated locations. It supports different interpolation
+     * types, including moving least squares (MLS), logarithmic interpolation, and log-domain MLS,
+     * with customizable weighting functions and interpolation parameters.
+     *
+     * @tparam loc_dim The spatial dimension of the interpolation (e.g., 2 for 2D, 3 for 3D).
+     * @tparam poly_order The polynomial order used in the interpolation basis (MLS &LOGMLS).
+     * @tparam num_cofeffcients The number of coefficients in the interpolation basis, applying to
+     * the polynomial shape function (MLS & LOGMLS).
+     *
+     * Usage:
+     *   - Construct with the desired interpolation type, weighting function, and parameters.
+     *      for example:
+     *        (a) LOG: (second and third template argument are ignored)
+     *          ScalarInterpolator<3> interpolator(ScalarInterpolationType::MLS,
+     *          WeightingFunction::exponential, interp_params)
+     *
+     *        (b) MLS/LOGMLS: (all three template arguments are used)
+     *          ScalarInterpolator<3, 2, 10>
+     *            interpolator( ScalarInterpolationType::MLS, WeightingFunction::exponential,
+     * interp_params);
+     *   - Use get_interpolated_scalar() to compute interpolated values at a given location.
+     *   - Use calculate_normalized_weights() to obtain normalized weights for reference points, if
+     * interested to return weights.
+     *
+     * Private helper methods implement the core interpolation algorithms, including MLS,
+     * logarithmic variants, and log MLS.
+     */
+    template <unsigned int loc_dim, unsigned int poly_order = 1, unsigned int num_cofeffcients = 1>
+    class ScalarInterpolator
+    {
+     public:
+      /**
+       * @brief Constructs a ScalarInterpolator with the specified interpolation type, weighting
+       * function, and parameters.
+       *
+       * @param scalar_interp_type The type of scalar interpolation to use.
+       * @param weight_func The weighting function to apply during interpolation.
+       * @param interp_params Additional parameters required for the interpolation process.
+       */
+      ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
+          const WeightingFunction weight_func, const InterpParams& interp_params);
+
+      /**
+       * @brief Interpolates scalar values at a given location using provided scalar data and
+       * reference locations.
+       *
+       * This function computes the interpolated scalar values at the specified interpolation
+       * location (`interp_loc`) based on the input scalar data and their corresponding reference
+       * locations.
+       *
+       * @param scalar_data A vector of vectors containing scalar values at each reference location.
+       * @param ref_locs A vector of reference locations.
+       * @param interp_loc The location at which the scalar value is to be interpolated.
+       * @return std::vector<double> The interpolated scalar values at the specified interpolation
+       * location.
+       */
+      std::vector<double> get_interpolated_scalar(
+          const std::vector<std::vector<double>>& scalar_data,
+          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc);
+
+      /**
+       * @brief Calculates normalized interpolation weights for a given interpolation location.
+       *
+       * This function computes the weights for each reference location based on the provided
+       * weighting function and interpolation parameters, and normalizes them so that their sum
+       * is 1.
+       *
+       * @param ref_locs A vector of reference locations
+       * @param interp_loc The interpolation location
+       * @param weight_func The weighting function used to compute the weights based on distance or
+       * other criteria.
+       * @param interp_params Additional parameters required by the weighting function.
+       * @return std::vector<double> A vector of normalized weights corresponding to each reference
+       * location.
+       */
+      static std::vector<double> calculate_normalized_weights(
+          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const WeightingFunction& weight_func,
+          const InterpParams& interp_params);
+
+     private:
+      /**
+       * @brief Computes the moving least squares (MLS) interpolation for a given location.
+       *
+       * This function performs MLS interpolation using the provided scalar data, reference
+       * locations, interpolation location, and associated weights. It returns the interpolated
+       * scalar values.
+       *
+       * @param scalar_data A vector of vectors containing scalar data at each reference location.
+       * @param ref_locs A vector of reference locations.
+       * @param interp_loc The location at which to interpolate.
+       * @param weights A vector of weights corresponding to each reference location, typically
+       * based on distance to interp_loc.
+       * @return std::vector<double> The interpolated scalar values at the specified interpolation
+       * location.
+       */
+      std::vector<double> moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights);
+
+      /**
+       * @brief Computes the logarithmic interpolation of scalar data using the provided weights.
+       *
+       * This function takes a 2D vector of scalar data and a vector of weights, and returns a
+       * vector containing the logarithmic interpolation results for each set of scalar values.
+       *
+       * @param scalar_data A 2D vector where each inner vector contains scalar values to be
+       * interpolated.
+       * @param weights A vector of weights corresponding to the scalar values for interpolation.
+       * @return A vector of doubles representing the logarithmic interpolation results.
+       */
+      std::vector<double> logarthmic(
+          const std::vector<std::vector<double>>& scalar_data, const std::vector<double>& weights);
+
+      /**
+       * @brief Computes the log moving least squares interpolation for scalar data.
+       *
+       * This function performs moving least squares interpolation in the logarithmic domain
+       * for a set of scalar data points. It uses the provided reference locations, interpolation
+       * location, and associated weights to compute the interpolated values.
+       *
+       * @param scalar_data A vector of vectors containing the scalar data values at each reference
+       * location.
+       * @param ref_locs A vector of reference locations.
+       * @param interp_loc The location at which the interpolation is to be performed.
+       * @param weights A vector of weights corresponding to each reference location.
+       * @return std::vector<double> The interpolated scalar values at the specified interpolation
+       * location.
+       */
+      std::vector<double> log_moving_least_square(
+          const std::vector<std::vector<double>>& scalar_data,
+          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights);
+
+      const ScalarInterpolationType scalar_interp_type_;
+      const WeightingFunction weight_func_;
+      const InterpParams interp_params_;
+    };
+  }  // namespace ScalarInterpolation
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/tests/4C_linalg_utils_scalar_interpolation_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_scalar_interpolation_test.cpp
@@ -1,0 +1,445 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_linalg_utils_scalar_interpolation.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+#include "4C_utils_exceptions.hpp"
+
+#include <Sacado_tradvec.hpp>
+#include <Teuchos_ParameterList.hpp>
+
+#include <array>
+#include <cmath>
+#include <iomanip>
+#include <ios>
+#include <utility>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  TEST(LinalgScalarInterpolationTest, CalculateNormalizedWeights1DInverseDistance)
+  {
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    // 1D
+    constexpr unsigned int loc_dim = 3;
+
+    // Reference locations: -1.0, 1.0
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    Core::LinAlg::Matrix<loc_dim, 1> loc1(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> loc2(Core::LinAlg::Initialization::zero);
+    loc1(0, 0) = -1.0;
+    loc2(0, 0) = 1.0;
+    ref_locs.push_back(loc1);
+    ref_locs.push_back(loc2);
+
+    // Interpolation location: 0.0
+    Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+    interp_loc(0, 0) = 0.5;
+
+    // Weighting function: inverse distance
+    WeightingFunction weight_func = WeightingFunction::inversedistance;
+
+    // Interpolation parameters
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.inverse_distance_power = 1.0;  // Use power of 1 for inverse distance
+
+    ScalarInterpolator<loc_dim> interpolator(
+        ScalarInterpolationType::LOG, weight_func, interp_params);
+
+    // Call the function
+    std::vector<double> weights =
+        interpolator.calculate_normalized_weights(ref_locs, interp_loc, weight_func, interp_params);
+
+    // So weights should be [0.25, 0.75]
+    std::vector<double> weights_ref = {0.25, 0.75};
+
+    ASSERT_EQ(weights.size(), 2);
+    for (size_t i = 0; i < weights.size(); ++i) ASSERT_NEAR(weights[i], weights_ref[i], 1e-8);
+  }
+
+  TEST(LinalgScalarInterpolationTest, CalculateNormalizedWeights1DExponential)
+  {
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    // 1D
+    constexpr unsigned int loc_dim = 3;
+
+    // Reference locations: -1.0, 1.0
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    Core::LinAlg::Matrix<loc_dim, 1> loc1(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> loc2(Core::LinAlg::Initialization::zero);
+    loc1(0, 0) = -1.0;
+    loc2(0, 0) = 1.0;
+    ref_locs.push_back(loc1);
+    ref_locs.push_back(loc2);
+
+    // Interpolation location: 0.5
+    Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+    interp_loc(0, 0) = 0.5;
+
+    // Weighting function: exponential
+    WeightingFunction weight_func = WeightingFunction::exponential;
+
+    // Interpolation parameters
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.exponential_decay_c = 1.0;  // decay parameter
+
+    ScalarInterpolator<loc_dim> interpolator(
+        ScalarInterpolationType::LOG, weight_func, interp_params);
+
+    // Call the function
+    std::vector<double> weights =
+        interpolator.calculate_normalized_weights(ref_locs, interp_loc, weight_func, interp_params);
+
+    // Calculate expected weights manually
+    // distances: |0.5 - (-1.0)| = 1.5, |0.5 - 1.0| = 0.5
+    // weights: exp(-c * 1.5^2) = exp(-2.25), exp(-c * 0.5^2) = exp(-0.25)
+    double w0 = std::exp(-interp_params.exponential_decay_c * 1.5 * 1.5);
+    double w1 = std::exp(-interp_params.exponential_decay_c * 0.5 * 0.5);
+    double sum = w0 + w1;
+    std::vector<double> weights_ref = {w0 / sum, w1 / sum};
+
+    ASSERT_EQ(weights.size(), 2);
+    for (size_t i = 0; i < weights.size(); ++i) ASSERT_NEAR(weights[i], weights_ref[i], 1e-8);
+  }
+
+  TEST(LinalgScalarInterpolationTest, LogInterpolation_ManualData)
+  {
+    // see Satheesh et al., 2024, 10.1002/nme.7373, Section 2.4.4 Comparison of eigenvalue
+    // interpolation methods
+
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    constexpr unsigned int loc_dim = 1;
+
+    // Reference locations and scalar data
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    std::vector<std::vector<double>> scalar_data;
+
+    Core::LinAlg::Matrix<loc_dim, 1> x1(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> x2(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> x3(Core::LinAlg::Initialization::zero);
+    x1(0, 0) = 1.0;
+    x2(0, 0) = 2.0;
+    x3(0, 0) = 3.0;
+    ref_locs.push_back(x1);
+    ref_locs.push_back(x2);
+    ref_locs.push_back(x3);
+
+    scalar_data.push_back({0.1});
+    scalar_data.push_back({0.1});
+    scalar_data.push_back({1.0});
+
+    WeightingFunction weight_func = WeightingFunction::exponential;
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.exponential_decay_c = 10.0;
+
+    ScalarInterpolator<loc_dim> interpolator(
+        ScalarInterpolationType::LOG, weight_func, interp_params);
+
+    // Interpolate at several points in [1, 3]
+    std::vector<double> interp_points = {
+        1.0, 1.14141414141414, 2.33333333333333, 2.91919191919192, 3.0};
+    std::vector<double> expected = {0.1, 0.1, 0.10825430938265, 0.999474046355807, 1.0};
+    for (size_t i = 0; i < interp_points.size(); ++i)
+    {
+      Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+      interp_loc(0, 0) = interp_points[i];
+
+      std::vector<double> result =
+          interpolator.get_interpolated_scalar(scalar_data, ref_locs, interp_loc);
+
+      ASSERT_EQ(result.size(), 1);
+      ASSERT_NEAR(result[0], expected[i], 1e-8);
+    }
+  }
+
+  TEST(LinalgScalarInterpolationTest, MLSInterpolation_ManualData)
+  {
+    // see Satheesh et al., 2024, 10.1002/nme.7373, Section 2.4.4 Comparison of eigenvalue
+    // interpolation methods
+
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    constexpr unsigned int loc_dim = 1;
+    constexpr unsigned int poly_order = 2;
+    constexpr unsigned int num_cofeffcients = 3;
+
+    // Reference locations and scalar data
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    std::vector<std::vector<double>> scalar_data;
+
+    Core::LinAlg::Matrix<loc_dim, 1> x1(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> x2(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> x3(Core::LinAlg::Initialization::zero);
+    x1(0, 0) = 1.0;
+    x2(0, 0) = 2.0;
+    x3(0, 0) = 3.0;
+    ref_locs.push_back(x1);
+    ref_locs.push_back(x2);
+    ref_locs.push_back(x3);
+
+    scalar_data.push_back({0.1, 0.1, 0.1});
+    scalar_data.push_back({0.1, 0.1, 0.1});
+    scalar_data.push_back({1.0, 1.0, 1.0});
+
+    WeightingFunction weight_func = WeightingFunction::exponential;
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.exponential_decay_c = 1.0;
+
+    ScalarInterpolator<loc_dim, poly_order, num_cofeffcients> interpolator(
+        ScalarInterpolationType::MLS, weight_func, interp_params);
+
+    // Interpolate at several points in [1, 3]
+    std::vector<double> interp_points = {
+        1.0, 1.14141414141414, 2.33333333333333, 2.91919191919192, 3.0};
+    std::vector<double> expected = {
+        0.1, 0.0453627180900034, 0.300000000000004, 0.893847566574832, 1.0};
+    for (size_t i = 0; i < interp_points.size(); ++i)
+    {
+      Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+      interp_loc(0, 0) = interp_points[i];
+
+      std::vector<double> result =
+          interpolator.get_interpolated_scalar(scalar_data, ref_locs, interp_loc);
+
+      ASSERT_EQ(result.size(), scalar_data[0].size());
+      for (size_t j = 0; j < result.size(); ++j) ASSERT_NEAR(result[j], expected[i], 1e-8);
+    }
+  }
+
+  TEST(LinalgScalarInterpolationTest, MLSInterpolation_3DTrilinear_Hex8Nodes)
+  {
+    // -----------------------------------------------------------------------------
+    // HEX8 Linear Element Analogy
+    // The 8 input nodes represent the corners of a reference hexahedral (HEX8) element,
+    // positioned in the natural coordinate system:
+    //      (ξ, η, ζ) ∈ { -1, +1 }^3
+    //
+    // Each node is assigned a scalar value (e.g., 1 through 8)
+    // The interpolation is performed at the centroid of the element:
+    //      ξ = 0, η = 0, ζ = 0
+    // For a HEX8 element with trilinear shape functions, this is the center of the cube.
+    // All shape functions evaluate to 1/8 at the center:
+    //      N_i(0, 0, 0) = 1/8, for i = 1 to 8
+    // Use FEM interpolation formula:
+    //      u_centroid = ∑ N_i * u_i
+    // Since all N_i = 1/8:
+    //      u_centroid = (1/8) * sum(u_1 to u_8)
+    //                 = (1/8) * (1 + 2 + ... + 8)
+    //                 = 4.5
+    // -----------------------------------------------------------------------------
+
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    constexpr unsigned int loc_dim = 3;
+    constexpr unsigned int poly_order = 1;
+    constexpr unsigned int num_cofeffcients = 8;
+
+    // Reference locations (cube nodes)
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    std::vector<std::vector<double>> scalar_data;
+
+    // Node coordinates as per your table
+    double coords[8][3] = {{-1, -1, -1}, {+1, -1, -1}, {+1, +1, -1}, {-1, +1, -1}, {-1, -1, +1},
+        {+1, -1, +1}, {+1, +1, +1}, {-1, +1, +1}};
+
+    // Fill ref_locs and scalar_data (values 1,2,...,8)
+    for (int i = 0; i < 8; ++i)
+    {
+      Core::LinAlg::Matrix<loc_dim, 1> node(Core::LinAlg::Initialization::zero);
+      node(0, 0) = coords[i][0];
+      node(1, 0) = coords[i][1];
+      node(2, 0) = coords[i][2];
+      ref_locs.push_back(node);
+      scalar_data.push_back({static_cast<double>(i + 1)});
+    }
+
+    WeightingFunction weight_func = WeightingFunction::exponential;
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.exponential_decay_c = 1.0;
+
+    ScalarInterpolator<loc_dim, poly_order, num_cofeffcients> interpolator(
+        ScalarInterpolationType::MLS, weight_func, interp_params);
+
+    // Interpolate at the center of the cube (0,0,0)
+    Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+    interp_loc(0, 0) = 0.0;
+    interp_loc(1, 0) = 0.0;
+    interp_loc(2, 0) = 0.0;
+
+    std::vector<double> result =
+        interpolator.get_interpolated_scalar(scalar_data, ref_locs, interp_loc);
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_NEAR(result[0], 4.5, 1e-8);
+  }
+
+  TEST(LinalgScalarInterpolationTest, MLSInterpolation_3DQuadratic_Hex20Nodes)
+  {
+    // -----------------------------------------------------------------------------
+    // HEX20 Quadratic Serendipity Element Analogy
+    // The 20 input nodes represent the corners and mid-edge nodes of a reference
+    // hexahedral (HEX20) element, positioned in the natural coordinate system:
+    //
+    //      Corner nodes at (ξ, η, ζ) ∈ { -1, +1 }^3
+    //      Mid-edge nodes lie at the midpoint of edges where one coordinate is zero
+    //      and the other two are ±1.
+    //
+    // Each node is assigned a scalar value (e.g., 1 through 20).
+    // The interpolation is performed at the centroid of the element:
+    //
+    //      ξ = 0, η = 0, ζ = 0
+    //
+    // At the centroid, the HEX20 shape functions evaluate as:
+    //      - Corner nodes: N_i(0, 0, 0) = -0.25 (for i = 1 to 8)
+    //      - Mid-edge nodes: N_i(0, 0, 0) = 0.25 (for i = 9 to 20)
+    //
+    // Using the FEM interpolation formula:
+    //      u_centroid = ∑ N_i * u_i
+    //
+    // For nodal values u_i = 1 to 20, this evaluates to:
+    //      u_centroid = (-0.25) * sum(u_1 to u_8) + 0.25 * sum(u_9 to u_20)
+    //                 = (-0.25) * 36 + 0.25 * 174
+    //                 = -9 + 43.5
+    //                 = 34.5
+    // Thus, the displacement at the centroid is 34.5.
+    // -----------------------------------------------------------------------------
+
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    constexpr unsigned int loc_dim = 3;
+    constexpr unsigned int poly_order = 2;
+    constexpr unsigned int num_cofeffcients = 10;
+
+    // 20-node HEX element: 8 corners + 12 mid-edge nodes
+    double coords[20][3] = {
+        {-1, -1, -1},  // 1
+        {+1, -1, -1},  // 2
+        {+1, +1, -1},  // 3
+        {-1, +1, -1},  // 4
+        {-1, -1, +1},  // 5
+        {+1, -1, +1},  // 6
+        {+1, +1, +1},  // 7
+        {-1, +1, +1},  // 8
+        {0, -1, -1},   // 9   (1-2)
+        {+1, 0, -1},   // 10  (2-3)
+        {0, +1, -1},   // 11  (3-4)
+        {-1, 0, -1},   // 12  (4-1)
+        {0, -1, +1},   // 13  (5-6)
+        {+1, 0, +1},   // 14  (6-7)
+        {0, +1, +1},   // 15  (7-8)
+        {-1, 0, +1},   // 16  (8-5)
+        {-1, -1, 0},   // 17  (1-5)
+        {+1, -1, 0},   // 18  (2-6)
+        {+1, +1, 0},   // 19  (3-7)
+        {-1, +1, 0}    // 20  (4-8)
+    };
+
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    std::vector<std::vector<double>> scalar_data;
+
+    for (int i = 0; i < 20; ++i)
+    {
+      Core::LinAlg::Matrix<loc_dim, 1> node(Core::LinAlg::Initialization::zero);
+      node(0, 0) = coords[i][0];
+      node(1, 0) = coords[i][1];
+      node(2, 0) = coords[i][2];
+      ref_locs.push_back(node);
+      scalar_data.push_back({static_cast<double>(i + 1)});
+    }
+
+    WeightingFunction weight_func = WeightingFunction::exponential;
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.exponential_decay_c = 1.0;
+
+    ScalarInterpolator<loc_dim, poly_order, num_cofeffcients> interpolator(
+        ScalarInterpolationType::MLS, weight_func, interp_params);
+
+    // Interpolate at the center of the cube (0,0,0)
+    Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+    interp_loc(0, 0) = 0.0;
+    interp_loc(1, 0) = 0.0;
+    interp_loc(2, 0) = 0.0;
+
+    std::vector<double> result =
+        interpolator.get_interpolated_scalar(scalar_data, ref_locs, interp_loc);
+
+    ASSERT_EQ(result.size(), 1);
+    ASSERT_NEAR(result[0], 34.5, 1e-8);
+  }
+
+  TEST(LinalgScalarInterpolationTest, LOGMLSInterpolation_ManualData)
+  {
+    // see Satheesh et al., 2024, 10.1002/nme.7373, Section 2.4.4 Comparison of eigenvalue
+    // interpolation methods
+
+    using namespace Core::LinAlg::ScalarInterpolation;
+
+    constexpr unsigned int loc_dim = 1;
+    constexpr unsigned int poly_order = 2;
+    constexpr unsigned int num_cofeffcients = 3;
+
+    // Reference locations and scalar data
+    std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs;
+    std::vector<std::vector<double>> scalar_data;
+
+    Core::LinAlg::Matrix<loc_dim, 1> x1(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> x2(Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Matrix<loc_dim, 1> x3(Core::LinAlg::Initialization::zero);
+    x1(0, 0) = 1.0;
+    x2(0, 0) = 2.0;
+    x3(0, 0) = 3.0;
+    ref_locs.push_back(x1);
+    ref_locs.push_back(x2);
+    ref_locs.push_back(x3);
+
+    scalar_data.push_back({0.1, 0.1, 0.1});
+    scalar_data.push_back({0.1, 0.1, 0.1});
+    scalar_data.push_back({1.0, 1.0, 1.0});
+
+    WeightingFunction weight_func = WeightingFunction::exponential;
+    InterpParams interp_params;
+    interp_params.distance_threshold = 1e-12;
+    interp_params.exponential_decay_c = 1.0;
+
+    ScalarInterpolator<loc_dim, poly_order, num_cofeffcients> interpolator(
+        ScalarInterpolationType::LOGMLS, weight_func, interp_params);
+
+    // Interpolate at several points in [1, 3]
+    std::vector<double> interp_points = {
+        1.0, 1.14141414141414, 2.33333333333333, 2.91919191919192, 3.0};
+    std::vector<double> expected = {
+        0.1, 0.0869544693275927, 0.166810053719997, 0.762171757370172, 1.0};
+    for (size_t i = 0; i < interp_points.size(); ++i)
+    {
+      Core::LinAlg::Matrix<loc_dim, 1> interp_loc(Core::LinAlg::Initialization::zero);
+      interp_loc(0, 0) = interp_points[i];
+
+      std::vector<double> result =
+          interpolator.get_interpolated_scalar(scalar_data, ref_locs, interp_loc);
+
+      ASSERT_EQ(result.size(), scalar_data[0].size());
+      for (size_t j = 0; j < result.size(); ++j) ASSERT_NEAR(result[j], expected[i], 1e-8);
+    }
+  }
+
+}  // namespace
+FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
## Description and Context
 This class provides functionality to interpolate scalar values at arbitrary locations. It supports different interpolation
 types, including moving least squares (MLS), logarithmic interpolation, and log-domain MLS,
 with customizable weighting functions and interpolation parameters.
 
 This class is required for tensor interpolation methods , see Satheesh et al., 2024, 10.1002/nme.7373
 
## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
