### PR TITLE
Generalize `dot` and `ddot` product for arbitrarily sized tensors

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor.hpp
@@ -61,8 +61,54 @@ namespace Core::LinAlg
   using TensorView = TensorInternal<T, TensorStorageType::view, n...>;  // view onto's other
                                                                         // memory
 
-  // Implementation of tensor operations
+  /*!
+   * @brief Creates a TensorView from a pointer to data and the tensor shape
+   *
+   * This function creates a TensorView from a pointer to data and the tensor shape specified by the
+   * template parameters. The data is expected to be stored in a contiguous memory block of size
+   * @p (n*...) with column-major layout.
+   *
+   * @tparam n The dimensions of the tensor.
+   * @param data Pointer to the data.
+   * @return A TensorView of type TensorView<ValueType, n...>.
+   */
+  template <std::size_t... n>
+  constexpr auto make_tensor_view(auto* data)
+  {
+    using ValueType = std::remove_pointer_t<decltype(data)>;
+    constexpr std::size_t size = (n * ...);
+    std::span<ValueType, size> data_span(data, size);
 
+    return TensorView<ValueType, n...>(std::move(data_span));
+  }
+
+  namespace Internal
+  {
+    template <typename T>
+    struct MakeTensorViewFromIntegerSequenceHelper
+    {
+    };
+
+
+    template <std::size_t... n>
+    struct MakeTensorViewFromIntegerSequenceHelper<std::integer_sequence<std::size_t, n...>>
+    {
+      static constexpr auto make_tensor_view_from_sequence(auto* data)
+      {
+        return make_tensor_view<n...>(data);
+      }
+    };
+  }  // namespace Internal
+
+
+  template <typename IntegerSequence>
+  constexpr auto make_tensor_view(auto* data)
+  {
+    return Internal::MakeTensorViewFromIntegerSequenceHelper<
+        IntegerSequence>::make_tensor_view_from_sequence(data);
+  }
+
+  // Implementation of tensor operations
   namespace Internal
   {
     template <typename T, typename S1>
@@ -174,89 +220,40 @@ namespace Core::LinAlg
   constexpr auto transpose(const Rank2TensorConcept auto& A);
 
   /*!
-   * @brief Computes the dot product of two rank-1 tensors
+   * @brief Computes the dot product of two tensors
    *
-   * This function performs the inner product between two vectors a * b. Both sizes need to match.
+   * This function performs the dot product of two tensors @p a and @p b with arbitrary rank. The
+   * last dimension of @p a must match the first dimension of @p b. Returns a scalar value if @p a
+   * and @p b are rank-1 tensors, otherwise returns a tensor.
    *
-   * @tparam TensorLeft The type of the rank-1 tensor (vector).
-   * @tparam TensorRight The type of the rank-1 tensor (vector).
-   * @param a The rank-1 tensor (vector).
-   * @param b The rank-1 tensor (vector).
-   * @return scalar resulting from the dot product.
+   * @tparam TensorLeft
+   * @tparam TensorRight
+   * @return scalar or tensur resulting from the dot product.
    */
   template <typename TensorLeft, typename TensorRight>
-    requires(Rank1TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
-             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
+    requires(
+        TensorLeft::rank() >= 1 && TensorRight::rank() >= 1 &&
+        TensorLeft::template extent<TensorLeft::rank() - 1>() == TensorRight::template extent<0>())
   constexpr auto dot(const TensorLeft& a, const TensorRight& b);
 
   /*!
-   * @brief Computes the dot product of a rank-2 tensor and a rank-1 tensor.
+   * @brief Computes the double dot product of two tensors.
    *
-   * This function performs the matrix-vector multiplication A * b, where A is a rank-2 tensor
-   * (matrix) and b is a rank-1 tensor (vector). The number of columns in A must match the size of
-   * b.
+   * This function computes the double dot product of two tensors @p A and @p B. If @p A and @p B
+   * are rank-2 tensors (matrices), the result is a scalar value, otherwise, the result is a tensor.
    *
-   * @tparam TensorLeft The type of the rank-2 tensor (matrix).
-   * @tparam TensorRight The type of the rank-1 tensor (vector).
-   * @param A The rank-2 tensor (matrix).
-   * @param b The rank-1 tensor (vector).
-   * @return A rank-1 tensor (vector) resulting from the dot product.
+   * @tparam TensorLeft The type of the first tensor.
+   * @tparam TensorRight The type of the second tensor.
+   * @param A The first tensor.
+   * @param B The second tensor.
+   * @return Scalar or tensor depending on the ranks of @p A and @p B.
    */
   template <typename TensorLeft, typename TensorRight>
-    requires(Rank2TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
-             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
-  constexpr auto dot(const TensorLeft& A, const TensorRight& b);
-
-  /*!
-   * @brief Computes the dot product of a rank-1 tensor and a rank-2 tensor.
-   *
-   * This function performs the vector-matrix multiplication a * B, where a is a rank-1 tensor
-   * (vector) and B is a rank-2 tensor (matrix). The size of a must match the number of rows in B.
-   *
-   * @tparam TensorLeft The type of the rank-1 tensor (vector).
-   * @tparam TensorRight The type of the rank-2 tensor (matrix).
-   * @param a The rank-1 tensor (vector).
-   * @param B The rank-2 tensor (matrix).
-   * @return A rank-1 tensor (vector) resulting from the dot product.
-   */
-  template <typename TensorLeft, typename TensorRight>
-    requires(Rank1TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
-             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
-  constexpr auto dot(const TensorLeft& a, const TensorRight& B);
-
-  /*!
-   * @brief Computes the dot product of two rank-2 tensors.
-   *
-   * This function performs the matrix-matrix multiplication A * B, where A and B are rank-2 tensors
-   * (matrices). The number of columns in A must match the number of rows in B.
-   *
-   * @tparam TensorLeft The type of the first rank-2 tensor (matrix).
-   * @tparam TensorRight The type of the second rank-2 tensor (matrix).
-   * @param A The first rank-2 tensor (matrix).
-   * @param B The second rank-2 tensor (matrix).
-   * @return A rank-2 tensor (matrix) resulting from the dot product.
-   */
-  template <typename TensorLeft, typename TensorRight>
-    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
-             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
-  constexpr auto dot(const TensorLeft& A, const TensorRight& B);
-
-  /*!
-   * @brief Computes the double dot product of two rank-2 tensors.
-   *
-   * This function computes the double dot product of two rank-2 tensors (matrices) A and B, which
-   * is defined as the sum of the element-wise products of the corresponding elements in A and B.
-   *
-   * @tparam TensorLeft The type of the first rank-2 tensor (matrix).
-   * @tparam TensorRight The type of the second rank-2 tensor (matrix).
-   * @param A The first rank-2 tensor (matrix).
-   * @param B The second rank-2 tensor (matrix).
-   * @return A scalar value representing the double dot product.
-   */
-  template <typename TensorLeft, typename TensorRight>
-    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
-             TensorLeft::template extent<0>() == TensorRight::template extent<0>() &&
-             TensorLeft::template extent<1>() == TensorRight::template extent<1>())
+    requires(
+        TensorLeft::rank() >= 2 && TensorRight::rank() >= 2 &&
+        TensorLeft::template extent<TensorLeft::rank() - 2>() ==
+            TensorRight::template extent<0>() &&
+        TensorLeft::template extent<TensorLeft::rank() - 1>() == TensorRight::template extent<1>())
   constexpr auto ddot(const TensorLeft& A, const TensorRight& B);
 
   /*!
@@ -468,76 +465,172 @@ namespace Core::LinAlg
 
   constexpr auto transpose(const Rank2TensorConcept auto& A) { return reorder_axis<1, 0>(A); }
 
+  namespace Internal
+  {
+    template <typename ValueType, typename Shape>
+    struct TensorTypeFromIntegerSequence;
+
+    template <typename ValueType, std::size_t... n>
+    struct TensorTypeFromIntegerSequence<ValueType, std::integer_sequence<std::size_t, n...>>
+    {
+      using type = Tensor<ValueType, n...>;
+    };
+
+    template <typename Tuple>
+    consteval auto make_array_from_tuple(Tuple&& tuple)
+    {
+      constexpr auto get_array = [](auto&&... x)
+      { return std::array{std::forward<decltype(x)>(x)...}; };
+      return std::apply(get_array, std::forward<Tuple>(tuple));
+    }
+
+    template <std::array array>
+    consteval auto make_integer_sequence()
+    {
+      constexpr auto array_to_integer_sequence = []<std::size_t... n>(
+                                                     std::index_sequence<n...>) consteval
+      { return std::integer_sequence<std::size_t, array[n]...>{}; };
+
+      return array_to_integer_sequence(std::make_index_sequence<array.size()>{});
+    }
+
+    template <typename TupleTypeLeft, typename TupleTypeRight>
+    consteval auto get_dot_product_result_shape(
+        const TupleTypeLeft& left_shape, const TupleTypeRight& right_shape)
+    {
+      const std::array left_shape_array = make_array_from_tuple(left_shape);
+      const std::array right_shape_array = make_array_from_tuple(right_shape);
+      constexpr std::size_t left_size = std::tuple_size_v<TupleTypeLeft>;
+      constexpr std::size_t right_size = std::tuple_size_v<TupleTypeRight>;
+
+
+      std::array<std::size_t, left_size + right_size - 2> result_shape{};
+
+      std::copy(left_shape_array.begin(), left_shape_array.end() - 1, result_shape.begin());
+      std::copy(right_shape_array.begin() + 1, right_shape_array.end(),
+          result_shape.begin() + (left_size - 1));
+
+      return result_shape;
+    }
+
+    template <typename TensorLeft, typename TensorRight>
+    using DotProductResultType =
+        TensorTypeFromIntegerSequence<decltype(std::declval<typename TensorLeft::value_type>() *
+                                               std::declval<typename TensorRight::value_type>()),
+            decltype(make_integer_sequence<get_dot_product_result_shape(
+                    TensorLeft::shape(), TensorRight::shape())>())>::type;
+
+    template <typename TupleType>
+    consteval std::size_t get_dot_product_left_matrix_size(const TupleType& left_shape)
+    {
+      const std::array left_shape_array = make_array_from_tuple(left_shape);
+      return std::accumulate(
+          left_shape_array.begin(), left_shape_array.end() - 1, 1, std::multiplies<std::size_t>());
+    }
+
+    template <typename TupleType>
+    consteval std::size_t get_dot_product_right_matrix_size(const TupleType& right_shape)
+    {
+      const std::array right_shape_array = make_array_from_tuple(right_shape);
+      return std::accumulate(right_shape_array.begin() + 1, right_shape_array.end(), 1,
+          std::multiplies<std::size_t>());
+    }
+  }  // namespace Internal
+
   template <typename TensorLeft, typename TensorRight>
-    requires(Rank1TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
-             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
+    requires(
+        TensorLeft::rank() >= 1 && TensorRight::rank() >= 1 &&
+        TensorLeft::template extent<TensorLeft::rank() - 1>() == TensorRight::template extent<0>())
   constexpr auto dot(const TensorLeft& a, const TensorRight& b)
   {
     using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
                                 std::declval<typename TensorRight::value_type>());
-    constexpr std::size_t m = TensorLeft::template extent<0>();
+    constexpr std::size_t k = TensorLeft::template extent<TensorLeft::rank() - 1>();
 
-    return DenseFunctions::dot<value_type, m, 1>(a.data(), b.data());
+    if constexpr (TensorLeft::rank() == 1 && TensorRight::rank() == 1)
+    {
+      // Special case for rank-1 tensors: Result is a scalar
+      return DenseFunctions::dot<value_type, k, 1>(a.data(), b.data());
+    }
+    else
+    {
+      constexpr std::size_t m = Internal::get_dot_product_left_matrix_size(TensorLeft::shape());
+      constexpr std::size_t n = Internal::get_dot_product_right_matrix_size(TensorRight::shape());
+
+      Internal::DotProductResultType<TensorLeft, TensorRight> dest;
+      DenseFunctions::multiply<value_type, m, k, n>(dest.data(), a.data(), b.data());
+      return dest;
+    }
   }
 
-  template <typename TensorLeft, typename TensorRight>
-    requires(Rank2TensorConcept<TensorLeft> && Rank1TensorConcept<TensorRight> &&
-             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
-  constexpr auto dot(const TensorLeft& A, const TensorRight& b)
+  namespace Internal
   {
-    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
-                                std::declval<typename TensorRight::value_type>());
-    constexpr std::size_t m = TensorLeft::template extent<0>();
-    constexpr std::size_t n = TensorLeft::template extent<1>();
+    template <typename T, T... n>
+    consteval auto to_integer_sequence(std::integer_sequence<T, n...>)
+    {
+      return std::integer_sequence<T, n...>{};
+    }
 
-    Tensor<value_type, m> dest;
-    DenseFunctions::multiply<value_type, m, n, 1>(dest.data(), A.data(), b.data());
-    return dest;
-  }
+    template <typename Array>
+    constexpr auto make_tuple_from_array(Array&& array)
+    {
+      return std::tuple_cat(array);
+    }
 
-  template <typename TensorLeft, typename TensorRight>
-    requires(Rank1TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
-             TensorLeft::template extent<0>() == TensorRight::template extent<0>())
-  constexpr auto dot(const TensorLeft& a, const TensorRight& B)
-  {
-    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
-                                std::declval<typename TensorRight::value_type>());
-    constexpr std::size_t m = TensorRight::template extent<0>();
-    constexpr std::size_t n = TensorRight::template extent<1>();
+    consteval auto ddot_product_right_tensor_reduced_shape(auto tuple)
+    {
+      return std::apply([](auto first, auto second, auto... args) constexpr
+          { return std::array{first * second, args...}; }, tuple);
+    }
 
-    Tensor<value_type, n> dest;
-    DenseFunctions::multiply<value_type, 1, m, n>(dest.data(), a.data(), B.data());
-    return dest;
-  }
+    consteval auto ddot_product_left_tensor_reduced_shape(auto tuple)
+    {
+      std::array input_array = make_array_from_tuple(tuple);
+      std::ranges::reverse(input_array);
 
-  template <typename TensorLeft, typename TensorRight>
-    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
-             TensorLeft::template extent<1>() == TensorRight::template extent<0>())
-  constexpr auto dot(const TensorLeft& A, const TensorRight& B)
-  {
-    using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
-                                std::declval<typename TensorRight::value_type>());
-    constexpr std::size_t m = TensorLeft::template extent<0>();
-    constexpr std::size_t k = TensorLeft::template extent<1>();
-    constexpr std::size_t n = TensorRight::template extent<1>();
+      std::tuple reversed_resulting_shape =
+          ddot_product_right_tensor_reduced_shape(make_tuple_from_array(input_array));
 
-    Core::LinAlg::Tensor<value_type, n, m> dest;
-    DenseFunctions::multiply<value_type, m, k, n>(dest.data(), A.data(), B.data());
-    return dest;
-  }
+      std::array output_array = make_array_from_tuple(reversed_resulting_shape);
+      std::ranges::reverse(output_array);
+      return output_array;
+    }
+  }  // namespace Internal
 
   template <typename TensorLeft, typename TensorRight>
-    requires(Rank2TensorConcept<TensorLeft> && Rank2TensorConcept<TensorRight> &&
-             TensorLeft::template extent<0>() == TensorRight::template extent<0>() &&
-             TensorLeft::template extent<1>() == TensorRight::template extent<1>())
+    requires(
+        TensorLeft::rank() >= 2 && TensorRight::rank() >= 2 &&
+        TensorLeft::template extent<TensorLeft::rank() - 2>() ==
+            TensorRight::template extent<0>() &&
+        TensorLeft::template extent<TensorLeft::rank() - 1>() == TensorRight::template extent<1>())
   constexpr auto ddot(const TensorLeft& A, const TensorRight& B)
   {
     using value_type = decltype(std::declval<typename TensorLeft::value_type>() *
                                 std::declval<typename TensorRight::value_type>());
-    constexpr std::size_t m = TensorLeft::template extent<0>();
-    constexpr std::size_t n = TensorLeft::template extent<1>();
 
-    return DenseFunctions::dot<value_type, m, n>(A.data(), B.data());
+    if constexpr (TensorLeft::rank() == 2 && TensorRight::rank() == 2)
+    {
+      // this is a special case since the result is a scalar
+      constexpr std::size_t m = TensorLeft::template extent<0>();
+      constexpr std::size_t n = TensorLeft::template extent<1>();
+
+      return DenseFunctions::dot<value_type, m, n>(A.data(), B.data());
+    }
+    else
+    {
+      // in this case, result is again a tensor
+      constexpr std::array reduced_shape_left =
+          Internal::ddot_product_left_tensor_reduced_shape(TensorLeft::shape());
+      constexpr std::array reduced_shape_right =
+          Internal::ddot_product_right_tensor_reduced_shape(TensorRight::shape());
+
+      // combine the two axis of the double-dot product and do a normal dot product
+      return dot(
+          make_tensor_view<
+              decltype(Internal::template make_integer_sequence<reduced_shape_left>())>(A.data()),
+          make_tensor_view<
+              decltype(Internal::template make_integer_sequence<reduced_shape_right>())>(B.data()));
+    }
   }
 
   template <typename TensorLeft, typename TensorRight>

--- a/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
@@ -181,6 +181,8 @@ namespace Core::LinAlg
       std::ranges::copy(other.container(), data_.begin());
     }
 
+    TensorInternal(ContainerType&& data) : data_(std::move(data)) {}
+
     /*!
      * @brief Access to the underlying raw data of the tensor
      *

--- a/src/core/linalg/tests/4C_linalg_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_operations_test.cpp
@@ -124,7 +124,7 @@ namespace
     EXPECT_EQ(t_t.at(1, 2), 6.0);
   }
 
-  TYPED_TEST(TensorOperationsTest, Vec_dot_Vec)
+  TYPED_TEST(TensorOperationsTest, VectorDotVector)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 2> a = math::Tensor<double, 2>{{2.0, 3.0}};
     TensorHolder<TestFixture::STORAGE_TYPE, double, 2> b = math::Tensor<double, 2>{{1.0, 2.0}};
@@ -139,7 +139,7 @@ namespace
     EXPECT_EQ(axb2, 8.0);
   }
 
-  TYPED_TEST(TensorOperationsTest, Mat_dot_Vec)
+  TYPED_TEST(TensorOperationsTest, MatrixDotVector)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
         {1.0, 2.0},
@@ -155,36 +155,36 @@ namespace
     EXPECT_EQ(Axb.at(2), 17.0);
   }
 
-  TYPED_TEST(TensorOperationsTest, Mat_dot_Mat)
+  TYPED_TEST(TensorOperationsTest, MatrixDotMatrix)
   {
-    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
-        {1.0, 2.0},
-        {3.0, 4.0},
-        {5.0, 6.0},
-    }};
-    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 3> B = math::Tensor<double, 2, 3>{{
-        {1.0, 2.0, 3.0},
-        {3.0, 4.0, 5.0},
-    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A =
+        math::Tensor<double, 3, 2>{{{0.9770807259226818, 0.4407738249006665},
+            {0.3182728054789512, 0.5197969858753801}, {0.5781364298824675, 0.8539337505004864}}};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 4> B = math::Tensor<double, 2, 4>{
+        {{0.06809727353795003, 0.46453080777933253, 0.7819491186191484, 0.7186028103822503},
+            {0.5860219800531759, 0.037094413234407875, 0.350656391283133, 0.563190684492745}}};
 
-    math::Tensor<double, 3, 3> AxB = math::dot(A.get_tensor(), B.get_tensor());
+    math::Tensor<double, 3, 4> AxB = math::dot(A.get_tensor(), B.get_tensor());
 
-    EXPECT_EQ(AxB.at(0, 0), 7.0);
-    EXPECT_EQ(AxB.at(0, 1), 10.0);
-    EXPECT_EQ(AxB.at(0, 2), 13.0);
+    EXPECT_EQ(AxB.at(0, 0), 0.3248396830857161);
+    EXPECT_EQ(AxB.at(0, 1), 0.47023434528225583);
+    EXPECT_EQ(AxB.at(0, 2), 0.91858757126673);
+    EXPECT_EQ(AxB.at(0, 3), 0.95037266777066);
 
-    EXPECT_EQ(AxB.at(1, 0), 15.0);
-    EXPECT_EQ(AxB.at(1, 1), 22.0);
-    EXPECT_EQ(AxB.at(1, 2), 29.0);
+    EXPECT_EQ(AxB.at(1, 0), 0.3262859691827539);
+    EXPECT_EQ(AxB.at(1, 1), 0.1671290876153926);
+    EXPECT_EQ(AxB.at(1, 2), 0.43114327499162);
+    EXPECT_EQ(AxB.at(1, 3), 0.5214565527578386);
 
-    EXPECT_EQ(AxB.at(2, 0), 23.0);
-    EXPECT_EQ(AxB.at(2, 1), 34.0);
-    EXPECT_EQ(AxB.at(2, 2), 45.0);
+    EXPECT_EQ(AxB.at(2, 0), 0.5397934619104899);
+    EXPECT_EQ(AxB.at(2, 1), 0.3002383541958349);
+    EXPECT_EQ(AxB.at(2, 2), 0.7515105991335884);
+    EXPECT_EQ(AxB.at(2, 3), 0.8963779967537278);
   }
 
 
 
-  TYPED_TEST(TensorOperationsTest, Vec_dot_Mat)
+  TYPED_TEST(TensorOperationsTest, VectorDotMatrix)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{{1.0, 2.0, 3.0}};
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> B = math::Tensor<double, 3, 2>{{
@@ -199,7 +199,7 @@ namespace
     EXPECT_EQ(a_dot_B.at(1), 28.0);
   }
 
-  TYPED_TEST(TensorOperationsTest, Mat_ddot_Mat)
+  TYPED_TEST(TensorOperationsTest, MatrixDdotMatrix)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
         {1.0, 2.0},
@@ -215,6 +215,132 @@ namespace
     double A_ddot_B = math::ddot(A.get_tensor(), B.get_tensor());
 
     EXPECT_EQ(A_ddot_B, 112.0);
+  }
+
+  TYPED_TEST(TensorOperationsTest, ThreeTensorDdotMatrix)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 4, 3, 2> A = math::Tensor<double, 4, 3, 2>{
+        {
+            {{0.771320643266746, 0.0207519493594015}, {0.6336482349262754, 0.7488038825386119},
+                {0.4985070123025904, 0.22479664553084766}},
+            {{0.19806286475962398, 0.7605307121989587}, {0.16911083656253545, 0.08833981417401027},
+                {0.6853598183677972, 0.9533933461949365}},
+            {{0.003948266327914451, 0.5121922633857766}, {0.8126209616521135, 0.6125260668293881},
+                {0.7217553174317995, 0.29187606817063316}},
+            {{0.9177741225129434, 0.7145757833976906}, {0.5425443680112613, 0.14217004760152696},
+                {0.3733407600514692, 0.6741336150663453}},
+        },
+    };
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> B =
+        math::Tensor<double, 3, 2>{{{0.4418331744229961, 0.4340139933332937},
+            {0.6177669784693172, 0.5131382425543909}, {0.6503971819314672, 0.6010389534045444}}};
+
+    Core::LinAlg::Tensor<double, 4> A_ddot_B = math::ddot(A.get_tensor(), B.get_tensor());
+
+    EXPECT_NEAR(A_ddot_B(0), 1.58482764506344, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1), 1.5861759767039691, 1e-10);
+    EXPECT_NEAR(A_ddot_B(2), 1.6852205412426562, 1e-10);
+    EXPECT_NEAR(A_ddot_B(3), 1.7717581672187814, 1e-10);
+  }
+
+  TYPED_TEST(TensorOperationsTest, MatrixDdotThreeTensor)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
+        {0.8052231968327465, 0.5216471523936341},
+        {0.9086488808086682, 0.3192360889885453},
+        {0.09045934927090737, 0.30070005663620336},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2, 4> B = math::Tensor<double, 3, 2, 4>{{
+        {{0.11398436186354977, 0.8286813263076767, 0.04689631938924976, 0.6262871483113925},
+            {0.5475861559192435, 0.8192869956700687, 0.1989475396788123, 0.8568503024577332}},
+        {{0.3516526394320879, 0.7546476915298572, 0.2959617068796787, 0.8839364795611863},
+            {0.3255116378322488, 0.16501589771914849, 0.3925292439465873, 0.0934603745586503}},
+        {{0.8211056578369285, 0.15115201964256386, 0.3841144486921996, 0.9442607122388011},
+            {0.9876254749018722, 0.4563045470947841, 0.8261228438427398, 0.25137413420705934}},
+    }};
+
+    Core::LinAlg::Tensor<double, 4> A_ddot_B = math::ddot(A.get_tensor(), B.get_tensor());
+
+    EXPECT_NEAR(A_ddot_B(0), 1.172129170338301, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1), 1.9839248816243478, 1e-10);
+    EXPECT_NEAR(A_ddot_B(2), 0.8189391251432785, 1e-10);
+    EXPECT_NEAR(A_ddot_B(3), 1.9453037032761435, 1e-10);
+  }
+
+  TYPED_TEST(TensorOperationsTest, ThreeTensDdotThreeTensor)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 4, 3, 2> A = math::Tensor<double, 4, 3, 2>{{
+        {{0.5973716482308843, 0.9028317603316274}, {0.5345579488018151, 0.5902013629854229},
+            {0.03928176722538734, 0.3571817586345363}},
+        {{0.07961309015596418, 0.30545991834281827}, {0.330719311982132, 0.7738302962105958},
+            {0.039959208689977266, 0.42949217843163834}},
+        {{0.3149268718426883, 0.6364911430675446}, {0.34634715008003303, 0.04309735620499444},
+            {0.879915174517916, 0.763240587143681}},
+        {{0.8780966427248583, 0.41750914383926696}, {0.6055775643937568, 0.5134666274082884},
+            {0.5978366479629736, 0.2622156611319503}},
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2, 2> B = math::Tensor<double, 3, 2, 2>{{
+        {{0.30087130894070724, 0.025399782050106068}, {0.30306256065103476, 0.24207587540352737}},
+        {{0.5575781886626442, 0.5655070198881675}, {0.47513224741505056, 0.2927979762895091}},
+        {{0.06425106069482445, 0.9788191457576426}, {0.33970784363786366, 0.4950486308824543}},
+    }};
+
+    auto A_ddot_B = math::ddot(A.get_tensor(), B.get_tensor());
+
+    EXPECT_NEAR(A_ddot_B(0, 0), 1.1556893879240193, 1e-10);
+    EXPECT_NEAR(A_ddot_B(0, 1), 0.92410502208987, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1, 0), 0.8170696456976152, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1, 1), 0.7412990229546594, 1e-10);
+    EXPECT_NEAR(A_ddot_B(2, 0), 0.8170559534228106, 1e-10);
+    EXPECT_NEAR(A_ddot_B(2, 1), 1.6096778150801772, 1e-10);
+    EXPECT_NEAR(A_ddot_B(3, 0), 1.0998352261678221, 1e-10);
+    EXPECT_NEAR(A_ddot_B(3, 1), 1.3311561690778437, 1e-10);
+  }
+
+  TYPED_TEST(TensorOperationsTest, FourTensorDdotMatrix)
+  {
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 2, 4, 3, 2> A = math::Tensor<double, 2, 4, 3,
+        2>{{
+        {
+            {{0.771320643266746, 0.0207519493594015}, {0.6336482349262754, 0.7488038825386119},
+                {0.4985070123025904, 0.22479664553084766}},
+            {{0.19806286475962398, 0.7605307121989587}, {0.16911083656253545, 0.08833981417401027},
+                {0.6853598183677972, 0.9533933461949365}},
+            {{0.003948266327914451, 0.5121922633857766}, {0.8126209616521135, 0.6125260668293881},
+                {0.7217553174317995, 0.29187606817063316}},
+            {{0.9177741225129434, 0.7145757833976906}, {0.5425443680112613, 0.14217004760152696},
+                {0.3733407600514692, 0.6741336150663453}},
+        },
+        {
+            {{0.4418331744229961, 0.4340139933332937}, {0.6177669784693172, 0.5131382425543909},
+                {0.6503971819314672, 0.6010389534045444}},
+            {{0.8052231968327465, 0.5216471523936341}, {0.9086488808086682, 0.3192360889885453},
+                {0.09045934927090737, 0.30070005663620336}},
+            {{0.11398436186354977, 0.8286813263076767}, {0.04689631938924976, 0.6262871483113925},
+                {0.5475861559192435, 0.8192869956700687}},
+            {{0.1989475396788123, 0.8568503024577332}, {0.3516526394320879, 0.7546476915298572},
+                {0.2959617068796787, 0.8839364795611863}},
+        },
+    }};
+    TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> B = math::Tensor<double, 3, 2>{
+        {
+            {0.3255116378322488, 0.16501589771914849},
+            {0.3925292439465873, 0.0934603745586503},
+            {0.8211056578369285, 0.15115201964256386},
+        },
+    };
+
+    Core::LinAlg::Tensor<double, 2, 4> A_ddot_B = math::ddot(A.get_tensor(), B.get_tensor());
+
+    EXPECT_NEAR(A_ddot_B(0, 0), 1.0165125966071782, 1e-10);
+    EXPECT_NEAR(A_ddot_B(0, 1), 0.971468800965393, 1e-10);
+    EXPECT_NEAR(A_ddot_B(0, 2), 1.0987845120181288, 1e-10);
+    EXPECT_NEAR(A_ddot_B(0, 3), 1.0513631864533974, 1e-10);
+
+    EXPECT_NEAR(A_ddot_B(1, 0), 1.1307838039469182, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1, 1), 0.8544248817704513, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1, 2), 0.8242530123983, 1e-10);
+    EXPECT_NEAR(A_ddot_B(1, 3), 0.7913418780962238, 1e-10);
   }
 
   TYPED_TEST(TensorOperationsTest, Mat_dyadic_Mat)
@@ -246,7 +372,7 @@ namespace
     }
   }
 
-  TYPED_TEST(TensorOperationsTest, Mat_dyadic_Vec)
+  TYPED_TEST(TensorOperationsTest, MatrixDyadicVector)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3, 2> A = math::Tensor<double, 3, 2>{{
         {1.0, 2.0},
@@ -271,7 +397,7 @@ namespace
     }
   }
 
-  TYPED_TEST(TensorOperationsTest, Vec_dyadic_Vec)
+  TYPED_TEST(TensorOperationsTest, VectorDyadicVector)
   {
     TensorHolder<TestFixture::STORAGE_TYPE, double, 3> a = math::Tensor<double, 3>{
         {1.0, 2.0, 3.0},


### PR DESCRIPTION
This PR extends the `dot` and `ddot` product for tensors of arbitrary size. Previously, only rank 1 and rank 2 tensors were possible. The tensor data is reinterpreted in a way so that normal matrix-multiplication routines can be used.