### PR TITLE
Increase number of test chunks for coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           build-directory: ${{ github.workspace }}/build
           source-directory: ${{ github.workspace }}
-          number-of-chunks: 60 # we need fine grained test chunks to avoid running out of storage
+          number-of-chunks: 90 # we need fine grained test chunks to avoid running out of storage
 
   gcc13_coverage_test:
     needs: gcc13_coverage_build


### PR DESCRIPTION
Our coverage report currently runs out of storage. This PR increases the number of test chunks from `60` to `90` to circumvent this problem.

![image](https://github.com/user-attachments/assets/75238ac2-92d1-4637-bc4b-6f4a67c02000)

https://github.com/4C-multiphysics/4C/actions/runs/15407249162