### PR TITLE
Avoid running pre-commit hooks multiple times

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+default_stages:
+  # This setting means that our own hooks are run in the pre-commit stage unless specified otherwise.
+  - pre-commit
 default_install_hook_types:
   - pre-commit
   - commit-msg


### PR DESCRIPTION
Without this change, most hooks run twice: once during `pre-commit` and once during `commit-msg` (since #797). Not the end of the world since they are super fast, but let's still correct this.