### PR TITLE
Implement `SymmetricTensor`

### DIFF
--- a/src/core/linalg/benchmark_tests/4C_linalg_symmetric_tensor_benchmark.cpp
+++ b/src/core/linalg/benchmark_tests/4C_linalg_symmetric_tensor_benchmark.cpp
@@ -1,0 +1,196 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_linalg_symmetric_tensor.hpp"
+
+#include <benchmark/benchmark.h>
+
+FOUR_C_NAMESPACE_OPEN
+template <std::size_t... size>
+Core::LinAlg::Tensor<double, size...> get_random_tensor()
+{
+  Core::LinAlg::Tensor<double, size...> tensor;
+  std::generate(tensor.container().begin(), tensor.container().end(),
+      []() { return static_cast<double>(std::rand()) / RAND_MAX; });
+  return tensor;
+}
+
+template <std::size_t size>
+static void symmetric_tensor_det(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> A_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    double result = Core::LinAlg::det(A_sym);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_tensor_det<2>);
+BENCHMARK(symmetric_tensor_det<3>);
+BENCHMARK(symmetric_tensor_det<4>);
+
+template <std::size_t size>
+static void symmetric_tensor_inv(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> A_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    auto result = Core::LinAlg::inv(A_sym);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_tensor_inv<2>);
+BENCHMARK(symmetric_tensor_inv<3>);
+
+template <std::size_t size>
+static void symmetric_matrix_dot_vector(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> A_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  Core::LinAlg::Tensor<double, size> b = get_random_tensor<size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size> result = A_sym * b;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_matrix_dot_vector<2>);
+BENCHMARK(symmetric_matrix_dot_vector<3>);
+BENCHMARK(symmetric_matrix_dot_vector<4>);
+BENCHMARK(symmetric_matrix_dot_vector<5>);
+BENCHMARK(symmetric_matrix_dot_vector<6>);
+BENCHMARK(symmetric_matrix_dot_vector<9>);
+
+template <std::size_t size>
+static void symmetric_matrix_dot_symmetric_matrix(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> A_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  Core::LinAlg::SymmetricTensor<double, size, size> B_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = A_sym * B_sym;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_matrix_dot_symmetric_matrix<2>);
+BENCHMARK(symmetric_matrix_dot_symmetric_matrix<3>);
+BENCHMARK(symmetric_matrix_dot_symmetric_matrix<4>);
+BENCHMARK(symmetric_matrix_dot_symmetric_matrix<5>);
+BENCHMARK(symmetric_matrix_dot_symmetric_matrix<6>);
+
+template <std::size_t size>
+static void symmetric_matrix_ddot_symmetric_matrix(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> A_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  Core::LinAlg::SymmetricTensor<double, size, size> B_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    double result = Core::LinAlg::ddot(A_sym, B_sym);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_matrix_ddot_symmetric_matrix<2>);
+BENCHMARK(symmetric_matrix_ddot_symmetric_matrix<3>);
+BENCHMARK(symmetric_matrix_ddot_symmetric_matrix<4>);
+
+template <std::size_t size>
+static void symmetric_four_tensor_ddot_symmetric_matrix(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size, size, size> A_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size, size, size>());
+  Core::LinAlg::SymmetricTensor<double, size, size> B_sym =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    Core::LinAlg::SymmetricTensor<double, size, size> result = Core::LinAlg::ddot(A_sym, B_sym);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_four_tensor_ddot_symmetric_matrix<2>);
+BENCHMARK(symmetric_four_tensor_ddot_symmetric_matrix<3>);
+BENCHMARK(symmetric_four_tensor_ddot_symmetric_matrix<4>);
+BENCHMARK(symmetric_four_tensor_ddot_symmetric_matrix<5>);
+BENCHMARK(symmetric_four_tensor_ddot_symmetric_matrix<6>);
+
+template <std::size_t size>
+static void self_dyadic_symmetric(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size> a = get_random_tensor<size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::SymmetricTensor<double, size, size> result = Core::LinAlg::self_dyadic(a);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(self_dyadic_symmetric<2>);
+BENCHMARK(self_dyadic_symmetric<3>);
+BENCHMARK(self_dyadic_symmetric<4>);
+BENCHMARK(self_dyadic_symmetric<5>);
+BENCHMARK(self_dyadic_symmetric<6>);
+
+template <std::size_t size>
+static void self_dyadic(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size> a = get_random_tensor<size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = Core::LinAlg::dyadic(a, a);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(self_dyadic<2>);
+BENCHMARK(self_dyadic<3>);
+BENCHMARK(self_dyadic<4>);
+BENCHMARK(self_dyadic<5>);
+BENCHMARK(self_dyadic<6>);
+
+template <std::size_t size>
+static void symmetric_matrix_plus_symmetric_matrix(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> a =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  Core::LinAlg::SymmetricTensor<double, size, size> b =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    Core::LinAlg::SymmetricTensor<double, size, size> result = a + b;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_matrix_plus_symmetric_matrix<2>);
+BENCHMARK(symmetric_matrix_plus_symmetric_matrix<3>);
+BENCHMARK(symmetric_matrix_plus_symmetric_matrix<4>);
+BENCHMARK(symmetric_matrix_plus_symmetric_matrix<5>);
+BENCHMARK(symmetric_matrix_plus_symmetric_matrix<6>);
+
+template <std::size_t size>
+static void symmetric_matrix_dyad_symmetric_matrix(benchmark::State& state)
+{
+  Core::LinAlg::SymmetricTensor<double, size, size> a =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  Core::LinAlg::SymmetricTensor<double, size, size> b =
+      Core::LinAlg::assume_symmetry(get_random_tensor<size, size>());
+  for (auto _ : state)
+  {
+    Core::LinAlg::SymmetricTensor<double, size, size, size, size> result =
+        Core::LinAlg::dyadic(a, b);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(symmetric_matrix_dyad_symmetric_matrix<2>);
+BENCHMARK(symmetric_matrix_dyad_symmetric_matrix<3>);
+BENCHMARK(symmetric_matrix_dyad_symmetric_matrix<4>);
+BENCHMARK(symmetric_matrix_dyad_symmetric_matrix<5>);
+BENCHMARK(symmetric_matrix_dyad_symmetric_matrix<6>);
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/benchmark_tests/4C_linalg_tensor_benchmark.cpp
+++ b/src/core/linalg/benchmark_tests/4C_linalg_tensor_benchmark.cpp
@@ -20,39 +20,35 @@ Core::LinAlg::Tensor<double, size...> get_random_tensor()
 }
 
 template <std::size_t size>
-static void matrix_matrix_product(benchmark::State& state)
+static void tensor_det(benchmark::State& state)
 {
   Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
-  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
   for (auto _ : state)
   {
-    Core::LinAlg::Tensor<double, size, size> result = A * B;
+    double result = Core::LinAlg::det(A);
     benchmark::DoNotOptimize(result);
   }
 }
-BENCHMARK(matrix_matrix_product<2>);
-BENCHMARK(matrix_matrix_product<3>);
-BENCHMARK(matrix_matrix_product<4>);
-
+BENCHMARK(tensor_det<2>);
+BENCHMARK(tensor_det<3>);
+BENCHMARK(tensor_det<4>);
 
 template <std::size_t size>
-static void matrix_matrix_t_product(benchmark::State& state)
+static void tensor_inv(benchmark::State& state)
 {
   Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
-  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
   for (auto _ : state)
   {
-    Core::LinAlg::Tensor<double, size, size> result = A * Core::LinAlg::transpose(B);
+    auto result = Core::LinAlg::inv(A);
     benchmark::DoNotOptimize(result);
   }
 }
-BENCHMARK(matrix_matrix_t_product<2>);
-BENCHMARK(matrix_matrix_t_product<3>);
-BENCHMARK(matrix_matrix_t_product<4>);
+BENCHMARK(tensor_inv<2>);
+BENCHMARK(tensor_inv<3>);
 
 
 template <std::size_t size>
-static void matrix_vector_product(benchmark::State& state)
+static void matrix_dot_vector(benchmark::State& state)
 {
   Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
   Core::LinAlg::Tensor<double, size> b = get_random_tensor<size>();
@@ -62,9 +58,99 @@ static void matrix_vector_product(benchmark::State& state)
     benchmark::DoNotOptimize(result);
   }
 }
-BENCHMARK(matrix_vector_product<2>);
-BENCHMARK(matrix_vector_product<3>);
-BENCHMARK(matrix_vector_product<4>);
+BENCHMARK(matrix_dot_vector<2>);
+BENCHMARK(matrix_dot_vector<3>);
+BENCHMARK(matrix_dot_vector<4>);
+BENCHMARK(matrix_dot_vector<5>);
+BENCHMARK(matrix_dot_vector<6>);
+BENCHMARK(matrix_dot_vector<9>);
+
+template <std::size_t size>
+static void matrix_dot_matrix(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = A * B;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_dot_matrix<2>);
+BENCHMARK(matrix_dot_matrix<3>);
+BENCHMARK(matrix_dot_matrix<4>);
+BENCHMARK(matrix_dot_matrix<5>);
+BENCHMARK(matrix_dot_matrix<6>);
+
+template <std::size_t size>
+static void matrix_ddot_matrix(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    double result = Core::LinAlg::ddot(A, B);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_ddot_matrix<2>);
+BENCHMARK(matrix_ddot_matrix<3>);
+BENCHMARK(matrix_ddot_matrix<4>);
+
+template <std::size_t size>
+static void four_tensor_ddot_matrix(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size, size, size> A_sym =
+      get_random_tensor<size, size, size, size>();
+  Core::LinAlg::Tensor<double, size, size> B_sym = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = Core::LinAlg::ddot(A_sym, B_sym);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(four_tensor_ddot_matrix<2>);
+BENCHMARK(four_tensor_ddot_matrix<3>);
+BENCHMARK(four_tensor_ddot_matrix<4>);
+BENCHMARK(four_tensor_ddot_matrix<5>);
+BENCHMARK(four_tensor_ddot_matrix<6>);
+
+template <std::size_t size>
+static void fourtensor_ddot_fourtensor(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size, size, size> A =
+      get_random_tensor<size, size, size, size>();
+  Core::LinAlg::Tensor<double, size, size, size, size> B =
+      get_random_tensor<size, size, size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size, size, size> result = Core::LinAlg::ddot(A, B);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(fourtensor_ddot_fourtensor<2>);
+BENCHMARK(fourtensor_ddot_fourtensor<3>);
+BENCHMARK(fourtensor_ddot_fourtensor<4>);
+BENCHMARK(fourtensor_ddot_fourtensor<5>);
+BENCHMARK(fourtensor_ddot_fourtensor<6>);
+
+
+template <std::size_t size>
+static void matrix_dot_matrix_t(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> A = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> B = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = A * Core::LinAlg::transpose(B);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_dot_matrix_t<2>);
+BENCHMARK(matrix_dot_matrix_t<3>);
+BENCHMARK(matrix_dot_matrix_t<4>);
+BENCHMARK(matrix_dot_matrix_t<5>);
+BENCHMARK(matrix_dot_matrix_t<6>);
 
 
 template <std::size_t size>
@@ -81,5 +167,41 @@ static void scaled_matrix_matrix_product(benchmark::State& state)
 BENCHMARK(scaled_matrix_matrix_product<2>);
 BENCHMARK(scaled_matrix_matrix_product<3>);
 BENCHMARK(scaled_matrix_matrix_product<4>);
+BENCHMARK(scaled_matrix_matrix_product<5>);
+BENCHMARK(scaled_matrix_matrix_product<6>);
+
+template <std::size_t size>
+static void matrix_plus_matrix(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> a = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> b = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size> result = a + b;
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_plus_matrix<2>);
+BENCHMARK(matrix_plus_matrix<3>);
+BENCHMARK(matrix_plus_matrix<4>);
+BENCHMARK(matrix_plus_matrix<5>);
+BENCHMARK(matrix_plus_matrix<6>);
+
+template <std::size_t size>
+static void matrix_dyad_matrix(benchmark::State& state)
+{
+  Core::LinAlg::Tensor<double, size, size> a = get_random_tensor<size, size>();
+  Core::LinAlg::Tensor<double, size, size> b = get_random_tensor<size, size>();
+  for (auto _ : state)
+  {
+    Core::LinAlg::Tensor<double, size, size, size, size> result = Core::LinAlg::dyadic(a, b);
+    benchmark::DoNotOptimize(result);
+  }
+}
+BENCHMARK(matrix_dyad_matrix<2>);
+BENCHMARK(matrix_dyad_matrix<3>);
+BENCHMARK(matrix_dyad_matrix<4>);
+BENCHMARK(matrix_dyad_matrix<5>);
+BENCHMARK(matrix_dyad_matrix<6>);
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_symmetric_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_symmetric_tensor.hpp
@@ -1,0 +1,692 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_SYMMETRIC_TENSOR_HPP
+#define FOUR_C_LINALG_SYMMETRIC_TENSOR_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_tensor.hpp"
+#include "4C_linalg_tensor_meta_utils.hpp"
+#include "4C_utils_exceptions.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <functional>
+#include <type_traits>
+#include <utility>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+
+  namespace Internal
+  {
+    template <std::size_t... n>
+    consteval auto get_symmetry_index_mapping()
+    {
+      static_assert(
+          sizeof...(n) == 2 || sizeof...(n) == 4, "Only rank 2 and rank 4 tensors are supported");
+
+      constexpr std::array shape = {n...};
+      if constexpr (sizeof...(n) == 2)
+      {
+        // i * (dim+1) for i = 0, 1, 2, ..., dim-1
+        // i * (dim+1)+1 for i = 0, ..., dim-2 or (i+1) * (dim+1)-1 for i = 0, ..., dim-2
+        // i * (dim+1)+2 for i = 0, ..., dim-3 or (i+2) * (dim+1)-2 for i = 0, ..., dim-3
+        // ...
+
+        static_assert(shape[0] == shape[1], "Symmetric tensor must have equal dimensions");
+        constexpr std::size_t dim = shape[0];
+        constexpr std::size_t full_size = dim * dim;
+        constexpr std::size_t symmetric_size = dim * (dim + 1) / 2;
+        std::array<std::size_t, full_size> indexes{};
+
+        std::size_t offset = 0;
+        std::size_t j = 0;
+        for (std::size_t i = 0; i < symmetric_size; ++i)
+        {
+          if (j >= dim - offset)
+          {
+            offset++;
+            j = 0;
+          }
+          if (j < dim - offset)
+          {
+            indexes[j * (dim + 1) + offset] = i;
+            indexes[(j + offset) * (dim + 1) - offset] = i;
+          }
+
+          ++j;
+        }
+
+        return indexes;
+      }
+      else if constexpr (sizeof...(n) == 4)
+      {
+        static_assert(shape[0] == shape[1] && shape[2] == shape[3],
+            "In symmetric tensor 4th order tensors, the first two and the last two dimensions must "
+            "match (for the implemented type of symmetry)");
+
+        // reuse the same logic pairwise for the first two and the last two dimensions
+        std::array indices_i =
+            get_symmetry_index_mapping<shape[0], shape[1]>();  // 1, 3, 5, 3, 2, ...
+        std::array indices_j =
+            get_symmetry_index_mapping<shape[2], shape[3]>();  // 1, 3, 5, 3, 2, ...
+
+
+        constexpr std::size_t symmetric_size_i = shape[0] * (shape[0] + 1) / 2;
+        constexpr std::size_t symmetric_size_j = shape[2] * (shape[2] + 1) / 2;
+        constexpr std::size_t full_size = indices_i.size() * indices_j.size();
+        std::array<std::size_t, full_size> indexes{};
+
+        for (std::size_t j = 0; j < indices_j.size(); ++j)
+        {
+          for (std::size_t i = 0; i < indices_i.size(); ++i)
+          {
+            indexes[i + j * indices_j.size()] =
+                Internal::get_flat_index<Internal::OrderType::column_major,
+                    Internal::TensorBoundCheck::no_check, symmetric_size_i, symmetric_size_j>(
+                    indices_i[i], indices_j[j]);
+          }
+        }
+
+        return indexes;
+      }
+    }
+
+    template <std::size_t... n>
+    consteval auto get_index_reorder_from_symmetric_tensor()
+    {
+      return get_symmetry_index_mapping<n...>();
+    }
+
+    template <std::size_t... n>
+    consteval auto get_index_reorder_to_symmetric_tensor()
+    {
+      constexpr std::array index_mapping = get_symmetry_index_mapping<n...>();
+      constexpr std::size_t max = std::ranges::max(index_mapping);
+
+      std::array<std::size_t, max + 1> reverse_mapping = {};
+      for (std::size_t i = 0; i < index_mapping.size(); ++i)
+      {
+        reverse_mapping[index_mapping[i]] = i;
+      }
+      return reverse_mapping;
+    }
+
+    template <std::size_t... n>
+    consteval auto get_enforced_equality_pairs()
+    {
+      auto evaluator = [](auto eval)
+      {
+        constexpr std::array index_reorder =
+            Internal::get_index_reorder_from_symmetric_tensor<n...>();
+        for (auto i = index_reorder.rbegin(); i != index_reorder.rend(); ++i)
+        {
+          auto j = std::find(index_reorder.begin(), index_reorder.end(), *i);
+
+          std::size_t i_index = std::distance(i, index_reorder.rend()) - 1;
+          std::size_t j_index = std::distance(index_reorder.begin(), j);
+
+
+          if (i_index != j_index)
+          {
+            eval(i_index, j_index);
+          }
+        }
+      };
+
+      constexpr std::size_t size = std::invoke(
+          [&]()
+          {
+            std::size_t size = 0;
+            evaluator([&size](auto i, auto j) { size++; });
+            return size;
+          });
+
+      std::array<std::pair<std::size_t, std::size_t>, size> pairs = {};
+      std::size_t index = 0;
+
+      evaluator(
+          [&index, &pairs](auto i, auto j)
+          {
+            pairs[index] = {i, j};
+            index++;
+          });
+
+      return pairs;
+    }
+
+    template <std::size_t... n>
+    struct SymmetricCompression
+    {
+      static constexpr std::size_t compressed_size =
+          get_index_reorder_to_symmetric_tensor<n...>().size();
+
+      template <TensorBoundCheck bound_check>
+      static constexpr std::size_t flatten_index(decltype(n)... i)
+      {
+        constexpr std::array index_reorder = get_index_reorder_from_symmetric_tensor<n...>();
+        return index_reorder[get_flat_index<OrderType::column_major, bound_check, n...>(i...)];
+      }
+    };
+
+    template <typename T>
+    struct IsSymmetricCompressionTypeHelper : public std::false_type
+    {
+    };
+
+    template <std::size_t... n>
+    struct IsSymmetricCompressionTypeHelper<SymmetricCompression<n...>> : public std::true_type
+    {
+    };
+
+    template <typename T>
+    constexpr bool is_symmetric_tensor =
+        IsSymmetricCompressionTypeHelper<TensorCompressionType<std::remove_cvref_t<T>>>::value;
+  }  // namespace Internal
+
+  /*!
+   * @brief An owning, dense tensor of arbitrary rank with symmetry
+   *
+   * Symmetry for 2nd order tensors: A_ij = A_ji
+   * Symmetry for 4th order tensors: A_ijkl = A_ijlk = A_jikl = A_jilk
+   *
+   * @note Only 2 and 4th order tensors are supported
+   *
+   * @note The underlying data storage of a symmetric 2-tensor is compatible with the stress-like
+   * Voigt notation. The underlying data storage of a symmetric 4 tensor is compatible with the
+   * linearization of a symmetric second order tensor in stress-like Voigt notation w.r.t. a
+   * symmetric second order tensor in strain-like Voigt notation.
+   *
+   * @copydetails Internal::Tensor
+   */
+  template <typename T, std::size_t... n>
+  using SymmetricTensor = TensorInternal<T, TensorStorageType::owning,
+      Internal::SymmetricCompression<n...>, n...>;  // owns the memory
+
+  /*!
+   * @brief A dense view on a tensor of arbitrary rank with symmetry
+   *
+   * Symmetry for 2nd order tensors: A_ij = A_ji
+   * Symmetry for 4th order tensors: A_ijkl = A_ijlk = A_jikl = A_jilk
+   *
+   * @note Only 2 and 4th order tensors are supported
+   *
+   * @note The underlying data storage is compatible with the stress-like Voigt notation. It can be
+   * used to view a stress-like Voigt vector as a symmetric tensor.
+   *
+   * @copydetails Internal::Tensor
+   */
+  template <typename T, std::size_t... n>
+  using SymmetricTensorView = TensorInternal<T, TensorStorageType::view,
+      Internal::SymmetricCompression<n...>, n...>;  // view onto's other
+                                                    // memory
+
+  /*!
+   * @brief Returns true if the given tensor is symmetric according to the definition of the
+   * SymmetricTensor
+   */
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  constexpr bool is_symmetric(
+      const TensorInternal<Number, storage_type, NoCompression<n...>, n...>& tensor);
+
+  /*!
+   * @brief Returns a symmetric tensor from the given tensor.
+   *
+   * @note It is assumed that the input tensor is symmetric. If this is not the case, the result is
+   * unspecified.
+   */
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  constexpr SymmetricTensor<Number, n...> assume_symmetry(
+      const TensorInternal<Number, storage_type, NoCompression<n...>, n...>& tensor);
+
+  /*!
+   * @brief Convert a tensor to a symmetric tensor and throw if it is not symmetric.
+   */
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  SymmetricTensor<Number, n...> assert_symmetry(
+      const TensorInternal<Number, storage_type, NoCompression<n...>, n...>& tensor);
+
+  /*!
+   * @brief Returns a full tensor from the given symmetric tensor.
+   *
+   * @note This function is typically not necessary since the interface to the outside is (in most
+   * cases) identical to the normal tensor
+   */
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  constexpr Tensor<Number, n...> get_full(
+      const TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
+          symmetric_tensor);
+
+  /*!
+   * @brief Print the tensor to the output stream
+   */
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  std::ostream& operator<<(std::ostream& os,
+      const TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
+          tensor);
+
+  /*!
+   * @brief Compute the determinant of a symmetric tensor
+   */
+  constexpr auto det(const TensorConcept auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>);
+
+  /*!
+   * @brief Compute the trace of a symmetric tensor
+   */
+  constexpr auto trace(const SquareTensor auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>);
+
+  /*!
+   * @brief Compute the inverse of a symmetric tensor
+   */
+  auto inv(const SquareTensor auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>);
+
+  /*!
+   * @brief Returns the tensor itself
+   */
+  constexpr auto transpose(const Rank2TensorConcept auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>);
+
+  /*!
+   * @brief Computes the dot product of one tensor, where at least one of them is a symmetric
+   * tensor.
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(
+        Internal::is_symmetric_tensor<TensorLeft> || Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto dot(const TensorLeft& a, const TensorRight& b);
+
+  /*!
+   * @brief Computes the double dot product of two tensors, where at least one of them is a
+   * symmetric tensor.
+   *
+   * @tparam TensorLeft
+   * @tparam TensorRight
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(
+        TensorLeft::rank() >= 2 && TensorRight::rank() >= 2 &&
+        TensorLeft::template extent<TensorLeft::rank() - 2>() ==
+            TensorRight::template extent<0>() &&
+        TensorLeft::template extent<TensorLeft::rank() - 1>() ==
+            TensorRight::template extent<1>() &&
+        (Internal::is_symmetric_tensor<TensorLeft> || Internal::is_symmetric_tensor<TensorRight>))
+  constexpr auto ddot(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Scales the tensor with a scalar value
+   */
+  template <typename Tensor, typename Scalar>
+    requires(std::is_arithmetic_v<Scalar> && Internal::is_symmetric_tensor<Tensor>)
+  constexpr auto scale(const Tensor& tensor, const Scalar& b);
+
+  /*!
+   * @brief Adds two symmetric tensors
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type> &&
+             Internal::is_symmetric_tensor<TensorLeft> &&
+             Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto add(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Subtracts two symmetric tensors
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type> &&
+             Internal::is_symmetric_tensor<TensorLeft> &&
+             Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto subtract(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Computes the dyadic product of two tensors, where both of them is a symmetric
+   * tensor
+   */
+  template <typename TensorLeft, typename TensorRight>
+    requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight> &&
+             Internal::is_symmetric_tensor<TensorLeft> &&
+             Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto dyadic(const TensorLeft& A, const TensorRight& B);
+
+  /*!
+   * @brief Computes the dyadic product of @p a with itself.
+   *
+   * @tparam num_dyads The number of dyads to compute. Default is 2, which means the result is a
+   * symmetric tensor of rank 2 (a \otimes a). If set to 4, the result is a symmetric tensor of rank
+   * 4 (a \otimes a \otimes a \otimes a).
+   */
+  template <unsigned num_dyads = 2>
+  constexpr auto self_dyadic(const auto& a)
+    requires(TensorConcept<std::remove_cvref_t<decltype(a)>> &&
+             std::remove_cvref_t<decltype(a)>::rank() == 1);
+
+
+  // actual implementations
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  constexpr bool is_symmetric(
+      const TensorInternal<Number, storage_type, NoCompression<n...>, n...>& tensor)
+  {
+    for (const auto& [i, j] : Internal::get_enforced_equality_pairs<n...>())
+    {
+      if (tensor.container()[i] != tensor.container()[j]) return false;
+    }
+    return true;
+  }
+
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  constexpr SymmetricTensor<Number, n...> assume_symmetry(
+      const TensorInternal<Number, storage_type, NoCompression<n...>, n...>& tensor)
+  {
+    constexpr std::array index_reorder = Internal::get_index_reorder_to_symmetric_tensor<n...>();
+    SymmetricTensor<Number, n...> symmetric_tensor;
+    std::transform(index_reorder.begin(), index_reorder.end(), symmetric_tensor.data(),
+        [&tensor](const auto& i) { return tensor.container()[i]; });
+    return symmetric_tensor;
+  }
+
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  SymmetricTensor<Number, n...> assert_symmetry(
+      const TensorInternal<Number, storage_type, NoCompression<n...>, n...>& tensor)
+  {
+    FOUR_C_ASSERT_ALWAYS(is_symmetric(tensor), "The tensor is not symmetric.");
+
+    return assume_symmetry(tensor);
+  }
+
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  constexpr Tensor<Number, n...> get_full(
+      const TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
+          symmetric_tensor)
+  {
+    // returns a full tensor of the input tensor
+    constexpr std::array index_reorder = Internal::get_index_reorder_from_symmetric_tensor<n...>();
+
+    Tensor<Number, n...> tensor;
+    std::transform(index_reorder.begin(), index_reorder.end(), tensor.data(),
+        [&symmetric_tensor](const auto& i) { return symmetric_tensor.container()[i]; });
+    return tensor;
+  }
+
+  template <typename Number, TensorStorageType storage_type, std::size_t... n>
+  std::ostream& operator<<(std::ostream& os,
+      const TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
+          tensor)
+  {
+    constexpr auto tensor_type = []() consteval
+    {
+      if constexpr (storage_type == TensorStorageType::owning)
+        return "SymmetricTensor";
+      else if constexpr (storage_type == TensorStorageType::view)
+        return "SymmetricTensorView";
+      else
+        FOUR_C_THROW("Unknown tensor type!");
+    }();
+
+    auto make_array_from_tuple = [](auto&&... args) constexpr
+    { return std::array<std::size_t, sizeof...(args)>{args...}; };
+
+    constexpr std::array shape =
+        std::apply(make_array_from_tuple, std::remove_cvref_t<decltype(tensor)>::shape());
+
+    const std::string shape_str =
+        std::accumulate(std::next(shape.begin()), shape.end(), std::to_string(shape[0]),
+            [](const std::string& a, const std::size_t b) { return a + ", " + std::to_string(b); });
+
+    os << tensor_type << "<" << Core::Utils::try_demangle(typeid(Number).name()) << ", "
+       << shape_str << ">";
+    print_values(os, get_full(tensor));
+
+    return os;
+  }
+
+  namespace Internal
+  {
+    auto get_reduced_dimensional_symmetric_tensor(
+        const auto& tensor, const auto& off_diagonal_scale_factor)
+      requires(std::remove_cvref_t<decltype(tensor)>::rank() == 2 &&
+               Internal::is_symmetric_tensor<decltype(tensor)>)
+    {
+      using TensorType = std::remove_cvref_t<decltype(tensor)>;
+      constexpr std::size_t size = TensorType::template extent<0>();
+
+      using ValueType = TensorType::value_type;
+
+      auto container = tensor.container();
+      Tensor<ValueType, TensorType::compressed_size> reduced_tensor(std::move(container));
+
+      // Scale off-diagonal elements of a symmetric 2-tensor
+      std::for_each(reduced_tensor.container().begin() + size, reduced_tensor.container().end(),
+          [&off_diagonal_scale_factor](auto& value) { value *= off_diagonal_scale_factor; });
+
+      return reduced_tensor;
+    }
+
+    auto get_reduced_dimensional_symmetric_tensor(const auto& tensor)
+      requires(std::remove_cvref_t<decltype(tensor)>::rank() == 4 &&
+               Internal::is_symmetric_tensor<decltype(tensor)>)
+    {
+      using TensorType = std::remove_cvref_t<decltype(tensor)>;
+      constexpr std::size_t size_left = TensorType::template extent<0>();
+      constexpr std::size_t size_right = TensorType::template extent<2>();
+
+      constexpr std::size_t new_size_left = size_left * (size_left + 1) / 2;
+      constexpr std::size_t new_size_right = size_right * (size_right + 1) / 2;
+
+      using ValueType = TensorType::value_type;
+
+      auto container = tensor.container();
+      Tensor<ValueType, new_size_left, new_size_right> reduced_tensor(std::move(container));
+      return reduced_tensor;
+    }
+
+    auto interpret_symmetric(const auto& tensor)
+      requires(std::remove_cvref_t<decltype(tensor)>::rank() == 1)
+    {
+      using TensorType = std::remove_cvref_t<decltype(tensor)>;
+      constexpr std::size_t size = TensorType::template extent<0>();
+
+      constexpr std::size_t symmetric_size = [](auto size) consteval
+      {
+        switch (size)
+        {
+          case 3:
+            return 2;
+          case 6:
+            return 3;
+          case 10:
+            return 4;
+          case 15:
+            return 5;
+          case 21:
+            return 6;
+          default:
+            FOUR_C_THROW("Unsupported symmetric tensor size: " + std::to_string(size));
+        }
+      }(size);
+
+      using ValueType = TensorType::value_type;
+
+      auto container = tensor.container();
+      SymmetricTensor<ValueType, symmetric_size, symmetric_size> symmetric_tensor(
+          std::move(container));
+      return symmetric_tensor;
+    }
+  }  // namespace Internal
+
+  // define tensor operations for symmetric tensors
+  constexpr auto det(const TensorConcept auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>)
+  {
+    return det(get_full(A));
+  }
+
+  constexpr auto trace(const SquareTensor auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>)
+  {
+    return trace(get_full(A));
+  }
+
+
+  auto inv(const SquareTensor auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>)
+  {
+    return assume_symmetry(inv(get_full(A)));
+  }
+
+
+  constexpr auto transpose(const Rank2TensorConcept auto& A)
+    requires(Internal::is_symmetric_tensor<decltype(A)>)
+  {
+    return A;
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(
+        Internal::is_symmetric_tensor<TensorLeft> || Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto dot(const TensorLeft& a, const TensorRight& b)
+  {
+    constexpr auto get_full_tensor = [](const auto& tensor) constexpr
+    {
+      if constexpr (Internal::is_symmetric_tensor<decltype(tensor)>)
+      {
+        return get_full(tensor);
+      }
+      else
+      {
+        return tensor;
+      }
+    };
+    return dot(get_full_tensor(a), get_full_tensor(b));
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(
+        TensorLeft::rank() >= 2 && TensorRight::rank() >= 2 &&
+        TensorLeft::template extent<TensorLeft::rank() - 2>() ==
+            TensorRight::template extent<0>() &&
+        TensorLeft::template extent<TensorLeft::rank() - 1>() ==
+            TensorRight::template extent<1>() &&
+        (Internal::is_symmetric_tensor<TensorLeft> || Internal::is_symmetric_tensor<TensorRight>))
+  constexpr auto ddot(const TensorLeft& A, const TensorRight& B)
+  {
+    // First handle common cases with an optimized implementation
+    if constexpr (Internal::is_symmetric_tensor<TensorLeft> &&
+                  Internal::is_symmetric_tensor<TensorRight> && TensorLeft::rank() == 4 &&
+                  TensorRight::rank() == 2)
+    {
+      return Internal::interpret_symmetric(
+          dot(Internal::get_reduced_dimensional_symmetric_tensor(A),
+              Internal::get_reduced_dimensional_symmetric_tensor(B, 2)));
+    }
+    else if constexpr (Internal::is_symmetric_tensor<TensorLeft> &&
+                       Internal::is_symmetric_tensor<TensorRight> && TensorLeft::rank() == 2 &&
+                       TensorRight::rank() == 4)
+    {
+      return Internal::interpret_symmetric(
+          dot(Internal::get_reduced_dimensional_symmetric_tensor(A, 2),
+              Internal::get_reduced_dimensional_symmetric_tensor(B)));
+    }
+
+    // All remaining cases are handled by the generic implementation
+    constexpr auto get_full_tensor = [](const auto& tensor) constexpr
+    {
+      if constexpr (Internal::is_symmetric_tensor<decltype(tensor)>)
+      {
+        return get_full(tensor);
+      }
+      else
+      {
+        return tensor;
+      }
+    };
+
+    constexpr auto maybe_symmetrify = [](const auto& tensor) constexpr
+    {
+      if constexpr (((Internal::is_symmetric_tensor<TensorLeft> && TensorLeft::rank() == 4 &&
+                         TensorRight::rank() == 2) ||
+                        (Internal::is_symmetric_tensor<TensorRight> && TensorRight::rank() == 4 &&
+                            TensorLeft::rank() == 2)))
+      {
+        // result is symmetric if one tensor is a symmetric 4th order tensor and the other one is a
+        // second order tensor
+        return assume_symmetry(tensor);
+      }
+      else
+      {
+        // Otherwise, the tensor is not guaranteed to be symmetric
+        return tensor;
+      }
+    };
+
+    return maybe_symmetrify(ddot(get_full_tensor(A), get_full_tensor(B)));
+  }
+
+  template <typename Tensor, typename Scalar>
+    requires(std::is_arithmetic_v<Scalar> && Internal::is_symmetric_tensor<Tensor>)
+  constexpr auto scale(const Tensor& tensor, const Scalar& b)
+  {
+    return assume_symmetry(scale(get_full(tensor), b));
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type> &&
+             Internal::is_symmetric_tensor<TensorLeft> &&
+             Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto add(const TensorLeft& A, const TensorRight& B)
+  {
+    return assume_symmetry(add(get_full(A), get_full(B)));
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(std::is_same_v<typename TensorLeft::shape_type, typename TensorRight::shape_type> &&
+             Internal::is_symmetric_tensor<TensorLeft> &&
+             Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto subtract(const TensorLeft& A, const TensorRight& B)
+  {
+    return assume_symmetry(subtract(get_full(A), get_full(B)));
+  }
+
+  template <typename TensorLeft, typename TensorRight>
+    requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight> &&
+             Internal::is_symmetric_tensor<TensorLeft> &&
+             Internal::is_symmetric_tensor<TensorRight>)
+  constexpr auto dyadic(const TensorLeft& A, const TensorRight& B)
+  {
+    return assume_symmetry(dyadic(get_full(A), get_full(B)));
+  }
+
+  template <unsigned num_dyads>
+  constexpr auto self_dyadic(const auto& a)
+    requires(TensorConcept<std::remove_cvref_t<decltype(a)>> &&
+             std::remove_cvref_t<decltype(a)>::rank() == 1)
+  {
+    static_assert(
+        num_dyads == 2 || num_dyads == 4, "Only self dyadic with two or four dyads are supported.");
+    if constexpr (num_dyads == 2)
+    {
+      return assume_symmetry(dyadic(a, a));
+    }
+    else if constexpr (num_dyads == 4)
+    {
+      const auto a_dyadic_a = self_dyadic<2>(a);
+      return dyadic(a_dyadic_a, a_dyadic_a);
+    }
+  }
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/tests/4C_linalg_symmetric_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_symmetric_tensor_operations_test.cpp
@@ -1,0 +1,381 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  template <std::size_t n>
+  Core::LinAlg::SymmetricTensor<double, n, n> create_symmetric_tensor(
+      double base_value = 1.0, double base_value2 = 0.1)
+  {
+    Core::LinAlg::SymmetricTensor<double, n, n> t{};
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      for (std::size_t j = 0; j < n; ++j)
+      {
+        t(i, j) = base_value + i * i + j * j + (i + 1) * (j + 1) * base_value2;
+      }
+    }
+    return t;
+  }
+
+  template <std::size_t n>
+  Core::LinAlg::SymmetricTensor<double, n, n, n, n> create_symmetric_four_tensor(
+      double base_value = 1.0)
+  {
+    Core::LinAlg::SymmetricTensor<double, n, n, n, n> t{};
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      for (std::size_t j = 0; j < n; ++j)
+      {
+        for (std::size_t k = 0; k < n; ++k)
+        {
+          for (std::size_t l = 0; l < n; ++l)
+          {
+            t(i, j, k, l) =
+                base_value + i * i + j * j + (i + 1) * (j + 1) * 0.1 + i * j * 0.01 + k * l * 0.01;
+          }
+        }
+      }
+    }
+    return t;
+  }
+
+  template <std::size_t... n>
+  Core::LinAlg::Tensor<double, n...> create_tensor()
+  {
+    Core::LinAlg::Tensor<double, n...> t{};
+
+    double previous_entry = 0.0;
+    for (auto& entry : t.container())
+    {
+      previous_entry += 1.0;
+      entry = previous_entry;
+    }
+    return t;
+  }
+
+  TEST(SymmetricTensorOperationsTest, det)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    EXPECT_NEAR(Core::LinAlg::det(t2_sym), -1.1, 1e-10);
+
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t3_sym = create_symmetric_tensor<3>();
+    EXPECT_NEAR(Core::LinAlg::det(t3_sym), -0.3999999999999977, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, trace)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    EXPECT_NEAR(Core::LinAlg::trace(t2_sym), 4.5, 1e-10);
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym = create_symmetric_tensor<3>();
+    EXPECT_NEAR(Core::LinAlg::trace(t_sym), 14.4, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, inv)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_inv = Core::LinAlg::inv(t2_sym);
+
+    EXPECT_NEAR(t2_sym_inv(0, 0), -3.090909090909090909, 1e-10);
+    EXPECT_NEAR(t2_sym_inv(0, 1), 2, 1e-10);
+
+    EXPECT_NEAR(t2_sym_inv(1, 0), 2, 1e-10);
+    EXPECT_NEAR(t2_sym_inv(1, 1), -1, 1e-10);
+
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym = create_symmetric_tensor<3>();
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym_inv = Core::LinAlg::inv(t_sym);
+
+    EXPECT_NEAR(t_sym_inv(0, 0), 24.75, 1e-10);
+    EXPECT_NEAR(t_sym_inv(0, 1), -33., 1e-10);
+    EXPECT_NEAR(t_sym_inv(0, 2), 8.75, 1e-10);
+
+    EXPECT_NEAR(t_sym_inv(1, 0), -33., 1e-10);
+    EXPECT_NEAR(t_sym_inv(1, 1), 43., 1e-10);
+    EXPECT_NEAR(t_sym_inv(1, 2), -11., 1e-10);
+
+    EXPECT_NEAR(t_sym_inv(2, 0), 8.75, 1e-10);
+    EXPECT_NEAR(t_sym_inv(2, 1), -11., 1e-10);
+    EXPECT_NEAR(t_sym_inv(2, 2), 2.75, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, transpose)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_t = Core::LinAlg::transpose(t2_sym);
+    FOUR_C_EXPECT_NEAR(t2_sym_t, t2_sym, 1e-20);
+
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym = create_symmetric_tensor<3>();
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym_t = Core::LinAlg::transpose(t_sym);
+    FOUR_C_EXPECT_NEAR(t_sym_t, t_sym, 1e-20);
+  }
+
+  TEST(SymmetricTensorOperationsTest, dot)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    {
+      Core::LinAlg::Tensor<double, 2, 3> t2 = create_tensor<2, 3>();
+      Core::LinAlg::Tensor<double, 2, 3> t2_sym_dot_t2 = Core::LinAlg::dot(t2_sym, t2);
+      EXPECT_NEAR(t2_sym_dot_t2(0, 0), 5.5, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2(0, 1), 12.1, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2(0, 2), 18.7, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2(1, 0), 9, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2(1, 1), 20.2, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2(1, 2), 31.4, 1e-10);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 2> t2 = create_tensor<3, 2>();
+      Core::LinAlg::Tensor<double, 3, 2> t2_dot_t2_sym = Core::LinAlg::dot(t2, t2_sym);
+      EXPECT_NEAR(t2_dot_t2_sym(0, 0), 9.9, 1e-10);
+      EXPECT_NEAR(t2_dot_t2_sym(0, 1), 15.8, 1e-10);
+      EXPECT_NEAR(t2_dot_t2_sym(1, 0), 13.2, 1e-10);
+      EXPECT_NEAR(t2_dot_t2_sym(1, 1), 21.4, 1e-10);
+      EXPECT_NEAR(t2_dot_t2_sym(2, 0), 16.5, 1e-10);
+      EXPECT_NEAR(t2_dot_t2_sym(2, 1), 27, 1e-10);
+    }
+
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_2 = create_symmetric_tensor<2>(1.1);
+      Core::LinAlg::Tensor<double, 2, 2> t2_sym_dot_t2_sym_2 = Core::LinAlg::dot(t2_sym, t2_sym_2);
+      EXPECT_NEAR(t2_sym_dot_t2_sym_2(0, 0), 6.38, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2_sym_2(0, 1), 10.23, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2_sym_2(1, 0), 10.46, 1e-10);
+      EXPECT_NEAR(t2_sym_dot_t2_sym_2(1, 1), 16.96, 1e-10);
+    }
+  }
+
+  TEST(SymmetricTensorOperationsTest, ddot)
+  {
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t4_sym = create_symmetric_four_tensor<2>();
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t4_sym_ddot_t2_sym =
+          Core::LinAlg::ddot(t4_sym, t2_sym);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 0), 9.824, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 1), 19.614, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 0), 19.614, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 1), 30.383, 1e-10);
+    }
+
+    {
+      Core::LinAlg::SymmetricTensor<double, 3, 3, 3, 3> t4_sym =
+          assume_symmetry(Core::LinAlg::Tensor<double, 3, 3, 3, 3>{{
+              {
+                  {{0.771321, 0.0207519, 0.633648}, {0.0207519, 0.498507, 0.224797},
+                      {0.633648, 0.224797, 0.169111}},
+                  {{0.0883398, 0.68536, 0.953393}, {0.68536, 0.512192, 0.812621},
+                      {0.953393, 0.812621, 0.291876}},
+                  {{0.917774, 0.714576, 0.542544}, {0.714576, 0.373341, 0.674134},
+                      {0.542544, 0.674134, 0.617767}},
+              },
+              {
+                  {{0.0883398, 0.68536, 0.953393}, {0.68536, 0.512192, 0.812621},
+                      {0.953393, 0.812621, 0.291876}},
+                  {{0.113984, 0.828681, 0.0468963}, {0.828681, 0.547586, 0.819287},
+                      {0.0468963, 0.819287, 0.351653}},
+                  {{0.754648, 0.295962, 0.883936}, {0.295962, 0.165016, 0.392529},
+                      {0.883936, 0.392529, 0.151152}},
+              },
+              {
+                  {{0.917774, 0.714576, 0.542544}, {0.714576, 0.373341, 0.674134},
+                      {0.542544, 0.674134, 0.617767}},
+                  {{0.754648, 0.295962, 0.883936}, {0.295962, 0.165016, 0.392529},
+                      {0.883936, 0.392529, 0.151152}},
+                  {{0.314927, 0.636491, 0.346347}, {0.636491, 0.879915, 0.763241},
+                      {0.346347, 0.763241, 0.605578}},
+              },
+          }});
+
+      Core::LinAlg::SymmetricTensor<double, 3, 3> t2_sym = Core::LinAlg::assume_symmetry(
+          Core::LinAlg::Tensor<double, 3, 3>{{{0.513467, 0.597837, 0.262216},
+              {0.597837, 0.0253998, 0.303063}, {0.262216, 0.303063, 0.565507}}});
+
+      Core::LinAlg::SymmetricTensor<double, 3, 3> t4_sym_ddot_t2_sym =
+          Core::LinAlg::ddot(t4_sym, t2_sym);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 0), 0.9977164139212, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 1), 2.0354347142422, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 2), 2.3776185361748, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 0), 2.0354347142422, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 1), 1.7833152290394, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 2), 1.5325161574708, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(2, 0), 2.3776185361748, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(2, 1), 1.5325161574708, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(2, 2), 1.931804289176, 1e-10);
+
+
+
+      Core::LinAlg::SymmetricTensor<double, 3, 3> t2_sym_ddot_t4_sym =
+          Core::LinAlg::ddot(t2_sym, t4_sym);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(0, 0), 1.6213839037404, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(0, 1), 1.7652477801221, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(0, 2), 2.48266139601174, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(1, 0), 1.7652477801221, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(1, 1), 1.6757006732928, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(1, 2), 2.1309429714246, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(2, 0), 2.48266139601174, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(2, 1), 2.1309429714246, 1e-10);
+      EXPECT_NEAR(t2_sym_ddot_t4_sym(2, 2), 1.2028059166724, 1e-10);
+    }
+
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t4_sym = create_symmetric_four_tensor<2>();
+      Core::LinAlg::Tensor<double, 2, 2> t2 = create_tensor<2, 2>();
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t4_sym_ddot_t2 = Core::LinAlg::ddot(t4_sym, t2);
+      EXPECT_NEAR(t4_sym_ddot_t2(0, 0), 11.04, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2(0, 1), 22.04, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2(1, 0), 22.04, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2(1, 1), 34.14, 1e-10);
+    }
+  }
+
+  TEST(SymmetricTensorOperationsTest, scale)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_inv = Core::LinAlg::scale(t2_sym, 2.0);
+
+    EXPECT_NEAR(t2_sym_inv(0, 0), 2.2, 1e-10);
+    EXPECT_NEAR(t2_sym_inv(0, 1), 4.4, 1e-10);
+
+    EXPECT_NEAR(t2_sym_inv(1, 0), 4.4, 1e-10);
+    EXPECT_NEAR(t2_sym_inv(1, 1), 6.8, 1e-10);
+
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym = create_symmetric_tensor<3>();
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t_sym_inv = Core::LinAlg::scale(t_sym, 2.0);
+
+    EXPECT_NEAR(t_sym_inv(0, 0), 2.2, 1e-10);
+    EXPECT_NEAR(t_sym_inv(0, 1), 4.4, 1e-10);
+    EXPECT_NEAR(t_sym_inv(0, 2), 10.6, 1e-10);
+
+    EXPECT_NEAR(t_sym_inv(1, 0), 4.4, 1e-10);
+    EXPECT_NEAR(t_sym_inv(1, 1), 6.8, 1e-10);
+    EXPECT_NEAR(t_sym_inv(1, 2), 13.2, 1e-10);
+
+    EXPECT_NEAR(t_sym_inv(2, 0), 10.6, 1e-10);
+    EXPECT_NEAR(t_sym_inv(2, 1), 13.2, 1e-10);
+    EXPECT_NEAR(t_sym_inv(2, 2), 19.8, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, add)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_2 = create_symmetric_tensor<2>(1.1);
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_addition =
+        Core::LinAlg::add(t2_sym, t2_sym_2);
+
+    EXPECT_NEAR(t2_sym_addition(0, 0), 2.3, 1e-10);
+    EXPECT_NEAR(t2_sym_addition(0, 1), 4.5, 1e-10);
+
+    EXPECT_NEAR(t2_sym_addition(1, 0), 4.5, 1e-10);
+    EXPECT_NEAR(t2_sym_addition(1, 1), 6.9, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, subtract)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_2 = create_symmetric_tensor<2>(1.1, 0.2);
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_subtraction =
+        Core::LinAlg::subtract(t2_sym, t2_sym_2);
+
+    EXPECT_NEAR(t2_sym_subtraction(0, 0), -0.2, 1e-10);
+    EXPECT_NEAR(t2_sym_subtraction(0, 1), -0.3, 1e-10);
+
+    EXPECT_NEAR(t2_sym_subtraction(1, 0), -0.3, 1e-10);
+    EXPECT_NEAR(t2_sym_subtraction(1, 1), -0.5, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, dyadic)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym_2 = create_symmetric_tensor<2>(1.1, 0.2);
+    Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t2_sym_dyad =
+        Core::LinAlg::dyadic(t2_sym, t2_sym_2);
+
+    EXPECT_NEAR(t2_sym_dyad(0, 0, 0, 0), 1.43, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(0, 0, 0, 1), 2.75, 1e-10);
+
+    EXPECT_NEAR(t2_sym_dyad(0, 0, 1, 0), 2.75, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(0, 0, 1, 1), 4.29, 1e-10);
+
+    EXPECT_NEAR(t2_sym_dyad(0, 1, 0, 0), 2.86, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(0, 1, 0, 1), 5.5, 1e-10);
+
+    EXPECT_NEAR(t2_sym_dyad(0, 1, 1, 0), 5.5, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(0, 1, 1, 1), 8.58, 1e-10);
+
+
+    EXPECT_NEAR(t2_sym_dyad(1, 0, 0, 0), 2.86, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(1, 0, 0, 1), 5.5, 1e-10);
+
+    EXPECT_NEAR(t2_sym_dyad(1, 0, 1, 0), 5.5, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(1, 0, 1, 1), 8.58, 1e-10);
+
+    EXPECT_NEAR(t2_sym_dyad(1, 1, 0, 0), 4.42, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(1, 1, 0, 1), 8.5, 1e-10);
+
+    EXPECT_NEAR(t2_sym_dyad(1, 1, 1, 0), 8.5, 1e-10);
+    EXPECT_NEAR(t2_sym_dyad(1, 1, 1, 1), 13.26, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, self_dyadic)
+  {
+    Core::LinAlg::Tensor<double, 2> t1 = create_tensor<2>();
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t1_self_dyad = Core::LinAlg::self_dyadic(t1);
+
+    std::cout << t1 << std::endl;
+
+    EXPECT_NEAR(t1_self_dyad(0, 0), 1, 1e-10);
+    EXPECT_NEAR(t1_self_dyad(0, 1), 2, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad(1, 0), 2, 1e-10);
+    EXPECT_NEAR(t1_self_dyad(1, 1), 4, 1e-10);
+
+
+    Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t1_self_dyad4 =
+        Core::LinAlg::self_dyadic<4>(t1);
+
+    EXPECT_NEAR(t1_self_dyad4(0, 0, 0, 0), 1, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(0, 0, 0, 1), 2, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(0, 0, 1, 0), 2, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(0, 0, 1, 1), 4, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(0, 1, 0, 0), 2, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(0, 1, 0, 1), 4, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(0, 1, 1, 0), 4, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(0, 1, 1, 1), 8, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(1, 0, 0, 0), 2, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(1, 0, 0, 1), 4, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(1, 0, 1, 0), 4, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(1, 0, 1, 1), 8, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(1, 1, 0, 0), 4, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(1, 1, 0, 1), 8, 1e-10);
+
+    EXPECT_NEAR(t1_self_dyad4(1, 1, 1, 0), 8, 1e-10);
+    EXPECT_NEAR(t1_self_dyad4(1, 1, 1, 1), 16, 1e-10);
+  }
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_symmetric_tensor_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_symmetric_tensor_test.cpp
@@ -1,0 +1,393 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+#include <cstddef>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  template <typename T>
+  class SymmetricTensorTemplatedTest : public ::testing::Test
+  {
+   public:
+    static constexpr std::size_t size = T::value;
+  };
+
+  using test_sizes = ::testing::Types<std::integral_constant<std::size_t, 2>,
+      std::integral_constant<std::size_t, 3>, std::integral_constant<std::size_t, 4>,
+      std::integral_constant<std::size_t, 5>>;
+
+  TYPED_TEST_SUITE(SymmetricTensorTemplatedTest, test_sizes);
+
+  TYPED_TEST(SymmetricTensorTemplatedTest, TestConstructability)
+  {
+    constexpr std::size_t size = TypeParam::value;
+    // Tensor should be default constructible
+    static_assert(
+        std::is_default_constructible_v<Core::LinAlg::SymmetricTensor<double, size, size>>);
+  }
+
+  TYPED_TEST(SymmetricTensorTemplatedTest, DefaultConstruct2Tensor)
+  {
+    constexpr std::size_t size = TypeParam::value;
+    Core::LinAlg::SymmetricTensor<double, size, size> t{};
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+      for (std::size_t j = 0; j < size; ++j)
+      {
+        EXPECT_DOUBLE_EQ(t(i, j), 0.0);
+      }
+    }
+  }
+
+  TYPED_TEST(SymmetricTensorTemplatedTest, DefaultConstruct4Tensor)
+  {
+    constexpr std::size_t size = TypeParam::value;
+    Core::LinAlg::SymmetricTensor<double, size, size, size, size> t{};
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+      for (std::size_t j = 0; j < size; ++j)
+      {
+        for (std::size_t k = 0; k < size; ++k)
+        {
+          for (std::size_t l = 0; l < size; ++l)
+          {
+            EXPECT_DOUBLE_EQ(t(i, j, k, l), 0.0);
+          }
+        }
+      }
+    }
+  }
+
+  TYPED_TEST(SymmetricTensorTemplatedTest, SymmetryRemainsAfterAssignmentFor2Tensor)
+  {
+    constexpr std::size_t size = TypeParam::value;
+    Core::LinAlg::SymmetricTensor<double, size, size> t{};
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+      for (std::size_t j = 0; j < size - i; ++j)
+      {
+        t(i, j) = i * 10 + j;
+      }
+    }
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+      for (std::size_t j = 0; j < size - 1; ++j)
+      {
+        t(i, j) = i * 10 + j;
+        t(j, i) = i * 10 + j;
+      }
+    }
+  }
+
+  TYPED_TEST(SymmetricTensorTemplatedTest, SymmetryRemainsAfterAssignmentFor4Tensor)
+  {
+    constexpr std::size_t size = TypeParam::value;
+    Core::LinAlg::SymmetricTensor<double, size, size, size, size> t{};
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+      for (std::size_t j = 0; j < size - i; ++j)
+      {
+        for (std::size_t k = 0; k < size; ++k)
+        {
+          for (std::size_t l = 0; l < size - k; ++l)
+          {
+            t(i, j, k, l) = i * 10 + j + k * 0.1 + l * 0.01;
+          }
+        }
+      }
+    }
+
+    for (std::size_t i = 0; i < size; ++i)
+    {
+      for (std::size_t j = 0; j < size - 1; ++j)
+      {
+        for (std::size_t k = 0; k < size; ++k)
+        {
+          for (std::size_t l = 0; l < size - k; ++l)
+          {
+            t(i, j, k, l) = i * 10 + j + k * 0.1 + l * 0.01;
+            t(j, i, k, l) = i * 10 + j + k * 0.1 + l * 0.01;
+            t(i, j, l, k) = i * 10 + j + k * 0.1 + l * 0.01;
+            t(j, i, l, k) = i * 10 + j + k * 0.1 + l * 0.01;
+          }
+        }
+      }
+    }
+  }
+
+  TEST(SymmetricTensorTest, InitializationAndIndexing2Tensor)
+  {
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t = Core::LinAlg::assert_symmetry(
+        Core::LinAlg::Tensor<double, 3, 3>{{{0.0, 0.1, 0.2}, {0.1, 1.1, 1.2}, {0.2, 1.2, 2.2}}});
+
+
+    EXPECT_DOUBLE_EQ(t(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(t(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(t(0, 2), 0.2);
+    EXPECT_DOUBLE_EQ(t(1, 0), 0.1);
+    EXPECT_DOUBLE_EQ(t(1, 1), 1.1);
+    EXPECT_DOUBLE_EQ(t(1, 2), 1.2);
+    EXPECT_DOUBLE_EQ(t(2, 0), 0.2);
+    EXPECT_DOUBLE_EQ(t(2, 1), 1.2);
+    EXPECT_DOUBLE_EQ(t(2, 2), 2.2);
+
+
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2 =
+        Core::LinAlg::assert_symmetry(Core::LinAlg::Tensor<double, 2, 2>{{{0.0, 0.1}, {0.1, 1.1}}});
+
+    EXPECT_DOUBLE_EQ(t2(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(t2(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(t2(1, 0), 0.1);
+    EXPECT_DOUBLE_EQ(t2(1, 1), 1.1);
+  }
+
+  TEST(SymmetricTensorTest, AlignmentSameAsVoigtMatrix)
+  {
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t = Core::LinAlg::assert_symmetry(
+        Core::LinAlg::Tensor<double, 3, 3>{{{0.0, 0.1, 0.2}, {0.1, 1.1, 1.2}, {0.2, 1.2, 2.2}}});
+
+    Core::LinAlg::Matrix<6, 1> m_voigt(t.data());
+    Core::LinAlg::Matrix<3, 3> m;
+    Core::LinAlg::Voigt::Stresses::vector_to_matrix(m_voigt, m);
+
+    EXPECT_DOUBLE_EQ(m(0, 0), 0.0);
+    EXPECT_DOUBLE_EQ(m(0, 1), 0.1);
+    EXPECT_DOUBLE_EQ(m(0, 2), 0.2);
+    EXPECT_DOUBLE_EQ(m(1, 0), 0.1);
+    EXPECT_DOUBLE_EQ(m(1, 1), 1.1);
+    EXPECT_DOUBLE_EQ(m(1, 2), 1.2);
+    EXPECT_DOUBLE_EQ(m(2, 0), 0.2);
+    EXPECT_DOUBLE_EQ(m(2, 1), 1.2);
+    EXPECT_DOUBLE_EQ(m(2, 2), 2.2);
+  }
+
+
+  TEST(SymmetricTensorTest, InitializationAndIndexing4Tensor)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t =
+        Core::LinAlg::assert_symmetry(Core::LinAlg::Tensor<double, 2, 2, 2, 2>{
+            {{{{0.000, 0.001}, {0.001, 0.011}}, {{0.100, 0.101}, {0.101, 0.111}}},
+                {{{0.100, 0.101}, {0.101, 0.111}}, {{1.100, 1.101}, {1.101, 1.111}}}}});
+
+    for (std::size_t i = 0; i < 2; ++i)
+    {
+      for (std::size_t j = 0; j < i + 1; ++j)
+      {
+        for (std::size_t k = 0; k < 2; ++k)
+        {
+          for (std::size_t l = 0; l < k + 1; ++l)
+          {
+            EXPECT_DOUBLE_EQ(t(i, j, k, l), i * 0.1 + j + k * 0.001 + l * 0.01);
+            EXPECT_DOUBLE_EQ(t(i, j, l, k), i * 0.1 + j + k * 0.001 + l * 0.01);
+            EXPECT_DOUBLE_EQ(t(j, i, k, l), i * 0.1 + j + k * 0.001 + l * 0.01);
+            EXPECT_DOUBLE_EQ(t(j, i, l, k), i * 0.1 + j + k * 0.001 + l * 0.01);
+          }
+        }
+      }
+    }
+  }
+
+  TEST(SymmetricTensorTest, IsSymmetric)
+  {
+    {
+      Core::LinAlg::Tensor<double, 2, 2> t2_nonsym = {{{1.0, 1.1}, {2.0, 2.1}}};
+      EXPECT_FALSE(Core::LinAlg::is_symmetric(t2_nonsym));
+
+      Core::LinAlg::Tensor<double, 2, 2> t2_sym = {{{1.0, 1.1}, {1.1, 2.1}}};
+      EXPECT_TRUE(Core::LinAlg::is_symmetric(t2_sym));
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 3> t2_nonsym = {
+          {{1.1, 1.2, 1.3}, {2.1, 2.2, 2.3}, {3.1, 3.2, 3.3}}};
+      EXPECT_FALSE(Core::LinAlg::is_symmetric(t2_nonsym));
+
+      Core::LinAlg::Tensor<double, 3, 3> t2_sym = {
+          {{1.1, 1.2, 1.3}, {1.2, 2.2, 2.3}, {1.3, 2.3, 3.3}}};
+      EXPECT_TRUE(Core::LinAlg::is_symmetric(t2_sym));
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t4_nonsym = {{
+          {
+              {{0.0, 0.01}, {0.1, 0.11}},
+              {{1.0, 1.01}, {1.1, 1.11}},
+          },
+          {
+              {{10.0, 10.01}, {10.1, 10.11}},
+              {{11.0, 11.01}, {11.1, 11.11}},
+          },
+      }};
+      EXPECT_FALSE(Core::LinAlg::is_symmetric(t4_nonsym));
+
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t4_sym = {{
+          {
+              {{0.0, 0.01}, {0.01, 0.11}},
+              {{1.0, 1.01}, {1.01, 1.11}},
+          },
+          {
+              {{1.0, 1.01}, {1.01, 1.11}},
+              {{11.0, 11.01}, {11.01, 11.11}},
+          },
+      }};
+      EXPECT_TRUE(Core::LinAlg::is_symmetric(t4_sym));
+    }
+  }
+
+  TEST(SymmetricTensorTest, AssumeSymmetry)
+  {
+    {
+      Core::LinAlg::Tensor<double, 2, 2> t2_sym = {{{1.0, 1.1}, {1.1, 2.1}}};
+      FOUR_C_EXPECT_NEAR(Core::LinAlg::assume_symmetry(t2_sym), t2_sym, 1e-20);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 3> t2_sym = {
+          {{1.1, 1.2, 1.3}, {1.2, 2.2, 2.3}, {1.3, 2.3, 3.3}}};
+      FOUR_C_EXPECT_NEAR(Core::LinAlg::assume_symmetry(t2_sym), t2_sym, 1e-20);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t4_sym = {{
+          {
+              {{0.0, 0.01}, {0.01, 0.11}},
+              {{1.0, 1.01}, {1.01, 1.11}},
+          },
+          {
+              {{1.0, 1.01}, {1.01, 1.11}},
+              {{11.0, 11.01}, {11.01, 11.11}},
+          },
+      }};
+      FOUR_C_EXPECT_NEAR(Core::LinAlg::assume_symmetry(t4_sym), t4_sym, 1e-20);
+    }
+  }
+
+  TEST(SymmetricTensorTest, GetFull)
+  {
+    {
+      Core::LinAlg::Tensor<double, 2, 2> t2_sym = {{{1.0, 1.1}, {1.1, 2.1}}};
+      FOUR_C_EXPECT_NEAR(
+          Core::LinAlg::get_full(Core::LinAlg::assume_symmetry(t2_sym)), t2_sym, 1e-20);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 3> t2_sym = {
+          {{1.1, 1.2, 1.3}, {1.2, 2.2, 2.3}, {1.3, 2.3, 3.3}}};
+      FOUR_C_EXPECT_NEAR(
+          Core::LinAlg::get_full(Core::LinAlg::assume_symmetry(t2_sym)), t2_sym, 1e-20);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t4_sym = {{
+          {
+              {{0.0, 0.01}, {0.01, 0.11}},
+              {{1.0, 1.01}, {1.01, 1.11}},
+          },
+          {
+              {{1.0, 1.01}, {1.01, 1.11}},
+              {{11.0, 11.01}, {11.01, 11.11}},
+          },
+      }};
+      FOUR_C_EXPECT_NEAR(
+          Core::LinAlg::get_full(Core::LinAlg::assume_symmetry(t4_sym)), t4_sym, 1e-20);
+    }
+  }
+
+  TEST(SymmetricTensorTest, AssertSymmetry)
+  {
+    {
+      Core::LinAlg::Tensor<double, 2, 2> t2_nonsym = {{{1.0, 1.1}, {2.0, 2.1}}};
+      EXPECT_ANY_THROW(Core::LinAlg::assert_symmetry(t2_nonsym));
+
+      Core::LinAlg::Tensor<double, 2, 2> t2_sym = {{{1.0, 1.1}, {1.1, 2.1}}};
+      EXPECT_NO_THROW(Core::LinAlg::assert_symmetry(t2_sym));
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 3> t2_nonsym = {
+          {{1.1, 1.2, 1.3}, {2.1, 2.2, 2.3}, {3.1, 3.2, 3.3}}};
+      EXPECT_ANY_THROW(Core::LinAlg::assert_symmetry(t2_nonsym));
+
+      Core::LinAlg::Tensor<double, 3, 3> t2_sym = {
+          {{1.1, 1.2, 1.3}, {1.2, 2.2, 2.3}, {1.3, 2.3, 3.3}}};
+      EXPECT_NO_THROW(Core::LinAlg::assert_symmetry(t2_sym));
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t4_nonsym = {{
+          {
+              {{0.0, 0.01}, {0.1, 0.11}},
+              {{1.0, 1.01}, {1.1, 1.11}},
+          },
+          {
+              {{10.0, 10.01}, {10.1, 10.11}},
+              {{11.0, 11.01}, {11.1, 11.11}},
+          },
+      }};
+      EXPECT_ANY_THROW(Core::LinAlg::assert_symmetry(t4_nonsym));
+
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t4_sym = {{
+          {
+              {{0.0, 0.01}, {0.01, 0.11}},
+              {{1.0, 1.01}, {1.01, 1.11}},
+          },
+          {
+              {{1.0, 1.01}, {1.01, 1.11}},
+              {{11.0, 11.01}, {11.01, 11.11}},
+          },
+      }};
+      EXPECT_NO_THROW(Core::LinAlg::assert_symmetry(t4_sym));
+    }
+  }
+
+  TEST(SymmetricTensorTest, PrintTensor)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 2, 2>{{{0.0, 0.1}, {1.1, 1.1}}});
+    std::stringstream ss;
+    ss << t2;
+    EXPECT_EQ(ss.str(), R"(SymmetricTensor<double, 2, 2>[
+ [0, 0.1],
+ [0.1, 1.1]
+])");
+  }
+
+  TEST(SymmetricTensorViewTest, PrintTensor)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 2, 2>{{{0.0, 0.1}, {1.1, 1.1}}});
+
+
+    Core::LinAlg::SymmetricTensorView<double, 2, 2> t2_view = t2;
+    std::stringstream ss;
+    ss << t2_view;
+    EXPECT_EQ(ss.str(), R"(SymmetricTensorView<double, 2, 2>[
+ [0, 0.1],
+ [0.1, 1.1]
+])");
+  }
+
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/unittests/common/unittest_utils/4C_unittest_utils_assertions_test.hpp
+++ b/unittests/common/unittest_utils/4C_unittest_utils_assertions_test.hpp
@@ -290,11 +290,14 @@ namespace TESTING::INTERNAL
    * @note This function is not intended to be used directly. Use FOUR_C_EXPECT_NEAR.
    */
   template <typename ToleranceType, typename T1, Core::LinAlg::TensorStorageType storage_type1,
-      typename T2, Core::LinAlg::TensorStorageType storage_type2, std::size_t... n>
+      typename Compression1, typename T2, Core::LinAlg::TensorStorageType storage_type2,
+      typename Compression2, std::size_t... n>
   inline ::testing::AssertionResult assert_near(const char* mat1Expr,
       const char* t2Expr,  // NOLINT
-      const char* toleranceExpr, const Core::LinAlg::TensorInternal<T1, storage_type1, n...>& t1,
-      const Core::LinAlg::TensorInternal<T2, storage_type2, n...>& t2, ToleranceType tolerance)
+      const char* toleranceExpr,
+      const Core::LinAlg::TensorInternal<T1, storage_type1, Compression1, n...>& t1,
+      const Core::LinAlg::TensorInternal<T2, storage_type2, Compression2, n...>& t2,
+      ToleranceType tolerance)
   {
     // argument is required for the EXPECT_PRED_FORMAT3 macro of GoogleTest for pretty printing
     (void)toleranceExpr;


### PR DESCRIPTION
This PR introduces the implementation of symmetric tensors including benchmark tests and unit tests. The interface is the same as for normal `Tensor`s.

```cpp
SymmetricTensor<double, 3, 3> tensor{}; // tensor filled with zeros
//SymmetricTensor<double, 3, 4> tensor{}; // ill formed

Tensor<double, 3> t = {{1.0, 2.0, 3.0}};

SymmetricTensor<double, 3, 3> t_dyadic_t = self_dyadic(t); // internal memory storage like our stress-like Voigt notation (like PK2-stress)
SymmetricTensor<double, 3, 3, 3, 3> t_dyadic_t _dyadic_t _dyadic_t = self_dyadic<4>(t); // internal storage like our linearization of a stress-like Voigt vector w.r.t. a strain-like Voigt vector (like our cmat-matrix)
```

The internal data structure is compatible to the stress-like Voigt notation, so that we can create a `SymmetricTensorView` onto an existing stress-like Voigt implementation allowing us to migrate materials step by step.

Most computations are done by computing the full tensor internally and then applying the normal tensor operations and then, if applicable, discard the duplicate computations. The compiler is able to optimize this away for most operations. Large tensors are problematic, so I added an optimization for the `ddot(symmetric 4-tensor, symmetric 2-tensor)`-product. Here are the results:

```
symmetric_tensor_det<2>                             0.318 ns        0.318 ns   2205296314
symmetric_tensor_det<3>                              1.06 ns         1.06 ns    664999210
symmetric_tensor_det<4>                               190 ns          189 ns      3655369
tensor_det<2>                                       0.315 ns        0.315 ns   2202936520
tensor_det<3>                                        1.07 ns         1.07 ns    648854595
tensor_det<4>                                         187 ns          187 ns      3699387
-> equal

symmetric_tensor_inv<2>                             0.870 ns        0.870 ns    794753744
symmetric_tensor_inv<3>                              3.14 ns         3.14 ns    221724024
tensor_inv<2>                                       0.942 ns        0.942 ns    739169915
tensor_inv<3>                                        3.47 ns         3.46 ns    215795189
-> faster

symmetric_matrix_dot_vector<2>                      0.509 ns        0.509 ns   1344275118
symmetric_matrix_dot_vector<3>                       1.14 ns         1.14 ns    610003920
symmetric_matrix_dot_vector<4>                       2.06 ns         2.06 ns    338300377
symmetric_matrix_dot_vector<5>                       3.34 ns         3.34 ns    208768308
symmetric_matrix_dot_vector<6>                       4.82 ns         4.82 ns    144469917
symmetric_matrix_dot_vector<9>                       23.2 ns         23.2 ns     29940098
matrix_dot_vector<2>                                0.513 ns        0.513 ns   1332707545
matrix_dot_vector<3>                                 1.14 ns         1.14 ns    613891739
matrix_dot_vector<4>                                 2.19 ns         2.19 ns    318691857
matrix_dot_vector<5>                                 3.46 ns         3.46 ns    203238989
matrix_dot_vector<6>                                 5.07 ns         5.07 ns    135596477
matrix_dot_vector<9>                                 11.6 ns         11.6 ns     59047475
-> faster for dim <= 6

symmetric_matrix_dot_symmetric_matrix<2>            0.870 ns        0.870 ns    730061974
symmetric_matrix_dot_symmetric_matrix<3>             3.18 ns         3.18 ns    218776037
symmetric_matrix_dot_symmetric_matrix<4>             7.99 ns         7.98 ns     86671736
symmetric_matrix_dot_symmetric_matrix<5>             16.9 ns         16.9 ns     41528530
symmetric_matrix_dot_symmetric_matrix<6>             35.9 ns         35.9 ns     19516376
matrix_dot_matrix<2>                                0.937 ns        0.937 ns    736508761
matrix_dot_matrix<3>                                 3.48 ns         3.48 ns    201187634
matrix_dot_matrix<4>                                 8.25 ns         8.25 ns     84569698
matrix_dot_matrix<5>                                 16.3 ns         16.3 ns     42973923
matrix_dot_matrix<6>                                 30.0 ns         30.0 ns     23357541
-> faster for dim <= 4

symmetric_matrix_ddot_symmetric_matrix<2>           0.473 ns        0.473 ns   1478017181
symmetric_matrix_ddot_symmetric_matrix<3>            1.08 ns         1.08 ns    646430087
symmetric_matrix_ddot_symmetric_matrix<4>            2.02 ns         2.02 ns    344192290
matrix_ddot_matrix<2>                               0.541 ns        0.540 ns   1271208618
matrix_ddot_matrix<3>                                1.25 ns         1.25 ns    553786156
matrix_ddot_matrix<4>                                2.74 ns         2.74 ns    255873108
-> faster

symmetric_four_tensor_ddot_symmetric_matrix<2>       1.20 ns         1.20 ns    572705026
symmetric_four_tensor_ddot_symmetric_matrix<3>       5.29 ns         5.29 ns    128590478
symmetric_four_tensor_ddot_symmetric_matrix<4>       17.5 ns         17.5 ns     39843522
symmetric_four_tensor_ddot_symmetric_matrix<5>       40.2 ns         40.2 ns     17379438
symmetric_four_tensor_ddot_symmetric_matrix<6>       92.5 ns         92.5 ns      7588904
four_tensor_ddot_matrix<2>                           2.18 ns         2.18 ns    319862157
four_tensor_ddot_matrix<3>                           11.7 ns         11.7 ns     58945962
four_tensor_ddot_matrix<4>                           41.5 ns         41.4 ns     16846761
four_tensor_ddot_matrix<5>                            102 ns          102 ns      6817490
four_tensor_ddot_matrix<6>                            225 ns          225 ns      3102732
-> faster

self_dyadic_symmetric<2>                            0.528 ns        0.528 ns   1318964981
self_dyadic_symmetric<3>                            0.916 ns        0.916 ns    774954996
self_dyadic_symmetric<4>                             1.58 ns         1.58 ns    441271412
self_dyadic_symmetric<5>                             2.47 ns         2.47 ns    283389213
self_dyadic_symmetric<6>                             3.55 ns         3.55 ns    196657203

self_dyadic<2>                                      0.533 ns        0.533 ns   1310159237
self_dyadic<3>                                       1.02 ns         1.02 ns    681179633
self_dyadic<4>                                       1.72 ns         1.72 ns    414717804
self_dyadic<5>                                       2.58 ns         2.58 ns    270125455
self_dyadic<6>                                       3.75 ns         3.75 ns    186944561

symmetric_matrix_plus_symmetric_matrix<2>           0.396 ns        0.396 ns   1766914670
symmetric_matrix_plus_symmetric_matrix<3>           0.691 ns        0.690 ns    995554324
symmetric_matrix_plus_symmetric_matrix<4>            1.09 ns         1.09 ns    640717404
symmetric_matrix_plus_symmetric_matrix<5>            1.59 ns         1.59 ns    442395317
symmetric_matrix_plus_symmetric_matrix<6>            2.20 ns         2.20 ns    318464186
matrix_plus_matrix<2>                               0.499 ns        0.499 ns   1351171030
matrix_plus_matrix<3>                               0.987 ns        0.987 ns    701111627
matrix_plus_matrix<4>                                2.16 ns         2.16 ns    326354115
matrix_plus_matrix<5>                                3.34 ns         3.34 ns    210315106
matrix_plus_matrix<6>                                4.82 ns         4.82 ns    145566523
-> faster

symmetric_matrix_dyad_symmetric_matrix<2>           0.987 ns        0.987 ns    705005568
symmetric_matrix_dyad_symmetric_matrix<3>            3.71 ns         3.71 ns    188088457
symmetric_matrix_dyad_symmetric_matrix<4>            49.6 ns         49.5 ns     13869170
symmetric_matrix_dyad_symmetric_matrix<5>             172 ns          172 ns      4020102
symmetric_matrix_dyad_symmetric_matrix<6>             324 ns          324 ns      2155738
matrix_dyad_matrix<2>                                1.68 ns         1.68 ns    405376962
matrix_dyad_matrix<3>                                8.30 ns         8.30 ns     83692162
matrix_dyad_matrix<4>                                45.7 ns         45.7 ns     15426889
matrix_dyad_matrix<5>                                 133 ns          133 ns      5270529
matrix_dyad_matrix<6>                                 252 ns          251 ns      2784687
-> faster for dim <= 3
```