### PR TITLE
InputField class to supply element-wise parameters

### DIFF
--- a/src/core/io/src/4C_io_input_field.hpp
+++ b/src/core/io/src/4C_io_input_field.hpp
@@ -1,0 +1,89 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_IO_INPUT_FIELD_HPP
+#define FOUR_C_IO_INPUT_FIELD_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_utils_exceptions.hpp"
+#include "4C_utils_std23_unreachable.hpp"
+
+#include <unordered_map>
+#include <variant>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::IO
+{
+  /**
+   * @brief A class to represent an input parameter field.
+   *
+   * In its current form, this class can either hold a single value of type T or a map of
+   * element-wise values of type T.
+   */
+  template <typename T>
+  class InputField
+  {
+   public:
+    using IndexType = int;
+    using StorageType = std::variant<T, std::unordered_map<IndexType, T>>;
+
+    /**
+     * Construct an InputField from a single @p const_data. This field will have the same value
+     * for every element index.
+     */
+    explicit InputField(T const_data) : data_(std::move(const_data)) {}
+
+    /**
+     * Construct an InputField from a map of element-wise data. The @p data map contains
+     * element indices as keys and the corresponding values of type T.
+     */
+    explicit InputField(std::unordered_map<IndexType, T> data) : data_(data) {}
+
+    /**
+     * Access the value of the field for the given @p element index. The @p element_id
+     * is not checked for validity and asking for an invalid index will lead to undefined behavior.
+     * Use the `at()` function if you want to check for validity.
+     */
+    [[nodiscard]] const T& operator[](IndexType element_id) const { return get(element_id, false); }
+
+    /**
+     * Access the value of the field for the given @p element index. If the @p element_id
+     * is not a valid index, this function will throw an error.
+     */
+    [[nodiscard]] const T& at(IndexType element_id) const { return get(element_id, true); }
+
+   private:
+    //! Internal getter which can optionally check for the validity of the element index.
+    const T& get(IndexType element_id, bool check) const
+    {
+      if (std::holds_alternative<T>(data_))
+      {
+        return std::get<T>(data_);
+      }
+      else if (std::holds_alternative<std::unordered_map<IndexType, T>>(data_))
+      {
+        const auto& map = std::get<std::unordered_map<IndexType, T>>(data_);
+        auto it = map.find(element_id);
+        if (check)
+        {
+          FOUR_C_ASSERT_ALWAYS(
+              it != map.end(), "Element index {} not found in InputField.", element_id);
+        }
+        return it->second;
+      }
+      std23::unreachable();
+    }
+
+    std::variant<T, std::unordered_map<IndexType, T>> data_;
+  };
+}  // namespace Core::IO
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -11,6 +11,7 @@
 #include "4C_inpar_material.hpp"
 #include "4C_inpar_structure.hpp"
 #include "4C_io_file_reader.hpp"
+#include "4C_io_input_field.hpp"
 #include "4C_io_input_spec_builders.hpp"
 #include "4C_mat_electrode.hpp"
 
@@ -474,8 +475,9 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
         return acc;
       };
 
-      container.add("MAPFILE_CONTENT",
-          Core::IO::convert_lines<actMapType, actMapType>(file_stream, map_reduction_operation));
+      container.add(
+          "MAPFILE_CONTENT", Core::IO::InputField(Core::IO::convert_lines<actMapType, actMapType>(
+                                 file_stream, map_reduction_operation)));
     };
 
     known_materials[Core::Materials::m_muscle_combo] = group("MAT_Muscle_Combo",
@@ -4139,7 +4141,7 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   // Map mixture rule for solid mixtures
   {
     // definition of operation and print string for post processed component "MASSFRACMAPFILE"
-    using mapType = std::unordered_map<int, std::vector<double>>;
+    using MapType = std::unordered_map<int, std::vector<double>>;
 
     auto on_parse = [](Core::IO::InputParameterContainer& container)
     {
@@ -4148,7 +4150,7 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
 
       if (file_stream.fail()) FOUR_C_THROW("Invalid file {}!", map_file.string());
 
-      auto map_reduction_operation = [](mapType acc, const mapType& next)
+      auto map_reduction_operation = [](MapType acc, const MapType& next)
       {
         for (const auto& [key, value] : next)
         {
@@ -4158,7 +4160,8 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
       };
 
       container.add("MASSFRACMAPFILE_CONTENT",
-          Core::IO::convert_lines<mapType, mapType>(file_stream, map_reduction_operation));
+          Core::IO::InputField(
+              Core::IO::convert_lines<MapType, MapType>(file_stream, map_reduction_operation)));
     };
 
     known_materials[Core::Materials::mix_rule_map] = group("MIX_Rule_Map",

--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
+#include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_derivatives.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
@@ -24,7 +25,7 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace
 {
-  using ActivationMapType = std::unordered_map<int, std::vector<std::pair<double, double>>>;
+  using ActivationFieldType = Core::IO::InputField<std::vector<std::pair<double, double>>>;
 
   Mat::PAR::MuscleCombo::ActivationParameterVariant get_activation_params(
       const Core::Mat::PAR::Parameter::Data& matdata,
@@ -38,7 +39,7 @@ namespace
     }
     else if (activation_type == Inpar::Mat::ActivationType::map)
     {
-      return matdata.parameters.get<const ActivationMapType>("MAPFILE_CONTENT");
+      return matdata.parameters.get<ActivationFieldType>("MAPFILE_CONTENT");
     }
     else
       return std::monostate{};
@@ -52,7 +53,7 @@ namespace
           function_id);
     }
 
-    Mat::MuscleCombo::ActivationEvaluatorVariant operator()(const ActivationMapType& map) const
+    Mat::MuscleCombo::ActivationEvaluatorVariant operator()(const ActivationFieldType& map) const
     {
       return &map;
     }
@@ -67,7 +68,7 @@ namespace
 
   struct ActivationEvalVisitor
   {
-    double operator()(const ActivationMapType*& map) const
+    double operator()(const ActivationFieldType* map) const
     {
       // use one-based element ids in the pattern file (corresponding to the ones in the input file)
       return Mat::Utils::Muscle::evaluate_time_space_dependent_active_stress_by_map(

--- a/src/mat/4C_mat_muscle_combo.hpp
+++ b/src/mat/4C_mat_muscle_combo.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_comm_parobjectfactory.hpp"
 #include "4C_inpar_material.hpp"
+#include "4C_io_input_field.hpp"
 #include "4C_mat_anisotropy.hpp"
 #include "4C_mat_anisotropy_extension_default.hpp"
 #include "4C_mat_so3_material.hpp"
@@ -73,7 +74,7 @@ namespace Mat
        *   The integer key refers to the element ids, the vector bundles time-activation pairs.
        */
       using ActivationParameterVariant = std::variant<std::monostate, const int,
-          const std::unordered_map<int, std::vector<std::pair<double, double>>>>;
+          const Core::IO::InputField<std::vector<std::pair<double, double>>>>;
       ActivationParameterVariant activationParams_;
       //! @}
 
@@ -176,7 +177,7 @@ namespace Mat
 
     using ActivationEvaluatorVariant =
         std::variant<std::monostate, const Core::Utils::FunctionOfSpaceTime*,
-            const std::unordered_map<int, std::vector<std::pair<double, double>>>*>;
+            const Core::IO::InputField<std::vector<std::pair<double, double>>>*>;
 
    private:
     /*!

--- a/src/mat/4C_mat_muscle_utils.cpp
+++ b/src/mat/4C_mat_muscle_utils.cpp
@@ -8,6 +8,7 @@
 #include "4C_mat_muscle_utils.hpp"
 
 #include "4C_comm_pack_helpers.hpp"
+#include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"
@@ -381,17 +382,13 @@ double Mat::Utils::Muscle::evaluate_time_space_dependent_active_stress_by_funct(
 
 double Mat::Utils::Muscle::evaluate_time_space_dependent_active_stress_by_map(
     const double sigma_max,
-    const std::unordered_map<int, std::vector<std::pair<double, double>>>& activation_map,
-    const double t_current, const int activation_map_key)
+    const Core::IO::InputField<std::vector<std::pair<double, double>>>& activation_field,
+    const double t_current, const int element_id)
 {
   // compute time-dependency ft
-  auto it = activation_map.find(activation_map_key);
 
-  if (it == activation_map.end())
-  {
-    FOUR_C_THROW("Key (element id) {} not found in activation map.", activation_map_key);
-  }
-  const double ft = lineraly_interpolate_between_times(it->second, t_current);
+  const auto& time_activation_values = activation_field.at(element_id);
+  const double ft = lineraly_interpolate_between_times(time_activation_values, t_current);
 
   // ft needs to be in interval [0, 1]
   if (ft < 0.00 || ft > 1.00)

--- a/src/mat/4C_mat_muscle_utils.hpp
+++ b/src/mat/4C_mat_muscle_utils.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_utils_function.hpp"
 
@@ -276,23 +277,22 @@ namespace Mat::Utils::Muscle
    * pattern: global element id: time_0, activation_0; time_1, activation_1; ....
    *
    * The time- and space-dependent activation function ft is computed by accessing the
-   * activation_map for a given element id and time. Evaluating the activation_map at the element id
-   * (key) returns a vector of pairs (value). Those vector entries correspond to a time-"activation
-   * value"-pair. The activation at the current time t_current is found via linear interpolation
-   * between the prescribed time-"activation value"-pairs.
+   * activation_field for a given element id and time. Evaluating the activation_field at the
+   * element id (key) returns a vector of pairs (value). Those vector entries correspond to a
+   * time-"activation value"-pair. The activation at the current time t_current is found via linear
+   * interpolation between the prescribed time-"activation value"-pairs.
    *
    * The time-dependent optimal active stress is obtained by sigma_opt = sigma_max * ft
    *
    * @param[in]     sigma_max Optimal (i.e. maximal) active stress
-   * @param[in]     activation_map Map to be evaluated
+   * @param[in]     activation_field field containing a vector of time-activation pairs for each
+   *                                 element id
    * @param[in]     t_current Current time
-   * @param[in]     activation_map_key Global element id serving as key for the defined mapping
-   * @param[out]    sigma_max_ft Time-/space-dependent optimal active stress for the given element
-   *                             id and t_current
+   * @param[in]     element_id Global element id serving as key for the defined mapping
    */
   double evaluate_time_space_dependent_active_stress_by_map(const double sigma_max,
-      const std::unordered_map<int, std::vector<std::pair<double, double>>>& activation_map,
-      const double t_current, const int activation_map_key);
+      const Core::IO::InputField<std::vector<std::pair<double, double>>>& activation_field,
+      const double t_current, const int element_id);
 
   /*!
    *  @brief Returns the fiber stretch in the current configuration

--- a/src/mixture/4C_mixture_rule_map.hpp
+++ b/src/mixture/4C_mixture_rule_map.hpp
@@ -10,11 +10,11 @@
 
 #include "4C_config.hpp"
 
+#include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_mixture_rule.hpp"
 
 #include <memory>
-#include <unordered_map>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -41,7 +41,7 @@ namespace Mixture
       /// @{
       const double initial_reference_density_;
       const int num_constituents_;
-      const std::unordered_map<int, std::vector<double>> mass_fractions_map_;
+      const Core::IO::InputField<std::vector<double>> mass_fractions_field_;
       /// @}
     };
 


### PR DESCRIPTION
This PR is a first step to generalize existing functionality for element-wise parameter fields with a more usable interface. See #786.

@lauraengelhardt I applied it to the two cases where you read a pattern file. This does not make a lot of sense yet. The parameter will become a lot nicer when @maxiludwig implements a better `InputSpec` for this type of parameter.