### PR TITLE
Remove various #defines of constants

### DIFF
--- a/src/core/fem/src/general/utils/4C_fem_general_utils_fem_shapefunctions.hpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_fem_shapefunctions.hpp
@@ -15,8 +15,6 @@
 #include <cmath>
 #include <type_traits>
 
-#define PY5TOL 1.0e-14
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::FE
@@ -324,7 +322,7 @@ namespace Core::FE
         NumberType ration;
 
         const NumberType check = t - 1.0;
-        if (Core::MathOperations<NumberType>::abs(check) > PY5TOL)
+        if (Core::MathOperations<NumberType>::abs(check) > 1e-14)
         {
           ration = (r * s * t) / (1.0 - t);
         }
@@ -957,7 +955,7 @@ namespace Core::FE
         NumberType rationdt;
 
         const NumberType check = t - 1.0;
-        if (Core::MathOperations<NumberType>::abs(check) > PY5TOL)
+        if (Core::MathOperations<NumberType>::abs(check) > 1e-14)
         {
           rationdr = s * t / (1.0 - t);
           rationds = r * t / (1.0 - t);

--- a/src/core/utils/src/numerics/4C_utils_clnwrapper.cpp
+++ b/src/core/utils/src/numerics/4C_utils_clnwrapper.cpp
@@ -10,6 +10,6 @@
 FOUR_C_NAMESPACE_OPEN
 
 // initial value of precision_
-unsigned int Core::CLN::ClnWrapper::precision_ = CLN_START_PRECISION;
+unsigned int Core::CLN::ClnWrapper::precision_ = Core::CLN::start_precision;
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/cut/4C_cut_kernel.hpp
+++ b/src/cut/4C_cut_kernel.hpp
@@ -1209,7 +1209,7 @@ namespace Cut::Kernel
     static bool custom_allocator_run_;
 
    protected:
-    static size_t cln_byte_size_[CLN_LIMIT_ITER];
+    static size_t cln_byte_size_[Core::CLN::limit_iter];
 
     static std::unordered_map<size_t, int> memory_allocations_;
 
@@ -1393,7 +1393,7 @@ namespace Cut::Kernel
 
       bool conv;
       int iter = 0;
-      int prec = CLN_START_PRECISION;  // standard initial precision
+      int prec = Core::CLN::start_precision;  // standard initial precision
       Core::CLN::ClnWrapper err;
       Core::CLN::ClnWrapper cond_number;
       cond_infinity_ = false;  // test check if condition number is equal to infinity
@@ -1464,7 +1464,8 @@ namespace Cut::Kernel
           cond_infinity_ = true;
         }
 
-        err = compute_error(xyze, px, this->local_coordinates(), CLN_REFERENCE_PREC) * cond_number;
+        err = compute_error(xyze, px, this->local_coordinates(), Core::CLN::reference_precision) *
+              cond_number;
         // get location taking error into account
         //  NOTE: Here one might need to get tolerance in the local coordinates, similarly as
         //  done
@@ -1475,11 +1476,11 @@ namespace Cut::Kernel
         update_memory_usage(prec, iter);
 #endif
 
-        prec += CLN_INCREMENT_STEP;
+        prec += Core::CLN::increment_step;
         iter++;
 
       } while (((!conv) || (err > CLN_LIMIT_ERROR) || (cond_infinity_)) &&
-               (iter < CLN_LIMIT_ITER) && (prec < CLN_LIMIT_PREC));
+               (iter < Core::CLN::limit_iter) && (prec < Core::CLN::limit_precision));
 
 
       // safely convert the values back
@@ -1621,7 +1622,7 @@ namespace Cut::Kernel
     static bool first_run_;
 
     // sizes of cln variables with different preciion
-    static size_t cln_sizes_[CLN_LIMIT_ITER];
+    static size_t cln_sizes_[Core::CLN::limit_iter];
   };
 
 #endif
@@ -2448,7 +2449,7 @@ namespace Cut::Kernel
             Core::FE::cell_type_to_string(side_type).c_str());
       }
 
-      int prec = CLN_START_PRECISION;  // standard initial precision
+      int prec = Core::CLN::start_precision;  // standard initial precision
       bool conv;
       Core::CLN::ClnWrapper err;
       Core::CLN::ClnWrapper cond_number;
@@ -2548,16 +2549,16 @@ namespace Cut::Kernel
         zero_area = this->zero_area();
         if (not zero_area)
           err = compute_error(xyze_side, px, this->local_coordinates(), this->get_normal_vector(),
-                    this->signed_distance(), CLN_REFERENCE_PREC) *
+                    this->signed_distance(), Core::CLN::reference_precision) *
                 cond_number;
 #if DEBUG_MEMORY_ALLOCATION
         update_memory_usage(prec, iter);
 #endif
-        prec += CLN_INCREMENT_STEP;
+        prec += Core::CLN::increment_step;
         iter++;
 
       } while (((!conv) || (err > CLN_LIMIT_ERROR) || (cond_infinity_) || zero_area) &&
-               (prec < CLN_LIMIT_PREC) && (iter < CLN_LIMIT_ITER));
+               (prec < Core::CLN::limit_precision) && (iter < Core::CLN::limit_iter));
 
       // now since we converged or went over maximum allowed number of loops  we convert the
       // values back if we did not converge, by newton tolerance, but the error is small enough
@@ -2875,7 +2876,7 @@ namespace Cut::Kernel
     static bool first_run_;
 
     // sizes of cln variables with different preciion
-    static size_t cln_sizes_[CLN_LIMIT_ITER];
+    static size_t cln_sizes_[Core::CLN::limit_iter];
   };  // class ComputeDistanceAdaptivePrecision
 
 #endif
@@ -3843,7 +3844,7 @@ namespace Cut::Kernel
       }
 
       // Converting values for the calculation on the CLN
-      int prec = CLN_START_PRECISION;
+      int prec = Core::CLN::start_precision;
       int iter = 0;
       bool conv;
       Core::CLN::ClnWrapper err;
@@ -3922,18 +3923,18 @@ namespace Cut::Kernel
           cond_infinity_ = true;
         }
 
-        err = cond_number *
-              compute_error(xyze_side, xyze_edge, this->local_coordinates(), CLN_REFERENCE_PREC);
+        err = cond_number * compute_error(xyze_side, xyze_edge, this->local_coordinates(),
+                                Core::CLN::reference_precision);
 
         // compute scaled value of the error with respect to global coordinate
 #if DEBUG_MEMORY_ALLOCATION
         update_memory_usage(prec, iter);
 #endif
-        prec += CLN_INCREMENT_STEP;
+        prec += Core::CLN::increment_step;
         iter++;
         // increase the precision
       } while (((!conv) || (err > CLN_LIMIT_ERROR) || (cond_infinity_)) &&
-               (prec < CLN_LIMIT_PREC) && (iter < CLN_LIMIT_ITER));
+               (prec < Core::CLN::limit_precision) && (iter < Core::CLN::limit_iter));
 
 
       if ((not conv) && (err < CLN_LIMIT_ERROR) && (err > 0.0) &&
@@ -4232,7 +4233,7 @@ namespace Cut::Kernel
     PointOnSurfaceLoc edge_location_;
 
     // sizes of cln variables with different preciion
-    static size_t cln_sizes_[CLN_LIMIT_ITER];
+    static size_t cln_sizes_[Core::CLN::limit_iter];
   };  // class ComputeIntersectionAdaptivePrecision
 
 #endif

--- a/src/fluid_turbulence/4C_fluid_turbulence_statistics_cha.cpp
+++ b/src/fluid_turbulence/4C_fluid_turbulence_statistics_cha.cpp
@@ -23,7 +23,10 @@
 
 FOUR_C_NAMESPACE_OPEN
 
-#define NODETOL 1e-9
+namespace
+{
+  constexpr double node_tolerance = 1e-9;
+}
 
 /*----------------------------------------------------------------------
 
@@ -262,7 +265,7 @@ FLD::TurbulenceStatisticsCha::TurbulenceStatisticsCha(
     {
       Core::Nodes::Node* node = discret_->l_row_node(i);
 
-      if (inflowchannel_ and node->x()[0] > inflowmax_ + NODETOL) continue;
+      if (inflowchannel_ and node->x()[0] > inflowmax_ + node_tolerance) continue;
 
       availablecoords.insert(node->x()[dim_]);
 
@@ -1407,12 +1410,12 @@ void FLD::TurbulenceStatisticsCha::do_time_sample(
 
         // if we have an inflow channel problem, the nodes outside the inflow discretization are
         // not in the bounding box -> we don't consider them for averaging
-        if (node->x()[0] < (*boundingbox_)(1, 0) + NODETOL and
-            node->x()[1] < (*boundingbox_)(1, 1) + NODETOL and
-            node->x()[2] < (*boundingbox_)(1, 2) + NODETOL and
-            node->x()[0] > (*boundingbox_)(0, 0) - NODETOL and
-            node->x()[1] > (*boundingbox_)(0, 1) - NODETOL and
-            node->x()[2] > (*boundingbox_)(0, 2) - NODETOL)
+        if (node->x()[0] < (*boundingbox_)(1, 0) + node_tolerance and
+            node->x()[1] < (*boundingbox_)(1, 1) + node_tolerance and
+            node->x()[2] < (*boundingbox_)(1, 2) + node_tolerance and
+            node->x()[0] > (*boundingbox_)(0, 0) - node_tolerance and
+            node->x()[1] > (*boundingbox_)(0, 1) - node_tolerance and
+            node->x()[2] > (*boundingbox_)(0, 2) - node_tolerance)
         {
           // this node belongs to the plane under consideration
           if (node->x()[dim_] < *plane + 2e-9 && node->x()[dim_] > *plane - 2e-9)
@@ -1539,12 +1542,12 @@ void FLD::TurbulenceStatisticsCha::do_loma_time_sample(const Core::LinAlg::Vecto
 
         // if we have an inflow channel problem, the nodes outside the inflow discretization are
         // not in the bounding box -> we don't consider them for averaging
-        if (node->x()[0] < (*boundingbox_)(1, 0) + NODETOL and
-            node->x()[1] < (*boundingbox_)(1, 1) + NODETOL and
-            node->x()[2] < (*boundingbox_)(1, 2) + NODETOL and
-            node->x()[0] > (*boundingbox_)(0, 0) - NODETOL and
-            node->x()[1] > (*boundingbox_)(0, 1) - NODETOL and
-            node->x()[2] > (*boundingbox_)(0, 2) - NODETOL)
+        if (node->x()[0] < (*boundingbox_)(1, 0) + node_tolerance and
+            node->x()[1] < (*boundingbox_)(1, 1) + node_tolerance and
+            node->x()[2] < (*boundingbox_)(1, 2) + node_tolerance and
+            node->x()[0] > (*boundingbox_)(0, 0) - node_tolerance and
+            node->x()[1] > (*boundingbox_)(0, 1) - node_tolerance and
+            node->x()[2] > (*boundingbox_)(0, 2) - node_tolerance)
         {
           // this node belongs to the plane under consideration
           if (node->x()[dim_] < *plane + 2e-9 && node->x()[dim_] > *plane - 2e-9)
@@ -1592,12 +1595,12 @@ void FLD::TurbulenceStatisticsCha::do_loma_time_sample(const Core::LinAlg::Vecto
 
         // if we have an inflow channel problem, the nodes outside the inflow discretization are
         // not in the bounding box -> we don't consider them for averaging
-        if (node->x()[0] < (*boundingbox_)(1, 0) + NODETOL and
-            node->x()[1] < (*boundingbox_)(1, 1) + NODETOL and
-            node->x()[2] < (*boundingbox_)(1, 2) + NODETOL and
-            node->x()[0] > (*boundingbox_)(0, 0) - NODETOL and
-            node->x()[1] > (*boundingbox_)(0, 1) - NODETOL and
-            node->x()[2] > (*boundingbox_)(0, 2) - NODETOL)
+        if (node->x()[0] < (*boundingbox_)(1, 0) + node_tolerance and
+            node->x()[1] < (*boundingbox_)(1, 1) + node_tolerance and
+            node->x()[2] < (*boundingbox_)(1, 2) + node_tolerance and
+            node->x()[0] > (*boundingbox_)(0, 0) - node_tolerance and
+            node->x()[1] > (*boundingbox_)(0, 1) - node_tolerance and
+            node->x()[2] > (*boundingbox_)(0, 2) - node_tolerance)
         {
           // this node belongs to the plane under consideration
           if (node->x()[dim_] < *plane + 2e-9 && node->x()[dim_] > *plane - 2e-9)
@@ -1697,12 +1700,12 @@ void FLD::TurbulenceStatisticsCha::do_scatra_time_sample(const Core::LinAlg::Vec
 
         // if we have an inflow channel problem, the nodes outside the inflow discretization are
         // not in the bounding box -> we don't consider them for averaging
-        if (node->x()[0] < (*boundingbox_)(1, 0) + NODETOL and
-            node->x()[1] < (*boundingbox_)(1, 1) + NODETOL and
-            node->x()[2] < (*boundingbox_)(1, 2) + NODETOL and
-            node->x()[0] > (*boundingbox_)(0, 0) - NODETOL and
-            node->x()[1] > (*boundingbox_)(0, 1) - NODETOL and
-            node->x()[2] > (*boundingbox_)(0, 2) - NODETOL)
+        if (node->x()[0] < (*boundingbox_)(1, 0) + node_tolerance and
+            node->x()[1] < (*boundingbox_)(1, 1) + node_tolerance and
+            node->x()[2] < (*boundingbox_)(1, 2) + node_tolerance and
+            node->x()[0] > (*boundingbox_)(0, 0) - node_tolerance and
+            node->x()[1] > (*boundingbox_)(0, 1) - node_tolerance and
+            node->x()[2] > (*boundingbox_)(0, 2) - node_tolerance)
         {
           // this node belongs to the plane under consideration
           if (node->x()[dim_] < *plane + 2e-9 && node->x()[dim_] > *plane - 2e-9)
@@ -1750,12 +1753,12 @@ void FLD::TurbulenceStatisticsCha::do_scatra_time_sample(const Core::LinAlg::Vec
 
         // if we have an inflow channel problem, the nodes outside the inflow discretization are
         // not in the bounding box -> we don't consider them for averaging
-        if (node->x()[0] < (*boundingbox_)(1, 0) + NODETOL and
-            node->x()[1] < (*boundingbox_)(1, 1) + NODETOL and
-            node->x()[2] < (*boundingbox_)(1, 2) + NODETOL and
-            node->x()[0] > (*boundingbox_)(0, 0) - NODETOL and
-            node->x()[1] > (*boundingbox_)(0, 1) - NODETOL and
-            node->x()[2] > (*boundingbox_)(0, 2) - NODETOL)
+        if (node->x()[0] < (*boundingbox_)(1, 0) + node_tolerance and
+            node->x()[1] < (*boundingbox_)(1, 1) + node_tolerance and
+            node->x()[2] < (*boundingbox_)(1, 2) + node_tolerance and
+            node->x()[0] > (*boundingbox_)(0, 0) - node_tolerance and
+            node->x()[1] > (*boundingbox_)(0, 1) - node_tolerance and
+            node->x()[2] > (*boundingbox_)(0, 2) - node_tolerance)
         {
           // this node belongs to the plane under consideration
           if (node->x()[dim_] < *plane + 2e-9 && node->x()[dim_] > *plane - 2e-9)
@@ -2508,12 +2511,12 @@ void FLD::TurbulenceStatisticsCha::evaluate_pointwise_mean_values_in_planes()
 
       // if we have an inflow channel problem, the nodes outside the inflow discretization are
       // not in the bounding box -> we don't consider them for averaging
-      if (node->x()[0] < (*boundingbox_)(1, 0) + NODETOL and
-          node->x()[1] < (*boundingbox_)(1, 1) + NODETOL and
-          node->x()[2] < (*boundingbox_)(1, 2) + NODETOL and
-          node->x()[0] > (*boundingbox_)(0, 0) - NODETOL and
-          node->x()[1] > (*boundingbox_)(0, 1) - NODETOL and
-          node->x()[2] > (*boundingbox_)(0, 2) - NODETOL)
+      if (node->x()[0] < (*boundingbox_)(1, 0) + node_tolerance and
+          node->x()[1] < (*boundingbox_)(1, 1) + node_tolerance and
+          node->x()[2] < (*boundingbox_)(1, 2) + node_tolerance and
+          node->x()[0] > (*boundingbox_)(0, 0) - node_tolerance and
+          node->x()[1] > (*boundingbox_)(0, 1) - node_tolerance and
+          node->x()[2] > (*boundingbox_)(0, 2) - node_tolerance)
       {
         // this node belongs to the plane under consideration
         if (node->x()[dim_] < *plane + 2e-9 && node->x()[dim_] > *plane - 2e-9)

--- a/src/mat/4C_mat_plasticelasthyper.cpp
+++ b/src/mat/4C_mat_plasticelasthyper.cpp
@@ -22,6 +22,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace
+{
+  constexpr double as_convergence_tol = 1e-12;
+}
+
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 Mat::PAR::PlasticElastHyper::PlasticElastHyper(const Core::Mat::PAR::Parameter::Data& matdata)
@@ -978,8 +983,8 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
   {
     if (activity_state_[gp] == false)  // gp switches state
     {
-      if (abs(ypl - absetatr_H) > AS_CONVERGENCE_TOL * inityield() ||
-          deltaDp->norm_inf() > AS_CONVERGENCE_TOL * inityield() / cpl())
+      if (abs(ypl - absetatr_H) > as_convergence_tol * inityield() ||
+          deltaDp->norm_inf() > as_convergence_tol * inityield() / cpl())
         *as_converged = false;
     }
     activity_state_[gp] = true;
@@ -989,8 +994,8 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
   {
     if (activity_state_[gp] == true)  // gp switches state
     {
-      if (abs(ypl - absetatr_H) > AS_CONVERGENCE_TOL * inityield() ||
-          deltaDp->norm_inf() > AS_CONVERGENCE_TOL * inityield() / cpl())
+      if (abs(ypl - absetatr_H) > as_convergence_tol * inityield() ||
+          deltaDp->norm_inf() > as_convergence_tol * inityield() / cpl())
         *as_converged = false;
     }
     activity_state_[gp] = false;
@@ -998,8 +1003,8 @@ void Mat::PlasticElastHyper::evaluate_ncp(const Core::LinAlg::Matrix<3, 3>* mStr
   }
 
   // check, if gp is at the corner of the root of the NCP function
-  if (abs(ypl - absetatr_H) > AS_CONVERGENCE_TOL * inityield() ||
-      deltaDp->norm_inf() > AS_CONVERGENCE_TOL * inityield() / cpl())
+  if (abs(ypl - absetatr_H) > as_convergence_tol * inityield() ||
+      deltaDp->norm_inf() > as_convergence_tol * inityield() / cpl())
   { /* gp not at the corner point */
   }
   else
@@ -1483,8 +1488,8 @@ void Mat::PlasticElastHyper::evaluate_nc_pand_spin(const Core::LinAlg::Matrix<3,
   {
     if (activity_state_[gp] == false)  // gp switches state
     {
-      if (abs(ypl - absetatr_H) > AS_CONVERGENCE_TOL * inityield() ||
-          deltaLp->norm_inf() > AS_CONVERGENCE_TOL * inityield() / cpl())
+      if (abs(ypl - absetatr_H) > as_convergence_tol * inityield() ||
+          deltaLp->norm_inf() > as_convergence_tol * inityield() / cpl())
         *as_converged = false;
     }
     activity_state_[gp] = true;
@@ -1494,8 +1499,8 @@ void Mat::PlasticElastHyper::evaluate_nc_pand_spin(const Core::LinAlg::Matrix<3,
   {
     if (activity_state_[gp] == true)  // gp switches state
     {
-      if (abs(ypl - absetatr_H) > AS_CONVERGENCE_TOL * inityield() ||
-          deltaLp->norm_inf() > AS_CONVERGENCE_TOL * inityield() / cpl())
+      if (abs(ypl - absetatr_H) > as_convergence_tol * inityield() ||
+          deltaLp->norm_inf() > as_convergence_tol * inityield() / cpl())
         *as_converged = false;
     }
     activity_state_[gp] = false;
@@ -1503,8 +1508,8 @@ void Mat::PlasticElastHyper::evaluate_nc_pand_spin(const Core::LinAlg::Matrix<3,
   }
 
   // check, if gp is at the corner of the root of the NCP function
-  if (abs(ypl - absetatr_H) > AS_CONVERGENCE_TOL * inityield() ||
-      deltaLp->norm_inf() > AS_CONVERGENCE_TOL * inityield() / cpl())
+  if (abs(ypl - absetatr_H) > as_convergence_tol * inityield() ||
+      deltaLp->norm_inf() > as_convergence_tol * inityield() / cpl())
   { /* gp not at the corner point */
   }
   else

--- a/src/mat/4C_mat_plasticelasthyper.hpp
+++ b/src/mat/4C_mat_plasticelasthyper.hpp
@@ -18,8 +18,6 @@
 #include "4C_material_parameter_base.hpp"
 #include "4C_tsi_input.hpp"
 
-#define AS_CONVERGENCE_TOL 1.e-12
-
 FOUR_C_NAMESPACE_OPEN
 
 // forward declaration due to avoid header definition

--- a/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.cpp
+++ b/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.cpp
@@ -15,6 +15,11 @@
 
 FOUR_C_NAMESPACE_OPEN
 
+namespace
+{
+  constexpr int numbgp = 50;
+  constexpr int twice = 100;
+}  // namespace
 
 Mat::Elastic::PAR::StructuralTensorParameter::StructuralTensorParameter(
     const Core::Mat::PAR::Parameter::Data& matdata)

--- a/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.hpp
+++ b/src/mat/elast/4C_mat_elast_aniso_structuraltensor_strategy.hpp
@@ -8,9 +8,6 @@
 #ifndef FOUR_C_MAT_ELAST_ANISO_STRUCTURALTENSOR_STRATEGY_HPP
 #define FOUR_C_MAT_ELAST_ANISO_STRUCTURALTENSOR_STRATEGY_HPP
 
-#define numbgp 50
-#define twice 100
-
 #include "4C_config.hpp"
 
 #include "4C_linalg_fixedsizematrix.hpp"


### PR DESCRIPTION
There are more #defines of constants left, but most of them are inside `_defines.hpp` files, which we should remove in the context of #207.