### PR TITLE
Use symmetric tensors in solid element evaluation

### DIFF
--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -20,7 +20,7 @@
 #include "4C_fem_general_utils_gausspoints.hpp"
 #include "4C_global_data.hpp"
 #include "4C_io.hpp"
-#include "4C_io_pstream.hpp"  // has to go before io.hpp
+#include "4C_io_pstream.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_utils_sparse_algebra_assemble.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
@@ -72,7 +72,7 @@ namespace
           dim * Core::FE::num_nodes(celltype)>>& stiffness_matrix)
   {
     Core::Elements::for_each_gauss_point<celltype>(element_nodes, gauss_integration,
-        [&](const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+        [&](const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
             const Core::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
             const Core::Elements::JacobianMapping<celltype, dim>& jacobian_mapping,
             double integration_factor, int gp)
@@ -158,7 +158,7 @@ namespace
   {
     // compute nodal normals of the element
     Core::Elements::for_each_gauss_point<celltype>(element_nodes, gauss_integration,
-        [&](const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+        [&](const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
             const Core::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
             const Core::Elements::JacobianMapping<celltype, dim>& jacobian_mapping,
             double integration_factor, int gp)
@@ -1124,7 +1124,7 @@ void Constraints::SpringDashpot::get_area(
               Core::FE::create_gauss_integration<celltype>(
                   Discret::Elements::DisTypeToOptGaussRule<celltype>::rule);
           Core::Elements::for_each_gauss_point<celltype>(element_nodes, gauss_integration,
-              [&](const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+              [&](const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
                   const Core::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
                   const Core::Elements::JacobianMapping<celltype, 3>& jacobian_mapping,
                   double integration_factor, int gp) { area += integration_factor; });

--- a/src/contact/4C_contact_nitsche_integrator.cpp
+++ b/src/contact/4C_contact_nitsche_integrator.cpp
@@ -13,6 +13,7 @@
 #include "4C_contact_node.hpp"
 #include "4C_contact_paramsinterface.hpp"
 #include "4C_fem_general_utils_boundary_integration.hpp"
+#include "4C_linalg_tensor_generators.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_elasthyper.hpp"
 #include "4C_solid_3D_ele.hpp"
@@ -480,7 +481,9 @@ void CONTACT::IntegratorNitsche::so_ele_cauchy(Mortar::Element& moEle, double* b
     auto* solid_ele = dynamic_cast<Discret::Elements::Solid*>(moEle.parent_element());
     FOUR_C_ASSERT_ALWAYS(solid_ele, "Unknown solid element type");
     const double cauchy_n_dir = solid_ele->get_normal_cauchy_stress_at_xi(
-        moEle.mo_data().parent_disp(), pxsi, normal, direction, linearizations);
+        moEle.mo_data().parent_disp(), Core::LinAlg::reinterpret_as_tensor<3>(pxsi),
+        Core::LinAlg::reinterpret_as_tensor<3>(normal),
+        Core::LinAlg::reinterpret_as_tensor<3>(direction), linearizations);
 
     cauchy_nt += w * cauchy_n_dir;
 

--- a/src/contact/4C_contact_nitsche_integrator_fsi.cpp
+++ b/src/contact/4C_contact_nitsche_integrator_fsi.cpp
@@ -10,6 +10,7 @@
 #include "4C_contact_element.hpp"
 #include "4C_contact_node.hpp"
 #include "4C_fem_general_utils_boundary_integration.hpp"
+#include "4C_linalg_tensor_matrix_conversion.hpp"
 #include "4C_solid_3D_ele.hpp"
 #include "4C_solid_3D_ele_calc_lib_nitsche.hpp"
 #include "4C_solid_poro_3D_ele_calc_lib_nitsche.hpp"
@@ -239,8 +240,9 @@ double CONTACT::Utils::solid_cauchy_at_xi(CONTACT::Element* cele,
         solid_ele != nullptr)
     {
       Discret::Elements::CauchyNDirLinearizations<3> cauchy_linearizations{};
-      sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(
-          cele->mo_data().parent_disp(), pxsi, n, dir, cauchy_linearizations);
+      sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(cele->mo_data().parent_disp(),
+          Core::LinAlg::reinterpret_as_tensor<3>(pxsi), Core::LinAlg::reinterpret_as_tensor<3>(n),
+          Core::LinAlg::reinterpret_as_tensor<3>(dir), cauchy_linearizations);
     }
     else
     {
@@ -256,7 +258,9 @@ double CONTACT::Utils::solid_cauchy_at_xi(CONTACT::Element* cele,
       Discret::Elements::SolidPoroCauchyNDirLinearizations<3> cauchy_linearizations{};
 
       sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(cele->mo_data().parent_disp(),
-          cele->mo_data().parent_pf_pres(), pxsi, n, dir, cauchy_linearizations);
+          cele->mo_data().parent_pf_pres(), Core::LinAlg::reinterpret_as_tensor<3>(pxsi),
+          Core::LinAlg::reinterpret_as_tensor<3>(n), Core::LinAlg::reinterpret_as_tensor<3>(dir),
+          cauchy_linearizations);
     }
     else
     {

--- a/src/contact/4C_contact_nitsche_integrator_poro.cpp
+++ b/src/contact/4C_contact_nitsche_integrator_poro.cpp
@@ -12,6 +12,7 @@
 #include "4C_contact_nitsche_utils.hpp"
 #include "4C_contact_node.hpp"
 #include "4C_contact_paramsinterface.hpp"
+#include "4C_linalg_tensor_generators.hpp"
 #include "4C_mat_structporo.hpp"
 #include "4C_solid_3D_ele.hpp"
 #include "4C_solid_poro_3D_ele_pressure_velocity_based.hpp"
@@ -187,8 +188,10 @@ void CONTACT::IntegratorNitschePoro::so_ele_cauchy(Mortar::Element& moEle, doubl
       cauchy_linearizations.d_cauchyndir_ddir = &dsntdt;
       cauchy_linearizations.d_cauchyndir_dxi = &dsntdpxi;
 
-      sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(
-          moEle.mo_data().parent_disp(), pxsi, normal, direction, cauchy_linearizations);
+      sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(moEle.mo_data().parent_disp(),
+          Core::LinAlg::reinterpret_as_tensor<3>(pxsi),
+          Core::LinAlg::reinterpret_as_tensor<3>(normal),
+          Core::LinAlg::reinterpret_as_tensor<3>(direction), cauchy_linearizations);
     }
     else if (auto* solid_ele = dynamic_cast<Discret::Elements::SolidPoroPressureVelocityBased*>(
                  moEle.parent_element());
@@ -201,7 +204,9 @@ void CONTACT::IntegratorNitschePoro::so_ele_cauchy(Mortar::Element& moEle, doubl
       cauchy_linearizations.solid.d_cauchyndir_dxi = &dsntdpxi;
 
       sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(moEle.mo_data().parent_disp(),
-          std::nullopt, pxsi, normal, direction, cauchy_linearizations);
+          std::nullopt, Core::LinAlg::reinterpret_as_tensor<3>(pxsi),
+          Core::LinAlg::reinterpret_as_tensor<3>(normal),
+          Core::LinAlg::reinterpret_as_tensor<3>(direction), cauchy_linearizations);
     }
     else
     {
@@ -222,7 +227,9 @@ void CONTACT::IntegratorNitschePoro::so_ele_cauchy(Mortar::Element& moEle, doubl
       cauchy_linearizations.d_cauchyndir_dp = &dsntdp;
 
       sigma_nt = solid_ele->get_normal_cauchy_stress_at_xi(moEle.mo_data().parent_disp(),
-          moEle.mo_data().parent_pf_pres(), pxsi, normal, direction, cauchy_linearizations);
+          moEle.mo_data().parent_pf_pres(), Core::LinAlg::reinterpret_as_tensor<3>(pxsi),
+          Core::LinAlg::reinterpret_as_tensor<3>(normal),
+          Core::LinAlg::reinterpret_as_tensor<3>(direction), cauchy_linearizations);
     }
     else
     {

--- a/src/contact/4C_contact_nitsche_integrator_ssi.cpp
+++ b/src/contact/4C_contact_nitsche_integrator_ssi.cpp
@@ -218,7 +218,9 @@ void CONTACT::IntegratorNitscheSsi::so_ele_cauchy_struct(Mortar::Element& mortar
             "element)!");
 
         return solid_scatra_ele->get_normal_cauchy_stress_at_xi(mortar_ele.mo_data().parent_disp(),
-            mortar_ele.mo_data().parent_scalar(), parent_xi, gp_normal, test_dir, linearizations);
+            mortar_ele.mo_data().parent_scalar(), Core::LinAlg::reinterpret_as_tensor<3>(parent_xi),
+            Core::LinAlg::reinterpret_as_tensor<3>(gp_normal),
+            Core::LinAlg::reinterpret_as_tensor<3>(test_dir), linearizations);
       });
 
   cauchy_nt_wgt += nitsche_wgt * sigma_nt;

--- a/src/core/fem/src/general/element/4C_fem_general_element_integration.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element_integration.hpp
@@ -19,6 +19,7 @@
 #include "4C_fem_general_utils_nurbs_shapefunctions.hpp"
 #include "4C_fem_nurbs_discretization_utils.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -99,10 +100,10 @@ namespace Core::Elements
    * parameter space
    */
   template <Core::FE::CellType celltype>
-  Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> evaluate_parameter_coordinate(
+  Core::LinAlg::Tensor<double, Core::FE::dim<celltype>> evaluate_parameter_coordinate(
       const Core::FE::GaussIntegration& intpoints, const int gp)
   {
-    Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> xi;
+    Core::LinAlg::Tensor<double, Core::FE::dim<celltype>> xi;
     for (int d = 0; d < Core::FE::dim<celltype>; ++d) xi(d) = intpoints.point(gp)[d];
 
     return xi;
@@ -130,7 +131,7 @@ namespace Core::Elements
    */
   template <Core::FE::CellType celltype, unsigned dim>
   ShapeFunctionsAndDerivatives<celltype> evaluate_shape_functions_and_derivs(
-      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
       const ElementNodes<celltype, dim>& nodal_coordinates)
     requires(Core::FE::use_lagrange_shapefnct<celltype>)
   {
@@ -143,7 +144,7 @@ namespace Core::Elements
 
   template <Core::FE::CellType celltype, unsigned dim>
   ShapeFunctionsAndDerivatives<celltype> evaluate_shape_functions_and_derivs(
-      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
       const ElementNodes<celltype, dim>& nodal_coordinates)
     requires(Core::FE::is_nurbs<celltype>)
   {
@@ -196,7 +197,7 @@ namespace Core::Elements
    */
   template <unsigned dim, Core::FE::CellType celltype, typename T>
   concept GaussPointEvaluatable = requires(T gp_evaluator,
-      Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> xi,
+      Core::LinAlg::Tensor<double, Core::FE::dim<celltype>> xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype, dim>& jacobian_mapping, double integration_factor, int gp) {
     { gp_evaluator(xi, shape_functions, jacobian_mapping, integration_factor, gp) };
@@ -237,7 +238,7 @@ namespace Core::Elements
   {
     for (int gp = 0; gp < integration.num_points(); ++gp)
     {
-      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1> xi =
+      const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>> xi =
           evaluate_parameter_coordinate<celltype>(integration, gp);
 
       const ShapeFunctionsAndDerivatives<celltype> shape_functions =

--- a/src/mat/4C_mat_constraintmixture.cpp
+++ b/src/mat/4C_mat_constraintmixture.cpp
@@ -18,6 +18,9 @@
 #include "4C_io_gmsh.hpp"          // for debug plotting with gmsh
 #include "4C_linalg_fixedsizematrix_solver.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
+#include "4C_linalg_tensor.hpp"
+#include "4C_linalg_tensor_generators.hpp"
+#include "4C_linalg_tensor_matrix_conversion.hpp"
 #include "4C_linalg_utils_densematrix_multiply.hpp"
 #include "4C_mat_constraintmixture_history.hpp"
 #include "4C_mat_par_bundle.hpp"
@@ -751,7 +754,7 @@ void Mat::ConstraintMixture::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
         params_->elastindegrad_ == "Wedge" || params_->elastindegrad_ == "Circles")
     {
       const auto& ele_center_reference_coordinates =
-          params.get<Core::LinAlg::Matrix<3, 1>>("elecenter_coords_ref");
+          params.get<Core::LinAlg::Tensor<double, 3>>("elecenter_coords_ref");
 
       elastin_degradation(ele_center_reference_coordinates, elastin_survival);
     }
@@ -767,7 +770,7 @@ void Mat::ConstraintMixture::evaluate(const Core::LinAlg::Matrix<3, 3>* defgrd,
         params_->elastindegrad_ == "Wedge" || params_->elastindegrad_ == "Circles")
     {
       const auto& gp_reference_coordinates =
-          params.get<Core::LinAlg::Matrix<3, 1>>("gp_coords_ref");
+          params.get<Core::LinAlg::Tensor<double, 3>>("gp_coords_ref");
 
       elastin_degradation(gp_reference_coordinates, elastin_survival);
     }
@@ -2057,7 +2060,7 @@ void Mat::ConstraintMixture::degradation(double t, double& degr)
  |  elastin_degradation                            (private)        05/13|
  *----------------------------------------------------------------------*/
 void Mat::ConstraintMixture::elastin_degradation(
-    Core::LinAlg::Matrix<3, 1> coord, double& elastin_survival) const
+    Core::LinAlg::Tensor<double, 3> coord, double& elastin_survival) const
 {
   if (params_->elastindegrad_ == "Rectangle")
   {
@@ -2192,7 +2195,7 @@ void Mat::ConstraintMixture::elastin_degradation(
     center2(0) = -12.0;
     center2(1) = 0.0;
     center2(2) = -10.0;
-    diff.update_t(coord);
+    diff.update_t(Core::LinAlg::make_matrix_view<3, 1>(coord));
     diff.update(-1.0, center2, 1.0);
     double rad2 = diff.norm2();
     if (rad2 < radmin)
@@ -3070,7 +3073,7 @@ bool Mat::ConstraintMixture::vis_data(
       {
         Core::Nodes::Node* locnode = mynodes[idnodes];
         double elastin_survival = 0.0;
-        Core::LinAlg::Matrix<3, 1> point_refe;
+        Core::LinAlg::Tensor<double, 3> point_refe;
         point_refe(0) = locnode->x()[0];
         point_refe(1) = locnode->x()[1];
         point_refe(2) = locnode->x()[2];

--- a/src/mat/4C_mat_constraintmixture.hpp
+++ b/src/mat/4C_mat_constraintmixture.hpp
@@ -12,6 +12,7 @@
 #include "4C_config.hpp"
 
 #include "4C_comm_parobjectfactory.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_so3_material.hpp"
 #include "4C_material_parameter_base.hpp"
 
@@ -427,8 +428,8 @@ namespace Mat
 
     /// function of elastin degradation (initial)
     void elastin_degradation(
-        Core::LinAlg::Matrix<3, 1> coord,  ///< gp coordinate in reference configuration
-        double& elastin_survival           ///< amount of elastin which is still there
+        Core::LinAlg::Tensor<double, 3> coord,  ///< gp coordinate in reference configuration
+        double& elastin_survival                ///< amount of elastin which is still there
     ) const;
 
     /// compute stress and cmat for implicit integration with whole stress as driving force

--- a/src/mat/4C_mat_growthremodel_elasthyper.hpp
+++ b/src/mat/4C_mat_growthremodel_elasthyper.hpp
@@ -13,6 +13,7 @@
 
 #include "4C_comm_parobjectfactory.hpp"
 #include "4C_linalg_FADmatrix_utils.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_anisotropy.hpp"
 #include "4C_mat_membrane_material_interfaces.hpp"
 #include "4C_mat_so3_material.hpp"
@@ -283,7 +284,7 @@ namespace Mat
 
     /// Calculates AXI, CIR and RAD structural tensors and sets new fiber directions in the case of
     /// a cylinder
-    void setup_axi_cir_rad_cylinder(Core::LinAlg::Matrix<3, 1> elecenter, double const dt);
+    void setup_axi_cir_rad_cylinder(Core::LinAlg::Tensor<double, 3> elecenter, double const dt);
 
     /// Setup anisotropic growth tensors. Here we assume that the growth direction corresponds with
     /// the radial/ thickness direction

--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_fixedsizematrix_tensor_derivatives.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_muscle_utils.hpp"
 #include "4C_mat_par_bundle.hpp"
@@ -89,7 +90,7 @@ namespace
 
     const double& Popt_;
     const double& t_tot_;
-    const Core::LinAlg::Matrix<3, 1>& element_center_reference_coordinates_;
+    const Core::LinAlg::Tensor<double, 3>& element_center_reference_coordinates_;
     const int& eleGID_;
   };
 }  // namespace
@@ -412,7 +413,7 @@ void Mat::MuscleCombo::evaluate_active_nominal_stress(Teuchos::ParameterList& pa
 
   // get element center coordinates in reference configuration
   const auto& element_center_reference_coordinates =
-      params.get<Core::LinAlg::Matrix<3, 1>>("elecenter_coords_ref");
+      params.get<Core::LinAlg::Tensor<double, 3>>("elecenter_coords_ref");
 
   // compute force-time-space dependency Poptft
   const double Poptft =

--- a/src/mat/4C_mat_muscle_utils.cpp
+++ b/src/mat/4C_mat_muscle_utils.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"
 
@@ -363,7 +364,7 @@ double Mat::Utils::Muscle::evaluate_time_dependent_active_stress_tanh(const doub
 
 double Mat::Utils::Muscle::evaluate_time_space_dependent_active_stress_by_funct(
     const double sigma_max, const Core::Utils::FunctionOfSpaceTime& activation_function,
-    const double t_current, const Core::LinAlg::Matrix<3, 1>& x)
+    const double t_current, const Core::LinAlg::Tensor<double, 3>& x)
 {
   const std::vector<double> x_vec{x(0), x(1), x(2)};
 

--- a/src/mat/4C_mat_muscle_utils.hpp
+++ b/src/mat/4C_mat_muscle_utils.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_io_input_field.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_utils_function.hpp"
 
 #include <unordered_map>
@@ -267,7 +268,7 @@ namespace Mat::Utils::Muscle
    */
   double evaluate_time_space_dependent_active_stress_by_funct(const double sigma_max,
       const Core::Utils::FunctionOfSpaceTime& activation_function, const double t_current,
-      const Core::LinAlg::Matrix<3, 1>& x);
+      const Core::LinAlg::Tensor<double, 3>& x);
 
   /*!
    * @brief Evaluate the time- and space-dependent optimal (i.e. maximal) active stress through

--- a/src/mat/elast/4C_mat_elast_anisoactivestress_evolution.cpp
+++ b/src/mat/elast/4C_mat_elast_anisoactivestress_evolution.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_anisotropy_extension.hpp"
 #include "4C_mat_material_factory.hpp"
 #include "4C_material_base.hpp"
@@ -139,7 +140,7 @@ void Mat::Elastic::AnisoActiveStressEvolution::add_stress_aniso_principal(
       FOUR_C_THROW("Parameter 'total time' could not be read!");
     }
     const auto& element_center_coordinates_ref =
-        params.get<Core::LinAlg::Matrix<3, 1>>("elecenter_coords_ref");
+        params.get<Core::LinAlg::Tensor<double, 3>>("elecenter_coords_ref");
     activationFunction =
         Global::Problem::instance()
             ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->sourceactiv_)

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_utils_function.hpp"
@@ -134,7 +135,7 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::add_stress_aniso_principal(
 {
   double time_ = params.get<double>("total time", 0.0);
   const auto& element_center_coordinates_ref =
-      params.get<Core::LinAlg::Matrix<3, 1>>("elecenter_coords_ref");
+      params.get<Core::LinAlg::Tensor<double, 3>>("elecenter_coords_ref");
   double stressFact_ = Global::Problem::instance()
                            ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->sourceactiv_)
                            .evaluate(element_center_coordinates_ref.data(), time_, 0);

--- a/src/membrane/4C_membrane_evaluate.cpp
+++ b/src/membrane/4C_membrane_evaluate.cpp
@@ -13,6 +13,9 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_solver.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_transformation.hpp"
+#include "4C_linalg_tensor.hpp"
+#include "4C_linalg_tensor_generators.hpp"
+#include "4C_linalg_tensor_matrix_conversion.hpp"
 #include "4C_linalg_utils_densematrix_eigen.hpp"
 #include "4C_mat_material_factory.hpp"
 #include "4C_mat_membrane_elasthyper.hpp"
@@ -780,15 +783,15 @@ void Discret::Elements::Membrane<distype>::mem_nlnstiffmass(
     if (material()->material_type() == Core::Materials::m_growthremodel_elasthyper)
     {
       // Gauss-point coordinates in reference configuration
-      Core::LinAlg::Matrix<noddof_, 1> gprefecoord(Core::LinAlg::Initialization::zero);
-      gprefecoord.multiply_tn(xrefe, shapefcts);
+      Core::LinAlg::Tensor<double, noddof_> gprefecoord{};
+      Core::LinAlg::make_matrix_view<noddof_, 1>(gprefecoord).multiply_tn(xrefe, shapefcts);
       params.set("gp_coords_ref", gprefecoord);
 
       // center of element in reference configuration
       Core::LinAlg::Matrix<numnod_, 1> funct_center;
       Core::FE::shape_function_2d(funct_center, 0.0, 0.0, distype);
-      Core::LinAlg::Matrix<noddof_, 1> midpoint;
-      midpoint.multiply_tn(xrefe, funct_center);
+      Core::LinAlg::Tensor<double, noddof_> midpoint;
+      Core::LinAlg::make_matrix_view<3, 1>(midpoint).multiply_tn(xrefe, funct_center);
       params.set("elecenter_coords_ref", midpoint);
     }
 

--- a/src/mixture/4C_mixture_constituent_elasthyper_damage.cpp
+++ b/src/mixture/4C_mixture_constituent_elasthyper_damage.cpp
@@ -9,6 +9,7 @@
 
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_elast_isoneohooke.hpp"
 #include "4C_mat_multiplicative_split_defgrad_elasthyper_service.hpp"
@@ -80,7 +81,7 @@ void Mixture::MixtureConstituentElastHyperDamage::read_element(
 void Mixture::MixtureConstituentElastHyperDamage::update(Core::LinAlg::Matrix<3, 3> const& defgrd,
     Teuchos::ParameterList& params, const int gp, const int eleGID)
 {
-  const auto& reference_coordinates = params.get<Core::LinAlg::Matrix<3, 1>>("gp_coords_ref");
+  const auto& reference_coordinates = params.get<Core::LinAlg::Tensor<double, 3>>("gp_coords_ref");
 
   double totaltime = params.get<double>("total time", -1);
   if (totaltime < 0.0)

--- a/src/mixture/4C_mixture_constituent_elasthyper_elastin_membrane.cpp
+++ b/src/mixture/4C_mixture_constituent_elasthyper_elastin_membrane.cpp
@@ -10,6 +10,7 @@
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix_generators.hpp"
 #include "4C_linalg_fixedsizematrix_tensor_products.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_anisotropy_extension.hpp"
 #include "4C_mat_elast_aniso_structuraltensor_strategy.hpp"
 #include "4C_mat_elast_isoneohooke.hpp"
@@ -218,7 +219,7 @@ void Mixture::MixtureConstituentElastHyperElastinMembrane::update(
     Core::LinAlg::Matrix<3, 3> const& defgrd, Teuchos::ParameterList& params, const int gp,
     const int eleGID)
 {
-  const auto& reference_coordinates = params.get<Core::LinAlg::Matrix<3, 1>>("gp_coords_ref");
+  const auto& reference_coordinates = params.get<Core::LinAlg::Tensor<double, 3>>("gp_coords_ref");
 
   double totaltime = params.get<double>("total time", -1);
   if (totaltime < 0.0)

--- a/src/mixture/4C_mixture_prestress_strategy_isocyl.cpp
+++ b/src/mixture/4C_mixture_prestress_strategy_isocyl.cpp
@@ -8,13 +8,13 @@
 #include "4C_mixture_prestress_strategy_isocyl.hpp"
 
 #include "4C_linalg_fixedsizematrix_generators.hpp"
-#include "4C_mat_anisotropy.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_anisotropy_coordinate_system_provider.hpp"
+#include "4C_mat_anisotropy_cylinder_coordinate_system_provider.hpp"
 #include "4C_mat_elast_isoneohooke.hpp"
 #include "4C_mat_elast_volsussmanbathe.hpp"
-#include "4C_mat_par_bundle.hpp"
 #include "4C_mat_service.hpp"
-#include "4C_mixture_constituent_elasthyper.hpp"
+#include "4C_mixture_constituent_elasthyperbase.hpp"
 #include "4C_mixture_rule.hpp"
 #include "4C_mixture_rule_growthremodel.hpp"
 
@@ -108,7 +108,7 @@ void Mixture::IsotropicCylinderPrestressStrategy::evaluate_prestress(const Mixtu
         "strategy!");
   }
 
-  const auto& reference_coordinates = params.get<Core::LinAlg::Matrix<3, 1>>("gp_coords_ref");
+  const auto& reference_coordinates = params.get<Core::LinAlg::Tensor<double, 3>>("gp_coords_ref");
 
   double r = 0;
   for (unsigned i = 0; i < 3; ++i)

--- a/src/mixture/4C_mixture_rule_function.cpp
+++ b/src/mixture/4C_mixture_rule_function.cpp
@@ -9,12 +9,11 @@
 
 #include "4C_global_data.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_material_parameter_base.hpp"
 #include "4C_mixture_constituent.hpp"
 #include "4C_utils_exceptions.hpp"
 
-#include <algorithm>
-#include <iosfwd>
 #include <memory>
 #include <string>
 
@@ -95,7 +94,8 @@ void Mixture::FunctionMixtureRule::evaluate(const Core::LinAlg::Matrix<3, 3>& F,
     // coordinates (and the current time)
 
     // get gauss point reference coordinates and current time
-    const auto& reference_coordinates = params.get<Core::LinAlg::Matrix<3, 1>>("gp_coords_ref");
+    const auto& reference_coordinates =
+        params.get<Core::LinAlg::Tensor<double, 3>>("gp_coords_ref");
     const double time = params.get<double>("total time");
 
     // evaluate the mass fraction function at the gauss point reference coordinates and current time

--- a/src/shell7p/4C_shell7p_ele_scatra_preevaluator.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra_preevaluator.cpp
@@ -10,6 +10,7 @@
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_fem_general_utils_integration.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_shell7p_ele_calc_lib.hpp"
 
 #include <Teuchos_ParameterList.hpp>
@@ -120,7 +121,7 @@ void Discret::Elements::Shell::pre_evaluate_scatra(Core::Elements::Element& ele,
       params.set<std::shared_ptr<std::vector<std::vector<double>>>>("gp_conc", gpscalar);
     }
   }
-  Core::LinAlg::Matrix<2, 1> center(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Tensor<double, 2> center{};
   params.set("elecenter_coords_ref", center);
 }
 

--- a/src/solid_3D_ele/4C_solid_3D_ele.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.hpp
@@ -193,8 +193,8 @@ namespace Discret::Elements
      * @return double (out) : The scalar Cauchy stress value
      */
     double get_normal_cauchy_stress_at_xi(const std::vector<double>& disp,
-        const Core::LinAlg::Matrix<3, 1>& xi, const Core::LinAlg::Matrix<3, 1>& n,
-        const Core::LinAlg::Matrix<3, 1>& dir, CauchyNDirLinearizations<3>& linearizations);
+        const Core::LinAlg::Tensor<double, 3>& xi, const Core::LinAlg::Tensor<double, 3>& n,
+        const Core::LinAlg::Tensor<double, 3>& dir, CauchyNDirLinearizations<3>& linearizations);
 
     void for_each_gauss_point(Core::FE::Discretization& discretization, std::vector<int>& lm,
         const std::function<void(Mat::So3Material&, double integration_factor, int gp)>& integrator)

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc.hpp
@@ -115,8 +115,8 @@ namespace Discret::Elements
 
     double get_normal_cauchy_stress_at_xi(const Core::Elements::Element& ele,
         Mat::So3Material& solid_material, const std::vector<double>& disp,
-        const Core::LinAlg::Matrix<3, 1>& xi, const Core::LinAlg::Matrix<3, 1>& n,
-        const Core::LinAlg::Matrix<3, 1>& dir, CauchyNDirLinearizations<3>& linearizations);
+        const Core::LinAlg::Tensor<double, 3>& xi, const Core::LinAlg::Tensor<double, 3>& n,
+        const Core::LinAlg::Tensor<double, 3>& dir, CauchyNDirLinearizations<3>& linearizations);
 
     void for_each_gauss_point(const Core::Elements::Element& ele, Mat::So3Material& solid_material,
         const Core::FE::Discretization& discretization, const std::vector<int>& lm,

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_displacement_based_linear_kinematics.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_displacement_based_linear_kinematics.hpp
@@ -53,28 +53,30 @@ namespace Discret::Elements
     template <typename Evaluator>
     static inline auto evaluate(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& nodal_coordinates,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping, Evaluator evaluator)
     {
       const DisplacementBasedLinearKinematicsLinearizationContainer<celltype> linearization{
           Discret::Elements::evaluate_linear_strain_gradient(jacobian_mapping)};
 
-      Core::LinAlg::Matrix<Internal::num_str<celltype>, 1> gl_strain =
-          evaluate_linear_gl_strain(nodal_coordinates, linearization.linear_b_operator_);
+      Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>
+          gl_strain =
+              evaluate_linear_gl_strain(nodal_coordinates, linearization.linear_b_operator_);
 
-      return evaluator(
-          Core::LinAlg::identity_matrix<Core::FE::dim<celltype>>(), gl_strain, linearization);
+      return evaluator(Core::LinAlg::get_full(Core::LinAlg::TensorGenerators::identity<double,
+                           Core::FE::dim<celltype>, Core::FE::dim<celltype>>),
+          gl_strain, linearization);
     }
 
     static inline Core::LinAlg::Matrix<9, Core::FE::num_nodes(celltype) * Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_displacements(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient)
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient)
     {
       // linearization is zero for small displacements
       return Core::LinAlg::Matrix<9, Core::FE::num_nodes(celltype) * Core::FE::dim<celltype>>(
@@ -84,11 +86,11 @@ namespace Discret::Elements
     static inline Core::LinAlg::Matrix<9, Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_xi(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient)
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient)
     {
       // linearization is zero for small displacements
       return Core::LinAlg::Matrix<9, Core::FE::dim<celltype>>(Core::LinAlg::Initialization::zero);
@@ -98,11 +100,11 @@ namespace Discret::Elements
         Core::FE::num_nodes(celltype) * Core::FE::dim<celltype> * Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_displacements_d_xi(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient)
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient)
     {
       // linearization is zero for small displacements
       return Core::LinAlg::Matrix<9,
@@ -129,7 +131,8 @@ namespace Discret::Elements
           linearization.linear_b_operator_, stress, integration_factor, force_vector);
     }
 
-    static void add_stiffness_matrix(const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+    static void add_stiffness_matrix(
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const DisplacementBasedLinearKinematicsLinearizationContainer<celltype>& linearization,
         const JacobianMapping<celltype>& jacobian_mapping, const Stress<celltype>& stress,

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_eas.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_eas.hpp
@@ -66,7 +66,7 @@ namespace Discret::Elements
     template <typename Evaluator>
     static auto evaluate(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
         const PreparationData& centeroid_transformation,
@@ -84,11 +84,11 @@ namespace Discret::Elements
     static inline Core::LinAlg::Matrix<9, Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_xi(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient,
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient,
         const PreparationData& centeroid_transformation,
         const EASHistoryData<celltype, eastype>& eas_data)
     {
@@ -99,11 +99,11 @@ namespace Discret::Elements
         Core::FE::num_nodes(celltype) * Core::FE::dim<celltype> * Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_displacements_d_xi(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient,
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient,
         const PreparationData& centeroid_transformation,
         const EASHistoryData<celltype, eastype>& eas_data)
     {
@@ -115,11 +115,11 @@ namespace Discret::Elements
     static inline Core::LinAlg::Matrix<9, Core::FE::num_nodes(celltype) * Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_displacements(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient,
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient,
         const PreparationData& centeroid_transformation,
         const EASHistoryData<celltype, eastype>& eas_data)
     {
@@ -146,7 +146,8 @@ namespace Discret::Elements
           eas_kinematics.b_op, stress, integration_factor, force_vector);
     }
 
-    static void add_stiffness_matrix(const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+    static void add_stiffness_matrix(
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const EASKinematics<celltype, eastype>& eas_kinematics,
         const JacobianMapping<celltype>& jacobian_mapping, const Stress<celltype>& stress,

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_fbar.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_fbar.hpp
@@ -65,7 +65,7 @@ namespace Discret::Elements
     template <typename Evaluator>
     static auto evaluate(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& nodal_coordinates,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
         const FBarPreparationData<celltype>& preparation_data, Evaluator evaluator)
@@ -100,11 +100,11 @@ namespace Discret::Elements
       const SpatialMaterialMapping<celltype> spatial_material_mapping_bar =
           evaluate_spatial_material_mapping(jacobian_mapping, nodal_coordinates, fbar_factor);
 
-      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::dim<celltype>> cauchygreen_bar =
-          evaluate_cauchy_green(spatial_material_mapping_bar);
+      const Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>
+          cauchygreen_bar = evaluate_cauchy_green(spatial_material_mapping_bar);
 
-      Core::LinAlg::Matrix<Internal::num_str<celltype>, 1> gl_strain_bar =
-          evaluate_green_lagrange_strain(cauchygreen_bar);
+      Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>
+          gl_strain_bar = evaluate_green_lagrange_strain(cauchygreen_bar);
 
       return evaluator(
           spatial_material_mapping_bar.deformation_gradient_, gl_strain_bar, linearization);
@@ -113,11 +113,11 @@ namespace Discret::Elements
     static inline Core::LinAlg::Matrix<9, Core::FE::num_nodes(celltype) * Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_displacements(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient,
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient,
         const FBarPreparationData<celltype>& preparation_data)
     {
       FOUR_C_THROW(
@@ -128,11 +128,11 @@ namespace Discret::Elements
     static inline Core::LinAlg::Matrix<9, Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_xi(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient,
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient,
         const FBarPreparationData<celltype>& preparation_data)
     {
       FOUR_C_THROW("This derivative of the deformation gradient w.r.t. xi is not implemented");
@@ -142,11 +142,11 @@ namespace Discret::Elements
         Core::FE::num_nodes(celltype) * Core::FE::dim<celltype> * Core::FE::dim<celltype>>
     evaluate_d_deformation_gradient_d_displacements_d_xi(const Core::Elements::Element& ele,
         const ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
-            deformation_gradient,
+        const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>,
+            Internal::num_dim<celltype>>& deformation_gradient,
         const FBarPreparationData<celltype>& preparation_data)
     {
       FOUR_C_THROW(
@@ -171,7 +171,8 @@ namespace Discret::Elements
           linearization.Bop, stress, integration_factor / linearization.fbar_factor, force_vector);
     }
 
-    static void add_stiffness_matrix(const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+    static void add_stiffness_matrix(
+        const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
         const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const FBarLinearizationContainer<celltype>& linearization,
         const JacobianMapping<celltype>& jacobian_mapping, const Stress<celltype>& stress,

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_formulation.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_formulation.hpp
@@ -24,10 +24,10 @@ namespace Discret::Elements
    public:
     ElementFormulationDerivativeEvaluator(const Core::Elements::Element& ele,
         const Discret::Elements::ElementNodes<celltype>& element_nodes,
-        const Core::LinAlg::Matrix<3, 1>& xi,
+        const Core::LinAlg::Tensor<double, 3>& xi,
         const Discret::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
         const Discret::Elements::JacobianMapping<celltype>& jacobian_mapping,
-        const Core::LinAlg::Matrix<3, 3>& deformation_gradient,
+        const Core::LinAlg::Tensor<double, 3, 3>& deformation_gradient,
         const Discret::Elements::PreparationData<SolidFormulation>& preparation_data,
         Discret::Elements::SolidFormulationHistory<SolidFormulation>& history_data)
         : ele_(ele),
@@ -69,10 +69,10 @@ namespace Discret::Elements
    private:
     const Core::Elements::Element& ele_;
     const Discret::Elements::ElementNodes<celltype>& element_nodes_;
-    const Core::LinAlg::Matrix<3, 1>& xi_;
+    const Core::LinAlg::Tensor<double, 3>& xi_;
     const Discret::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions_;
     const Discret::Elements::JacobianMapping<celltype>& jacobian_mapping_;
-    const Core::LinAlg::Matrix<3, 3>& deformation_gradient_;
+    const Core::LinAlg::Tensor<double, 3, 3>& deformation_gradient_;
     const Discret::Elements::PreparationData<SolidFormulation>& preparation_data_;
     Discret::Elements::SolidFormulationHistory<SolidFormulation>& history_data_;
   };

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_nitsche.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_nitsche.hpp
@@ -16,7 +16,6 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_solid_3D_ele_calc_lib_formulation.hpp"
-#include "4C_utils_demangle.hpp"
 #include "4C_utils_exceptions.hpp"
 
 #include <optional>
@@ -400,9 +399,9 @@ namespace Discret::Elements
       std::void_t<decltype(std::declval<T>()->get_normal_cauchy_stress_at_xi(
           std::declval<const Core::Elements::Element&>(), std::declval<Mat::So3Material&>(),
           std::declval<const std::vector<double>&>(),
-          std::declval<const Core::LinAlg::Matrix<dim, 1>&>(),
-          std::declval<const Core::LinAlg::Matrix<dim, 1>&>(),
-          std::declval<const Core::LinAlg::Matrix<dim, 1>&>(),
+          std::declval<const Core::LinAlg::Tensor<double, dim>&>(),
+          std::declval<const Core::LinAlg::Tensor<double, dim>&>(),
+          std::declval<const Core::LinAlg::Tensor<double, dim>&>(),
           std::declval<CauchyNDirLinearizations<dim>&>()))>> = true;
 
   namespace Internal
@@ -411,9 +410,9 @@ namespace Discret::Elements
     struct EvaluateCauchyNDirAction
     {
       EvaluateCauchyNDirAction(const Core::Elements::Element& e, Mat::So3Material& m,
-          const std::vector<double>& d, const Core::LinAlg::Matrix<dim, 1>& x,
-          const Core::LinAlg::Matrix<dim, 1>& normal, const Core::LinAlg::Matrix<dim, 1>& direction,
-          CauchyNDirLinearizations<dim>& lins)
+          const std::vector<double>& d, const Core::LinAlg::Tensor<double, dim>& x,
+          const Core::LinAlg::Tensor<double, dim>& normal,
+          const Core::LinAlg::Tensor<double, dim>& direction, CauchyNDirLinearizations<dim>& lins)
           : element(e), mat(m), disp(d), xi(x), n(normal), dir(direction), linearizations(lins)
       {
       }
@@ -439,9 +438,9 @@ namespace Discret::Elements
       const Core::Elements::Element& element;
       Mat::So3Material& mat;
       const std::vector<double>& disp;
-      const Core::LinAlg::Matrix<dim, 1>& xi;
-      const Core::LinAlg::Matrix<dim, 1>& n;
-      const Core::LinAlg::Matrix<dim, 1>& dir;
+      const Core::LinAlg::Tensor<double, dim>& xi;
+      const Core::LinAlg::Tensor<double, dim>& n;
+      const Core::LinAlg::Tensor<double, dim>& dir;
       CauchyNDirLinearizations<dim>& linearizations;
     };
   }  // namespace Internal
@@ -455,8 +454,8 @@ namespace Discret::Elements
   template <typename VariantType>
   double get_normal_cauchy_stress_at_xi(VariantType& variant,
       const Core::Elements::Element& element, Mat::So3Material& mat,
-      const std::vector<double>& disp, const Core::LinAlg::Matrix<3, 1>& xi,
-      const Core::LinAlg::Matrix<3, 1>& n, const Core::LinAlg::Matrix<3, 1>& dir,
+      const std::vector<double>& disp, const Core::LinAlg::Tensor<double, 3>& xi,
+      const Core::LinAlg::Tensor<double, 3>& n, const Core::LinAlg::Tensor<double, 3>& dir,
       CauchyNDirLinearizations<3>& linearizations)
   {
     return std::visit(

--- a/src/solid_3D_ele/4C_solid_3D_ele_evaluate.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_evaluate.cpp
@@ -305,8 +305,8 @@ int Discret::Elements::Solid::evaluate_neumann(Teuchos::ParameterList& params,
 }
 
 double Discret::Elements::Solid::get_normal_cauchy_stress_at_xi(const std::vector<double>& disp,
-    const Core::LinAlg::Matrix<3, 1>& xi, const Core::LinAlg::Matrix<3, 1>& n,
-    const Core::LinAlg::Matrix<3, 1>& dir, CauchyNDirLinearizations<3>& linearizations)
+    const Core::LinAlg::Tensor<double, 3>& xi, const Core::LinAlg::Tensor<double, 3>& n,
+    const Core::LinAlg::Tensor<double, 3>& dir, CauchyNDirLinearizations<3>& linearizations)
 {
   return Discret::Elements::get_normal_cauchy_stress_at_xi(
       solid_calc_variant_, *this, *solid_material(), disp, xi, n, dir, linearizations);

--- a/src/solid_3D_ele/4C_solid_3D_ele_formulation.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_formulation.hpp
@@ -327,7 +327,7 @@ namespace Discret::Elements
   template <typename SolidFormulation, Core::FE::CellType celltype, typename Evaluator>
   inline auto evaluate(const Core::Elements::Element& ele,
       const ElementNodes<celltype>& element_nodes,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype>& jacobian_mapping,
       const PreparationData<SolidFormulation>& preparation_data,
@@ -352,7 +352,7 @@ namespace Discret::Elements
   template <typename SolidFormulation, Core::FE::CellType celltype, typename Evaluator>
   inline auto evaluate(const Core::Elements::Element& ele,
       const ElementNodes<celltype>& element_nodes,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype>& jacobian_mapping,
       const PreparationData<SolidFormulation>& preparation_data,
@@ -373,10 +373,10 @@ namespace Discret::Elements
   inline Core::LinAlg::Matrix<9, Core::FE::num_nodes(celltype) * Core::FE::dim<celltype>>
   evaluate_d_deformation_gradient_d_displacements(const Core::Elements::Element& ele,
       const ElementNodes<celltype>& element_nodes,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype>& jacobian_mapping,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
           deformation_gradient,
       const PreparationData<SolidFormulation>& preparation_data,
       SolidFormulationHistory<SolidFormulation>& history_data)
@@ -405,10 +405,10 @@ namespace Discret::Elements
   template <typename SolidFormulation, Core::FE::CellType celltype>
   inline Core::LinAlg::Matrix<9, Core::FE::dim<celltype>> evaluate_d_deformation_gradient_d_xi(
       const Core::Elements::Element& ele, const ElementNodes<celltype>& element_nodes,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype>& jacobian_mapping,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
           deformation_gradient,
       const PreparationData<SolidFormulation>& preparation_data,
       SolidFormulationHistory<SolidFormulation>& history_data)
@@ -440,10 +440,10 @@ namespace Discret::Elements
       Core::FE::num_nodes(celltype) * Core::FE::dim<celltype> * Core::FE::dim<celltype>>
   evaluate_d_deformation_gradient_d_displacements_d_xi(const Core::Elements::Element& ele,
       const ElementNodes<celltype>& element_nodes,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype>& jacobian_mapping,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
           deformation_gradient,
       const PreparationData<SolidFormulation>& preparation_data,
       SolidFormulationHistory<SolidFormulation>& history_data)
@@ -501,7 +501,7 @@ namespace Discret::Elements
    */
   template <typename SolidFormulation, Core::FE::CellType celltype>
   static inline void add_stiffness_matrix(
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const typename SolidFormulation::LinearizationContainer& linearization,
       const JacobianMapping<celltype>& jacobian_mapping, const Stress<celltype>& stress,
@@ -730,10 +730,10 @@ namespace Discret::Elements
   template <typename SolidFormulation, Core::FE::CellType celltype>
   static inline void update_prestress(const Core::Elements::Element& ele,
       const ElementNodes<celltype>& element_nodes,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, 1>& xi,
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>>& xi,
       const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
       const JacobianMapping<celltype>& jacobian_mapping,
-      const Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
+      const Core::LinAlg::Tensor<double, Internal::num_dim<celltype>, Internal::num_dim<celltype>>&
           deformation_gradient,
       const PreparationData<SolidFormulation>& preparation_data,
       SolidFormulationHistory<SolidFormulation>& history_data, [[maybe_unused]] const int gp)

--- a/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
@@ -14,6 +14,7 @@
 #include "4C_fem_general_utils_gausspoints.hpp"
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 #include "4C_global_data.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_solid_3D_ele_calc_lib_integration.hpp"
 #include "4C_utils_exceptions.hpp"
 #include "4C_utils_function.hpp"
@@ -74,7 +75,7 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
       Core::Elements::evaluate_element_nodes<celltype, dim>(discretization, element);
 
   Core::Elements::for_each_gauss_point<celltype, dim>(element_nodes, gauss_integration,
-      [&](const Core::LinAlg::Matrix<Core::FE::dim<celltype>, 1>& xi,
+      [&](const Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>& xi,
           const Core::Elements::ShapeFunctionsAndDerivatives<celltype>& shape_functions,
           const Core::Elements::JacobianMapping<celltype, dim>& jacobian_mapping,
           double integration_factor, int gp)

--- a/src/solid_3D_ele/4C_solid_3D_ele_utils.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_utils.hpp
@@ -14,6 +14,7 @@
 #include "4C_inpar_structure.hpp"
 #include "4C_io_input_spec.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_solid_3D_ele_properties.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -24,34 +25,37 @@ namespace Solid::Utils
       Core::Elements::Element* dwele, int& numdf, int& dimns, int& nv, int& np);
 
   /*!
-   * @brief Converts the 2nd Piola-Kirchhoff stress tensor in stress like Voigt notation to the
-   * Cauchy stress tensor in stress like Voigt notation
+   * @brief Converts the 2nd Piola-Kirchhoff stress tensor to the
+   * Cauchy stress tensor
    *
-   * @param pk2 (in) : 2nd Piola-Kirchhoff stress tensor in stress like Voigt notation
+   * @param pk2 (in) : 2nd Piola-Kirchhoff stress tensor
    * @param defgrd (in) : Deformation gradient
-   * @param cauchy (out) : Cauchy stress tensor in stress like Voigt notation
+   * @return Cauchy stress tensor
    */
-  void pk2_to_cauchy(const Core::LinAlg::Matrix<6, 1>& pk2,
-      const Core::LinAlg::Matrix<3, 3>& defgrd, Core::LinAlg::Matrix<6, 1>& cauchy);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> pk2_to_cauchy(
+      const Core::LinAlg::SymmetricTensor<double, 3, 3>& pk2,
+      const Core::LinAlg::Tensor<double, 3, 3>& defgrd);
 
   /*!
-   * @brief Convert Green Lagrange strain tensor in strain like Voigt notation to Euler-Almansi
-   * strain tensor in strain like Voigt notation.
+   * @brief Convert Green Lagrange strain tensor to Euler-Almansi
+   * strain tensor.
    *
-   * @param gl (in) : Green Lagrange strain tensor in strain like Voigt notation
-   * @return Core::LinAlg::Matrix<6, 1> : Euler-Almansi strain tensor in strain like Voigt notation
+   * @param gl (in) : Green Lagrange strain tensor
+   * @return Core::LinAlg::Matrix<6, 1> : Euler-Almansi strain tensor
    */
-  Core::LinAlg::Matrix<6, 1> green_lagrange_to_euler_almansi(
-      const Core::LinAlg::Matrix<6, 1>& gl, const Core::LinAlg::Matrix<3, 3>& defgrd);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> green_lagrange_to_euler_almansi(
+      const Core::LinAlg::SymmetricTensor<double, 3, 3>& gl,
+      const Core::LinAlg::Tensor<double, 3, 3>& defgrd);
 
   /*!
-   * @brief Convert Green Lagrange strain tensor in strain like Voigt notation to Lograithmic strain
-   * tensor in strain like Voigt notation.
+   * @brief Convert Green Lagrange strain tensor in strain to Lograithmic strain
+   * tensor.
    *
-   * @param gl (in) : Green Lagrange strain tensor in strain like Voigt notation
-   * @return Core::LinAlg::Matrix<6, 1> : Logarithmic strain tensor in strain like Voigt notation
+   * @param gl (in) : Green Lagrange strain tensor
+   * @return Core::LinAlg::Matrix<6, 1> : Logarithmic strain tensor
    */
-  Core::LinAlg::Matrix<6, 1> green_lagrange_to_log_strain(const Core::LinAlg::Matrix<6, 1>& gl);
+  Core::LinAlg::SymmetricTensor<double, 3, 3> green_lagrange_to_log_strain(
+      const Core::LinAlg::SymmetricTensor<double, 3, 3>& gl);
 
   namespace ReadElement
   {

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_lib.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_lib.hpp
@@ -22,6 +22,7 @@
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
+#include "4C_linalg_tensor_generators.hpp"
 #include "4C_linalg_vector.hpp"
 #include "4C_mat_fluidporo.hpp"
 #include "4C_mat_fluidporo_multiphase.hpp"
@@ -925,8 +926,11 @@ namespace Discret::Elements
         anisotropy_properties.directions_, anisotropic_permeability_coeffs);
     porofluidmat.compute_lin_mat_reaction_tensor(linreac_dphi, linreac_dJ,
         spatial_material_mapping.determinant_deformation_gradient_, porosity);
-    temp.multiply(1.0, matreatensor, spatial_material_mapping.inverse_deformation_gradient_);
-    reatensor.multiply_tn(spatial_material_mapping.inverse_deformation_gradient_, temp);
+    temp.multiply(1.0, matreatensor,
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_));
+    reatensor.multiply_tn(
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_),
+        temp);
     rea_disp_vel.multiply(reatensor, disp_velocity);
     rea_fluid_vel.multiply(reatensor, fluid_velocity);
 
@@ -1014,8 +1018,11 @@ namespace Discret::Elements
     porofluidmat.compute_lin_mat_reaction_tensor(linreac_dporosity, linreac_ddet_defgrd,
         spatial_material_mapping.determinant_deformation_gradient_, porosity);
 
-    temp.multiply(1.0, matreatensor, spatial_material_mapping.inverse_deformation_gradient_);
-    reatensor.multiply_tn(spatial_material_mapping.inverse_deformation_gradient_, temp);
+    temp.multiply(1.0, matreatensor,
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_));
+    reatensor.multiply_tn(
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_),
+        temp);
     rea_disp_vel.multiply(reatensor, disp_velocity);
     rea_fluid_vel.multiply(reatensor, fluid_velocity);
   }
@@ -1059,7 +1066,8 @@ namespace Discret::Elements
     Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>> CinvFvel;
     Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>> tmp;
     CinvFvel.multiply(inverse_right_cauchy_green, fvelder);
-    tmp.multiply_nt(CinvFvel, spatial_material_mapping.inverse_deformation_gradient_);
+    tmp.multiply_nt(CinvFvel,
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_));
     Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_dim<celltype>> tmp2(tmp);
     tmp.update_t(1.0, tmp2, 1.0);
 
@@ -1076,7 +1084,8 @@ namespace Discret::Elements
     static Core::LinAlg::Matrix<Internal::num_dim<celltype>, Internal::num_nodes<celltype>>
         N_XYZ_Finv;
     N_XYZ_Finv.multiply(
-        spatial_material_mapping.inverse_deformation_gradient_, jacobian_mapping.N_XYZ_);
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_),
+        jacobian_mapping.N_XYZ_);
 
     // dfstress/dv^f
     Core::LinAlg::Matrix<Internal::num_str<celltype>, Internal::num_dof_per_ele<celltype>>
@@ -1354,8 +1363,11 @@ namespace Discret::Elements
         anisotropy_properties.directions_, anisotropic_permeability_coeffs);
     porofluidmat.compute_lin_mat_reaction_tensor(linreac_dphi, linreac_dJ,
         spatial_material_mapping.determinant_deformation_gradient_, porosity);
-    temp.multiply(1.0, matreatensor, spatial_material_mapping.inverse_deformation_gradient_);
-    reatensor.multiply_tn(spatial_material_mapping.inverse_deformation_gradient_, temp);
+    temp.multiply(1.0, matreatensor,
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_));
+    reatensor.multiply_tn(
+        Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_),
+        temp);
     reavel.multiply(reatensor, disp_velocity);
     reafvel.multiply(reatensor, fluid_velocity);
     for (int idim = 0; idim < numdim_; idim++)
@@ -2040,8 +2052,8 @@ namespace Discret::Elements
   {
     CauchyGreenAndInverse<celltype> cauchygreen;
 
-    cauchygreen.right_cauchy_green_ =
-        Discret::Elements::evaluate_cauchy_green(spatial_material_mapping);
+    cauchygreen.right_cauchy_green_ = Core::LinAlg::make_matrix(
+        Core::LinAlg::get_full(Discret::Elements::evaluate_cauchy_green(spatial_material_mapping)));
     cauchygreen.inverse_right_cauchy_green_.invert(cauchygreen.right_cauchy_green_);
 
     return cauchygreen;

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
@@ -70,7 +70,7 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::evaluate_nonlin
 
   // Loop over all Gauss points
   for_each_gauss_point(nodal_coordinates, gauss_integration_,
-      [&](const Core::LinAlg::Matrix<num_dim_, 1>& xi,
+      [&](const Core::LinAlg::Tensor<double, num_dim_>& xi,
           const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
           const JacobianMapping<celltype>& jacobian_mapping, double integration_factor, int gp)
       {
@@ -190,7 +190,7 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<
 
   // Loop over all Gauss points
   for_each_gauss_point(nodal_coordinates, gauss_integration_,
-      [&](const Core::LinAlg::Matrix<num_dim_, 1>& xi,
+      [&](const Core::LinAlg::Tensor<double, num_dim_>& xi,
           const ShapeFunctionsAndDerivatives<celltype>& shape_functions,
           const JacobianMapping<celltype>& jacobian_mapping, double integration_factor, int gp
 

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.hpp
@@ -215,8 +215,9 @@ namespace Discret::Elements
      * can be made mandatory.
      */
     double get_normal_cauchy_stress_at_xi(const std::vector<double>& disp,
-        const std::optional<std::vector<double>>& pressures, const Core::LinAlg::Matrix<3, 1>& xi,
-        const Core::LinAlg::Matrix<3, 1>& n, const Core::LinAlg::Matrix<3, 1>& dir,
+        const std::optional<std::vector<double>>& pressures,
+        const Core::LinAlg::Tensor<double, 3>& xi, const Core::LinAlg::Tensor<double, 3>& n,
+        const Core::LinAlg::Tensor<double, 3>& dir,
         SolidPoroCauchyNDirLinearizations<3>& linearizations);
 
     void vis_names(std::map<std::string, int>& names) override;

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.hpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.hpp
@@ -164,8 +164,8 @@ namespace Discret::Elements
      * @return double
      */
     double get_normal_cauchy_stress_at_xi(const std::vector<double>& disp,
-        const std::vector<double>& scalars, const Core::LinAlg::Matrix<3, 1>& xi,
-        const Core::LinAlg::Matrix<3, 1>& n, const Core::LinAlg::Matrix<3, 1>& dir,
+        const std::vector<double>& scalars, const Core::LinAlg::Tensor<double, 3>& xi,
+        const Core::LinAlg::Tensor<double, 3>& n, const Core::LinAlg::Tensor<double, 3>& dir,
         SolidScatraCauchyNDirLinearizations<3>& linearizations);
 
    private:

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.hpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc.hpp
@@ -88,8 +88,8 @@ namespace Discret::Elements
 
     double get_normal_cauchy_stress_at_xi(const Core::Elements::Element& ele,
         Mat::So3Material& solid_material, const std::vector<double>& disp,
-        const std::vector<double>& scalars, const Core::LinAlg::Matrix<3, 1>& xi,
-        const Core::LinAlg::Matrix<3, 1>& n, const Core::LinAlg::Matrix<3, 1>& dir,
+        const std::vector<double>& scalars, const Core::LinAlg::Tensor<double, 3>& xi,
+        const Core::LinAlg::Tensor<double, 3>& n, const Core::LinAlg::Tensor<double, 3>& dir,
         SolidScatraCauchyNDirLinearizations<3>& linearizations);
 
    private:

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc_lib_nitsche.hpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_calc_lib_nitsche.hpp
@@ -59,9 +59,9 @@ namespace Discret::Elements
       std::void_t<decltype(std::declval<T>()->get_normal_cauchy_stress_at_xi(
           std::declval<const Core::Elements::Element&>(), std::declval<Mat::So3Material&>(),
           std::declval<const std::vector<double>&>(), std::declval<const std::vector<double>&>(),
-          std::declval<const Core::LinAlg::Matrix<dim, 1>&>(),
-          std::declval<const Core::LinAlg::Matrix<dim, 1>&>(),
-          std::declval<const Core::LinAlg::Matrix<dim, 1>&>(),
+          std::declval<const Core::LinAlg::Tensor<double, dim>&>(),
+          std::declval<const Core::LinAlg::Tensor<double, dim>&>(),
+          std::declval<const Core::LinAlg::Tensor<double, dim>&>(),
           std::declval<SolidScatraCauchyNDirLinearizations<dim>&>()))>> = true;
 
 
@@ -72,8 +72,9 @@ namespace Discret::Elements
     {
       EvaluateSolidScatraCauchyNDirAction(const Core::Elements::Element& e, Mat::So3Material& m,
           const std::vector<double>& d, const std::vector<double>& s,
-          const Core::LinAlg::Matrix<dim, 1>& x, const Core::LinAlg::Matrix<dim, 1>& normal,
-          const Core::LinAlg::Matrix<dim, 1>& direction,
+          const Core::LinAlg::Tensor<double, dim>& x,
+          const Core::LinAlg::Tensor<double, dim>& normal,
+          const Core::LinAlg::Tensor<double, dim>& direction,
           SolidScatraCauchyNDirLinearizations<dim>& lins)
           : element(e),
             mat(m),
@@ -109,9 +110,9 @@ namespace Discret::Elements
       Mat::So3Material& mat;
       const std::vector<double>& disp;
       const std::vector<double>& scalars;
-      const Core::LinAlg::Matrix<dim, 1>& xi;
-      const Core::LinAlg::Matrix<dim, 1>& n;
-      const Core::LinAlg::Matrix<dim, 1>& dir;
+      const Core::LinAlg::Tensor<double, dim>& xi;
+      const Core::LinAlg::Tensor<double, dim>& n;
+      const Core::LinAlg::Tensor<double, dim>& dir;
       SolidScatraCauchyNDirLinearizations<dim>& linearizations;
     };
   }  // namespace Internal
@@ -120,8 +121,9 @@ namespace Discret::Elements
   double get_normal_cauchy_stress_at_xi(VariantType& variant,
       const Core::Elements::Element& element, Mat::So3Material& mat,
       const std::vector<double>& disp, const std::vector<double>& scalars,
-      const Core::LinAlg::Matrix<3, 1>& xi, const Core::LinAlg::Matrix<3, 1>& n,
-      const Core::LinAlg::Matrix<3, 1>& dir, SolidScatraCauchyNDirLinearizations<3>& linearizations)
+      const Core::LinAlg::Tensor<double, 3>& xi, const Core::LinAlg::Tensor<double, 3>& n,
+      const Core::LinAlg::Tensor<double, 3>& dir,
+      SolidScatraCauchyNDirLinearizations<3>& linearizations)
   {
     return std::visit(Internal::EvaluateSolidScatraCauchyNDirAction<3>(
                           element, mat, disp, scalars, xi, n, dir, linearizations),

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_evaluate.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele_evaluate.cpp
@@ -158,8 +158,8 @@ int Discret::Elements::SolidScatra::evaluate_neumann(Teuchos::ParameterList& par
 
 double Discret::Elements::SolidScatra::get_normal_cauchy_stress_at_xi(
     const std::vector<double>& disp, const std::vector<double>& scalars,
-    const Core::LinAlg::Matrix<3, 1>& xi, const Core::LinAlg::Matrix<3, 1>& n,
-    const Core::LinAlg::Matrix<3, 1>& dir,
+    const Core::LinAlg::Tensor<double, 3>& xi, const Core::LinAlg::Tensor<double, 3>& n,
+    const Core::LinAlg::Tensor<double, 3>& dir,
     Discret::Elements::SolidScatraCauchyNDirLinearizations<3>& linearizations)
 {
   return Discret::Elements::get_normal_cauchy_stress_at_xi(solid_scatra_calc_variant_, *this,

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
@@ -14,6 +14,8 @@
 #include "4C_fem_general_extract_values.hpp"
 #include "4C_inpar_structure.hpp"
 #include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linalg_utils_sparse_algebra_math.hpp"
@@ -48,8 +50,10 @@ namespace
         Discret::Elements::evaluate_jacobian_mapping_centroid(element_nodes);
 
 
-    Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::dim<celltype>> jac0stretch;
-    jac0stretch.multiply_tn(jacobian_mapping.inverse_jacobian_, jacobian_mapping.inverse_jacobian_);
+    Core::LinAlg::SymmetricTensor<double, Core::FE::dim<celltype>, Core::FE::dim<celltype>>
+        jac0stretch = Core::LinAlg::assume_symmetry(
+            Core::LinAlg::transpose(jacobian_mapping.inverse_jacobian_) *
+            jacobian_mapping.inverse_jacobian_);
     const double r_stretch = sqrt(jac0stretch(0, 0));
     const double s_stretch = sqrt(jac0stretch(1, 1));
     const double t_stretch = sqrt(jac0stretch(2, 2));

--- a/src/w1/4C_w1_scatra_evaluate.cpp
+++ b/src/w1/4C_w1_scatra_evaluate.cpp
@@ -8,6 +8,7 @@
 #include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_extract_values.hpp"
+#include "4C_linalg_tensor.hpp"
 #include "4C_mat_material_factory.hpp"
 #include "4C_material_base.hpp"
 #include "4C_structure_new_elements_paramsinterface.hpp"
@@ -57,7 +58,7 @@ void Discret::Elements::Wall1Scatra::pre_evaluate(Teuchos::ParameterList& params
         std::dynamic_pointer_cast<Core::Mat::Material>(scatraele->material());
     params.set<std::shared_ptr<Core::Mat::Material>>("scatramat", scatramat);
   }
-  Core::LinAlg::Matrix<2, 1> xrefe(Core::LinAlg::Initialization::zero);
+  Core::LinAlg::Tensor<double, 2> xrefe{};
   for (int i = 0; i < numnode; ++i)
   {
     const auto& x = nodes()[i]->x();

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -22,6 +22,8 @@
 #include "4C_io_input_parameter_container.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
+#include "4C_linalg_tensor.hpp"
+#include "4C_linalg_tensor_generators.hpp"
 #include "4C_linalg_utils_densematrix_communication.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
@@ -2359,8 +2361,10 @@ void XFEM::MeshCouplingFSI::evaluate_structural_cauchy_stress(Core::Elements::El
             linearizations.d_cauchyndir_dd = &d_cauchy_d_d;
             linearizations.d2_cauchyndir_dd2 = &d2_cauchy_d_d2;
 
-            cauchy_n_dir = solid_ele->get_normal_cauchy_stress_at_xi(
-                eledisp, rst_slave, normal, dir, linearizations);
+            cauchy_n_dir = solid_ele->get_normal_cauchy_stress_at_xi(eledisp,
+                Core::LinAlg::reinterpret_as_tensor<3>(rst_slave),
+                Core::LinAlg::reinterpret_as_tensor<3>(normal),
+                Core::LinAlg::reinterpret_as_tensor<3>(dir), linearizations);
           };
         }
         else

--- a/unittests/solid_3D_ele/4C_solid_3D_ele_calc_lib_test.cpp
+++ b/unittests/solid_3D_ele/4C_solid_3D_ele_calc_lib_test.cpp
@@ -9,6 +9,8 @@
 
 #include "4C_solid_3D_ele_calc_lib.hpp"
 
+#include "4C_unittest_utils_assertions_test.hpp"
+
 namespace
 {
   using namespace FourC;
@@ -18,13 +20,12 @@ namespace
     // only tested for hex8, but equivalent for hex18, hex27, ...
     const auto distype = Core::FE::CellType::hex8;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid_ref(
-        Core::LinAlg::Initialization::zero);
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid_ref{};
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid =
         Discret::Elements::evaluate_parameter_coordinate_centroid<distype>();
 
-    EXPECT_EQ(xi_centroid, xi_centroid_ref);
+    FOUR_C_EXPECT_NEAR(xi_centroid, xi_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateParameterCoordinateCentroid, DisTypeTet)
@@ -32,45 +33,40 @@ namespace
     // only tested for tet4, but equivalent for tet10
     const auto distype = Core::FE::CellType::tet4;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    xi_centroid_ref(0) = 0.25;
-    xi_centroid_ref(1) = 0.25;
-    xi_centroid_ref(2) = 0.25;
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid_ref = {
+        {0.25, 0.25, 0.25}};
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid =
         Discret::Elements::evaluate_parameter_coordinate_centroid<distype>();
 
-    EXPECT_EQ(xi_centroid, xi_centroid_ref);
+    FOUR_C_EXPECT_NEAR(xi_centroid, xi_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateParameterCoordinateCentroid, DisTypePyramid)
   {
     const auto distype = Core::FE::CellType::pyramid5;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    xi_centroid_ref(2) = 0.25;
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid_ref = {
+        {0.0, 0.0, 0.25}};
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid =
         Discret::Elements::evaluate_parameter_coordinate_centroid<distype>();
 
-    EXPECT_EQ(xi_centroid, xi_centroid_ref);
+    FOUR_C_EXPECT_NEAR(xi_centroid, xi_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateParameterCoordinateCentroid, DisTypeWedge)
   {
     const auto distype = Core::FE::CellType::wedge6;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    xi_centroid_ref(0) = 1.0 / 3.0;
-    xi_centroid_ref(1) = 1.0 / 3.0;
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid_ref = {
+        {1.0 / 3.0, 1.0 / 3.0, 0.0}};
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> xi_centroid =
+
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> xi_centroid =
         Discret::Elements::evaluate_parameter_coordinate_centroid<distype>();
 
-    EXPECT_EQ(xi_centroid, xi_centroid_ref);
+    FOUR_C_EXPECT_NEAR(xi_centroid, xi_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateReferenceCoordinateCentroid, DisTypeHex)
@@ -114,16 +110,14 @@ namespace
     nodal_coordinates.reference_coordinates(1, 7) = 1;
     nodal_coordinates.reference_coordinates(2, 7) = 2;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    x_centroid_ref(0) = 2;
-    x_centroid_ref(1) = 0.5;
-    x_centroid_ref(2) = 1.0;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid_ref = {
+        {2, 0.5, 1.0}};
+
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid =
         Discret::Elements::evaluate_reference_coordinate_centroid<distype>(nodal_coordinates);
 
-    EXPECT_EQ(x_centroid, x_centroid_ref);
+    FOUR_C_EXPECT_NEAR(x_centroid, x_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateReferenceCoordinateCentroid, DisTypeTet)
@@ -151,16 +145,13 @@ namespace
     nodal_coordinates.reference_coordinates(1, 3) = 0;
     nodal_coordinates.reference_coordinates(2, 3) = 4;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    x_centroid_ref(0) = 0.25;
-    x_centroid_ref(1) = 0.5;
-    x_centroid_ref(2) = 1.0;
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid_ref = {
+        {0.25, 0.5, 1.0}};
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid =
         Discret::Elements::evaluate_reference_coordinate_centroid<distype>(nodal_coordinates);
 
-    EXPECT_EQ(x_centroid, x_centroid_ref);
+    FOUR_C_EXPECT_NEAR(x_centroid, x_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateReferenceCoordinateCentroid, DisTypePyramid)
@@ -192,16 +183,14 @@ namespace
     nodal_coordinates.reference_coordinates(1, 4) = 0;
     nodal_coordinates.reference_coordinates(2, 4) = 4;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    x_centroid_ref(0) = 1.0;
-    x_centroid_ref(1) = 0.0;
-    x_centroid_ref(2) = 1.0;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid_ref = {
+        {1.0, 0.0, 1.0}};
+
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid =
         Discret::Elements::evaluate_reference_coordinate_centroid<distype>(nodal_coordinates);
 
-    EXPECT_EQ(x_centroid, x_centroid_ref);
+    FOUR_C_EXPECT_NEAR(x_centroid, x_centroid_ref, 1e-15);
   }
 
   TEST(EvaluateReferenceCoordinateCentroid, DisTypeWedge)
@@ -237,18 +226,12 @@ namespace
     nodal_coordinates.reference_coordinates(1, 5) = 6;
     nodal_coordinates.reference_coordinates(2, 5) = 1;
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid_ref(
-        Core::LinAlg::Initialization::zero);
-    x_centroid_ref(0) = 1;
-    x_centroid_ref(1) = 2;
-    x_centroid_ref(2) = 0.5;
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid_ref = {
+        {1.0, 2.0, 0.5}};
 
-    Core::LinAlg::Matrix<Discret::Elements::Internal::num_dim<distype>, 1> x_centroid =
+    Core::LinAlg::Tensor<double, Discret::Elements::Internal::num_dim<distype>> x_centroid =
         Discret::Elements::evaluate_reference_coordinate_centroid<distype>(nodal_coordinates);
 
-    for (int j = 0; j < Discret::Elements::Internal::num_dim<distype>; j++)
-    {
-      EXPECT_NEAR(x_centroid(j), x_centroid_ref(j), 1e-14);
-    }
+    FOUR_C_EXPECT_NEAR(x_centroid, x_centroid_ref, 1e-15);
   }
 }  // namespace

--- a/unittests/solid_3D_ele/4C_solid_3D_ele_utils_test.cpp
+++ b/unittests/solid_3D_ele/4C_solid_3D_ele_utils_test.cpp
@@ -9,73 +9,80 @@
 
 #include "4C_solid_3D_ele_utils.hpp"
 
+#include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
 
 namespace
 {
   using namespace FourC;
 
-  Core::LinAlg::Matrix<3, 3> get_f()
+  Core::LinAlg::Tensor<double, 3, 3> get_f()
   {
-    Core::LinAlg::Matrix<3, 3> F(Core::LinAlg::Initialization::zero);
-    F(0, 0) = 1.1;
-    F(0, 1) = 0.2;
-    F(0, 2) = 0.5;
-    F(1, 0) = 0.14;
-    F(1, 1) = 1.2;
-    F(1, 2) = 0.3;
-    F(2, 0) = 0.05;
-    F(2, 1) = 0.2;
-    F(2, 2) = 1.3;
+    Core::LinAlg::Tensor<double, 3, 3> F{{
+        {1.1, 0.2, 0.5},
+        {0.14, 1.2, 0.3},
+        {0.05, 0.2, 1.3},
+    }};
 
     return F;
   }
 
   TEST(TestStressStrainMeasures, green_lagrange_to_euler_almansi)
   {
-    Core::LinAlg::Matrix<6, 1> green_lagrange_strain(
-        std::array<double, 6>{0.11605, 0.26, 0.515, 0.398, 0.72, 0.657}.data());
+    Core::LinAlg::SymmetricTensor<double, 3, 3> green_lagrange_strain =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{{
+            {0.11605, 0.199, 0.3285},
+            {0.199, 0.26, 0.36},
+            {0.3285, 0.36, 0.515},
+        }});
 
-    Core::LinAlg::Matrix<6, 1> euler_almansi_strain =
+    Core::LinAlg::SymmetricTensor<double, 3, 3> euler_almansi_strain =
         Solid::Utils::green_lagrange_to_euler_almansi(green_lagrange_strain, get_f());
 
-    Core::LinAlg::Matrix<6, 1> euler_almansi_strain_ref(
-        std::array<double, 6>{0.055233442151184, 0.101134166403205, 0.104112596224498,
-            0.182642289473823, 0.214768580862521, 0.315358749090858}
-            .data());
+    Core::LinAlg::SymmetricTensor<double, 3, 3> euler_almansi_strain_ref =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{
+            {{0.055233442151184, 0.0913211447369115, 0.157679374545429},
+                {0.0913211447369115, 0.101134166403205, 0.1073842904312605},
+                {0.157679374545429, 0.1073842904312605, 0.104112596224498}}});
 
     FOUR_C_EXPECT_NEAR(euler_almansi_strain, euler_almansi_strain_ref, 1e-13);
   }
 
   TEST(TestStressStrainMeasures, green_lagrange_to_log_strain)
   {
-    Core::LinAlg::Matrix<6, 1> green_lagrange_strain(
-        std::array<double, 6>{0.11605, 0.26, 0.515, 0.398, 0.72, 0.657}.data());
+    Core::LinAlg::SymmetricTensor<double, 3, 3> green_lagrange_strain =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{{
+            {0.11605, 0.199, 0.3285},
+            {0.199, 0.26, 0.36},
+            {0.3285, 0.36, 0.515},
+        }});
 
-    Core::LinAlg::Matrix<6, 1> log_strain =
+    Core::LinAlg::SymmetricTensor<double, 3, 3> log_strain =
         Solid::Utils::green_lagrange_to_log_strain(green_lagrange_strain);
 
-    Core::LinAlg::Matrix<6, 1> log_strain_ref(
-        std::array<double, 6>{0.039139830823291, 0.150129540734586, 0.281109187392933,
-            0.218832208837098, 0.400808067245772, 0.400940161591198}
-            .data());
+    Core::LinAlg::SymmetricTensor<double, 3, 3> log_strain_ref = Core::LinAlg::assume_symmetry(
+        Core::LinAlg::Tensor<double, 3, 3>{{{0.039139830823291, 0.10941610441855, 0.20047008079560},
+            {0.10941610441855, 0.150129540734586, 0.20040403362289},
+            {0.20047008079560, 0.20040403362289, 0.281109187392933}}});
 
     FOUR_C_EXPECT_NEAR(log_strain, log_strain_ref, 1e-13);
   }
 
   TEST(TestStressStrainMeasures, SecondPiolaKirchhoffToCauchy)
   {
-    Core::LinAlg::Matrix<6, 1> pk2(std::array<double, 6>{283.6946919505318, 195.86721709838096,
-        202.01904686970775, 142.72731871521245, 182.86374040756576, 278.020938548381}
-            .data());
+    Core::LinAlg::SymmetricTensor<double, 3, 3> pk2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{
+            {{283.6946919505318, 142.72731871521245, 278.020938548381},
+                {142.72731871521245, 195.86721709838096, 182.86374040756576},
+                {278.020938548381, 182.86374040756576, 202.01904686970775}}});
 
-    Core::LinAlg::Matrix<6, 1> cauchy(Core::LinAlg::Initialization::zero);
-    Solid::Utils::pk2_to_cauchy(pk2, get_f(), cauchy);
+    Core::LinAlg::SymmetricTensor<double, 3, 3> cauchy = Solid::Utils::pk2_to_cauchy(pk2, get_f());
 
-    Core::LinAlg::Matrix<6, 1> cauchy_ref(
-        std::array<double, 6>{504.0646185061422, 317.85764952017706, 302.4131750725638,
-            340.6815203116966, 306.97914008976466, 411.0514636046741}
-            .data());
+    Core::LinAlg::SymmetricTensor<double, 3, 3> cauchy_ref =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{
+            {{504.0646185061422, 340.6815203116966, 411.0514636046741},
+                {340.6815203116966, 317.85764952017706, 306.97914008976466},
+                {411.0514636046741, 306.97914008976466, 302.4131750725638}}});
 
     FOUR_C_EXPECT_NEAR(cauchy, cauchy_ref, 1e-12);
   }


### PR DESCRIPTION
This PR uses the symmetric tensors in the solid element evaluation routine. Draft for now since the changes from #862 are required.