### PR TITLE
Implement some small improvements to tensor class

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_symmetric_tensor_eigen.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_symmetric_tensor_eigen.hpp
@@ -1,0 +1,55 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_SYMMETRIC_TENSOR_EIGEN_HPP
+#define FOUR_C_LINALG_SYMMETRIC_TENSOR_EIGEN_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+
+#include <Teuchos_LAPACK.hpp>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  /*!
+   * @brief Computes the eigenvalue decomposition of a symmetric 2-tensor
+   *
+   * @tparam Tensor
+   * @return A tuple of a std::array containing the eigenvalues and a 2-tensor containing the
+   * eigenvectors.
+   */
+  template <typename Tensor>
+    requires(is_symmetric_tensor<Tensor> && Tensor::rank() == 2)
+  auto eig(const Tensor& t)
+  {
+    // Lapack uses this tensor to compute the eigenvectors
+    auto eigenvectors = get_full(t);
+
+    constexpr std::size_t size = Tensor::template extent<0>();
+
+
+    std::array<double, size> eigenvalues;
+    // ----- perform eigendecomposition ----- //
+    const int lwork = 2 * size * size + 6 * size + 1;
+    std::array<double, lwork> work;
+    int info;
+    Teuchos::LAPACK<int, double> lapack;
+    lapack.SYEV(
+        'V', 'U', size, eigenvectors.data(), size, eigenvalues.data(), work.data(), lwork, &info);
+    FOUR_C_ASSERT_ALWAYS(info == 0, "Eigenvalue decomposition failed with error code {}", info);
+
+    return std::make_tuple(eigenvalues, eigenvectors);
+  }
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/src/dense/4C_linalg_tensor_generators.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_generators.hpp
@@ -1,0 +1,123 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_TENSOR_GENERATORS_HPP
+#define FOUR_C_LINALG_TENSOR_GENERATORS_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor.hpp"
+
+#include <type_traits>
+
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg::TensorGenerators
+{
+  /*!
+   * @brief Diagonal 2-tensor with the given value on the diagonal.
+   */
+  template <std::size_t... n>
+    requires(sizeof...(n) == 2 && std::array{n...}[0] == std::array{n...}[1])
+  constexpr auto diagonal(const auto& value)
+  {
+    SymmetricTensor<std::remove_cvref_t<decltype(value)>, n...> t{};
+    for (std::size_t i = 0; i < std::array{n...}[0]; ++i)
+    {
+      t(i, i) = value;
+    }
+    return t;
+  }
+
+  /*!
+   * @brief Diagonal 2-tensor with the given values on the diagonal.
+   */
+  template <std::size_t n, typename T>
+  constexpr SymmetricTensor<T, n, n> diagonal(const std::array<T, n>& values)
+  {
+    SymmetricTensor<T, n, n> t{};
+    for (std::size_t i = 0; i < n; ++i)
+    {
+      t(i, i) = values[i];
+    }
+    return t;
+  }
+
+  /*!
+   * @brief Tensor with every value given by @p value.
+   */
+  template <std::size_t... n>
+    requires(sizeof...(n) == 2 && std::array{n...}[0] == std::array{n...}[1])
+  constexpr auto full(const auto& value)
+  {
+    SymmetricTensor<std::remove_cvref_t<decltype(value)>, n...> t;
+    t.fill(value);
+    return t;
+  }
+
+  /*!
+   * @brief Tensor with every value given by @p value.
+   */
+  template <std::size_t... n>
+    requires(sizeof...(n) != 2 || std::array{n...}[0] != std::array{n...}[1])
+  constexpr auto full(const auto& value)
+  {
+    Tensor<std::remove_cvref_t<decltype(value)>, n...> t;
+    t.fill(value);
+    return t;
+  }
+
+  /*!
+   * @brief Identity tensor with given dimensions. Might be a 2-tensor or a 4-tensor.
+   */
+  template <typename T, std::size_t... n>
+    requires((sizeof...(n) == 2 && std::array{n...}[0] == std::array{n...}[1]) ||
+                (sizeof...(n) == 4 && std::array{n...}[0] == std::array{n...}[1] &&
+                    std::array{n...}[0] == std::array{n...}[2] &&
+                    std::array{n...}[0] == std::array{n...}[3]))
+  static constexpr auto identity = []() consteval
+  {
+    constexpr std::size_t rank = sizeof...(n);
+    if constexpr (rank == 2)
+    {
+      return diagonal<n...>(static_cast<T>(1));
+    }
+    else if constexpr (rank == 4)
+    {
+      constexpr std::array n_arr = {n...};
+      Tensor<double, n...> t{};
+      for (std::size_t ik = 0; ik < n_arr[0]; ++ik)
+      {
+        for (std::size_t jl = 0; jl < n_arr[1]; ++jl)
+        {
+          t(ik, jl, ik, jl) = T(1);
+        }
+      }
+      return t;
+    }
+  }();
+
+  /*!
+   * @brief Symmetric 4th-order identity tensor
+   */
+  template <typename T, std::size_t n1, std::size_t n2, std::size_t n3, std::size_t n4>
+    requires(n1 == n2 && n1 == n3 && n1 == n4)
+  static constexpr SymmetricTensor<T, n1, n2, n3, n4> symmetric_identity =
+      Core::LinAlg::assume_symmetry(
+          0.5 * (identity<T, n1, n2, n3, n4> +
+                    Core::LinAlg::reorder_axis<0, 1, 3, 2>(identity<T, n1, n2, n3, n4>)));
+
+  template <typename T, std::size_t... n>
+  static constexpr SymmetricTensor<T, n...> ones = full<T, n...>(1);
+}  // namespace Core::LinAlg::TensorGenerators
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
@@ -202,14 +202,14 @@ namespace Core::LinAlg
      *
      * @return Number*
      */
-    [[nodiscard]] Number* data() { return data_.data(); }
+    [[nodiscard]] constexpr Number* data() { return data_.data(); }
 
     /*!
      * @brief Access to the underlying raw data of the tensor for readonly access
      *
      * @return Number*
      */
-    [[nodiscard]] const Number* data() const { return data_.data(); }
+    [[nodiscard]] constexpr const Number* data() const { return data_.data(); }
 
     /*!
      * @brief Access to the underlying container (std::array or std::span, depending on whether it
@@ -217,7 +217,7 @@ namespace Core::LinAlg
      *
      * @return Number*
      */
-    [[nodiscard]] ContainerType& container() { return data_; }
+    [[nodiscard]] constexpr ContainerType& container() { return data_; }
 
     /*!
      * @brief Access to the underlying readonly container (std::array or std::span, depending on
@@ -225,7 +225,7 @@ namespace Core::LinAlg
      *
      * @return Number*
      */
-    [[nodiscard]] const ContainerType& container() const { return data_; }
+    [[nodiscard]] constexpr const ContainerType& container() const { return data_; }
 
     /*!
      * @brief Indexing operator to access individual values of the tensor (without bound checks)
@@ -233,7 +233,7 @@ namespace Core::LinAlg
      * @param i
      * @return Number&
      */
-    [[nodiscard]] Number& operator()(decltype(n)... i);
+    [[nodiscard]] constexpr Number& operator()(decltype(n)... i);
 
     /*!
      * @brief Indexing operator to access individual values of the tensor in readonly mode
@@ -242,7 +242,7 @@ namespace Core::LinAlg
      * @param i
      * @return Number&
      */
-    [[nodiscard]] const Number& operator()(decltype(n)... i) const;
+    [[nodiscard]] constexpr const Number& operator()(decltype(n)... i) const;
 
     /*!
      * @brief Indexing operator to access individual values of the tensor (with bound checks)
@@ -326,13 +326,14 @@ namespace Core::LinAlg
   }
 
   template <typename Number, TensorStorageType storage_type, typename Compression, std::size_t... n>
-  Number& TensorInternal<Number, storage_type, Compression, n...>::operator()(decltype(n)... i)
+  constexpr Number& TensorInternal<Number, storage_type, Compression, n...>::operator()(
+      decltype(n)... i)
   {
     return data_[Compression::template flatten_index<Internal::TensorBoundCheck::no_check>(i...)];
   }
 
   template <typename Number, TensorStorageType storage_type, typename Compression, std::size_t... n>
-  const Number& TensorInternal<Number, storage_type, Compression, n...>::operator()(
+  constexpr const Number& TensorInternal<Number, storage_type, Compression, n...>::operator()(
       decltype(n)... i) const
   {
     return data_[Compression::template flatten_index<Internal::TensorBoundCheck::no_check>(i...)];

--- a/src/core/linalg/src/dense/4C_linalg_tensor_matrix_conversion.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_matrix_conversion.hpp
@@ -1,0 +1,212 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_LINALG_TENSOR_MATRIX_CONVERSION_HPP
+#define FOUR_C_LINALG_TENSOR_MATRIX_CONVERSION_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor.hpp"
+
+#include <type_traits>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::LinAlg
+{
+  /*!
+   * @brief Create a 2-tensor given a fixed-size matrix.
+   *
+   * @param matrix
+   * @return auto
+   */
+  template <typename T, unsigned int m, unsigned int n>
+  auto make_tensor(const Matrix<m, n, T>& matrix)
+  {
+    using MatrixType = std::remove_cvref_t<decltype(matrix)>;
+    Tensor<typename MatrixType::scalar_type, MatrixType::m(), MatrixType::n()> tensor;
+    std::copy_n(matrix.data(), MatrixType::m() * MatrixType::n(), tensor.data());
+    return tensor;
+  }
+
+  /*!
+   * @brief Create a 2-tensor view onto a fixed-size matrix.
+   *
+   * @param matrix
+   * @return auto
+   */
+  auto make_tensor_view(auto& matrix)
+  {
+    return make_tensor_view<std::remove_cvref_t<decltype(matrix)>::num_rows(),
+        std::remove_cvref_t<decltype(matrix)>::num_cols()>(matrix.data());
+  }
+
+  /*!
+   * @brief Creates a symmetric tensor from a stress-like Voigt notation matrix.
+   */
+  constexpr auto make_symmetric_tensor_from_stress_like_voigt_matrix(const auto& stress_like_voigt)
+    requires(std::remove_cvref_t<decltype(stress_like_voigt)>::num_cols() == 1)
+  {
+    constexpr std::size_t voigt_size = std::remove_cvref_t<decltype(stress_like_voigt)>::num_rows();
+    constexpr std::size_t symmetric_size = [](auto size) consteval
+    {
+      switch (size)
+      {
+        case 3:
+          return 2;
+        case 6:
+          return 3;
+        case 10:
+          return 4;
+        case 15:
+          return 5;
+        case 21:
+          return 6;
+        default:
+          FOUR_C_THROW("Unsupported symmetric tensor size: " + std::to_string(size));
+      }
+    }(voigt_size);
+
+    SymmetricTensor<typename std::remove_cvref_t<decltype(stress_like_voigt)>::scalar_type,
+        symmetric_size, symmetric_size>
+        symmetric_tensor;
+
+    std::copy_n(stress_like_voigt.data(), voigt_size, symmetric_tensor.data());
+
+    return symmetric_tensor;
+  }
+
+  /*!
+   * @brief Create an arbitrarily-ranked tensor from a matrix.
+   *
+   * The number of elements of the tensor and the matrix must match. A common use case is to create
+   * a rank-1 Tensor form a 3x1 Matrix.
+   *
+   * @tparam n Shape of the tensor
+   */
+  template <std::size_t... n>
+  auto reinterpret_as_tensor(const auto& matrix)
+    requires((n * ...) == std::remove_cvref_t<decltype(matrix)>::num_cols() *
+                              std::remove_cvref_t<decltype(matrix)>::num_rows())
+  {
+    Tensor<typename std::remove_cvref_t<decltype(matrix)>::scalar_type, n...> tensor;
+    std::copy_n(matrix.data(), (n * ...), tensor.data());
+    return tensor;
+  }
+
+  /*!
+   * @brief Create an arbitrarily-ranked tensor view from a matrix.
+   *
+   * The number of elements of the tensor view and the matrix must match. A common use case is to
+   * create a rank-1 TensorView form a 3x1 Matrix-view.
+   *
+   * @tparam n
+   */
+  template <std::size_t... n>
+  auto reinterpret_as_tensor_view(auto& matrix)
+    requires((n * ...) == std::remove_cvref_t<decltype(matrix)>::num_cols() *
+                              std::remove_cvref_t<decltype(matrix)>::num_rows())
+  {
+    return make_tensor_view<n...>(matrix.data());
+  }
+
+  /*!
+   * @brief Creates a matrix that views a 2-tensor
+   */
+  auto make_matrix_view(auto& tensor)
+    requires(std::remove_cvref_t<decltype(tensor)>::rank() == 2)
+  {
+    using ValueType = std::remove_cvref_t<decltype(tensor)>::value_type;
+    constexpr std::size_t n1 = std::remove_cvref_t<decltype(tensor)>::template extent<0>();
+    constexpr std::size_t n2 = std::remove_cvref_t<decltype(tensor)>::template extent<1>();
+    return Core::LinAlg::Matrix<n1, n2, ValueType>{tensor.data(), true};
+  }
+
+  /*!
+   * @brief Creates a matrix of size n1xn2 that views a 1-tensor
+   */
+  template <std::size_t n1, std::size_t n2>
+  auto make_matrix_view(auto& tensor)
+    requires(std::remove_cvref_t<decltype(tensor)>::rank() == 1 &&
+             n1 * n2 == std::remove_cvref_t<decltype(tensor)>::template extent<0>())
+  {
+    using ValueType = std::remove_cvref_t<decltype(tensor)>::value_type;
+    return Core::LinAlg::Matrix<n1, n2, ValueType>{tensor.data(), true};
+  }
+
+  /*!
+   * @brief Creates a matrix from a 2-tensor
+   */
+  template <std::size_t n1, std::size_t n2, typename T>
+  Core::LinAlg::Matrix<n1, n2, T> make_matrix(const Core::LinAlg::Tensor<T, n1, n2>& tensor)
+  {
+    return Core::LinAlg::Matrix<n1, n2, T>{tensor.data(), false};
+  }
+
+  /*!
+   * @brief Creates a matrix of shape n1xn2 from a 1-tensor of shape n=n1*n2
+   */
+  template <std::size_t n1, std::size_t n2, typename T, std::size_t n>
+    requires((n1 * n2) == n)
+  Core::LinAlg::Matrix<n1, n2, T> make_matrix(const Core::LinAlg::Tensor<T, n>& tensor)
+  {
+    return Core::LinAlg::Matrix<n1, n2, T>{tensor.data(), false};
+  }
+
+  /*!
+   * @brief Creates a stress-like Voigt notation matrix view from a symmetric tensor.
+   *
+   * If @p tensor is a symmetric 2-tensor of dimension 3, it will be converted to a 6x1 matrix.
+   * If @p tensor is a symmetric 4-tensor of dimension 3, it will be converted to a 6x6 matrix.
+   *
+   */
+  auto make_stress_like_voigt_view(auto& tensor)
+    requires(is_symmetric_tensor<decltype(tensor)>)
+  {
+    using ValueType = std::remove_cvref_t<decltype(tensor)>::value_type;
+    constexpr std::size_t rank = std::remove_cvref_t<decltype(tensor)>::rank();
+    static_assert(rank == 2 || rank == 4,
+        "Tensor must be a symmetric tensor of rank 2 or 4 for Voigt notation");
+
+    if constexpr (rank == 2)
+    {
+      constexpr std::size_t compressed_size =
+          std::remove_cvref_t<decltype(tensor)>::compressed_size;
+      return Core::LinAlg::Matrix<compressed_size, 1, ValueType>(tensor.data(), true);
+    }
+    else if constexpr (rank == 4)
+    {
+      constexpr std::size_t size_left = std::remove_cvref_t<decltype(tensor)>::template extent<0>();
+      constexpr std::size_t size_right =
+          std::remove_cvref_t<decltype(tensor)>::template extent<2>();
+      return Core::LinAlg::Matrix<size_left*(size_left + 1) / 2, size_right*(size_right + 1) / 2,
+          ValueType>(tensor.data(), true);
+    }
+  }
+
+  /*!
+   * @brief Creates a strain-like Voigt notation matrix from a symmetric tensor.
+   *
+   * If @p tensor is a symmetric 2-tensor of dimension 3, it will be converted to a 6x1 matrix in
+   * strain-like Voigt notation.
+   *
+   */
+  template <typename T, std::size_t size>
+  Core::LinAlg::Matrix<size*(size + 1) / 2, 1, T> make_strain_like_voigt_matrix(
+      const Core::LinAlg::SymmetricTensor<T, size, size>& tensor)
+  {
+    Core::LinAlg::Matrix<size*(size + 1) / 2, 1, T> matrix(tensor.data());
+    Voigt::Stresses::to_strain_like(matrix, matrix);
+    return matrix;
+  }
+}  // namespace Core::LinAlg
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/linalg/tests/4C_linalg_symmetric_tensor_eigen_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_symmetric_tensor_eigen_test.cpp
@@ -1,0 +1,101 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_symmetric_tensor_eigen.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor_generators.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  TEST(SymmetricTensorEigenTest, eig2x2)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 2, 2>{
+            {{0.9964456203546112, 0.490484665405466}, {0.490484665405466, 0.5611378979071144}}});
+
+    const auto& [eigenvalues, eigenvectors] = Core::LinAlg::eig(t);
+    EXPECT_NEAR(eigenvalues[0], 0.242183512545406, 1e-10);
+    EXPECT_NEAR(eigenvalues[1], 1.31540000571632, 1e-10);
+
+    Core::LinAlg::Tensor<double, 2, 2> original_matrix =
+        eigenvectors * Core::LinAlg::TensorGenerators::diagonal(eigenvalues) *
+        Core::LinAlg::transpose(eigenvectors);
+
+    FOUR_C_EXPECT_NEAR(original_matrix, t, 1e-10);
+  }
+
+  TEST(SymmetricTensorEigenTest, eig2x2view)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 2, 2>{
+            {{0.9964456203546112, 0.490484665405466}, {0.490484665405466, 0.5611378979071144}}});
+
+    Core::LinAlg::SymmetricTensorView<const double, 2, 2> t_view = t;
+
+    const auto& [eigenvalues, eigenvectors] = Core::LinAlg::eig(t_view);
+    EXPECT_NEAR(eigenvalues[0], 0.242183512545406, 1e-10);
+    EXPECT_NEAR(eigenvalues[1], 1.31540000571632, 1e-10);
+
+    Core::LinAlg::Tensor<double, 2, 2> original_matrix =
+        eigenvectors * Core::LinAlg::TensorGenerators::diagonal(eigenvalues) *
+        Core::LinAlg::transpose(eigenvectors);
+
+    FOUR_C_EXPECT_NEAR(original_matrix, t, 1e-10);
+  }
+
+  TEST(SymmetricTensorEigenTest, eig3x3)
+  {
+    Core::LinAlg::SymmetricTensor<double, 3, 3> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{
+            {{1.1948716876311152, 0.5399232848096387, 0.6905691418748001},
+                {0.5399232848096387, 0.8273468489149256, 0.2538261251935583},
+                {0.6905691418748001, 0.2538261251935583, 0.48064209250998646}}});
+
+    const auto& [eigenvalues, eigenvectors] = Core::LinAlg::eig(t);
+    EXPECT_NEAR(eigenvalues[0], 0.052879897400611, 1e-10);
+    EXPECT_NEAR(eigenvalues[1], 0.516153257193444, 1e-10);
+    EXPECT_NEAR(eigenvalues[2], 1.933827474461972, 1e-10);
+
+    Core::LinAlg::Tensor<double, 3, 3> original_matrix =
+        eigenvectors * Core::LinAlg::TensorGenerators::diagonal(eigenvalues) *
+        Core::LinAlg::transpose(eigenvectors);
+
+    FOUR_C_EXPECT_NEAR(original_matrix, t, 1e-10);
+  }
+
+  TEST(SymmetricTensorEigenTest, eig3x3view)
+  {
+    const Core::LinAlg::SymmetricTensor<double, 3, 3> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{
+            {{1.1948716876311152, 0.5399232848096387, 0.6905691418748001},
+                {0.5399232848096387, 0.8273468489149256, 0.2538261251935583},
+                {0.6905691418748001, 0.2538261251935583, 0.48064209250998646}}});
+
+    Core::LinAlg::SymmetricTensorView<const double, 3, 3> t_view = t;
+
+    const auto& [eigenvalues, eigenvectors] = Core::LinAlg::eig(t_view);
+    EXPECT_NEAR(eigenvalues[0], 0.052879897400611, 1e-10);
+    EXPECT_NEAR(eigenvalues[1], 0.516153257193444, 1e-10);
+    EXPECT_NEAR(eigenvalues[2], 1.933827474461972, 1e-10);
+
+    Core::LinAlg::Tensor<double, 3, 3> original_matrix =
+        eigenvectors * Core::LinAlg::TensorGenerators::diagonal(eigenvalues) *
+        Core::LinAlg::transpose(eigenvectors);
+
+    FOUR_C_EXPECT_NEAR(original_matrix, t, 1e-10);
+  }
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_symmetric_tensor_operations_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_symmetric_tensor_operations_test.cpp
@@ -246,6 +246,25 @@ namespace
     }
   }
 
+  TEST(SymmetricTensorOperationsTest, ddotView)
+  {
+    {
+      const Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t4_sym =
+          create_symmetric_four_tensor<2>();
+      const Core::LinAlg::SymmetricTensorView<const double, 2, 2, 2, 2> t4_sym_view = t4_sym;
+      const Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
+      const Core::LinAlg::SymmetricTensorView<const double, 2, 2> t2_sym_view = t2_sym;
+
+
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t4_sym_ddot_t2_sym =
+          Core::LinAlg::ddot(t4_sym_view, t2_sym_view);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 0), 9.824, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(0, 1), 19.614, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 0), 19.614, 1e-10);
+      EXPECT_NEAR(t4_sym_ddot_t2_sym(1, 1), 30.383, 1e-10);
+    }
+  }
+
   TEST(SymmetricTensorOperationsTest, scale)
   {
     Core::LinAlg::SymmetricTensor<double, 2, 2> t2_sym = create_symmetric_tensor<2>();
@@ -335,12 +354,10 @@ namespace
     EXPECT_NEAR(t2_sym_dyad(1, 1, 1, 1), 13.26, 1e-10);
   }
 
-  TEST(SymmetricTensorOperationsTest, self_dyadic)
+  TEST(SymmetricTensorOperationsTest, selfDyadic)
   {
     Core::LinAlg::Tensor<double, 2> t1 = create_tensor<2>();
     Core::LinAlg::SymmetricTensor<double, 2, 2> t1_self_dyad = Core::LinAlg::self_dyadic(t1);
-
-    std::cout << t1 << std::endl;
 
     EXPECT_NEAR(t1_self_dyad(0, 0), 1, 1e-10);
     EXPECT_NEAR(t1_self_dyad(0, 1), 2, 1e-10);
@@ -375,6 +392,83 @@ namespace
 
     EXPECT_NEAR(t1_self_dyad4(1, 1, 1, 0), 8, 1e-10);
     EXPECT_NEAR(t1_self_dyad4(1, 1, 1, 1), 16, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, addInplace)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t1 = create_symmetric_tensor<2>(1.1);
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2 = create_symmetric_tensor<2>(0.1);
+
+    t1 += t2;
+
+    EXPECT_NEAR(t1(0, 0), 1.4, 1e-10);
+    EXPECT_NEAR(t1(0, 1), 3.6, 1e-10);
+
+    EXPECT_NEAR(t1(1, 0), 3.6, 1e-10);
+    EXPECT_NEAR(t1(1, 1), 6.0, 1e-10);
+  }
+
+  TEST(SymmetricTensorOperationsTest, subtractInplace)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t1 = create_symmetric_tensor<2>(1.1);
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t2 = create_symmetric_tensor<2>(0.2, 0.2);
+
+    t1 -= t2;
+
+    EXPECT_NEAR(t1(0, 0), 0.8, 1e-10);
+    EXPECT_NEAR(t1(0, 1), 0.7, 1e-10);
+
+    EXPECT_NEAR(t1(1, 0), 0.7, 1e-10);
+    EXPECT_NEAR(t1(1, 1), 0.5, 1e-10);
+  }
+
+
+  TEST(SymmetricTensorOperationsTest, scaleInplace)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t1 = create_symmetric_tensor<2>(1.1);
+
+    t1 *= 2;
+
+    EXPECT_NEAR(t1(0, 0), 2.4, 1e-10);
+    EXPECT_NEAR(t1(0, 1), 4.6, 1e-10);
+
+    EXPECT_NEAR(t1(1, 0), 4.6, 1e-10);
+    EXPECT_NEAR(t1(1, 1), 7.0, 1e-10);
+  }
+
+
+  TEST(SymmetricTensorOperationsTest, divideInplace)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t1 = create_symmetric_tensor<2>(1.1);
+
+    t1 /= 2;
+    EXPECT_NEAR(t1(0, 0), 0.6, 1e-10);
+    EXPECT_NEAR(t1(0, 1), 1.15, 1e-10);
+
+    EXPECT_NEAR(t1(1, 0), 1.15, 1e-10);
+    EXPECT_NEAR(t1(1, 1), 1.75, 1e-10);
+
+
+    t1 /= 1.2;
+    EXPECT_NEAR(t1(0, 0), 0.5, 1e-10);
+    EXPECT_NEAR(t1(0, 1), 0.95833333333333333, 1e-10);
+
+    EXPECT_NEAR(t1(1, 0), 0.95833333333333333, 1e-10);
+    EXPECT_NEAR(t1(1, 1), 1.45833333333333333, 1e-10);
+  }
+
+
+  TEST(SymmetricTensorOperationsTest, multiplyInplace)
+  {
+    Core::LinAlg::SymmetricTensor<double, 2, 2> t1 = create_symmetric_tensor<2>(1.1);
+
+    t1 *= 2;
+
+    EXPECT_NEAR(t1(0, 0), 2.4, 1e-10);
+    EXPECT_NEAR(t1(0, 1), 4.6, 1e-10);
+
+    EXPECT_NEAR(t1(1, 0), 4.6, 1e-10);
+    EXPECT_NEAR(t1(1, 1), 7.0, 1e-10);
   }
 }  // namespace
 

--- a/src/core/linalg/tests/4C_linalg_symmetric_tensor_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_symmetric_tensor_test.cpp
@@ -388,6 +388,21 @@ namespace
 ])");
   }
 
+  TEST(SymmetricTensorViewTest, MakeSymmetricTensorView)
+  {
+    std::array<double, 6> data = {1.1, 2.2, 3.3, 1.2, 2.3, 1.3};
+
+    Core::LinAlg::SymmetricTensorView<double, 3, 3> t2_view =
+        Core::LinAlg::make_symmetric_tensor_view<3, 3>(data.data());
+
+    EXPECT_DOUBLE_EQ(t2_view(0, 0), 1.1);
+    EXPECT_DOUBLE_EQ(t2_view(1, 1), 2.2);
+    EXPECT_DOUBLE_EQ(t2_view(2, 2), 3.3);
+    EXPECT_DOUBLE_EQ(t2_view(0, 1), 1.2);
+    EXPECT_DOUBLE_EQ(t2_view(1, 2), 2.3);
+    EXPECT_DOUBLE_EQ(t2_view(0, 2), 1.3);
+  }
+
 }  // namespace
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_tensor_generators_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_generators_test.cpp
@@ -1,0 +1,146 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_tensor_generators.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+#include <array>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  TEST(TensorGeneratorTest, diagonal)
+  {
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t =
+          Core::LinAlg::TensorGenerators::diagonal(std::array{1.0, 2.0});
+      EXPECT_EQ(t(0, 0), 1.0);
+      EXPECT_EQ(t(1, 1), 2.0);
+      EXPECT_EQ(t(0, 1), 0.0);
+      EXPECT_EQ(t(1, 0), 0.0);
+    }
+
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t =
+          Core::LinAlg::TensorGenerators::diagonal<2, 2>(2.0);
+      EXPECT_EQ(t(0, 0), 2.0);
+      EXPECT_EQ(t(1, 1), 2.0);
+      EXPECT_EQ(t(0, 1), 0.0);
+      EXPECT_EQ(t(1, 0), 0.0);
+    }
+  }
+
+  TEST(TensorGeneratorTest, full)
+  {
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t =
+          Core::LinAlg::TensorGenerators::full<2, 2>(1.2);
+      EXPECT_EQ(t(0, 0), 1.2);
+      EXPECT_EQ(t(1, 1), 1.2);
+      EXPECT_EQ(t(0, 1), 1.2);
+      EXPECT_EQ(t(1, 0), 1.2);
+    }
+    {
+      Core::LinAlg::Tensor<double, 2> t = Core::LinAlg::TensorGenerators::full<2>(1.2);
+      EXPECT_EQ(t(0), 1.2);
+      EXPECT_EQ(t(1), 1.2);
+    }
+  }
+
+
+
+  TEST(TensorGeneratorTest, identity)
+  {
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2> t =
+          Core::LinAlg::TensorGenerators::identity<double, 2, 2>;
+      EXPECT_EQ(t(0, 0), 1.0);
+      EXPECT_EQ(t(1, 1), 1.0);
+      EXPECT_EQ(t(0, 1), 0.0);
+      EXPECT_EQ(t(1, 0), 0.0);
+    }
+    {
+      Core::LinAlg::Tensor<double, 2, 2, 2, 2> t =
+          Core::LinAlg::TensorGenerators::identity<double, 2, 2, 2, 2>;
+      EXPECT_EQ(t(0, 0, 0, 0), 1.0);
+      EXPECT_EQ(t(0, 0, 0, 1), 0.0);
+      EXPECT_EQ(t(0, 0, 1, 0), 0.0);
+      EXPECT_EQ(t(0, 0, 1, 1), 0.0);
+      EXPECT_EQ(t(0, 1, 0, 0), 0.0);
+      EXPECT_EQ(t(0, 1, 0, 1), 1.0);
+      EXPECT_EQ(t(0, 1, 1, 0), 0.0);
+      EXPECT_EQ(t(0, 1, 1, 1), 0.0);
+      EXPECT_EQ(t(1, 0, 0, 0), 0.0);
+      EXPECT_EQ(t(1, 0, 0, 1), 0.0);
+      EXPECT_EQ(t(1, 0, 1, 0), 1.0);
+      EXPECT_EQ(t(1, 0, 1, 1), 0.0);
+      EXPECT_EQ(t(1, 1, 0, 0), 0.0);
+      EXPECT_EQ(t(1, 1, 0, 1), 0.0);
+      EXPECT_EQ(t(1, 1, 1, 0), 0.0);
+      EXPECT_EQ(t(1, 1, 1, 1), 1.0);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 3> t = {{
+          {1.1, 1.2, 1.3},
+          {2.1, 2.2, 2.3},
+          {3.1, 3.2, 3.3},
+      }};
+
+      Core::LinAlg::Tensor<double, 3, 3> t2 =
+          Core::LinAlg::ddot(Core::LinAlg::TensorGenerators::identity<double, 3, 3, 3, 3>, t);
+
+      FOUR_C_EXPECT_NEAR(t, t2, 1e-15);
+    }
+  }
+
+  TEST(TensorGeneratorTest, symmetricIdentity)
+  {
+    {
+      Core::LinAlg::SymmetricTensor<double, 2, 2, 2, 2> t =
+          Core::LinAlg::TensorGenerators::symmetric_identity<double, 2, 2, 2, 2>;
+      EXPECT_EQ(t(0, 0, 0, 0), 1.0);
+      EXPECT_EQ(t(0, 0, 0, 1), 0.0);
+      EXPECT_EQ(t(0, 0, 1, 0), 0.0);
+      EXPECT_EQ(t(0, 0, 1, 1), 0.0);
+      EXPECT_EQ(t(0, 1, 0, 0), 0.0);
+      EXPECT_EQ(t(0, 1, 0, 1), 0.5);
+      EXPECT_EQ(t(0, 1, 1, 0), 0.5);
+      EXPECT_EQ(t(0, 1, 1, 1), 0.0);
+      EXPECT_EQ(t(1, 0, 0, 0), 0.0);
+      EXPECT_EQ(t(1, 0, 0, 1), 0.5);
+      EXPECT_EQ(t(1, 0, 1, 0), 0.5);
+      EXPECT_EQ(t(1, 0, 1, 1), 0.0);
+      EXPECT_EQ(t(1, 1, 0, 0), 0.0);
+      EXPECT_EQ(t(1, 1, 0, 1), 0.0);
+      EXPECT_EQ(t(1, 1, 1, 0), 0.0);
+      EXPECT_EQ(t(1, 1, 1, 1), 1.0);
+    }
+
+    {
+      Core::LinAlg::Tensor<double, 3, 3> t = {{
+          {1.1, 1.2, 1.3},
+          {2.1, 2.2, 2.3},
+          {3.1, 3.2, 3.3},
+      }};
+
+      Core::LinAlg::SymmetricTensor<double, 3, 3> t2 = Core::LinAlg::ddot(
+          Core::LinAlg::TensorGenerators::symmetric_identity<double, 3, 3, 3, 3>, t);
+
+      FOUR_C_EXPECT_NEAR(0.5 * (t + Core::LinAlg::transpose(t)), t2, 1e-15);
+    }
+  }
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/tests/4C_linalg_tensor_matrix_conversion_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_matrix_conversion_test.cpp
@@ -1,0 +1,262 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_tensor_matrix_conversion.hpp"
+
+#include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_symmetric_tensor_eigen.hpp"
+#include "4C_linalg_tensor_generators.hpp"
+#include "4C_unittest_utils_assertions_test.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  TEST(TensorMatrixConversionTest, makeTensor)
+  {
+    Core::LinAlg::Matrix<3, 2> matrix;
+    matrix(0, 0) = 1.0;
+    matrix(0, 1) = 2.0;
+    matrix(1, 0) = 3.0;
+    matrix(1, 1) = 4.0;
+    matrix(2, 0) = 5.0;
+    matrix(2, 1) = 6.0;
+
+    Core::LinAlg::Tensor<double, 3, 2> tensor = Core::LinAlg::make_tensor(matrix);
+    EXPECT_DOUBLE_EQ(tensor(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(tensor(0, 1), 2.0);
+    EXPECT_DOUBLE_EQ(tensor(1, 0), 3.0);
+    EXPECT_DOUBLE_EQ(tensor(1, 1), 4.0);
+    EXPECT_DOUBLE_EQ(tensor(2, 0), 5.0);
+    EXPECT_DOUBLE_EQ(tensor(2, 1), 6.0);
+  }
+
+  TEST(TensorMatrixConversionTest, makeTensorView)
+  {
+    Core::LinAlg::Matrix<3, 2> matrix;
+    matrix(0, 0) = 1.0;
+    matrix(0, 1) = 2.0;
+    matrix(1, 0) = 3.0;
+    matrix(1, 1) = 4.0;
+    matrix(2, 0) = 5.0;
+    matrix(2, 1) = 6.0;
+
+    Core::LinAlg::TensorView<double, 3, 2> tensor = Core::LinAlg::make_tensor_view(matrix);
+    EXPECT_DOUBLE_EQ(tensor(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(tensor(0, 1), 2.0);
+    EXPECT_DOUBLE_EQ(tensor(1, 0), 3.0);
+    EXPECT_DOUBLE_EQ(tensor(1, 1), 4.0);
+    EXPECT_DOUBLE_EQ(tensor(2, 0), 5.0);
+    EXPECT_DOUBLE_EQ(tensor(2, 1), 6.0);
+
+    tensor(2, 0) = 7.0;
+    EXPECT_DOUBLE_EQ(matrix(2, 0), 7.0);
+  }
+
+  TEST(TensorMatrixConversionTest, makeConstTensorView)
+  {
+    const Core::LinAlg::Matrix<3, 2> matrix = []()
+    {
+      Core::LinAlg::Matrix<3, 2> matrix;
+      matrix(0, 0) = 1.0;
+      matrix(0, 1) = 2.0;
+      matrix(1, 0) = 3.0;
+      matrix(1, 1) = 4.0;
+      matrix(2, 0) = 5.0;
+      matrix(2, 1) = 6.0;
+      return matrix;
+    }();
+
+    Core::LinAlg::TensorView<const double, 3, 2> tensor = Core::LinAlg::make_tensor_view(matrix);
+    EXPECT_DOUBLE_EQ(tensor(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(tensor(0, 1), 2.0);
+    EXPECT_DOUBLE_EQ(tensor(1, 0), 3.0);
+    EXPECT_DOUBLE_EQ(tensor(1, 1), 4.0);
+    EXPECT_DOUBLE_EQ(tensor(2, 0), 5.0);
+    EXPECT_DOUBLE_EQ(tensor(2, 1), 6.0);
+
+    EXPECT_EQ(tensor.data(), matrix.data());
+  }
+
+
+  TEST(TensorMatrixConversionTest, MakeSymmetricTensorFromStressLikeVoigtMatrix)
+  {
+    Core::LinAlg::Matrix<6, 1> stress_like_voigt;
+    stress_like_voigt(0, 0) = 1.0;
+    stress_like_voigt(1, 0) = 2.0;
+    stress_like_voigt(2, 0) = 3.0;
+    stress_like_voigt(3, 0) = 4.0;
+    stress_like_voigt(4, 0) = 5.0;
+    stress_like_voigt(5, 0) = 6.0;
+
+    Core::LinAlg::SymmetricTensor<double, 3, 3> symmetric_tensor =
+        Core::LinAlg::make_symmetric_tensor_from_stress_like_voigt_matrix(stress_like_voigt);
+
+    EXPECT_DOUBLE_EQ(symmetric_tensor(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(symmetric_tensor(1, 1), 2.0);
+    EXPECT_DOUBLE_EQ(symmetric_tensor(2, 2), 3.0);
+    EXPECT_DOUBLE_EQ(symmetric_tensor(0, 1), 4.0);
+    EXPECT_DOUBLE_EQ(symmetric_tensor(1, 2), 5.0);
+    EXPECT_DOUBLE_EQ(symmetric_tensor(0, 2), 6.0);
+  }
+
+  TEST(TensorMatrixConversionTest, reinterpretAsTensor)
+  {
+    Core::LinAlg::Matrix<3, 1> matrix;
+    matrix(0, 0) = 1.0;
+    matrix(1, 0) = 2.0;
+    matrix(2, 0) = 3.0;
+
+    Core::LinAlg::Tensor<double, 3> tensor = Core::LinAlg::reinterpret_as_tensor<3>(matrix);
+    EXPECT_DOUBLE_EQ(tensor(0), 1.0);
+    EXPECT_DOUBLE_EQ(tensor(1), 2.0);
+    EXPECT_DOUBLE_EQ(tensor(2), 3.0);
+  }
+
+  TEST(TensorMatrixConversionTest, reinterpretAsTensorView)
+  {
+    const Core::LinAlg::Matrix<3, 1> matrix = []()
+    {
+      Core::LinAlg::Matrix<3, 1> matrix;
+      matrix(0, 0) = 1.0;
+      matrix(1, 0) = 2.0;
+      matrix(2, 0) = 3.0;
+      return matrix;
+    }();
+
+    Core::LinAlg::TensorView<const double, 3> tensor =
+        Core::LinAlg::reinterpret_as_tensor_view<3>(matrix);
+    EXPECT_DOUBLE_EQ(tensor(0), 1.0);
+    EXPECT_DOUBLE_EQ(tensor(1), 2.0);
+    EXPECT_DOUBLE_EQ(tensor(2), 3.0);
+
+    EXPECT_EQ(tensor.data(), matrix.data());
+  }
+
+  TEST(TensorMatrixConversionTest, reinterpretAsConstTensorView)
+  {
+    Core::LinAlg::Matrix<3, 1> matrix;
+    matrix(0, 0) = 1.0;
+    matrix(1, 0) = 2.0;
+    matrix(2, 0) = 3.0;
+
+    Core::LinAlg::TensorView<double, 3> tensor =
+        Core::LinAlg::reinterpret_as_tensor_view<3>(matrix);
+    EXPECT_DOUBLE_EQ(tensor(0), 1.0);
+    EXPECT_DOUBLE_EQ(tensor(1), 2.0);
+    EXPECT_DOUBLE_EQ(tensor(2), 3.0);
+
+    tensor(2) = 7.0;
+    EXPECT_DOUBLE_EQ(matrix(2, 0), 7.0);
+  }
+
+  TEST(TensorMatrixConversionTest, makeMatrixView)
+  {
+    Core::LinAlg::Tensor<double, 3, 2> tensor = {{{1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0}}};
+
+    Core::LinAlg::Matrix<3, 2> matrix_view = Core::LinAlg::make_matrix_view(tensor);
+    EXPECT_DOUBLE_EQ(matrix_view(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(matrix_view(0, 1), 2.0);
+    EXPECT_DOUBLE_EQ(matrix_view(1, 0), 3.0);
+    EXPECT_DOUBLE_EQ(matrix_view(1, 1), 4.0);
+    EXPECT_DOUBLE_EQ(matrix_view(2, 0), 5.0);
+    EXPECT_DOUBLE_EQ(matrix_view(2, 1), 6.0);
+
+    matrix_view(2, 0) = 7.0;
+    EXPECT_DOUBLE_EQ(tensor(2, 0), 7.0);
+  }
+
+  TEST(TensorMatrixConversionTest, makeMatrixViewReinterpretation)
+  {
+    Core::LinAlg::Tensor<double, 3> tensor = {{1.0, 2.0, 3.0}};
+
+    Core::LinAlg::Matrix<3, 1> matrix_view = Core::LinAlg::make_matrix_view<3, 1>(tensor);
+    EXPECT_DOUBLE_EQ(matrix_view(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(matrix_view(1, 0), 2.0);
+    EXPECT_DOUBLE_EQ(matrix_view(2, 0), 3.0);
+
+    matrix_view(2, 0) = 7.0;
+    EXPECT_DOUBLE_EQ(tensor(2), 7.0);
+  }
+
+  TEST(TensorMatrixConversionTest, makeMatrix)
+  {
+    Core::LinAlg::Tensor<double, 3, 2> tensor = {{{1.0, 2.0}, {3.0, 4.0}, {5.0, 6.0}}};
+
+    Core::LinAlg::Matrix<3, 2> matrix = Core::LinAlg::make_matrix(tensor);
+    EXPECT_DOUBLE_EQ(matrix(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(matrix(0, 1), 2.0);
+    EXPECT_DOUBLE_EQ(matrix(1, 0), 3.0);
+    EXPECT_DOUBLE_EQ(matrix(1, 1), 4.0);
+    EXPECT_DOUBLE_EQ(matrix(2, 0), 5.0);
+    EXPECT_DOUBLE_EQ(matrix(2, 1), 6.0);
+
+    matrix(2, 0) = 7.0;
+    EXPECT_DOUBLE_EQ(tensor(2, 0), 5.0);
+  }
+
+  TEST(TensorMatrixConversionTest, makeMatrixReinterpretation)
+  {
+    Core::LinAlg::Tensor<double, 3> tensor = {{1.0, 2.0, 3.0}};
+
+    Core::LinAlg::Matrix<3, 1> matrix = Core::LinAlg::make_matrix<3, 1>(tensor);
+    EXPECT_DOUBLE_EQ(matrix(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(matrix(1, 0), 2.0);
+    EXPECT_DOUBLE_EQ(matrix(2, 0), 3.0);
+
+    matrix(2, 0) = 7.0;
+    EXPECT_DOUBLE_EQ(tensor(2), 3.0);
+  }
+
+  TEST(TensorMatrixConversionTest, MakeStressLikeVoigtView)
+  {
+    Core::LinAlg::SymmetricTensor<double, 3, 3> tensor =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{{
+            {1.0, 4.0, 6.0},
+            {4.0, 2.0, 5.0},
+            {6.0, 5.0, 3.0},
+        }});
+
+    Core::LinAlg::Matrix<6, 1> voigt_view = Core::LinAlg::make_stress_like_voigt_view(tensor);
+    EXPECT_DOUBLE_EQ(voigt_view(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(voigt_view(1, 0), 2.0);
+    EXPECT_DOUBLE_EQ(voigt_view(2, 0), 3.0);
+    EXPECT_DOUBLE_EQ(voigt_view(3, 0), 4.0);
+    EXPECT_DOUBLE_EQ(voigt_view(4, 0), 5.0);
+    EXPECT_DOUBLE_EQ(voigt_view(5, 0), 6.0);
+
+    voigt_view(3, 0) = 7.0;
+    EXPECT_DOUBLE_EQ(tensor(0, 1), 7.0);
+  }
+
+  TEST(TensorMatrixConversionTest, MakeStrainLikeVoigtMatrix)
+  {
+    Core::LinAlg::SymmetricTensor<double, 3, 3> tensor =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<double, 3, 3>{{
+            {1.0, 4.0, 6.0},
+            {4.0, 2.0, 5.0},
+            {6.0, 5.0, 3.0},
+        }});
+
+    Core::LinAlg::Matrix<6, 1> voigt_strain = Core::LinAlg::make_strain_like_voigt_matrix(tensor);
+    EXPECT_DOUBLE_EQ(voigt_strain(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(voigt_strain(1, 0), 2.0);
+    EXPECT_DOUBLE_EQ(voigt_strain(2, 0), 3.0);
+    EXPECT_DOUBLE_EQ(voigt_strain(3, 0), 8.0);
+    EXPECT_DOUBLE_EQ(voigt_strain(4, 0), 10.0);
+    EXPECT_DOUBLE_EQ(voigt_strain(5, 0), 12.0);
+
+    EXPECT_DOUBLE_EQ(tensor(0, 1), 4.0);
+  }
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
The following improvements are added

 * Add eigen-decomposition for symmetric tensors
 * Add generators for diagonal, identity (2nd and 4th order), symmetric identity (4th order), full tensors
 * Add conversion functions to convert tensors to matrices and vice versa
 * Add in-place operators for symmetric tensors
 * Add a lot of unit tests

This PR will then enable us to use Symmetric tensors during the solid evaluation #869 (and in a later step during solid material evaluation)