### PR TITLE
Fix failing asan for benchmark tests

### DIFF
--- a/cmake/functions/four_c_auto_define_benchmark_tests.cmake
+++ b/cmake/functions/four_c_auto_define_benchmark_tests.cmake
@@ -28,7 +28,12 @@ function(_set_up_benchmark_test_target _module_under_test _target)
 
   target_link_libraries(${_target} PRIVATE benchmark::benchmark)
 
-  add_test(NAME ${_target} COMMAND $<TARGET_FILE:${_target}> --benchmark_dry_run)
+  add_test(
+    NAME ${_target}
+    COMMAND
+      bash -c
+      ${FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS}\ $<TARGET_FILE:${_target}>\ --benchmark_dry_run
+    )
   set_tests_properties(${_target} PROPERTIES TIMEOUT ${UNITTEST_TIMEOUT})
   set_tests_properties(${_target} PROPERTIES PROCESSORS 1)
   set_tests_properties(${_target} PROPERTIES ENVIRONMENT "OMP_NUM_THREADS=1")

--- a/tests/benchmark_tests/4C_benchmark_tests_main.cpp
+++ b/tests/benchmark_tests/4C_benchmark_tests_main.cpp
@@ -22,6 +22,7 @@ int main(int argc, char** argv)
   } cleanup;
   // Kokkos should be initialized right after MPI.
   Kokkos::ScopeGuard kokkos_guard{};
+  Core::Utils::SingletonOwnerRegistry::ScopeGuard guard;
 
   benchmark::Initialize(&argc, argv);
   benchmark::RunSpecifiedBenchmarks();


### PR DESCRIPTION
Added the missing asan options to the executable of the address sanitizer.