### PR TITLE
Remove non-const getter members from `BaseDataSDyn` and remove some obsolete

### DIFF
--- a/src/structure_new/src/4C_structure_new_factory.cpp
+++ b/src/structure_new/src/4C_structure_new_factory.cpp
@@ -50,8 +50,8 @@ std::shared_ptr<Solid::Integrator> Solid::Factory::build_implicit_integrator(
 {
   std::shared_ptr<Solid::IMPLICIT::Generic> impl_int_ptr = nullptr;
 
-  const enum Inpar::Solid::DynamicType& dyntype = datasdyn.get_dynamic_type();
-  const enum Inpar::Solid::PreStress& prestresstype = datasdyn.get_pre_stress_type();
+  const enum Inpar::Solid::DynamicType dyntype = datasdyn.get_dynamic_type();
+  const enum Inpar::Solid::PreStress prestresstype = datasdyn.get_pre_stress_type();
 
   // check if we have a problem that needs to be prestressed
   const bool is_prestress = prestresstype != Inpar::Solid::PreStress::none;

--- a/src/structure_new/src/4C_structure_new_timint_base.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.cpp
@@ -158,12 +158,12 @@ bool Solid::TimeInt::Base::not_finished() const
   }
 
   // check the current time
-  const double& timenp = dataglobalstate_->get_time_np();
-  const double& timemax = datasdyn_->get_time_max();
-  const double& dt = (*dataglobalstate_->get_delta_time())[0];
+  const double timenp = dataglobalstate_->get_time_np();
+  const double timemax = datasdyn_->get_time_max();
+  const double dt = (*dataglobalstate_->get_delta_time())[0];
   // check the step counter
-  const int& stepnp = dataglobalstate_->get_step_np();
-  const int& stepmax = datasdyn_->get_step_max();
+  const int stepnp = dataglobalstate_->get_step_np();
+  const int stepmax = datasdyn_->get_step_max();
 
   return (timenp <= timemax + 1.0e-8 * dt and stepnp <= stepmax);
 }

--- a/src/structure_new/src/4C_structure_new_timint_base.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_base.hpp
@@ -346,7 +346,7 @@ namespace Solid
       void set_time_end(double timemax) override
       {
         check_init();
-        datasdyn_->get_time_max() = timemax;
+        datasdyn_->set_time_max(timemax);
       }
 
       /// Get time step size \f$\Delta t_n\f$
@@ -405,7 +405,7 @@ namespace Solid
       void set_step_end(int step_end) override
       {
         check_init_setup();
-        datasdyn_->get_step_max() = step_end;
+        datasdyn_->set_step_max(step_end);
       }
 
       //! Get divcont type
@@ -433,7 +433,8 @@ namespace Solid
       virtual double set_random_time_step_factor(double rand_tsfac)
       {
         check_init_setup();
-        return datasdyn_->get_random_time_step_factor() = rand_tsfac;
+        datasdyn_->set_random_time_step_factor(rand_tsfac);
+        return datasdyn_->get_random_time_step_factor();
       }
 
       //! Get current refinement level for time step adaption
@@ -447,7 +448,8 @@ namespace Solid
       virtual int set_div_con_refine_level(int divconrefinementlevel)
       {
         check_init_setup();
-        return datasdyn_->get_div_con_refine_level() = divconrefinementlevel;
+        datasdyn_->set_div_con_refine_level(divconrefinementlevel);
+        return datasdyn_->get_div_con_refine_level();
       }
 
       //! Get step of current refinement level for time step adaption
@@ -461,7 +463,8 @@ namespace Solid
       virtual int set_div_con_num_fine_step(int divconnumfinestep)
       {
         check_init_setup();
-        return datasdyn_->get_div_con_num_fine_step() = divconnumfinestep;
+        datasdyn_->set_div_con_num_fine_step(divconnumfinestep);
+        return datasdyn_->get_div_con_num_fine_step();
       }
 
       /// set evaluation action

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.hpp
@@ -685,13 +685,6 @@ namespace Solid
         return dt_;
       };
 
-      /// Return timer for solution technique
-      std::shared_ptr<Teuchos::Time>& get_timer()
-      {
-        check_init_setup();
-        return timer_;
-      };
-
       /// Return the prediction indicator
       bool& is_predict()
       {

--- a/src/structure_new/src/4C_structure_new_timint_basedatasdyn.hpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedatasdyn.hpp
@@ -75,10 +75,10 @@ namespace Solid
 
      protected:
       /// get the indicator state
-      inline const bool& is_init() const { return isinit_; };
+      inline bool is_init() const { return isinit_; };
 
       /// get the indicator state
-      inline const bool& is_setup() const { return issetup_; };
+      inline bool is_setup() const { return issetup_; };
 
       /// Check if init() has been called, yet.
       inline void check_init() const
@@ -97,14 +97,14 @@ namespace Solid
       ///@{
 
       /// Returns final time \f$t_\text{fin}\f$
-      const double& get_time_max() const
+      double get_time_max() const
       {
         check_init_setup();
         return timemax_;
       };
 
       /// Returns final time step \f$N\f$
-      const int& get_step_max() const
+      int get_step_max() const
       {
         check_init_setup();
         return stepmax_;
@@ -124,14 +124,14 @@ namespace Solid
       };
 
       /// Returns dynamic type
-      const enum Inpar::Solid::DynamicType& get_dynamic_type() const
+      enum Inpar::Solid::DynamicType get_dynamic_type() const
       {
         check_init_setup();
         return dyntype_;
       };
 
       /// Get type of shell thickness scaling
-      const enum Inpar::Solid::StcScale& get_stc_algo_type() const
+      enum Inpar::Solid::StcScale get_stc_algo_type() const
       {
         check_init_setup();
         return stcscale_;
@@ -224,7 +224,7 @@ namespace Solid
 
       /// Returns number of times you want to halve your timestep in case nonlinear solver
       /// diverges
-      const int& get_max_div_con_refine_level() const
+      int get_max_div_con_refine_level() const
       {
         check_init_setup();
         return maxdivconrefinementlevel_;
@@ -235,13 +235,6 @@ namespace Solid
       {
         check_init_setup();
         return *noxparams_;
-      }
-
-      /// Returns local parameters
-      const Teuchos::ParameterList& get_local_params() const
-      {
-        check_init_setup();
-        return *locaparams_;
       }
 
       /// Returns the initial pseudo time step for the PTC method
@@ -343,21 +336,21 @@ namespace Solid
       /// @name Get the different status test control parameters (read only)
       ///@{
       /// Returns the STR vector norm type
-      const enum Inpar::Solid::VectorNorm& get_norm_type() const
+      enum Inpar::Solid::VectorNorm get_norm_type() const
       {
         check_init_setup();
         return normtype_;
       }
 
       /// Returns the NOX normtype
-      const enum ::NOX::Abstract::Vector::NormType& get_nox_norm_type() const
+      enum ::NOX::Abstract::Vector::NormType get_nox_norm_type() const
       {
         check_init_setup();
         return nox_normtype_;
       }
 
       /// Return random factor for timestep in case nonlinear solver diverges
-      const double& get_random_time_step_factor() const
+      double get_random_time_step_factor() const
       {
         check_init_setup();
         return rand_tsfac_;
@@ -365,7 +358,7 @@ namespace Solid
 
 
       /// Return level of refinement in case of divercontype_ == adapt_step
-      const int& get_div_con_refine_level() const
+      int get_div_con_refine_level() const
       {
         check_init_setup();
         return divconrefinementlevel_;
@@ -373,7 +366,7 @@ namespace Solid
 
 
       /// Return number of fine steps in case of in case of divercontype_ == adapt_step
-      const int& get_div_con_num_fine_step() const
+      int get_div_con_num_fine_step() const
       {
         check_init_setup();
         return divconnumfinestep_;
@@ -428,105 +421,46 @@ namespace Solid
       ///@}
       ///@}
 
-      /// @name Get mutable general control parameters (read and write access)
+      /// @name Set some general control parameters
       ///@{
-
-      /// Returns final time \f$t_\text{fin}\f$
-      double& get_time_max()
+      /// Set final time step \f$N\f$
+      void set_step_max(int new_stepmax)
       {
         check_init_setup();
-        return timemax_;
+        stepmax_ = new_stepmax;
       };
 
-      /// Returns final time step \f$N\f$
-      int& get_step_max()
+      /// Set final time \f$t_\text{fin}\f$
+      void set_time_max(double new_timemax)
       {
         check_init_setup();
-        return stepmax_;
+        timemax_ = new_timemax;
       };
 
-      /// Returns timer for solution technique
-      std::shared_ptr<Teuchos::Time>& get_timer()
+      /// Set random factor for timestep in case nonlinear solver diverges
+      void set_random_time_step_factor(double new_rand_tsfac)
       {
         check_init_setup();
-        return timer_;
-      };
-
-      /// Returns minimal non-linear iteration number
-      int& get_iter_min()
-      {
-        check_init_setup();
-        return itermin_;
-      };
-
-      /// Returns maximal non-linear iteration number
-      int& get_iter_max()
-      {
-        check_init_setup();
-        return itermax_;
-      };
-
-      double& get_pre_stress_time()
-      {
-        check_init_setup();
-        return prestresstime_;
+        rand_tsfac_ = new_rand_tsfac;
       }
 
-      double& get_pre_stress_displacement_tolerance()
+      /// Set level of refinement in case of divercontype_ == adapt_step
+      void set_div_con_refine_level(int new_divconrefinementlevel)
       {
         check_init_setup();
-        return prestress_displacement_tolerance_;
+        divconrefinementlevel_ = new_divconrefinementlevel;
       }
 
-      [[nodiscard]] int& get_pre_stress_minimum_number_of_load_steps()
+      /// Return number of fine steps in case of in case of divercontype_ == adapt_step
+      void set_div_con_num_fine_step(int new_divconnumfinestep)
       {
         check_init_setup();
-        return prestress_min_number_of_load_steps_;
+        divconnumfinestep_ = new_divconnumfinestep;
       }
+      ///@}
 
-      /// Returns prestress type
-      enum Inpar::Solid::PreStress& get_pre_stress_type()
-      {
-        check_init_setup();
-        return prestresstype_;
-      };
-
-      /// Returns predictor type
-      enum Inpar::Solid::PredEnum& get_predictor_type()
-      {
-        check_init_setup();
-        return predtype_;
-      };
-
-      /// Returns dynamic type
-      enum Inpar::Solid::DynamicType& get_dynamic_type()
-      {
-        check_init_setup();
-        return dyntype_;
-      };
-
-      /// Returns nonlinear solver type
-      enum Inpar::Solid::NonlinSolTech& get_nln_solver_type()
-      {
-        check_init_setup();
-        return nlnsolvertype_;
-      };
-
-      /// Returns mid-time energy type
-      enum Inpar::Solid::MidAverageEnum& get_mid_time_energy_type()
-      {
-        check_init_setup();
-        return mid_time_energy_type_;
-      }
-
-      /// Returns the divergence action
-      /// Short: What to do if the non-linear solver fails.
-      enum Inpar::Solid::DivContAct& get_divergence_action()
-      {
-        check_init_setup();
-        return divergenceaction_;
-      };
-
+      /// @name Get mutable NOX parameters (read and write access)
+      ///@{
       /// Returns nox parameters
       Teuchos::ParameterList& get_nox_params()
       {
@@ -539,34 +473,6 @@ namespace Solid
       {
         check_init_setup();
         return noxparams_;
-      }
-
-      /// Returns local parameters
-      Teuchos::ParameterList& get_local_params()
-      {
-        check_init_setup();
-        return *locaparams_;
-      }
-
-      /// Return random factor for time step in case nonlinear solver diverges
-      double& get_random_time_step_factor()
-      {
-        check_init_setup();
-        return rand_tsfac_;
-      }
-
-      /// Return level of refinement in case of divercontype_ == adapt_step
-      int& get_div_con_refine_level()
-      {
-        check_init_setup();
-        return divconrefinementlevel_;
-      }
-
-      /// Return number of fine steps in case of in case of divercontype_ == adapt_step
-      int& get_div_con_num_fine_step()
-      {
-        check_init_setup();
-        return divconnumfinestep_;
       }
 
       ///@}
@@ -590,57 +496,8 @@ namespace Solid
       }
       ///@}
 
-
-      /// @name Get mutable damping control parameters (read and write access)
-      ///@{
-      /// Returns damping type
-      enum Inpar::Solid::DampKind& get_damping_type()
-      {
-        check_init_setup();
-        return damptype_;
-      };
-
-      /// Returns damping factor for stiffness \f$c_\text{K}\f$
-      double& get_damping_stiffness_factor()
-      {
-        check_init_setup();
-        return dampk_;
-      };
-
-      /// Returns damping factor for mass \f$c_\text{M}\f$
-      double& get_damping_mass_factor()
-      {
-        check_init_setup();
-        return dampm_;
-      };
-      ///@}
-
-      /// @name Get mutable mass and inertia control parameters (read and write access)
-      ///@{
-      /// Returns mass linearization type
-      enum Inpar::Solid::MassLin& get_mass_lin_type()
-      {
-        check_init_setup();
-        return masslintype_;
-      };
-      ///@}
-
       /// @name Get model evaluator control parameters (read and write access)
       ///@{
-      /// Returns types of the current active models
-      std::set<enum Inpar::Solid::ModelType>& get_model_types()
-      {
-        check_init_setup();
-        return *modeltypes_;
-      };
-
-      /// Returns the current active element technologies
-      std::set<enum Inpar::Solid::EleTech>& get_element_technologies()
-      {
-        check_init_setup();
-        return *eletechs_;
-      };
-
       /// Return a pointer to the coupling model evaluator
       const std::shared_ptr<Solid::ModelEvaluator::Generic>& coupling_model_ptr()
       {
@@ -800,9 +657,6 @@ namespace Solid
 
       /// nox parameters list
       std::shared_ptr<Teuchos::ParameterList> noxparams_;
-
-      /// local parameter list
-      std::shared_ptr<Teuchos::ParameterList> locaparams_;
 
       /// initial pseudo time step for the pseudo transient continuation (PTC) method
       double ptc_delta_init_;

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -53,7 +53,7 @@ void Solid::TimeInt::Implicit::setup()
   // ---------------------------------------------------------------------------
   // build predictor
   // ---------------------------------------------------------------------------
-  const enum Inpar::Solid::PredEnum& predtype = data_sdyn().get_predictor_type();
+  const enum Inpar::Solid::PredEnum predtype = data_sdyn().get_predictor_type();
   predictor_ptr_ = Solid::Predict::build_predictor(predtype);
   predictor_ptr_->init(predtype, implint_ptr_, dbc_ptr(), data_global_state_ptr(), data_io_ptr(),
       data_sdyn().get_nox_params_ptr());
@@ -62,7 +62,7 @@ void Solid::TimeInt::Implicit::setup()
   // ---------------------------------------------------------------------------
   // build non-linear solver
   // ---------------------------------------------------------------------------
-  const enum Inpar::Solid::NonlinSolTech& nlnSolverType = data_sdyn().get_nln_solver_type();
+  const enum Inpar::Solid::NonlinSolTech nlnSolverType = data_sdyn().get_nln_solver_type();
   if (nlnSolverType == Inpar::Solid::soltech_singlestep)
     std::cout << "WARNING!!! You are trying to solve implicitly using the \"singlestep\" nonlinear "
                  "solver. This is not encouraged, since it only works for linear statics analysis. "

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -569,8 +569,8 @@ void Solid::ModelEvaluator::Structure::rayleigh_damping_matrix()
 {
   if (eval_data().get_damping_type() != Inpar::Solid::damp_rayleigh) return;
 
-  const double& dampk = tim_int().get_data_sdyn().get_damping_stiffness_factor();
-  const double& dampm = tim_int().get_data_sdyn().get_damping_mass_factor();
+  const double dampk = tim_int().get_data_sdyn().get_damping_stiffness_factor();
+  const double dampm = tim_int().get_data_sdyn().get_damping_mass_factor();
 
   // damping matrix with initial stiffness
   damp().add(stiff(), false, dampk, 0.0);


### PR DESCRIPTION
## Description and Context
Why dealing with NOX infrastructure, I encountered many members. I tried to remove non-const getters which are not in use, also I refactored the getters of basic type to return value instead of references.

## Related Issues and Pull Requests
#359
