### PR TITLE
InputSpecBuilders::selection can store in structs

### DIFF
--- a/src/scatra/4C_scatra_functions.hpp
+++ b/src/scatra/4C_scatra_functions.hpp
@@ -58,13 +58,14 @@ namespace ScaTra
     double y_axis{};
   };
 
-  /**
-   * Parameters of the particle magnetization model
-   */
-  struct ParticleMagnetizationModelParameters
+  struct ParticleMagnetization
   {
-    double saturation_magnetization{};
-    double susceptibility{};
+    ParticleMagnetizationModelType model_type{};
+    struct ModelParameters
+    {
+      double saturation_magnetization{-1.};
+      double susceptibility{-1.};
+    } particle_magnetization_parameters{};
   };
 
   /**
@@ -76,12 +77,12 @@ namespace ScaTra
     double magnet_length{};
     double magnetic_permeability{};
     double magnet_magnetization{};
-    Position magnet_position{};
+    std::vector<double> magnet_position{};
     double dynamic_viscosity_fluid{};
     Rotation magnet_rotation{};
     double particle_radius{};
-    ParticleMagnetizationModelType particle_magnetization_model_type{};
-    ParticleMagnetizationModelParameters particle_magnetization_parameters{};
+
+    ParticleMagnetization particle_magnetization;
   };
 
   /// Attach functions to the @p function_manager.

--- a/tests/input_files/scatra_2D_external_force_magnet.4C.yaml
+++ b/tests/input_files/scatra_2D_external_force_magnet.4C.yaml
@@ -84,13 +84,15 @@ FUNCT7:
         magnet_position: [0.5, -0.2, 0.0]
         magnet_magnetization: 5e3
         dynamic_viscosity_fluid: 1.0e-3
-        rotation_around_x_axis: 90
-        rotation_around_y_axis: 45
+        rotation:
+          around_x_axis: 90
+          around_y_axis: 45
         particle_radius: 100e-6
-      particle_magnetization_model:
-        type: linear_with_saturation
-        saturation_magnetization: 4.78e2
-        susceptibility: 100.0
+        particle_magnetization_model:
+          type: linear_with_saturation
+          linear_with_saturation:
+            saturation_magnetization: 4.78e2
+            susceptibility: 100.0
 FUNCT8:
   - COMPONENT: 0
     SYMBOLIC_FUNCTION_OF_SPACE_TIME: "1"

--- a/unittests/scatra/4C_scatra_functions_test.cpp
+++ b/unittests/scatra/4C_scatra_functions_test.cpp
@@ -15,19 +15,24 @@ namespace
 
   TEST(ScatraFunctionsMagnet, TestEvaluateMagneticForceCylindricalMagnetLinearSaturation)
   {
-    constexpr auto parameters = ScaTra::CylinderMagnetParameters{
+    const auto parameters = ScaTra::CylinderMagnetParameters{
         .magnet_radius = 1.2,
         .magnet_length = 2.0,
         .magnetic_permeability = 12.234,
         .magnet_magnetization = 0.234,
-        .magnet_position = {.x = -1.0, .y = 0.0, .z = 2.3},
+        .magnet_position = {-1.0, 0.0, 2.3},
         .dynamic_viscosity_fluid = 2.0,
         .magnet_rotation = {.x_axis = 0.0, .y_axis = 0.0},
         .particle_radius = 1.0,
-        .particle_magnetization_model_type =
-            ScaTra::ParticleMagnetizationModelType::linear_with_saturation,
-        .particle_magnetization_parameters = {.saturation_magnetization = 10,
-            .susceptibility = 3.0},
+        .particle_magnetization =
+            {
+                .model_type = ScaTra::ParticleMagnetizationModelType::linear_with_saturation,
+                .particle_magnetization_parameters =
+                    {
+                        .saturation_magnetization = 10.0,
+                        .susceptibility = 3.0,
+                    },
+            },
     };
     const auto cylindrical_magnet = ScaTra::CylinderMagnetFunction(parameters);
 
@@ -53,17 +58,23 @@ namespace
 
   TEST(ScatraFunctionsMagnet, TestEvaluateMagneticForceCylindricalMagnetLinear)
   {
-    constexpr auto parameters = ScaTra::CylinderMagnetParameters{
+    const auto parameters = ScaTra::CylinderMagnetParameters{
         .magnet_radius = 1.2,
         .magnet_length = 2.0,
         .magnetic_permeability = 12.234,
         .magnet_magnetization = 0.234,
-        .magnet_position = {.x = -1.0, .y = 0.0, .z = 2.3},
+        .magnet_position = {-1.0, 0.0, 2.3},
         .dynamic_viscosity_fluid = 2.0,
         .magnet_rotation = {.x_axis = 0.0, .y_axis = 0.0},
         .particle_radius = 1.0,
-        .particle_magnetization_model_type = ScaTra::ParticleMagnetizationModelType::linear,
-        .particle_magnetization_parameters = {.susceptibility = 10.0},
+        .particle_magnetization =
+            {
+                .model_type = ScaTra::ParticleMagnetizationModelType::linear,
+                .particle_magnetization_parameters =
+                    {
+                        .susceptibility = 10.0,
+                    },
+            },
     };
     const auto cylindrical_magnet = ScaTra::CylinderMagnetFunction(parameters);
 
@@ -89,20 +100,22 @@ namespace
 
   TEST(ScatraFunctionsMagnet, TestEvaluateMagneticForceCylindricalMagnetSuperparamagnetic)
   {
-    constexpr auto parameters = ScaTra::CylinderMagnetParameters{
+    const auto parameters = ScaTra::CylinderMagnetParameters{
         .magnet_radius = 1.2,
         .magnet_length = 2.0,
         .magnetic_permeability = 12.234,
         .magnet_magnetization = 0.234,
-        .magnet_position = {.x = -1.0, .y = 0.0, .z = 2.3},
+        .magnet_position = {-1.0, 0.0, 2.3},
         .dynamic_viscosity_fluid = 2.0,
         .magnet_rotation = {.x_axis = 0.0, .y_axis = 0.0},
         .particle_radius = 1.0,
-        .particle_magnetization_model_type =
-            ScaTra::ParticleMagnetizationModelType::superparamagnetic,
-        .particle_magnetization_parameters =
+        .particle_magnetization =
             {
-                .saturation_magnetization = 10,
+                .model_type = ScaTra::ParticleMagnetizationModelType::superparamagnetic,
+                .particle_magnetization_parameters =
+                    {
+                        .saturation_magnetization = 10.0,
+                    },
             },
     };
     const auto cylindrical_magnet = ScaTra::CylinderMagnetFunction(parameters);
@@ -129,19 +142,24 @@ namespace
 
   TEST(ScatraFunctionsMagnet, TestRealValues)
   {
-    constexpr auto parameters = ScaTra::CylinderMagnetParameters{
+    const auto parameters = ScaTra::CylinderMagnetParameters{
         .magnet_radius = 2.5,
         .magnet_length = 5.0,
         .magnetic_permeability = 1.25663706212,
         .magnet_magnetization = 1e3,
-        .magnet_position = {.x = 0.0, .y = 0.0, .z = -4.5},
+        .magnet_position = {0.0, 0.0, -4.5},
         .dynamic_viscosity_fluid = 0.001,
         .magnet_rotation = {.x_axis = 0.0, .y_axis = 0.0},
         .particle_radius = 100e-6,
-        .particle_magnetization_model_type =
-            ScaTra::ParticleMagnetizationModelType::linear_with_saturation,
-        .particle_magnetization_parameters = {.saturation_magnetization = 4.78e2,
-            .susceptibility = 3.0},
+        .particle_magnetization =
+            {
+                .model_type = ScaTra::ParticleMagnetizationModelType::linear_with_saturation,
+                .particle_magnetization_parameters =
+                    {
+                        .saturation_magnetization = 4.78e2,
+                        .susceptibility = 3.0,
+                    },
+            },
 
     };
     const auto cylindrical_magnet = ScaTra::CylinderMagnetFunction(parameters);


### PR DESCRIPTION
Since we prefer to use `selection` over `one_of`, it should also be able to store directly to a struct following #873. 