### PR TITLE
Fix spacing for fill complete console output

### DIFF
--- a/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
@@ -66,7 +66,7 @@ int Core::FE::Discretization::fill_complete(
         << "\n+--------------------------------------------------------------------+"
         << Core::IO::endl;
     Core::IO::cout(Core::IO::verbose)
-        << "| fill_complete() on discretization " << std::setw(34) << std::left << name()
+        << "| fill_complete() on discretization " << std::setw(33) << std::left << name()
         << std::setw(1) << std::right << "|" << Core::IO::endl;
   }
 
@@ -101,7 +101,7 @@ int Core::FE::Discretization::fill_complete(
     if (myrank == 0)
     {
       Core::IO::cout(Core::IO::verbose)
-          << "| assign_degrees_of_freedom() ...                                       |"
+          << "| assign_degrees_of_freedom() ...                                    |"
           << Core::IO::endl;
     }
     assign_degrees_of_freedom(0);
@@ -113,7 +113,7 @@ int Core::FE::Discretization::fill_complete(
     if (myrank == 0)
     {
       Core::IO::cout(Core::IO::verbose)
-          << "| initialize_elements() ...                                           |"
+          << "| initialize_elements() ...                                          |"
           << Core::IO::endl;
     }
     initialize_elements();
@@ -125,7 +125,7 @@ int Core::FE::Discretization::fill_complete(
     if (myrank == 0)
     {
       Core::IO::cout(Core::IO::verbose)
-          << "| boundary_conditions_geometry() ...                                   |"
+          << "| boundary_conditions_geometry() ...                                 |"
           << Core::IO::endl;
     }
 


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
The `|` symbols were not aligned in the `fill_complete()` call ... it annoyed me so this PR fixes it.