### PR TITLE
Fix structure new solver factory

### DIFF
--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -21,21 +21,22 @@ FOUR_C_NAMESPACE_OPEN
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
 void Core::LinearSolver::Parameters::compute_solver_parameters(
-    Core::FE::Discretization& dis, Teuchos::ParameterList& solverlist)
+    const Core::FE::Discretization& dis, Teuchos::ParameterList& solverlist)
 {
-  std::shared_ptr<Core::LinAlg::Map> nullspaceMap =
+  const auto nullspace_node_map =
       solverlist.get<std::shared_ptr<Core::LinAlg::Map>>("null space: node map", nullptr);
   auto nullspace_dof_map =
       solverlist.get<std::shared_ptr<Core::LinAlg::Map>>("null space: dof map", nullptr);
 
   int numdf = 1;
   int dimns = 1;
-  int nv = 0;
-  int np = 0;
 
   // set parameter information for solver
   {
-    if (nullspaceMap == nullptr and dis.num_my_row_nodes() > 0)
+    int nv = 0;
+    int np = 0;
+
+    if (nullspace_node_map == nullptr and dis.num_my_row_nodes() > 0)
     {
       // no map given, just grab the block information on the first element that appears
       Core::Elements::Element* dwele = dis.l_row_element(0);
@@ -49,7 +50,7 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
         Core::Nodes::Node* actnode = dis.l_row_node(i);
         std::vector<int> dofs = dis.dof(0, actnode);
 
-        const int localIndex = nullspaceMap->lid(dofs[0]);
+        const int localIndex = nullspace_node_map->lid(dofs[0]);
 
         if (localIndex == -1) continue;
 
@@ -65,8 +66,6 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
     Core::Communication::max_all(ldata.data(), gdata.data(), 4, dis.get_comm());
     numdf = gdata[0];
     dimns = gdata[1];
-    nv = gdata[2];
-    np = gdata[3];
 
     // store nullspace information in solver list
     solverlist.set("PDE equations", numdf);
@@ -78,10 +77,10 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
   // set coordinate information
   {
     std::shared_ptr<Core::LinAlg::MultiVector<double>> coordinates;
-    if (nullspaceMap == nullptr)
+    if (nullspace_node_map == nullptr)
       coordinates = dis.build_node_coordinates();
     else
-      coordinates = dis.build_node_coordinates(nullspaceMap);
+      coordinates = dis.build_node_coordinates(nullspace_node_map);
 
     solverlist.set<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("Coordinates", coordinates);
   }
@@ -95,7 +94,7 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
       nullspace_dof_map = std::make_shared<Core::LinAlg::Map>(*dis.dof_row_map());
     }
 
-    auto nullspace = Core::FE::compute_null_space(dis, numdf, dimns, *nullspace_dof_map);
+    const auto nullspace = Core::FE::compute_null_space(dis, numdf, dimns, *nullspace_dof_map);
 
     solverlist.set<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("nullspace", nullspace);
     solverlist.set("null space: vectors", nullspace->Values());

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -24,7 +24,9 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
     Core::FE::Discretization& dis, Teuchos::ParameterList& solverlist)
 {
   std::shared_ptr<Core::LinAlg::Map> nullspaceMap =
-      solverlist.get<std::shared_ptr<Core::LinAlg::Map>>("null space: map", nullptr);
+      solverlist.get<std::shared_ptr<Core::LinAlg::Map>>("null space: node map", nullptr);
+  auto nullspace_dof_map =
+      solverlist.get<std::shared_ptr<Core::LinAlg::Map>>("null space: dof map", nullptr);
 
   int numdf = 1;
   int dimns = 1;
@@ -86,14 +88,14 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
 
   // set nullspace information
   {
-    if (nullspaceMap == nullptr)
+    if (nullspace_dof_map == nullptr)
     {
       // if no map is given, we calculate the nullspace on the map describing the
       // whole discretization
-      nullspaceMap = std::make_shared<Core::LinAlg::Map>(*dis.dof_row_map());
+      nullspace_dof_map = std::make_shared<Core::LinAlg::Map>(*dis.dof_row_map());
     }
 
-    auto nullspace = Core::FE::compute_null_space(dis, numdf, dimns, *nullspaceMap);
+    auto nullspace = Core::FE::compute_null_space(dis, numdf, dimns, *nullspace_dof_map);
 
     solverlist.set<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("nullspace", nullspace);
     solverlist.set("null space: vectors", nullspace->Values());

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.hpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.hpp
@@ -36,7 +36,7 @@ namespace Core::LinearSolver
       into the solver parameter list.
     */
     static void compute_solver_parameters(
-        Core::FE::Discretization& dis, Teuchos::ParameterList& solverlist);
+        const Core::FE::Discretization& dis, Teuchos::ParameterList& solverlist);
 
     /*!
      * \brief Fix the nullspace to match a new given map


### PR DESCRIPTION
## Description and Context
While working on the usage of Teko in the last remaining `AMGnxn` or `multigrid_nxn`, I believe I have realized an inconsistency in the current usage of `Core::LinearSolver::Parameters::compute_solver_parameters`. The creation of the nullspace can be influenced by a map, e.g., if the source of the block structure of your matrix is a subdivision of the geometry (like we have it in electrochemistry problems, this is why I stumbled over this).

However, so far, only one map has been used, even though the methods that consume this map have different requirements (can be seen from the methods definition and from the default maps that are handed in, if no external map has been provided):
- build_node_coordinates -> requires a node-based map
- Core::FE::compute_null_space -> requires a dof-based map

Now, I provide two maps, one node-based and one dof-based, and consume the respective in the relevant call. There is one test case that uses this functionality: `beam3eb_static_beam_to_solid_volume_meshtying_cube.4C.yaml`. It passes before the change and after the change, maybe because it only subdivides into beam and solid. However, when I did that locally for electrochemistry problems (changes not yet completed), I got the wrong dimensionality of the coordinates, due to the map mismatch I described above.

The relevant changes concerning the described map mismatch are only in the first commit. The second commit just does some additional cleanup.

I'll also mark the relevant lines of code in a diff afterwards.

## Related Issues and Pull Requests
related #754 
