### PR TITLE
Simplify selection in input files

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -304,6 +304,10 @@ namespace
       case InputSpecType::selection:
       {
         print_match_state();
+        if (entry.state == MatchEntry::State::partial && !entry.additional_info.empty())
+        {
+          out << " " << entry.additional_info;
+        }
         out << '\n';
         if (entry.state == MatchEntry::State::partial)
         {

--- a/src/core/io/tests/4C_io_input_input_field_test.cpp
+++ b/src/core/io/tests/4C_io_input_input_field_test.cpp
@@ -47,8 +47,7 @@ namespace
       ryml::Tree tree = init_yaml_tree_with_exceptions();
       ryml::NodeRef root = tree.rootref();
       ryml::parse_in_arena(R"(stiffness:
-              type: constant
-              value: 1.0)",
+              constant: 1.0)",
           root);
 
       ConstYamlNodeRef node(root, "");
@@ -62,8 +61,7 @@ namespace
       SCOPED_TRACE("Input field from file");
       ryml::Tree tree = init_yaml_tree_with_exceptions();
       ryml::NodeRef root = tree.rootref();
-      ryml::parse_in_arena(
-          ("stiffness:\n    type: from_file\n    value: " + input_field_file).c_str(), root);
+      ryml::parse_in_arena(("stiffness:\n    from_file: " + input_field_file).c_str(), root);
       std::flush(std::cout);
       ConstYamlNodeRef node(root, "");
       InputParameterContainer container;

--- a/src/scatra/4C_scatra_functions.cpp
+++ b/src/scatra/4C_scatra_functions.cpp
@@ -86,18 +86,15 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
   auto particle_magnetization = selection<ParticleMagnetizationModelType, ParticleMagnetization>(
       "particle_magnetization_model",
       {
-          .selector = "type",
-          .choices =
-              {
-                  {ParticleMagnetizationModelType::linear, std::move(linear)},
-                  {ParticleMagnetizationModelType::linear_with_saturation,
-                      std::move(linear_with_saturation)},
-                  {ParticleMagnetizationModelType::superparamagnetic, std::move(superparamagnetic)},
-              },
-          .store_selector = in_struct(&ParticleMagnetization::model_type),
+          std::move(linear),
+          std::move(linear_with_saturation),
+          std::move(superparamagnetic),
       },
-      {.description = "Magnetization model for the demagnetization factor f(|H|)",
-          .store = in_struct(&CylinderMagnetParameters::particle_magnetization)});
+      {
+          .description = "Magnetization model for the demagnetization factor f(|H|)",
+          .store = in_struct(&CylinderMagnetParameters::particle_magnetization),
+          .store_selector = in_struct(&ParticleMagnetization::model_type),
+      });
 
   auto spec = group("SCATRA_FUNCTION",
       {

--- a/tests/input_files/scatra_2D_external_force_magnet.4C.yaml
+++ b/tests/input_files/scatra_2D_external_force_magnet.4C.yaml
@@ -89,7 +89,6 @@ FUNCT7:
           around_y_axis: 45
         particle_radius: 100e-6
         particle_magnetization_model:
-          type: linear_with_saturation
           linear_with_saturation:
             saturation_magnetization: 4.78e2
             susceptibility: 100.0

--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -211,42 +211,12 @@ def schema_from_selection(selection):
     specs = []
 
     for choice in selection.choices:
-        # Add the selection parameter
-        selector_variable = Primitive(
-            name=selection.selector,
-            type="string",
-            required=True,
-            description=f"Selector type {choice.name} for {selection.name} (string)",
-            constant=choice.name,
-        )
-
-        choice = All_Of(
-            name=choice.name,
-            required=True,
-            description=f"Selector type {choice.name} for {selection.name} (string)",
-            specs=[selector_variable, choice.spec],
-        )
-        specs.append(choice)
+        specs.append(choice.spec)
 
     # The choices are options of a one_of
     schema = schema_from_one_of(One_Of(description=selection.description, specs=specs))
 
     schema["title"] = selection.short_description()
-
-    # Add the options additionally as property to be able to chose between them
-    schema["properties"] = {
-        selection.selector: schema_from_base_type(
-            Enum(
-                name=selection.selector,
-                type="string",
-                required=True,
-                description=f"Selector type for {selection.name} (string)\n"
-                + "\nchoices are: "
-                + ", ".join([choice.name for choice in selection.choices]),
-                choices=[choice.name for choice in selection.choices],
-            )
-        )
-    }
 
     # Selection can be noneable
     if selection.noneable:

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -302,7 +302,6 @@ class Selection(Collection):
     name: str = None
     noneable: bool = False
     required: bool = False
-    selector: str = None
 
     def __post_init__(self):
         self.type = "selection"


### PR DESCRIPTION
Depends on #890 

Simplify the way a selection looks in the input file by kicking the selector value. Instead, we now require every possible choice to be named exactly like one of the enum constants you are selecting over (this is checked).

Old

```yaml
time_integration:
  type: OST
  OST:
    theta: 0.66
```

New

```yaml
time_integration:
  OST:
    theta: 0.66
```