### PR TITLE
Fix `input_field_callback()`

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -593,7 +593,7 @@ namespace Core::IO
       }
       else if (in.get<InputFieldType>("type") == InputFieldType::constant)
       {
-        double data = in.get<T>("value");
+        T data = in.get<T>("value");
         std::any_cast<InputParameterContainer&>(out).add(name, IO::InputField<T>(data));
       }
       else


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
I think for the `value` case in the `input_field_callback()` we want to use the template type instead of storing into a hard-coded `double`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Follows #890 