### PR TITLE
Add artery flow rate to function coupling

### DIFF
--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.hpp
@@ -429,6 +429,7 @@ namespace PoroPressureBased
     //! evaluate the function coupling
     void evaluate_function_coupling(const double& gp_weight,
         const Core::LinAlg::Matrix<1, num_nodes_artery_>& shape_functions_artery,
+        const Core::LinAlg::Matrix<1, num_nodes_artery_>& shape_functions_artery_deriv,
         const Core::LinAlg::Matrix<1, num_nodes_homogenized_>& shape_functions_homogenized,
         const double& jacobi, Core::LinAlg::SerialDenseVector& ele_rhs_artery,
         Core::LinAlg::SerialDenseVector& ele_rhs_homogenized,
@@ -451,7 +452,9 @@ namespace PoroPressureBased
     //! get values of artery at GP
     void get_artery_values_at_gp(
         const Core::LinAlg::Matrix<1, num_nodes_artery_>& shape_functions_artery,
-        double& artery_pressure, std::vector<double>& artery_scalars);
+        const Core::LinAlg::Matrix<1, num_nodes_artery_>& shape_functions_artery_deriv,
+        double& artery_pressure, double& artery_pressure_gradient,
+        std::vector<double>& artery_scalars);
 
     //! get scalar values of homogenized discretization at GP
     void get_homogenized_scalar_values_at_gp(
@@ -482,11 +485,14 @@ namespace PoroPressureBased
         Core::LinAlg::SerialDenseMatrix& ele_matrix_homogenized_homogenized);
 
     //! evaluate function and its derivative
-
     void evaluate_function_and_deriv(const Core::Utils::FunctionOfAnything& function,
-        const double& artery_pressure, const std::vector<double>& artery_scalars,
-        const std::vector<double>& homogenized_scalars, double& function_value,
-        std::vector<double>& artery_derivs, std::vector<double>& homogenized_derivs);
+        const double& artery_pressure, const double& artery_element_flow_rate,
+        const std::vector<double>& artery_scalars, const std::vector<double>& homogenized_scalars,
+        double& function_value, std::vector<double>& artery_derivs,
+        std::vector<double>& homogenized_derivs);
+
+    //! evaluate artery flow rate based on Hagen-Poiseuille law
+    double evaluate_artery_flow_rate(double artery_pressure_gradient) const;
 
     //! set scalar as constants into function
     void set_scalar_values_as_constants(std::vector<std::pair<std::string, double>>& constants,

--- a/tests/input_files/poromultielastscatra_2D_quad4_linebased_artery_coupling_mono.4C.yaml
+++ b/tests/input_files/poromultielastscatra_2D_quad4_linebased_artery_coupling_mono.4C.yaml
@@ -273,13 +273,13 @@ FUNCT8:
 FUNCT9:
   - SYMBOLIC_FUNCTION_OF_SPACE_TIME: "x*y*t"
 FUNCT10:
-  - VARFUNCTION: "pi*D*0.1*(p_art-p3)"
+  - VARFUNCTION: "pi*D*0.1*(p_art-p3)+Q_art*1.0e-7"
 FUNCT11:
-  - VARFUNCTION: "pi*D*0.8*(phi_art1-phi1)+pi*D*0.001*(p_art-p3)*(phi_art1-phi1)"
+  - VARFUNCTION: "pi*D*0.8*(phi_art1-phi1)+pi*D*0.001*(p_art-p3)*(phi_art1-phi1)+Q_art*1.0e-7"
 FUNCT12:
-  - VARFUNCTION: "pi*D*1.0*(p_art-p3)"
+  - VARFUNCTION: "pi*D*1.0*(p_art-p3)+Q_art*1.0e-7"
 FUNCT13:
-  - VARFUNCTION: "pi*D*8.0*(phi_art1-phi1)+pi*D*0.01*(p_art-p3)*(phi_art1-phi1)"
+  - VARFUNCTION: "pi*D*8.0*(phi_art1-phi1)+pi*D*0.01*(p_art-p3)*(phi_art1-phi1)+Q_art*1.0e-7"
 FUNCT14:
   - VARFUNCTION: "D0"
 DESIGN SURF PORO DIRICH CONDITIONS:
@@ -657,95 +657,95 @@ RESULT DESCRIPTION:
       DIS: "artery"
       NODE: 66
       QUANTITY: "pressure"
-      VALUE: 68.85394773275169
+      VALUE: 6.88539474204398942e+01
       TOLERANCE: 1e-08
   - ARTNET:
       DIS: "artery"
       NODE: 67
       QUANTITY: "pressure"
-      VALUE: 48.24751595102863
+      VALUE: 4.82475155073472877e+01
       TOLERANCE: 1e-08
   - ARTNET:
       DIS: "artery"
       NODE: 68
       QUANTITY: "pressure"
-      VALUE: 33.06302924217277
+      VALUE: 3.30630287716203739e+01
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 12
       QUANTITY: "pressure3"
-      VALUE: 5.569410071518632
+      VALUE: 5.56941001760523946
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 22
       QUANTITY: "pressure3"
-      VALUE: 5.244129870589827
+      VALUE: 5.24412979342100893
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 21
       QUANTITY: "pressure3"
-      VALUE: 5.15672152241522
+      VALUE: 5.15672144618893480
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 29
       QUANTITY: "pressure3"
-      VALUE: 5.378127296213489
+      VALUE: 5.37812718975774384
       TOLERANCE: 1e-08
   - POROFLUIDMULTIPHASE:
       DIS: "porofluid"
       NODE: 44
       QUANTITY: "pressure3"
-      VALUE: 1.7867759892960327
+      VALUE: 1.78677591959180448
       TOLERANCE: 1e-08
   - SCATRA:
       DIS: "artery_scatra"
       NODE: 67
       QUANTITY: "phi1"
-      VALUE: 0.9809431561793567
+      VALUE: 9.80943146493071350e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "artery_scatra"
       NODE: 69
       QUANTITY: "phi1"
-      VALUE: 0.9524822296114175
+      VALUE: 9.52482214153308027e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "artery_scatra"
       NODE: 71
       QUANTITY: "phi1"
-      VALUE: 0.9141179546944582
+      VALUE: 9.14117936526582131e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "artery_scatra"
       NODE: 73
       QUANTITY: "phi1"
-      VALUE: 0.8728506582471492
+      VALUE: 8.72850639527837258e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "scatra"
       NODE: 14
       QUANTITY: "phi1"
-      VALUE: 0.9028716904247225
+      VALUE: 9.02871683138080749e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "scatra"
       NODE: 21
       QUANTITY: "phi1"
-      VALUE: 0.9226385957858885
+      VALUE: 9.22638589059604275e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "scatra"
       NODE: 35
       QUANTITY: "phi1"
-      VALUE: 0.8710774571527193
+      VALUE: 8.71077446196721450e-01
       TOLERANCE: 1e-10
   - SCATRA:
       DIS: "scatra"
       NODE: 29
       QUANTITY: "phi1"
-      VALUE: 0.9206215345430621
+      VALUE: 9.20621524260734070e-01
       TOLERANCE: 1e-10


### PR DESCRIPTION
This PR adds the flow rate of the reduced-dimensional arteries to the function coupling in the porofluid-elasticity framework with scalar transport. 
