### PR TITLE
Allow FAD-types in tensors

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_symmetric_tensor.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_symmetric_tensor.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_linalg_tensor.hpp"
+#include "4C_linalg_tensor_internals.hpp"
 #include "4C_linalg_tensor_meta_utils.hpp"
 #include "4C_utils_exceptions.hpp"
 
@@ -192,8 +193,9 @@ namespace Core::LinAlg
   }  // namespace Internal
 
   template <typename T>
-  constexpr bool is_symmetric_tensor = Internal::IsSymmetricCompressionTypeHelper<
-      TensorCompressionType<std::remove_cvref_t<T>>>::value;
+  constexpr bool is_symmetric_tensor =
+      is_tensor<T> && Internal::IsSymmetricCompressionTypeHelper<
+                          TensorCompressionType<std::remove_cvref_t<T>>>::value;
 
   /*!
    * @brief An owning, dense tensor of arbitrary rank with symmetry
@@ -304,7 +306,8 @@ namespace Core::LinAlg
    * @tparam OtherTensor
    */
   template <typename OtherTensor, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    requires(is_tensor<OtherTensor> &&
+             std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator+=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -316,7 +319,8 @@ namespace Core::LinAlg
    * @tparam OtherTensor
    */
   template <typename OtherTensor, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    requires(is_tensor<OtherTensor> &&
+             std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator-=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -328,7 +332,7 @@ namespace Core::LinAlg
    * @tparam OtherTensor
    */
   template <typename Scalar, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_arithmetic_v<Scalar>)
+    requires(is_scalar<Scalar>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator*=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -343,7 +347,7 @@ namespace Core::LinAlg
    * @tparam n
    */
   template <typename Scalar, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_arithmetic_v<Scalar>)
+    requires(is_scalar<Scalar>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator/=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -352,7 +356,7 @@ namespace Core::LinAlg
   /*!
    * @brief Compute the determinant of a symmetric tensor
    */
-  constexpr auto det(const TensorConcept auto& A)
+  constexpr auto det(const auto& A)
     requires(is_symmetric_tensor<decltype(A)>);
 
   /*!
@@ -389,7 +393,8 @@ namespace Core::LinAlg
    * @tparam TensorRight
    */
   template <typename TensorLeft, typename TensorRight>
-    requires(TensorLeft::rank() >= 2 && TensorRight::rank() >= 2 &&
+    requires(is_tensor<TensorLeft> && is_tensor<TensorRight> && TensorLeft::rank() >= 2 &&
+             TensorRight::rank() >= 2 &&
              TensorLeft::template extent<TensorLeft::rank() - 2>() ==
                  TensorRight::template extent<0>() &&
              TensorLeft::template extent<TensorLeft::rank() - 1>() ==
@@ -401,7 +406,7 @@ namespace Core::LinAlg
    * @brief Scales the tensor with a scalar value
    */
   template <typename Tensor, typename Scalar>
-    requires(std::is_arithmetic_v<Scalar> && is_symmetric_tensor<Tensor>)
+    requires(is_scalar<Scalar> && is_symmetric_tensor<Tensor>)
   constexpr auto scale(const Tensor& tensor, const Scalar& b);
 
   /*!
@@ -425,8 +430,7 @@ namespace Core::LinAlg
    * tensor
    */
   template <typename TensorLeft, typename TensorRight>
-    requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight> &&
-             is_symmetric_tensor<TensorLeft> && is_symmetric_tensor<TensorRight>)
+    requires(is_symmetric_tensor<TensorLeft> && is_symmetric_tensor<TensorRight>)
   constexpr auto dyadic(const TensorLeft& A, const TensorRight& B);
 
   /*!
@@ -438,8 +442,7 @@ namespace Core::LinAlg
    */
   template <unsigned num_dyads = 2>
   constexpr auto self_dyadic(const auto& a)
-    requires(TensorConcept<std::remove_cvref_t<decltype(a)>> &&
-             std::remove_cvref_t<decltype(a)>::rank() == 1);
+    requires(is_tensor<decltype(a)> && std::remove_cvref_t<decltype(a)>::rank() == 1);
 
   // actual implementations
   template <typename Number, TensorStorageType storage_type, std::size_t... n>
@@ -520,7 +523,8 @@ namespace Core::LinAlg
   }
 
   template <typename OtherTensor, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    requires(is_tensor<OtherTensor> &&
+             std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator+=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -534,7 +538,8 @@ namespace Core::LinAlg
   }
 
   template <typename OtherTensor, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
+    requires(is_tensor<OtherTensor> &&
+             std::is_same_v<typename OtherTensor::shape_type, typename OtherTensor::shape_type>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator-=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -548,7 +553,7 @@ namespace Core::LinAlg
   }
 
   template <typename Scalar, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_arithmetic_v<Scalar>)
+    requires(is_scalar<Scalar>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator*=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -559,7 +564,7 @@ namespace Core::LinAlg
   }
 
   template <typename Scalar, typename Number, TensorStorageType storage_type, std::size_t... n>
-    requires(std::is_arithmetic_v<Scalar>)
+    requires(is_scalar<Scalar>)
   constexpr TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>&
   operator/=(
       TensorInternal<Number, storage_type, Internal::SymmetricCompression<n...>, n...>& tensor,
@@ -652,7 +657,7 @@ namespace Core::LinAlg
   }  // namespace Internal
 
   // define tensor operations for symmetric tensors
-  constexpr auto det(const TensorConcept auto& A)
+  constexpr auto det(const auto& A)
     requires(is_symmetric_tensor<decltype(A)>)
   {
     return det(get_full(A));
@@ -697,7 +702,8 @@ namespace Core::LinAlg
   }
 
   template <typename TensorLeft, typename TensorRight>
-    requires(TensorLeft::rank() >= 2 && TensorRight::rank() >= 2 &&
+    requires(is_tensor<TensorLeft> && is_tensor<TensorRight> && TensorLeft::rank() >= 2 &&
+             TensorRight::rank() >= 2 &&
              TensorLeft::template extent<TensorLeft::rank() - 2>() ==
                  TensorRight::template extent<0>() &&
              TensorLeft::template extent<TensorLeft::rank() - 1>() ==
@@ -756,7 +762,7 @@ namespace Core::LinAlg
   }
 
   template <typename Tensor, typename Scalar>
-    requires(std::is_arithmetic_v<Scalar> && is_symmetric_tensor<Tensor>)
+    requires(is_scalar<Scalar> && is_symmetric_tensor<Tensor>)
   constexpr auto scale(const Tensor& tensor, const Scalar& b)
   {
     return assume_symmetry(scale(get_full(tensor), b));
@@ -779,8 +785,7 @@ namespace Core::LinAlg
   }
 
   template <typename TensorLeft, typename TensorRight>
-    requires(TensorConcept<TensorLeft> && TensorConcept<TensorRight> &&
-             is_symmetric_tensor<TensorLeft> && is_symmetric_tensor<TensorRight>)
+    requires(is_symmetric_tensor<TensorLeft> && is_symmetric_tensor<TensorRight>)
   constexpr auto dyadic(const TensorLeft& A, const TensorRight& B)
   {
     return assume_symmetry(dyadic(get_full(A), get_full(B)));
@@ -788,8 +793,7 @@ namespace Core::LinAlg
 
   template <unsigned num_dyads>
   constexpr auto self_dyadic(const auto& a)
-    requires(TensorConcept<std::remove_cvref_t<decltype(a)>> &&
-             std::remove_cvref_t<decltype(a)>::rank() == 1)
+    requires(is_tensor<decltype(a)> && std::remove_cvref_t<decltype(a)>::rank() == 1)
   {
     static_assert(
         num_dyads == 2 || num_dyads == 4, "Only self dyadic with two or four dyads are supported.");

--- a/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
@@ -10,12 +10,11 @@
 
 #include "4C_config.hpp"
 
-#include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_tensor_meta_utils.hpp"
+#include "4C_utils_fad_meta.hpp"
 
 #include <algorithm>
 #include <array>
-#include <concepts>
 #include <cstddef>
 #include <cstring>
 #include <span>
@@ -296,6 +295,16 @@ namespace Core::LinAlg
 
   namespace Internal
   {
+    template <typename T>
+    struct HasTensorBase : std::false_type
+    {
+    };
+    template <typename Number, TensorStorageType storage_type, typename Compression,
+        std::size_t... n>
+    struct HasTensorBase<TensorInternal<Number, storage_type, Compression, n...>> : std::true_type
+    {
+    };
+
     template <typename Tensor>
     struct CompressionTypeHelper;
 
@@ -306,6 +315,21 @@ namespace Core::LinAlg
       using type = Compression;
     };
   }  // namespace Internal
+
+  /*!
+   * @brief A check whether a given type is a tensor
+   *
+   * @tparam T
+   */
+  template <typename T>
+  static constexpr bool is_tensor = Internal::HasTensorBase<std::remove_cvref_t<T>>::value;
+
+  /*!
+   * @brief A check whether a type is a admissible scalar type for a tensor
+   */
+  template <typename Scalar>
+  static constexpr bool is_scalar =
+      std::is_arithmetic_v<Scalar> || FADUtils::SacadoFadType<std::remove_cvref_t<Scalar>>;
 
   template <typename Tensor>
   using TensorCompressionType =

--- a/src/core/linalg/tests/4C_linalg_tensor_fad_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_fad_test.cpp
@@ -1,0 +1,294 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_symmetric_tensor.hpp"
+#include "4C_linalg_tensor.hpp"
+
+#include <Sacado.hpp>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace
+{
+  TEST(TensorFAD, TensorWithFADTypeScale)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::Tensor<FadType, 2> t = {{FadType(2, 0, 1.1), FadType(2, 1, 1.2)}};
+    {
+      auto scaled_t = 2.3 * t;  // scaled with double
+      static_assert(std::is_same_v<typename decltype(scaled_t)::value_type, FadType>);
+      EXPECT_NEAR(scaled_t(0).val(), 2.53, 1e-10);
+      EXPECT_NEAR(scaled_t(1).val(), 2.76, 1e-10);
+      EXPECT_NEAR(scaled_t(0).dx(0), 2.3, 1e-10);
+      EXPECT_NEAR(scaled_t(1).dx(0), 0.0, 1e-10);
+      EXPECT_NEAR(scaled_t(0).dx(1), 0.0, 1e-10);
+      EXPECT_NEAR(scaled_t(1).dx(1), 2.3, 1e-10);
+    }
+
+    {
+      FadType a(2.3);
+      auto scaled_t = 2 * a * t;  // scaled with Fad-operation
+      static_assert(std::is_same_v<typename decltype(scaled_t)::value_type, FadType>);
+      EXPECT_NEAR(scaled_t(0).val(), 5.06, 1e-10);
+      EXPECT_NEAR(scaled_t(1).val(), 5.52, 1e-10);
+      EXPECT_NEAR(scaled_t(0).dx(0), 4.6, 1e-10);
+      EXPECT_NEAR(scaled_t(1).dx(0), 0.0, 1e-10);
+      EXPECT_NEAR(scaled_t(0).dx(1), 0.0, 1e-10);
+      EXPECT_NEAR(scaled_t(1).dx(1), 4.6, 1e-10);
+    }
+
+    {
+      FadType a(2);
+      auto scaled_t = 2 * a * t;  // scaled with Fad-operation
+      static_assert(std::is_same_v<typename decltype(scaled_t)::value_type, FadType>);
+      EXPECT_NEAR(scaled_t(0).val(), 4.4, 1e-10);
+      EXPECT_NEAR(scaled_t(1).val(), 4.8, 1e-10);
+      EXPECT_NEAR(scaled_t(0).dx(0), 4, 1e-10);
+      EXPECT_NEAR(scaled_t(1).dx(0), 0.0, 1e-10);
+      EXPECT_NEAR(scaled_t(0).dx(1), 0.0, 1e-10);
+      EXPECT_NEAR(scaled_t(1).dx(1), 4, 1e-10);
+    }
+  }
+  TEST(TensorFAD, TensorWithFADTypeAdd)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::Tensor<FadType, 2> t = {{FadType(2, 0, 1.1), FadType(2, 1, 1.2)}};
+    const Core::LinAlg::Tensor<FadType, 2> t2 = {{FadType(1.2), FadType(1.3)}};
+    {
+      auto result = t + t2;
+      static_assert(std::is_same_v<typename decltype(result)::value_type, FadType>);
+      EXPECT_NEAR(result(0).val(), 2.3, 1e-10);
+      EXPECT_NEAR(result(1).val(), 2.5, 1e-10);
+      EXPECT_NEAR(result(0).dx(0), 1.0, 1e-10);
+      EXPECT_NEAR(result(1).dx(0), 0.0, 1e-10);
+      EXPECT_NEAR(result(0).dx(1), 0.0, 1e-10);
+      EXPECT_NEAR(result(1).dx(1), 1.0, 1e-10);
+    }
+  }
+  TEST(TensorFAD, TensorWithFADTypeSubtract)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::Tensor<FadType, 2> t = {{FadType(2, 0, 1.1), FadType(2, 1, 1.2)}};
+    const Core::LinAlg::Tensor<FadType, 2> t2 = {{FadType(1.2), FadType(1.4)}};
+    {
+      auto result = t - t2;
+      static_assert(std::is_same_v<typename decltype(result)::value_type, FadType>);
+      EXPECT_NEAR(result(0).val(), -0.1, 1e-10);
+      EXPECT_NEAR(result(1).val(), -0.2, 1e-10);
+      EXPECT_NEAR(result(0).dx(0), 1.0, 1e-10);
+      EXPECT_NEAR(result(1).dx(0), 0.0, 1e-10);
+      EXPECT_NEAR(result(0).dx(1), 0.0, 1e-10);
+      EXPECT_NEAR(result(1).dx(1), 1.0, 1e-10);
+    }
+  }
+  TEST(TensorFAD, TensorWithFADTypeDot)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::Tensor<FadType, 2> t = {{FadType(2, 0, 1.1), FadType(2, 1, 1.2)}};
+    const Core::LinAlg::Tensor<FadType, 2> t2 = {{FadType(1.2), FadType(1.4)}};
+    {
+      auto result = t * t2;
+      static_assert(std::is_same_v<decltype(result), FadType>);
+      EXPECT_NEAR(result.val(), 3.0, 1e-10);
+      EXPECT_NEAR(result.dx(0), 1.2, 1e-10);
+      EXPECT_NEAR(result.dx(1), 1.4, 1e-10);
+    }
+  }
+  TEST(TensorFAD, TensorWithFADTypeDDot)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::Tensor<FadType, 2, 2> t = {{
+        {FadType(4, 0, 1.1), FadType(4, 1, 1.2)},
+        {FadType(4, 2, 2.1), FadType(4, 3, 2.2)},
+    }};
+    const Core::LinAlg::Tensor<FadType, 2, 2> t2 = {{
+        {FadType(1.2), FadType(1.4)},
+        {FadType(2.2), FadType(2.4)},
+    }};
+    {
+      auto result = Core::LinAlg::ddot(t, t2);
+      static_assert(std::is_same_v<decltype(result), FadType>);
+      EXPECT_NEAR(result.val(), 12.9, 1e-10);
+      EXPECT_NEAR(result.dx(0), 1.2, 1e-10);
+      EXPECT_NEAR(result.dx(1), 1.4, 1e-10);
+      EXPECT_NEAR(result.dx(2), 2.2, 1e-10);
+      EXPECT_NEAR(result.dx(3), 2.4, 1e-10);
+    }
+  }
+
+  TEST(TensorFAD, SymmetricTensorWithFADTypeScale)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(3, 0, 1.1), FadType(3, 1, 1.2)},
+            {FadType(3, 1, 1.2), FadType(3, 2, 2.2)},
+        }});
+    {
+      auto result = 2.0 * t;
+      static_assert(std::is_same_v<typename decltype(result)::value_type, FadType>);
+      EXPECT_NEAR(result(0, 0).val(), 2.2, 1e-10);
+      EXPECT_NEAR(result(0, 1).val(), 2.4, 1e-10);
+      EXPECT_NEAR(result(1, 1).val(), 4.4, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(0), 2, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(0), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(0), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(1), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(1), 2, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(1), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(2), 2, 1e-10);
+    }
+  }
+  TEST(TensorFAD, SymmetricTensorWithFADTypeAdd)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(3, 0, 1.1), FadType(3, 1, 1.2)},
+            {FadType(3, 1, 1.2), FadType(3, 2, 2.2)},
+        }});
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(1.2), FadType(1.4)},
+            {FadType(1.4), FadType(2.4)},
+        }});
+    {
+      auto result = t + t2;
+      static_assert(std::is_same_v<typename decltype(result)::value_type, FadType>);
+      EXPECT_NEAR(result(0, 0).val(), 2.3, 1e-10);
+      EXPECT_NEAR(result(0, 1).val(), 2.6, 1e-10);
+      EXPECT_NEAR(result(1, 1).val(), 4.6, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(0), 1, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(0), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(0), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(1), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(1), 1, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(1), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(2), 1, 1e-10);
+    }
+  }
+  TEST(TensorFAD, SymmetricTensorWithFADTypeSubtract)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(3, 0, 1.1), FadType(3, 1, 1.2)},
+            {FadType(3, 1, 1.2), FadType(3, 2, 2.2)},
+        }});
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(1.2), FadType(1.4)},
+            {FadType(1.4), FadType(2.4)},
+        }});
+    {
+      auto result = t - t2;
+      static_assert(std::is_same_v<typename decltype(result)::value_type, FadType>);
+      EXPECT_NEAR(result(0, 0).val(), -0.1, 1e-10);
+      EXPECT_NEAR(result(0, 1).val(), -0.2, 1e-10);
+      EXPECT_NEAR(result(1, 1).val(), -0.2, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(0), 1, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(0), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(0), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(1), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(1), 1, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(1), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(2), 1, 1e-10);
+    }
+  }
+  TEST(TensorFAD, SymmetricTensorWithFADTypeDot)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(3, 0, 1.1), FadType(3, 1, 1.2)},
+            {FadType(3, 1, 1.2), FadType(3, 2, 2.2)},
+        }});
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(1.2), FadType(1.4)},
+            {FadType(1.4), FadType(2.4)},
+        }});
+    {
+      auto result = t * t2;
+      static_assert(std::is_same_v<typename decltype(result)::value_type, FadType>);
+      EXPECT_NEAR(result(0, 0).val(), 3, 1e-10);
+      EXPECT_NEAR(result(0, 1).val(), 4.42, 1e-10);
+      EXPECT_NEAR(result(1, 0).val(), 4.52, 1e-10);
+      EXPECT_NEAR(result(1, 1).val(), 6.96, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(0), 1.2, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(0), 1.4, 1e-10);
+      EXPECT_NEAR(result(1, 0).dx(0), 0, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(0), 0, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(1), 1.4, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(1), 2.4, 1e-10);
+      EXPECT_NEAR(result(1, 0).dx(1), 1.2, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(1), 1.4, 1e-10);
+
+      EXPECT_NEAR(result(0, 0).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(0, 1).dx(2), 0, 1e-10);
+      EXPECT_NEAR(result(1, 0).dx(2), 1.4, 1e-10);
+      EXPECT_NEAR(result(1, 1).dx(2), 2.4, 1e-10);
+    }
+  }
+  TEST(TensorFAD, SymmetricTensorWithFADTypeDDot)
+  {
+    using FadType = Sacado::Fad::DFad<double>;
+
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(3, 0, 1.1), FadType(3, 1, 1.2)},
+            {FadType(3, 1, 1.2), FadType(3, 2, 2.2)},
+        }});
+    const Core::LinAlg::SymmetricTensor<FadType, 2, 2> t2 =
+        Core::LinAlg::assume_symmetry(Core::LinAlg::Tensor<FadType, 2, 2>{{
+            {FadType(1.2), FadType(1.4)},
+            {FadType(1.4), FadType(2.4)},
+        }});
+    {
+      auto result = Core::LinAlg::ddot(t, t2);
+      static_assert(std::is_same_v<decltype(result), FadType>);
+      EXPECT_NEAR(result.val(), 9.96, 1e-10);
+      EXPECT_NEAR(result.dx(0), 1.2, 1e-10);
+      EXPECT_NEAR(result.dx(1), 2.8, 1e-10);
+      EXPECT_NEAR(result.dx(2), 2.4, 1e-10);
+    }
+  }
+
+}  // namespace
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/utils/src/numerics/4C_utils_fad_meta.hpp
+++ b/src/core/utils/src/numerics/4C_utils_fad_meta.hpp
@@ -1,0 +1,183 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_UTILS_FAD_META_HPP
+#define FOUR_C_UTILS_FAD_META_HPP
+
+#include "4C_config.hpp"
+
+#include <concepts>
+#include <functional>
+#include <type_traits>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::FADUtils
+{
+  /*!
+   * @brief A concept that checks whether a type is a Sacado-Fad type (without actually needing to
+   * include the heavy Sacado header).
+   *
+   * @tparam Scalar
+   */
+  template <typename Scalar>
+  concept SacadoFadType = requires(Scalar a) {
+    { a.val() } -> std::convertible_to<typename Scalar::value_type>;
+    { a.dx(0) } -> std::convertible_to<typename Scalar::value_type>;
+  };
+
+  namespace Internal
+  {
+    // Note: A Fad-expression has a ExprT1 or a ExprT2 typedef if it is an Expression (and not a
+    // pure FAD-Type)
+    template <typename T>
+    concept HasExpr1Type = requires { typename T::ExprT1; };
+    template <typename T>
+    concept HasExpr2Type = requires { typename T::ExprT2; };
+
+    /*!
+     * @brief A small helper meta-utility to extract the base type of a FAD expression.
+     *
+     * @note It relies on the the fact that a FAD expression have an ExprT1 or an ExprT2 typedef.
+     */
+    template <typename Expr>
+    struct ExtractAutoDiffBaseType;
+
+    template <typename Expr>
+      requires(SacadoFadType<Expr> && !HasExpr1Type<Expr> && !HasExpr2Type<Expr>)
+    struct ExtractAutoDiffBaseType<Expr>
+    {
+      using type = Expr;
+    };
+
+    template <typename Expr>
+      requires(SacadoFadType<Expr> && HasExpr1Type<Expr>)
+    struct ExtractAutoDiffBaseType<Expr>
+    {
+      using type = ExtractAutoDiffBaseType<typename Expr::ExprT1>::type;
+    };
+
+    template <typename Expr>
+      requires(SacadoFadType<Expr> && !HasExpr1Type<Expr> && HasExpr2Type<Expr>)
+    struct ExtractAutoDiffBaseType<Expr>
+    {
+      using type = ExtractAutoDiffBaseType<typename Expr::ExprT2>::type;
+    };
+  }  // namespace Internal
+
+  /*!
+   * @brief This template metafunction extracts the base type of a FAD expression from Sacado.
+   *
+   * Sacado-Fad internally uses lazy evaluation so that the use of auto as a return type is
+   * dangerous and fails in certain situations. This class can extract the base type of a FAD
+   * expression that can be used as an explicit return type.
+   *
+   * @note This meta-utilities don't rely on the large Sacado-header.
+   *
+   * @tparam Expr Arbitrary FAD expression type.
+   */
+  template <SacadoFadType T>
+  using AutoDiffBaseType = typename Internal::ExtractAutoDiffBaseType<T>::type;
+
+  namespace Internal
+  {
+    template <typename Op>
+    struct OperationDeducer;
+
+    template <>
+    struct OperationDeducer<std::plus<>>
+    {
+      template <typename T1, typename T2>
+      static constexpr auto apply(const T1& a, const T2& b)
+      {
+        return a + b;
+      }
+    };
+
+    template <>
+    struct OperationDeducer<std::minus<>>
+    {
+      template <typename T1, typename T2>
+      static constexpr auto apply(const T1& a, const T2& b)
+      {
+        return a - b;
+      }
+    };
+
+    template <>
+    struct OperationDeducer<std::multiplies<>>
+    {
+      template <typename T1, typename T2>
+      static constexpr auto apply(const T1& a, const T2& b)
+      {
+        return a * b;
+      }
+    };
+
+    template <>
+    struct OperationDeducer<std::divides<>>
+    {
+      template <typename T1, typename T2>
+      static constexpr auto apply(const T1& a, const T2& b)
+      {
+        return a / b;
+      }
+    };
+
+    template <typename T1, typename T2, typename Operation>
+    struct ScalarOperationResultType;
+
+    template <typename T1, typename T2, typename Operation>
+      requires(std::is_arithmetic_v<T1> && std::is_arithmetic_v<T2>)
+    struct ScalarOperationResultType<T1, T2, Operation>
+    {
+      using type =
+          decltype(OperationDeducer<Operation>::apply(std::declval<T1>(), std::declval<T2>()));
+    };
+
+    template <typename T1, SacadoFadType T2, typename Operation>
+      requires(std::is_arithmetic_v<T1> && std::is_same_v<T1, typename T2::value_type>)
+    struct ScalarOperationResultType<T1, T2, Operation>
+    {
+      using type = AutoDiffBaseType<T2>;
+    };
+
+    template <SacadoFadType T1, typename T2, typename Operation>
+      requires(std::is_arithmetic_v<T2> && std::is_same_v<T2, typename T1::value_type>)
+    struct ScalarOperationResultType<T1, T2, Operation>
+    {
+      using type = AutoDiffBaseType<T1>;
+    };
+
+    template <SacadoFadType T1, SacadoFadType T2, typename Operation>
+      requires(std::is_same_v<typename T1::value_type, typename T2::value_type>)
+    struct ScalarOperationResultType<T1, T2, Operation>
+    {
+      using type = AutoDiffBaseType<T1>;
+    };
+  }  // namespace Internal
+
+  /**
+   * @brief A template meta function that determines the result type of a scalar operation that
+   * might involves a FAD-type.
+   *
+   * @note FAD-types are reduced to their base type
+   *
+   * @tparam Scalar1 The first scalar type involved in the operation.
+   * @tparam Scalar2 The second scalar type involved in the operation.
+   * @tparam Operation The operation to be applied to the scalar types (std::plus, std::minus,
+   * std::multiplies, std::divides).
+   */
+  template <typename Scalar1, typename Scalar2, typename Operation>
+  using ScalarOperationResultType =
+      Internal::ScalarOperationResultType<Scalar1, Scalar2, Operation>::type;
+}  // namespace Core::FADUtils
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif


### PR DESCRIPTION
Achieving this was actually more involved than hoped.

During review, pay special attention to the new meta-utility header `src/core/utils/src/numerics/4C_utils_fad_meta.hpp`

Our tensors automatically deduce the result type of the operations. This is problematic for the Sacado-Fad types, which build upon lazy evaluation and need to be casted to their base-type. Obtaining the base-type was quite tricky, especially since I needed to avoid loading the heavy Sacado-header in the tensor-header.

A small caveat remains: We require that all scalar-types are the same if a FAD-type is detected. For some reason, automatic differentiation does not work otherwise. I ensured that other usages don't compile

```c++
Tensor<FAD, 2> fad_tensor = {{FAD(2, 0, 1.0), FAD(2, 1, 2.0)}};
// auto result = 2 * fad_tensor; // does not compile
auto result = 2.0 * fad_tensor; // compiles
```