### PR TITLE
Allow to store input_field to structs

### DIFF
--- a/src/core/io/src/4C_io_input_field.hpp
+++ b/src/core/io/src/4C_io_input_field.hpp
@@ -31,7 +31,13 @@ namespace Core::IO
   {
    public:
     using IndexType = int;
-    using StorageType = std::variant<T, std::unordered_map<IndexType, T>>;
+    using StorageType = std::variant<std::monostate, T, std::unordered_map<IndexType, T>>;
+
+    /**
+     * Default constructor. This InputField will not hold any data and will throw an error if
+     * any attempt is made to access its data. You need to assign a value to it before using it.
+     */
+    InputField() = default;
 
     /**
      * Construct an InputField from a single @p const_data. This field will have the same value
@@ -66,7 +72,7 @@ namespace Core::IO
       {
         return std::get<T>(data_);
       }
-      else if (std::holds_alternative<std::unordered_map<IndexType, T>>(data_))
+      if (std::holds_alternative<std::unordered_map<IndexType, T>>(data_))
       {
         const auto& map = std::get<std::unordered_map<IndexType, T>>(data_);
         auto it = map.find(element_id);
@@ -77,10 +83,14 @@ namespace Core::IO
         }
         return it->second;
       }
+      if (std::holds_alternative<std::monostate>(data_))
+      {
+        FOUR_C_THROW("InputField is empty.");
+      }
       std23::unreachable();
     }
 
-    std::variant<T, std::unordered_map<IndexType, T>> data_;
+    StorageType data_;
   };
 }  // namespace Core::IO
 

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -1167,7 +1167,7 @@ specs:
                                    parameter<double>("c"),
                                })}),
         },
-        {.description = "", .required = false, .store_selector = in_container<Model>("type")});
+        {.description = "", .store_selector = in_container<Model>("type")});
     {
       SCOPED_TRACE("First selection");
       ryml::Tree tree = init_yaml_tree_with_exceptions();


### PR DESCRIPTION
The last missing piece to make the input_field() as powerful as all other parameters: allow to store it in struct members. Note that I need to make the InputField default constructible to allow a default-constructible struct with such a member. 

@maxiludwig I fixed a few small things along the way. Most importantly, the `input_field` should really take its own set of options and not use the ones from `parameter`. I just made `input_field` and `selection` parameters required for now as I am not sure what the best logic would be to make them optional.

This PR also fixes the duplicated access, i.e. no more `group("stiffness").get<>("stiffness");` but just `get<>("stiffness");`

@maxfirmbach Let's watch out for an git-invisible conflict with #893 since the access will change as indicated above.