### PR TITLE
Disallow matching unnamed specs

### DIFF
--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -54,10 +54,14 @@ void Core::IO::InputSpec::match(ConstYamlNodeRef yaml, InputParameterContainer& 
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
 
-  auto spec_for_matching = Internal::wrap_with_all_of(*this);
-  Internal::MatchTree match_tree{spec_for_matching, yaml};
+  const auto& spec_name = impl().name();
+  FOUR_C_ASSERT_ALWAYS(spec_name != "",
+      "You are trying to match an unnamed InputSpec. "
+      "You can only match a named spec, not an all_of or one_of spec.");
 
-  if (auto* stores_to = spec_for_matching.impl().data.stores_to;
+  Internal::MatchTree match_tree{*this, yaml};
+
+  if (auto* stores_to = impl().data.stores_to;
       stores_to && *stores_to != typeid(InputParameterContainer))
   {
     FOUR_C_THROW(
@@ -68,7 +72,7 @@ void Core::IO::InputSpec::match(ConstYamlNodeRef yaml, InputParameterContainer& 
 
   InputSpecBuilders::Storage storage;
   Internal::init_storage_with_container(storage);
-  spec_for_matching.pimpl_->match(yaml, storage, match_tree.root());
+  impl().match(yaml, storage, match_tree.root());
   container.merge(std::any_cast<InputParameterContainer&&>(std::move(storage)));
 
   match_tree.assert_match();

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -700,6 +700,7 @@ bool Core::IO::Internal::GroupSpec::match(ConstYamlNodeRef node,
     // Match will stay a partial match.
     return false;
   }
+  match_entry.state = IO::Internal::MatchEntry::State::matched;
   move_my_storage(container, std::move(struct_storage));
   return true;
 }
@@ -786,14 +787,7 @@ bool Core::IO::Internal::AllOfSpec::match(ConstYamlNodeRef node,
 {
   match_entry.matched_node = node.node.id();
 
-  bool all_matched = fully_match_specs(specs, node, container, match_entry);
-
-  if (!all_matched)
-  {
-    return false;
-  }
-
-  return true;
+  return fully_match_specs(specs, node, container, match_entry);
 }
 
 

--- a/src/core/io/tests/4C_io_input_file_test.cpp
+++ b/src/core/io/tests/4C_io_input_file_test.cpp
@@ -136,11 +136,12 @@ namespace
 
     MPI_Comm comm(MPI_COMM_WORLD);
     Core::IO::InputFile input(
-        {{"INCLUDED SECTION 2", all_of({
-                                    parameter<int>("a"),
-                                    parameter<double>("b"),
-                                    parameter<bool>("c"),
-                                })},
+        {{"INCLUDED SECTION 2", group("INCLUDED SECTION 2",
+                                    {
+                                        parameter<int>("a"),
+                                        parameter<double>("b"),
+                                        parameter<bool>("c"),
+                                    })},
             {"SECTION WITH SUBSTRUCTURE", list("SECTION WITH SUBSTRUCTURE",
                                               all_of({
                                                   parameter<int>("MAT"),
@@ -164,9 +165,10 @@ namespace
 
     Core::IO::InputParameterContainer container;
     input.match_section("INCLUDED SECTION 2", container);
-    EXPECT_EQ(container.get<int>("a"), 1);
-    EXPECT_EQ(container.get<double>("b"), 2.0);
-    EXPECT_EQ(container.get<bool>("c"), true);
+    const auto& included_section_2 = container.group("INCLUDED SECTION 2");
+    EXPECT_EQ(included_section_2.get<int>("a"), 1);
+    EXPECT_EQ(included_section_2.get<double>("b"), 2.0);
+    EXPECT_EQ(included_section_2.get<bool>("c"), true);
 
     container.clear();
     input.match_section("SECTION WITH SUBSTRUCTURE", container);


### PR DESCRIPTION
This simplifies internals and further incentivizes users to not use all_of/one_of as they cannot match them. All existing input already conforms to the new approach; I only had to adapt the tests.

Another motivation for this change is the fact that we made a copy of the spec before matching (to wrap it in an all_of) and this is quite expensive. It took half the time of a microbenchmark I made (will push this separately).