### PR TITLE
Remove interpolation namespaces from Core::LinAlg

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.cpp
@@ -20,8 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-Core::LinAlg::Matrix<num_coefficients, 1>
-Core::LinAlg::ScalarInterpolation::polynomial_shape_function(
+Core::LinAlg::Matrix<num_coefficients, 1> Core::LinAlg::polynomial_shape_function(
     const Core::LinAlg::Matrix<loc_dim, 1>& location)
 {
   Core::LinAlg::Matrix<num_coefficients, 1> polynomial(Core::LinAlg::Initialization::zero);
@@ -145,40 +144,41 @@ Core::LinAlg::ScalarInterpolation::polynomial_shape_function(
 }
 
 // 1D linear
-template Core::LinAlg::Matrix<2, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<1,
-    1, 2>(const Core::LinAlg::Matrix<1, 1>&);
+template Core::LinAlg::Matrix<2, 1> Core::LinAlg::polynomial_shape_function<1, 1, 2>(
+    const Core::LinAlg::Matrix<1, 1>&);
 
 // 1D quadratic
-template Core::LinAlg::Matrix<3, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<1,
-    2, 3>(const Core::LinAlg::Matrix<1, 1>&);
+template Core::LinAlg::Matrix<3, 1> Core::LinAlg::polynomial_shape_function<1, 2, 3>(
+    const Core::LinAlg::Matrix<1, 1>&);
 
 // 2D linear
-template Core::LinAlg::Matrix<4, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<2,
-    1, 4>(const Core::LinAlg::Matrix<2, 1>&);
+template Core::LinAlg::Matrix<4, 1> Core::LinAlg::polynomial_shape_function<2, 1, 4>(
+    const Core::LinAlg::Matrix<2, 1>&);
 
 // 2D quadratic (incomplete)
-template Core::LinAlg::Matrix<6, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<2,
-    2, 6>(const Core::LinAlg::Matrix<2, 1>&);
+template Core::LinAlg::Matrix<6, 1> Core::LinAlg::polynomial_shape_function<2, 2, 6>(
+    const Core::LinAlg::Matrix<2, 1>&);
 
 // 2D quadratic (complete)
-template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<2,
-    2, 8>(const Core::LinAlg::Matrix<2, 1>&);
+template Core::LinAlg::Matrix<8, 1> Core::LinAlg::polynomial_shape_function<2, 2, 8>(
+    const Core::LinAlg::Matrix<2, 1>&);
 
 // 3D linear
-template Core::LinAlg::Matrix<8, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<3,
-    1, 8>(const Core::LinAlg::Matrix<3, 1>&);
+template Core::LinAlg::Matrix<8, 1> Core::LinAlg::polynomial_shape_function<3, 1, 8>(
+    const Core::LinAlg::Matrix<3, 1>&);
 
 // 3D quadratic
-template Core::LinAlg::Matrix<10, 1> Core::LinAlg::ScalarInterpolation::polynomial_shape_function<3,
-    2, 10>(const Core::LinAlg::Matrix<3, 1>&);
+template Core::LinAlg::Matrix<10, 1> Core::LinAlg::polynomial_shape_function<3, 2, 10>(
+    const Core::LinAlg::Matrix<3, 1>&);
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim>
-std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+std::vector<double> Core::LinAlg::calculate_normalized_weights(
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-    const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const WeightingFunction weight_func,
-    const InterpParams& interp_params)
+    const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc,
+    const ScalarInterpolationWeightingFunction weight_func,
+    const ScalarInterpolationParams& interp_params)
 {
   std::vector<double> weights(ref_locs.size(), 0.0);
   std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs_tmp(ref_locs);
@@ -189,7 +189,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weig
   // calculate the weight based on the chosen weighting function
   switch (weight_func)
   {
-    case WeightingFunction::inverse_distance:
+    case ScalarInterpolationWeightingFunction::inverse_distance:
     {
       double exponent = loc_dim;  // default exponent for inverse distance
       if (interp_params.inverse_distance_power.has_value())
@@ -206,7 +206,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weig
     }
     break;
 
-    case WeightingFunction::exponential:
+    case ScalarInterpolationWeightingFunction::exponential:
     {
       for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)
       {
@@ -219,7 +219,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weig
     }
     break;
 
-    case WeightingFunction::unity:
+    case ScalarInterpolationWeightingFunction::unity:
     {
       for (unsigned int i = 0; i < ref_locs_tmp.size(); ++i)
         weights[i] = 1.0 / static_cast<double>(ref_locs_tmp.size());
@@ -257,25 +257,26 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weig
 }
 
 // Explicit template instantiations for calculate_normalized_weights
-template std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights<1>(
+template std::vector<double> Core::LinAlg::calculate_normalized_weights<1>(
     const std::vector<Core::LinAlg::Matrix<1, 1>>&, const Core::LinAlg::Matrix<1, 1>&,
-    const Core::LinAlg::ScalarInterpolation::WeightingFunction,
-    const Core::LinAlg::ScalarInterpolation::InterpParams&);
-template std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights<2>(
+    const Core::LinAlg::ScalarInterpolationWeightingFunction,
+    const Core::LinAlg::ScalarInterpolationParams&);
+template std::vector<double> Core::LinAlg::calculate_normalized_weights<2>(
     const std::vector<Core::LinAlg::Matrix<2, 1>>&, const Core::LinAlg::Matrix<2, 1>&,
-    const Core::LinAlg::ScalarInterpolation::WeightingFunction,
-    const Core::LinAlg::ScalarInterpolation::InterpParams&);
-template std::vector<double> Core::LinAlg::ScalarInterpolation::calculate_normalized_weights<3>(
+    const Core::LinAlg::ScalarInterpolationWeightingFunction,
+    const Core::LinAlg::ScalarInterpolationParams&);
+template std::vector<double> Core::LinAlg::calculate_normalized_weights<3>(
     const std::vector<Core::LinAlg::Matrix<3, 1>>&, const Core::LinAlg::Matrix<3, 1>&,
-    const Core::LinAlg::ScalarInterpolation::WeightingFunction,
-    const Core::LinAlg::ScalarInterpolation::InterpParams&);
+    const Core::LinAlg::ScalarInterpolationWeightingFunction,
+    const Core::LinAlg::ScalarInterpolationParams&);
 
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_coefficients>::ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
-    const WeightingFunction weight_func, const InterpParams& interp_params)
+Core::LinAlg::ScalarInterpolator<loc_dim, poly_order, num_coefficients>::ScalarInterpolator(
+    const ScalarInterpolationType scalar_interp_type,
+    const ScalarInterpolationWeightingFunction weight_func,
+    const ScalarInterpolationParams& interp_params)
     : scalar_interp_type_(scalar_interp_type),
       weight_func_(weight_func),
       interp_params_(interp_params)
@@ -293,7 +294,7 @@ Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+std::vector<double> Core::LinAlg::ScalarInterpolator<loc_dim, poly_order,
     num_coefficients>::logarithmic_weighted_average(const std::vector<std::vector<double>>&
                                                         scalar_data,
     const std::vector<double>& weights)
@@ -324,8 +325,9 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_coefficients>::moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+std::vector<double>
+Core::LinAlg::ScalarInterpolator<loc_dim, poly_order, num_coefficients>::moving_least_square(
+    const std::vector<std::vector<double>>& scalar_data,
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
     const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights)
 {
@@ -346,8 +348,8 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
     // compute the polynomial shape function for the current reference location
     p_i.put_scalar(0.0);  // reset p_i to zero
-    p_i.update(Core::LinAlg::ScalarInterpolation::polynomial_shape_function<loc_dim, poly_order,
-        num_coefficients>(ref_locs_tmp[i]));
+    p_i.update(Core::LinAlg::polynomial_shape_function<loc_dim, poly_order, num_coefficients>(
+        ref_locs_tmp[i]));
 
     // bj = w * p_i * scalar_data[i][j]
     for (unsigned int j = 0; j < field_size; ++j)  // number of scalar fields
@@ -380,7 +382,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
     yj.multiply(Pinv, bj[j]);  // compute the coeffiicents
 
     p_inter.put_scalar(0.0);  // reset p_inter to zero
-    p_inter.update(Core::LinAlg::ScalarInterpolation::polynomial_shape_function<loc_dim, poly_order,
+    p_inter.update(Core::LinAlg::polynomial_shape_function<loc_dim, poly_order,
         num_coefficients>(interp_loc_shifted));  // compute the polynomial shape function at
                                                  // the interpolation point
 
@@ -396,7 +398,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
+std::vector<double> Core::LinAlg::ScalarInterpolator<loc_dim, poly_order,
     num_coefficients>::logarithmic_moving_least_squares(const std::vector<std::vector<double>>&
                                                             scalar_data,
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
@@ -437,8 +439,9 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 /*--------------------------------------------------------------------*
  *--------------------------------------------------------------------*/
 template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_dim, poly_order,
-    num_coefficients>::get_interpolated_scalar(const std::vector<std::vector<double>>& scalar_data,
+std::vector<double>
+Core::LinAlg::ScalarInterpolator<loc_dim, poly_order, num_coefficients>::get_interpolated_scalar(
+    const std::vector<std::vector<double>>& scalar_data,
     const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
     const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc)
 {
@@ -450,7 +453,7 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
   if (ref_locs.size() < 1)
     FOUR_C_THROW("At least one reference location is required for interpolation.");
 
-  auto weights = Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+  auto weights = Core::LinAlg::calculate_normalized_weights(
       ref_locs, interp_loc, weight_func_, interp_params_);
 
   // If one weight is 1.0, return the corresponding scalar data directly
@@ -459,14 +462,13 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 
   switch (scalar_interp_type_)  // Choose the interpolation method based on the type
   {
-    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::logarithmic_weighted_average:
+    case Core::LinAlg::ScalarInterpolationType::logarithmic_weighted_average:
       return logarithmic_weighted_average(scalar_data, weights);
       break;
-    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::moving_least_squares:
+    case Core::LinAlg::ScalarInterpolationType::moving_least_squares:
       return moving_least_square(scalar_data, ref_locs, interp_loc, weights);
       break;
-    case Core::LinAlg::ScalarInterpolation::ScalarInterpolationType::
-        logarithmic_moving_least_squares:
+    case Core::LinAlg::ScalarInterpolationType::logarithmic_moving_least_squares:
       return logarithmic_moving_least_squares(scalar_data, ref_locs, interp_loc, weights);
       break;
     default:
@@ -476,18 +478,18 @@ std::vector<double> Core::LinAlg::ScalarInterpolation::ScalarInterpolator<loc_di
 }
 
 // Explicit template instantiations
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<1>;
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2>;
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<3>;
+template class Core::LinAlg::ScalarInterpolator<1>;
+template class Core::LinAlg::ScalarInterpolator<2>;
+template class Core::LinAlg::ScalarInterpolator<3>;
 
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<1, 1, 2>;
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<1, 2, 3>;
+template class Core::LinAlg::ScalarInterpolator<1, 1, 2>;
+template class Core::LinAlg::ScalarInterpolator<1, 2, 3>;
 
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2, 1, 4>;
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2, 2, 6>;
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<2, 2, 8>;
+template class Core::LinAlg::ScalarInterpolator<2, 1, 4>;
+template class Core::LinAlg::ScalarInterpolator<2, 2, 6>;
+template class Core::LinAlg::ScalarInterpolator<2, 2, 8>;
 
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<3, 1, 8>;
-template class Core::LinAlg::ScalarInterpolation::ScalarInterpolator<3, 2, 10>;
+template class Core::LinAlg::ScalarInterpolator<3, 1, 8>;
+template class Core::LinAlg::ScalarInterpolator<3, 2, 10>;
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_scalar_interpolation.hpp
@@ -18,206 +18,204 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg
 {
-  namespace ScalarInterpolation
+  /// enum class for the interpolation type
+  enum class ScalarInterpolationType
   {
-    /// enum class for the interpolation type
-    enum class ScalarInterpolationType
-    {
-      logarithmic_weighted_average,      ///< logarithmic weighted average,
-      moving_least_squares,              ///< moving least squares,
-      logarithmic_moving_least_squares,  ///< logarithmic moving least squares,
-    };
+    logarithmic_weighted_average,      ///< logarithmic weighted average,
+    moving_least_squares,              ///< moving least squares,
+    logarithmic_moving_least_squares,  ///< logarithmic moving least squares,
+  };
 
-    /// enum class for the interpolation weighting function
-    enum class WeightingFunction
-    {
-      inverse_distance,  ///< inverse distance weighting
-      exponential,       ///< exponential weighting
-      unity,             ///< equal weighting
-    };
+  /// enum class for the interpolation weighting function
+  enum class ScalarInterpolationWeightingFunction
+  {
+    inverse_distance,  ///< inverse distance weighting
+    exponential,       ///< exponential weighting
+    unity,             ///< equal weighting
+  };
 
-    /// struct containing parameters used for the scalar interpolation
-    struct InterpParams
-    {
-      /// exponential decay factor of the weighting functions, as shown in Satheesh,
-      /// 2024, 10.1002/nme.7373, Eq. (21)
-      double exponential_decay_c = 10.0;
+  /// struct containing parameters used for the scalar interpolation
+  struct ScalarInterpolationParams
+  {
+    /// exponential decay factor of the weighting functions, as shown in Satheesh,
+    /// 2024, 10.1002/nme.7373, Eq. (21)
+    double exponential_decay_c = 10.0;
 
-      /// inverse distance power
-      /// used for the inverse distance weighting function
-      /// (i.e., 1 / (distance^power))
-      std::optional<double> inverse_distance_power;
+    /// inverse distance power
+    /// used for the inverse distance weighting function
+    /// (i.e., 1 / (distance^power))
+    std::optional<double> inverse_distance_power;
 
-      double distance_threshold = 1.0e-8;  ///< threshold for distance to avoid singularities
-    };
+    double distance_threshold = 1.0e-8;  ///< threshold for distance to avoid singularities
+  };
+
+  /**
+   * @brief Computes the polynomial shape function values at a given location.
+   *
+   * This templated function evaluates the shape function for a polynomial of specified order
+   * at a given location in the local coordinate system.
+   *
+   * @tparam loc_dim Dimension of the local coordinate system.
+   * @tparam poly_order Order of the polynomial shape function.
+   * @tparam num_coefficients Number of coefficients (basis functions) in the polynomial, this is
+   * important in the context of an incomplete polynomial basis. Example: An incomplete quadratic
+   * basis: [1,x,y,x^2], missing xy and y^2
+   * @param location The local coordinates where the shape function is to be evaluated.
+   * @return A column vector containing the values of the shape function basis at the given
+   * location.
+   */
+  template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
+  Core::LinAlg::Matrix<num_coefficients, 1> polynomial_shape_function(
+      const Core::LinAlg::Matrix<loc_dim, 1>& location);
+
+  /**
+   * @brief Calculates normalized interpolation weights for a given interpolation location.
+   *
+   * This function computes the weights for each reference location based on the provided
+   * weighting function and interpolation parameters, and normalizes them so that their sum
+   * is 1.
+   *
+   * @param ref_locs A vector of reference locations
+   * @param interp_loc The interpolation location
+   * @param weight_func The weighting function used to compute the weights based on distance or
+   * other criteria.
+   * @param interp_params Additional parameters required by the weighting function.
+   * @return std::vector<double> A vector of normalized weights corresponding to each reference
+   * location.
+   */
+  template <unsigned int loc_dim>
+  std::vector<double> calculate_normalized_weights(
+      const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+      const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc,
+      const ScalarInterpolationWeightingFunction weight_func,
+      const ScalarInterpolationParams& interp_params);
+
+
+  /**
+   * @class ScalarInterpolator
+   * @brief A class template for performing scalar interpolation using various methods and
+   * weighting functions.
+   *
+   * This class provides functionality to interpolate scalar values at arbitrary locations based
+   * on reference data points and their associated locations. It supports different interpolation
+   * types, including moving least squares (MLS), logarithmic interpolation, and log-domain MLS,
+   * with customizable weighting functions and interpolation parameters.
+   *
+   * @tparam loc_dim The spatial dimension of the interpolation (e.g., 2 for 2D, 3 for 3D).
+   * @tparam poly_order The polynomial order used in the interpolation basis (MLS &LOGMLS).
+   * @tparam num_coefficients The number of coefficients in the interpolation basis, applying to
+   * the polynomial shape function (MLS & LOGMLS).
+   *
+   * Usage:
+   *   - Construct with the desired interpolation type, weighting function, and parameters.
+   *      for example:
+   *        (a) LOG: (second and third template argument are ignored)
+   *          ScalarInterpolator<3> interpolator(ScalarInterpolationType::MLS,
+   *          ScalarInterpolationWeightingFunction::exponential, interp_params)
+   *
+   *        (b) MLS/LOGMLS: (all three template arguments are used)
+   *          ScalarInterpolator<3, 2, 10>
+   *            interpolator( ScalarInterpolationType::MLS,
+   * ScalarInterpolationWeightingFunction::exponential, interp_params);
+   *   - Use get_interpolated_scalar() to compute interpolated values at a given location.
+   *   - Use calculate_normalized_weights() to obtain normalized weights for reference points, if
+   * interested to return weights.
+   *
+   * Private helper methods implement the core interpolation algorithms, including MLS,
+   * logarithmic variants, and log MLS.
+   */
+  template <unsigned int loc_dim, unsigned int poly_order = 1, unsigned int num_coefficients = 1>
+  class ScalarInterpolator
+  {
+   public:
+    /**
+     * @brief Constructs a ScalarInterpolator with the specified interpolation type, weighting
+     * function, and parameters.
+     *
+     * @param scalar_interp_type The type of scalar interpolation to use.
+     * @param weight_func The weighting function to apply during interpolation.
+     * @param interp_params Additional parameters required for the interpolation process.
+     */
+    ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
+        const ScalarInterpolationWeightingFunction weight_func,
+        const ScalarInterpolationParams& interp_params);
 
     /**
-     * @brief Computes the polynomial shape function values at a given location.
+     * @brief Interpolates scalar values at a given location using provided scalar data and
+     * reference locations.
      *
-     * This templated function evaluates the shape function for a polynomial of specified order
-     * at a given location in the local coordinate system.
+     * This function computes the interpolated scalar values at the specified interpolation
+     * location @p interp_loc based on the input scalar data and their corresponding reference
+     * locations.
      *
-     * @tparam loc_dim Dimension of the local coordinate system.
-     * @tparam poly_order Order of the polynomial shape function.
-     * @tparam num_coefficients Number of coefficients (basis functions) in the polynomial, this is
-     * important in the context of an incomplete polynomial basis. Example: An incomplete quadratic
-     * basis: [1,x,y,x^2], missing xy and y^2
-     * @param location The local coordinates where the shape function is to be evaluated.
-     * @return A column vector containing the values of the shape function basis at the given
+     * @param scalar_data A vector of vectors containing scalar values at each reference location.
+     * @param ref_locs A vector of reference locations.
+     * @param interp_loc The location at which the scalar value is to be interpolated.
+     * @return std::vector<double> The interpolated scalar values at the specified interpolation
      * location.
      */
-    template <unsigned int loc_dim, unsigned int poly_order, unsigned int num_coefficients>
-    Core::LinAlg::Matrix<num_coefficients, 1> polynomial_shape_function(
-        const Core::LinAlg::Matrix<loc_dim, 1>& location);
-
-    /**
-     * @brief Calculates normalized interpolation weights for a given interpolation location.
-     *
-     * This function computes the weights for each reference location based on the provided
-     * weighting function and interpolation parameters, and normalizes them so that their sum
-     * is 1.
-     *
-     * @param ref_locs A vector of reference locations
-     * @param interp_loc The interpolation location
-     * @param weight_func The weighting function used to compute the weights based on distance or
-     * other criteria.
-     * @param interp_params Additional parameters required by the weighting function.
-     * @return std::vector<double> A vector of normalized weights corresponding to each reference
-     * location.
-     */
-    template <unsigned int loc_dim>
-    std::vector<double> calculate_normalized_weights(
+    std::vector<double> get_interpolated_scalar(const std::vector<std::vector<double>>& scalar_data,
         const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const WeightingFunction weight_func,
-        const InterpParams& interp_params);
+        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc);
 
+   private:
+    /**
+     * @brief Computes the moving least squares (MLS) interpolation for a given location.
+     *
+     * This function performs MLS interpolation using the provided scalar data, reference
+     * locations, interpolation location, and associated weights. It returns the interpolated
+     * scalar values.
+     *
+     * @param scalar_data A vector of vectors containing scalar data at each reference location.
+     * @param ref_locs A vector of reference locations.
+     * @param interp_loc The location at which to interpolate.
+     * @param weights A vector of weights corresponding to each reference location, typically
+     * based on distance to interp_loc.
+     * @return std::vector<double> The interpolated scalar values at the specified interpolation
+     * location.
+     */
+    std::vector<double> moving_least_square(const std::vector<std::vector<double>>& scalar_data,
+        const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights);
 
     /**
-     * @class ScalarInterpolator
-     * @brief A class template for performing scalar interpolation using various methods and
-     * weighting functions.
+     * @brief Computes the logarithmic interpolation of scalar data using the provided weights.
      *
-     * This class provides functionality to interpolate scalar values at arbitrary locations based
-     * on reference data points and their associated locations. It supports different interpolation
-     * types, including moving least squares (MLS), logarithmic interpolation, and log-domain MLS,
-     * with customizable weighting functions and interpolation parameters.
+     * This function takes a 2D vector of scalar data and a vector of weights, and returns a
+     * vector containing the logarithmic interpolation results for each set of scalar values.
      *
-     * @tparam loc_dim The spatial dimension of the interpolation (e.g., 2 for 2D, 3 for 3D).
-     * @tparam poly_order The polynomial order used in the interpolation basis (MLS &LOGMLS).
-     * @tparam num_coefficients The number of coefficients in the interpolation basis, applying to
-     * the polynomial shape function (MLS & LOGMLS).
-     *
-     * Usage:
-     *   - Construct with the desired interpolation type, weighting function, and parameters.
-     *      for example:
-     *        (a) LOG: (second and third template argument are ignored)
-     *          ScalarInterpolator<3> interpolator(ScalarInterpolationType::MLS,
-     *          WeightingFunction::exponential, interp_params)
-     *
-     *        (b) MLS/LOGMLS: (all three template arguments are used)
-     *          ScalarInterpolator<3, 2, 10>
-     *            interpolator( ScalarInterpolationType::MLS, WeightingFunction::exponential,
-     * interp_params);
-     *   - Use get_interpolated_scalar() to compute interpolated values at a given location.
-     *   - Use calculate_normalized_weights() to obtain normalized weights for reference points, if
-     * interested to return weights.
-     *
-     * Private helper methods implement the core interpolation algorithms, including MLS,
-     * logarithmic variants, and log MLS.
+     * @param scalar_data A 2D vector where each inner vector contains scalar values to be
+     * interpolated.
+     * @param weights A vector of weights corresponding to the scalar values for interpolation.
+     * @return A vector of doubles representing the logarithmic interpolation results.
      */
-    template <unsigned int loc_dim, unsigned int poly_order = 1, unsigned int num_coefficients = 1>
-    class ScalarInterpolator
-    {
-     public:
-      /**
-       * @brief Constructs a ScalarInterpolator with the specified interpolation type, weighting
-       * function, and parameters.
-       *
-       * @param scalar_interp_type The type of scalar interpolation to use.
-       * @param weight_func The weighting function to apply during interpolation.
-       * @param interp_params Additional parameters required for the interpolation process.
-       */
-      ScalarInterpolator(const ScalarInterpolationType scalar_interp_type,
-          const WeightingFunction weight_func, const InterpParams& interp_params);
+    std::vector<double> logarithmic_weighted_average(
+        const std::vector<std::vector<double>>& scalar_data, const std::vector<double>& weights);
 
-      /**
-       * @brief Interpolates scalar values at a given location using provided scalar data and
-       * reference locations.
-       *
-       * This function computes the interpolated scalar values at the specified interpolation
-       * location @p interp_loc based on the input scalar data and their corresponding reference
-       * locations.
-       *
-       * @param scalar_data A vector of vectors containing scalar values at each reference location.
-       * @param ref_locs A vector of reference locations.
-       * @param interp_loc The location at which the scalar value is to be interpolated.
-       * @return std::vector<double> The interpolated scalar values at the specified interpolation
-       * location.
-       */
-      std::vector<double> get_interpolated_scalar(
-          const std::vector<std::vector<double>>& scalar_data,
-          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc);
+    /**
+     * @brief Computes the log moving least squares interpolation for scalar data.
+     *
+     * This function performs moving least squares interpolation in the logarithmic domain
+     * for a set of scalar data points. It uses the provided reference locations, interpolation
+     * location, and associated weights to compute the interpolated values.
+     *
+     * @param scalar_data A vector of vectors containing the scalar data values at each reference
+     * location.
+     * @param ref_locs A vector of reference locations.
+     * @param interp_loc The location at which the interpolation is to be performed.
+     * @param weights A vector of weights corresponding to each reference location.
+     * @return std::vector<double> The interpolated scalar values at the specified interpolation
+     * location.
+     */
+    std::vector<double> logarithmic_moving_least_squares(
+        const std::vector<std::vector<double>>& scalar_data,
+        const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights);
 
-     private:
-      /**
-       * @brief Computes the moving least squares (MLS) interpolation for a given location.
-       *
-       * This function performs MLS interpolation using the provided scalar data, reference
-       * locations, interpolation location, and associated weights. It returns the interpolated
-       * scalar values.
-       *
-       * @param scalar_data A vector of vectors containing scalar data at each reference location.
-       * @param ref_locs A vector of reference locations.
-       * @param interp_loc The location at which to interpolate.
-       * @param weights A vector of weights corresponding to each reference location, typically
-       * based on distance to interp_loc.
-       * @return std::vector<double> The interpolated scalar values at the specified interpolation
-       * location.
-       */
-      std::vector<double> moving_least_square(const std::vector<std::vector<double>>& scalar_data,
-          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights);
-
-      /**
-       * @brief Computes the logarithmic interpolation of scalar data using the provided weights.
-       *
-       * This function takes a 2D vector of scalar data and a vector of weights, and returns a
-       * vector containing the logarithmic interpolation results for each set of scalar values.
-       *
-       * @param scalar_data A 2D vector where each inner vector contains scalar values to be
-       * interpolated.
-       * @param weights A vector of weights corresponding to the scalar values for interpolation.
-       * @return A vector of doubles representing the logarithmic interpolation results.
-       */
-      std::vector<double> logarithmic_weighted_average(
-          const std::vector<std::vector<double>>& scalar_data, const std::vector<double>& weights);
-
-      /**
-       * @brief Computes the log moving least squares interpolation for scalar data.
-       *
-       * This function performs moving least squares interpolation in the logarithmic domain
-       * for a set of scalar data points. It uses the provided reference locations, interpolation
-       * location, and associated weights to compute the interpolated values.
-       *
-       * @param scalar_data A vector of vectors containing the scalar data values at each reference
-       * location.
-       * @param ref_locs A vector of reference locations.
-       * @param interp_loc The location at which the interpolation is to be performed.
-       * @param weights A vector of weights corresponding to each reference location.
-       * @return std::vector<double> The interpolated scalar values at the specified interpolation
-       * location.
-       */
-      std::vector<double> logarithmic_moving_least_squares(
-          const std::vector<std::vector<double>>& scalar_data,
-          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, const std::vector<double>& weights);
-
-      const ScalarInterpolationType scalar_interp_type_;
-      const WeightingFunction weight_func_;
-      const InterpParams interp_params_;
-    };
-  }  // namespace ScalarInterpolation
+    const ScalarInterpolationType scalar_interp_type_;
+    const ScalarInterpolationWeightingFunction weight_func_;
+    const ScalarInterpolationParams interp_params_;
+  };
 }  // namespace Core::LinAlg
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utils_tensor_interpolation.hpp
@@ -13,230 +13,216 @@
 #include "4C_fem_general_utils_polynomial.hpp"
 #include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
+#include "4C_linalg_utils_scalar_interpolation.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
+
 
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg
 {
-  namespace TensorInterpolation
+  /// enum class for the error types of the tensor interpolator
+  enum class TensorInterpolationErrorType
   {
-    /// enum class for the error types of the tensor interpolator
-    enum class TensorInterpolationErrorType
-    {
-      NoErrors,             ///< no evaluation errors
-      LinSolveFailQMatrix,  ///< the solution of the linear system of equations for the rotation
-                            ///< matrix Q failed
-      LinSolveFailRMatrix,  ///< the solution of the linear system of equations for the rotation
-                            ///< matrix R failed
-    };
+    NoErrors,             ///< no evaluation errors
+    LinSolveFailQMatrix,  ///< the solution of the linear system of equations for the rotation
+                          ///< matrix Q failed
+    LinSolveFailRMatrix,  ///< the solution of the linear system of equations for the rotation
+                          ///< matrix R failed
+  };
 
-    /// enum class for the interpolation type of the relative rotation matrices
-    enum class RotationInterpolationType
-    {
-      RotationVector,  ///< interpolation of relative rotation vectors,
-      Quaternion,      ///< interpolation of relative quaternions,
-    };
+  /// enum class for the interpolation type of the relative rotation matrices
+  enum class RotationInterpolationType
+  {
+    RotationVector,  ///< interpolation of relative rotation vectors,
+    Quaternion,      ///< interpolation of relative quaternions,
+  };
 
-    /// enum class for the interpolation type of the eigenvalue matrix
-    enum class EigenvalInterpolationType
-    {
-      LOG,     ///< logarithmic weighted average,
-      MLS,     ///< moving least squares,
-      LOGMLS,  ///< logarithmic moving least squares,
-    };
+  /// enum class for the interpolation type of the eigenvalue matrix
+  enum class EigenvalInterpolationType
+  {
+    LOG,     ///< logarithmic weighted average,
+    MLS,     ///< moving least squares,
+    LOGMLS,  ///< logarithmic moving least squares,
+  };
 
-    /// make error message: error types to error message for the tensor interpolator
-    inline std::string make_error_message(const TensorInterpolationErrorType err_type)
+  /// make error message: error types to error message for the tensor interpolator
+  inline std::string make_error_message(const TensorInterpolationErrorType err_type)
+  {
+    switch (err_type)
     {
-      switch (err_type)
-      {
-        case TensorInterpolationErrorType::NoErrors:
-          return "No Errors";
-        case TensorInterpolationErrorType::LinSolveFailQMatrix:
-          return "The solution of the linear system of equations for the rotation matrix Q "
-                 "(second-order tensor interpolation) has failed!";
-        case TensorInterpolationErrorType::LinSolveFailRMatrix:
-          return "The solution of the linear system of equations for the rotation matrix R "
-                 "(second-order tensor interpolation) has failed!";
-        default:
-          FOUR_C_THROW("to_string(Core::LinAlg::TensorInterpErrorType): you should not be here!");
-      }
+      case TensorInterpolationErrorType::NoErrors:
+        return "No Errors";
+      case TensorInterpolationErrorType::LinSolveFailQMatrix:
+        return "The solution of the linear system of equations for the rotation matrix Q "
+               "(second-order tensor interpolation) has failed!";
+      case TensorInterpolationErrorType::LinSolveFailRMatrix:
+        return "The solution of the linear system of equations for the rotation matrix R "
+               "(second-order tensor interpolation) has failed!";
+      default:
+        FOUR_C_THROW("to_string(Core::LinAlg::TensorInterpErrorType): you should not be here!");
     }
+  }
 
-    /// struct containing parameters used for the tensor interpolation
-    struct InterpParams
-    {
-      /// exponential decay factor of the
-      ///  weighting functions, as shown in Satheesh,
-      ///  2024, 10.1002/nme.7373, Eq. (21). We currently use the same factor
-      ///  for the rotation and eigenvalue interpolation.
-      double exponential_decay_c = 10.0;
+  /*!
+   * \class SecondOrderTensorInterpolator
+   *
+   * Interpolation of invertible second-order tensors (3x3), preserving tensor
+   * characteristics.
+   *
+   * The class provides the capability to interpolate a second-order tensor \f$
+   * \boldsymbol{T}_{\text{p}}
+   * \f$ at the specified location  \f$ \boldsymbol{x}_\text{p} \f$, given a set of tensors \f$
+   * \boldsymbol{T}_j \f$ (second-order, 3x3) at the spatial positions \f$ \boldsymbol{x}_j \f$.
+   * The interpolation scheme, using a combined polar and spectral decomposition, preserves
+   * several tensor characteristics, such as positive definiteness and monotonicity of
+   * invariants. For further information on the interpolation scheme, refer to:
+   * -# Satheesh et al., Structure-Preserving Invariant Interpolation Schemes for Invertible
+   * Second-Order Tensors, Int J Numerical Methods Eng. 2024, 125, 10.1002/nme.7373
+   *
+   * @tparam loc_dim dimension of the location vectors \f$ \boldsymbol{x}_j \f$
+   */
 
-      /// perturbation factor used for the numerical approximation of
-      /// the interpolation gradient
-      double perturbation_factor = 1.0e-8;
-    };
+  template <unsigned int loc_dim>
+  class SecondOrderTensorInterpolator
+  {
+   public:
+    /*! @brief Constructor of the second-order tensor interpolator class
+     *
+     *  @param[in] order polynomial order (1:linear, 2: quadratic, ...) used for interpolating
+     * the rotation vectors at the specified location
+     *  @param[in] rot_interp_type interpolation algorithm used for
+     *  the rotation matrices
+     *  @param[in] eigenval_interp_type interpolation algorithm used for
+     *  the eigenvalue matrices
+     *  @param[in] interp_params interpolation parameters
+     */
+    SecondOrderTensorInterpolator(unsigned int order,
+        const RotationInterpolationType rot_interp_type,
+        const EigenvalInterpolationType eigenval_interp_type,
+        const ScalarInterpolationParams& interp_params);
 
+    /*! @brief Helper function to define the polynomial space
+     *
+     *  @param[in] order polynomial order (1:linear, 2: quadratic, ...) used for interpolating
+     * the rotation vectors at the specified location
+     *  @returns polynomial space(monomials) with desired polynomial order and dimensionality
+     */
+    Core::FE::PolynomialSpaceComplete<loc_dim, Core::FE::Polynomial> create_polynomial_space(
+        unsigned int order);
 
     /*!
-     * \class SecondOrderTensorInterpolator
+     * @brief Interpolate matrix (second-order 3x3 tensor) from a set of defined reference
+     * matrices at specified locations.
      *
-     * Interpolation of invertible second-order tensors (3x3), preserving tensor
-     * characteristics.
+     * This method performs tensor interpolation based on a given set of tensors \f$
+     * \boldsymbol{T}_j \f$ (second-order, 3x3) at the spatial positions/locations \f$
+     * \boldsymbol{x}_j \f$. Concretely, the tensor is interpolated at the specified location \f$
+     * \boldsymbol{x}_{\text{p}} \f$. Specifically, the R-LOG method from the paper below is
+     * currently implemented (rotation vector interpolation + logarithmic weighted average method
+     * for eigenvalues):
+     * -# Satheesh et al., Structure-Preserving Invariant Interpolation Schemes for Invertible
+     * Second-Order Tensors, Int J Number Methods Eng. 2024, 125, 10.1002/nme.7373
+     * @param[in]  ref_matrices  reference 3x3 matrices \f$ \boldsymbol{T}_j \f$ used as basis for
+     *                            interpolation
+     * @param[in]  ref_locs  locations \f$ \boldsymbol{x}_j \f$ of the reference matrices
+     * @param[in]  interp_loc location \f$ \boldsymbol{x}_{\text{p}} \f$ of the interpolated
+     * tensor
+     * @param[in, out] err_type  error type of the tensor interpolator
+     *  (shall be TensorInterpErrorType::NoErrors if no errors occurred)
+     * @returns interpolated 3x3 matrix
+     */
+    Core::LinAlg::Matrix<3, 3> get_interpolated_matrix(
+        const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
+        const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, TensorInterpolationErrorType& err_type);
+
+    /*!
+     * @brief Interpolate matrix (second-order 3x3 tensor) from a set of defined reference
+     * matrices at specified locations.
      *
-     * The class provides the capability to interpolate a second-order tensor \f$
-     * \boldsymbol{T}_{\text{p}}
-     * \f$ at the specified location  \f$ \boldsymbol{x}_\text{p} \f$, given a set of tensors \f$
-     * \boldsymbol{T}_j \f$ (second-order, 3x3) at the spatial positions \f$ \boldsymbol{x}_j \f$.
-     * The interpolation scheme, using a combined polar and spectral decomposition, preserves
-     * several tensor characteristics, such as positive definiteness and monotonicity of
-     * invariants. For further information on the interpolation scheme, refer to:
+     * This method performs tensor interpolation based on a given set of tensors \f$
+     * \boldsymbol{T}_j \f$ (second-order, 3x3) at the spatial positions/locations \f$
+     * \boldsymbol{x}_j \f$. Concretely, the tensor is interpolated at the specified location \f$
+     * \boldsymbol{x}_{\text{p}} \f$. Specifically, the R-LOG method from the paper below is
+     * currently implemented (rotation vector interpolation + logarithmic weighted average method
+     * for eigenvalues):
      * -# Satheesh et al., Structure-Preserving Invariant Interpolation Schemes for Invertible
      * Second-Order Tensors, Int J Numerical Methods Eng. 2024, 125, 10.1002/nme.7373
-     *
-     * @tparam loc_dim dimension of the location vectors \f$ \boldsymbol{x}_j \f$
+     * @param[in]  ref_matrices  reference 3x3 matrices \f$ \boldsymbol{T}_j \f$ used as basis for
+     *                            interpolation
+     * @param[in]  ref_locs  locations \f$ \boldsymbol{x}_j \f$ of the reference matrices
+     * @param[in]  interp_loc location \f$ \boldsymbol{x}_{\text{p}} \f$ of the interpolated
+     * tensor
+     * @param[in, out] err_type  error type of the tensor interpolator
+     *  (shall be TensorInterpErrorType::NoErrors if no errors occurred)
+     * @returns interpolated 3x3 matrix
      */
+    Core::LinAlg::Matrix<3, 3> get_interpolated_matrix(
+        const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
+        const std::vector<double>& ref_locs, const double interp_loc,
+        TensorInterpolationErrorType& err_type);
 
-    template <unsigned int loc_dim>
-    class SecondOrderTensorInterpolator
-    {
-     public:
-      /*! @brief Constructor of the second-order tensor interpolator class
-       *
-       *  @param[in] order polynomial order (1:linear, 2: quadratic, ...) used for interpolating
-       * the rotation vectors at the specified location
-       *  @param[in] rot_interp_type interpolation algorithm used for
-       *  the rotation matrices
-       *  @param[in] eigenval_interp_type interpolation algorithm used for
-       *  the eigenvalue matrices
-       *  @param[in] interp_params interpolation parameters
-       */
-      SecondOrderTensorInterpolator(unsigned int order,
-          const RotationInterpolationType rot_interp_type,
-          const EigenvalInterpolationType eigenval_interp_type, const InterpParams& interp_params);
+    /*!
+     * @name Get interpolation gradient, i.e. the derivative of the
+     * interpolated matrix with respect to the interpolation location
+     * vector / scalar.
+     *
+     * @note The derivative is computed numerically using a
+     * perturbation approach with finite differences.
+     *
+     * @param[in]  ref_matrices  reference 3x3 matrices \f$ \boldsymbol{T}_j \f$ used as basis for
+     *                            interpolation
+     * @param[in]  ref_locs  locations \f$ \boldsymbol{x}_j \f$ of the reference matrices
+     * @param[in]  interp_loc location \f$ \boldsymbol{x}_{\text{p}} \f$ of the interpolated
+     * tensor
+     * @param[in, out] err_type  error type of the tensor interpolator
+     *  (shall be TensorInterpErrorType::NoErrors if no errors occurred)
+     * @param[in]  perturbation_factor perturbation factor \f$
+     * \epsilon_{\text{perturb}} \f$ to be used in the numerical
+     * gradient determination (default: 1.0e-8).
+     * @returns derivative of the interpolated matrix with respect to
+     * the interpolation location vector. The result is a 9 x <dim>
+     * matrix, where the second dimension corresponds to the dimension of
+     * the location vector (1D, 2D, 3D).
+     */
+    //! @{
+    /*!
+     * @brief Standard method for interpolation locations with
+     * variable dimensionality.
+     */
+    Core::LinAlg::Matrix<9, loc_dim> get_interpolation_gradient(
+        const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
+        const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
+        const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc, TensorInterpolationErrorType& err_type,
+        const double perturbation_factor = 1.0e-8);
 
-      /*! @brief Helper function to define the polynomial space
-       *
-       *  @param[in] order polynomial order (1:linear, 2: quadratic, ...) used for interpolating
-       * the rotation vectors at the specified location
-       *  @returns polynomial space(monomials) with desired polynomial order and dimensionality
-       */
-      Core::FE::PolynomialSpaceComplete<loc_dim, Core::FE::Polynomial> create_polynomial_space(
-          unsigned int order);
+    /*!
+     * @brief Specialized method for 1D interpolation locations.
+     * @note Calls the standard method but is more easy to handle when
+     * using 1D locations.
+     */
+    Core::LinAlg::Matrix<9, 1> get_interpolation_gradient(
+        const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
+        const std::vector<double>& ref_locs, const double interp_loc,
+        TensorInterpolationErrorType& err_type, const double perturbation_factor = 1.0e-8);
+    //! @}
 
-      /*!
-       * @brief Interpolate matrix (second-order 3x3 tensor) from a set of defined reference
-       * matrices at specified locations.
-       *
-       * This method performs tensor interpolation based on a given set of tensors \f$
-       * \boldsymbol{T}_j \f$ (second-order, 3x3) at the spatial positions/locations \f$
-       * \boldsymbol{x}_j \f$. Concretely, the tensor is interpolated at the specified location \f$
-       * \boldsymbol{x}_{\text{p}} \f$. Specifically, the R-LOG method from the paper below is
-       * currently implemented (rotation vector interpolation + logarithmic weighted average method
-       * for eigenvalues):
-       * -# Satheesh et al., Structure-Preserving Invariant Interpolation Schemes for Invertible
-       * Second-Order Tensors, Int J Number Methods Eng. 2024, 125, 10.1002/nme.7373
-       * @param[in]  ref_matrices  reference 3x3 matrices \f$ \boldsymbol{T}_j \f$ used as basis for
-       *                            interpolation
-       * @param[in]  ref_locs  locations \f$ \boldsymbol{x}_j \f$ of the reference matrices
-       * @param[in]  interp_loc location \f$ \boldsymbol{x}_{\text{p}} \f$ of the interpolated
-       * tensor
-       * @param[in, out] err_type  error type of the tensor interpolator
-       *  (shall be TensorInterpErrorType::NoErrors if no errors occurred)
-       * @returns interpolated 3x3 matrix
-       */
-      Core::LinAlg::Matrix<3, 3> get_interpolated_matrix(
-          const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
-          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc,
-          TensorInterpolationErrorType& err_type);
+   private:
+    /// polynomial space used for the interpolation of rotation vectors depending
+    /// on the desired order (created in constructor call)
+    Core::FE::PolynomialSpaceComplete<loc_dim, Core::FE::Polynomial> polynomial_space_;
 
-      /*!
-       * @brief Interpolate matrix (second-order 3x3 tensor) from a set of defined reference
-       * matrices at specified locations.
-       *
-       * This method performs tensor interpolation based on a given set of tensors \f$
-       * \boldsymbol{T}_j \f$ (second-order, 3x3) at the spatial positions/locations \f$
-       * \boldsymbol{x}_j \f$. Concretely, the tensor is interpolated at the specified location \f$
-       * \boldsymbol{x}_{\text{p}} \f$. Specifically, the R-LOG method from the paper below is
-       * currently implemented (rotation vector interpolation + logarithmic weighted average method
-       * for eigenvalues):
-       * -# Satheesh et al., Structure-Preserving Invariant Interpolation Schemes for Invertible
-       * Second-Order Tensors, Int J Numerical Methods Eng. 2024, 125, 10.1002/nme.7373
-       * @param[in]  ref_matrices  reference 3x3 matrices \f$ \boldsymbol{T}_j \f$ used as basis for
-       *                            interpolation
-       * @param[in]  ref_locs  locations \f$ \boldsymbol{x}_j \f$ of the reference matrices
-       * @param[in]  interp_loc location \f$ \boldsymbol{x}_{\text{p}} \f$ of the interpolated
-       * tensor
-       * @param[in, out] err_type  error type of the tensor interpolator
-       *  (shall be TensorInterpErrorType::NoErrors if no errors occurred)
-       * @returns interpolated 3x3 matrix
-       */
-      Core::LinAlg::Matrix<3, 3> get_interpolated_matrix(
-          const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
-          const std::vector<double>& ref_locs, const double interp_loc,
-          TensorInterpolationErrorType& err_type);
+    /// rotation interpolation type
+    const RotationInterpolationType rot_interp_type_;
 
-      /*!
-       * @name Get interpolation gradient, i.e. the derivative of the
-       * interpolated matrix with respect to the interpolation location
-       * vector / scalar.
-       *
-       * @note The derivative is computed numerically using a
-       * perturbation approach with finite differences.
-       *
-       * @param[in]  ref_matrices  reference 3x3 matrices \f$ \boldsymbol{T}_j \f$ used as basis for
-       *                            interpolation
-       * @param[in]  ref_locs  locations \f$ \boldsymbol{x}_j \f$ of the reference matrices
-       * @param[in]  interp_loc location \f$ \boldsymbol{x}_{\text{p}} \f$ of the interpolated
-       * tensor
-       * @param[in, out] err_type  error type of the tensor interpolator
-       *  (shall be TensorInterpErrorType::NoErrors if no errors occurred)
-       * @returns derivative of the interpolated matrix with respect to
-       * the interpolation location vector. The result is a 9 x <dim>
-       * matrix, where the second dimension corresponds to the dimension of
-       * the location vector (1D, 2D, 3D).
-       */
-      //! @{
-      /*!
-       * @brief Standard method for interpolation locations with
-       * variable dimensionality.
-       */
-      Core::LinAlg::Matrix<9, loc_dim> get_interpolation_gradient(
-          const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
-          const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-          const Core::LinAlg::Matrix<loc_dim, 1>& interp_loc,
-          TensorInterpolationErrorType& err_type);
+    /// eigenvalue interpolation type
+    const EigenvalInterpolationType eigenval_interp_type_;
 
-      /*!
-       * @brief Specialized method for 1D interpolation locations.
-       * @note Calls the standard method but is more easy to handle when
-       * using 1D locations.
-       */
-      Core::LinAlg::Matrix<9, 1> get_interpolation_gradient(
-          const std::vector<Core::LinAlg::Matrix<3, 3>>& ref_matrices,
-          const std::vector<double>& ref_locs, const double interp_loc,
-          TensorInterpolationErrorType& err_type);
-      //! @}
-
-     private:
-      /// polynomial space used for the interpolation of rotation vectors depending
-      /// on the desired order (created in constructor call)
-      Core::FE::PolynomialSpaceComplete<loc_dim, Core::FE::Polynomial> polynomial_space_;
-
-      /// rotation interpolation type
-      const RotationInterpolationType rot_interp_type_;
-
-      /// eigenvalue interpolation type
-      const EigenvalInterpolationType eigenval_interp_type_;
-
-      /// interpolation parameters
-      const InterpParams interp_params_;
-    };
-
-  }  // namespace TensorInterpolation
+    /// interpolation parameters
+    const ScalarInterpolationParams interp_params_;
+  };
 
   /*!
    * @brief Perform polar decomposition \f$ \boldsymbol{T} = \boldsymbol{R} \boldsymbol{U} \f$ of

--- a/src/core/linalg/src/dense/4C_linalg_utlis_quaternion_interpolation.cpp
+++ b/src/core/linalg/src/dense/4C_linalg_utlis_quaternion_interpolation.cpp
@@ -69,8 +69,8 @@ Core::LinAlg::GeneralizedSphericalLinearInterpolator<loc_dim>::
     GeneralizedSphericalLinearInterpolator(
         const std::vector<Core::LinAlg::Matrix<4, 1>>& unit_quaternions,
         const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-        const Core::LinAlg::ScalarInterpolation::WeightingFunction weight_func,
-        const Core::LinAlg::ScalarInterpolation::InterpParams& interp_params)
+        const Core::LinAlg::ScalarInterpolationWeightingFunction weight_func,
+        const Core::LinAlg::ScalarInterpolationParams& interp_params)
     : unit_quaternions_(unit_quaternions),
       ref_locs_(ref_locs),
       weight_func_(weight_func),
@@ -155,7 +155,7 @@ Core::LinAlg::GeneralizedSphericalLinearInterpolator<loc_dim>::get_interpolated_
 {
   if (interp_loc != nullptr and normalized_weights_.empty())
   {
-    normalized_weights_ = Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+    normalized_weights_ = Core::LinAlg::calculate_normalized_weights(
         ref_locs_, *interp_loc, weight_func_, interp_params_);
   }
 

--- a/src/core/linalg/src/dense/4C_linalg_utlis_quaternion_interpolation.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_utlis_quaternion_interpolation.hpp
@@ -64,8 +64,8 @@ namespace Core
       GeneralizedSphericalLinearInterpolator(
           const std::vector<Core::LinAlg::Matrix<4, 1>>& unit_quaternions,
           const std::vector<Core::LinAlg::Matrix<loc_dim, 1>>& ref_locs,
-          const Core::LinAlg::ScalarInterpolation::WeightingFunction weight_func,
-          const Core::LinAlg::ScalarInterpolation::InterpParams& interp_params);
+          const Core::LinAlg::ScalarInterpolationWeightingFunction weight_func,
+          const Core::LinAlg::ScalarInterpolationParams& interp_params);
 
       /**
        * @brief Constructs a GeneralizedSphericalLinearInterpolator with a set of normalized
@@ -212,8 +212,8 @@ namespace Core
       std::vector<Core::LinAlg::Matrix<4, 1>> unit_quaternions_;
       std::vector<double> normalized_weights_;
       std::vector<Core::LinAlg::Matrix<loc_dim, 1>> ref_locs_;
-      Core::LinAlg::ScalarInterpolation::WeightingFunction weight_func_;
-      Core::LinAlg::ScalarInterpolation::InterpParams interp_params_;
+      Core::LinAlg::ScalarInterpolationWeightingFunction weight_func_;
+      Core::LinAlg::ScalarInterpolationParams interp_params_;
     };
   }  // namespace LinAlg
 }  // namespace Core

--- a/src/core/linalg/tests/4C_linalg_utils_quaternion_interpolation_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_quaternion_interpolation_test.cpp
@@ -8,6 +8,7 @@
 #include <gtest/gtest.h>
 
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_utils_scalar_interpolation.hpp"
 #include "4C_linalg_utlis_quaternion_interpolation.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -207,8 +208,8 @@ TEST(QuaternionInterpolationTest, SlerpThreeQuaternions_2DRefLoc_EquidistantInte
   interp_loc(1, 0) = (ref_locs[0](1, 0) + ref_locs[1](1, 0) + ref_locs[2](1, 0)) / 3.0;
 
   // Use inverse distance weighting function and default params
-  auto weight_func = Core::LinAlg::ScalarInterpolation::WeightingFunction::inverse_distance;
-  Core::LinAlg::ScalarInterpolation::InterpParams interp_params;
+  auto weight_func = Core::LinAlg::ScalarInterpolationWeightingFunction::inverse_distance;
+  Core::LinAlg::ScalarInterpolationParams interp_params;
 
   Core::LinAlg::GeneralizedSphericalLinearInterpolator<2> interpolator(
       quats, ref_locs, weight_func, interp_params);
@@ -306,8 +307,8 @@ TEST(QuaternionInterpolationTest, SlerpFourQuaternions_2DRefLoc_EquidistantInter
   interp_loc(1, 0) = 0.5;
 
   // Use inverse distance weighting function and default params
-  auto weight_func = Core::LinAlg::ScalarInterpolation::WeightingFunction::inverse_distance;
-  Core::LinAlg::ScalarInterpolation::InterpParams interp_params;
+  auto weight_func = Core::LinAlg::ScalarInterpolationWeightingFunction::inverse_distance;
+  Core::LinAlg::ScalarInterpolationParams interp_params;
 
   Core::LinAlg::GeneralizedSphericalLinearInterpolator<2> interpolator(
       quats, ref_locs, weight_func, interp_params);

--- a/src/core/linalg/tests/4C_linalg_utils_scalar_interpolation_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_scalar_interpolation_test.cpp
@@ -26,7 +26,7 @@ namespace
 {
   TEST(LinalgScalarInterpolationTest, CalculateNormalizedWeights1DInverseDistance)
   {
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     // 1D
     constexpr unsigned int loc_dim = 3;
@@ -45,15 +45,16 @@ namespace
     interp_loc(0, 0) = 0.5;
 
     // Weighting function: inverse distance
-    WeightingFunction weight_func = WeightingFunction::inverse_distance;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::inverse_distance;
 
     // Interpolation parameters
-    InterpParams interp_params;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.inverse_distance_power = 1.0;  // Use power of 1 for inverse distance
 
     // Call the function
-    std::vector<double> weights = Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+    std::vector<double> weights = Core::LinAlg::calculate_normalized_weights(
         ref_locs, interp_loc, weight_func, interp_params);
 
     // So weights should be [0.25, 0.75]
@@ -65,7 +66,7 @@ namespace
 
   TEST(LinalgScalarInterpolationTest, CalculateNormalizedWeights1DExponential)
   {
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     // 1D
     constexpr unsigned int loc_dim = 3;
@@ -84,15 +85,16 @@ namespace
     interp_loc(0, 0) = 0.5;
 
     // Weighting function: exponential
-    WeightingFunction weight_func = WeightingFunction::exponential;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::exponential;
 
     // Interpolation parameters
-    InterpParams interp_params;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.exponential_decay_c = 1.0;  // decay parameter
 
     // Call the function
-    std::vector<double> weights = Core::LinAlg::ScalarInterpolation::calculate_normalized_weights(
+    std::vector<double> weights = Core::LinAlg::calculate_normalized_weights(
         ref_locs, interp_loc, weight_func, interp_params);
 
     // Calculate expected weights manually
@@ -112,7 +114,7 @@ namespace
     // see Satheesh et al., 2024, 10.1002/nme.7373, Section 2.4.4 Comparison of eigenvalue
     // interpolation methods
 
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     constexpr unsigned int loc_dim = 1;
 
@@ -134,8 +136,9 @@ namespace
     scalar_data.push_back({0.1});
     scalar_data.push_back({1.0});
 
-    WeightingFunction weight_func = WeightingFunction::exponential;
-    InterpParams interp_params;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::exponential;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.exponential_decay_c = 10.0;
 
@@ -164,7 +167,7 @@ namespace
     // see Satheesh et al., 2024, 10.1002/nme.7373, Section 2.4.4 Comparison of eigenvalue
     // interpolation methods
 
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     constexpr unsigned int loc_dim = 1;
     constexpr unsigned int poly_order = 2;
@@ -188,8 +191,9 @@ namespace
     scalar_data.push_back({0.1, 0.1, 0.1});
     scalar_data.push_back({1.0, 1.0, 1.0});
 
-    WeightingFunction weight_func = WeightingFunction::exponential;
-    InterpParams interp_params;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::exponential;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.exponential_decay_c = 1.0;
 
@@ -236,7 +240,7 @@ namespace
     //                       = 4.5
     // -----------------------------------------------------------------------------
 
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     constexpr unsigned int loc_dim = 3;
     constexpr unsigned int poly_order = 1;
@@ -261,8 +265,9 @@ namespace
       scalar_data.push_back({static_cast<double>(i + 1)});
     }
 
-    WeightingFunction weight_func = WeightingFunction::exponential;
-    InterpParams interp_params;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::exponential;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.exponential_decay_c = 1.0;
 
@@ -313,7 +318,7 @@ namespace
     // Thus, the displacement at the centroid is $34.5$.
     // -----------------------------------------------------------------------------
 
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     constexpr unsigned int loc_dim = 3;
     constexpr unsigned int poly_order = 2;
@@ -356,8 +361,9 @@ namespace
       scalar_data.push_back({static_cast<double>(i + 1)});
     }
 
-    WeightingFunction weight_func = WeightingFunction::exponential;
-    InterpParams interp_params;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::exponential;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.exponential_decay_c = 1.0;
 
@@ -379,7 +385,7 @@ namespace
     // see Satheesh et al., 2024, 10.1002/nme.7373, Section 2.4.4 Comparison of eigenvalue
     // interpolation methods
 
-    using namespace Core::LinAlg::ScalarInterpolation;
+    using namespace Core::LinAlg;
 
     constexpr unsigned int loc_dim = 1;
     constexpr unsigned int poly_order = 2;
@@ -403,8 +409,9 @@ namespace
     scalar_data.push_back({0.1, 0.1, 0.1});
     scalar_data.push_back({1.0, 1.0, 1.0});
 
-    WeightingFunction weight_func = WeightingFunction::exponential;
-    InterpParams interp_params;
+    ScalarInterpolationWeightingFunction weight_func =
+        ScalarInterpolationWeightingFunction::exponential;
+    ScalarInterpolationParams interp_params;
     interp_params.distance_threshold = 1e-12;
     interp_params.exponential_decay_c = 1.0;
 

--- a/src/core/linalg/tests/4C_linalg_utils_tensor_interpolation_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_utils_tensor_interpolation_test.cpp
@@ -10,6 +10,7 @@
 #include "4C_linalg_utils_tensor_interpolation.hpp"
 
 #include "4C_linalg_fixedsizematrix.hpp"
+#include "4C_linalg_utils_scalar_interpolation.hpp"
 #include "4C_unittest_utils_assertions_test.hpp"
 #include "4C_utils_exceptions.hpp"
 
@@ -35,12 +36,12 @@ namespace
     Core::LinAlg::Matrix<3, 3> temp3x3(Core::LinAlg::Initialization::zero);
 
     // create interpolation parameter object
-    Core::LinAlg::TensorInterpolation::InterpParams interp_params;
+    Core::LinAlg::ScalarInterpolationParams interp_params;
 
     // create tensor interpolator
-    Core::LinAlg::TensorInterpolation::SecondOrderTensorInterpolator<1> interp{1,
-        Core::LinAlg::TensorInterpolation::RotationInterpolationType::RotationVector,
-        Core::LinAlg::TensorInterpolation::EigenvalInterpolationType::LOG, interp_params};
+    Core::LinAlg::SecondOrderTensorInterpolator<1> interp{1,
+        Core::LinAlg::RotationInterpolationType::RotationVector,
+        Core::LinAlg::EigenvalInterpolationType::LOG, interp_params};
 
     std::vector<Core::LinAlg::Matrix<3, 3>> ref_matrices;
     std::vector<Core::LinAlg::Matrix<1, 1>> ref_locs;
@@ -87,14 +88,12 @@ namespace
 
     Core::LinAlg::Matrix<1, 1> loc_interp(Core::LinAlg::Initialization::zero);
 
-    Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType err_type =
-        Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors;
+    Core::LinAlg::TensorInterpolationErrorType err_type =
+        Core::LinAlg::TensorInterpolationErrorType::NoErrors;
     Core::LinAlg::Matrix<3, 3> T_interp =
         interp.get_interpolated_matrix(ref_matrices, ref_locs, loc_interp, err_type);
-    FOUR_C_ASSERT_ALWAYS(
-        err_type == Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors,
-        "Tensor interpolation failed with err: {}",
-        Core::LinAlg::TensorInterpolation::make_error_message(err_type));
+    FOUR_C_ASSERT_ALWAYS(err_type == Core::LinAlg::TensorInterpolationErrorType::NoErrors,
+        "Tensor interpolation failed with err: {}", Core::LinAlg::make_error_message(err_type));
 
     // reference result
     Core::LinAlg::Matrix<3, 3> lambda_T_ref(Core::LinAlg::Initialization::zero);
@@ -127,12 +126,12 @@ namespace
     Core::LinAlg::Matrix<3, 3> temp3x3(Core::LinAlg::Initialization::zero);
 
     // create interpolation parameter object
-    Core::LinAlg::TensorInterpolation::InterpParams interp_params;
+    Core::LinAlg::ScalarInterpolationParams interp_params;
 
     // create tensor interpolator
-    Core::LinAlg::TensorInterpolation::SecondOrderTensorInterpolator<1> interp{1,
-        Core::LinAlg::TensorInterpolation::RotationInterpolationType::RotationVector,
-        Core::LinAlg::TensorInterpolation::EigenvalInterpolationType::LOG, interp_params};
+    Core::LinAlg::SecondOrderTensorInterpolator<1> interp{1,
+        Core::LinAlg::RotationInterpolationType::RotationVector,
+        Core::LinAlg::EigenvalInterpolationType::LOG, interp_params};
 
     std::vector<Core::LinAlg::Matrix<3, 3>> ref_matrices;
     std::vector<Core::LinAlg::Matrix<1, 1>> ref_locs;
@@ -187,14 +186,12 @@ namespace
 
     Core::LinAlg::Matrix<1, 1> loc_interp(Core::LinAlg::Initialization::zero);
 
-    Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType err_type =
-        Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors;
+    Core::LinAlg::TensorInterpolationErrorType err_type =
+        Core::LinAlg::TensorInterpolationErrorType::NoErrors;
     Core::LinAlg::Matrix<3, 3> T_interp =
         interp.get_interpolated_matrix(ref_matrices, ref_locs, loc_interp, err_type);
-    FOUR_C_ASSERT_ALWAYS(
-        err_type == Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors,
-        "Tensor interpolation failed with err: {}",
-        Core::LinAlg::TensorInterpolation::make_error_message(err_type));
+    FOUR_C_ASSERT_ALWAYS(err_type == Core::LinAlg::TensorInterpolationErrorType::NoErrors,
+        "Tensor interpolation failed with err: {}", Core::LinAlg::make_error_message(err_type));
 
     // reference result
     Core::LinAlg::Matrix<3, 3> lambda_T_ref(Core::LinAlg::Initialization::zero);
@@ -299,25 +296,23 @@ namespace
         Core::LinAlg::calc_rot_vect_from_rot_matrix(right_matrix_Q);
 
     // create interpolation parameter object
-    Core::LinAlg::TensorInterpolation::InterpParams interp_params;
+    Core::LinAlg::ScalarInterpolationParams interp_params;
 
     // create tensor interpolator
-    Core::LinAlg::TensorInterpolation::SecondOrderTensorInterpolator<1> interp{1,
-        Core::LinAlg::TensorInterpolation::RotationInterpolationType::RotationVector,
-        Core::LinAlg::TensorInterpolation::EigenvalInterpolationType::LOG, interp_params};
+    Core::LinAlg::SecondOrderTensorInterpolator<1> interp{1,
+        Core::LinAlg::RotationInterpolationType::RotationVector,
+        Core::LinAlg::EigenvalInterpolationType::LOG, interp_params};
 
     // get interp matrix (loc = specified)
     double loc = 5.695328e-01;
     std::vector<Core::LinAlg::Matrix<3, 3>> ref_matrices{left_matrix, right_matrix};
     std::vector<double> ref_locs{0.0, 1.0};
-    Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType err_type =
-        Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors;
+    Core::LinAlg::TensorInterpolationErrorType err_type =
+        Core::LinAlg::TensorInterpolationErrorType::NoErrors;
     Core::LinAlg::Matrix<3, 3> interp_matrix =
         interp.get_interpolated_matrix(ref_matrices, ref_locs, loc, err_type);
-    FOUR_C_ASSERT_ALWAYS(
-        err_type == Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors,
-        "Tensor interpolation failed with err: {}",
-        Core::LinAlg::TensorInterpolation::make_error_message(err_type));
+    FOUR_C_ASSERT_ALWAYS(err_type == Core::LinAlg::TensorInterpolationErrorType::NoErrors,
+        "Tensor interpolation failed with err: {}", Core::LinAlg::make_error_message(err_type));
 
     // perform polar decomposition of interp matrix
     Core::LinAlg::Matrix<3, 3> interp_matrix_R{Core::LinAlg::Initialization::zero};
@@ -518,37 +513,33 @@ namespace
     interp_loc(0) = 0.5;
 
     // create interpolation parameter object
-    Core::LinAlg::TensorInterpolation::InterpParams interp_params;
+    Core::LinAlg::ScalarInterpolationParams interp_params;
     interp_params.exponential_decay_c = 10.0;
-    interp_params.perturbation_factor = 1.0e-10;
+    const double perturbation_factor = 1.0e-10;
 
     // create tensor interpolator
-    Core::LinAlg::TensorInterpolation::SecondOrderTensorInterpolator<1> interp{1,
-        Core::LinAlg::TensorInterpolation::RotationInterpolationType::RotationVector,
-        Core::LinAlg::TensorInterpolation::EigenvalInterpolationType::LOG, interp_params};
+    Core::LinAlg::SecondOrderTensorInterpolator<1> interp{1,
+        Core::LinAlg::RotationInterpolationType::RotationVector,
+        Core::LinAlg::EigenvalInterpolationType::LOG, interp_params};
 
     // declare error type
-    Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType err_type =
-        Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors;
+    Core::LinAlg::TensorInterpolationErrorType err_type =
+        Core::LinAlg::TensorInterpolationErrorType::NoErrors;
 
     // get interpolation gradient
     std::vector<Core::LinAlg::Matrix<3, 3>> ref_matrices{left_matrix, right_matrix};
     std::vector<Core::LinAlg::Matrix<1, 1>> ref_locs{left_matrix_loc, right_matrix_loc};
     // ... using the standard method
-    Core::LinAlg::Matrix<9, 1> interp_gradient_standard =
-        interp.get_interpolation_gradient(ref_matrices, ref_locs, interp_loc, err_type);
-    FOUR_C_ASSERT_ALWAYS(
-        err_type == Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors,
-        "Tensor interpolation failed with err: {}",
-        Core::LinAlg::TensorInterpolation::make_error_message(err_type));
+    Core::LinAlg::Matrix<9, 1> interp_gradient_standard = interp.get_interpolation_gradient(
+        ref_matrices, ref_locs, interp_loc, err_type, perturbation_factor);
+    FOUR_C_ASSERT_ALWAYS(err_type == Core::LinAlg::TensorInterpolationErrorType::NoErrors,
+        "Tensor interpolation failed with err: {}", Core::LinAlg::make_error_message(err_type));
     // ... using the specialized method
     Core::LinAlg::Matrix<9, 1> interp_gradient_specialized = interp.get_interpolation_gradient(
         ref_matrices, std::vector<double>{left_matrix_loc(0, 0), right_matrix_loc(0, 0)},
-        interp_loc(0, 0), err_type);
-    FOUR_C_ASSERT_ALWAYS(
-        err_type == Core::LinAlg::TensorInterpolation::TensorInterpolationErrorType::NoErrors,
-        "Tensor interpolation failed with err: {}",
-        Core::LinAlg::TensorInterpolation::make_error_message(err_type));
+        interp_loc(0, 0), err_type, perturbation_factor);
+    FOUR_C_ASSERT_ALWAYS(err_type == Core::LinAlg::TensorInterpolationErrorType::NoErrors,
+        "Tensor interpolation failed with err: {}", Core::LinAlg::make_error_message(err_type));
 
 
     // declare the reference eigenvalue derivatives

--- a/src/mat/4C_mat_inelastic_defgrad_factors.hpp
+++ b/src/mat/4C_mat_inelastic_defgrad_factors.hpp
@@ -1508,7 +1508,7 @@ namespace Mat
     StateQuantityDerivatives state_quantity_derivatives_;
 
     //! tensor interpolator used in the substepping procedure (one-dimensional, of order 1)
-    Core::LinAlg::TensorInterpolation::SecondOrderTensorInterpolator<1> tensor_interpolator_;
+    Core::LinAlg::SecondOrderTensorInterpolator<1> tensor_interpolator_;
 
     //! tensor interpolation: reference matrices
     std::vector<Core::LinAlg::Matrix<3, 3>> ref_matrices_;


### PR DESCRIPTION
- Removed the TensorInterpolation namespace.
- Removed the ScalarInterpolation namespace.
- Renamed WeightingFunction to ScalarInterpolationWeightingFunction for more clarity within Core::LinAlg.
- Removed InterpParams for the tensor interpolator since it holds the same parameters as its scalar interpolation analogon. The latter was renamed to the more descriptive ScalarInterpolationParams. Moreover, the perturbation factor used within the interpolation gradient (tensor interpolation) was explicitly added as input to the associated functions with default value of 1.0e-8.

<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
