### PR TITLE
Clean up group functionality in InputSpec

### DIFF
--- a/src/ale/4C_ale_input.cpp
+++ b/src/ale/4C_ale_input.cpp
@@ -89,7 +89,7 @@ void ALE::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           parameter<int>(
               "LINEAR_SOLVER", {.description = "number of linear solver used for ale problems...",
                                    .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/beamcontact/4C_beamcontact_input.cpp
+++ b/src/beamcontact/4C_beamcontact_input.cpp
@@ -189,8 +189,7 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           parameter<int>(
               "BEAMS_BOXESINOCT", {.description = "max number of bounding boxes in any leaf octant",
                                       .default_value = 8})},
-      {.defaultable =
-              true}); /*------------------------------------------------------------------------*/
+      {.required = false});
   /* parameters for visualization of beam contact via output at runtime */
 
   list["BEAM CONTACT/RUNTIME VTK OUTPUT"] = group("BEAM CONTACT/RUNTIME VTK OUTPUT",
@@ -220,7 +219,7 @@ void BeamContact::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           parameter<bool>(
               "GAPS", {.description = "write visualization output for gap, i.e. penetration",
                           .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 /**

--- a/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.cpp
+++ b/src/beaminteraction/src/potential/4C_beaminteraction_potential_input.cpp
@@ -85,8 +85,7 @@ void BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                       "Within this length of the master beam end point the potential is smoothly "
                       "reduced to one half to account for infinitely long master beam "
                       "surrogates."})},
-      {.defaultable =
-              true}); /*------------------------------------------------------------------------*/
+      {.required = false});
   /* parameters for visualization of potential-based beam interactions via output at runtime */
 
   list["BEAM POTENTIAL/RUNTIME VTK OUTPUT"] = group("BEAM POTENTIAL/RUNTIME VTK OUTPUT",
@@ -128,7 +127,7 @@ void BeamPotential::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                               "master and slave beam element global ID (uid_0_beam_1_gid, "
                               "uid_1_beam_2_gid) and local Gauss point ID (uid_2_gp_id)",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 void BeamPotential::set_valid_conditions(

--- a/src/browniandyn/4C_browniandyn_input.cpp
+++ b/src/browniandyn/4C_browniandyn_input.cpp
@@ -60,7 +60,7 @@ void BrownianDynamics::set_valid_parameters(std::map<std::string, Core::IO::Inpu
                       "multiplied by fluid viscosity): translational perpendicular/parallel to "
                       "beam axis, rotational around axis",
                   .default_value = "0.0 0.0 0.0"})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact/4C_contact_input.cpp
+++ b/src/contact/4C_contact_input.cpp
@@ -222,7 +222,7 @@ void CONTACT::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& l
           parameter<double>("REGULARIZATION_STIFFNESS",
               {.description = "initial contact stiffness (i.e. initial \"penalty parameter\")",
                   .default_value = -1.})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/geometric_search/src/4C_geometric_search_input.cpp
+++ b/src/core/geometric_search/src/4C_geometric_search_input.cpp
@@ -34,7 +34,7 @@ void Core::GeometricSearch::set_valid_parameters(std::map<std::string, Core::IO:
           parameter<bool>("WRITE_GEOMETRIC_SEARCH_VISUALIZATION",
               {.description = "If visualization output for the geometric search should be written",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/benchmarks/4C_io_input_benchmark.cpp
+++ b/src/core/io/benchmarks/4C_io_input_benchmark.cpp
@@ -94,7 +94,7 @@ TestGroup:
         } selection_param;
       } nested_group;
     };
-    auto spec = group_struct<TestGroup>("TestGroup",
+    auto spec = group<TestGroup>("TestGroup",
         {
             parameter<int>("int_param", {.store = in_struct(&TestGroup::int_param)}),
             parameter<double>("double_param", {.store = in_struct(&TestGroup::double_param)}),
@@ -102,7 +102,7 @@ TestGroup:
             parameter<std::vector<int>>(
                 "vector_param", {.default_value = std::vector{1, 2, 3},
                                     .store = in_struct(&TestGroup::vector_param)}),
-            group_struct<TestGroup::NestedGroup>("NestedGroup",
+            group<TestGroup::NestedGroup>("NestedGroup",
                 {
                     selection<Selector, TestGroup::NestedGroup::SelectionParam>("selection_param",
                         {
@@ -112,7 +112,7 @@ TestGroup:
                             parameter<double>(
                                 "b", {.store = as_variant<double>(
                                           &TestGroup::NestedGroup::SelectionParam::options)}),
-                            group_struct<C>("c",
+                            group<C>("c",
                                 {
                                     parameter<int>("e", {.store = in_struct(&C::e)}),
                                     parameter<double>("f", {.store = in_struct(&C::f)}),

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -1296,56 +1296,6 @@ Core::IO::InputSpec Core::IO::Internal::wrap_with_all_of(Core::IO::InputSpec spe
     return make_all_of({std::move(spec)});
 }
 
-Core::IO::InputSpec Core::IO::InputSpecBuilders::group(
-    std::string name, std::vector<InputSpec> specs, Core::IO::InputSpecBuilders::GroupData data)
-{
-  auto internal_all_of = make_all_of(std::move(specs));
-
-  if (auto* stores_to = internal_all_of.impl().data.stores_to;
-      stores_to && *stores_to != typeid(InputParameterContainer))
-  {
-    FOUR_C_THROW(
-        "Group '{}' cannot store to type '{}'. Groups can only store to InputParameterContainer.\n"
-        "Did you mean to use a group_struct?",
-        name, Core::Utils::try_demangle(stores_to->name()));
-  }
-
-  if (!data.required.has_value())
-  {
-    data.required = !data.defaultable;
-  }
-  if (data.required.value() && data.defaultable)
-  {
-    FOUR_C_THROW("Group '{}': a group cannot be both required and defaultable.", name);
-  }
-  if (data.defaultable && !internal_all_of.impl().has_default_value())
-  {
-    FOUR_C_THROW(
-        "Group '{}': a group cannot be defaultable if not all of its child specs have default "
-        "values.",
-        name.c_str());
-  }
-
-  InputSpecImpl::CommonData common_data{
-      .name = name,
-      .description = data.description,
-      .required = data.required.value(),
-      .has_default_value = data.defaultable,
-      .n_specs = internal_all_of.impl().data.n_specs + 1,
-      .type = InputSpecType::group,
-      .stores_to = &typeid(InputParameterContainer),
-  };
-
-  return IO::Internal::make_spec(
-      Internal::GroupSpec{
-          .name = name,
-          .data = std::move(data),
-          .spec = std::move(internal_all_of),
-          .init_my_storage = init_storage_with_container,
-          .move_my_storage = store_container_in_container(name),
-      },
-      common_data);
-}
 
 Core::IO::InputSpec Core::IO::InputSpecBuilders::all_of(std::vector<InputSpec> specs)
 {

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -675,7 +675,7 @@ bool Core::IO::Internal::GroupSpec::match(ConstYamlNodeRef node,
       return true;
     }
 
-    if (!data.required.value())
+    if (!data.required)
     {
       // Not present and not required.
       match_entry.state = IO::Internal::MatchEntry::State::not_required;
@@ -735,8 +735,7 @@ void Core::IO::Internal::GroupSpec::emit_metadata(YamlNodeRef node) const
   {
     node.node["description"] << data.description;
   }
-  emit_value_as_yaml(node.wrap(node.node["required"]), data.required.value());
-  emit_value_as_yaml(node.wrap(node.node["defaultable"]), data.defaultable);
+  emit_value_as_yaml(node.wrap(node.node["required"]), data.required);
   node.node["specs"] |= ryml::SEQ;
   {
     auto child = node.node["specs"].append_child();
@@ -762,14 +761,14 @@ bool Core::IO::Internal::GroupSpec::emit(YamlNodeRef node, const InputParameterC
       return false;
     }
     // If no children were added, remove the group node as well, unless it is required.
-    if (!data.required.value() && group_node.num_children() == 0)
+    if (!data.required && group_node.num_children() == 0)
     {
       checkpoint.restore();
     }
     return true;
   }
   // If group is not present, success depends on whether it is required.
-  return !data.required.value();
+  return !data.required;
 }
 
 void Core::IO::Internal::AllOfSpec::parse(

--- a/src/core/io/tests/4C_io_input_field_test.cpp
+++ b/src/core/io/tests/4C_io_input_field_test.cpp
@@ -136,7 +136,7 @@ namespace
       InputField<double> stiffness;
     };
 
-    auto spec = group_struct<Data>(
+    auto spec = group<Data>(
         "data", {
                     input_field<double>("stiffness",
                         {.description = "A stiffness field", .store = in_struct(&Data::stiffness)}),

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -384,7 +384,6 @@ required: true
             },
             {
                 .required = false,
-                .defaultable = true,
             }),
         parameter<std::string>("c"),
     });
@@ -810,7 +809,6 @@ specs:
           - name: group2
             type: group
             required: false
-            defaultable: false
             specs:
               - type: all_of
                 specs:
@@ -893,7 +891,6 @@ specs:
           - name: group2
             type: group
             required: false
-            defaultable: false
             specs:
               - type: all_of
                 specs:
@@ -950,7 +947,6 @@ specs:
             type: group
             description: A group
             required: true
-            defaultable: false
             specs:
               - type: all_of
                 specs:
@@ -981,7 +977,6 @@ specs:
           - name: group2
             type: group
             required: false
-            defaultable: false
             specs:
               - type: all_of
                 specs:
@@ -2227,7 +2222,7 @@ parameters:
             parameter<int>("b", {.default_value = 2, .store = in_struct(&S::b)}),
             parameter<std::string>("s", {.default_value = "default", .store = in_struct(&S::s)}),
         },
-        {.defaultable = true});
+        {.required = false});
 
     ryml::Tree tree = init_yaml_tree_with_exceptions();
     ryml::NodeRef root = tree.rootref();

--- a/src/cut/4C_cut_input.cpp
+++ b/src/cut/4C_cut_input.cpp
@@ -109,7 +109,7 @@ void Cut::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           parameter<bool>("INTEGRATE_INSIDE_CELLS",
               {.description = "Should the integration be done on inside cells",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/ehl/4C_ehl_input.cpp
+++ b/src/ehl/4C_ehl_input.cpp
@@ -72,8 +72,7 @@ void EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           parameter<bool>("DRY_CONTACT_MODEL",
               {.description = "set unprojectable nodes to zero pressure via Dirichlet condition",
                   .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required = false});
   /* parameters for monolithic EHL */
   list["ELASTO HYDRO DYNAMIC/MONOLITHIC"] = group("ELASTO HYDRO DYNAMIC/MONOLITHIC",
       {
@@ -152,7 +151,7 @@ void EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 
           parameter<bool>("INFNORMSCALING",
               {.description = "Scale blocks of matrix with row infnorm?", .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned EHL */
@@ -175,7 +174,7 @@ void EHL::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
               {.description =
                       "tolerance for convergence check of outer iteration within partitioned EHL",
                   .default_value = 1e-6})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/elch/4C_elch_input.cpp
+++ b/src/elch/4C_elch_input.cpp
@@ -121,8 +121,8 @@ void ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list
                       "the cell voltage, SOC, and C-Rate will be written to the csv file every "
                       "step, even if RESULTSEVERY is not 1",
                   .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   // attention: this list is a sublist of elchcontrol
   list["ELCH CONTROL/DIFFCOND"] = group("ELCH CONTROL/DIFFCOND",
       {
@@ -158,7 +158,7 @@ void ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list
                   .default_value = -1.0}),
           parameter<double>("PERMITTIVITY_VACUUM",
               {.description = "Vacuum permittivity", .default_value = 8.8541878128e-12})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   // sublist for space-charge layers
@@ -201,7 +201,7 @@ void ElCh::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list
           parameter<int>(
               "INITFUNCNO", {.description = "function number for scalar transport initial field",
                                 .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/fbi/4C_fbi_input.cpp
+++ b/src/fbi/4C_fbi_input.cpp
@@ -40,7 +40,7 @@ void FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
                                       .default_value = BeamToFluidPreSortStrategy::bruteforce}),
 
       },
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   std::vector<Core::IO::InputSpec> beam_to_fluid_meshtying = {
@@ -73,7 +73,7 @@ void FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
 
   list["FLUID BEAM INTERACTION/BEAM TO FLUID MESHTYING"] =
       group("FLUID BEAM INTERACTION/BEAM TO FLUID MESHTYING", beam_to_fluid_meshtying,
-          {.defaultable = true});
+          {.required = false});
 
 
 
@@ -125,7 +125,7 @@ void FBI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
                   .default_value = 5}),
 
       },
-      {.defaultable = true});
+      {.required = false});
 }
 
 void FBI::set_valid_conditions(std::vector<Core::Conditions::ConditionDefinition>& condlist)

--- a/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
@@ -104,7 +104,7 @@ std::map<std::string, Core::IO::InputSpec> Global::valid_parameters()
           parameter<int>("NUMAIRWAYSDIS",
               {.description = "Number of meshes in reduced dimensional airways network field",
                   .default_value = 1})},
-      {.defaultable = true});
+      {.required = false});
 
   specs["PROBLEM SIZE"] = group("PROBLEM SIZE",
       {
@@ -125,7 +125,7 @@ std::map<std::string, Core::IO::InputSpec> Global::valid_parameters()
           parameter<int>("MATERIALS", {.description = "number of materials", .default_value = 0}),
           parameter<int>("NUMDF",
               {.description = "maximum number of degrees of freedom", .default_value = 3})},
-      {.defaultable = true});
+      {.required = false});
   Inpar::PROBLEMTYPE::set_valid_parameters(specs);
 
   /*----------------------------------------------------------------------*/
@@ -142,7 +142,7 @@ std::map<std::string, Core::IO::InputSpec> Global::valid_parameters()
               {.description = "Number of linear solver for the projection of least squares "
                               "Dirichlet boundary conditions for NURBS discretizations",
                   .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 
   const auto add_geometry_section = [](auto& specs, const std::string& field_identifier)
   {

--- a/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
+++ b/src/inpar/4C_inpar_IO_monitor_structure_dbc.cpp
@@ -57,7 +57,7 @@ namespace Inpar
                   {.description =
                           "write information about monitored boundary condition to output file",
                       .default_value = false})},
-          {.defaultable = true});
+          {.required = false});
     }
 
     std::string to_string(FileType type)

--- a/src/inpar/4C_inpar_IO_runtime_output.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output.cpp
@@ -80,7 +80,7 @@ namespace Inpar
                   {.description = "Specify which output writer shall be used to write the "
                                   "visualization data to disk",
                       .default_value = Core::IO::OutputWriter::vtu_per_rank})},
-          {.defaultable = true});
+          {.required = false});
     }
 
 

--- a/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_fluid.cpp
@@ -62,7 +62,7 @@ namespace Inpar
                 parameter<bool>("NODE_GID",
                     {.description = "write 4C internal node GIDs", .default_value = false}),
             },
-            {.defaultable = true});
+            {.required = false});
       }
     }  // namespace FLUID
   }  // namespace IORuntimeOutput

--- a/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_output_structure_beams.cpp
@@ -125,7 +125,7 @@ namespace Inpar
                     {.description =
                             "Number of subsegments along a single beam element for visualization",
                         .default_value = 5})},
-            {.defaultable = true});
+            {.required = false});
       }
     }  // namespace Beam
   }  // namespace IORuntimeOutput

--- a/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtk_output_structure.cpp
@@ -87,7 +87,7 @@ namespace Inpar
                     },
                     {.description = "Output of an optional quantity",
                         .default_value = Inpar::Solid::optquantity_none})},
-            {.defaultable = true});
+            {.required = false});
       }
 
 

--- a/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
+++ b/src/inpar/4C_inpar_IO_runtime_vtp_output_structure.cpp
@@ -55,7 +55,7 @@ namespace Inpar
               // write force actin in linker
               parameter<bool>("LINKINGFORCE",
                   {.description = "write force acting in linker", .default_value = false})},
-          {.defaultable = true});
+          {.required = false});
     }
 
 

--- a/src/inpar/4C_inpar_beam_to_solid.cpp
+++ b/src/inpar/4C_inpar_beam_to_solid.cpp
@@ -106,7 +106,7 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
 
   list["BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING"] =
       group("BEAM INTERACTION/BEAM TO SOLID VOLUME MESHTYING", beam_to_solid_volume_mestying,
-          {.defaultable = true});
+          {.required = false});
 
 
   // Beam to solid volume mesh tying output parameters.
@@ -158,7 +158,7 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
                                             "for testing of created VTK files).",
                                 .default_value = false}),
       },
-      {.defaultable = true});
+      {.required = false});
 
 
   // Beam to solid surface mesh tying parameters.
@@ -203,7 +203,7 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
   Inpar::GeometryPair::set_valid_parameters_line_to_surface(beam_to_solid_surface_meshtying);
   list["BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING"] =
       group("BEAM INTERACTION/BEAM TO SOLID SURFACE MESHTYING", beam_to_solid_surface_meshtying,
-          {.defaultable = true});
+          {.required = false});
 
 
   // Beam to solid surface contact parameters.
@@ -252,7 +252,7 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
 
   list["BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT"] =
       group("BEAM INTERACTION/BEAM TO SOLID SURFACE CONTACT", beam_to_solid_surface_contact,
-          {.defaultable = true});
+          {.required = false});
 
 
   // Beam to solid surface output parameters.
@@ -303,7 +303,7 @@ void Inpar::BeamToSolid::set_valid_parameters(std::map<std::string, Core::IO::In
                                             "for testing of created VTK files).",
                                 .default_value = false}),
       },
-      {.defaultable = true});
+      {.required = false});
 }
 
 /**

--- a/src/inpar/4C_inpar_beaminteraction.cpp
+++ b/src/inpar/4C_inpar_beaminteraction.cpp
@@ -44,8 +44,8 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
           parameter<SearchStrategy>("SEARCH_STRATEGY",
               {.description = "Type of search strategy used for finding coupling pairs",
                   .default_value = SearchStrategy::bruteforce_with_binning})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   /* parameters for crosslinking submodel */
 
   list["BEAM INTERACTION/CROSSLINKING"] = group("BEAM INTERACTION/CROSSLINKING",
@@ -107,7 +107,7 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
           parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
               {.description = "Lower and upper arc parameter bound for binding spots on a filament",
                   .default_value = "0.0 1.0"})},
-      {.defaultable = true});
+      {.required = false});
 
 
   /*----------------------------------------------------------------------*/
@@ -152,7 +152,7 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
           parameter<std::string>("FILAMENTBSPOTRANGELOCAL",
               {.description = "Lower and upper arc parameter bound for binding spots on a filament",
                   .default_value = "0.0 1.0"})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for beam to ? contact submodel*/
@@ -172,7 +172,7 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
                   {"penalty", bstr_penalty},
               },
               {.description = "Type of employed solving strategy", .default_value = bstr_none})},
-      {.defaultable = true});
+      {.required = false});
 
   // ...
 
@@ -194,7 +194,7 @@ void Inpar::BeamInteraction::set_valid_parameters(std::map<std::string, Core::IO
           parameter<double>("PENALTY_PARAMETER",
               {.description = "Penalty parameter for beam-to-rigidsphere contact",
                   .default_value = 0.0})},
-      {.defaultable = true});
+      {.required = false});
 
   // ...
 

--- a/src/inpar/4C_inpar_binningstrategy.cpp
+++ b/src/inpar/4C_inpar_binningstrategy.cpp
@@ -47,7 +47,7 @@ void Inpar::BINSTRATEGY::set_valid_parameters(std::map<std::string, Core::IO::In
           parameter<Core::Binstrategy::WriteBins>(
               "WRITEBINS", {.description = "Write none, row or column bins for visualization",
                                .default_value = Core::Binstrategy::WriteBins::none})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_bio.cpp
+++ b/src/inpar/4C_inpar_bio.cpp
@@ -59,7 +59,7 @@ void Inpar::ArtDyn::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               },
               {.description = "Initial Field for artery problem",
                   .default_value = initfield_zero_field})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 
@@ -91,7 +91,7 @@ void Inpar::ArteryNetwork::set_valid_parameters(std::map<std::string, Core::IO::
           parameter<double>("MAXTIME", {.description = "", .default_value = 4.0}),
 
           parameter<double>("NORMAL", {.description = "", .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 
@@ -258,7 +258,7 @@ void Inpar::BioFilm::set_valid_parameters(std::map<std::string, Core::IO::InputS
           parameter<bool>(
               "OUTPUT_GMSH", {.description = "Do you want to write Gmsh postprocessing files?",
                                  .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_cardiac_monodomain.cpp
+++ b/src/inpar/4C_inpar_cardiac_monodomain.cpp
@@ -30,7 +30,7 @@ void Inpar::ElectroPhysiology::set_valid_parameters(
           parameter<double>("ACTTHRES", {.description = "threshold for the potential for computing "
                                                         "and postprocessing activation time ",
                                             .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_cardiovascular0d.cpp
+++ b/src/inpar/4C_inpar_cardiovascular0d.cpp
@@ -66,7 +66,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
           parameter<double>("K_PTC",
               {.description = "PTC parameter: 0 means normal Newton, ->infty means steepest desc",
                   .default_value = 0.0})},
-      {.defaultable = true});
+      {.required = false});
   list["CARDIOVASCULAR 0D-STRUCTURE COUPLING/SYS-PUL CIRCULATION PARAMETERS"] = group(
       "CARDIOVASCULAR 0D-STRUCTURE COUPLING/SYS-PUL CIRCULATION PARAMETERS",
       {
@@ -375,7 +375,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
           parameter<double>(
               "V_cap_pul_u", {.description = "unstressed volume of pulmonary capillaries",
                                  .default_value = 123.0e3})},
-      {.defaultable = true});
+      {.required = false});
 
 
 
@@ -626,7 +626,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
           parameter<double>(
               "ppO2_ven_sys_0", {.description = "initial systemic venous O2 partial pressure",
                                     .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 
   list["MOR"] = group("MOR",
       {
@@ -634,7 +634,7 @@ void Inpar::Cardiovascular0D::set_valid_parameters(std::map<std::string, Core::I
           parameter<std::string>(
               "POD_MATRIX", {.description = "filename of file containing projection matrix",
                                 .default_value = "none"})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_constraint_framework.cpp
+++ b/src/inpar/4C_inpar_constraint_framework.cpp
@@ -41,7 +41,7 @@ void Inpar::Constraints::set_valid_parameters(std::map<std::string, Core::IO::In
               {.description =
                       "Penalty parameter for the constraint enforcement in embedded mesh coupling",
                   .default_value = 0.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_fluid.cpp
+++ b/src/inpar/4C_inpar_fluid.cpp
@@ -290,8 +290,8 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               {.description = "Do not evaluate ghosted elements but communicate them "
                               "--> faster if element call is expensive",
                   .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   list["FLUID DYNAMIC/NONLINEAR SOLVER TOLERANCES"] =
       group("FLUID DYNAMIC/NONLINEAR SOLVER TOLERANCES",
           {
@@ -311,7 +311,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               parameter<double>("TOL_PRES_INC",
                   {.description = "Tolerance for convergence check of pressure increment",
                       .default_value = 1e-6})},
-          {.defaultable = true});
+          {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["FLUID DYNAMIC/RESIDUAL-BASED STABILIZATION"] = group(
@@ -516,7 +516,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
                       "Flag to (de)activate Reynolds-stress term loma continuity equation-> "
                       "residual-based VMM.",
                   .default_value = reynolds_stress_stab_none})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["FLUID DYNAMIC/EDGE-BASED STABILIZATION"] = group("FLUID DYNAMIC/EDGE-BASED STABILIZATION",
@@ -648,7 +648,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
                               "maximal volume equivalent diameter "
                               "of adjacent elements",
                   .default_value = EOS_he_max_diameter_to_opp_surf})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["FLUID DYNAMIC/POROUS-FLOW STABILIZATION"] = group("FLUID DYNAMIC/POROUS-FLOW STABILIZATION",
@@ -842,7 +842,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
                       "Flag to (de)activate Reynolds-stress term loma continuity equation-> "
                       "residual-based VMM.",
                   .default_value = reynolds_stress_stab_none})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["FLUID DYNAMIC/TURBULENCE MODEL"] = group("FLUID DYNAMIC/TURBULENCE MODEL",
@@ -1084,7 +1084,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               {.description =
                       "Flag to (de)activate XFEM dofs in calculation of fine-scale velocity.",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for Smagorinsky model
@@ -1138,7 +1138,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               },
               {.description = "The Vreman model requires a filter width.",
                   .default_value = cuberootvol})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for Smagorinsky model
@@ -1212,7 +1212,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
 
           parameter<int>("PROJECTION_SOLVER",
               {.description = "Set solver number for l2-projection.", .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for multifractal subgrid-scales
@@ -1324,7 +1324,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
               {.description = "Flag to (de)activate cross- and Reynolds-stress terms in "
                               "loma continuity equation.",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["FLUID DYNAMIC/TURBULENT INFLOW"] = group("FLUID DYNAMIC/TURBULENT INFLOW",
@@ -1424,7 +1424,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           parameter<int>("INFLOW_DUMPING_PERIOD",
               {.description = "Period of time steps after which statistical data shall be dumped",
                   .default_value = 1})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   // sublist with additional input parameters for time adaptivity in fluid/ coupled problems
@@ -1450,7 +1450,7 @@ void Inpar::FLUID::set_valid_parameters(std::map<std::string, Core::IO::InputSpe
           parameter<double>(
               "ADAPTIVE_DT_INC", {.description = "Increment of whole step for adaptive dt via CFL",
                                      .default_value = 0.8})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 
@@ -1496,7 +1496,7 @@ void Inpar::LowMach::set_valid_parameters(std::map<std::string, Core::IO::InputS
           parameter<int>(
               "LINEAR_SOLVER", {.description = "number of linear solver used for LOMA problem",
                                    .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_fpsi.cpp
+++ b/src/inpar/4C_inpar_fpsi.cpp
@@ -133,7 +133,7 @@ void Inpar::FPSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {.description = "Beavers-Joseph-Coefficient for Slip-Boundary-Condition at "
                               "Fluid-Porous-Interface (0.1-4)",
                   .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_fs3i.cpp
+++ b/src/inpar/4C_inpar_fs3i.cpp
@@ -113,7 +113,7 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
                   .default_value = false}),
 
       },
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned FS3I */
@@ -134,7 +134,7 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
 
           parameter<int>("ITEMAX",
               {.description = "Maximum number of outer iterations", .default_value = 10})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------  */
   /* parameters for stabilization of the structure-scalar field             */
@@ -145,7 +145,7 @@ void Inpar::FS3I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
 
   list["FS3I DYNAMIC/STRUCTURE SCALAR STABILIZATION"] =
       group("FS3I DYNAMIC/STRUCTURE SCALAR STABILIZATION",
-          {Inpar::ScaTra::all_specs_for_scatra_stabilization()}, {.defaultable = true});
+          {Inpar::ScaTra::all_specs_for_scatra_stabilization()}, {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -107,8 +107,8 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               },
               {.description = "Verbosity of the FSI problem.",
                   .default_value = Inpar::FSI::verbosity_full})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   /* parameters for time step size adaptivity in fsi dynamics */
   list["FSI DYNAMIC/TIMEADAPTIVITY"] = group("FSI DYNAMIC/TIMEADAPTIVITY",
       {
@@ -181,7 +181,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           parameter<bool>(
               "TIMEADAPTON", {.description = "Activate or deactivate time step size adaptivity",
                                  .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   /*--------------------------------------------------------------------------*/
 
@@ -401,7 +401,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           parameter<double>("TOL_VEL_INC_INF",
               {.description = "Absolute tolerance for fluid velocity increment in Inf-norm",
                   .default_value = 1e-6})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned FSI solvers */
@@ -472,7 +472,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           parameter<double>(
               "RELAX", {.description = "fixed relaxation parameter for partitioned FSI solvers",
                            .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 
   /* ----------------------------------------------------------------------- */
   list["FSI DYNAMIC/CONSTRAINT"] = group("FSI DYNAMIC/CONSTRAINT",
@@ -482,7 +482,7 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {.description = "Number of iterations for simple pc", .default_value = 2}),
           parameter<double>(
               "ALPHA", {.description = "alpha parameter for simple pc", .default_value = 0.8})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 /*----------------------------------------------------------------------------*/

--- a/src/inpar/4C_inpar_io.cpp
+++ b/src/inpar/4C_inpar_io.cpp
@@ -193,8 +193,7 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
                   .default_value = -1.0}),
           parameter<int>("RESTARTEVERY",
               {.description = "write restart every RESTARTEVERY steps", .default_value = -1})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required = false});
   list["IO/EVERY ITERATION"] = group("IO/EVERY ITERATION",
       {
 
@@ -220,7 +219,7 @@ void Inpar::IO::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>&
                       "If yes, the ownership of elements and nodes are written each Newton step, "
                       "instead of only once per time/load step.",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_levelset.cpp
+++ b/src/inpar/4C_inpar_levelset.cpp
@@ -49,8 +49,8 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
               {.description = "number of layers around the interface which keep their computed "
                               "convective velocity",
                   .default_value = -1})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   list["LEVEL-SET CONTROL/REINITIALIZATION"] = group("LEVEL-SET CONTROL/REINITIALIZATION",
       {
 
@@ -214,7 +214,7 @@ void Inpar::LevelSet::set_valid_parameters(std::map<std::string, Core::IO::Input
           parameter<Inpar::ScaTra::DiffFunc>(
               "DIFF_FUNC", {.description = "function for diffusivity",
                                .default_value = Inpar::ScaTra::hyperbolic})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -158,8 +158,7 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                       "feature, purely to enhance visualization. Currently, this is limited to "
                       "solid meshtying and contact w/o friction.",
                   .default_value = false})},
-      {.defaultable =
-              true}); /*--------------------------------------------------------------------*/
+      {.required = false}); /*--------------------------------------------------------------------*/
   // parameters for parallel redistribution of mortar interfaces
   list["MORTAR COUPLING/PARALLEL REDISTRIBUTION"] = group("MORTAR COUPLING/PARALLEL REDISTRIBUTION",
       {
@@ -211,7 +210,7 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               {.description = "Print details of the parallel distribution, i.e. "
                               "number of nodes/elements for each rank.",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 void Inpar::Mortar::set_valid_conditions(

--- a/src/inpar/4C_inpar_mpc_rve.cpp
+++ b/src/inpar/4C_inpar_mpc_rve.cpp
@@ -33,7 +33,7 @@ void Inpar::RveMpc::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
           parameter<double>("PENALTY_PARAM",
               {.description = "Value of the penalty parameter", .default_value = 1e5})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 // set mpc specific conditions

--- a/src/inpar/4C_inpar_particle.cpp
+++ b/src/inpar/4C_inpar_particle.cpp
@@ -119,8 +119,8 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           parameter<double>("RIGID_BODY_PHASECHANGE_RADIUS",
               {.description = "search radius for neighboring rigid bodies in case of phase change",
                   .default_value = -1.0})},
-      {.defaultable =
-              true}); /*-------------------------------------------------------------------------*
+      {.required =
+              false}); /*-------------------------------------------------------------------------*
 | control parameters for initial/boundary conditions |
 *-------------------------------------------------------------------------*/
   list["PARTICLE DYNAMIC/INITIAL AND BOUNDARY CONDITIONS"] = group(
@@ -174,7 +174,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
                       "Refer to the function ID describing the temperature boundary condition of "
                       "particle phase",
                   .default_value = "none"})},
-      {.defaultable = true});
+      {.required = false});
 
   /*-------------------------------------------------------------------------*
    | smoothed particle hydrodynamics (SPH) specific control parameters       |
@@ -421,7 +421,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
               {.description = "rigid particle contact stiffness", .default_value = -1.0}),
           parameter<double>("RIGIDPARTICLECONTACTDAMP",
               {.description = "rigid particle contact damping parameter", .default_value = 0.0})},
-      {.defaultable = true});
+      {.required = false});
 
   /*-------------------------------------------------------------------------*
    | discrete element method (DEM) specific control parameters               |
@@ -547,7 +547,7 @@ void Inpar::PARTICLE::set_valid_parameters(std::map<std::string, Core::IO::Input
           parameter<double>("ADHESION_SURFACE_ENERGY_FACTOR",
               {.description = "factor to calculate minimum adhesion surface energy",
                   .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 /*---------------------------------------------------------------------------*

--- a/src/inpar/4C_inpar_pasi.cpp
+++ b/src/inpar/4C_inpar_pasi.cpp
@@ -77,7 +77,7 @@ void Inpar::PaSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           parameter<double>(
               "MINOMEGA", {.description = "smallest omega allowed for Aitken relaxation",
                               .default_value = 0.1})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_plasticity.cpp
+++ b/src/inpar/4C_inpar_plasticity.cpp
@@ -83,7 +83,7 @@ void Inpar::Plasticity::set_valid_parameters(std::map<std::string, Core::IO::Inp
           parameter<TSI::DissipationMode>(
               "DISSIPATION_MODE", {.description = "method to calculate the plastic dissipation",
                                       .default_value = TSI::pl_multiplier})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_poroelast.cpp
+++ b/src/inpar/4C_inpar_poroelast.cpp
@@ -185,7 +185,7 @@ void Inpar::PoroElast::set_valid_parameters(std::map<std::string, Core::IO::Inpu
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
               {.description = "flag for equilibration of global system of equations",
                   .default_value = Core::LinAlg::EquilibrationMethod::none})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_poroscatra.cpp
+++ b/src/inpar/4C_inpar_poroscatra.cpp
@@ -141,7 +141,7 @@ void Inpar::PoroScaTra::set_valid_parameters(std::map<std::string, Core::IO::Inp
 
           parameter<bool>(
               "MATCHINGGRID", {.description = "is matching grid", .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_rebalance.cpp
+++ b/src/inpar/4C_inpar_rebalance.cpp
@@ -36,7 +36,7 @@ void Inpar::Rebalance::set_valid_parameters(std::map<std::string, Core::IO::Inpu
                       "size "
                       "of a subdomain.",
                   .default_value = 0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_s2i.cpp
+++ b/src/inpar/4C_inpar_s2i.cpp
@@ -106,7 +106,7 @@ void Inpar::S2I::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {.description = "evaluate integral of coupling flux on slave side "
                               "for each s2i condition and write it to csv file",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -331,8 +331,8 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           // flag for adaptive time stepping
           parameter<bool>("ADAPTIVE_TIMESTEPPING",
               {.description = "flag for adaptive time stepping", .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   list["SCALAR TRANSPORT DYNAMIC/NONLINEAR"] = group("SCALAR TRANSPORT DYNAMIC/NONLINEAR",
       {
 
@@ -366,11 +366,11 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                       "The linear solver shall be this much better than the current nonlinear "
                       "residual in the nonlinear convergence limit",
                   .default_value = 0.1})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["SCALAR TRANSPORT DYNAMIC/STABILIZATION"] = group("SCALAR TRANSPORT DYNAMIC/STABILIZATION",
-      {all_specs_for_scatra_stabilization()}, {.defaultable = true});
+      {all_specs_for_scatra_stabilization()}, {.required = false});
 
   // ----------------------------------------------------------------------
   // artery mesh tying
@@ -418,7 +418,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           // scale for coupling (scatra part)
           parameter<std::string>("SCALEREAC_CONT",
               {.description = "scale for coupling (scatra part)", .default_value = "0"})},
-      {.defaultable = true});
+      {.required = false});
 
   // ----------------------------------------------------------------------
   list["SCALAR TRANSPORT DYNAMIC/EXTERNAL FORCE"] = group("SCALAR TRANSPORT DYNAMIC/EXTERNAL FORCE",
@@ -435,7 +435,7 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           // Function ID for mobility of the scalar
           parameter<int>("INTRINSIC_MOBILITY_FUNCTION_ID",
               {.description = "Function ID for intrinsic mobility", .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_searchtree.cpp
+++ b/src/inpar/4C_inpar_searchtree.cpp
@@ -27,7 +27,7 @@ void Inpar::Geo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
                   {"quadtree2d", Inpar::Geo::Quadtree2D},
               },
               {.description = "set tree type", .default_value = Inpar::Geo::Notree})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_solver.cpp
+++ b/src/inpar/4C_inpar_solver.cpp
@@ -149,7 +149,7 @@ namespace Inpar::SOLVER
       std::stringstream ss_description;
       ss_description << "solver parameters for solver block " << i;
       list[ss.str()] = Core::IO::InputSpecBuilders::group(
-          ss.str(), {spec_solver}, {.description = ss_description.str(), .defaultable = true});
+          ss.str(), {spec_solver}, {.description = ss_description.str(), .required = false});
     }
   }
 

--- a/src/inpar/4C_inpar_solver_nonlin.cpp
+++ b/src/inpar/4C_inpar_solver_nonlin.cpp
@@ -28,7 +28,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                   "Inexact Trust Region Based", "Tensor Based", "Single Step"},
               {.description = "Choose a nonlinear solver method.",
                   .default_value = "Line Search Based"})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list direction
   list["STRUCT NOX/Direction"] = group("STRUCT NOX/Direction",
@@ -43,7 +43,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           deprecated_selection<std::string>("User Defined Method", {"Newton", "Modified Newton"},
               {.description = "Choose a user-defined direction method.",
                   .default_value = "Modified Newton"})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-list "Newton"
   list["STRUCT NOX/Direction/Newton"] = group("STRUCT NOX/Direction/Newton",
@@ -67,7 +67,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                       "If set to true, we will use the computed direction even if the linear "
                       "solve does not achieve the tolerance specified by the forcing term",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-list "Steepest Descent"
   list["STRUCT NOX/Direction/Steepest Descent"] = group("STRUCT NOX/Direction/Steepest Descent",
@@ -76,7 +76,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           deprecated_selection<std::string>("Scaling Type",
               {"2-Norm", "Quadratic Model Min", "F 2-Norm", "None"},
               {.description = "", .default_value = "None"})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list "Pseudo Transient"
   list["STRUCT NOX/Pseudo Transient"] = group("STRUCT NOX/Pseudo Transient",
@@ -123,7 +123,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
               {"every iter", "every timestep"},
               {.description = "Build scaling operator in every iteration or timestep",
                   .default_value = "every timestep"})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list "Line Search"
   list["STRUCT NOX/Line Search"] = group("STRUCT NOX/Line Search",
@@ -138,7 +138,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           parameter<::NOX::StatusTest::CheckType>("Inner Status Test Check Type",
               {.description = "Specify the check type for the inner status tests.",
                   .default_value = ::NOX::StatusTest::Minimal})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-list "Full Step"
   list["STRUCT NOX/Line Search/Full Step"] = group("STRUCT NOX/Line Search/Full Step",
@@ -146,7 +146,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
           parameter<double>(
               "Full Step", {.description = "length of a full step", .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-list "Backtrack"
   list["STRUCT NOX/Line Search/Backtrack"] = group("STRUCT NOX/Line Search/Backtrack",
@@ -171,7 +171,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                       "Set to true, if exceptions during the force evaluation and backtracking "
                       "routine should be allowed.",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-list "Polynomial"
   list["STRUCT NOX/Line Search/Polynomial"] = group("STRUCT NOX/Line Search/Polynomial",
@@ -242,7 +242,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
           parameter<double>(
               "Allowed Relative Increase", {.description = "", .default_value = 100.0})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-list "More'-Thuente"
   list["STRUCT NOX/Line Search/More'-Thuente"] = group("STRUCT NOX/Line Search/More'-Thuente",
@@ -294,7 +294,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                       "method. Setting this to true eliminates having to compute the Jacobian at "
                       "each inner iteration of the More'-Thuente line search",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list "Trust Region"
   list["STRUCT NOX/Trust Region"] = group("STRUCT NOX/Trust Region",
@@ -326,7 +326,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           parameter<double>("Expansion Factor", {.description = "", .default_value = 4.0}),
 
           parameter<double>("Recovery Step", {.description = "", .default_value = 1.0})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list "Printing"
   list["STRUCT NOX/Printing"] = group("STRUCT NOX/Printing",
@@ -351,7 +351,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           parameter<bool>("Test Details", {.description = "", .default_value = false}),
 
           parameter<bool>("Debug", {.description = "", .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list "Status Test"
   list["STRUCT NOX/Status Test"] = group("STRUCT NOX/Status Test",
@@ -359,7 +359,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
           Core::IO::InputSpecBuilders::parameter<std::optional<std::filesystem::path>>("XML File",
               {.description = "Filename of XML file with configuration of nox status test"})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-list "Solver Options"
   list["STRUCT NOX/Solver Options"] = group("STRUCT NOX/Solver Options",
@@ -373,7 +373,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
 
           deprecated_selection<std::string>("Status Test Check Type",
               {"Complete", "Minimal", "None"}, {.description = "", .default_value = "Complete"})},
-      {.defaultable = true});
+      {.required = false});
 
   // sub-sub-sub-list "Linear Solver"
   list["STRUCT NOX/Direction/Newton/Linear Solver"] = group(
@@ -400,7 +400,7 @@ void Inpar::NlnSol::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           parameter<bool>("Output Solver Details",
               {.description = "Switch the linear solver output on and off.",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_ssi.cpp
+++ b/src/inpar/4C_inpar_ssi.cpp
@@ -100,8 +100,8 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           parameter<bool>("REDISTRIBUTE_SOLID",
               {.description = "redistribution by binning of solid mechanics discretization",
                   .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   /* parameters for partitioned SSI */
   /*----------------------------------------------------------------------*/
   list["SSI CONTROL/PARTITIONED"] = group("SSI CONTROL/PARTITIONED",
@@ -122,7 +122,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {.description =
                       "tolerance for convergence check of outer iteration within partitioned SSI",
                   .default_value = 1e-6})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for monolithic SSI */
@@ -183,7 +183,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {.description = "relax the tolerance of the linear solver within "
                               "the first RELAX_LIN_SOLVER_STEP steps",
                   .default_value = -1})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for SSI with manifold */
@@ -221,7 +221,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               "OUTPUT_INFLOW", {.description = "write output of inflow of scatra manifold - scatra "
                                                "coupling into scatra manifold to csv file",
                                    .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for SSI with elch */
@@ -232,7 +232,7 @@ void Inpar::SSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           parameter<bool>("INITPOTCALC",
               {.description = "Automatically calculate initial field for electric potential",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 /*--------------------------------------------------------------------

--- a/src/inpar/4C_inpar_ssti.cpp
+++ b/src/inpar/4C_inpar_ssti.cpp
@@ -66,8 +66,8 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
                   .default_value = ScaTraTimIntType::elch}),
           parameter<bool>("ADAPTIVE_TIMESTEPPING",
               {.description = "flag for adaptive time stepping", .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   /* parameters for monolithic SSTI                                       */
   /*----------------------------------------------------------------------*/
   list["SSTI CONTROL/MONOLITHIC"] = group("SSTI CONTROL/MONOLITHIC",
@@ -109,7 +109,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
                       "use equilibration method of ScaTra to equilibrate initial calculation "
                       "of potential",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for thermo                                                */
@@ -128,7 +128,7 @@ void Inpar::SSTI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               },
               {.description = "defines, how to set the initial field",
                   .default_value = Inpar::ScaTra::InitialField::initfield_field_by_function})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_sti.cpp
+++ b/src/inpar/4C_inpar_sti.cpp
@@ -77,8 +77,8 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               {.description = "flag for double condensation of linear equations associated with "
                               "temperature field",
                   .default_value = false})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   // valid parameters for monolithic scatra-thermo interaction
   list["STI DYNAMIC/MONOLITHIC"] = group("STI DYNAMIC/MONOLITHIC",
       {
@@ -96,7 +96,7 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
               },
               {.description = "type of global system matrix in global system of equations",
                   .default_value = Core::LinAlg::MatrixType::block_condition})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   // valid parameters for partitioned scatra-thermo interaction
@@ -110,7 +110,7 @@ void Inpar::STI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
           parameter<double>("OMEGAMAX",
               {.description = "maximum value of Aitken relaxation parameter (0.0 = no constraint)",
                   .default_value = 0.})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/inpar/4C_inpar_structure.cpp
+++ b/src/inpar/4C_inpar_structure.cpp
@@ -424,8 +424,8 @@ namespace Inpar
               // Function to evaluate initial displacement
               parameter<int>("STARTFUNCNO",
                   {.description = "Function for Initial displacement", .default_value = -1})},
-          {.defaultable =
-                  true}); /*--------------------------------------------------------------------*/
+          {.required =
+                  false}); /*--------------------------------------------------------------------*/
       /* parameters for time step size adaptivity in structural dynamics */
       list["STRUCTURAL DYNAMIC/TIMEADAPTIVITY"] = group("STRUCTURAL DYNAMIC/TIMEADAPTIVITY",
           {
@@ -495,7 +495,7 @@ namespace Inpar
               parameter<int>("ADAPTSTEPMAX",
                   {.description = "Limit maximally allowed step size reduction attempts (>0)",
                       .default_value = 0})},
-          {.defaultable = true});
+          {.required = false});
 
       /// valid parameters for JOINT EXPLICIT
 
@@ -543,7 +543,7 @@ namespace Inpar
               parameter<double>("M_DAMP", {.description = "", .default_value = -1.0}),
 
               parameter<double>("K_DAMP", {.description = "", .default_value = -1.0})},
-          {.defaultable = true});
+          {.required = false});
 
       /*----------------------------------------------------------------------*/
       /* parameters for generalised-alpha structural integrator */
@@ -570,7 +570,7 @@ namespace Inpar
                   "RHO_INF", {.description = "Spectral radius for generalised-alpha time "
                                              "integration, valid range is [0,1]",
                                  .default_value = 1.0})},
-          {.defaultable = true});
+          {.required = false});
 
       /*----------------------------------------------------------------------*/
       /* parameters for one-step-theta structural integrator */
@@ -579,7 +579,7 @@ namespace Inpar
 
               parameter<double>("THETA",
                   {.description = "One-step-theta factor in (0,1]", .default_value = 0.5})},
-          {.defaultable = true});
+          {.required = false});
 
       /*----------------------------------------------------------------------*/
       /* parameters for error evaluation */
@@ -592,7 +592,7 @@ namespace Inpar
                       .default_value = false}),
               parameter<int>("ANALYTICAL_DISPLACEMENT_FUNCTION",
                   {.description = "function ID of the analytical solution", .default_value = -1})},
-          {.defaultable = true});
+          {.required = false});
     }
 
 

--- a/src/inpar/4C_inpar_volmortar.cpp
+++ b/src/inpar/4C_inpar_volmortar.cpp
@@ -85,7 +85,7 @@ void Inpar::VolMortar::set_valid_parameters(std::map<std::string, Core::IO::Inpu
           parameter<bool>("KEEP_EXTENDEDGHOSTING",
               {.description = "If chosen, extended ghosting is kept for simulation",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_wear.cpp
+++ b/src/inpar/4C_inpar_wear.cpp
@@ -99,7 +99,7 @@ void Inpar::Wear::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               },
               {.description = "Definition wear time scale compares to std. time scale",
                   .default_value = wear_time_equal})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/inpar/4C_inpar_xfem.cpp
+++ b/src/inpar/4C_inpar_xfem.cpp
@@ -80,8 +80,8 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               },
               {.description = "Method for finding Gauss Points for the boundary cells",
                   .default_value = Cut::BCellGaussPts_Tessellation})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   list["XFLUID DYNAMIC/GENERAL"] = group("XFLUID DYNAMIC/GENERAL",
       {
 
@@ -147,7 +147,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           parameter<bool>("XFLUID_TIMEINT_CHECK_SLIDINGONSURFACE",
               {.description = "Xfluid TimeIntegration Special Check if node is sliding on surface!",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["XFLUID DYNAMIC/STABILIZATION"] = group("XFLUID DYNAMIC/STABILIZATION",
@@ -316,7 +316,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
                       "Apply ghost penalty stabilization also for inner faces if this is possible "
                       "due to the dofsets",
                   .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   list["XFLUID DYNAMIC/XFPSI MONOLITHIC"] = group("XFLUID DYNAMIC/XFPSI MONOLITHIC",
@@ -374,7 +374,7 @@ void Inpar::XFEM::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
               {.description = "the extrapolation of the fluid stress in the contact "
                               "zone is relaxed to zero after a certtain distance",
                   .default_value = true})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/lubrication/src/4C_lubrication_input.cpp
+++ b/src/lubrication/src/4C_lubrication_input.cpp
@@ -165,7 +165,7 @@ void Lubrication::set_valid_parameters(std::map<std::string, Core::IO::InputSpec
           /// Flag for considering the pure Reynolds Equation
           parameter<bool>("PURE_LUB",
               {.description = "the problem is pure lubrication", .default_value = false})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_input.cpp
@@ -195,8 +195,8 @@ void PoroPressureBased::set_valid_parameters_porofluid(
           parameter<std::string>("STARTING_DBC_FUNCT",
               {.description = "Function prescribing the starting Dirichlet BC.",
                   .default_value = "0"})},
-      {.defaultable =
-              true});  // ----------------------------------------------------------------------
+      {.required =
+              false});  // ----------------------------------------------------------------------
   // artery mesh tying
   list["POROFLUIDMULTIPHASE DYNAMIC/ARTERY COUPLING"] = group(
       "POROFLUIDMULTIPHASE DYNAMIC/ARTERY COUPLING",
@@ -305,7 +305,7 @@ void PoroPressureBased::set_valid_parameters_porofluid(
                       "overall network size are additionally deleted (a valid choice of this "
                       "parameter should lie between 0 and 1)",
                   .default_value = -1.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
+++ b/src/porofluid_pressure_based_elast/4C_porofluid_pressure_based_elast_input.cpp
@@ -61,8 +61,8 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
           // coupling with 1D artery network active
           parameter<bool>("ARTERY_COUPLING",
               {.description = "Coupling with 1D blood vessels.", .default_value = false})},
-      {.defaultable =
-              true});  // ----------------------------------------------------------------------
+      {.required =
+              false});  // ----------------------------------------------------------------------
   // (2) monolithic parameters
   list["POROMULTIPHASE DYNAMIC/MONOLITHIC"] = group("POROMULTIPHASE DYNAMIC/MONOLITHIC",
       {
@@ -121,7 +121,7 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
                       "The linear solver shall be this much better than the current nonlinear "
                       "residual in the nonlinear convergence limit",
                   .default_value = 0.001})},
-      {.defaultable = true});
+      {.required = false});
 
   // ----------------------------------------------------------------------
   // (3) partitioned parameters
@@ -152,7 +152,7 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast(
           parameter<double>(
               "MAXOMEGA", {.description = "largest omega allowed for Aitken relaxation",
                               .default_value = 10.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_input.cpp
@@ -63,8 +63,8 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
               {.description = "What to do with time integration when Poromultiphase-Scatra "
                               "iteration failed",
                   .default_value = DivergenceAction::stop})},
-      {.defaultable =
-              true});  // ----------------------------------------------------------------------
+      {.required =
+              false});  // ----------------------------------------------------------------------
   // (2) monolithic parameters
   list["POROMULTIPHASESCATRA DYNAMIC/MONOLITHIC"] = group("POROMULTIPHASESCATRA DYNAMIC/MONOLITHIC",
       {
@@ -123,7 +123,7 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
           parameter<Core::LinAlg::EquilibrationMethod>("EQUILIBRATION",
               {.description = "flag for equilibration of global system of equations",
                   .default_value = Core::LinAlg::EquilibrationMethod::none})},
-      {.defaultable = true});
+      {.required = false});
 
   // ----------------------------------------------------------------------
   // (3) partitioned parameters
@@ -135,7 +135,7 @@ void PoroPressureBased::set_valid_parameters_porofluid_elast_scatra(
               parameter<double>(
                   "CONVTOL", {.description = "tolerance for convergence check of outer iteration",
                                  .default_value = 1e-6})},
-          {.defaultable = true});
+          {.required = false});
 }
 
 void PoroPressureBased::set_valid_conditions_porofluid_elast_scatra(

--- a/src/red_airways/4C_red_airways_input.cpp
+++ b/src/red_airways/4C_red_airways_input.cpp
@@ -180,7 +180,7 @@ void Airway::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
           parameter<double>("TRANSPULMPRESS",
               {.description = "Transpulmonary pressure needed for recalculation of acini volumes",
                   .default_value = 800.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 

--- a/src/scatra/4C_scatra_functions.cpp
+++ b/src/scatra/4C_scatra_functions.cpp
@@ -49,7 +49,7 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
   using namespace Core::IO::InputSpecBuilders;
   using namespace Core::IO::InputSpecBuilders::Validators;
 
-  auto linear = group_struct<ParticleMagnetization::ModelParameters>("linear",
+  auto linear = group<ParticleMagnetization::ModelParameters>("linear",
       {
           parameter<double>("susceptibility",
               {.description = "Magnetic susceptibility",
@@ -59,7 +59,7 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
       {.store = in_struct(&ParticleMagnetization::particle_magnetization_parameters)});
 
   auto linear_with_saturation =
-      group_struct<ParticleMagnetization::ModelParameters>("linear_with_saturation",
+      group<ParticleMagnetization::ModelParameters>("linear_with_saturation",
           {
               parameter<double>("saturation_magnetization",
                   {.description = "Saturation magnetization",
@@ -73,7 +73,7 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
           },
           {.store = in_struct(&ParticleMagnetization::particle_magnetization_parameters)});
 
-  auto superparamagnetic = group_struct<ParticleMagnetization::ModelParameters>("superparamagnetic",
+  auto superparamagnetic = group<ParticleMagnetization::ModelParameters>("superparamagnetic",
       {
           parameter<double>("saturation_magnetization",
               {.description = "Saturation magnetization",
@@ -99,7 +99,7 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
   auto spec = group("SCATRA_FUNCTION",
       {
           parameter<ScatraFunctionType>("type"),
-          group_struct<CylinderMagnetParameters>("parameters",
+          group<CylinderMagnetParameters>("parameters",
               {
                   parameter<double>("magnet_radius",
                       {.description = "Radius of the cylinder magnet",
@@ -128,7 +128,7 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
                       {.description = "Dynamic viscosity of the fluid",
                           .validator = positive<double>(),
                           .store = in_struct(&CylinderMagnetParameters::dynamic_viscosity_fluid)}),
-                  group_struct<Rotation>("rotation",
+                  group<Rotation>("rotation",
                       {
                           parameter<double>("around_x_axis",
                               {.description = "Rotation of the magnet around the x-axis in degrees",

--- a/src/scatra/4C_scatra_functions.cpp
+++ b/src/scatra/4C_scatra_functions.cpp
@@ -142,7 +142,7 @@ void ScaTra::add_valid_scatra_functions(Core::Utils::FunctionManager& function_m
                                   .store = in_struct(&Rotation::y_axis)}),
                       },
                       {.description = "Rotation of the magnet around different axes",
-                          .defaultable = true,
+                          .required = false,
                           .store = in_struct(&CylinderMagnetParameters::magnet_rotation)}),
                   parameter<double>("particle_radius",
                       {.description = "Radius of the magnetic particle",

--- a/src/thermo/src/utils/4C_thermo_input.cpp
+++ b/src/thermo/src/utils/4C_thermo_input.cpp
@@ -168,8 +168,8 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
                   .default_value = no_error_calculation}),
           parameter<int>("CALCERRORFUNCNO",
               {.description = "Function for Error Calculation", .default_value = -1})},
-      {.defaultable =
-              true}); /*----------------------------------------------------------------------*/
+      {.required =
+              false}); /*----------------------------------------------------------------------*/
   /* parameters for generalised-alpha thermal integrator */
   list["THERMAL DYNAMIC/GENALPHA"] = group("THERMAL DYNAMIC/GENALPHA",
       {
@@ -192,7 +192,7 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
               {.description = "Generalised-alpha factor in [0.5,1)", .default_value = 0.5}),
           parameter<double>("RHO_INF",
               {.description = "Generalised-alpha factor in [0,1]", .default_value = -1.0})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for one-step-theta thermal integrator */
@@ -201,7 +201,7 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
 
           parameter<double>(
               "THETA", {.description = "One-step-theta factor in (0,1]", .default_value = 0.5})},
-      {.defaultable = true});
+      {.required = false});
 
   // vtk runtime output
   {
@@ -235,7 +235,7 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
             // whether to write node GIDs
             parameter<bool>("NODE_GID",
                 {.description = "write 4C internal node GIDs", .default_value = false})},
-        {.defaultable = true});
+        {.required = false});
   }
 
   // csv runtime output
@@ -250,7 +250,7 @@ void Thermo::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& li
             // whether to write energy state
             parameter<bool>(
                 "ENERGY", {.description = "write energy output", .default_value = false})},
-        {.defaultable = true});
+        {.required = false});
   }
 }
 

--- a/src/tsi/4C_tsi_input.cpp
+++ b/src/tsi/4C_tsi_input.cpp
@@ -65,7 +65,7 @@ void TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
               },
               {.description = "type of norm for convergence check of primary variables in TSI",
                   .default_value = convnorm_abs})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for monolithic TSI */
@@ -165,7 +165,7 @@ void TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
                   {"or", LS_or},
               },
               {.description = "line-search strategy", .default_value = LS_none})},
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for partitioned TSI */
@@ -191,7 +191,7 @@ void TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
                       "tolerance for convergence check of outer iteraiton within partitioned TSI",
                   .default_value = 1e-6}),
       },
-      {.defaultable = true});
+      {.required = false});
 
   /*----------------------------------------------------------------------*/
   /* parameters for tsi contact */
@@ -227,7 +227,7 @@ void TSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>& list)
           parameter<double>("PENALTYPARAM_THERMO",
               {.description = "Penalty parameter for Nitsche solution strategy",
                   .default_value = 0.0})},
-      {.defaultable = true});
+      {.required = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -189,7 +189,6 @@ def schema_from_group(group):
     # Use All_of to create the schema
     metadata_dict = asdict(group)
     noneable = metadata_dict.pop("noneable", False)
-    metadata_dict.pop("defaultable", False)
     schema = schema_from_all_of(All_Of(**metadata_dict))
     schema["title"] = group.short_description()
 

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -277,7 +277,6 @@ class Group(Collection):
     specs: list = field(default_factory=list)
     name: str = None
     noneable: bool = False
-    defaultable: bool = False
 
     def short_description(self):
         """Create short description."""


### PR DESCRIPTION
- I introduced `group_struct` in #904, but meanwhile, the interface has evolved in #884. The first commit removes the `group_struct` function and moves this functionality into the `group` function.
- Whether a group is defaultable or not, is fully deducible. Users can now only specify if the group should be required (the default) or optional. (Idea by @gilrrei)