### PR TITLE
Some small improvements to Tensor

### DIFF
--- a/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
@@ -33,9 +33,6 @@ namespace Core::LinAlg
     view
   };
 
-  template <typename Tensor>
-  constexpr bool is_compressed_tensor = std::remove_cvref_t<Tensor>::is_compressed;
-
   /*!
    * @brief General tensor class for dense tensors of arbitrary rank
    *
@@ -161,7 +158,7 @@ namespace Core::LinAlg
      * @endcode
      *
      */
-    TensorInternal(const Internal::TensorInitializerList<Number, n...>::type& lst)
+    constexpr TensorInternal(const Internal::TensorInitializerList<Number, n...>::type& lst)
       requires(std::is_default_constructible_v<ContainerType> && !is_compressed);
 
     /*!
@@ -324,6 +321,10 @@ namespace Core::LinAlg
   template <typename T>
   static constexpr bool is_tensor = Internal::HasTensorBase<std::remove_cvref_t<T>>::value;
 
+  template <typename Tensor>
+  constexpr bool is_compressed_tensor =
+      is_tensor<Tensor> && std::remove_cvref_t<Tensor>::is_compressed;
+
   /*!
    * @brief A check whether a type is a admissible scalar type for a tensor
    */
@@ -338,7 +339,7 @@ namespace Core::LinAlg
   // actual implementations
 
   template <typename Number, TensorStorageType storage_type, typename Compression, std::size_t... n>
-  TensorInternal<Number, storage_type, Compression, n...>::TensorInternal(
+  constexpr TensorInternal<Number, storage_type, Compression, n...>::TensorInternal(
       const Internal::TensorInitializerList<Number, n...>::type& lst)
     requires(std::is_default_constructible_v<ContainerType> && !is_compressed)
   {

--- a/src/core/linalg/src/dense/4C_linalg_tensor_matrix_conversion.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_matrix_conversion.hpp
@@ -13,6 +13,7 @@
 #include "4C_linalg_fixedsizematrix_voigt_notation.hpp"
 #include "4C_linalg_symmetric_tensor.hpp"
 #include "4C_linalg_tensor.hpp"
+#include "4C_linalg_tensor_internals.hpp"
 
 #include <type_traits>
 
@@ -120,7 +121,8 @@ namespace Core::LinAlg
    * @brief Creates a matrix that views a 2-tensor
    */
   auto make_matrix_view(auto& tensor)
-    requires(std::remove_cvref_t<decltype(tensor)>::rank() == 2)
+    requires(std::remove_cvref_t<decltype(tensor)>::rank() == 2 &&
+             !is_compressed_tensor<decltype(tensor)>)
   {
     using ValueType = std::remove_cvref_t<decltype(tensor)>::value_type;
     constexpr std::size_t n1 = std::remove_cvref_t<decltype(tensor)>::template extent<0>();
@@ -134,7 +136,8 @@ namespace Core::LinAlg
   template <std::size_t n1, std::size_t n2>
   auto make_matrix_view(auto& tensor)
     requires(std::remove_cvref_t<decltype(tensor)>::rank() == 1 &&
-             n1 * n2 == std::remove_cvref_t<decltype(tensor)>::template extent<0>())
+             n1 * n2 == std::remove_cvref_t<decltype(tensor)>::template extent<0>() &&
+             !is_compressed_tensor<decltype(tensor)>)
   {
     using ValueType = std::remove_cvref_t<decltype(tensor)>::value_type;
     return Core::LinAlg::Matrix<n1, n2, ValueType>{tensor.data(), true};


### PR DESCRIPTION
* Adding a few missing `constexpr`
* `is_compressed_tensor` now implies `is_tensor`
* Make sure that matrix views can only be created from non-symmetric tensors.