### PR TITLE
Remove some raw epetra export and import calls

### DIFF
--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -506,7 +506,7 @@ namespace Core::Communication
     // export full matrices to the two desired processors
     Core::LinAlg::Import serialimporter(*serialrowmap, rowmap);
     Core::LinAlg::SparseMatrix serialCrsMatrix(*serialrowmap, 0);
-    serialCrsMatrix.import(matrix, serialimporter.get_epetra_import(), Insert);
+    serialCrsMatrix.import(matrix, serialimporter, Insert);
     serialCrsMatrix.complete(*serialdomainmap, *serialrowmap);
 
     // fill data of matrices to container which can be easily communicated via MPI

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -609,16 +609,16 @@ namespace Core::LinAlg
 
     /** \name Import / Export methods */
     //@{
-    int import(
-        const SparseMatrix& A, const Epetra_Import& importer, Epetra_CombineMode combine_mode)
+    int import(const SparseMatrix& A, const Core::LinAlg::Import& importer,
+        Epetra_CombineMode combine_mode)
     {
-      return sysmat_->Import(*A.epetra_matrix(), importer, combine_mode);
+      return sysmat_->Import(*A.epetra_matrix(), importer.get_epetra_import(), combine_mode);
     }
 
-    int import(
-        const SparseMatrix& A, const Epetra_Export& exporter, Epetra_CombineMode combine_mode)
+    int import(const SparseMatrix& A, const Core::LinAlg::Export& exporter,
+        Epetra_CombineMode combine_mode)
     {
-      return sysmat_->Import(*A.epetra_matrix(), exporter, combine_mode);
+      return sysmat_->Import(*A.epetra_matrix(), exporter.get_epetra_export(), combine_mode);
     }
 
     //@}

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -761,7 +761,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::master_
   // OK. You cannot use the same exporter for different matrices. So we
   // recreate one all the time... This has to be optimized later on.
   Core::LinAlg::Export exporter(*permmasterdofmap_, *masterdofmap_);
-  int err = permsm->import(sm, exporter.get_epetra_export(), Insert);
+  int err = permsm->import(sm, exporter, Insert);
 
   if (err) FOUR_C_THROW("Import failed with err={}", err);
 
@@ -787,7 +787,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Coupling::Adapter::Coupling::slave_t
   // OK. You cannot use the same exporter for different matrices. So we
   // recreate one all the time... This has to be optimized later on.
   Core::LinAlg::Export exporter(*permslavedofmap_, *slavedofmap_);
-  int err = permsm->import(sm, exporter.get_epetra_export(), Insert);
+  int err = permsm->import(sm, exporter, Insert);
 
   if (err) FOUR_C_THROW("Import failed with err={}", err);
 
@@ -846,7 +846,7 @@ void Coupling::Adapter::Coupling::setup_coupling_matrices(const Core::LinAlg::Ma
   auto tmp = std::make_shared<Core::LinAlg::SparseMatrix>(slavedomainmap, 1);
 
   Core::LinAlg::Import exporter(slavedomainmap, *perm_slave_dof_map());
-  int err = tmp->import(*matsm_trans_, exporter.get_epetra_import(), Insert);
+  int err = tmp->import(*matsm_trans_, exporter, Insert);
   if (err) FOUR_C_THROW("Import failed with err={}", err);
 
   tmp->complete(shiftedmastermap, slavedomainmap);

--- a/src/mortar/4C_mortar_matrix_transform.cpp
+++ b/src/mortar/4C_mortar_matrix_transform.cpp
@@ -123,7 +123,7 @@ void Mortar::MatrixRowColTransformer::redistributed_to_unredistributed(
 {
   throw_if_not_init_and_setup();
 
-  const int err = dst_mat.import(src_mat, slave_to_master_[bt]->get_epetra_export(), Insert);
+  const int err = dst_mat.import(src_mat, *slave_to_master_[bt], Insert);
 
   // reset the distributor of the exporter after use
   reset_exporter(slave_to_master_[bt]);
@@ -156,7 +156,7 @@ void Mortar::MatrixRowColTransformer::unredistributed_to_redistributed(
 {
   throw_if_not_init_and_setup();
 
-  const int err = dst_mat.import(src_mat, master_to_slave_[bt]->get_epetra_export(), Insert);
+  const int err = dst_mat.import(src_mat, *master_to_slave_[bt], Insert);
 
   // reset the distributor of the exporter after use
   reset_exporter(master_to_slave_[bt]);

--- a/src/mortar/4C_mortar_utils.cpp
+++ b/src/mortar/4C_mortar_utils.cpp
@@ -386,7 +386,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Mortar::redistribute(
   Core::LinAlg::Export exporter(permrowmap, src.row_map());
 
   auto permsrc = std::make_shared<Core::LinAlg::SparseMatrix>(permrowmap, src.max_num_entries());
-  int err = permsrc->import(src, exporter.get_epetra_export(), Insert);
+  int err = permsrc->import(src, exporter, Insert);
   if (err) FOUR_C_THROW("Import failed with err={}", err);
 
   permsrc->complete(permdomainmap, permrowmap);

--- a/src/sti/4C_sti_monolithic.cpp
+++ b/src/sti/4C_sti_monolithic.cpp
@@ -572,8 +572,7 @@ void STI::Monolithic::output_matrix_to_file(
   Core::LinAlg::SparseMatrix crsmatrix(fullrowmap, 0);
   if (sparsematrix != nullptr)
   {
-    if (crsmatrix.import(
-            *sparsematrix, Core::LinAlg::Import(fullrowmap, rowmap).get_epetra_import(), Insert))
+    if (crsmatrix.import(*sparsematrix, Core::LinAlg::Import(fullrowmap, rowmap), Insert))
       FOUR_C_THROW("Matrix import failed!");
   }
   else
@@ -583,9 +582,7 @@ void STI::Monolithic::output_matrix_to_file(
       for (int j = 0; j < blocksparsematrix->cols(); ++j)
       {
         if (crsmatrix.import(blocksparsematrix->matrix(i, j),
-                Core::LinAlg::Import(fullrowmap, blocksparsematrix->range_map(i))
-                    .get_epetra_import(),
-                Insert))
+                Core::LinAlg::Import(fullrowmap, blocksparsematrix->range_map(i)), Insert))
           FOUR_C_THROW("Matrix import failed!");
       }
     }


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR follows the work on the wrapper classes for `Epetra_Export` and `Epetra_Import` removing some `get_epetra_export()` and `get_epetra_import()` calls from the physics modules. However there are still a few more calls that need to be removed, e.g. places where the code (either a Epetra_CrsMatrix or a FEVector) directly calls the import or export methods of `Epetra` .
## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
#755
