### PR TITLE
ReducedLung: Refactor terminal units 

### DIFF
--- a/src/reduced_lung/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/4C_reduced_lung_main.cpp
@@ -17,9 +17,9 @@
 #include "4C_io_discretization_visualization_writer_mesh.hpp"
 #include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
-#include "4C_mat_maxwell_0d_acinus_NeoHookean.hpp"
 #include "4C_red_airways_elementbase.hpp"
 #include "4C_reduced_lung_helpers.hpp"
+#include "4C_reduced_lung_terminal_unit.hpp"
 #include "4C_utils_function_of_time.hpp"
 
 #include <Teuchos_StandardParameterEntryValidators.hpp>
@@ -61,7 +61,7 @@ namespace ReducedLung
     // Create vectors of local entities (equations acting on the dofs).
     // Physical "elements" of the lung tree introducing the dofs.
     std::vector<Airway> airways;
-    std::vector<TerminalUnit> terminal_units;
+    TerminalUnits terminal_units;
     std::map<int, int> dof_per_ele;  // Map global element id -> dof.
     int n_airways = 0;
     int n_terminal_units = 0;
@@ -81,21 +81,16 @@ namespace ReducedLung
       }
       else if (ele->element_type() == Discret::Elements::RedAcinusType::instance())
       {
-        double E;
-        double eta;
         if (ele->material(0)->material_type() == Core::Materials::m_0d_maxwell_acinus_neohookean)
         {
-          auto* param = ele->material(0)->parameter();
-          auto* mat = static_cast<Mat::PAR::Maxwell0dAcinus*>(param);
-          E = mat->stiffness1_;
-          eta = mat->viscosity1_;
+          // Default terminal unit model until the new input is available.
+          add_terminal_unit_ele<KelvinVoigt, LinearElasticity>(
+              terminal_units, ele, local_element_id);
         }
         else
         {
           FOUR_C_THROW("Material not implemented.");
         }
-        terminal_units.push_back(TerminalUnit{element_id, local_element_id, n_terminal_units,
-            TerminalUnitType::kelvin_voigt, E, eta});
         dof_per_ele[element_id] = 3;
         n_terminal_units++;
       }
@@ -137,13 +132,14 @@ namespace ReducedLung
         airway.global_dof_ids.insert(airway.global_dof_ids.end(), first_dof_gid + i);
       }
     }
-    for (auto& terminal_unit : terminal_units)
+    for (auto& model : terminal_units.models)
     {
-      int first_dof_gid = first_global_dof_of_ele[terminal_unit.global_element_id];
-      int n_dof = dof_per_ele[terminal_unit.global_element_id];
-      for (int i = 0; i < n_dof; i++)
+      for (size_t i = 0; i < model.data.number_of_elements(); i++)
       {
-        terminal_unit.global_dof_ids.insert(terminal_unit.global_dof_ids.end(), first_dof_gid + i);
+        int first_dof_gid = first_global_dof_of_ele[model.data.global_element_id[i]];
+        model.data.gid_p1.push_back(first_dof_gid);
+        model.data.gid_p2.push_back(first_dof_gid + 1);
+        model.data.gid_q.push_back(first_dof_gid + 2);
       }
     }
 
@@ -166,8 +162,9 @@ namespace ReducedLung
       }
       return result;
     };
-    auto global_ele_ids_per_node = Core::Communication::all_reduce<std::map<int, std::vector<int>>>(
-        ele_ids_per_node, merge_maps, comm);
+    FourC::Core::Communication::IsCommunicatable auto global_ele_ids_per_node =
+        Core::Communication::all_reduce<std::map<int, std::vector<int>>>(
+            ele_ids_per_node, merge_maps, comm);
 
     // Create entities with equations connecting elements (acting on "nodes" of the lung tree).
     std::vector<BoundaryCondition> boundary_conditions;
@@ -176,16 +173,15 @@ namespace ReducedLung
     int n_boundary_conditions = 0;
     int n_connections = 0;
     int n_bifurcations = 0;
-    // Loop over all local elements, get their nodes, create associated entity. This way, they are
-    // created on the same ranks as at least one of their connected elements. This reduces the
-    // amount of communication of dofs between ranks.
-
+    // Find all nodes with boundary conditions
     std::vector<const Core::Conditions::Condition*> conditions;
     actdis->get_condition("RedAirwayPrescribedCond", conditions);
     const auto red_airway_prescribed_conditions =
         Core::Conditions::find_conditioned_node_ids_and_conditions(
             *actdis, conditions, Core::Conditions::LookFor::locally_owned_and_ghosted);
-
+    // Loop over all local elements, get their nodes, create associated entity. This way, they are
+    // created on the same ranks as at least one of their connected elements. This reduces the
+    // amount of communication of dofs between ranks.
     for (const auto* ele : actdis->my_row_element_range())
     {
       const auto* nodes = ele->nodes();
@@ -347,21 +343,25 @@ namespace ReducedLung
       }
     }
 
-    // Calculate local and global number of "element" equations
+    // Calculate local and global number of "element" equations and assign local row IDs to define
+    // the structure of the system of equations.
     int n_local_equations = 0;
     for (const auto& airway : airways)
     {
       n_local_equations += airway.n_state_equations;
     }
-    for (const auto& terminal_unit : terminal_units)
+    for (auto& tu_model : terminal_units.models)
     {
-      n_local_equations += terminal_unit.n_state_equations;
+      for (size_t i = 0; i < tu_model.data.number_of_elements(); i++)
+      {
+        tu_model.data.local_row_id.push_back(n_local_equations);
+        n_local_equations++;
+      }
     }
-
     // Assign local equation ids to connections, bifurcations, and boundary conditions.
     for (Connection& conn : connections)
     {
-      // Every connection adds 1 momentum  and 1 mass balance equation.
+      // Every connection adds 1 momentum and 1 mass balance equation.
       conn.first_local_equation_id = n_local_equations;
       n_local_equations += 2;
     }
@@ -414,11 +414,13 @@ namespace ReducedLung
         airway.local_dof_ids.push_back(locally_relevant_dof_map.lid(gid));
       }
     }
-    for (TerminalUnit& terminal_unit : terminal_units)
+    for (auto& tu_model : terminal_units.models)
     {
-      for (const int& gid : terminal_unit.global_dof_ids)
+      for (size_t i = 0; i < tu_model.data.number_of_elements(); i++)
       {
-        terminal_unit.local_dof_ids.push_back(locally_relevant_dof_map.lid(gid));
+        tu_model.data.lid_p1.push_back(locally_relevant_dof_map.lid(tu_model.data.gid_p1[i]));
+        tu_model.data.lid_p2.push_back(locally_relevant_dof_map.lid(tu_model.data.gid_p2[i]));
+        tu_model.data.lid_q.push_back(locally_relevant_dof_map.lid(tu_model.data.gid_q[i]));
       }
     }
     for (Connection& conn : connections)
@@ -472,24 +474,6 @@ namespace ReducedLung
                                          current_length / (airway_params.area * airway_params.area);
     }
 
-    // Local terminal unit vectors. Potentially add to terminal unit objects in the future.
-    std::vector<double> volume(n_terminal_units);
-    std::vector<double> volume_0(n_terminal_units);
-
-    // Fill terminal unit data.
-    for (const TerminalUnit& terminal_unit : terminal_units)
-    {
-      const int terminal_unit_id = terminal_unit.local_terminal_unit_id;
-      const auto* terminal_unit_ele = static_cast<Discret::Elements::RedAcinus*>(
-          actdis->g_element(terminal_unit.global_element_id));
-      const std::vector<double>& coords_1 = terminal_unit_ele->nodes()[0]->x();
-      const std::vector<double>& coords_2 = terminal_unit_ele->nodes()[1]->x();
-      const double radius = std::sqrt((coords_1[0] - coords_2[0]) * (coords_1[0] - coords_2[0]) +
-                                      (coords_1[1] - coords_2[1]) * (coords_1[1] - coords_2[1]) +
-                                      (coords_1[2] - coords_2[2]) * (coords_1[2] - coords_2[2]));
-      volume[terminal_unit_id] = volume_0[terminal_unit_id] = radius * radius * M_PI;
-    }
-
     // Create system matrix and vectors:
     // Vector with all degrees of freedom (p1, p2, q, ...) associated to the elements.
     auto dofs = Core::LinAlg::Vector<double>(locally_owned_dof_map, true);
@@ -507,6 +491,7 @@ namespace ReducedLung
     // Jacobian of the system equations.
     auto sysmat = Core::LinAlg::SparseMatrix(row_map, locally_relevant_dof_map, 3);
 
+    // Write results every ... time steps.
     const int results_every = rawdyn.get<int>("RESULTSEVERY");
     // Time integration parameters.
     const double dt = rawdyn.get<double>("TIMESTEP");
@@ -563,33 +548,8 @@ namespace ReducedLung
       }
 
       // Assemble terminal unit equations.
-      for (const TerminalUnit& terminal_unit : terminal_units)
-      {
-        // Momentum balance: p_in - p_pl - E*(V-V0)/V0 - nu*q/V0 = 0.
-        const double& V_tu = volume[terminal_unit.local_terminal_unit_id];
-        const double& V0_tu = volume_0[terminal_unit.local_terminal_unit_id];
-        const double& E = terminal_unit.E;
-        const double& eta = terminal_unit.eta;
-        const std::array<double, 3> vals{1.0, -1.0, -(E * dt + eta) / V0_tu};
-        const double res =
-            -locally_relevant_dofs[terminal_unit.local_dof_ids[p_in]] +
-            locally_relevant_dofs[terminal_unit.local_dof_ids[p_out]] +
-            (E * dt + eta) / V0_tu * locally_relevant_dofs[terminal_unit.local_dof_ids[q_in]] +
-            E * (V_tu - V0_tu) / V0_tu;
-        if (!sysmat.filled())
-        {
-          err = sysmat.insert_my_values(terminal_unit.local_element_id, vals.size(), vals.data(),
-              terminal_unit.local_dof_ids.data());
-        }
-        else
-        {
-          err = sysmat.replace_my_values(terminal_unit.local_element_id, vals.size(), vals.data(),
-              terminal_unit.local_dof_ids.data());
-        }
-        FOUR_C_ASSERT(err == 0, "Internal error: Terminal Unit equation assembly did not work.");
-        err = rhs.replace_local_value(terminal_unit.local_element_id, res);
-        FOUR_C_ASSERT(err == 0, "Internal error: Terminal Unit equation calculation did not work.");
-      }
+      update_terminal_unit_negative_residual_vector(rhs, terminal_units, locally_relevant_dofs, dt);
+      update_terminal_unit_jacobian(sysmat, terminal_units, locally_relevant_dofs, dt);
 
       // Assemble connection equations.
       for (const Connection& conn : connections)
@@ -751,14 +711,8 @@ namespace ReducedLung
       dofs.update(1.0, x_mapped_to_dofs, 1.0);
       export_to(dofs, locally_relevant_dofs);
 
-      // Update variable parameters depending on dofs.
-      for (const auto& terminal_unit : terminal_units)
-      {
-        const int& q_id = terminal_unit.local_dof_ids[2];
-        const int& tu_id = terminal_unit.local_terminal_unit_id;
-        // Backwards Euler: V_n+1 = V_n + q_n+1 * dt.
-        volume[tu_id] += locally_relevant_dofs[q_id] * dt;
-      }
+      // Update variable parameters depending on converged dofs.
+      update_terminal_unit_internal_state_vectors(terminal_units, locally_relevant_dofs, dt);
 
       // Runtime output
       if (n % results_every == 0)

--- a/src/reduced_lung/4C_reduced_lung_terminal_unit.cpp
+++ b/src/reduced_lung/4C_reduced_lung_terminal_unit.cpp
@@ -1,0 +1,227 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_config.hpp"
+
+#include "4C_reduced_lung_terminal_unit.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung
+{
+
+  std::vector<double>& evaluate_linear_elastic_pressure(LinearElasticity& linear_elastic_model,
+      TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+  {
+    for (size_t i = 0; i < data.number_of_elements(); i++)
+    {
+      linear_elastic_model.elastic_pressure_p_el[i] =
+          linear_elastic_model.elasticity_E[i] *
+          ((data.volume_v[i] + dt * locally_relevant_dofs[data.lid_q[i]]) /
+                  data.reference_volume_v0[i] -
+              1);
+    }
+    return linear_elastic_model.elastic_pressure_p_el;
+  }
+
+  std::vector<double>& evaluate_ogden_hyperelastic_pressure(
+      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+  {
+    for (size_t i = 0; i < data.number_of_elements(); i++)
+    {
+      double v0_over_vi = data.reference_volume_v0[i] /
+                          (data.volume_v[i] + dt * locally_relevant_dofs[data.lid_q[i]]);
+      ogden_hyperelastic_model.elastic_pressure_p_el[i] =
+          ogden_hyperelastic_model.bulk_modulus_kappa[i] /
+          ogden_hyperelastic_model.nonlinear_stiffening_beta[i] * v0_over_vi *
+          (1 - std::pow(v0_over_vi, ogden_hyperelastic_model.nonlinear_stiffening_beta[i]));
+    }
+    return ogden_hyperelastic_model.elastic_pressure_p_el;
+  }
+
+  void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
+      const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      const std::vector<double>& elastic_pressure_p_el)
+  {
+    for (size_t i = 0; i < data.number_of_elements(); i++)
+    {
+      double negative_kelvin_voigt_residual =
+          -1 * (locally_relevant_dofs[data.lid_p1[i]] - locally_relevant_dofs[data.lid_p2[i]] -
+                   elastic_pressure_p_el[i] -
+                   kelvin_voigt_model.viscosity_eta[i] * locally_relevant_dofs[data.lid_q[i]] /
+                       data.reference_volume_v0[i]);
+      target.replace_local_value(data.local_row_id[i], negative_kelvin_voigt_residual);
+    }
+  }
+
+  void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
+      const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      const std::vector<double>& elastic_pressure_p_el, double dt)
+  {
+    for (size_t i = 0; i < data.number_of_elements(); i++)
+    {
+      double negative_four_element_maxwell_residual =
+          -1 * (locally_relevant_dofs[data.lid_p1[i]] - locally_relevant_dofs[data.lid_p2[i]] -
+                   elastic_pressure_p_el[i] -
+                   (four_element_maxwell_model.viscosity_eta[i] +
+                       (four_element_maxwell_model.elasticity_E_m[i] * dt *
+                           four_element_maxwell_model.viscosity_eta_m[i]) /
+                           (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                               four_element_maxwell_model.viscosity_eta_m[i])) /
+                       data.reference_volume_v0[i] * locally_relevant_dofs[data.lid_q[i]] -
+                   four_element_maxwell_model.viscosity_eta_m[i] /
+                       (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                           four_element_maxwell_model.viscosity_eta_m[i]) *
+                       four_element_maxwell_model.maxwell_pressure_p_m[i]);
+      target.replace_local_value(data.local_row_id[i], negative_four_element_maxwell_residual);
+    }
+  }
+
+  std::vector<double>& linear_elastic_pressure_gradient(
+      LinearElasticity& linear_elastic_model, TerminalUnitData& data, double dt)
+  {
+    for (size_t i = 0; i < data.number_of_elements(); i++)
+    {
+      linear_elastic_model.elastic_pressure_grad_dp_el[i] =
+          linear_elastic_model.elasticity_E[i] * dt / data.reference_volume_v0[i];
+    }
+    return linear_elastic_model.elastic_pressure_grad_dp_el;
+  }
+
+  std::vector<double>& ogden_hyperelastic_pressure_gradient(
+      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+  {
+    for (size_t i = 0; i < data.number_of_elements(); i++)
+    {
+      double v0_over_vi = data.reference_volume_v0[i] /
+                          (data.volume_v[i] + dt * locally_relevant_dofs[data.lid_q[i]]);
+      ogden_hyperelastic_model.elastic_pressure_grad_dp_el[i] =
+          ogden_hyperelastic_model.bulk_modulus_kappa[i] * dt /
+          (ogden_hyperelastic_model.nonlinear_stiffening_beta[i] * data.reference_volume_v0[i]) *
+          v0_over_vi * v0_over_vi *
+          ((ogden_hyperelastic_model.nonlinear_stiffening_beta[i] + 1) *
+                  std::pow(v0_over_vi, ogden_hyperelastic_model.nonlinear_stiffening_beta[i]) -
+              1);
+    }
+    return ogden_hyperelastic_model.elastic_pressure_grad_dp_el;
+  }
+
+  void evaluate_kelvin_voigt_jacobian(Core::LinAlg::SparseMatrix& target,
+      const KelvinVoigt& kelvin_voigt_model, TerminalUnitData& data,
+      const std::vector<double>& elastic_pressure_grad_dp_el)
+  {
+    [[maybe_unused]] int err;
+    if (!target.filled())
+    {
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        std::array<int, 3> column_indices{data.lid_p1[i], data.lid_p2[i], data.lid_q[i]};
+        std::array<double, 3> values{1.0, -1.0,
+            -elastic_pressure_grad_dp_el[i] -
+                kelvin_voigt_model.viscosity_eta[i] / data.reference_volume_v0[i]};
+        err =
+            target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+        FOUR_C_ASSERT(
+            err == 0, "Internal error: Terminal Unit kelvin-voigt equation assembly did not work.");
+      }
+    }
+    else
+    {
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double grad_q = -elastic_pressure_grad_dp_el[i] -
+                        kelvin_voigt_model.viscosity_eta[i] / data.reference_volume_v0[i];
+        err = target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        FOUR_C_ASSERT(
+            err == 0, "Internal error: Terminal Unit kelvin-voigt equation assembly did not work.");
+      }
+    }
+  }
+
+  void evaluate_four_element_maxwell_jacobian(Core::LinAlg::SparseMatrix& target,
+      const FourElementMaxwell& four_element_maxwell_model, TerminalUnitData& data,
+      const std::vector<double>& elastic_pressure_grad_dp_el, double dt)
+  {
+    [[maybe_unused]] int err;
+    if (!target.filled())
+    {
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        std::array<int, 3> column_indices{data.lid_p1[i], data.lid_p2[i], data.lid_q[i]};
+        std::array<double, 3> values{1.0, -1.0,
+            -elastic_pressure_grad_dp_el[i] -
+                (four_element_maxwell_model.viscosity_eta[i] +
+                    four_element_maxwell_model.elasticity_E_m[i] * dt *
+                        four_element_maxwell_model.viscosity_eta_m[i] /
+                        (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                            four_element_maxwell_model.viscosity_eta_m[i])) /
+                    data.reference_volume_v0[i]};
+        err =
+            target.insert_my_values(data.local_row_id[i], 3, values.data(), column_indices.data());
+        FOUR_C_ASSERT(err == 0,
+            "Internal error: Terminal Unit four-element maxwell equation assembly did not work.");
+      }
+    }
+    else
+    {
+      for (size_t i = 0; i < data.number_of_elements(); i++)
+      {
+        double grad_q = -elastic_pressure_grad_dp_el[i] -
+                        (four_element_maxwell_model.viscosity_eta[i] +
+                            four_element_maxwell_model.elasticity_E_m[i] * dt *
+                                four_element_maxwell_model.viscosity_eta_m[i] /
+                                (four_element_maxwell_model.elasticity_E_m[i] * dt +
+                                    four_element_maxwell_model.viscosity_eta_m[i])) /
+                            data.reference_volume_v0[i];
+        err = target.replace_my_values(data.local_row_id[i], 1, &grad_q, &data.lid_q[i]);
+        FOUR_C_ASSERT(err == 0,
+            "Internal error: Terminal Unit four-element maxwell equation assembly did not work.");
+      }
+    }
+  }
+
+  void update_terminal_unit_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+      TerminalUnits& terminal_units, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      double dt)
+  {
+    for (auto& model : terminal_units.models)
+    {
+      model.negative_residual_evaluator(model.data, res_vector, locally_relevant_dofs, dt);
+    }
+  }
+
+  void update_terminal_unit_jacobian(Core::LinAlg::SparseMatrix& jac, TerminalUnits& terminal_units,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+  {
+    for (auto& model : terminal_units.models)
+    {
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+    }
+  }
+
+  void update_terminal_unit_internal_state_vectors(TerminalUnits& terminal_units,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt)
+  {
+    for (auto& model : terminal_units.models)
+    {
+      // Update volume
+      for (size_t i = 0; i < model.data.number_of_elements(); i++)
+      {
+        model.data.volume_v[i] += locally_relevant_dofs[model.data.lid_q[i]] * dt;
+      }
+      // Model specific updates
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+    }
+  }
+}  // namespace ReducedLung
+
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/reduced_lung/4C_reduced_lung_terminal_unit.hpp
+++ b/src/reduced_lung/4C_reduced_lung_terminal_unit.hpp
@@ -1,0 +1,632 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+
+#ifndef FOUR_C_REDUCED_LUNG_TERMINAL_UNIT_HPP
+#define FOUR_C_REDUCED_LUNG_TERMINAL_UNIT_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_fem_general_element.hpp"
+#include "4C_fem_general_node.hpp"
+#include "4C_linalg_sparsematrix.hpp"
+#include "4C_linalg_vector.hpp"
+#include "4C_mat_maxwell_0d_acinus.hpp"
+
+#include <variant>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace ReducedLung
+{
+
+  /**
+   * @brief Shared data container for all terminal unit elements.
+   *
+   * Stores identifiers and physical parameters (volume, pressure, etc.) for each terminal unit,
+   * which are used across all rheological and elasticity models.
+   *
+   * @note This data is independent of specific models and is shared across evaluators.
+   */
+  struct TerminalUnitData
+  {
+    // Global element IDs.
+    std::vector<int> global_element_id;
+    // Local element IDs in row map of the old discretization. May become obsolete with new input.
+    std::vector<int> local_element_id;
+    // IDs of the local rows in the row map. This defines the place for these terminal units in the
+    // system of equations.
+    std::vector<int> local_row_id;
+    // Global dof IDs
+    std::vector<int> gid_p1;
+    std::vector<int> gid_p2;
+    std::vector<int> gid_q;
+    // Dof IDs from locally relevant / column map. Used for lookup in dof-vector during assembly.
+    std::vector<int> lid_p1;
+    std::vector<int> lid_p2;
+    std::vector<int> lid_q;
+    // Physical quantities of each terminal unit.
+    std::vector<double> volume_v;
+    std::vector<double> reference_volume_v0;
+
+    /**
+     * Access this function when looping over elements.
+     */
+    [[nodiscard]] size_t number_of_elements() const { return global_element_id.size(); }
+  };
+
+  // ----- Rheological models of viscoelasticity -----
+
+  /**
+   * @brief Rheological Kelvin-Voigt model (spring and dashpot in parallel).
+   *
+   * @note The stress component from the spring is calculated with a given elasticity model
+   * (potentially nonlinear).
+   */
+  struct KelvinVoigt
+  {
+    std::vector<double> viscosity_eta;
+  };
+
+  /**
+   * @brief Rheological four-element Maxwell model (Kelvin-Voigt body and Maxwell body in parallel).
+   *
+   * The Maxwell body introduces an additional internal pressure state p_m, which is stored in this
+   * model and updated after every time step.
+   *
+   * @note The stress component from the spring in the Kelvin-Voigt body is calculated with a given
+   * elasticity model (potentially nonlinear).
+   */
+  struct FourElementMaxwell
+  {
+    std::vector<double> viscosity_eta;
+    std::vector<double> elasticity_E_m;
+    std::vector<double> viscosity_eta_m;
+    // Internal pressure state of the maxwell body
+    std::vector<double> maxwell_pressure_p_m;
+  };
+
+  // ----- Specialized Elasticity models -----
+
+  /**
+   * @brief Linear elasticity model. Substitutes a spring in a rheological model.
+   *
+   * Computes elastic pressure as linear function of volume.
+   * Includes internal variables for pressure and its gradient.
+   */
+  struct LinearElasticity
+  {
+    std::vector<double> elasticity_E;
+    // Internal elastic pressure state
+    std::vector<double> elastic_pressure_p_el;
+    std::vector<double> elastic_pressure_grad_dp_el;
+  };
+
+  /**
+   * @brief Ogden-type hyperelastic model. Substitutes a spring in a rheological model.
+   *
+   * Nonlinear stiffening behavior based on a bulk modulus and shape parameter.
+   * Includes internal variables for pressure and gradient.
+   *
+   * @note Ill-posed for beta = 0!
+   */
+  struct OgdenHyperelasticity
+  {
+    std::vector<double> bulk_modulus_kappa;
+    std::vector<double> nonlinear_stiffening_beta;
+    // Internal elastic pressure state
+    std::vector<double> elastic_pressure_p_el;
+    std::vector<double> elastic_pressure_grad_dp_el;
+  };
+
+  // Function handle for evaluating the negative model residuals.
+  using NegativeResidualEvaluator = std::function<void(TerminalUnitData& model_data,
+      Core::LinAlg::Vector<double>& target_vector,
+      const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+  // Function handle for evaluating the model gradients w.r.t. the primary variables.
+  using JacobianEvaluator = std::function<void(TerminalUnitData& model_data,
+      Core::LinAlg::SparseMatrix& target_matrix,
+      const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+  // Function handle for updating the internal state vectors storing information from the previous
+  // time step.
+  using InternalStateUpdater = std::function<void(TerminalUnitData& model_data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dof_vector, double time_step_size_dt)>;
+
+  // Model types
+  using RheologicalModel = std::variant<KelvinVoigt, FourElementMaxwell>;
+  using ElasticityModel = std::variant<LinearElasticity, OgdenHyperelasticity>;
+
+  /**
+   * @brief Encapsulates a unique combination of rheological and elasticity models.
+   *
+   * Stores the element-specific data and associated evaluation functions
+   * (residuals, Jacobians, internal state updates) for a given model combination. Every
+   * terminal-unit specific information or action can be found here.
+   */
+  struct TerminalUnitModel
+  {
+    TerminalUnitData data;
+    RheologicalModel rheological_model;
+    ElasticityModel elasticity_model;
+    NegativeResidualEvaluator negative_residual_evaluator;
+    JacobianEvaluator jacobian_evaluator;
+    InternalStateUpdater internal_state_updater;
+  };
+
+  /**
+   * @brief All terminal unit models together and interface for access.
+   *
+   * Stores all different terminal unit models as distinct building blocks. Acts as interface for
+   * distributing terminal units to the correct models in the input phase amd allows access to all
+   * terminal unit model blocks for assembly, output, etc..
+   */
+  struct TerminalUnits
+  {
+    std::vector<TerminalUnitModel> models;
+  };
+
+  /**
+   * @brief Evaluates the linear elastic pressure for all terminal units in one model.
+   *
+   * @param[in,out] linear_elastic_model Elastic model containing parameters and internal pressure
+   * state vector. Must belong to the same TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata (IDs, volume, etc.).
+   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param[in] dt Current time step size.
+   * @return Reference to internal elastic pressure vector, updated in-place with current values.
+   *
+   * @note This function updates and returns the internal vector `elastic_pressure_p_el` stored
+   * in the linear_elastic_model. It must not be used concurrently across models.
+   */
+  std::vector<double>& evaluate_linear_elastic_pressure(LinearElasticity& linear_elastic_model,
+      TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+  /**
+   * @brief Evaluates the nonlinear Ogden hyperelastic pressure for each terminal unit in one model.
+   *
+   * @param[in,out] ogden_hyperelastic_model Model parameters and internal pressure state vector.
+   * Must belong to the same TerminalUnitModel as data.
+   * @param[in] data Metadata and volume of each terminal unit.
+   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param[in] dt Time step size.
+   * @return Reference to internal elastic pressure vector, updated in-place with current values.
+   *
+   * @note This function updates and returns the internal vector `elastic_pressure_p_el` stored
+   * in the ogden_hyperelastic_model. It must not be used concurrently across models.
+   */
+  std::vector<double>& evaluate_ogden_hyperelastic_pressure(
+      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+  /**
+   * @brief Assembles the negative residual for a Kelvin-Voigt viscoelastic model.
+   *
+   * @param[out] target Target vector to which the residual is written.
+   * @param[in] kelvin_voigt_model Model containing viscosity parameters. Must belong to the same
+   * TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata.
+   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param[in] elastic_pressure_p_el Current elastic pressure values from the spring model.
+   *
+   * @note The function writes directly into the `target` vector using the row IDs from `data`.
+   */
+  void evaluate_negative_kelvin_voigt_residual(Core::LinAlg::Vector<double>& target,
+      const KelvinVoigt& kelvin_voigt_model, const TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      const std::vector<double>& elastic_pressure_p_el);
+
+  /**
+   * @brief Assembles the negative residual for a four-element Maxwell viscoelastic model.
+   *
+   * @param[out] target Target vector to which the residual is written.
+   * @param[in] four_element_maxwell_model Model parameters and internal Maxwell body pressure
+   * state. Must belong to the same TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata.
+   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param[in] elastic_pressure_p_el Current elastic pressure values from the spring model in the
+   * Kelvin-Voigt body.
+   * @param[in] dt Current time step size.
+   *
+   * @note The function writes directly into the `target` vector using the row IDs from `data`. It
+   * relies on an up-to-date internal Maxwell pressure state (p_m updated with DOFs from the last
+   * time step).
+   */
+  void evaluate_negative_four_element_maxwell_residual(Core::LinAlg::Vector<double>& target,
+      const FourElementMaxwell& four_element_maxwell_model, const TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      const std::vector<double>& elastic_pressure_p_el, double dt);
+
+  /**
+   * @brief Computes the gradient of the linear elastic pressure  model w.r.t. the inflow q.
+   *
+   * The elastic pressure is independent of the pressure state (p1 and p2).
+   *
+   * @param[in,out] linear_elastic_model Model with stiffness parameters and gradient vector. Must
+   * belong to the same TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata.
+   * @param[in] dt Current time step size.
+   * @return Reference to the internal gradient vector dp_el, updated in-place.
+   */
+  std::vector<double>& linear_elastic_pressure_gradient(
+      LinearElasticity& linear_elastic_model, TerminalUnitData& data, double dt);
+
+  /**
+   * @brief Computes the gradient of the nonlinear Ogden hyperelastic pressure w.r.t. inflow q.
+   *
+   * The elastic pressure is independent of the pressure state (p1 and p2). The elastic pressure
+   * gradient depends on the current volume state and inflow.
+   *
+   * @param[in,out] ogden_hyperelastic_model Ogden parameters and gradient vector. Must belong
+   * to the same TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata.
+   * @param[in] locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param[in] dt Current time step size.
+   * @return Reference to the internal gradient vector dp_el, updated in-place.
+   */
+  std::vector<double>& ogden_hyperelastic_pressure_gradient(
+      OgdenHyperelasticity& ogden_hyperelastic_model, TerminalUnitData& data,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+  /**
+   * @brief Assembles the Jacobian matrix entries for the Kelvin-Voigt viscoelastic model.
+   *
+   * @param[out] target Sparse matrix to which the Jacobian entries are written.
+   * @param[in] kelvin_voigt_model Rheological model with viscosity parameters. Must belong
+   * to the same TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata.
+   * @param[in] elastic_pressure_grad_dp_el Gradient of the elastic pressure from the spring model
+   * w.r.t. inflow.
+   *
+   * @note The function writes directly into the `target` matrix using the row IDs and column (DOF)
+   * IDs from `data`.
+   */
+  void evaluate_kelvin_voigt_jacobian(Core::LinAlg::SparseMatrix& target,
+      const KelvinVoigt& kelvin_voigt_model, TerminalUnitData& data,
+      const std::vector<double>& elastic_pressure_grad_dp_el);
+
+  /**
+   * @brief Assembles the Jacobian matrix for the four-element Maxwell viscoelastic model.
+   *
+   * @param[out] target Sparse matrix to which the Jacobian entries are written.
+   * @param[in] four_element_maxwell_model Four-element Maxwell parameters and internal Maxwell
+   * pressure state. Must belong to the same TerminalUnitModel as data.
+   * @param[in] data Terminal unit metadata.
+   * @param[in] elastic_pressure_grad_dp_el Gradient of the elastic pressure from the spring model
+   * w.r.t. inflow.
+   * @param[in] dt Current time step size.
+   *
+   * @note The function writes directly into the `target` matrix using the row IDs and column (DOF)
+   * IDs from `data`.
+   */
+  void evaluate_four_element_maxwell_jacobian(Core::LinAlg::SparseMatrix& target,
+      const FourElementMaxwell& four_element_maxwell_model, TerminalUnitData& data,
+      const std::vector<double>& elastic_pressure_grad_dp_el, double dt);
+
+  /**
+   * Creates a function for evaluating the elastic pressure given a specific elasticity model. This
+   * function is given to the NegativeResidualEvaluator.
+   */
+  struct MakeElasticPressureEvaluator
+  {
+    std::function<std::vector<double>&(
+        TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>
+    operator()(LinearElasticity& linear_elasticity_model)
+    {
+      return [&linear_elasticity_model](TerminalUnitData& data,
+                 const Core::LinAlg::Vector<double>& dofs, double dt) -> std::vector<double>&
+      { return evaluate_linear_elastic_pressure(linear_elasticity_model, data, dofs, dt); };
+    }
+    std::function<std::vector<double>&(
+        TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>
+    operator()(OgdenHyperelasticity& ogden_model)
+    {
+      return [&ogden_model](TerminalUnitData& data, const Core::LinAlg::Vector<double>& dofs,
+                 double dt) -> std::vector<double>&
+      { return evaluate_ogden_hyperelastic_pressure(ogden_model, data, dofs, dt); };
+    }
+  };
+
+  /**
+   * Creates the model-specific evaluator function for assembling the negative model residual.
+   */
+  struct MakeNegativeResidualEvaluator
+  {
+    NegativeResidualEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
+    {
+      auto elastic_pressure_evaluator =
+          std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
+      return [elastic_pressure_evaluator, &kelvin_voigt_model](TerminalUnitData& data,
+                 Core::LinAlg::Vector<double>& target, const Core::LinAlg::Vector<double>& dofs,
+                 double dt)
+      {
+        auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
+        evaluate_negative_kelvin_voigt_residual(target, kelvin_voigt_model, data, dofs, p_el);
+      };
+    }
+    NegativeResidualEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
+    {
+      auto elastic_pressure_evaluator =
+          std::visit(MakeElasticPressureEvaluator{}, elasticity_model);
+      return [elastic_pressure_evaluator, &four_element_maxwell_model](TerminalUnitData& data,
+                 Core::LinAlg::Vector<double>& target, const Core::LinAlg::Vector<double>& dofs,
+                 double dt)
+      {
+        auto& p_el = elastic_pressure_evaluator(data, dofs, dt);
+        evaluate_negative_four_element_maxwell_residual(
+            target, four_element_maxwell_model, data, dofs, p_el, dt);
+      };
+    }
+
+    ElasticityModel& elasticity_model;
+  };
+
+
+  /**
+   * Creates a function for evaluating the elastic pressure gradient w.r.t. inflow q given a
+   * specific elasticity model. This function is given to the JacobianEvaluator.
+   */
+  struct MakeElasticPressureGradientEvaluator
+  {
+    std::function<std::vector<double>&(
+        TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>
+    operator()(LinearElasticity& linear_elasticity_model)
+    {
+      return [&linear_elasticity_model](TerminalUnitData& data,
+                 const Core::LinAlg::Vector<double>& dofs, double dt) -> std::vector<double>&
+      { return linear_elastic_pressure_gradient(linear_elasticity_model, data, dt); };
+    }
+    std::function<std::vector<double>&(
+        TerminalUnitData&, const Core::LinAlg::Vector<double>&, double)>
+    operator()(OgdenHyperelasticity& ogden_model)
+    {
+      return [&ogden_model](TerminalUnitData& data, const Core::LinAlg::Vector<double>& dofs,
+                 double dt) -> std::vector<double>&
+      { return ogden_hyperelastic_pressure_gradient(ogden_model, data, dofs, dt); };
+    }
+  };
+
+  /**
+   * Creates the model-specific evaluator function for assembling the Jacobian.
+   */
+  struct MakeJacobianEvaluator
+  {
+    JacobianEvaluator operator()(KelvinVoigt& kelvin_voigt_model)
+    {
+      auto elastic_pressure_gradient_evaluator =
+          std::visit(MakeElasticPressureGradientEvaluator{}, elasticity_model);
+      return [elastic_pressure_gradient_evaluator, &kelvin_voigt_model](TerminalUnitData& data,
+                 Core::LinAlg::SparseMatrix& target, const Core::LinAlg::Vector<double>& dofs,
+                 double dt)
+      {
+        auto& dp_el = elastic_pressure_gradient_evaluator(data, dofs, dt);
+        evaluate_kelvin_voigt_jacobian(target, kelvin_voigt_model, data, dp_el);
+      };
+    }
+    JacobianEvaluator operator()(FourElementMaxwell& four_element_maxwell_model)
+    {
+      auto elastic_pressure_gradient_evaluator =
+          std::visit(MakeElasticPressureGradientEvaluator{}, elasticity_model);
+      return [elastic_pressure_gradient_evaluator, &four_element_maxwell_model](
+                 TerminalUnitData& data, Core::LinAlg::SparseMatrix& target,
+                 const Core::LinAlg::Vector<double>& dofs, double dt)
+      {
+        auto& dp_el = elastic_pressure_gradient_evaluator(data, dofs, dt);
+        evaluate_four_element_maxwell_jacobian(target, four_element_maxwell_model, data, dp_el, dt);
+      };
+    }
+
+    ElasticityModel& elasticity_model;
+  };
+
+  /**
+   * Creates the model-specific updater that updates internal states (variables that need to be
+   * tracked over time for model evaluation).
+   */
+  struct MakeInternalStateUpdater
+  {
+    InternalStateUpdater operator()(KelvinVoigt& kelvin_voigt_model)
+    {
+      return [&](TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+                 double dt) {};
+    }
+    InternalStateUpdater operator()(FourElementMaxwell& four_element_maxwell)
+    {
+      return [&](TerminalUnitData& data, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+                 double dt)
+      {
+        for (size_t i = 0; i < data.number_of_elements(); i++)
+        {
+          four_element_maxwell.maxwell_pressure_p_m[i] *=
+              four_element_maxwell.viscosity_eta_m[i] /
+              (four_element_maxwell.elasticity_E_m[i] * dt +
+                  four_element_maxwell.viscosity_eta_m[i]);
+          four_element_maxwell.maxwell_pressure_p_m[i] +=
+              four_element_maxwell.elasticity_E_m[i] * dt *
+              four_element_maxwell.viscosity_eta_m[i] /
+              (four_element_maxwell.elasticity_E_m[i] * dt +
+                  four_element_maxwell.viscosity_eta_m[i]) /
+              data.reference_volume_v0[i] * locally_relevant_dofs[data.lid_q[i]];
+        }
+      };
+    }
+  };
+
+  /**
+   * @brief Returns an existing or newly created model for a given rheological/elasticity pair.
+   *
+   * May become obsolete with the new input
+   *
+   * @tparam R Rheological model type.
+   * @tparam E Elasticity model type.
+   * @param terminal_units Global container for all terminal unit models.
+   * @return Reference to the matching TerminalUnitModel.
+   *
+   * @note Ensures reuse of model instances for shared material parameter sets.
+   */
+  template <typename R, typename E>
+  TerminalUnitModel& return_or_create_and_return_reference_to_terminal_unit_model(
+      TerminalUnits& terminal_units)
+  {
+    for (auto& model : terminal_units.models)
+    {
+      if (std::holds_alternative<R>(model.rheological_model) &&
+          std::holds_alternative<E>(model.elasticity_model))
+      {
+        return model;
+      }
+    }
+
+    // Create instance of the TerminalUnitModel
+    terminal_units.models.emplace_back();
+    TerminalUnitModel& new_model = terminal_units.models.back();
+
+    // Create models
+    new_model.rheological_model = R{};
+    new_model.elasticity_model = E{};
+
+    // Create evaluators with the newly instantiated TerminalUnitModel as reference.
+    new_model.negative_residual_evaluator = std::visit(
+        MakeNegativeResidualEvaluator{new_model.elasticity_model}, new_model.rheological_model);
+
+    new_model.jacobian_evaluator =
+        std::visit(MakeJacobianEvaluator{new_model.elasticity_model}, new_model.rheological_model);
+
+    new_model.internal_state_updater =
+        std::visit(MakeInternalStateUpdater{}, new_model.rheological_model);
+
+    return new_model;
+  }
+
+  struct AddRheologicalModelParameter
+  {
+    void operator()(KelvinVoigt& kelvin_voigt_model) const
+    {
+      kelvin_voigt_model.viscosity_eta.push_back(
+          static_cast<Mat::PAR::Maxwell0dAcinus*>(ele->material(0)->parameter())->viscosity1_);
+    }
+    void operator()(FourElementMaxwell& model) const
+    {
+      model.elasticity_E_m.push_back(
+          static_cast<Mat::PAR::Maxwell0dAcinus*>(ele->material(0)->parameter())->stiffness2_);
+      model.viscosity_eta.push_back(
+          static_cast<Mat::PAR::Maxwell0dAcinus*>(ele->material(0)->parameter())->viscosity1_);
+      model.viscosity_eta_m.push_back(
+          static_cast<Mat::PAR::Maxwell0dAcinus*>(ele->material(0)->parameter())->viscosity2_);
+      model.maxwell_pressure_p_m.push_back(0.0);
+    }
+
+    Core::Elements::Element* ele;
+  };
+
+  struct AddElasticityModelParameter
+  {
+    void operator()(LinearElasticity& linear_elasticity_model) const
+    {
+      linear_elasticity_model.elasticity_E.push_back(
+          static_cast<Mat::PAR::Maxwell0dAcinus*>(ele->material(0)->parameter())->stiffness1_);
+      // Vector initialization for internal pressure state.
+      linear_elasticity_model.elastic_pressure_p_el.push_back(0.0);
+      linear_elasticity_model.elastic_pressure_grad_dp_el.push_back(0.0);
+    }
+    void operator()(OgdenHyperelasticity& ogden_model) const {}
+
+    Core::Elements::Element* ele;
+  };
+
+  /**
+   * @brief Adds a new element to the appropriate TerminalUnitModel group.
+   *
+   * Computes volume, assigns material parameters, and initializes internal state.
+   *
+   * @tparam R Rheological model.
+   * @tparam E Elasticity model.
+   * @param terminal_units Global container for all terminal unit models.
+   * @param ele Pointer to element to be added.
+   * @param local_element_id Local identifier in 4C discretization.
+   */
+  template <typename R, typename E>
+  void add_terminal_unit_ele(
+      TerminalUnits& terminal_units, Core::Elements::Element* ele, int local_element_id)
+  {
+    TerminalUnitModel& model =
+        return_or_create_and_return_reference_to_terminal_unit_model<R, E>(terminal_units);
+
+    model.data.global_element_id.push_back(ele->id());
+    model.data.local_element_id.push_back(local_element_id);
+    const auto& coords_node_1 = ele->nodes()[0]->x();
+    const auto& coords_node_2 = ele->nodes()[1]->x();
+    const double radius =
+        std::sqrt((coords_node_1[0] - coords_node_2[0]) * (coords_node_1[0] - coords_node_2[0]) +
+                  (coords_node_1[1] - coords_node_2[1]) * (coords_node_1[1] - coords_node_2[1]) +
+                  (coords_node_1[2] - coords_node_2[2]) * (coords_node_1[2] - coords_node_2[2]));
+    const double volume = radius * radius * M_PI;
+    model.data.volume_v.push_back(volume);
+    model.data.reference_volume_v0.push_back(volume);
+    std::visit(AddRheologicalModelParameter{ele}, model.rheological_model);
+    std::visit(AddElasticityModelParameter{ele}, model.elasticity_model);
+  }
+
+  /**
+   * @brief Assembles the negative residual vector of all terminal units.
+   *
+   * Applies model-specific logic to compute viscoelastic responses of all terminal units and store
+   * them in the residual.
+   *
+   * @param res_vector Residual vector in row map layout
+   * @param terminal_units All grouped terminal unit models.
+   * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param dt Current time step size.
+   */
+  void update_terminal_unit_negative_residual_vector(Core::LinAlg::Vector<double>& res_vector,
+      TerminalUnits& terminal_units, const Core::LinAlg::Vector<double>& locally_relevant_dofs,
+      double dt);
+
+  /**
+   * @brief Assembles the Jacobian matrix contributions from all terminal units.
+   *
+   * Derivatives w.r.t. pressure and flow variables are computed using model-specific logic. They
+   * are directly stored in the given Jacobian.
+   *
+   * @param jac Jacobian matrix in (row, column) map layout.
+   * @param terminal_units All grouped terminal unit models.
+   * @param locally_relevant_dofs DOF vector containing current inflow and pressure values in
+   * column map layout.
+   * @param dt Current time step size.
+   */
+  void update_terminal_unit_jacobian(Core::LinAlg::SparseMatrix& jac, TerminalUnits& terminal_units,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+
+  /**
+   * @brief Updates the internal state memory of each terminal unit model.
+   *
+   * Used to store history variables (e.g. volume, Maxwell pressure) from previous time steps.
+   *
+   * @param terminal_units All grouped terminal unit models.
+   * @param locally_relevant_dofs DOF vector containing inflow and pressure values in
+   * column map layout. The DOFs have to be in a converged state.
+   * @param dt Time step size.
+   *
+   * @note Needs to be executed once between time steps to update the internal state with the
+   * converged DOFs.
+   */
+  void update_terminal_unit_internal_state_vectors(TerminalUnits& terminal_units,
+      const Core::LinAlg::Vector<double>& locally_relevant_dofs, double dt);
+}  // namespace ReducedLung
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/reduced_lung/tests/4C_reduced_lung_terminal_unit_test.cpp
+++ b/src/reduced_lung/tests/4C_reduced_lung_terminal_unit_test.cpp
@@ -1,0 +1,188 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_reduced_lung_terminal_unit.hpp"
+
+#include "4C_linalg_utils_sparse_algebra_manipulation.hpp"
+#include "4C_reduced_lung_helpers.hpp"
+
+namespace
+{
+  using namespace FourC::ReducedLung;
+  using namespace FourC::Core::LinAlg;
+
+  // Helper: Compute and compare FD approximation with Jacobian column
+  void check_jacobian_column_against_fd(const std::vector<int>& dof_lids, int jac_col,
+      TerminalUnitModel& model, SparseMatrix& jac, Vector<double>& dofs, double dt, double eps,
+      const Map& row_map)
+  {
+    SCOPED_TRACE("Comparing FD approximation with Jacobian column " + std::to_string(jac_col));
+
+    // Perturb in +epsilon direction
+    for (int lid : dof_lids) dofs[lid] += eps;
+    Vector<double> res_plus(row_map, true);
+    model.negative_residual_evaluator(model.data, res_plus, dofs, dt);
+
+    // Perturb in -epsilon direction
+    for (int lid : dof_lids) dofs[lid] -= 2 * eps;
+    Vector<double> res_minus(row_map, true);
+    model.negative_residual_evaluator(model.data, res_minus, dofs, dt);
+
+    // Restore original state
+    for (int lid : dof_lids) dofs[lid] += eps;
+
+    // Compute FD approximation
+    Vector<double> fd_derivative(row_map, true);
+    fd_derivative.update(-1.0 / (2 * eps), res_plus, 1.0 / (2 * eps), res_minus, 0.0);
+
+    // Compare with Jacobian column
+    for (size_t i = 0; i < model.data.number_of_elements(); ++i)
+    {
+      int n_entries = 0;
+      double* jac_vals = nullptr;
+      int* col_indices = nullptr;
+      jac.extract_my_row_view(i, n_entries, jac_vals, col_indices);
+
+      ASSERT_EQ(col_indices[jac_col], dof_lids[i]);
+      EXPECT_NEAR(jac_vals[jac_col], fd_derivative[i], eps)
+          << "Mismatch at row " << i << ", col " << jac_col;
+    }
+  }
+
+  // Tests the implementation of different model combinations by comparing the analytic jacobian
+  // with a finite difference approximation of the residual functions.
+  TEST(TerminalUnitTests, JacobianVsFiniteDifference)
+  {
+    TerminalUnits terminal_units;
+    TerminalUnitModel model;
+
+    // Artificial terminal unit data for evaluating the model equations
+    model.data = TerminalUnitData{std::vector<int>{0, 1, 2}, std::vector<int>{0, 1, 2},
+        std::vector<int>{0, 1, 2}, std::vector<int>{0, 3, 6}, std::vector<int>{1, 4, 7},
+        std::vector<int>{2, 5, 8}, std::vector<int>{0, 3, 6}, std::vector<int>{1, 4, 7},
+        std::vector<int>{2, 5, 8}, std::vector<double>{1.0, 5.0, 150.0},
+        std::vector<double>{1.0, 10.0, 100.0}};
+    terminal_units.models.push_back(model);
+
+    // Maps for the system of equations
+    const auto dof_map = create_domain_map(MPI_COMM_WORLD, {}, terminal_units);
+    const auto row_map = create_row_map(MPI_COMM_WORLD, {}, terminal_units, {}, {}, {});
+    const auto col_map = create_column_map(MPI_COMM_WORLD, {}, terminal_units,
+        {{0, 3}, {1, 3}, {2, 3}}, {{0, 0}, {1, 3}, {2, 6}}, {}, {}, {});
+
+    // Artificial dof vector
+    Vector<double> dofs(dof_map, true);
+    Vector<double> locally_relevant_dofs(col_map, true);
+    dofs.replace_local_values(9, std::array<double, 9>{1, 1, 1, 1, 1, 1, 1, 1, 1}.data(),
+        std::array<int, 9>{0, 1, 2, 3, 4, 5, 6, 7, 8}.data());
+    export_to(dofs, locally_relevant_dofs);
+
+    double dt = 1e-1;         // Dummy time step size
+    const double eps = 1e-6;  // Perturbation parameter for the FD approximation
+
+    // Model parameters: Kelvin Voigt + Linear Elasticity
+    {
+      SparseMatrix jac(row_map, col_map, 3);
+      model.rheological_model = KelvinVoigt{std::vector<double>{0.0, 1.0, 100.0}};
+      model.elasticity_model = LinearElasticity{std::vector<double>{1.0, 1.0, 0.0},
+          std::vector<double>{0.0, 0.0, 0.0}, std::vector<double>{0.0, 0.0, 0.0}};
+      model.negative_residual_evaluator = std::visit(
+          MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
+      model.jacobian_evaluator =
+          std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
+
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_q, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+
+    // Model combination: Kelvin Voigt + Ogden Hyoerelasticity
+    {
+      SparseMatrix jac(row_map, col_map, 3);
+      model.rheological_model = KelvinVoigt{std::vector<double>{0.0, 1.0, 100.0}};
+      model.elasticity_model = OgdenHyperelasticity{std::vector<double>{1.0, 1.0, 1.0},
+          std::vector<double>{5.0, -0.4, -8.0}, std::vector<double>{0.0, 0.0, 0.0},
+          std::vector<double>{0.0, 0.0, 0.0}};
+      model.negative_residual_evaluator = std::visit(
+          MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
+      model.jacobian_evaluator =
+          std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
+
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_q, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+
+    // Model parameters: Four Element Maxwell + Linear Elasticity. Also checks internal state update
+    // of Four Element Maxwell.
+    {
+      SparseMatrix jac(row_map, col_map, 3);
+      model.rheological_model = FourElementMaxwell{std::vector<double>{0.0, 1.0, 100.0},
+          std::vector<double>{10.0, 0.0, 20.0}, std::vector<double>{2.5, 10.0, 0.0},
+          std::vector<double>{0.0, 0.0, 0.0}};
+      model.elasticity_model = LinearElasticity{std::vector<double>{1.0, 1.0, 0.0},
+          std::vector<double>{0.0, 0.0, 0.0}, std::vector<double>{0.0, 0.0, 0.0}};
+      model.negative_residual_evaluator = std::visit(
+          MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
+      model.jacobian_evaluator =
+          std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
+      model.internal_state_updater =
+          std::visit(MakeInternalStateUpdater{}, model.rheological_model);
+
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_q, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+
+      model.internal_state_updater(model.data, locally_relevant_dofs, dt);
+      jac.complete();  // Sparsity pattern already filled the first time
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_q, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+
+    // Model parameters: Four Element Maxwell + Ogden Hyperelasticity
+    {
+      SparseMatrix jac(row_map, col_map, 3);
+      model.rheological_model = FourElementMaxwell{std::vector<double>{10.5, 1.0, 100.0},
+          std::vector<double>{10.0, 0.0, 20.0}, std::vector<double>{2.5, 10.0, 0.0},
+          std::vector<double>{0.0, 0.0, 0.0}};
+      model.elasticity_model = OgdenHyperelasticity{std::vector<double>{0.0, 1.0, 1.0},
+          std::vector<double>{1.0, 6.4, -3.0}, std::vector<double>{0.0, 0.0, 0.0},
+          std::vector<double>{0.0, 0.0, 0.0}};
+      model.negative_residual_evaluator = std::visit(
+          MakeNegativeResidualEvaluator{model.elasticity_model}, model.rheological_model);
+      model.jacobian_evaluator =
+          std::visit(MakeJacobianEvaluator{model.elasticity_model}, model.rheological_model);
+
+      model.jacobian_evaluator(model.data, jac, locally_relevant_dofs, dt);
+      check_jacobian_column_against_fd(
+          model.data.lid_p1, 0, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_p2, 1, model, jac, locally_relevant_dofs, dt, eps, row_map);
+      check_jacobian_column_against_fd(
+          model.data.lid_q, 2, model, jac, locally_relevant_dofs, dt, eps, row_map);
+    }
+  }
+}  // namespace

--- a/src/reduced_lung/tests/CMakeLists.txt
+++ b/src/reduced_lung/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+four_c_auto_define_tests()


### PR DESCRIPTION
## Description and Context

This is the first step to make the data structures in `ReducedLung` more flexible and easier to handle. The new layout is applied to the terminal units in this PR. The other "elements" in `ReducedLung` will follow. The new layout allows arbitrary model combinations for the viscoelastic-type algebraic equations that are used in terminal units. 

Breakdown:
- Terminal units are saved in model-specific structs with arrays indexed by the different corresponding elements. During assembly, all given terminal unit models are looped one by one.
- Additional models: 
     - Ogden nonlinear elasticity for springs.
     - Four-element Maxwell rheological model.
- Implementation tests of the model functions and their derivatives using finite differences.


Until the new `ReducedLung` input is written, all terminal units remain defaulted to Kelvin-Voigt with linear elasticity.

@maxiludwig 