### PR TITLE
Docs: update tools page with info on related projects

### DIFF
--- a/doc/documentation/src/tools/tools.rst
+++ b/doc/documentation/src/tools/tools.rst
@@ -1,25 +1,45 @@
 .. _toolsAndScripts:
 
-=================
-Tools and Scripts
-=================
+=====
+Tools
+=====
 
-A number of tools and scripts are available for |FOURC|, some of which are located in the scripts repository.
-They are explained briefly in this section.
+A number of tools are available to work with |FOURC|.
 
-abaqus to |FOURC| input converter
-=================================
+4C-Webviewer
+~~~~~~~~~~~~
 
-The converter for abaqus input files is based on meshio, but contrary to the common meshio strategy
-not only the mesh is converted to the .dat file, but also the boundary conditions and step data.
+The `4C-Webviewer <https://github.com/4C-multiphysics/4C-webviewer>`_ is designed to visualize and edit the input of 4C.
+Instead of working with the text-based YAML input files directly, users can view and interact with the geometry of the problem they want to solve using 4C within their browser.
 
-|FOURC| converter to other formats
-===================================
 
-- **dattoensight:** Converts a dat file into ensight control and data files, so that the input (including all node and side sets)
-  can be viewed, e.g., in paraview.
+FourCIPP
+~~~~~~~~
 
-- **dat2mesh:** Converts a .dat file into a ``gmesh`` input file, so that it can be read by other pre processors.
+`FourCIPP <https://github.com/4C-multiphysics/fourcipp>`_ (FourC Input Python Parser) holds a Python Parser to simply interact with 4C YAML input files.
+This tool provides a streamlined approach to data handling for third party tools.
+
+cubitpy
+~~~~~~~
+
+`cubitpy <https://github.com/imcs-compsim/cubitpy>`_ provides utility functions and 4C related functionality for the Cubit and Coreform python interface,
+especially for the creation of input files for 4C.
+
+lnmmeshio
+~~~~~~~~~
+
+`lnmmeshio <https://github.com/amgebauer/lnmmeshio>`_ is a Python package to read and write discretizations of different formats including the 4C format.
+
+meshpy
+~~~~~~
+
+`meshpy <https://github.com/imcs-compsim/meshpy>`_ is a general purpose 3D beam finite element input generator written in Python.
+It contains advanced geometry creation and manipulation functions to create complex beam geometries, including a consistent handling of finite rotations.
+
+QUEENS
+~~~~~~
+
+`QUEENS <https://github.com/queens-py/queens>`_ (Quantification of Uncertain Effects in Engineering Systems) is a Python framework for solver-independent multi-query analyses of large-scale computational models.
 
 
 


### PR DESCRIPTION
Part of #598 

Update the tools page with basic information on related projects. I dropped the outdated dat-related projects. This page could provide links to learn about these tools. In the future, we should link to tutorials in these projects that specifically work with 4C

@dragos-ana @amgebauer @isteinbrecher @davidrudlstorfer @gilrrei @sbrandstaeter This is just a basic page. Feel free to edit sections with more info, appropriate tutorials, links, etc.

If I forgot any projects, please tell me here (or add them later). I did not leave anything out deliberately.