### PR TITLE
Input: remove redefinition of node counts

### DIFF
--- a/apps/global_full/4C_global_full_main.cpp
+++ b/apps/global_full/4C_global_full_main.cpp
@@ -335,8 +335,20 @@ int main(int argc, char* argv[])
   {
     if (Core::Communication::my_mpi_rank(lcomm) == 0)
     {
+      ryml::Tree tree = Core::IO::init_yaml_tree_with_exceptions();
+      ryml::NodeRef root = tree.rootref();
+      root |= ryml::MAP;
+      Core::IO::YamlNodeRef root_ref(root, "");
+
+      // Write the non-user input metadata that is defined globally for 4C.
+      Global::emit_general_metadata(root_ref);
+
+      // Write the user input defined for various physics module.
       Core::IO::InputFile input_file = Global::set_up_input_file(lcomm);
-      input_file.emit_metadata(std::cout);
+      input_file.emit_metadata(root_ref);
+
+      // Finally, dump everything.
+      std::cout << tree;
     }
   }
   else if ((argc >= 3) && (strcmp(argv[1], "--to-yaml") == 0))

--- a/src/ale/4C_ale_ale2.cpp
+++ b/src/ale/4C_ale_ale2.cpp
@@ -86,27 +86,22 @@ void Discret::Elements::Ale2Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
   });
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
   });
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
   });
 }

--- a/src/ale/4C_ale_ale3.cpp
+++ b/src/ale/4C_ale_ale3.cpp
@@ -85,42 +85,34 @@ void Discret::Elements::Ale3Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["HEX20"] = all_of({
-      parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
   });
 
   defs["HEX27"] = all_of({
-      parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
   });
 
   defs["TET4"] = all_of({
-      parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["TET10"] = all_of({
-      parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
   });
 
   defs["WEDGE6"] = all_of({
-      parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
   });
 
   defs["WEDGE15"] = all_of({
-      parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
   });
 
   defs["PYRAMID5"] = all_of({
-      parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
   });
 }

--- a/src/art_net/4C_art_net_artery.cpp
+++ b/src/art_net/4C_art_net_artery.cpp
@@ -60,7 +60,6 @@ void Discret::Elements::ArteryType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<int>("GP"),
       parameter<std::string>("TYPE"),

--- a/src/beam3/4C_beam3_euler_bernoulli.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli.cpp
@@ -214,7 +214,6 @@ void Discret::Elements::Beam3ebType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
   });
 }

--- a/src/beam3/4C_beam3_kirchhoff.cpp
+++ b/src/beam3/4C_beam3_kirchhoff.cpp
@@ -97,7 +97,6 @@ void Discret::Elements::Beam3kType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("WK"),
       parameter<int>("ROTVEC"),
       parameter<int>("MAT"),
@@ -106,7 +105,6 @@ void Discret::Elements::Beam3kType::setup_element_definition(
   });
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("WK"),
       parameter<int>("ROTVEC"),
       parameter<int>("MAT"),
@@ -115,7 +113,6 @@ void Discret::Elements::Beam3kType::setup_element_definition(
   });
 
   defs["LINE4"] = all_of({
-      parameter<std::vector<int>>("LINE4", {.size = 4}),
       parameter<int>("WK"),
       parameter<int>("ROTVEC"),
       parameter<int>("MAT"),

--- a/src/beam3/4C_beam3_reissner.cpp
+++ b/src/beam3/4C_beam3_reissner.cpp
@@ -108,7 +108,6 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::vector<double>>("TRIADS", {.size = 6}),
       parameter<bool>("USE_FAD", {.default_value = false}),
@@ -121,7 +120,6 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   });
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::vector<double>>("TRIADS", {.size = 9}),
       parameter<bool>("USE_FAD", {.default_value = false}),
@@ -134,7 +132,6 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   });
 
   defs["LINE4"] = all_of({
-      parameter<std::vector<int>>("LINE4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::vector<double>>("TRIADS", {.size = 12}),
       parameter<bool>("USE_FAD", {.default_value = false}),
@@ -147,7 +144,6 @@ void Discret::Elements::Beam3rType::setup_element_definition(
   });
 
   defs["LINE5"] = all_of({
-      parameter<std::vector<int>>("LINE5", {.size = 5}),
       parameter<int>("MAT"),
       parameter<std::vector<double>>("TRIADS", {.size = 15}),
       parameter<bool>("USE_FAD", {.default_value = false}),

--- a/src/bele/4C_bele_bele3.cpp
+++ b/src/bele/4C_bele_bele3.cpp
@@ -96,27 +96,22 @@ void Discret::Elements::Bele3Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs3["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<std::optional<int>>("MAT"),
   });
 
   defs3["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<std::optional<int>>("MAT"),
   });
 
   defs3["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<std::optional<int>>("MAT"),
   });
 
   defs3["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<std::optional<int>>("MAT"),
   });
 
   defs3["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<std::optional<int>>("MAT"),
   });
 }

--- a/src/bele/4C_bele_vele3.cpp
+++ b/src/bele/4C_bele_vele3.cpp
@@ -70,9 +70,7 @@ void Discret::Elements::Vele3Type::setup_element_definition(
 
   using namespace Core::IO::InputSpecBuilders;
 
-  defs["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
-  });
+  defs["HEX8"] = all_of({});
 }
 
 std::shared_ptr<Core::Elements::Element> Discret::Elements::Vele3SurfaceType::create(

--- a/src/core/fem/src/general/element/4C_fem_general_element.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.cpp
@@ -198,10 +198,9 @@ void Core::Elements::Element::set_node_ids(const int nnode, const int* nodes)
 
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-void Core::Elements::Element::set_node_ids_one_based_index(
-    const std::string& distype, const Core::IO::InputParameterContainer& container)
+void Core::Elements::Element::set_node_ids_one_based_index(std::span<const int> node_ids)
 {
-  nodeid_ = container.get<std::vector<int>>(distype);
+  nodeid_ = std::vector<int>(node_ids.begin(), node_ids.end());
   for (int& i : nodeid_) i -= 1;
   node_.resize(0);
 }

--- a/src/core/fem/src/general/element/4C_fem_general_element.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.hpp
@@ -721,8 +721,7 @@ might become invalid after a redistribution of the discretization.
      * Set the list of node ids this element is connected to. Here, the index
      * starts at 1, not 0. This is used for the legacy element input.
      */
-    void set_node_ids_one_based_index(
-        const std::string& distype, const Core::IO::InputParameterContainer& container);
+    void set_node_ids_one_based_index(std::span<const int> node_ids);
 
     /*!
     \brief Set a the face with index faceindex this element is connected to

--- a/src/core/io/src/4C_io_gridgenerator.cpp
+++ b/src/core/io/src/4C_io_gridgenerator.cpp
@@ -153,23 +153,6 @@ namespace Core::IO::GridGenerator
           std::make_shared<Core::LinAlg::Map>(-1, nummynewele, mynewele.data(), 0, comm);
     }
 
-    // Build an input line that matches what is expected from an input file.
-    // Prepend the distype which is not part of the user-supplied arguments but must be parsed.
-    // The distype is followed by nodal ids, which are set to dummy values of -1 here.
-    const std::string argument_line = std::invoke(
-        [&]()
-        {
-          std::ostringstream eleargstream;
-          eleargstream << inputData.distype_;
-          const int num_nodes = Core::FE::num_nodes(distype_enum);
-          for (int i = 0; i < num_nodes; ++i)
-          {
-            eleargstream << " " << -1;
-          }
-          eleargstream << " " << inputData.elearguments_;
-          return eleargstream.str();
-        });
-
     // Create the actual elements according to the row map
     for (int lid = 0; lid < elementRowMap->num_my_elements(); ++lid)
     {
@@ -179,7 +162,8 @@ namespace Core::IO::GridGenerator
       const auto& linedef = ed.element_lines(inputData.elementtype_, inputData.distype_);
 
       Core::IO::InputParameterContainer ele_data;
-      Core::IO::ValueParser parser(argument_line, {.user_scope_message = "GridGenerator: "});
+      Core::IO::ValueParser parser(
+          inputData.elearguments_, {.user_scope_message = "GridGenerator: "});
       linedef.fully_parse(parser, ele_data);
 
       // Create specified elements

--- a/src/core/io/src/4C_io_input_file.hpp
+++ b/src/core/io/src/4C_io_input_file.hpp
@@ -11,23 +11,20 @@
 #include "4C_config.hpp"
 
 #include "4C_comm_mpi_utils.hpp"
-#include "4C_comm_pack_buffer.hpp"
 #include "4C_io_input_parameter_container.hpp"
+#include "4C_io_yaml.hpp"
 
 #include <filesystem>
-#include <list>
 #include <map>
 #include <memory>
-#include <optional>
 #include <ranges>
-#include <set>
 #include <string>
-#include <variant>
 
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::IO
 {
+  class YamlNodeRef;
   class InputSpec;
 
   namespace Internal
@@ -94,6 +91,9 @@ namespace Core::IO
   class InputFile
   {
    public:
+    //! Name of the special section that can contain arbitrary data.
+    static constexpr auto description_section_name = "TITLE";
+
     /**
      * A Fragment is a part of the input file. Fragments are used to store the content of a section.
      * and are used to match() against an InputSpec. Instead of using a concrete data type, the
@@ -152,17 +152,6 @@ namespace Core::IO
     InputFile(std::map<std::string, InputSpec> valid_sections,
         std::vector<std::string> legacy_section_names, MPI_Comm comm);
 
-    /**
-     * Like the other constructor, but also accepts partial specs for legacy sections. This is
-     * useful to provide at least some partial information about the expected format of a legacy
-     * section in the metadata output. 4C will not do anything with the partial specs.
-     *
-     * @note This constructor is meant to ease the transition from legacy sections to fully
-     * parseable sections.
-     */
-    InputFile(std::map<std::string, InputSpec> valid_sections,
-        std::vector<std::string> legacy_section_names,
-        std::map<std::string, InputSpec> legacy_partial_specs, MPI_Comm comm);
 
     /**
      * Destructor.
@@ -232,12 +221,12 @@ namespace Core::IO
     [[nodiscard]] MPI_Comm get_comm() const;
 
     /**
-     * Emit metadata about the input file to the given output stream @p out. The metadata
+     * Emit metadata about the input file to the given @p node in a YAML tree. The metadata
      * contains information about all sections and parameters that are known to this object. The
      * metadata information can be useful for additional tools that generate schema files or
-     * documentation. The output is formatted as YAML.
+     * documentation.
      */
-    void emit_metadata(std::ostream& out) const;
+    void emit_metadata(YamlNodeRef node) const;
 
     /**
      * Write the content of the input file to the given output stream @p out. The content is

--- a/src/fluid_ele/4C_fluid_ele.cpp
+++ b/src/fluid_ele/4C_fluid_ele.cpp
@@ -76,104 +76,87 @@ void Discret::Elements::FluidType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defsgeneral["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["HEX20"] = all_of({
-      parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["HEX27"] = all_of({
-      parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["TET4"] = all_of({
-      parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["TET10"] = all_of({
-      parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["WEDGE6"] = all_of({
-      parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["WEDGE15"] = all_of({
-      parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["PYRAMID5"] = all_of({
-      parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["NURBS8"] = all_of({
-      parameter<std::vector<int>>("NURBS8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["NURBS27"] = all_of({
-      parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   // 2D elements
   defsgeneral["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["NURBS4"] = all_of({
-      parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
 
   defsgeneral["NURBS9"] = all_of({
-      parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });

--- a/src/fluid_ele/4C_fluid_ele_xwall.cpp
+++ b/src/fluid_ele/4C_fluid_ele_xwall.cpp
@@ -71,12 +71,10 @@ void Discret::Elements::FluidXWallType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defsxwall["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });
   defsxwall["TET4"] = all_of({
-      parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("NA"),
   });

--- a/src/global_data/4C_global_data_read.hpp
+++ b/src/global_data/4C_global_data_read.hpp
@@ -26,8 +26,15 @@ namespace Global
    */
   [[nodiscard]] Core::IO::InputFile set_up_input_file(MPI_Comm comm);
 
-  /// Read the discretization. This mainly means the mesh. The MeshReader is returned to the caller
-  /// in case it needs to be used for further processing.
+  /**
+   * Write the metadata that is not tied to any specific input of a physical problem and thus
+   * not modified by developers of physics modules. This includes version information or general
+   * definitions of cell geometries.
+   */
+  void emit_general_metadata(Core::IO::YamlNodeRef node);
+
+  /// Read the discretization. This mainly means the mesh. The MeshReader is returned to the
+  /// caller in case it needs to be used for further processing.
   std::unique_ptr<Core::IO::MeshReader> read_discretization(
       Global::Problem& problem, Core::IO::InputFile& input, const bool read_mesh = true);
 

--- a/src/lubrication/src/4C_lubrication_ele.cpp
+++ b/src/lubrication/src/4C_lubrication_ele.cpp
@@ -76,37 +76,30 @@ void Discret::Elements::LubricationType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
   });
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
   });
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
   });
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
   });
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
   });
 }

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -75,7 +75,6 @@ void Discret::Elements::MembraneTri3Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
@@ -150,7 +149,6 @@ void Discret::Elements::MembraneTri6Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
@@ -225,7 +223,6 @@ void Discret::Elements::MembraneQuad4Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),
@@ -300,7 +297,6 @@ void Discret::Elements::MembraneQuad9Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<double>("THICK"),

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.cpp
@@ -82,52 +82,42 @@ void Discret::Elements::PoroFluidMultiPhaseType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
   });
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
   });
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
   });
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
   });
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
   });
 
   defs["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["TET4"] = all_of({
-      parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["TET10"] = all_of({
-      parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
   });
 }

--- a/src/red_airways/4C_red_airways_acinus.cpp
+++ b/src/red_airways/4C_red_airways_acinus.cpp
@@ -65,7 +65,6 @@ void Discret::Elements::RedAcinusType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       deprecated_selection<std::string>("TYPE",
           {"NeoHookean", "Exponential", "DoubleExponential", "VolumetricOgden"},

--- a/src/red_airways/4C_red_airways_airway.cpp
+++ b/src/red_airways/4C_red_airways_airway.cpp
@@ -66,7 +66,6 @@ void Discret::Elements::RedAirwayType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("ElemSolvingType"),
       deprecated_selection<std::string>("TYPE",

--- a/src/red_airways/4C_red_airways_interacinardep.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep.cpp
@@ -73,7 +73,6 @@ void Discret::Elements::RedInterAcinarDepType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
   });
 }

--- a/src/rigidsphere/4C_rigidsphere.cpp
+++ b/src/rigidsphere/4C_rigidsphere.cpp
@@ -96,7 +96,6 @@ void Discret::Elements::RigidsphereType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["POINT1"] = all_of({
-      parameter<std::vector<int>>("POINT1", {.size = 1}),
       parameter<double>("RADIUS"),
       parameter<double>("DENSITY"),
   });

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -96,147 +96,126 @@ void Discret::Elements::TransportType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["HEX20"] = all_of({
-      parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["HEX27"] = all_of({
-      parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS27"] = all_of({
-      parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS8"] = all_of({
-      parameter<std::vector<int>>("NURBS8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TET4"] = all_of({
-      parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TET10"] = all_of({
-      parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["WEDGE6"] = all_of({
-      parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["WEDGE15"] = all_of({
-      parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["PYRAMID5"] = all_of({
-      parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS4"] = all_of({
-      parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS9"] = all_of({
-      parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS2"] = all_of({
-      parameter<std::vector<int>>("NURBS2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),
   });
 
   defs["NURBS3"] = all_of({
-      parameter<std::vector<int>>("NURBS3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("TYPE"),
       parameter<std::optional<std::vector<double>>>("FIBER1", {.size = 3}),

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -84,7 +84,6 @@ void Discret::Elements::Shell7pType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defsgeneral["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
@@ -99,7 +98,6 @@ void Discret::Elements::Shell7pType::setup_element_definition(
   });
 
   defsgeneral["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
@@ -114,7 +112,6 @@ void Discret::Elements::Shell7pType::setup_element_definition(
   });
 
   defsgeneral["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
@@ -129,7 +126,6 @@ void Discret::Elements::Shell7pType::setup_element_definition(
   });
 
   defsgeneral["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
@@ -142,7 +138,6 @@ void Discret::Elements::Shell7pType::setup_element_definition(
   });
 
   defsgeneral["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -79,7 +79,6 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defsgeneral["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
@@ -95,7 +94,6 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
   });
 
   defsgeneral["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
@@ -111,7 +109,6 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
   });
 
   defsgeneral["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<std::vector<std::string>>("EAS", {.size = 5}),
@@ -127,7 +124,6 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
   });
 
   defsgeneral["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),
@@ -141,7 +137,6 @@ void Discret::Elements::Shell7pScatraType::setup_element_definition(
   });
 
   defsgeneral["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<double>("THICK"),
       parameter<double>("SDC"),

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
@@ -96,7 +96,6 @@ void Discret::Elements::KirchhoffLoveShellNurbsType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["NURBS9"] = all_of({
-      parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::vector<int>>("GP", {.size = 2}),
   });

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -47,8 +47,6 @@ namespace
   auto get_default_input_spec()
   {
     return all_of({
-        parameter<std::vector<int>>(
-            Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes(celltype)}),
         parameter<int>("MAT"),
         get_kinem_type_input_spec(),
         parameter<Discret::Elements::PrestressTechnology>(
@@ -117,7 +115,6 @@ void Discret::Elements::SolidType::setup_element_definition(
   });
 
   defsgeneral["NURBS27"] = all_of({
-      parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
       get_kinem_type_input_spec(),
   });

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -38,8 +38,6 @@ namespace Discret::Elements::SolidPoroPressureBasedInternal
     auto get_default_input_spec()
     {
       return all_of({
-          parameter<std::vector<int>>(
-              Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes(celltype)}),
           parameter<int>("MAT"),
           deprecated_selection<Inpar::Solid::KinemType>("KINEM",
               {

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -40,8 +40,6 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
     auto get_default_input_spec()
     {
       return all_of({
-          parameter<std::vector<int>>(
-              Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes(celltype)}),
           parameter<int>("MAT"),
           deprecated_selection<Inpar::Solid::KinemType>("KINEM",
               {

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.cpp
@@ -39,8 +39,6 @@ namespace Discret::Elements::SolidPoroPressureVelocityBasedInternal
     auto get_default_input_spec()
     {
       return all_of({
-          parameter<std::vector<int>>(
-              Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes(celltype)}),
           parameter<int>("MAT"),
           deprecated_selection<Inpar::Solid::KinemType>("KINEM",
               {

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -30,8 +30,6 @@ namespace
   auto get_default_input_spec()
   {
     return all_of({
-        parameter<std::vector<int>>(
-            Core::FE::cell_type_to_string(celltype), {.size = Core::FE::num_nodes(celltype)}),
         parameter<int>("MAT"),
         deprecated_selection<Inpar::Solid::KinemType>("KINEM",
             {

--- a/src/thermo/src/element/4C_thermo_element.cpp
+++ b/src/thermo/src/element/4C_thermo_element.cpp
@@ -109,92 +109,74 @@ void Thermo::ElementType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["HEX8"] = all_of({
-      parameter<std::vector<int>>("HEX8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["HEX20"] = all_of({
-      parameter<std::vector<int>>("HEX20", {.size = 20}),
       parameter<int>("MAT"),
   });
 
   defs["HEX27"] = all_of({
-      parameter<std::vector<int>>("HEX27", {.size = 27}),
       parameter<int>("MAT"),
   });
 
   defs["TET4"] = all_of({
-      parameter<std::vector<int>>("TET4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["TET10"] = all_of({
-      parameter<std::vector<int>>("TET10", {.size = 10}),
       parameter<int>("MAT"),
   });
 
   defs["WEDGE6"] = all_of({
-      parameter<std::vector<int>>("WEDGE6", {.size = 6}),
       parameter<int>("MAT"),
   });
 
   defs["WEDGE15"] = all_of({
-      parameter<std::vector<int>>("WEDGE15", {.size = 15}),
       parameter<int>("MAT"),
   });
 
   defs["PYRAMID5"] = all_of({
-      parameter<std::vector<int>>("PYRAMID5", {.size = 5}),
       parameter<int>("MAT"),
   });
 
   defs["NURBS27"] = all_of({
-      parameter<std::vector<int>>("NURBS27", {.size = 27}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
   });
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
   });
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
   });
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
   });
 
   defs["NURBS4"] = all_of({
-      parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
   });
 
   defs["NURBS9"] = all_of({
-      parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
   });
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
   });
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
   });
 }  // setup_element_definition()

--- a/src/torsion3/4C_torsion3.cpp
+++ b/src/torsion3/4C_torsion3.cpp
@@ -75,7 +75,6 @@ void Discret::Elements::Torsion3Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE3"] = all_of({
-      parameter<std::vector<int>>("LINE3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("BENDINGPOTENTIAL"),
   });

--- a/src/truss3/4C_truss3.cpp
+++ b/src/truss3/4C_truss3.cpp
@@ -75,7 +75,6 @@ void Discret::Elements::Truss3Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["LINE2"] = all_of({
-      parameter<std::vector<int>>("LINE2", {.size = 2}),
       parameter<int>("MAT"),
       parameter<double>("CROSS"),
       parameter<std::string>("KINEM"),

--- a/src/w1/4C_w1.cpp
+++ b/src/w1/4C_w1.cpp
@@ -74,7 +74,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["QUAD4"] = all_of({
-      parameter<std::vector<int>>("QUAD4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -84,7 +83,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   });
 
   defs["QUAD8"] = all_of({
-      parameter<std::vector<int>>("QUAD8", {.size = 8}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -94,7 +92,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   });
 
   defs["QUAD9"] = all_of({
-      parameter<std::vector<int>>("QUAD9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -104,7 +101,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   });
 
   defs["TRI3"] = all_of({
-      parameter<std::vector<int>>("TRI3", {.size = 3}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -114,7 +110,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   });
 
   defs["TRI6"] = all_of({
-      parameter<std::vector<int>>("TRI6", {.size = 6}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -124,7 +119,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   });
 
   defs["NURBS4"] = all_of({
-      parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -134,7 +128,6 @@ void Discret::Elements::Wall1Type::setup_element_definition(
   });
 
   defs["NURBS9"] = all_of({
-      parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),

--- a/src/w1/4C_w1_nurbs.cpp
+++ b/src/w1/4C_w1_nurbs.cpp
@@ -71,7 +71,6 @@ void Discret::Elements::Nurbs::Wall1NurbsType::setup_element_definition(
   using namespace Core::IO::InputSpecBuilders;
 
   defs["NURBS4"] = all_of({
-      parameter<std::vector<int>>("NURBS4", {.size = 4}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),
@@ -81,7 +80,6 @@ void Discret::Elements::Nurbs::Wall1NurbsType::setup_element_definition(
   });
 
   defs["NURBS9"] = all_of({
-      parameter<std::vector<int>>("NURBS9", {.size = 9}),
       parameter<int>("MAT"),
       parameter<std::string>("KINEM"),
       parameter<std::string>("EAS"),


### PR DESCRIPTION
Previously, every element defined geometric primitives itself; now we use the primitve name to infer this. 

@gilrrei @davidrudlstorfer this will break FourCIPP (I think). The elements no longer repeat the nodal ID vector since it is obvious from the element type. What would be a useful way to export the different geometries? Or do you code this in FourCIPP?

This is only the next step in the transformation of the element input. In the next steps, the strings will become enums, and I will make the number of nodes more flexible (see https://github.com/4C-multiphysics/4C/pull/891#issuecomment-3008578195).

Follows #891 


