### PR TITLE
Generalize data types supported in Exporter

### DIFF
--- a/src/core/comm/src/4C_comm_exporter.cpp
+++ b/src/core/comm/src/4C_comm_exporter.cpp
@@ -221,8 +221,6 @@ void Core::Communication::Exporter::generic_export(ExporterHelper& helper)
   if (send_plan().size() == 0) return;
   // if (SourceMap().SameAs(TargetMap())) return;
 
-  helper.pre_export_test(this);
-
   //------------------------------------------------ do the send/recv loop
   for (int i = 0; i < num_proc() - 1; ++i)
   {
@@ -304,18 +302,6 @@ void Core::Communication::Exporter::generic_export(ExporterHelper& helper)
   }
 
   helper.post_export_cleanup(this);
-}
-
-void Core::Communication::Exporter::do_export(std::map<int, int>& data)
-{
-  PODExporterHelper<int> helper(data);
-  generic_export(helper);
-}
-
-void Core::Communication::Exporter::do_export(std::map<int, double>& data)
-{
-  PODExporterHelper<double> helper(data);
-  generic_export(helper);
 }
 
 void Core::Communication::Exporter::do_export(

--- a/src/stru_multi/4C_stru_multi_microstatic.cpp
+++ b/src/stru_multi/4C_stru_multi_microstatic.cpp
@@ -911,7 +911,7 @@ void MultiScale::MicroStatic::read_restart(const int step,
 
   Core::Communication::Exporter exporter(
       read_in_ele_row_map, *discret_->element_col_map(), discret_->get_comm());
-  exporter.do_export<char>(mapdata);
+  exporter.do_export(mapdata);
 
   for (const auto& [ele_id, data] : mapdata)
   {


### PR DESCRIPTION
Use our concepts for types that can be communicated via MPI instead of specializations for a few select cases.