### PR TITLE
Remove option every_timestep from mesh relocation

### DIFF
--- a/src/inpar/4C_inpar_mortar.cpp
+++ b/src/inpar/4C_inpar_mortar.cpp
@@ -98,7 +98,6 @@ void Inpar::Mortar::set_valid_parameters(std::map<std::string, Core::IO::InputSp
           deprecated_selection<Inpar::Mortar::MeshRelocation>("MESH_RELOCATION",
               {
                   {"Initial", relocation_initial},
-                  {"Every_Timestep", relocation_timestep},
                   {"None", relocation_none},
               },
               {.description = "Type of mesh relocation", .default_value = relocation_initial}),

--- a/src/inpar/4C_inpar_mortar.hpp
+++ b/src/inpar/4C_inpar_mortar.hpp
@@ -76,9 +76,8 @@ namespace Inpar
     /// (this enum represents the input file parameter MESH_RELOCATION)
     enum MeshRelocation
     {
-      relocation_initial,   ///< only initial mesh relocation
-      relocation_timestep,  ///< mesh relocation in every time step, but no initial mesh relocation
-      relocation_none       ///< no mesh relocation
+      relocation_initial,  ///< only initial mesh relocation
+      relocation_none      ///< no mesh relocation
     };
 
     /// Type of ghosting of interface values

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -526,12 +526,6 @@ void Solid::TimInt::prepare_contact_meshtying(const Teuchos::ParameterList& sdyn
       // (3) apply result of mesh initialization to underlying problem discretization
       apply_mesh_initialization(Xslavemod);
     }
-    else if (mesh_relocation_parameter == Inpar::Mortar::relocation_timestep)
-    {
-      FOUR_C_THROW(
-          "Meshtying with MESH_RELOCATION every_timestep not permitted. Change to MESH_RELOCATION "
-          "initial or MESH_RELOCATION no.");
-    }
   }
 
   // initialization of contact

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -159,12 +159,6 @@ void Solid::ModelEvaluator::Meshtying::setup()
         apply_mesh_initialization(Xslavemod_noredist);
       }
     }
-    else if (mesh_relocation_parameter == Inpar::Mortar::relocation_timestep)
-    {
-      FOUR_C_THROW(
-          "Meshtying with MESH_RELOCATION every_timestep not permitted. Change to MESH_RELOCATION "
-          "initial or MESH_RELOCATION no.");
-    }
   }
 
   issetup_ = true;


### PR DESCRIPTION
## Description and Context
As untested, this PR removes the option `every_timestep` for `MESH_RELOCATION`.

## Related Issues and Pull Requests
#77