### PR TITLE
Clean up unused and complicated code for condition

### DIFF
--- a/src/core/fem/src/condition/4C_fem_condition.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition.cpp
@@ -38,10 +38,10 @@ void Core::Conditions::Condition::print(std::ostream& os) const
     for (const auto& node_gid : nodes_) os << " " << node_gid;
     os << std::endl;
   }
-  if (geometry_ != nullptr and (int) geometry_->size())
+  if (!geometry_.empty())
   {
     os << "Elements of this condition:";
-    for (const auto& [ele_id, ele] : *geometry_) os << " " << ele_id;
+    for (const auto& [ele_id, ele] : geometry_) os << " " << ele_id;
     os << std::endl;
   }
 }
@@ -49,15 +49,14 @@ void Core::Conditions::Condition::print(std::ostream& os) const
 void Core::Conditions::Condition::adjust_id(const int shift)
 {
   std::map<int, std::shared_ptr<Core::Elements::Element>> geometry;
-  std::map<int, std::shared_ptr<Core::Elements::Element>>::iterator iter;
 
-  for (const auto& [ele_id, ele] : *geometry_)
+  for (const auto& [ele_id, ele] : geometry_)
   {
     ele->set_id(ele_id + shift);
-    geometry[ele_id + shift] = (*geometry_)[ele_id];
+    geometry[ele_id + shift] = (geometry_)[ele_id];
   }
 
-  swap(*geometry_, geometry);
+  swap(geometry_, geometry);
 }
 
 std::shared_ptr<Core::Conditions::Condition> Core::Conditions::Condition::copy_without_geometry()

--- a/src/core/fem/src/condition/4C_fem_condition.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition.hpp
@@ -78,24 +78,19 @@ namespace Core::Conditions
 
     //! @name Constructors and destructors
 
-    /*!
-    \brief Standard Constructor
-
-    The way a condition is treated later on depends on the type of the
-    condition. E.g. Dirichlet conditions are treated differently from
-    Neumann conditions. How they are treated is not described here but in
-    Core::FE::Discretization.
-
-    \note In case you might wonder where this condition class actually stores
-          data necessary for the condition: This class implements Core::IO::InputParameterContainer.
-
-    \param id (in): a unique id for this condition
-    \param type (in): type of the condition
-    \param buildgeometry (in): flag indicating whether explicit condition geometry
-                               (elements) have to be build
-    \param gtype (in): type of geometric entity this condition lives on
-    \param entity_type (in): type of entity this condition is associated with
-    */
+    /**
+     * The way a condition is treated later on depends on the type of the
+     * condition. E.g. Dirichlet conditions are treated differently from
+     * Neumann conditions. How they are treated is not described here but in
+     * Core::FE::Discretization.
+     *
+     * \param id (in): a unique id for this condition
+     * \param type (in): type of the condition
+     * \param buildgeometry (in): flag indicating whether explicit condition geometry
+     *                            (elements) have to be build
+     * \param gtype (in): type of geometric entity this condition lives on
+     * \param entity_type (in): type of entity this condition is associated with
+     */
     Condition(const int id, const Core::Conditions::ConditionType type, const bool buildgeometry,
         const Core::Conditions::GeometryType gtype, EntityType entity_type);
 
@@ -178,11 +173,11 @@ namespace Core::Conditions
     \brief Get a reference to the geometry description of the condition
 
     */
-    std::map<int, std::shared_ptr<Core::Elements::Element>>& geometry() { return *geometry_; }
+    std::map<int, std::shared_ptr<Core::Elements::Element>>& geometry() { return geometry_; }
 
     [[nodiscard]] const std::map<int, std::shared_ptr<Core::Elements::Element>>& geometry() const
     {
-      return *geometry_;
+      return geometry_;
     }
 
     //! Access the container that stores the input parameters.
@@ -231,15 +226,15 @@ namespace Core::Conditions
                       Do not mess with their std::shared_ptr!
 
     */
-    void set_geometry(std::shared_ptr<std::map<int, std::shared_ptr<Core::Elements::Element>>> geom)
+    void set_geometry(std::map<int, std::shared_ptr<Core::Elements::Element>>&& geom)
     {
-      geometry_ = geom;
+      geometry_ = std::move(geom);
     }
 
     /*!
     \brief Delete a geometry description of the condition
     */
-    void clear_geometry() { geometry_ = nullptr; }
+    void clear_geometry() { geometry_.clear(); }
 
     //@}
 
@@ -266,7 +261,7 @@ namespace Core::Conditions
     EntityType entity_type_{};
 
     //! Geometry description of this condition
-    std::shared_ptr<std::map<int, std::shared_ptr<Core::Elements::Element>>> geometry_{};
+    std::map<int, std::shared_ptr<Core::Elements::Element>> geometry_;
 
     Core::IO::InputParameterContainer container_;
   };  // class Condition

--- a/src/core/fem/src/condition/4C_fem_condition_definition.hpp
+++ b/src/core/fem/src/condition/4C_fem_condition_definition.hpp
@@ -38,26 +38,11 @@ namespace Core::IO
 namespace Core::Conditions
 {
 
-  //--------------------------------------------------------------
-
-  /// definition of a valid condition in 4C input
-  /*!
-
-    A ConditionDefinition is the definition of a condition input file
-    section. This definition includes the knowledge what this section looks
-    like, how to read it and how to write it. In particular given a
-    ConditionDefinition object it is possible to (a) write an empty input file
-    section that describes this condition, (b) read an input file and create
-    Core::Conditions::Condition objects for each line in this section and (c) write the input
-    file section filled with all corresponding conditions from a given
-    Core::FE::Discretization.
-
-    So this is quite sophisticated internal stuff here. If you want to
-    introduce a new condition to 4C, all you have to do is add an
-    appropriate definition in valid_conditions(). This will take care of the
-    reading part and you will get your Core::FE::Discretization filled with proper
-    Core::Conditions::Condition objects.
-
+  /**
+   * @brief Definition of a condition.
+   *
+   * This class groups all data that is needed to create a Condition. It contains the InputSpec
+   * defining the parameters of the condition and information about the associated geometry.
    */
   class ConditionDefinition
   {
@@ -75,14 +60,11 @@ namespace Core::Conditions
         Core::Conditions::ConditionType condtype, bool buildgeometry,
         Core::Conditions::GeometryType gtype);
 
-    /// add a concrete component to the condition line definition
-    /*!
-      Add new components to the input line. One at a time. Form left to
-      right. The order is important! On reading we try and read component
-      after component.
+    /**
+     * Add an InputSpec @p spec as another component of this condition. The ordering of the
+     * components is irrelevant.
      */
     void add_component(Core::IO::InputSpec&& spec);
-
     void add_component(const Core::IO::InputSpec& spec);
 
     /// read all conditions from my input file section
@@ -93,9 +75,6 @@ namespace Core::Conditions
      */
     void read(Core::IO::InputFile& input,
         std::multimap<int, std::shared_ptr<Core::Conditions::Condition>>& cmap) const;
-
-    /// print my input file section
-    std::ostream& print(std::ostream& stream);
 
     /// name of my section in input file
     std::string section_name() const { return sectionname_; }

--- a/src/core/fem/src/discretization/4C_fem_discretization_conditions.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_conditions.cpp
@@ -299,11 +299,11 @@ bool Core::FE::Discretization::build_lines_in_condition(
 
 
   // Lines be added to the condition: (line_id) -> (line).
-  auto finallines = std::make_shared<std::map<int, std::shared_ptr<Core::Elements::Element>>>();
+  std::map<int, std::shared_ptr<Core::Elements::Element>> finallines;
 
-  assign_global_ids(get_comm(), linemap, *finallines);
+  assign_global_ids(get_comm(), linemap, finallines);
 
-  cond->set_geometry(finallines);
+  cond->set_geometry(std::move(finallines));
 
   // elements were created that need new unique ids
   return true;
@@ -413,11 +413,10 @@ bool Core::FE::Discretization::build_surfaces_in_condition(
   }  // loop over all conditioned row nodes
 
   // surfaces be added to the condition: (surf_id) -> (surface).
-  std::shared_ptr<std::map<int, std::shared_ptr<Core::Elements::Element>>> final_geometry =
-      std::make_shared<std::map<int, std::shared_ptr<Core::Elements::Element>>>();
+  std::map<int, std::shared_ptr<Core::Elements::Element>> final_geometry;
 
-  assign_global_ids(get_comm(), surfmap, *final_geometry);
-  cond->set_geometry(final_geometry);
+  assign_global_ids(get_comm(), surfmap, final_geometry);
+  cond->set_geometry(std::move(final_geometry));
 
   // elements were created that need new unique ids
   return true;
@@ -439,7 +438,7 @@ bool Core::FE::Discretization::build_volumes_in_condition(
       std::not_fn(Core::Conditions::MyGID(colmap)));
 
   // this is the map we want to construct
-  auto geom = std::make_shared<std::map<int, std::shared_ptr<Core::Elements::Element>>>();
+  std::map<int, std::shared_ptr<Core::Elements::Element>> geom;
 
   for (const auto& [ele_id, actele] : element_)
   {
@@ -460,11 +459,11 @@ bool Core::FE::Discretization::build_volumes_in_condition(
 
     if (allin)
     {
-      (*geom)[ele_id] = actele;
+      geom[ele_id] = actele;
     }
   }
 
-  cond->set_geometry(geom);
+  cond->set_geometry(std::move(geom));
 
   // no elements where created to assign new unique ids to
   return false;

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1612,24 +1612,19 @@ void Global::read_conditions(
         }
         case Core::Conditions::EntityType::node_set_id:
         {
-          // We are rather inconsistent with +/-1 here. The condition internally subtracts 1 from
-          // the ID but this is wrong for the node set ID. For node sets, the ID is meant to
-          // exactly refer to the ID in the mesh file, so we need to add the 1 back.
-          const int node_set_id = entity_id + 1;
-          FOUR_C_ASSERT_ALWAYS(node_sets.contains(node_set_id),
+          FOUR_C_ASSERT_ALWAYS(node_sets.contains(entity_id),
               "Cannot apply condition '{}' to node set {} which is not specified in the mesh file.",
-              condition_definition.name(), node_set_id);
-          condition->set_nodes(node_sets[node_set_id]);
+              condition_definition.name(), entity_id);
+          condition->set_nodes(node_sets[entity_id]);
           break;
         }
         case Core::Conditions::EntityType::element_block_id:
         {
-          const int eb_id = entity_id + 1;
-          FOUR_C_ASSERT_ALWAYS(element_block_nodes.contains(eb_id),
+          FOUR_C_ASSERT_ALWAYS(element_block_nodes.contains(entity_id),
               "Cannot apply condition '{}' to element block {} which is not specified in the mesh "
               "file.",
-              condition_definition.name(), eb_id);
-          condition->set_nodes(element_block_nodes[eb_id]);
+              condition_definition.name(), entity_id);
+          condition->set_nodes(element_block_nodes[entity_id]);
           break;
         }
       }

--- a/src/global_legacy_module/4C_global_legacy_module_validconditions.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validconditions.cpp
@@ -38,15 +38,6 @@
 FOUR_C_NAMESPACE_OPEN
 
 
-void Global::print_empty_condition_definitions(
-    std::ostream& stream, std::vector<Core::Conditions::ConditionDefinition>& condlist)
-{
-  for (auto& i : condlist)
-  {
-    i.print(stream);
-  }
-}
-
 namespace
 {
   // collect some problem-specific conditions that do not fit in the generic sections

--- a/src/global_legacy_module/4C_global_legacy_module_validconditions.hpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validconditions.hpp
@@ -10,28 +10,16 @@
 
 #include "4C_config.hpp"
 
-#include <Teuchos_Array.hpp>
+#include "4C_fem_condition_definition.hpp"
 
-#include <iostream>
-#include <memory>
-#include <string>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
-
-namespace Core::Conditions
-{
-  class ConditionDefinition;
-}
-
 
 namespace Global
 {
   /// construct list with all conditions and documentation
   std::vector<Core::Conditions::ConditionDefinition> valid_conditions();
-  /// print all known condition sections without contents
-  void print_empty_condition_definitions(
-      std::ostream& stream, std::vector<Core::Conditions::ConditionDefinition>& condlist);
 }  // namespace Global
 
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
- Compute correct IDs for manual node set specification early.
- Update a few docs.
- Remove unused helpers.
