### PR TITLE
Adjust tolerance of gaga-FSI test

### DIFF
--- a/tests/input_files/fsi_fp_mono_ss_ga_ga.4C.yaml
+++ b/tests/input_files/fsi_fp_mono_ss_ga_ga.4C.yaml
@@ -272,7 +272,7 @@ RESULT DESCRIPTION:
       NODE: 20
       QUANTITY: "lambday"
       VALUE: -1.1677962558503907
-      TOLERANCE: 1e-05
+      TOLERANCE: 5e-05
   - FSI:
       NODE: 20
       QUANTITY: "lambdaz"


### PR DESCRIPTION
As suspected, this test is susceptible for little different evaluation of the st-venant-kirchhoff material. The new way to evaluate the St. Venant-Kirchhoff material is $\boldsymbol{S}=\lambda \mathrm{tr} (\boldsymbol{E}) \boldsymbol{I} + 2 \mu \boldsymbol{E}$, the old way was $\boldsymbol{S} = \boldsymbol{C} : \boldsymbol{E}$.

Changing it back to $\boldsymbol{S} = \boldsymbol{C} : \boldsymbol{E}$ fixes the failing test on my workstation.

This PR adapts the tolerance slightly (unifies `lambday` with `lambdax` and `lambdaz`). The tolerance for `lambdax` and `lambdaz` have been adapted in #662.

Closes #951