### PR TITLE
Enable and cleanup vtk based output in poro pressurebased framework

### DIFF
--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -271,6 +271,18 @@ void PoroPressureBased::PorofluidAlgorithm::init(bool isale, int nds_disp, int n
   // the values of the integrals
   domain_integrals_ = std::make_shared<Core::LinAlg::SerialDenseVector>(num_domainint_funct_);
 
+  if (num_domainint_funct_ > 0)
+  {
+    // setup csv writer for domain integrals
+    runtime_csvwriter_domain_integrals_.emplace(
+        myrank_, *Global::Problem::instance()->output_control_file(), "domain_integrals");
+    for (int funct_i = 0; funct_i < num_domainint_funct_; funct_i++)
+    {
+      runtime_csvwriter_domain_integrals_->register_data_vector(
+          "Function ID " + std::to_string(domainint_funct_[funct_i]), 1, 14);
+    }
+  }
+
   set_element_general_parameters();
 
   // build mesh tying strategy
@@ -1552,42 +1564,17 @@ void PoroPressureBased::PorofluidAlgorithm::evaluate_domain_integrals()
   // evaluate
   discret_->evaluate_scalars(eleparams, domain_integrals_);
 
-  if (myrank_ == 0)  // only one core should do output
+  // check for csv writer
+  FOUR_C_ASSERT(runtime_csvwriter_domain_integrals_.has_value(),
+      "internal error: runtime csv writer not created.");
+
+  // fill csv-output with functions
+  std::map<std::string, std::vector<double>> output_data;
+  for (int i = 0; i < num_domainint_funct_; i++)
   {
-    // set filename and file
-    const std::string filename(
-        Global::Problem::instance()->output_control_file()->file_name() + ".domain_int" + ".csv");
-    std::ofstream file;
-
-    if (step_ == 0)
-    {
-      // inform user that function output has been requested
-      std::cout << "\nINFO for domain integrals:\nUser requested " << num_domainint_funct_
-                << " function(s) which will be integrated over the entire domain" << std::endl;
-      std::cout << "The result will be written into " << filename << "\n" << std::endl;
-
-      // open file and write header
-      file.open(filename, std::fstream::trunc);
-      file << "Step,Time";
-      for (int i = 0; i < num_domainint_funct_; i++)
-      {
-        file << ",Function_" << domainint_funct_[i];
-      }
-      file << "\n";
-      file.close();
-    }
-
-    // usual output
-    file.open(filename, std::fstream::app);
-    // step, time and results for each function
-    file << step_ << "," << time_;
-    for (int i = 0; i < num_domainint_funct_; i++)
-      file << "," << std::setprecision(14) << (*domain_integrals_)[i];
-
-    // close file
-    file << "\n";
-    file.close();
-  }  // if myrank == 0
+    output_data["Function ID " + std::to_string(domainint_funct_[i])] = {(*domain_integrals_)[i]};
+  }
+  runtime_csvwriter_domain_integrals_->write_data_to_file(time(), step(), output_data);
 
   discret_->clear_state();
 }

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.hpp
@@ -16,6 +16,7 @@
 #include "4C_adapter_porofluid_pressure_based.hpp"
 #include "4C_fem_discretization.hpp"
 #include "4C_io_discretization_visualization_writer_mesh.hpp"
+#include "4C_io_runtime_csv_writer.hpp"
 #include "4C_linalg_map.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_porofluid_pressure_based_input.hpp"
@@ -305,6 +306,10 @@ namespace PoroPressureBased
     {
       return meshtying_;
     }
+
+   protected:
+    //! runtime CSV-writer for domain integrals
+    std::optional<Core::IO::RuntimeCsvWriter> runtime_csvwriter_domain_integrals_;
 
    private:
     /// set time parameter for element evaluation (called before every time step)
@@ -691,7 +696,7 @@ namespace PoroPressureBased
     //! time factor for one-step-theta time integration
     double theta_;
 
-   private:
+    //! pointer to visualization writer object
     std::unique_ptr<Core::IO::DiscretizationVisualizationWriterMesh> visualization_writer_;
 
     /*========================================================================*/


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context

The first commit updates the porofluid_pressurebased framwork output, as we are already using the new vtk-based output in the artery framework (see #467).
The second commit adds the runtime csv-writer for domain integrals.

<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
part of #211 
