### PR TITLE
Adapt value of fsi result test

### DIFF
--- a/tests/input_files/fsi_fp_mono_ss_ga_ga.4C.yaml
+++ b/tests/input_files/fsi_fp_mono_ss_ga_ga.4C.yaml
@@ -266,7 +266,7 @@ RESULT DESCRIPTION:
   - FSI:
       NODE: 20
       QUANTITY: "lambdax"
-      VALUE: 2.7240872012880604
+      VALUE: 2.724065
       TOLERANCE: 5e-05
   - FSI:
       NODE: 20


### PR DESCRIPTION
Let's see whether centering the reference value fixes the problem for all configurations.

Reference nightly pipeline on my fork: https://github.com/amgebauer/4C/actions/runs/15993962767

Closes #951 