### PR TITLE
Remove all raw epetra import calls

### DIFF
--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -540,8 +540,8 @@ void Core::FE::Discretization::set_state(
     }
     // (re)build importer if necessary
     if (stateimporter_[nds] == nullptr or
-        not stateimporter_[nds]->sourcemap().same_as(state.get_map().get_epetra_block_map()) or
-        not stateimporter_[nds]->targetmap().same_as(colmap->get_epetra_block_map()))
+        not stateimporter_[nds]->source_map().same_as(state.get_map().get_epetra_block_map()) or
+        not stateimporter_[nds]->target_map().same_as(colmap->get_epetra_block_map()))
     {
       stateimporter_[nds] = std::make_shared<Core::LinAlg::Import>(*colmap, state.get_map());
     }

--- a/src/core/linalg/src/sparse/4C_linalg_transfer.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_transfer.cpp
@@ -16,11 +16,11 @@
 FOUR_C_NAMESPACE_OPEN
 
 //! Standard constructor using source and target maps
-Core::LinAlg::Import::Import::Import(const Map& targetMap, const Map& sourceMap)
+Core::LinAlg::Import::Import::Import(const Map& target_map, const Map& source_map)
     : import_(Utils::make_owner<Epetra_Import>(
-          targetMap.get_epetra_block_map(), sourceMap.get_epetra_block_map())),
-      sourceMap_(sourceMap),
-      targetMap_(targetMap)
+          target_map.get_epetra_block_map(), source_map.get_epetra_block_map())),
+      source_map_(source_map),
+      target_map_(target_map)
 {
 }
 
@@ -39,9 +39,9 @@ Core::LinAlg::Export::Export(const Export& exporter)
     : export_(Utils::make_owner<Epetra_Export>(exporter.get_epetra_export()))
 {
 }
-const Core::LinAlg::Map& Core::LinAlg::Import::Import::sourcemap() const { return sourceMap_; }
+const Core::LinAlg::Map& Core::LinAlg::Import::Import::source_map() const { return source_map_; }
 
-const Core::LinAlg::Map& Core::LinAlg::Import::Import::targetmap() const { return targetMap_; }
+const Core::LinAlg::Map& Core::LinAlg::Import::Import::target_map() const { return target_map_; }
 
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_transfer.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_transfer.hpp
@@ -22,17 +22,17 @@ namespace Core::LinAlg
   class Import
   {
    public:
-    Import(const Map& targetMap, const Map& sourceMap);
+    Import(const Map& target_map, const Map& source_map);
 
     const Epetra_Import& get_epetra_import() const;
-    const Map& sourcemap() const;
-    const Map& targetmap() const;
+    const Map& source_map() const;
+    const Map& target_map() const;
 
 
    private:
     Utils::OwnerOrView<Epetra_Import> import_;
-    Map sourceMap_;
-    Map targetMap_;
+    Map source_map_;
+    Map target_map_;
   };
   class Export
   {

--- a/src/deal_ii/src/4C_deal_ii_vector_conversion.cpp
+++ b/src/deal_ii/src/4C_deal_ii_vector_conversion.cpp
@@ -124,7 +124,7 @@ void DealiiWrappers::VectorConverter<VectorType, dim, spacedim>::to_dealii(
     VectorType& dealii_vector, const Core::LinAlg::Vector<double>& four_c_vector) const
 {
   FOUR_C_ASSERT_ALWAYS(
-      four_c_vector.get_map().point_same_as(dealii_to_four_c_importer_.targetmap()),
+      four_c_vector.get_map().point_same_as(dealii_to_four_c_importer_.target_map()),
       "The 4C vector passed to the converter needs to have dof_row_map layout.");
   const int n_local_elements = dealii_vector.locally_owned_size();
   FOUR_C_ASSERT(n_local_elements == dealii_to_four_c_map_.num_my_elements(), "Internal error.");
@@ -142,7 +142,7 @@ void DealiiWrappers::VectorConverter<VectorType, dim, spacedim>::to_four_c(
     Core::LinAlg::Vector<double>& four_c_vector, const VectorType& dealii_vector) const
 {
   FOUR_C_ASSERT_ALWAYS(
-      four_c_vector.get_map().point_same_as(dealii_to_four_c_importer_.targetmap()),
+      four_c_vector.get_map().point_same_as(dealii_to_four_c_importer_.target_map()),
       "The 4C vector passed to the converter needs to have dof_row_map layout.");
   const int n_local_elements = dealii_vector.locally_owned_size();
   FOUR_C_ASSERT(n_local_elements == dealii_to_four_c_map_.num_my_elements(), "Internal error.");


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
With this PR all the physics modules are rid of `get_epetra_import` and are contained only within `linalg`. Additionally our own implementation for obtaining source and target map is included.
## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
#755 