### PR TITLE
Introduce `NOX::Nln::GroupBase` and remove `NOX::Epetra::Group`

### DIFF
--- a/src/fsi/src/monolithic/4C_fsi_monolithic.hpp
+++ b/src/fsi/src/monolithic/4C_fsi_monolithic.hpp
@@ -422,7 +422,7 @@ namespace FSI
 
     //! setup of NOX convergence tests
     virtual Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp) = 0;
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp) = 0;
 
     /*! \brief Extract the three field vectors from a given composed vector
      *

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.cpp
@@ -961,7 +961,7 @@ void FSI::MonolithicFluidSplit::unscale_solution(Core::LinAlg::BlockSparseMatrix
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo> FSI::MonolithicFluidSplit::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // --------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicfluidsplit.hpp
@@ -178,7 +178,7 @@ namespace FSI
 
     /// setup of NOX convergence tests
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp) override;
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp) override;
 
     //! Extract the three field vectors from a given composed vector
     //!

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.cpp
@@ -850,7 +850,7 @@ void FSI::MonolithicStructureSplit::unscale_solution(Core::LinAlg::BlockSparseMa
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo> FSI::MonolithicStructureSplit::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // --------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_monolithicstructuresplit.hpp
@@ -155,7 +155,7 @@ namespace FSI
 
     /// setup of NOX convergence tests
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp) override;
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp) override;
 
     //! Extract the three field vectors from a given composed vector
     //!

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
@@ -1124,7 +1124,7 @@ void FSI::MortarMonolithicFluidSplit::unscale_solution(Core::LinAlg::BlockSparse
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo> FSI::MortarMonolithicFluidSplit::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // ---------------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.hpp
@@ -187,7 +187,7 @@ namespace FSI
 
     /// setup of NOX convergence tests
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp) override;
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp) override;
 
     /* \brief Extract the three field vectors from a given composed vector
      *

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
@@ -305,7 +305,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::create_system_matrix()
 /*----------------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo>
 FSI::MortarMonolithicFluidSplitSaddlePoint::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // ---------------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.hpp
@@ -102,7 +102,7 @@ namespace FSI
     void create_system_matrix();
 
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp) final;
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp) final;
 
     void update() final;
 

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
@@ -1004,7 +1004,7 @@ void FSI::MortarMonolithicStructureSplit::unscale_solution(Core::LinAlg::BlockSp
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo> FSI::MortarMonolithicStructureSplit::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // ---------------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.hpp
@@ -191,8 +191,8 @@ namespace FSI
 
     /// setup of NOX convergence tests
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams,       ///< parameter list
-        Teuchos::RCP<::NOX::Epetra::Group> grp  ///< the NOX group
+        Teuchos::ParameterList& nlParams,         ///< parameter list
+        Teuchos::RCP<::NOX::Abstract::Group> grp  ///< the NOX group
         ) override;
 
     /*! \brief Extract the three field vectors from a given composed vector

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.cpp
@@ -1121,7 +1121,7 @@ void FSI::SlidingMonolithicFluidSplit::unscale_solution(Core::LinAlg::BlockSpars
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo> FSI::SlidingMonolithicFluidSplit::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // ---------------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_fluidsplit.hpp
@@ -206,7 +206,7 @@ namespace FSI
 
     /// setup of NOX convergence tests
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp) override;
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp) override;
 
     /* \brief Extract the three field vectors from a given composed vector
      *

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
@@ -971,7 +971,7 @@ void FSI::SlidingMonolithicStructureSplit::unscale_solution(
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Teuchos::RCP<::NOX::StatusTest::Combo> FSI::SlidingMonolithicStructureSplit::create_status_test(
-    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp)
+    Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp)
 {
   // ---------------------------------------------------------------------------
   // Setup the test framework

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.hpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.hpp
@@ -209,8 +209,8 @@ namespace FSI
 
     /// setup of NOX convergence tests
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams,       ///< parameter list
-        Teuchos::RCP<::NOX::Epetra::Group> grp  ///< the NOX group
+        Teuchos::ParameterList& nlParams,         ///< parameter list
+        Teuchos::RCP<::NOX::Abstract::Group> grp  ///< the NOX group
         ) override;
 
     /*! \brief Extract the three field vectors from a given composed vector

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
@@ -17,7 +17,7 @@ FOUR_C_NAMESPACE_OPEN
 NOX::FSI::Group::Group(FourC::FSI::MonolithicInterface& mfsi, Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
-    : ::NOX::Epetra::Group(printParams, i, x, linSys), mfsi_(mfsi)
+    : NOX::Nln::GroupBase(printParams, i, x, linSys), mfsi_(mfsi)
 {
 }
 
@@ -42,7 +42,7 @@ void NOX::FSI::Group::capture_system_state()
  *----------------------------------------------------------------------*/
 ::NOX::Abstract::Group::ReturnType NOX::FSI::Group::computeF()
 {
-  ::NOX::Abstract::Group::ReturnType ret = ::NOX::Epetra::Group::computeF();
+  ::NOX::Abstract::Group::ReturnType ret = NOX::Nln::GroupBase::computeF();
   if (ret == ::NOX::Abstract::Group::Ok)
   {
     if (not isValidJacobian)
@@ -60,7 +60,7 @@ void NOX::FSI::Group::capture_system_state()
  *----------------------------------------------------------------------*/
 ::NOX::Abstract::Group::ReturnType NOX::FSI::Group::computeJacobian()
 {
-  ::NOX::Abstract::Group::ReturnType ret = ::NOX::Epetra::Group::computeJacobian();
+  ::NOX::Abstract::Group::ReturnType ret = NOX::Nln::GroupBase::computeJacobian();
   if (ret == ::NOX::Abstract::Group::Ok)
   {
     if (not isValidRHS)
@@ -81,7 +81,7 @@ void NOX::FSI::Group::capture_system_state()
   Core::LinAlg::View rhs_view(RHSVector.getEpetraVector());
   mfsi_.scale_system(rhs_view);
 
-  ::NOX::Abstract::Group::ReturnType status = ::NOX::Epetra::Group::computeNewton(p);
+  ::NOX::Abstract::Group::ReturnType status = NOX::Nln::GroupBase::computeNewton(p);
   Core::LinAlg::View newton_vector_view(NewtonVector.getEpetraVector());
 
   mfsi_.unscale_solution(newton_vector_view, rhs_view);

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.hpp
@@ -10,7 +10,7 @@
 
 #include "4C_config.hpp"
 
-#include <NOX_Epetra_Group.H>
+#include "4C_solver_nonlin_nox_group_base.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -25,7 +25,7 @@ namespace NOX
   namespace FSI
   {
     /// Special NOX group that always sets Jacobian and RHS at the same time.
-    class Group : public ::NOX::Epetra::Group
+    class Group : public NOX::Nln::GroupBase
     {
      public:
       Group(FourC::FSI::MonolithicInterface& mfsi,                    ///< monolithic FSI interface

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -141,9 +141,8 @@ namespace NOX
         \brief Explicitly constructs a preconditioner based on the solution vector x and the
         parameter list p.
 
-        The user has the option of recomputing the graph when a new
-        preconditioner is created. The ::NOX::Epetra::Group controls the
-        isValid flag for the preconditioner and will control when to call this.
+        The user has the option of recomputing the graph when a new preconditioner is created. The
+        Group controls the isValid flag for the preconditioner and will control when to call this.
       */
       bool createPreconditioner(const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
           bool recomputeGraph) const override;
@@ -151,8 +150,8 @@ namespace NOX
       /*!
         \brief Deletes the preconditioner.
 
-        The ::NOX::Epetra::Group controls the isValid flag for the preconditioner and will control
-        when to call this.
+        The Group controls the isValid flag for the preconditioner and will control when to call
+        this.
       */
       bool destroyPreconditioner() const override;
 

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.hpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.hpp
@@ -184,7 +184,7 @@ namespace FSI
 
     /// create convergence tests
     virtual void create_status_test(Teuchos::ParameterList& nlParams,
-        Teuchos::RCP<::NOX::Epetra::Group> grp, Teuchos::RCP<::NOX::StatusTest::Combo> converged);
+        Teuchos::RCP<::NOX::Abstract::Group> grp, Teuchos::RCP<::NOX::StatusTest::Combo> converged);
 
     /// return coupsfm_
     Coupling::Adapter::CouplingMortar& structure_fluid_coupling_mortar();
@@ -219,7 +219,7 @@ namespace FSI
 
     /// create convergence tests including testing framework
     Teuchos::RCP<::NOX::StatusTest::Combo> create_status_test(
-        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Epetra::Group> grp);
+        Teuchos::ParameterList& nlParams, Teuchos::RCP<::NOX::Abstract::Group> grp);
 
     //! connection of interface dofs for finite differences
     std::shared_ptr<Core::LinAlg::Graph> raw_graph_;

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_mpe.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_mpe.cpp
@@ -51,7 +51,8 @@ bool NOX::FSI::MinimalPolynomial::compute(
 {
   // We work in a local copy of the group so that we do not spoil the
   // current state.
-  ::NOX::Epetra::Group group(dynamic_cast<::NOX::Epetra::Group&>(grp));
+  Teuchos::RCP<::NOX::Abstract::Group> copy_group_ptr = grp.clone();
+  ::NOX::Abstract::Group& group = *copy_group_ptr;
 
   const ::NOX::Abstract::Vector& x = group.getX();
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
@@ -22,8 +22,7 @@ NOX::Nln::CONSTRAINT::Group::Group(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys,
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr)
-    : ::NOX::Epetra::Group(printParams, i, x, linSys),
-      NOX::Nln::Group(printParams, grpOptionParams, i, x, linSys),
+    : NOX::Nln::Group(printParams, grpOptionParams, i, x, linSys),
       user_constraint_interfaces_(iConstr)
 {
   return;
@@ -32,9 +31,7 @@ NOX::Nln::CONSTRAINT::Group::Group(Teuchos::ParameterList& printParams,
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::CONSTRAINT::Group::Group(const NOX::Nln::CONSTRAINT::Group& source, ::NOX::CopyType type)
-    : ::NOX::Epetra::Group(source, type),
-      NOX::Nln::Group(source, type),
-      user_constraint_interfaces_(source.user_constraint_interfaces_)
+    : NOX::Nln::Group(source, type), user_constraint_interfaces_(source.user_constraint_interfaces_)
 {
   // empty
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
@@ -29,7 +29,7 @@ namespace NOX
   {
     namespace CONSTRAINT
     {
-      class Group : public virtual NOX::Nln::Group
+      class Group : public NOX::Nln::Group
       {
        public:
         //! Standard constructor

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
@@ -23,7 +23,7 @@ FOUR_C_NAMESPACE_OPEN
 NOX::Nln::Group::Group(Teuchos::ParameterList& printParams, Teuchos::ParameterList& grpOptionParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
-    : ::NOX::Epetra::Group(printParams, i, x, linSys),
+    : GroupBase(printParams, i, x, linSys),
       skipUpdateX_(false),
       corr_type_(NOX::Nln::CorrectionType::vague),
       prePostOperatorPtr_(Teuchos::make_rcp<NOX::Nln::GROUP::PrePostOperator>(grpOptionParams))
@@ -34,7 +34,7 @@ NOX::Nln::Group::Group(Teuchos::ParameterList& printParams, Teuchos::ParameterLi
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::Group::Group(const NOX::Nln::Group& source, ::NOX::CopyType type)
-    : ::NOX::Epetra::Group(source, type),
+    : GroupBase(source, type),
       skipUpdateX_(false),
       corr_type_(NOX::Nln::CorrectionType::vague),
       prePostOperatorPtr_(source.prePostOperatorPtr_)

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
@@ -14,9 +14,9 @@
 
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_solver_nonlin_nox_forward_decl.hpp"
+#include "4C_solver_nonlin_nox_group_base.hpp"
 #include "4C_solver_nonlin_nox_statustest_normupdate.hpp"
 
-#include <NOX_Epetra_Group.H>  // base class
 #include <NOX_StatusTest_NormF.H>
 
 #include <set>
@@ -48,7 +48,7 @@ namespace NOX
       class PrePostOperator;
     }  // namespace GROUP
 
-    class Group : public virtual ::NOX::Epetra::Group
+    class Group : public GroupBase
     {
      public:
       //! Standard Constructor

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
@@ -1,0 +1,24 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_solver_nonlin_nox_group_base.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+NOX::Nln::GroupBase::GroupBase(Teuchos::ParameterList& printParams,
+    const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+    const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
+    : ::NOX::Epetra::Group(printParams, i, x, linSys)
+{
+}
+
+NOX::Nln::GroupBase::GroupBase(const NOX::Nln::GroupBase& source, ::NOX::CopyType type)
+    : ::NOX::Epetra::Group(source, type)
+{
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
@@ -1,0 +1,37 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_SOLVER_NONLIN_NOX_GROUP_BASE_HPP
+#define FOUR_C_SOLVER_NONLIN_NOX_GROUP_BASE_HPP
+
+/*----------------------------------------------------------------------------*/
+/* headers */
+#include "4C_config.hpp"
+
+#include <NOX_Epetra_Group.H>  // base class
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace NOX
+{
+  namespace Nln
+  {
+    class GroupBase : public ::NOX::Epetra::Group
+    {
+     public:
+      GroupBase(Teuchos::ParameterList& printParams,
+          const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
+          const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys);
+
+      GroupBase(const NOX::Nln::GroupBase& source, ::NOX::CopyType type);
+    };  // class GroupBase
+  }  // namespace Nln
+}  // namespace NOX
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_backtrack.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linesearch_backtrack.cpp
@@ -112,9 +112,7 @@ bool NOX::Nln::LineSearch::Backtrack::compute(::NOX::Abstract::Group& grp, doubl
   // want to access the jacobian, we have to use the oldGrp
   // (target of the copy process), instead.                hiermeier 08/15
   // ----------------------------------------------------------------------
-  const ::NOX::Epetra::Group* epetraOldGrpPtr = dynamic_cast<const ::NOX::Epetra::Group*>(&oldGrp);
-  if (not epetraOldGrpPtr->isJacobian())
-    throw_error("compute()", "Ownership changed unexpectedly!");
+  if (not oldGrp.isJacobian()) throw_error("compute()", "Ownership changed unexpectedly!");
 
   /* Setup the inner status test */
   status_ = inner_tests_ptr_->check_status(*this, s, oldGrp, check_type_);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
@@ -17,15 +17,14 @@ NOX::Nln::SINGLESTEP::Group::Group(Teuchos::ParameterList& printParams,
     Teuchos::ParameterList& grpOptionParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
-    : ::NOX::Epetra::Group(printParams, i, x, linSys),
-      NOX::Nln::Group(printParams, grpOptionParams, i, x, linSys)
+    : NOX::Nln::Group(printParams, grpOptionParams, i, x, linSys)
 {
 }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::SINGLESTEP::Group::Group(const NOX::Nln::SINGLESTEP::Group& source, ::NOX::CopyType type)
-    : ::NOX::Epetra::Group(source, type), NOX::Nln::Group(source, type)
+    : NOX::Nln::Group(source, type)
 {
 }
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
@@ -39,14 +39,6 @@ Teuchos::RCP<::NOX::Abstract::Group> NOX::Nln::SINGLESTEP::Group::clone(::NOX::C
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-::NOX::Abstract::Group& NOX::Nln::SINGLESTEP::Group::operator=(const ::NOX::Epetra::Group& source)
-{
-  NOX::Nln::Group::operator=(source);
-  return *this;
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
 void NOX::Nln::SINGLESTEP::Group::computeX(
     const ::NOX::Abstract::Group& grp, const ::NOX::Abstract::Vector& d, double step)
 {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.hpp
@@ -42,9 +42,6 @@ namespace NOX
         //! generate a clone of the given object concerning the given \c CopyType
         Teuchos::RCP<::NOX::Abstract::Group> clone(::NOX::CopyType type) const override;
 
-        //! assign operator
-        ::NOX::Abstract::Group& operator=(const ::NOX::Epetra::Group& source) override;
-
         //! compute/update the current state variables
         void computeX(
             const NOX::Nln::SINGLESTEP::Group& grp, const ::NOX::Epetra::Vector& d, double step);

--- a/src/structure/4C_structure_timint_noxgroup.cpp
+++ b/src/structure/4C_structure_timint_noxgroup.cpp
@@ -16,7 +16,7 @@ FOUR_C_NAMESPACE_OPEN
 NOX::Solid::Group::Group(FourC::Solid::TimIntImpl& sti, Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
-    : ::NOX::Epetra::Group(printParams, i, x, linSys)
+    : NOX::Nln::GroupBase(printParams, i, x, linSys)
 {
 }
 
@@ -24,7 +24,7 @@ NOX::Solid::Group::Group(FourC::Solid::TimIntImpl& sti, Teuchos::ParameterList& 
 /*----------------------------------------------------------------------------*/
 ::NOX::Abstract::Group::ReturnType NOX::Solid::Group::computeF()
 {
-  ::NOX::Abstract::Group::ReturnType ret = ::NOX::Epetra::Group::computeF();
+  ::NOX::Abstract::Group::ReturnType ret = NOX::Nln::GroupBase::computeF();
 
   // Not sure why we call this (historical reasons???)
   sharedLinearSystem.getObject(this);
@@ -39,7 +39,7 @@ NOX::Solid::Group::Group(FourC::Solid::TimIntImpl& sti, Teuchos::ParameterList& 
 /*----------------------------------------------------------------------------*/
 ::NOX::Abstract::Group::ReturnType NOX::Solid::Group::computeJacobian()
 {
-  ::NOX::Abstract::Group::ReturnType ret = ::NOX::Epetra::Group::computeJacobian();
+  ::NOX::Abstract::Group::ReturnType ret = NOX::Nln::GroupBase::computeJacobian();
   if (ret == ::NOX::Abstract::Group::Ok)
   {
     isValidJacobian = true;

--- a/src/structure/4C_structure_timint_noxgroup.hpp
+++ b/src/structure/4C_structure_timint_noxgroup.hpp
@@ -12,6 +12,7 @@
 /* headers */
 #include "4C_config.hpp"
 
+#include "4C_solver_nonlin_nox_group_base.hpp"
 #include "4C_structure_timint_impl.hpp"
 
 #include <NOX_Epetra_Group.H>
@@ -34,12 +35,12 @@ namespace NOX
   {
     /*==================================================================*/
     /*!
-     * \brief Special ::NOX::Epetra::Group that always //ToDo (mayr) That's not correct anymore.
+     * \brief Special Group that always //ToDo (mayr) That's not correct anymore.
      *        sets Jacobian and RHS at the same time.
      *
 
      */
-    class Group : public ::NOX::Epetra::Group
+    class Group : public NOX::Nln::GroupBase
     {
      public:
       //! Constructor


### PR DESCRIPTION
## Description and Context
I am working now on our own implementation of `NOX::Abstract::Group`, ultimately, `NOX::Epetra::Group` should be removed. As an intermediate step, I have decided to create base class `GroupBase` for our current group implementations.

Most of appearances of `NOX::Epetra::Group` across the code (except from the groups and `NOX::FSI::SDRelaxation`) have been removed.

## Related Issues and Pull Requests
#359, #379
