### PR TITLE
Remove some get_epetra_block_map calls

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_mor_pod.cpp
@@ -59,7 +59,7 @@ Cardiovascular0D::ProperOrthogonalDecomposition::ProperOrthogonalDecomposition(
   // build an importer
   Core::LinAlg::Import dofrowimporter(*full_model_dof_row_map_, reduced_basis->get_map());
   projmatrix_ = std::make_shared<Core::LinAlg::MultiVector<double>>(
-      full_model_dof_row_map_->get_epetra_block_map(), reduced_basis->NumVectors(), true);
+      *full_model_dof_row_map_, reduced_basis->NumVectors(), true);
   int err = projmatrix_->Import(*reduced_basis, dofrowimporter, Insert, nullptr);
   if (err != 0) FOUR_C_THROW("POD projection matrix could not be mapped onto the dof map");
 

--- a/src/contact/4C_contact_lagrange_strategy.cpp
+++ b/src/contact/4C_contact_lagrange_strategy.cpp
@@ -1762,8 +1762,7 @@ void CONTACT::LagrangeStrategy::add_line_to_lin_contributions(Core::LinAlg::Spar
   // create new contact force vector for LTL contact
   auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_block_map());
 
-  fconservation_ =
-      std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_block_map());
+  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(
@@ -1818,8 +1817,7 @@ void CONTACT::LagrangeStrategy::add_line_to_lin_contributions_friction(
   // create new contact force vector for LTL contact
   auto fc = std::make_shared<Epetra_FEVector>(feff->get_map().get_epetra_block_map());
 
-  fconservation_ =
-      std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map().get_epetra_block_map());
+  fconservation_ = std::make_shared<Core::LinAlg::Vector<double>>(feff->get_map());
 
   // create new contact stiffness matric for LTL contact
   auto kc = std::make_shared<Core::LinAlg::SparseMatrix>(

--- a/src/contact/4C_contact_meshtying_manager.cpp
+++ b/src/contact/4C_contact_meshtying_manager.cpp
@@ -668,8 +668,7 @@ void CONTACT::MtManager::postprocess_quantities(Core::IO::DiscretizationWriter& 
 
   // evaluate slave and master forces
   std::shared_ptr<Core::LinAlg::Vector<double>> fcslave =
-      std::make_shared<Core::LinAlg::Vector<double>>(
-          get_strategy().d_matrix()->row_map().get_epetra_block_map());
+      std::make_shared<Core::LinAlg::Vector<double>>(get_strategy().d_matrix()->row_map());
   std::shared_ptr<Core::LinAlg::Vector<double>> fcmaster =
       std::make_shared<Core::LinAlg::Vector<double>>(get_strategy().m_matrix()->domain_map());
   std::shared_ptr<Core::LinAlg::Vector<double>> fcslaveexp =

--- a/src/contact/4C_contact_noxinterface.cpp
+++ b/src/contact/4C_contact_noxinterface.cpp
@@ -71,8 +71,7 @@ double CONTACT::NoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vecto
   std::shared_ptr<Core::LinAlg::Vector<double>> constrRhs_red = nullptr;
   // Note: PointSameAs is faster than SameAs and should do the job right here,
   // since we replace the map afterwards anyway.               hiermeier 08/17
-  if (not constrRhs->get_map().point_same_as(
-          strategy().lm_dof_row_map(true).get_epetra_block_map()))
+  if (not constrRhs->get_map().point_same_as(strategy().lm_dof_row_map(true)))
   {
     constrRhs_red = std::make_shared<Core::LinAlg::Vector<double>>(strategy().lm_dof_row_map(true));
     Core::LinAlg::export_to(*constrRhs, *constrRhs_red);

--- a/src/core/comm/src/4C_comm_utils.cpp
+++ b/src/core/comm/src/4C_comm_utils.cpp
@@ -354,8 +354,7 @@ namespace Core::Communication
           vec.get_map(), Core::Communication::num_mpi_ranks(lcomm) - 1);
 
     // export full vectors to the two desired processors
-    Core::LinAlg::MultiVector<double> fullvec(
-        proc0map->get_epetra_block_map(), vec.NumVectors(), true);
+    Core::LinAlg::MultiVector<double> fullvec(*proc0map, vec.NumVectors(), true);
     Core::LinAlg::export_to(vec, fullvec);
 
     const int myglobalrank = Core::Communication::my_mpi_rank(gcomm);

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -515,7 +515,7 @@ void Core::FE::Discretization::set_state(
   // This is a rough test, but it might be ok at this place. It is an
   // error anyway to hand in a vector that is not related to our dof
   // maps.
-  if (vecmap.point_same_as(colmap->get_epetra_block_map()))
+  if (vecmap.point_same_as(*colmap))
   {
     FOUR_C_ASSERT(colmap->same_as(vecmap),
         "col map of discretization {} and state vector {} are different. This is a fatal bug!",
@@ -540,8 +540,8 @@ void Core::FE::Discretization::set_state(
     }
     // (re)build importer if necessary
     if (stateimporter_[nds] == nullptr or
-        not stateimporter_[nds]->source_map().same_as(state.get_map().get_epetra_block_map()) or
-        not stateimporter_[nds]->target_map().same_as(colmap->get_epetra_block_map()))
+        not stateimporter_[nds]->source_map().same_as(state.get_map()) or
+        not stateimporter_[nds]->target_map().same_as(*colmap))
     {
       stateimporter_[nds] = std::make_shared<Core::LinAlg::Import>(*colmap, state.get_map());
     }
@@ -784,7 +784,7 @@ void Core::FE::Discretization::add_multi_vector_to_parameter_list(Teuchos::Param
 
     // if it's already in column map just copy it
     // This is a rough test, but it might be ok at this place.
-    if (vec->get_map().point_same_as(nodecolmap->get_epetra_block_map()))
+    if (vec->get_map().point_same_as(*nodecolmap))
     {
       // make a copy as in parallel such that no additional RCP points to the state vector
       std::shared_ptr<Core::LinAlg::MultiVector<double>> tmp =

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -845,8 +845,8 @@ void Core::FE::Discretization::setup_ghosting(
   // Construct FE graph. This graph allows processor off-rows to be inserted
   // as well. The communication issue is solved.
 
-  auto graph = std::make_shared<Core::LinAlg::Graph>(Copy, rownodes.get_epetra_block_map(),
-      entriesperrow.data(), false, Core::LinAlg::Graph::GraphType::FE_GRAPH);
+  auto graph = std::make_shared<Core::LinAlg::Graph>(
+      Copy, rownodes, entriesperrow.data(), false, Core::LinAlg::Graph::GraphType::FE_GRAPH);
 
   gids.clear();
   entriesperrow.clear();

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -36,8 +36,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
     FOUR_C_THROW("action type for element is missing");
 
   // decide whether a dof or an element based map is given
-  FOUR_C_ASSERT(state.get_map().point_same_as(dis.dof_row_map()->get_epetra_block_map()),
-      "Only works for same maps.");
+  FOUR_C_ASSERT(state.get_map().point_same_as(*dis.dof_row_map()), "Only works for same maps.");
 
   // handle pbcs if existing
   // build inverse map from slave to master nodes

--- a/src/core/linalg/src/sparse/4C_linalg_map.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_map.hpp
@@ -141,12 +141,6 @@ namespace Core::LinAlg
     //! Returns local ID of global ID, return -1 if not found on this processor.
     int lid(int GID) const { return wrapped().LID(GID); }
 
-    //! Returns true if this and Map have identical point-wise structure
-    bool point_same_as(const Epetra_Map& Map) const { return wrapped().PointSameAs(Map); }
-
-    //! Returns true if this and Map have identical point-wise structure
-    bool point_same_as(const Epetra_BlockMap& Map) const { return wrapped().PointSameAs(Map); }
-
     //! Returns the processor IDs and corresponding local index value for a given list of global
     //! indices
     int remote_id_list(int NumIDs, int* GIDList, int* PIDList, int* LIDList) const

--- a/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
+++ b/src/core/linalg/tests/4C_linalg_map_test.np2.cpp
@@ -49,8 +49,7 @@ namespace
     vector.replace_map(*new_map);
 
     // Ensure that the underlying epetra maps are identical
-    EXPECT_EQ(
-        vector.get_map().get_epetra_block_map().SameAs(new_map->get_epetra_block_map()), true);
+    EXPECT_EQ(vector.get_map().same_as(*new_map), true);
 
     // create a new map with index base 2
     new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 2, comm);
@@ -72,11 +71,10 @@ namespace
         std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 0, comm);
 
     // create a multi vector
-    auto vector = Core::LinAlg::MultiVector<double>(starting_map->get_epetra_block_map(), true);
+    auto vector = Core::LinAlg::MultiVector<double>(*starting_map, true);
 
     // check that the vector has the same epetra map
-    EXPECT_TRUE(
-        vector.get_map().get_epetra_block_map().SameAs(starting_map->get_epetra_block_map()));
+    EXPECT_TRUE(vector.get_map().same_as(*starting_map));
 
     // create a new map with different index base
     auto new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 1, comm);
@@ -88,7 +86,7 @@ namespace
     EXPECT_TRUE(vector.get_map().same_as(*new_map));
 
     // check that the epetra maps are same
-    EXPECT_TRUE(vector.get_map().get_epetra_block_map().SameAs(new_map->get_epetra_block_map()));
+    EXPECT_TRUE(vector.get_map().same_as(*new_map));
 
     // create a new map with index base 2
     new_map = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 2, comm);

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -556,7 +556,7 @@ std::shared_ptr<const Core::LinAlg::Vector<double>> Core::Rebalance::get_col_ver
   // This is a rought test, but it might be ok at this place. It is an
   // error anyway to hand in a vector that is not related to our dof
   // maps.
-  if (vecmap.point_same_as(colmap->get_epetra_block_map())) return state;
+  if (vecmap.point_same_as(*colmap)) return state;
   // if it's not in column map export and allocate
   else
   {

--- a/src/coupling/src/adapter/4C_coupling_adapter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter.cpp
@@ -614,10 +614,9 @@ void Coupling::Adapter::Coupling::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().point_same_as(masterdofmap_->get_epetra_block_map()))
+  if (not mv.get_map().point_same_as(*masterdofmap_))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().point_same_as(slavedofmap_->get_epetra_block_map()))
-    FOUR_C_THROW("slave dof map vector expected");
+  if (not sv.get_map().point_same_as(*slavedofmap_)) FOUR_C_THROW("slave dof map vector expected");
   if (sv.NumVectors() != mv.NumVectors())
     FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
 #endif
@@ -649,9 +648,9 @@ void Coupling::Adapter::Coupling::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().point_same_as(masterdofmap_->get_epetra_block_map()))
+  if (not mv.get_map().point_same_as(*masterdofmap_))
     FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().point_same_as(slavedofmap_->get_epetra_block_map()))
+  if (not sv.get_map().point_same_as(*slavedofmap_))
   {
     std::cout << "slavedofmap_" << std::endl;
     std::cout << *slavedofmap_ << std::endl;

--- a/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_converter.cpp
@@ -121,7 +121,7 @@ bool Coupling::Adapter::MatrixLogicalSplitAndTransform::operator()(
     // check if the permuted map is simply a subset of the current rowmap (no communication)
     int subset = 1;
     for (int i = 0; i < permsrcmap.num_my_elements(); ++i)
-      if (!src.row_map().my_gid(permsrcmap.get_epetra_block_map().GID(i)))
+      if (!src.row_map().my_gid(permsrcmap.gid(i)))
       {
         subset = 0;
         break;

--- a/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_mortar.cpp
@@ -1287,10 +1287,8 @@ void Coupling::Adapter::CouplingMortar::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().point_same_as(P_->col_map().get_epetra_block_map()))
-    FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().point_same_as(D_->col_map().get_epetra_block_map()))
-    FOUR_C_THROW("slave dof map vector expected");
+  if (not mv.get_map().point_same_as(P_->col_map())) FOUR_C_THROW("master dof map vector expected");
+  if (not sv.get_map().point_same_as(D_->col_map())) FOUR_C_THROW("slave dof map vector expected");
 #endif
 
   // safety check
@@ -1318,10 +1316,8 @@ void Coupling::Adapter::CouplingMortar::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  if (not mv.get_map().point_same_as(P_->col_map().get_epetra_block_map()))
-    FOUR_C_THROW("master dof map vector expected");
-  if (not sv.get_map().point_same_as(D_->col_map().get_epetra_block_map()))
-    FOUR_C_THROW("slave dof map vector expected");
+  if (not mv.get_map().point_same_as(P_->col_map())) FOUR_C_THROW("master dof map vector expected");
+  if (not sv.get_map().point_same_as(D_->col_map())) FOUR_C_THROW("slave dof map vector expected");
 #endif
 
   // safety check

--- a/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
@@ -297,10 +297,8 @@ void Coupling::Adapter::MortarVolCoupl::master_to_slave(
     const Core::LinAlg::MultiVector<double>& mv, Core::LinAlg::MultiVector<double>& sv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  FOUR_C_ASSERT(mv.get_map().point_same_as(p21_->domain_map().get_epetra_block_map()),
-      "master dof map vector expected");
-  FOUR_C_ASSERT(sv.get_map().point_same_as(p21_->row_map().get_epetra_block_map()),
-      "slave dof map vector expected");
+  FOUR_C_ASSERT(mv.get_map().point_same_as(p21_->domain_map()), "master dof map vector expected");
+  FOUR_C_ASSERT(sv.get_map().point_same_as(p21_->row_map()), "slave dof map vector expected");
   FOUR_C_ASSERT(sv.NumVectors() == mv.NumVectors(), "column number mismatch {}!={}",
       sv.NumVectors(), mv.NumVectors());
 #endif
@@ -390,10 +388,8 @@ void Coupling::Adapter::MortarVolCoupl::slave_to_master(
     const Core::LinAlg::MultiVector<double>& sv, Core::LinAlg::MultiVector<double>& mv) const
 {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-  FOUR_C_ASSERT(mv.get_map().point_same_as(p12_->row_map().get_epetra_block_map()),
-      "master dof map vector expected");
-  FOUR_C_ASSERT(sv.get_map().point_same_as(p21_->row_map().get_epetra_block_map()),
-      "slave dof map vector expected");
+  FOUR_C_ASSERT(mv.get_map().point_same_as(p12_->row_map()), "master dof map vector expected");
+  FOUR_C_ASSERT(sv.get_map().point_same_as(p21_->row_map()), "slave dof map vector expected");
   FOUR_C_ASSERT(sv.NumVectors() == mv.NumVectors(), "column number mismatch {}!={}",
       sv.NumVectors(), mv.NumVectors());
 #endif

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_fluidfluidmonolithic_fluidsplit_nonox.cpp
@@ -1174,8 +1174,7 @@ void FSI::FluidFluidMonolithicFluidSplitNoNOX::handle_fluid_dof_map_change_in_ne
 bool FSI::FluidFluidMonolithicFluidSplitNoNOX::has_fluid_dof_map_changed(
     const Core::LinAlg::Map& fluidincrementmap)
 {
-  bool isoldmap =
-      fluidincrementmap.same_as(fluid_field()->interface()->other_map()->get_epetra_block_map());
+  bool isoldmap = fluidincrementmap.same_as(*fluid_field()->interface()->other_map());
   return !isoldmap;
 }
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -1850,7 +1850,7 @@ void PoroPressureBased::PorofluidAlgorithm::set_velocity_field(
   if (nds_vel_ >= discret_->num_dof_sets())
     FOUR_C_THROW("Too few dofsets on poro fluid discretization!");
 
-  if (not vel->get_map().same_as(discret_->dof_row_map(nds_vel_)->get_epetra_block_map()))
+  if (not vel->get_map().same_as(*discret_->dof_row_map(nds_vel_)))
     FOUR_C_THROW(
         "Map of given velocity and associated dof row map in poro fluid discretization"
         " do not match!");

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -1523,9 +1523,8 @@ void EnsightWriter::write_dof_result_step(std::ofstream& file, PostResult& resul
   // get min. value on this proc or set to max. value of integers if this proc has no elements
   int min_gid_my_datamap =
       num_my_datamap > 0 ? datamap.min_my_gid() : std::numeric_limits<int>::max();
-  int min_gid_my_dofrowmap = num_my_dofrowmap > 0
-                                 ? dis->dof_row_map()->get_epetra_block_map().MinMyGID()
-                                 : std::numeric_limits<int>::max();
+  int min_gid_my_dofrowmap =
+      num_my_dofrowmap > 0 ? dis->dof_row_map()->min_my_gid() : std::numeric_limits<int>::max();
 
   // find min. GID over all procs
   int min_gid_glob_datamap = std::numeric_limits<int>::max();

--- a/src/xfem/4C_xfem_discretization.cpp
+++ b/src/xfem/4C_xfem_discretization.cpp
@@ -224,7 +224,7 @@ void XFEM::DiscretizationXFEM::set_initial_state(unsigned nds, const std::string
   // This is a rough test, but it might be ok at this place. It is an
   // error anyway to hand in a vector that is not related to our dof
   // maps.
-  if (vecmap.point_same_as(colmap->get_epetra_block_map()))
+  if (vecmap.point_same_as(*colmap))
   {
     state_[nds][name] = state;
   }

--- a/src/xfem/4C_xfem_xfield_field_coupling.cpp
+++ b/src/xfem/4C_xfem_xfield_field_coupling.cpp
@@ -131,9 +131,9 @@ void XFEM::XFieldField::Coupling::master_to_slave(const Core::LinAlg::MultiVecto
     case XFEM::map_nodes:
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not mv.get_map().point_same_as(masternodemap_->get_epetra_block_map()))
+      if (not mv.get_map().point_same_as(*masternodemap_))
         FOUR_C_THROW("master node map vector expected");
-      if (not sv.get_map().point_same_as(slavenodemap_->get_epetra_block_map()))
+      if (not sv.get_map().point_same_as(*slavenodemap_))
         FOUR_C_THROW("slave node map vector expected");
       if (sv.NumVectors() != mv.NumVectors())
         FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());
@@ -163,9 +163,9 @@ void XFEM::XFieldField::Coupling::slave_to_master(const Core::LinAlg::MultiVecto
     case XFEM::map_nodes:
     {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-      if (not mv.get_map().point_same_as(masternodemap_->get_epetra_block_map()))
+      if (not mv.get_map().point_same_as(*masternodemap_))
         FOUR_C_THROW("master node map vector expected");
-      if (not sv.get_map().point_same_as(slavenodemap_->get_epetra_block_map()))
+      if (not sv.get_map().point_same_as(*slavenodemap_))
         FOUR_C_THROW("slave node map vector expected");
       if (sv.NumVectors() != mv.NumVectors())
         FOUR_C_THROW("column number mismatch {}!={}", sv.NumVectors(), mv.NumVectors());


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Removes  some `get_epetra_block_map` calls

There are still more `get_epetra_block_map` calls on `Epetra_FEVector` and can be removed once we have our wrapper for it.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

Part of https://github.com/4C-multiphysics/4C/issues/863