### PR TITLE
Fix include style pre-commit hook

### DIFF
--- a/utilities/four_c_utils/src/four_c_utils/check_includes.py
+++ b/utilities/four_c_utils/src/four_c_utils/check_includes.py
@@ -63,7 +63,7 @@ def check_and_fix_includes(file: Path) -> Tuple[list, bool]:
             continue
 
         if "4C" in line:
-            match = re.search(r"#include <(4C_\w+\.hpp)>(.*)", line)
+            match = re.search(r"#include <(4C_.*\.hpp)>(.*)", line)
             if match:
                 new_line = f'#include "{match[1]}"{match[2]}\n'
                 replace_line_in_file(file, line_no, new_line)


### PR DESCRIPTION
This fix is needed to also detect [these file types](https://4c-multiphysics.github.io/4C/documentation/developer_guide/codingguidelines.html#types-of-source-files-used-within-fourc).