### PR TITLE
Fix missing version macros for Trilinos

### DIFF
--- a/cmake/configure/configure_Trilinos.cmake
+++ b/cmake/configure/configure_Trilinos.cmake
@@ -46,6 +46,8 @@ if(EXISTS "${Trilinos_DIR}/../../../TrilinosRepoVersion.txt")
   list(GET TrilinosRepoVersionFileLine2 0 _sha)
 
   set(FOUR_C_Trilinos_GIT_HASH ${_sha})
+else()
+  set(FOUR_C_Trilinos_GIT_HASH "unknown")
 endif()
 
 target_link_libraries(


### PR DESCRIPTION
If no Trilinos hash can be found, we set the hash to "unknown". This triggers the intended behavior:

```
-- Could not identify your version of Trilinos with hash unknown.
-- Supported versions are:
--   - 2025.4 (hash 06db4c850654feacabdaed61ee8308219266b6a5, package's own version name: none)
--   - 2025.3 (hash 8cdf0375d278598c12edc3fd7059cb133c6f4426, package's own version name: 16.2.0)
--   - 2025.2 (hash 11a16481fa1af48e3cfdb0aa84c29617ce94479f, package's own version name: 16.1.0)
--   - 2025.1 (hash 1eab15637f2998d1e86fe127b78200f2c9687cb5, package's own version name: none)
-- Assume your version is newer than the latest supported version 2025.4.
CMake Warning at cmake/functions/four_c_configure_dependency.cmake:161 (message):
  Your version of package Trilinos with hash unknown could not be identified
  as a supported version.  Please check the supported versions in the file
  'dependencies/supported_version/Trilinos.txt'.  I made the assumption that
  the package is newer than the latest supported version and gave it the
  internal version number 2025.5.  If this assumption is wrong, please
  provide the correct version information in the cache variable
  'FOUR_C_TRILINOS_INTERNAL_VERSION'.
```
FYI @pbeckm
Closes #986 