### PR TITLE
Exodus reader always checks for errors

### DIFF
--- a/src/core/io/src/4C_io_exodus.hpp
+++ b/src/core/io/src/4C_io_exodus.hpp
@@ -128,7 +128,7 @@ namespace Core::IO::Exodus
     std::string title_;
 
     //! exodus filename
-    std::string exodus_filename_;
+    std::filesystem::path exodus_filename_;
   };
 
 


### PR DESCRIPTION
We previously ignored some errors and warnings that EXODUS could generate. 