### PR TITLE
Remove FE::Utils namespace

### DIFF
--- a/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
@@ -344,7 +344,7 @@ void Core::FE::Discretization::evaluate_dirichlet(Teuchos::ParameterList& params
     std::shared_ptr<Core::LinAlg::Vector<int>> toggle,
     std::shared_ptr<Core::LinAlg::MapExtractor> dbcmapextractor) const
 {
-  Core::FE::Utils::evaluate_dirichlet(
+  Core::FE::evaluate_dirichlet(
       *this, params, systemvector, systemvectord, systemvectordd, toggle, dbcmapextractor);
 }
 
@@ -661,8 +661,7 @@ void Core::FE::Discretization::evaluate_initial_field(
     const Core::Utils::FunctionManager& function_manager, const std::string& fieldstring,
     Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids) const
 {
-  Core::FE::Utils::evaluate_initial_field(
-      function_manager, *this, fieldstring, fieldvector, locids);
+  Core::FE::evaluate_initial_field(function_manager, *this, fieldstring, fieldvector, locids);
 }  // Core::FE::Discretization::EvaluateInitialField
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
@@ -146,7 +146,7 @@ void Core::FE::DiscretizationFaces::build_faces(const bool verbose)
         break;
       }
       default:
-        FOUR_C_THROW("Core::FE::Utils::build... not supported");
+        FOUR_C_THROW("Core::FE::build... not supported");
         break;
     }
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
@@ -286,9 +286,9 @@ std::ostream& operator<<(std::ostream& os, const Core::FE::DiscretizationHDG& di
 }
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Utils::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond, double time,
-    Core::FE::Utils::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+    Core::FE::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
     int hierarchical_order) const
 {
   // no need to check the cast, because it has been done during
@@ -301,14 +301,14 @@ void Core::FE::Utils::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterL
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Utils::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
-    double time, Core::FE::Utils::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+    double time, Core::FE::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
     int hierarchical_order) const
 
 {
   // call to corresponding method in base class; safety checks inside
-  Core::FE::Utils::Dbc::read_dirichlet_condition(
+  Core::FE::Dbc::read_dirichlet_condition(
       params, discret, cond, time, info, dbcgids, hierarchical_order);
 
   // say good bye if there are no face elements
@@ -406,7 +406,7 @@ void Core::FE::Utils::DbcHDG::read_dirichlet_condition(const Teuchos::ParameterL
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Utils::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond, double time,
 
     const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
@@ -422,13 +422,13 @@ void Core::FE::Utils::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterLis
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Utils::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::DbcHDG::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
     double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
     const Core::LinAlg::Vector<int>& toggle) const
 {
   // call corresponding method from base class; safety checks inside
-  Core::FE::Utils::Dbc::do_dirichlet_condition(
+  Core::FE::Dbc::do_dirichlet_condition(
       params, discret, cond, time, systemvectors, toggle, nullptr);
 
   // say good bye if there are no face elements

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.hpp
@@ -102,40 +102,37 @@ namespace Core::FE
 
   };  // class DiscretizationHDG
 
-  namespace Utils
+  /** \brief Specialized Dbc evaluation class for HDG discretizations
+   *
+   *  */
+  class DbcHDG : public Dbc
   {
-    /** \brief Specialized Dbc evaluation class for HDG discretizations
-     *
-     *  */
-    class DbcHDG : public Dbc
-    {
-     public:
-      /// constructor
-      DbcHDG() {};
+   public:
+    /// constructor
+    DbcHDG() {};
 
-     protected:
-      void read_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
-          double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
-          int hierarchical_order) const override;
+   protected:
+    void read_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
+        double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+        int hierarchical_order) const override;
 
-      void read_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
-          double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
-          int hierarchical_order) const;
+    void read_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
+        double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+        int hierarchical_order) const;
 
-      void do_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
-          double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          const Core::LinAlg::Vector<int>& toggle,
-          const std::shared_ptr<std::set<int>>* dbcgids) const override;
+    void do_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
+        double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        const Core::LinAlg::Vector<int>& toggle,
+        const std::shared_ptr<std::set<int>>* dbcgids) const override;
 
-      void do_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
-          double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          const Core::LinAlg::Vector<int>& toggle) const;
-    };  // class DbcHDG
-  }  // namespace Utils
+    void do_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
+        double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        const Core::LinAlg::Vector<int>& toggle) const;
+  };  // class DbcHDG
 }  // namespace Core::FE
 
 /// << operator

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
@@ -19,7 +19,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::evaluate_initial_field(const Core::Utils::FunctionManager& function_manager,
+void Core::FE::evaluate_initial_field(const Core::Utils::FunctionManager& function_manager,
     const Core::FE::Discretization& discret, const std::string& fieldstring,
     Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids)
 {
@@ -57,7 +57,7 @@ void Core::FE::Utils::evaluate_initial_field(const Core::Utils::FunctionManager&
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::do_initial_field(const Core::Utils::FunctionManager& function_manager,
+void Core::FE::do_initial_field(const Core::Utils::FunctionManager& function_manager,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
     Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids)
 {

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.hpp
@@ -38,358 +38,355 @@ namespace Core::FE
 {
   class Discretization;
   class DiscretizationFaces;
-  namespace Utils
+  class Dbc;
+
+  /** \brief Evaluate the elements of the given discretization and fill the
+   *         system matrix and vector
+   *
+   *  This evaluate routine supports the evaluation of a subset of all column
+   *  elements inside the given discretization. If the \c col_ele_map pointer
+   *  is not set or set to \c nullptr, this routine generates almost no overhead
+   *  and is equivalent to the more familiar implementation in Core::FE::Discretization.
+   *
+   *  \param discret      (in)  : discretization containing the considered elements
+   *  \param eparams      (in)  : element parameter list
+   *  \param systemmatrix (out) : system-matrix which is supposed to be filled
+   *  \param systemvector (out) : system-vector which is supposed to be filled
+   *  \param col_ele_map  (in)  : column element map, which can be a subset of the
+   *                              discretization column map ( optional )
+   */
+  void evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
+      const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
+      const Core::LinAlg::Map* col_ele_map = nullptr);
+
+
+  /** \brief Evaluate Dirichlet boundary conditions
+   *
+   *  non-member functions to call the dbc public routines
+   */
+  void evaluate_dirichlet(const Core::FE::Discretization& discret,
+      const Teuchos::ParameterList& params,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectordd,
+      const std::shared_ptr<Core::LinAlg::Vector<int>>& toggle,
+      const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor);
+
+  /** \brief Evaluate Dirichlet boundary conditions
+   *
+   *  Call this variant, if you need no new dbc map extractor.
+   *  See the corresponding called function for more detailed information.
+   */
+  inline void evaluate_dirichlet(const Core::FE::Discretization& discret,
+      const Teuchos::ParameterList& params,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
+      const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectordd,
+      const std::shared_ptr<Core::LinAlg::Vector<int>>& toggle)
   {
-    class Dbc;
+    evaluate_dirichlet(
+        discret, params, systemvector, systemvectord, systemvectordd, toggle, nullptr);
+  }
 
-    /** \brief Evaluate the elements of the given discretization and fill the
-     *         system matrix and vector
-     *
-     *  This evaluate routine supports the evaluation of a subset of all column
-     *  elements inside the given discretization. If the \c col_ele_map pointer
-     *  is not set or set to \c nullptr, this routine generates almost no overhead
-     *  and is equivalent to the more familiar implementation in Core::FE::Discretization.
-     *
-     *  \param discret      (in)  : discretization containing the considered elements
-     *  \param eparams      (in)  : element parameter list
-     *  \param systemmatrix (out) : system-matrix which is supposed to be filled
-     *  \param systemvector (out) : system-vector which is supposed to be filled
-     *  \param col_ele_map  (in)  : column element map, which can be a subset of the
-     *                              discretization column map ( optional )
+  /*!
+  \brief Evaluate a specified initial field (scalar or vector field)
+
+  Loop all initial field conditions attached to the discretization @p discret and evaluate them to
+  @p fieldvector if their names match the user-provided string @p fieldstring. Information on
+  which local DOFs ids are addressed by the condition MUST be pre-defined and is represented by
+  the @p locids vector. As an example, if we provide an initial velocity for a 3D structural
+  dynamics simulation, locids must contain the local DOF ids {0,1,2}. Another example would be
+  prescribing an initial pressure in a 3D fluid dynamics simulation, where locids would have to
+  contain only the local pressure DOF id, namely {3}.
+  */
+  void evaluate_initial_field(const Core::Utils::FunctionManager& function_manager,
+      const Core::FE::Discretization& discret, const std::string& fieldstring,
+      Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids);
+
+
+  /*!
+  \brief Evaluate a specified initial field (scalar or vector field)
+
+  This is the actual evaluation method.
+
+  */
+  void do_initial_field(const Core::Utils::FunctionManager& function_manager,
+      const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
+      Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids);
+
+  /** \brief Build a Dbc object
+   *
+   *  The Dbc object is build in dependency of the given discretization.
+   */
+  std::shared_ptr<const Dbc> build_dbc(const Core::FE::Discretization* discret_ptr);
+
+  /** \brief Default Dirchilet boundary condition evaluation class
+   */
+  class Dbc
+  {
+   protected:
+    enum DbcSet
+    {
+      set_row = 0,  ///< access the dbc row GID set
+      set_col = 1   ///< access the dbc column GID set
+    };
+
+   public:
+    struct DbcInfo
+    {
+      /*!
+       * \brief toggle vector to store the fix/free state of a dof
+       */
+      Core::LinAlg::Vector<int> toggle;
+
+      /*!
+       * \brief record the lowest geometrical order that a dof applies
+       */
+      Core::LinAlg::Vector<int> hierarchy;
+
+      /*!
+       * \brief record the last condition id prescribed and assign value to dof
+       */
+      Core::LinAlg::Vector<int> condition;
+
+      /*!
+       * \brief the prescribed value assigned to dof
+       * \note This is necessary to check the DBC consistency
+       */
+      Core::LinAlg::Vector<double> values;
+
+      /*!
+       * \brief constructor using the toggle vector as input
+       * \note all the vectors use the same map
+       */
+      DbcInfo(const Core::LinAlg::Vector<int>& toggle_input)
+          : toggle(toggle_input),
+            hierarchy(Core::LinAlg::Vector<int>(toggle_input.get_map())),
+            condition(Core::LinAlg::Vector<int>(toggle_input.get_map())),
+            values(Core::LinAlg::Vector<double>(toggle_input.get_map(), true))
+      {
+        hierarchy.put_value(std::numeric_limits<int>::max());
+        condition.put_value(-1);
+      }
+
+      /*!
+       * \brief constructor using the vector map as input
+       * \note all the vectors use the same map
+       */
+      DbcInfo(const Core::LinAlg::Map& toggle_map)
+          : toggle(Core::LinAlg::Vector<int>(toggle_map)),
+            hierarchy(Core::LinAlg::Vector<int>(toggle_map)),
+            condition(Core::LinAlg::Vector<int>(toggle_map)),
+            values(Core::LinAlg::Vector<double>(toggle_map, true))
+      {
+        hierarchy.put_value(std::numeric_limits<int>::max());
+        condition.put_value(-1);
+      }
+    };
+
+    /// Virtual destructor.
+    virtual ~Dbc() = default;
+
+    /** \brief Extract parameters and setup some temporal variables, before the actual
+     *  evaluation process can start
      */
-    void evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
-        const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix,
-        const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
-        const Core::LinAlg::Map* col_ele_map = nullptr);
-
-
-    /** \brief Evaluate Dirichlet boundary conditions
-     *
-     *  non-member functions to call the dbc public routines
-     */
-    void evaluate_dirichlet(const Core::FE::Discretization& discret,
-        const Teuchos::ParameterList& params,
+    void operator()(const Core::FE::Discretization& discret, const Teuchos::ParameterList& params,
         const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
         const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
         const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectordd,
         const std::shared_ptr<Core::LinAlg::Vector<int>>& toggle,
-        const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor);
+        const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor) const;
+
+   protected:
+    /// create the toggle vector based on the given systemvector maps
+    std::shared_ptr<Core::LinAlg::Vector<int>> create_toggle_vector(
+        const std::shared_ptr<Core::LinAlg::Vector<int>> toggle_input,
+        const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors) const;
 
     /** \brief Evaluate Dirichlet boundary conditions
      *
-     *  Call this variant, if you need no new dbc map extractor.
-     *  See the corresponding called function for more detailed information.
-     */
-    inline void evaluate_dirichlet(const Core::FE::Discretization& discret,
-        const Teuchos::ParameterList& params,
-        const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
-        const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
-        const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectordd,
-        const std::shared_ptr<Core::LinAlg::Vector<int>>& toggle)
-    {
-      evaluate_dirichlet(
-          discret, params, systemvector, systemvectord, systemvectordd, toggle, nullptr);
-    }
-
-    /*!
-    \brief Evaluate a specified initial field (scalar or vector field)
-
-    Loop all initial field conditions attached to the discretization @p discret and evaluate them to
-    @p fieldvector if their names match the user-provided string @p fieldstring. Information on
-    which local DOFs ids are addressed by the condition MUST be pre-defined and is represented by
-    the @p locids vector. As an example, if we provide an initial velocity for a 3D structural
-    dynamics simulation, locids must contain the local DOF ids {0,1,2}. Another example would be
-    prescribing an initial pressure in a 3D fluid dynamics simulation, where locids would have to
-    contain only the local pressure DOF id, namely {3}.
-    */
-    void evaluate_initial_field(const Core::Utils::FunctionManager& function_manager,
-        const Core::FE::Discretization& discret, const std::string& fieldstring,
-        Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids);
-
-
-    /*!
-    \brief Evaluate a specified initial field (scalar or vector field)
-
-    This is the actual evaluation method.
-
-    */
-    void do_initial_field(const Core::Utils::FunctionManager& function_manager,
-        const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
-        Core::LinAlg::Vector<double>& fieldvector, const std::vector<int>& locids);
-
-    /** \brief Build a Dbc object
+     *  Loop all Dirichlet conditions attached to the discretization and evaluate
+     *  them. This method considers all conditions in condition_ with the names
+     *  "PointDirichlet", "LineDirichlet", "SurfaceDirichlet" and "VolumeDirichlet".
+     *  It takes a current time from the parameter list params named "total time"
+     *  and evaluates the appropriate time curves at that time for each
+     *  Dirichlet condition separately. If "total time" is not included
+     *  in the parameters, no time curves are used.
      *
-     *  The Dbc object is build in dependency of the given discretization.
+     *  \note Opposed to the other 'Evaluate' method does this one NOT assembly
+     *        but OVERWRITE values in the output vector systemvector. For this
+     *        reason, dirichlet boundary conditions are evaluated in the
+     *        following order: First "VolumeDirichlet", then "SurfaceDirichlet",
+     *        then "LineDirichlet" and finally "PointDirichlet". This way, the
+     *        lower entity dirichlet BCs override the higher ones and a point
+     *        Dirichlet BCs has priority over other dirichlet BCs in the input
+     *        file.
+     *
+     *  Parameters recognized by this method:
+     *  \code
+     *  params.set("total time",acttime); // current total time
+     *  \endcode
+     *
+     *  \param params           (in): Teuchos Parameter List
+     *  \param discret          (in): discretization corresponding to the input
+     *                                system vectors
+     *  \param params           (in): List of parameters
+     *  \param systemvector    (out): Vector holding prescribed Dirichlet values
+     *  \param systemvectord   (out): Vector holding 1st time derivative of
+     *                                prescribed Dirichlet values
+     *  \param systemvectordd  (out): Vector holding 2nd time derivative prescribed
+     *                                Dirichlet values
+     *  \param toggle          (out): Vector containing 1.0 for each Dirichlet dof
+     *                                and 0 for everything else
+     *  \param dbcmapextractor (out): Map extractor containing maps for the DOFs
+     *                                subjected to Dirichlet boundary conditions
+     *                                and the remaining/free DOFs
      */
-    std::shared_ptr<const Dbc> build_dbc(const Core::FE::Discretization* discret_ptr);
+    virtual void evaluate(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, double time,
+        const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors, DbcInfo& info,
+        std::shared_ptr<std::set<int>>* dbcgids) const;
 
-    /** \brief Default Dirchilet boundary condition evaluation class
+    /** \brief loop through Dirichlet conditions and evaluate them
+     *
+     *  Note that this method does not sum up but 'sets' values in systemvector.
+     *  For this reason, Dirichlet BCs are evaluated hierarchical meaning
+     *  in this order:
+     *                 VolumeDirichlet
+     *                 SurfaceDirichlet
+     *                 LineDirichlet
+     *                 PointDirichlet
+     *  This way, lower entities override higher ones which is
+     *  equivalent to inheritance of dirichlet BCs.
+     *
+     *  Lower entities MUST NOT set dof values in systemvector before
+     *  we know if higher entities also prescribe/release Dirichlet BCs
+     *  for the same dofs!
+     *
+     *  Therefore, we first have to assess the full hierarchy and
+     *  set the toggle vector for a dof to 1 if an entity prescribes a
+     *  dirichlet BC and we have to set it to 0 again if a higher entity
+     *  does NOT prescribe a dirichlet BC for the same dof. This is done
+     *  in read_dirichlet_condition(...). We do this for each type of entity,
+     *  starting with volume DBCs.
+     *
+     *  Only then we call do_dirichlet_condition(...) for each type of entity,
+     *  starting with volume DBCs.
+     *
+     *  This way, it is guaranteed, that the highest entity defined in
+     *  the input file determines if the systemvector for the corresponding
+     *  dofs is actually touched, or not, irrespective of the dirichlet BC
+     *  definition of a lower entity.
      */
-    class Dbc
-    {
-     protected:
-      enum DbcSet
-      {
-        set_row = 0,  ///< access the dbc row GID set
-        set_col = 1   ///< access the dbc column GID set
-      };
+    void read_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
+        double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids) const;
 
-     public:
-      struct DbcInfo
-      {
-        /*!
-         * \brief toggle vector to store the fix/free state of a dof
-         */
-        Core::LinAlg::Vector<int> toggle;
+    /// loop over the conditions and read the given type
+    void read_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
+        double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+        const enum Core::Conditions::ConditionType& type) const;
 
-        /*!
-         * \brief record the lowest geometrical order that a dof applies
-         */
-        Core::LinAlg::Vector<int> hierarchy;
+    /** \brief Determine dofs subject to Dirichlet condition from input file
+     *
+     *  \param params   (in)  : Teuchos Parameter List
+     *  \param discret  (in)  :  discretization corresponding to the input
+     *                           system vectors
+     *  \param cond     (in)  :  The condition object
+     *  \param toggle   (out) :  Its i-th component is set 1 if it has a
+     *                           DBC, otherwise this component remains untouched
+     *  \param dbcgids  (out) :  Map containing DOFs subjected to Dirichlet
+     *                           boundary conditions (row and optional column)
+     *
+     *  \remark If you want to be sure which Dirichlet values are set, look at
+     *          the highest entity for a certain node in your input file.
+     *
+     *  The corresponding condition, e.g.:
+     *  ---------DESIGN LINE DIRICH CONDITIONS
+     *  // example_line
+     *  E 1 - NUMDOF 6 ONOFF 0 1 1 VAL 0.0 1.0 1.0 FUNCT 1 0 0
+     *
+     *  tells you which dofs are actually conditioned. In the example given
+     *  above, the highest entity which contains a certain node is a LINE.
+     *  The first dof has an ONOFF-toggle of ZERO. This means, that the nodes
+     *  in LINE 'E 1' definitely DO NOT HAVE a dirichlet BC on their first dof.
+     *  No matter what is defined in a condition line of lower priority. The
+     *  corresponding entries in the systemvectors remain untouched.
+     */
+    virtual void read_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
+        double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+        int hierarchical_order) const;
 
-        /*!
-         * \brief record the last condition id prescribed and assign value to dof
-         */
-        Core::LinAlg::Vector<int> condition;
+    /** \brief Assignment of the values to the system vectors.
+     *
+     *  (1) Assign VolumeDirichlet DBC GIDs
+     *  (2) Assign SurfaceDirichlet DBC GIDs
+     *  (3) Assign LineDirichlet DBC GIDs
+     *  (4) Assign PointDirichlet DBC GIDs
+     */
+    void do_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret,
+        std::span<const Core::Conditions::Condition*> conds, double time,
+        const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        const Core::LinAlg::Vector<int>& toggle,
+        const std::shared_ptr<std::set<int>>* dbcgids) const;
 
-        /*!
-         * \brief the prescribed value assigned to dof
-         * \note This is necessary to check the DBC consistency
-         */
-        Core::LinAlg::Vector<double> values;
+    /// loop over the conditions and assign the given type
+    void do_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret,
+        std::span<const Core::Conditions::Condition*> conds, double time,
+        const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids,
+        const enum Core::Conditions::ConditionType& type) const;
 
-        /*!
-         * \brief constructor using the toggle vector as input
-         * \note all the vectors use the same map
-         */
-        DbcInfo(const Core::LinAlg::Vector<int>& toggle_input)
-            : toggle(toggle_input),
-              hierarchy(Core::LinAlg::Vector<int>(toggle_input.get_map())),
-              condition(Core::LinAlg::Vector<int>(toggle_input.get_map())),
-              values(Core::LinAlg::Vector<double>(toggle_input.get_map(), true))
-        {
-          hierarchy.put_value(std::numeric_limits<int>::max());
-          condition.put_value(-1);
-        }
+    /** \brief Apply the Dirichlet values to the system vectors
+     *
+     *  \param params          (in): Teuchos Parameter List
+     *  \param discret         (in): discretization corresponding to the input
+     *                               system vectors
+     *  \param cond            (in): The condition object
+     *  \param time            (in): Evaluation time
+     *  \param systemvector   (out): Vector to apply DBCs to (eg displ. in
+     *                               structure, vel. in fluids)
+     *  \param systemvectord  (out): First time derivative of DBCs
+     *  \param systemvectordd (out): Second time derivative of DBCs
+     *  \param toggle          (in): Its i-th component is set 1 if it has
+     *                               a DBC, otherwise this component remains
+     *                               untouched
+     *
+     *  \remark If you want to be sure which Dirichlet values are set, look at
+     *          the highest entity for a certain node in your input file.
+     *
+     *  The corresponding condition, e.g.:
+     *  ---------DESIGN LINE DIRICH CONDITIONS
+     *  // example_line
+     *  E 1 - NUMDOF 6 ONOFF 0 1 1 VAL 0.0 1.0 1.0 FUNCT 1 0 0
+     *
+     *  tells you which dofs are actually conditioned. In the example given
+     *  above, the highest entity which contains a certain node is a LINE.
+     *  The first dof has an ONOFF-toggle of ZERO. This means, that the
+     *  nodes in LINE 'E 1' definitely DO NOT HAVE a dirichlet BC on their
+     *  first dof. No matter what is defined in a condition line of lower
+     *  priority. The corresponding entries in the systemvectors remain
+     *  untouched.
+     *
+     */
+    virtual void do_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
+        double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        const Core::LinAlg::Vector<int>& toggle,
+        const std::shared_ptr<std::set<int>>* dbcgids) const;
 
-        /*!
-         * \brief constructor using the vector map as input
-         * \note all the vectors use the same map
-         */
-        DbcInfo(const Core::LinAlg::Map& toggle_map)
-            : toggle(Core::LinAlg::Vector<int>(toggle_map)),
-              hierarchy(Core::LinAlg::Vector<int>(toggle_map)),
-              condition(Core::LinAlg::Vector<int>(toggle_map)),
-              values(Core::LinAlg::Vector<double>(toggle_map, true))
-        {
-          hierarchy.put_value(std::numeric_limits<int>::max());
-          condition.put_value(-1);
-        }
-      };
+    /** \brief Create a Dbc map extractor, if desired
+     */
+    void build_dbc_map_extractor(const Core::FE::Discretization& discret,
+        const std::shared_ptr<const std::set<int>>& dbcrowgids,
+        const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor) const;
 
-      /// Virtual destructor.
-      virtual ~Dbc() = default;
-
-      /** \brief Extract parameters and setup some temporal variables, before the actual
-       *  evaluation process can start
-       */
-      void operator()(const Core::FE::Discretization& discret, const Teuchos::ParameterList& params,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectordd,
-          const std::shared_ptr<Core::LinAlg::Vector<int>>& toggle,
-          const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor) const;
-
-     protected:
-      /// create the toggle vector based on the given systemvector maps
-      std::shared_ptr<Core::LinAlg::Vector<int>> create_toggle_vector(
-          const std::shared_ptr<Core::LinAlg::Vector<int>> toggle_input,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors) const;
-
-      /** \brief Evaluate Dirichlet boundary conditions
-       *
-       *  Loop all Dirichlet conditions attached to the discretization and evaluate
-       *  them. This method considers all conditions in condition_ with the names
-       *  "PointDirichlet", "LineDirichlet", "SurfaceDirichlet" and "VolumeDirichlet".
-       *  It takes a current time from the parameter list params named "total time"
-       *  and evaluates the appropriate time curves at that time for each
-       *  Dirichlet condition separately. If "total time" is not included
-       *  in the parameters, no time curves are used.
-       *
-       *  \note Opposed to the other 'Evaluate' method does this one NOT assembly
-       *        but OVERWRITE values in the output vector systemvector. For this
-       *        reason, dirichlet boundary conditions are evaluated in the
-       *        following order: First "VolumeDirichlet", then "SurfaceDirichlet",
-       *        then "LineDirichlet" and finally "PointDirichlet". This way, the
-       *        lower entity dirichlet BCs override the higher ones and a point
-       *        Dirichlet BCs has priority over other dirichlet BCs in the input
-       *        file.
-       *
-       *  Parameters recognized by this method:
-       *  \code
-       *  params.set("total time",acttime); // current total time
-       *  \endcode
-       *
-       *  \param params           (in): Teuchos Parameter List
-       *  \param discret          (in): discretization corresponding to the input
-       *                                system vectors
-       *  \param params           (in): List of parameters
-       *  \param systemvector    (out): Vector holding prescribed Dirichlet values
-       *  \param systemvectord   (out): Vector holding 1st time derivative of
-       *                                prescribed Dirichlet values
-       *  \param systemvectordd  (out): Vector holding 2nd time derivative prescribed
-       *                                Dirichlet values
-       *  \param toggle          (out): Vector containing 1.0 for each Dirichlet dof
-       *                                and 0 for everything else
-       *  \param dbcmapextractor (out): Map extractor containing maps for the DOFs
-       *                                subjected to Dirichlet boundary conditions
-       *                                and the remaining/free DOFs
-       */
-      virtual void evaluate(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, double time,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors, DbcInfo& info,
-          std::shared_ptr<std::set<int>>* dbcgids) const;
-
-      /** \brief loop through Dirichlet conditions and evaluate them
-       *
-       *  Note that this method does not sum up but 'sets' values in systemvector.
-       *  For this reason, Dirichlet BCs are evaluated hierarchical meaning
-       *  in this order:
-       *                 VolumeDirichlet
-       *                 SurfaceDirichlet
-       *                 LineDirichlet
-       *                 PointDirichlet
-       *  This way, lower entities override higher ones which is
-       *  equivalent to inheritance of dirichlet BCs.
-       *
-       *  Lower entities MUST NOT set dof values in systemvector before
-       *  we know if higher entities also prescribe/release Dirichlet BCs
-       *  for the same dofs!
-       *
-       *  Therefore, we first have to assess the full hierarchy and
-       *  set the toggle vector for a dof to 1 if an entity prescribes a
-       *  dirichlet BC and we have to set it to 0 again if a higher entity
-       *  does NOT prescribe a dirichlet BC for the same dof. This is done
-       *  in read_dirichlet_condition(...). We do this for each type of entity,
-       *  starting with volume DBCs.
-       *
-       *  Only then we call do_dirichlet_condition(...) for each type of entity,
-       *  starting with volume DBCs.
-       *
-       *  This way, it is guaranteed, that the highest entity defined in
-       *  the input file determines if the systemvector for the corresponding
-       *  dofs is actually touched, or not, irrespective of the dirichlet BC
-       *  definition of a lower entity.
-       */
-      void read_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
-          double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids) const;
-
-      /// loop over the conditions and read the given type
-      void read_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
-          double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
-          const enum Core::Conditions::ConditionType& type) const;
-
-      /** \brief Determine dofs subject to Dirichlet condition from input file
-       *
-       *  \param params   (in)  : Teuchos Parameter List
-       *  \param discret  (in)  :  discretization corresponding to the input
-       *                           system vectors
-       *  \param cond     (in)  :  The condition object
-       *  \param toggle   (out) :  Its i-th component is set 1 if it has a
-       *                           DBC, otherwise this component remains untouched
-       *  \param dbcgids  (out) :  Map containing DOFs subjected to Dirichlet
-       *                           boundary conditions (row and optional column)
-       *
-       *  \remark If you want to be sure which Dirichlet values are set, look at
-       *          the highest entity for a certain node in your input file.
-       *
-       *  The corresponding condition, e.g.:
-       *  ---------DESIGN LINE DIRICH CONDITIONS
-       *  // example_line
-       *  E 1 - NUMDOF 6 ONOFF 0 1 1 VAL 0.0 1.0 1.0 FUNCT 1 0 0
-       *
-       *  tells you which dofs are actually conditioned. In the example given
-       *  above, the highest entity which contains a certain node is a LINE.
-       *  The first dof has an ONOFF-toggle of ZERO. This means, that the nodes
-       *  in LINE 'E 1' definitely DO NOT HAVE a dirichlet BC on their first dof.
-       *  No matter what is defined in a condition line of lower priority. The
-       *  corresponding entries in the systemvectors remain untouched.
-       */
-      virtual void read_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
-          double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
-          int hierarchical_order) const;
-
-      /** \brief Assignment of the values to the system vectors.
-       *
-       *  (1) Assign VolumeDirichlet DBC GIDs
-       *  (2) Assign SurfaceDirichlet DBC GIDs
-       *  (3) Assign LineDirichlet DBC GIDs
-       *  (4) Assign PointDirichlet DBC GIDs
-       */
-      void do_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret,
-          std::span<const Core::Conditions::Condition*> conds, double time,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          const Core::LinAlg::Vector<int>& toggle,
-          const std::shared_ptr<std::set<int>>* dbcgids) const;
-
-      /// loop over the conditions and assign the given type
-      void do_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret,
-          std::span<const Core::Conditions::Condition*> conds, double time,
-          const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids,
-          const enum Core::Conditions::ConditionType& type) const;
-
-      /** \brief Apply the Dirichlet values to the system vectors
-       *
-       *  \param params          (in): Teuchos Parameter List
-       *  \param discret         (in): discretization corresponding to the input
-       *                               system vectors
-       *  \param cond            (in): The condition object
-       *  \param time            (in): Evaluation time
-       *  \param systemvector   (out): Vector to apply DBCs to (eg displ. in
-       *                               structure, vel. in fluids)
-       *  \param systemvectord  (out): First time derivative of DBCs
-       *  \param systemvectordd (out): Second time derivative of DBCs
-       *  \param toggle          (in): Its i-th component is set 1 if it has
-       *                               a DBC, otherwise this component remains
-       *                               untouched
-       *
-       *  \remark If you want to be sure which Dirichlet values are set, look at
-       *          the highest entity for a certain node in your input file.
-       *
-       *  The corresponding condition, e.g.:
-       *  ---------DESIGN LINE DIRICH CONDITIONS
-       *  // example_line
-       *  E 1 - NUMDOF 6 ONOFF 0 1 1 VAL 0.0 1.0 1.0 FUNCT 1 0 0
-       *
-       *  tells you which dofs are actually conditioned. In the example given
-       *  above, the highest entity which contains a certain node is a LINE.
-       *  The first dof has an ONOFF-toggle of ZERO. This means, that the
-       *  nodes in LINE 'E 1' definitely DO NOT HAVE a dirichlet BC on their
-       *  first dof. No matter what is defined in a condition line of lower
-       *  priority. The corresponding entries in the systemvectors remain
-       *  untouched.
-       *
-       */
-      virtual void do_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
-          double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          const Core::LinAlg::Vector<int>& toggle,
-          const std::shared_ptr<std::set<int>>* dbcgids) const;
-
-      /** \brief Create a Dbc map extractor, if desired
-       */
-      void build_dbc_map_extractor(const Core::FE::Discretization& discret,
-          const std::shared_ptr<const std::set<int>>& dbcrowgids,
-          const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor) const;
-
-    };  // class Dbc
-  }  // namespace Utils
+  };  // class Dbc
 }  // namespace Core::FE
 
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
@@ -20,7 +20,7 @@ FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::evaluate_dirichlet(const Core::FE::Discretization& discret,
+void Core::FE::evaluate_dirichlet(const Core::FE::Discretization& discret,
     const Teuchos::ParameterList& params,
     const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
     const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
@@ -29,30 +29,30 @@ void Core::FE::Utils::evaluate_dirichlet(const Core::FE::Discretization& discret
     const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor)
 {
   // create const version
-  const std::shared_ptr<const Core::FE::Utils::Dbc> dbc = build_dbc(&discret);
+  const std::shared_ptr<const Core::FE::Dbc> dbc = build_dbc(&discret);
   (*dbc)(discret, params, systemvector, systemvectord, systemvectordd, toggle, dbcmapextractor);
 }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::shared_ptr<const Core::FE::Utils::Dbc> Core::FE::Utils::build_dbc(
+std::shared_ptr<const Core::FE::Dbc> Core::FE::build_dbc(
     const Core::FE::Discretization* discret_ptr)
 {
   // HDG discretization
   if (dynamic_cast<const Core::FE::DiscretizationHDG*>(discret_ptr) != nullptr)
-    return std::make_shared<const Core::FE::Utils::DbcHDG>();
+    return std::make_shared<const Core::FE::DbcHDG>();
 
   // Nurbs discretization
   if (dynamic_cast<const Core::FE::Nurbs::NurbsDiscretization*>(discret_ptr) != nullptr)
-    return std::make_shared<const Core::FE::Utils::DbcNurbs>();
+    return std::make_shared<const Core::FE::DbcNurbs>();
 
   // default case
-  return std::make_shared<const Core::FE::Utils::Dbc>();
+  return std::make_shared<const Core::FE::Dbc>();
 }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::operator()(const Core::FE::Discretization& discret,
+void Core::FE::Dbc::operator()(const Core::FE::Discretization& discret,
     const Teuchos::ParameterList& params,
     const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
     const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvectord,
@@ -105,7 +105,7 @@ void Core::FE::Utils::Dbc::operator()(const Core::FE::Discretization& discret,
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-std::shared_ptr<Core::LinAlg::Vector<int>> Core::FE::Utils::Dbc::create_toggle_vector(
+std::shared_ptr<Core::LinAlg::Vector<int>> Core::FE::Dbc::create_toggle_vector(
     const std::shared_ptr<Core::LinAlg::Vector<int>> toggle_input,
     const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors) const
 {
@@ -141,7 +141,7 @@ std::shared_ptr<Core::LinAlg::Vector<int>> Core::FE::Utils::Dbc::create_toggle_v
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::evaluate(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::evaluate(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, double time,
     const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors, DbcInfo& info,
     std::shared_ptr<std::set<int>>* dbcgids) const
@@ -161,7 +161,7 @@ void Core::FE::Utils::Dbc::evaluate(const Teuchos::ParameterList& params,
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
     double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids) const
 {
@@ -182,7 +182,7 @@ void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
     double time, DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
     const enum Core::Conditions::ConditionType& type) const
@@ -219,7 +219,7 @@ void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond, double time,
     DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids, int hierarchical_order) const
 {
@@ -417,7 +417,7 @@ void Core::FE::Utils::Dbc::read_dirichlet_condition(const Teuchos::ParameterList
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, std::span<const Conditions::Condition*> conds,
     double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
     const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids) const
@@ -434,7 +434,7 @@ void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& 
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, std::span<const Core::Conditions::Condition*> conds,
     double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
     const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids,
@@ -451,7 +451,7 @@ void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& 
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond, double time,
     const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
     const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids) const
@@ -559,14 +559,14 @@ void Core::FE::Utils::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& 
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Utils::Dbc::build_dbc_map_extractor(const Core::FE::Discretization& discret,
+void Core::FE::Dbc::build_dbc_map_extractor(const Core::FE::Discretization& discret,
     const std::shared_ptr<const std::set<int>>& dbcrowgids,
     const std::shared_ptr<Core::LinAlg::MapExtractor>& dbcmapextractor) const
 {
   if (!dbcmapextractor) return;
 
   FOUR_C_ASSERT(dbcrowgids,
-      "The variable `dbcrowgids` in `Core::FE::Utils::Dbc::build_dbc_map_extractor` is a null "
+      "The variable `dbcrowgids` in `Core::FE::Dbc::build_dbc_map_extractor` is a null "
       "pointer. This violates the implicit assumption that it must be non-null when "
       "`dbcmapextractor` is non-null.");
 

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_evaluate.cpp
@@ -51,13 +51,13 @@ namespace
         actele = discret.l_col_element(i);
 
       {
-        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate LocationVector");
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Evaluate LocationVector");
         // get element location vector, dirichlet flags and ownerships
         actele->location_vector(discret, la);
       }
 
       {
-        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate Resize");
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Evaluate Resize");
 
         // get dimension of element matrices and vectors
         // Reshape element matrices and vectors and init to zero
@@ -65,7 +65,7 @@ namespace
       }
 
       {
-        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate elements");
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Evaluate elements");
         // call the element evaluate method
         int err =
             actele->evaluate(eparams, discret, la, strategy.elematrix1(), strategy.elematrix2(),
@@ -76,7 +76,7 @@ namespace
       }
 
       {
-        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate assemble");
+        TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Evaluate assemble");
         int eid = actele->id();
         strategy.assemble_matrix1(eid, la[row].lm_, la[col].lm_, la[row].lmowner_, la[col].stride_);
         strategy.assemble_matrix2(eid, la[row].lm_, la[col].lm_, la[row].lmowner_, la[col].stride_);
@@ -91,12 +91,12 @@ namespace
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
+void Core::FE::evaluate(Core::FE::Discretization& discret, Teuchos::ParameterList& eparams,
     const std::shared_ptr<Core::LinAlg::SparseOperator>& systemmatrix,
     const std::shared_ptr<Core::LinAlg::Vector<double>>& systemvector,
     const Core::LinAlg::Map* col_ele_map)
 {
-  TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Utils::Evaluate");
+  TEUCHOS_FUNC_TIME_MONITOR("Core::FE::Evaluate");
   Core::FE::AssembleStrategy strategy(0, 0, systemmatrix, nullptr, systemvector, nullptr, nullptr);
   evaluate_internal(discret, eparams, strategy, col_ele_map);
 }

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
@@ -95,13 +95,13 @@ Core::FE::Nurbs::NurbsDiscretization::get_knot_vector() const
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
+void Core::FE::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, double time,
     const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-    Core::FE::Utils::Dbc::DbcInfo& info, std::shared_ptr<std::set<int>>* dbcgids) const
+    Core::FE::Dbc::DbcInfo& info, std::shared_ptr<std::set<int>>* dbcgids) const
 {
   // --------------------------- Step 1 ---------------------------------------
-  Core::FE::Utils::Dbc::evaluate(params, discret, time, systemvectors, info, dbcgids);
+  Core::FE::Dbc::evaluate(params, discret, time, systemvectors, info, dbcgids);
 
   // --------------------------- Step 2 ---------------------------------------
   std::vector<std::string> dbc_cond_names(2, "");
@@ -119,7 +119,7 @@ void Core::FE::Utils::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
     std::copy(curr_conds.begin(), curr_conds.end(), std::back_inserter(conds));
   }
 
-  Core::FE::Utils::Dbc::DbcInfo info2(info.toggle.get_map());
+  Core::FE::Dbc::DbcInfo info2(info.toggle.get_map());
   read_dirichlet_condition(params, discret, conds, time, info2, dbcgids);
 
   // --------------------------- Step 3 ---------------------------------------
@@ -136,7 +136,7 @@ void Core::FE::Utils::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
   if (not discret_nurbs) FOUR_C_THROW("Dynamic cast failed!");
 
   // build dummy column toggle vector and auxiliary vectors
-  Core::FE::Utils::Dbc::DbcInfo info_col(*discret_nurbs->dof_col_map());
+  Core::FE::Dbc::DbcInfo info_col(*discret_nurbs->dof_col_map());
   read_dirichlet_condition(params, discret, conds, time, info_col, dbcgids_nurbs);
 
   // --------------------------- Step 4 ---------------------------------------
@@ -146,7 +146,7 @@ void Core::FE::Utils::DbcNurbs::evaluate(const Teuchos::ParameterList& params,
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Core::FE::Utils::DbcNurbs::do_dirichlet_condition(const Teuchos::ParameterList& params,
+void Core::FE::DbcNurbs::do_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond, double time,
     const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
     const Core::LinAlg::Vector<int>& toggle, const std::shared_ptr<std::set<int>>* dbcgids) const
@@ -154,7 +154,7 @@ void Core::FE::Utils::DbcNurbs::do_dirichlet_condition(const Teuchos::ParameterL
   // default call
   if (dbcgids[set_col] == nullptr)
   {
-    Core::FE::Utils::Dbc::do_dirichlet_condition(
+    Core::FE::Dbc::do_dirichlet_condition(
         params, discret, cond, time, systemvectors, toggle, dbcgids);
     return;
   }
@@ -513,7 +513,7 @@ void Core::FE::Utils::DbcNurbs::do_dirichlet_condition(const Teuchos::ParameterL
  |  evaluate Dirichlet conditions (public)                   vuong 08/14|
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
-void Core::FE::Utils::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_boundary(
+void Core::FE::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_boundary(
     Core::Elements::Element& actele, const std::vector<Core::LinAlg::SerialDenseVector>* knots,
     const std::vector<int>& lm, const std::vector<std::optional<int>>& funct,
     const std::vector<double>& val, const unsigned deg, const double time,
@@ -654,7 +654,7 @@ void Core::FE::Utils::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_boundary(
  |  evaluate Dirichlet conditions (public)                   vuong 08/14|
  *----------------------------------------------------------------------*/
 template <Core::FE::CellType distype>
-void Core::FE::Utils::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_domain(
+void Core::FE::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_domain(
     Core::Elements::Element& actele, const std::vector<Core::LinAlg::SerialDenseVector>* knots,
     const std::vector<int>& lm, const std::vector<std::optional<int>>& funct,
     const std::vector<double>& val, const unsigned deg, const double time,

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.hpp
@@ -142,75 +142,72 @@ namespace Core::FE
     };  // class NurbsDiscretization
   }  // namespace Nurbs
 
-  namespace Utils
+  class DbcNurbs : public Core::FE::Dbc
   {
-    class DbcNurbs : public Core::FE::Utils::Dbc
-    {
-      using Dbc::do_dirichlet_condition;
+    using Dbc::do_dirichlet_condition;
 
-     public:
-      /// constructor
-      DbcNurbs() = default;
+   public:
+    /// constructor
+    DbcNurbs() = default;
 
 
-     protected:
-      void evaluate(const Teuchos::ParameterList& params, const Core::FE::Discretization& discret,
-          double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          DbcInfo& info, std::shared_ptr<std::set<int>>* dbcgids) const override;
+   protected:
+    void evaluate(const Teuchos::ParameterList& params, const Core::FE::Discretization& discret,
+        double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        DbcInfo& info, std::shared_ptr<std::set<int>>* dbcgids) const override;
 
-      void do_dirichlet_condition(const Teuchos::ParameterList& params,
-          const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
-          double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
-          const Core::LinAlg::Vector<int>& toggle,
-          const std::shared_ptr<std::set<int>>* dbcgids) const override;
+    void do_dirichlet_condition(const Teuchos::ParameterList& params,
+        const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond,
+        double time, const std::shared_ptr<Core::LinAlg::Vector<double>>* systemvectors,
+        const Core::LinAlg::Vector<int>& toggle,
+        const std::shared_ptr<std::set<int>>* dbcgids) const override;
 
-     private:
-      /*!
-      \brief Fill mass matrix and rhs vector for evaluation of least squares dirichlet on a boundary
+   private:
+    /*!
+    \brief Fill mass matrix and rhs vector for evaluation of least squares dirichlet on a boundary
 
-      \param ele          The element that is to be evaluated
+    \param ele          The element that is to be evaluated
+    \param knots        element knot vector
+    \param lm           reduced location vector of element (DBC DOFs only)
+    \param funct        function information (read from the condition)
+    \param val          value information (read from the condition)
+    \param deg          degree of time derivative needed
+    \param time         current time
+    \param elemass      element matrix to be filled
+    \param elerhs       element right hand side to be filled
+
+    */
+    template <Core::FE::CellType distype>
+    void fill_matrix_and_rhs_for_ls_dirichlet_boundary(Core::Elements::Element& ele,
+        const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
+        const std::vector<std::optional<int>>& funct, const std::vector<double>& val,
+        const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
+        std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
+        const Core::Utils::FunctionManager& function_manager) const;
+
+    /*!
+    \brief Fill mass matrix and rhs vector for evaluation of least squares dirichlet on a domain
+
+    \param ele          The element that is to be evaluated
       \param knots        element knot vector
-      \param lm           reduced location vector of element (DBC DOFs only)
-      \param funct        function information (read from the condition)
-      \param val          value information (read from the condition)
-      \param deg          degree of time derivative needed
-      \param time         current time
-      \param elemass      element matrix to be filled
-      \param elerhs       element right hand side to be filled
+    \param lm           reduced location vector of element (DBC DOFs only)
+    \param funct        function information (read from the condition)
+    \param val          value information (read from the condition)
+    \param deg          degree of time derivative needed
+    \param time         current time
+    \param elemass      element matrix to be filled
+    \param elerhs       element right hand side to be filled
 
-      */
-      template <Core::FE::CellType distype>
-      void fill_matrix_and_rhs_for_ls_dirichlet_boundary(Core::Elements::Element& ele,
-          const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
-          const std::vector<std::optional<int>>& funct, const std::vector<double>& val,
-          const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
-          std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
-          const Core::Utils::FunctionManager& function_manager) const;
+    */
+    template <Core::FE::CellType distype>
+    void fill_matrix_and_rhs_for_ls_dirichlet_domain(Core::Elements::Element& ele,
+        const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
+        const std::vector<std::optional<int>>& funct, const std::vector<double>& val,
+        const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
+        std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
+        const Core::Utils::FunctionManager& function_manager) const;
 
-      /*!
-      \brief Fill mass matrix and rhs vector for evaluation of least squares dirichlet on a domain
-
-      \param ele          The element that is to be evaluated
-        \param knots        element knot vector
-      \param lm           reduced location vector of element (DBC DOFs only)
-      \param funct        function information (read from the condition)
-      \param val          value information (read from the condition)
-      \param deg          degree of time derivative needed
-      \param time         current time
-      \param elemass      element matrix to be filled
-      \param elerhs       element right hand side to be filled
-
-      */
-      template <Core::FE::CellType distype>
-      void fill_matrix_and_rhs_for_ls_dirichlet_domain(Core::Elements::Element& ele,
-          const std::vector<Core::LinAlg::SerialDenseVector>* knots, const std::vector<int>& lm,
-          const std::vector<std::optional<int>>& funct, const std::vector<double>& val,
-          const unsigned deg, const double time, Core::LinAlg::SerialDenseMatrix& elemass,
-          std::vector<Core::LinAlg::SerialDenseVector>& elerhs,
-          const Core::Utils::FunctionManager& function_manager) const;
-
-    };  // class DbcNurbs
-  }  // namespace Utils
+  };  // class DbcNurbs
 }  // namespace Core::FE
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/fluid/4C_fluid_DbcHDG.cpp
+++ b/src/fluid/4C_fluid_DbcHDG.cpp
@@ -21,7 +21,7 @@ FOUR_C_NAMESPACE_OPEN
  *----------------------------------------------------------------------*/
 void FLD::Utils::DbcHdgFluid::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::Discretization& discret, const Core::Conditions::Condition& cond, double time,
-    Core::FE::Utils::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+    Core::FE::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
     int hierarchical_order) const
 {
   // no need to check the cast, because it has been done during
@@ -36,12 +36,12 @@ void FLD::Utils::DbcHdgFluid::read_dirichlet_condition(const Teuchos::ParameterL
  *----------------------------------------------------------------------*/
 void FLD::Utils::DbcHdgFluid::read_dirichlet_condition(const Teuchos::ParameterList& params,
     const Core::FE::DiscretizationFaces& discret, const Core::Conditions::Condition& cond,
-    double time, Core::FE::Utils::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
+    double time, Core::FE::Dbc::DbcInfo& info, const std::shared_ptr<std::set<int>>* dbcgids,
     int hierarchical_order) const
 
 {
   // call to corresponding method in base class; safety checks inside
-  Core::FE::Utils::Dbc::read_dirichlet_condition(
+  Core::FE::Dbc::read_dirichlet_condition(
       params, discret, cond, time, info, dbcgids, hierarchical_order);
 
   // say good bye if there are no face elements
@@ -160,7 +160,7 @@ void FLD::Utils::DbcHdgFluid::do_dirichlet_condition(const Teuchos::ParameterLis
     const Core::LinAlg::Vector<int>& toggle) const
 {
   // call corresponding method from base class; safety checks inside
-  Core::FE::Utils::Dbc::do_dirichlet_condition(
+  Core::FE::Dbc::do_dirichlet_condition(
       params, discret, cond, time, systemvectors, toggle, nullptr);
 
   // say good bye if there are no face elements

--- a/src/fluid/4C_fluid_DbcHDG.hpp
+++ b/src/fluid/4C_fluid_DbcHDG.hpp
@@ -30,7 +30,7 @@ namespace FLD
     /** \brief Specialized Dbc evaluation class for HDG discretizations
      *
      *  */
-    class DbcHdgFluid : public Core::FE::Utils::Dbc
+    class DbcHdgFluid : public Core::FE::Dbc
     {
      public:
       /// constructor

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -6492,7 +6492,7 @@ void FLD::FluidImplicitTimeInt::apply_dirichlet_bc(Teuchos::ParameterList& param
   // If we have HDG discret
   if (dynamic_cast<const Core::FE::DiscretizationHDG*>(&(*discret_)) != nullptr)
   {
-    auto dbc = std::shared_ptr<const Core::FE::Utils::Dbc>(new const FLD::Utils::DbcHdgFluid());
+    auto dbc = std::shared_ptr<const Core::FE::Dbc>(new const FLD::Utils::DbcHdgFluid());
     (*dbc)(*discret_, params, systemvector, systemvectord, systemvectordd, nullptr,
         recreatemap ? dbcmaps_ : nullptr);
   }

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -2296,8 +2296,7 @@ void Solid::TimInt::determine_stress_strain()
 
     std::shared_ptr<Core::LinAlg::SparseOperator> system_matrix = nullptr;
     std::shared_ptr<Core::LinAlg::Vector<double>> system_vector = nullptr;
-    Core::FE::Utils::evaluate(
-        *discret_, p, system_matrix, system_vector, discret_->element_row_map());
+    Core::FE::evaluate(*discret_, p, system_matrix, system_vector, discret_->element_row_map());
     discret_->clear_state();
   }
 }

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -240,7 +240,7 @@ void Solid::TimeInt::BaseDataGlobalState::set_initial_fields()
   localdofs.push_back(1);
   localdofs.push_back(2);
 
-  Core::FE::Utils::evaluate_initial_field(
+  Core::FE::evaluate_initial_field(
       Global::Problem::instance()->function_manager(), *discret_, field, *velnp_, localdofs);
 
   // set initial porosity field if existing
@@ -248,8 +248,8 @@ void Solid::TimeInt::BaseDataGlobalState::set_initial_fields()
   std::vector<int> porositylocaldofs;
   porositylocaldofs.push_back(Global::Problem::instance()->n_dim());
 
-  Core::FE::Utils::evaluate_initial_field(Global::Problem::instance()->function_manager(),
-      *discret_, porosityfield, *(*dis_)(0), porositylocaldofs);
+  Core::FE::evaluate_initial_field(Global::Problem::instance()->function_manager(), *discret_,
+      porosityfield, *(*dis_)(0), porositylocaldofs);
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_structure.cpp
@@ -1344,7 +1344,7 @@ void Solid::ModelEvaluator::Structure::evaluate_internal_specified_elements(
   // this is about to go, once the old time integration is deleted
   params_interface2_parameter_list(eval_data_ptr(), p);
 
-  Core::FE::Utils::evaluate(*discret_ptr(), p, *eval_mat, *eval_vec, ele_map_to_be_evaluated);
+  Core::FE::evaluate(*discret_ptr(), p, *eval_mat, *eval_vec, ele_map_to_be_evaluated);
 
   discret().clear_state();
 }


### PR DESCRIPTION
Found this while working on #935 where this clashes with `Core::Utils`. I don't think the nested `FE::Utils` namespace is useful, so I removed it to follow the general recommendation that if in doubt, fewer namespaces are better.

Part of #51 

I recommend ignoring whitespace changes for the review.