### PR TITLE
Don't append timestamp to ccache key

### DIFF
--- a/.github/actions/build_4C/action.yml
+++ b/.github/actions/build_4C/action.yml
@@ -44,6 +44,7 @@ runs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ${{ steps.prepare-cache-key.outputs.cache_key }}
+        append-timestamp: false
     - uses: ./.github/actions/configure_4C
       with:
         cmake-preset: ${{ inputs.cmake-preset }}


### PR DESCRIPTION
I don't really understand why the ccache action per default appends the timestamp to the cache key. The result is that we have a lot of redundant caches for single branches and might lose the (important) caches from the main branch. Without the timestap, new cache entries replaces old ones from the same branch.

@davidrudlstorfer 