### PR TITLE
Remove undefined behaviour for access of empty std::vectors

### DIFF
--- a/src/core/comm/src/4C_comm_pack_buffer.hpp
+++ b/src/core/comm/src/4C_comm_pack_buffer.hpp
@@ -111,7 +111,7 @@ namespace Core::Communication
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       // Check that the type matches the type that was packed.
       std::size_t hash;
-      std::memcpy(&hash, &data_[position_], sizeof(hash));
+      std::memcpy(&hash, data_.data() + position_, sizeof(hash));
       position_ += sizeof(hash);
       FOUR_C_ASSERT(hash == typeid(T).hash_code(),
           "Type mismatch during unpacking. Tried to extract type {}", typeid(T).name());
@@ -119,7 +119,7 @@ namespace Core::Communication
 
       // We know that stuff is trivially copyable, so we can safely use memcpy. We cast to void* to
       // circumvent a GCC warning
-      std::memcpy(static_cast<void*>(&stuff), &data_[position_], sizeof(T));
+      std::memcpy(static_cast<void*>(&stuff), data_.data() + position_, sizeof(T));
       position_ += sizeof(T);
     }
 
@@ -137,16 +137,17 @@ namespace Core::Communication
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       // Check that the type matches the type that was packed.
       std::size_t hash;
-      std::memcpy(&hash, &data_[position_], sizeof(hash));
+      std::memcpy(&hash, data_.data() + position_, sizeof(hash));
       position_ += sizeof(hash);
       FOUR_C_ASSERT(hash == typeid(T).hash_code(),
           "Type mismatch during unpacking. Tried to extract type {}", typeid(T).name());
 #endif
 
-
+      FOUR_C_ASSERT(position_ + stuff_size <= data_.size(),
+          "UnpackBuffer: Trying to extract more data than available in the buffer.");
       // We know that stuff is trivially copyable, so we can safely use memcpy. We cast to void* to
       // circumvent a GCC warning
-      std::memcpy(static_cast<void*>(stuff), &data_[position_], stuff_size);
+      memcpy(static_cast<void*>(stuff), data_.data() + position_, stuff_size);
       position_ += stuff_size;
     }
 
@@ -162,12 +163,13 @@ namespace Core::Communication
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       // Check that the type matches the type that was packed.
       std::size_t hash;
-      std::memcpy(&hash, &data_[position_], sizeof(hash));
+      std::memcpy(&hash, data_.data() + position_, sizeof(hash));
       position += sizeof(hash);
       FOUR_C_ASSERT(hash == typeid(T).hash_code(), "Type mismatch during unpacking.");
 #endif
-
-      memcpy(&stuff, &data_[position], sizeof(T));
+      FOUR_C_ASSERT(position < data_.size(),
+          "UnpackBuffer: Trying to extract more data than available in the buffer.");
+      memcpy(&stuff, data_.data() + position, sizeof(T));
     }
 
     /**

--- a/src/core/fem/src/discretization/4C_fem_discretization_conditions.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_conditions.cpp
@@ -164,7 +164,7 @@ void Core::FE::Discretization::assign_global_ids(MPI_Comm comm,
       index += 1;
       std::vector<int> element;
       element.reserve(esize);
-      std::copy(&recv[index], &recv[index + esize], std::back_inserter(element));
+      std::copy(recv.begin() + index, recv.begin() + index + esize, std::back_inserter(element));
       index += esize;
       elements.insert(element);
     }
@@ -201,7 +201,7 @@ void Core::FE::Discretization::assign_global_ids(MPI_Comm comm,
     index += 1;
     std::vector<int> element;
     element.reserve(esize);
-    std::copy(&send[index], &send[index + esize], std::back_inserter(element));
+    std::copy(send.begin() + index, send.begin() + index + esize, std::back_inserter(element));
     index += esize;
 
     // set gid to my elements

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -301,7 +301,8 @@ std::shared_ptr<const Core::LinAlg::Graph> Core::Rebalance::build_graph(
     }
     Core::Communication::broadcast(&size, 1, proc, dis.get_comm());
     if (proc != myrank) recvnodes.resize(size);
-    Core::Communication::broadcast(&recvnodes[0], size, proc, dis.get_comm());
+    Core::Communication::broadcast(
+        recvnodes.empty() ? nullptr : &recvnodes[0], size, proc, dis.get_comm());
     if (proc != myrank && size)
     {
       int* ptr = &recvnodes[0];


### PR DESCRIPTION
Below, I have updated some places at which we currently have code of the form `&vec[0]`, which is undefined behaviour if the vector is empty, as the access operator is not defined in that case. My gcc asserts this in debug mode, that's how I came across the issue. 
My proposed solution is to use std::vector::data() plus pointer arithmetics, as data() is guaranteed to return null for an empty vector. However this takes out the assertion in debug mode completely so maybe the approach depicted in `src/core/rebalance/src/4C_rebalance_graph_based.cpp` is more suitable. 
