### PR TITLE
Simplify string conversion

### DIFF
--- a/apps/post_processor/4C_post_processor_single_field_writers.cpp
+++ b/apps/post_processor/4C_post_processor_single_field_writers.cpp
@@ -272,9 +272,7 @@ void FluidFilter::write_all_results(PostField* field)
 
   for (int k = 0; k < num_levelsets; k++)
   {
-    std::ostringstream temp;
-    temp << k;
-    std::string name = "phinp_" + temp.str();
+    std::string name = "phinp_" + std::to_string(k);
     writer_->write_result(name, name, nodebased, 1);
   }
 

--- a/src/mat/4C_mat_fluidporo_multiphase_singlereaction.cpp
+++ b/src/mat/4C_mat_fluidporo_multiphase_singlereaction.cpp
@@ -72,27 +72,17 @@ void Mat::PAR::FluidPoroSingleReaction::initialize_internal()
   {
     // add scalar names
     {
-      std::ostringstream temp;
-      temp << k + 1;
-      scalarnames_[k] = "phi" + temp.str();
+      scalarnames_[k] = "phi" + std::to_string(k + 1);
     }
   }
 
   for (int k = 0; k < numfluidphases_; k++)
   {
     // add pressure names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      pressurenames_[k] = "p" + temp.str();
-    }
+    pressurenames_[k] = "p" + std::to_string(k + 1);
 
     // add saturation names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      saturationnames_[k] = "S" + temp.str();
-    }
+    saturationnames_[k] = "S" + std::to_string(k + 1);
   }
 
 
@@ -100,17 +90,10 @@ void Mat::PAR::FluidPoroSingleReaction::initialize_internal()
   for (int k = 0; k < numvolfrac_; k++)
   {
     // add volume fraction names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      volfracnames_[k] = "VF" + temp.str();
-    }
+    volfracnames_[k] = "VF" + std::to_string(k + 1);
+
     // add volume fraction pressure names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      volfracpressurenames_[k] = "VFP" + temp.str();
-    }
+    volfracpressurenames_[k] = "VFP" + std::to_string(k + 1);
   }
 
   isinit_ = true;

--- a/src/mat/4C_mat_list_reactions.cpp
+++ b/src/mat/4C_mat_list_reactions.cpp
@@ -373,9 +373,7 @@ void Mat::MatListReactions::calc_rea_body_force_deriv_matrix_add_variables(const
   // add scalar values as constants
   for (unsigned iscal = 0; iscal < phinp.size(); iscal++)
   {
-    std::ostringstream temp;
-    temp << iscal + 1;
-    constants_mod.emplace_back("phi" + temp.str(), phinp[iscal]);
+    constants_mod.emplace_back("phi" + std::to_string(iscal + 1), phinp[iscal]);
   }
   constants_mod.emplace_back("t", time);
   constants_mod.emplace_back("x", gpcoord[0]);

--- a/src/mat/4C_mat_scatra_reaction_coupling.cpp
+++ b/src/mat/4C_mat_scatra_reaction_coupling.cpp
@@ -611,10 +611,7 @@ void Mat::PAR::REACTIONCOUPLING::ByFunction::initialize_internal(
         for (int k = 0; k < numscal; k++)
         {
           // construct the strings for scalar
-          std::ostringstream temp;
-          temp << k + 1;
-          std::string name = "phi" + temp.str();
-
+          std::string name = "phi" + std::to_string(k + 1);
 
           // save the phi values with correct name
           variables_.emplace_back(name, 0.0);

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -668,9 +668,7 @@ void PoroPressureBased::PorofluidAlgorithm::collect_runtime_output_data()
     {
       Core::LinAlg::MultiVector<double> flux_k(*noderowmap, 3, true);
 
-      std::ostringstream temp;
-      temp << k + 1;
-      std::string name = "flux_" + temp.str();
+      std::string name = "flux_" + std::to_string(k + 1);
       for (int i = 0; i < flux_k.MyLength(); ++i)
       {
         // get value for each component of flux vector

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_pair.cpp
@@ -4031,55 +4031,32 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingPair<dis_type_artery,
   for (int k = 0; k < num_scalars_homogenized_; k++)
   {
     // add scalar names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      scalar_names_[k] = "phi" + temp.str();
-    }
+    scalar_names_[k] = "phi" + std::to_string(k + 1);
   }
 
   for (int k = 0; k < num_scalars_artery_; k++)
   {
     // add artery-scalar names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      artery_scalar_names_[k] = "phi_art" + temp.str();
-    }
+    artery_scalar_names_[k] = "phi_art" + std::to_string(k + 1);
   }
 
   for (int k = 0; k < num_fluid_phases_; k++)
   {
     // add pressure names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      pressure_names_[k] = "p" + temp.str();
-    }
+    pressure_names_[k] = "p" + std::to_string(k + 1);
 
     // add saturation names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      saturation_names_[k] = "S" + temp.str();
-    }
+    saturation_names_[k] = "S" + std::to_string(k + 1);
   }
 
   // add additional volume fractions
   for (int k = 0; k < num_volfracs_; k++)
   {
     // add volume fraction names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      volfrac_names_[k] = "VF" + temp.str();
-    }
+    volfrac_names_[k] = "VF" + std::to_string(k + 1);
+
     // add volume fraction pressure names
-    {
-      std::ostringstream temp;
-      temp << k + 1;
-      volfrac_pressure_names_[k] = "VFP" + temp.str();
-    }
+    volfrac_pressure_names_[k] = "VFP" + std::to_string(k + 1);
   }
 }
 

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluator.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_evaluator.cpp
@@ -2955,13 +2955,12 @@ void Discret::Elements::PoroFluidEvaluator::EvaluatorDomainIntegrals<nsd,
   // set pressure, saturation and density values as constants
   for (int k = 0; k < numfluidphases; k++)
   {
-    std::ostringstream temp;
-    temp << k + 1;
-    constants.push_back(std::pair<std::string, double>("p" + temp.str(), phasemanager.pressure(k)));
     constants.push_back(
-        std::pair<std::string, double>("S" + temp.str(), phasemanager.saturation(k)));
+        std::pair<std::string, double>("p" + std::to_string(k + 1), phasemanager.pressure(k)));
     constants.push_back(
-        std::pair<std::string, double>("DENS" + temp.str(), phasemanager.density(k)));
+        std::pair<std::string, double>("S" + std::to_string(k + 1), phasemanager.saturation(k)));
+    constants.push_back(
+        std::pair<std::string, double>("DENS" + std::to_string(k + 1), phasemanager.density(k)));
   }
 
   // set porosity value as constant
@@ -2970,23 +2969,19 @@ void Discret::Elements::PoroFluidEvaluator::EvaluatorDomainIntegrals<nsd,
   // set volfrac, volfrac pressure and volfrac density values as constants
   for (int k = 0; k < numvolfrac; k++)
   {
-    std::ostringstream temp;
-    temp << k + 1;
     constants.push_back(
-        std::pair<std::string, double>("VF" + temp.str(), phasemanager.vol_frac(k)));
-    constants.push_back(
-        std::pair<std::string, double>("VFP" + temp.str(), phasemanager.vol_frac_pressure(k)));
-    constants.push_back(
-        std::pair<std::string, double>("VFDENS" + temp.str(), phasemanager.vol_frac_density(k)));
+        std::pair<std::string, double>("VF" + std::to_string(k + 1), phasemanager.vol_frac(k)));
+    constants.push_back(std::pair<std::string, double>(
+        "VFP" + std::to_string(k + 1), phasemanager.vol_frac_pressure(k)));
+    constants.push_back(std::pair<std::string, double>(
+        "VFDENS" + std::to_string(k + 1), phasemanager.vol_frac_density(k)));
   }
 
   // set scalar values as constants
   for (int k = 0; k < numscal_; k++)
   {
-    std::ostringstream temp;
-    temp << k + 1;
-    constants.push_back(
-        std::pair<std::string, double>("phi" + temp.str(), variablemanager.scalarnp()->at(k)));
+    constants.push_back(std::pair<std::string, double>(
+        "phi" + std::to_string(k + 1), variablemanager.scalarnp()->at(k)));
   }
 
   // calculate the coordinates of the gauss point

--- a/src/scatra/4C_scatra_timint_cardiac_monodomain.cpp
+++ b/src/scatra/4C_scatra_timint_cardiac_monodomain.cpp
@@ -113,14 +113,12 @@ void ScaTra::TimIntCardiacMonodomain::collect_runtime_output_data()
 
     for (int k = 0; k < material_internal_state_np_->NumVectors(); ++k)
     {
-      std::ostringstream temp;
-      temp << k + 1;
       material_internal_state_np_component_ =
           std::make_shared<Core::LinAlg::Vector<double>>((*material_internal_state_np_)(k));
 
       visualization_writer().append_result_data_vector_with_context(
           *material_internal_state_np_component_, Core::IO::OutputEntity::element,
-          {"mat_int_state_" + temp.str()});
+          {"mat_int_state_" + std::to_string(k + 1)});
     }
   }
 
@@ -138,14 +136,12 @@ void ScaTra::TimIntCardiacMonodomain::collect_runtime_output_data()
 
     for (int k = 0; k < material_ionic_currents_np_->NumVectors(); ++k)
     {
-      std::ostringstream temp;
-      temp << k + 1;
       material_ionic_currents_np_component_ =
           std::make_shared<Core::LinAlg::Vector<double>>((*material_ionic_currents_np_)(k));
 
       visualization_writer().append_result_data_vector_with_context(
           *material_ionic_currents_np_component_, Core::IO::OutputEntity::element,
-          {"mat_ionic_currents_" + temp.str()});
+          {"mat_ionic_currents_" + std::to_string(k + 1)});
     }
   }
 }

--- a/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme_hdg.cpp
+++ b/src/scatra/4C_scatra_timint_cardiac_monodomain_scheme_hdg.cpp
@@ -115,14 +115,12 @@ void ScaTra::TimIntCardiacMonodomainHDG::collect_runtime_output_data()
 
     for (int k = 0; k < material_internal_state_np_->NumVectors(); ++k)
     {
-      std::ostringstream temp;
-      temp << k + 1;
       material_internal_state_np_component_ =
           std::make_shared<Core::LinAlg::Vector<double>>((*material_internal_state_np_)(k));
 
       visualization_writer().append_result_data_vector_with_context(
           *material_internal_state_np_component_, Core::IO::OutputEntity::element,
-          {"mat_int_state" + temp.str()});
+          {"mat_int_state" + std::to_string(k + 1)});
     }
   }
 }

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -1191,10 +1191,8 @@ void ScaTra::ScaTraTimIntElch::post_process_single_electrode_info(
         currentintegral / boundaryint_porous + currentdlintegral / boundaryint_porous);
 
     // write results to file
-    std::ostringstream temp;
-    temp << id;
-    const std::string fname =
-        problem_->output_control_file()->file_name() + ".electrode_status_" + temp.str() + ".txt";
+    const std::string fname = problem_->output_control_file()->file_name() + ".electrode_status_" +
+                              std::to_string(id) + ".txt";
 
     std::ofstream f;
     if (step() == 0)

--- a/src/scatra/4C_scatra_timint_elch_scheme.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scheme.cpp
@@ -119,24 +119,21 @@ void ScaTra::ScaTraTimIntElchOST::write_restart() const
       // galvanostatic mode: only applied potential of cathode is adapted
       if (condid_cathode == condid or dlcapexists_)
       {
-        std::stringstream temp;
-        temp << condid;
-
         // electrode potential of the adjusted electrode kinetics BC at time n+1
         auto pot = mycond->parameters().get<double>("POT");
-        output_->write_double("pot_" + temp.str(), pot);
+        output_->write_double("pot_" + std::to_string(condid), pot);
 
         // electrode potential of the adjusted electrode kinetics BC at time n
         auto pot0n = mycond->parameters().get<double>("pot0n");
-        output_->write_double("pot0n_" + temp.str(), pot0n);
+        output_->write_double("pot0n_" + std::to_string(condid), pot0n);
 
         // electrode potential time derivative of the adjusted electrode kinetics BC at time n
         auto pot0dtn = mycond->parameters().get<double>("pot0dtn");
-        output_->write_double("pot0dtn_" + temp.str(), pot0dtn);
+        output_->write_double("pot0dtn_" + std::to_string(condid), pot0dtn);
 
         // history of electrode potential of the adjusted electrode kinetics BC
         auto pothist = mycond->parameters().get<double>("pot0hist");
-        output_->write_double("pot0hist_" + temp.str(), pothist);
+        output_->write_double("pot0hist_" + std::to_string(condid), pothist);
       }
     }
   }
@@ -181,16 +178,13 @@ void ScaTra::ScaTraTimIntElchOST::read_restart(
       // galvanostatic mode: only applied potential of cathode is adapted
       if (condid_cathode == condid or dlcapexists_)
       {
-        std::stringstream temp;
-        temp << condid;
-
-        double pot = reader->read_double("pot_" + temp.str());
+        double pot = reader->read_double("pot_" + std::to_string(condid));
         const_cast<Core::Conditions::Condition*>(mycond)->parameters().add("POT", pot);
-        double pot0n = reader->read_double("pot0n_" + temp.str());
+        double pot0n = reader->read_double("pot0n_" + std::to_string(condid));
         const_cast<Core::Conditions::Condition*>(mycond)->parameters().add("pot0n", pot0n);
-        double pot0hist = reader->read_double("pot0hist_" + temp.str());
+        double pot0hist = reader->read_double("pot0hist_" + std::to_string(condid));
         const_cast<Core::Conditions::Condition*>(mycond)->parameters().add("pot0hist", pot0hist);
-        double pot0dtn = reader->read_double("pot0dtn_" + temp.str());
+        double pot0dtn = reader->read_double("pot0dtn_" + std::to_string(condid));
         const_cast<Core::Conditions::Condition*>(mycond)->parameters().add("pot0dtn", pot0dtn);
         read_pot = true;
         if (myrank_ == 0)

--- a/src/scatra/4C_scatra_timint_implicit_service.cpp
+++ b/src/scatra/4C_scatra_timint_implicit_service.cpp
@@ -490,11 +490,9 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> ScaTra::ScaTraTimIntImpl::cal
     // print out results to file as well (only if really desired)
     if ((myrank_ == 0) and writetofile)
     {
-      std::ostringstream temp;
-      temp << icond;
-      temp << discret_->name();
       const std::string fname = problem_->output_control_file()->file_name() +
-                                ".boundaryflux_ScaTraFluxCalc_" + temp.str() + ".txt";
+                                ".boundaryflux_ScaTraFluxCalc_" + std::to_string(icond) +
+                                discret_->name() + ".txt";
 
       std::ofstream f;
       if (step() <= 1)
@@ -852,9 +850,7 @@ void ScaTra::ScaTraTimIntImpl::add_flux_approx_to_parameter_list(Teuchos::Parame
       std::make_shared<Core::LinAlg::MultiVector<double>>(*noderowmap, 3, true);
   for (int k = 0; k < num_scal(); ++k)
   {
-    std::ostringstream temp;
-    temp << k;
-    std::string name = "flux_phi_" + temp.str();
+    const std::string name = "flux_phi_" + std::to_string(k);
     for (int i = 0; i < fluxk->MyLength(); ++i)
     {
       Core::Nodes::Node* actnode = discret_->l_row_node(i);
@@ -1162,9 +1158,7 @@ void ScaTra::ScaTraTimIntImpl::collect_output_flux_data(
   auto fluxk = Core::LinAlg::MultiVector<double>(*noderowmap, 3, true);
   for (int writefluxid : *writefluxids_)
   {
-    std::ostringstream temp;
-    temp << writefluxid;
-    std::string name = "flux_" + fluxtype + "_phi_" + temp.str();
+    std::string name = "flux_" + fluxtype + "_phi_" + std::to_string(writefluxid);
     for (int i = 0; i < fluxk.MyLength(); ++i)
     {
       Core::Nodes::Node* actnode = discret_->l_row_node(i);
@@ -2015,10 +2009,8 @@ void ScaTra::ScaTraTimIntImpl::evaluate_error_compared_to_analytical_sol()
 
         if (myrank_ == 0)
         {
-          std::ostringstream temp;
-          temp << k;
           const std::string simulation = problem_->output_control_file()->file_name();
-          const std::string fname = simulation + "_c" + temp.str() + "_time.relerror";
+          const std::string fname = simulation + "_c" + std::to_string(k) + "_time.relerror";
           std::ofstream f;
 
           // create new error file and write initial error
@@ -2107,10 +2099,8 @@ void ScaTra::ScaTraTimIntImpl::evaluate_error_compared_to_analytical_sol()
         for (int k = 0; k < num_dof_per_node(); ++k)
         {
           // determine name of file associated with current degree of freedom
-          std::ostringstream temp;
-          temp << k;
-          const std::string fname =
-              problem_->output_control_file()->file_name() + "_dof_" + temp.str() + ".relerror";
+          const std::string fname = problem_->output_control_file()->file_name() + "_dof_" +
+                                    std::to_string(k) + ".relerror";
 
           // initialize output file stream
           std::ofstream f;

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc_loma.cpp
@@ -141,9 +141,7 @@ void Discret::Elements::ScaTraEleBoundaryCalcLoma<distype, probdim>::calc_loma_t
   Core::LinAlg::SerialDenseMatrix eflux(3, nenparent);
   Core::Elements::Element* peleptr = (Core::Elements::Element*)parentele;
   int k = my::numscal_ - 1;  // temperature is always last degree of freedom!!
-  std::ostringstream temp;
-  temp << k;
-  std::string name = "flux_phi_" + temp.str();
+  std::string name = "flux_phi_" + std::to_string(k);
   // try to get the pointer to the entry (and check if type is
   // std::shared_ptr<Core::LinAlg::MultiVector<double>>)
   std::shared_ptr<Core::LinAlg::MultiVector<double>>* f =

--- a/src/thermo/src/element/4C_thermo_element.cpp
+++ b/src/thermo/src/element/4C_thermo_element.cpp
@@ -297,22 +297,6 @@ std::vector<std::shared_ptr<Core::Elements::Element>> Thermo::Element::surfaces(
 }  // Surfaces()
 
 /*----------------------------------------------------------------------*
- | return names of visualization data (public)               dano 09/09 |
- *----------------------------------------------------------------------*/
-void Thermo::Element::vis_names(std::map<std::string, int>& names)
-{
-  // see whether we have additional data for visualization in our container
-  for (int k = 0; k < numdofpernode_; k++)
-  {
-    std::ostringstream temp;
-    temp << k;
-  }  // loop over temperatures
-
-  return;
-}  // vis_names()
-
-
-/*----------------------------------------------------------------------*
  | return visualization data (public)                        dano 09/09 |
  *----------------------------------------------------------------------*/
 bool Thermo::Element::vis_data(const std::string& name, std::vector<double>& data)

--- a/src/thermo/src/element/4C_thermo_element.hpp
+++ b/src/thermo/src/element/4C_thermo_element.hpp
@@ -252,7 +252,7 @@ namespace Thermo
     //! \param names (out): On return, the derived class has filled names with
     //!                     key names of data it wants to visualize and with int
     //!                     dimensions of that data.
-    void vis_names(std::map<std::string, int>& names) override;
+    void vis_names(std::map<std::string, int>& names) override {};
 
     //! \brief Query data to be visualized using BINIO of a given name
     //!

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -269,18 +269,13 @@ void XFEM::LevelSetCoupling::output(
 {
   // output for level-set interface
   // written for fluid fields
-
-  std::ostringstream temp;
-  temp << lsc_idx;
-  std::string name = "phinp_" + temp.str();
-
+  const std::string name = "phinp_" + std::to_string(lsc_idx);
   bg_output_->write_vector(name, phinp_);
 
   // write restart
   if (write_restart_data)
   {
-    std::string name_restart = "phinp_res_" + temp.str();
-
+    const std::string name_restart = "phinp_res_" + std::to_string(lsc_idx);
     bg_output_->write_vector(name_restart, phinp_);
   }
 
@@ -290,10 +285,7 @@ void XFEM::LevelSetCoupling::output(
   // write restart
   if (write_restart_data)
   {
-    std::ostringstream temp2;
-    temp2 << lsc_idx;
-    std::string name_restart = "cutter_phinp_res_" + temp.str();
-
+    const std::string name_restart = "cutter_phinp_res_" + std::to_string(lsc_idx);
     cutter_output_->write_vector(name_restart, cutter_phinp_);
   }
 }

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -106,10 +106,7 @@ void XFEM::MeshCoupling::create_cutter_dis_from_condition(std::string suffix)
   // "boundary_of_fluid_2")
   std::string cutterdis_name("boundary_of_");
   cutterdis_name += cond_dis_->name() + suffix;
-
-  std::ostringstream temp;
-  temp << coupling_id_;
-  cutterdis_name += "_" + temp.str();
+  cutterdis_name += "_" + std::to_string(coupling_id_);
 
   //--------------------------------
   // create the new cutter discretization form the conditioned coupling discretization


### PR DESCRIPTION
While working in #1000, I came across `std::to_string(k)` to replace the `temp` strings. 

@sebproell Does this make sense or does it cause some problems I am not aware of? Thanks!