### PR TITLE
Revert "Don't append timestamp to ccache key"

### DIFF
--- a/.github/actions/build_4C/action.yml
+++ b/.github/actions/build_4C/action.yml
@@ -44,7 +44,6 @@ runs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         key: ${{ steps.prepare-cache-key.outputs.cache_key }}
-        append-timestamp: false
     - uses: ./.github/actions/configure_4C
       with:
         cmake-preset: ${{ inputs.cmake-preset }}


### PR DESCRIPTION
The Github cache is immutable, so a cache-key can only be used once. So, I think it is sensible to append the timestamp.

Instead, we might manually delete old cache entries of a branch.