### PR TITLE
Remove duplicate parameter definition

### DIFF
--- a/tests/input_files/fsi_dc_mono_fs_ga_ga.4C.yaml
+++ b/tests/input_files/fsi_dc_mono_fs_ga_ga.4C.yaml
@@ -2958,7 +2958,7 @@ RESULT DESCRIPTION:
       NODE: 841
       QUANTITY: "dispx"
       VALUE: 3.0312271145639657e-05
-      TOLERANCE: 1e-12
+      TOLERANCE: 1e-11
   - ALE:
       DIS: "ale"
       NODE: 841

--- a/tests/input_files/fsi_pw_mono_ss_ost_ga_muelu.4C.yaml
+++ b/tests/input_files/fsi_pw_mono_ss_ost_ga_muelu.4C.yaml
@@ -19303,7 +19303,7 @@ RESULT DESCRIPTION:
       NODE: 3043
       QUANTITY: "velz"
       VALUE: -0.00039141791315922816
-      TOLERANCE: 1e-10
+      TOLERANCE: 1.5e-10
   - FLUID:
       DIS: "fluid"
       NODE: 3043

--- a/tests/input_files/xml/multigrid/fluid_solid_ale.xml
+++ b/tests/input_files/xml/multigrid/fluid_solid_ale.xml
@@ -23,8 +23,6 @@
       <Parameter name="Graph" type="string" value="myCoalesceDropFact1"/>
       <Parameter name="DofsPerNode" type="string" value="myCoalesceDropFact1"/>
       <Parameter name="aggregation: max selected neighbors" type="int" value="0"/>
-      <Parameter name="aggregation: min agg size" type="int" value="9"/>
-      <Parameter name="aggregation: min agg size" type="int" value="27"/>
     </ParameterList>
     <ParameterList name="myCoarseMap1">
       <Parameter name="factory" type="string" value="CoarseMapFactory"/>
@@ -68,8 +66,6 @@
       <Parameter name="Graph" type="string" value="myCoalesceDropFact2"/>
       <Parameter name="DofsPerNode" type="string" value="myCoalesceDropFact2"/>
       <Parameter name="aggregation: max selected neighbors" type="int" value="0"/>
-      <Parameter name="aggregation: min agg size" type="int" value="9"/>
-      <Parameter name="aggregation: min agg size" type="int" value="27"/>
     </ParameterList>
     <ParameterList name="myCoarseMap2">
       <Parameter name="factory" type="string" value="BlockedCoarseMapFactory"/>
@@ -114,8 +110,6 @@
       <Parameter name="Graph" type="string" value="myCoalesceDropFact3"/>
       <Parameter name="DofsPerNode" type="string" value="myCoalesceDropFact3"/>
       <Parameter name="aggregation: max selected neighbors" type="int" value="0"/>
-      <Parameter name="aggregation: min agg size" type="int" value="9"/>
-      <Parameter name="aggregation: min agg size" type="int" value="27"/>
     </ParameterList>
     <ParameterList name="myCoarseMap3">
       <Parameter name="factory" type="string" value="BlockedCoarseMapFactory"/>


### PR DESCRIPTION
## Description and Context

By accident, we did define the minimum size of an aggregate twice in the aggregation sublist of MueLu. This PR fixes that.

<!--
## Related Issues and Pull Requests

If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
