### PR TITLE
Add link to related projects to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See our [documentation](https://4c-multiphysics.github.io/4C/documentation/insta
 how to build 4C from source on your machine.
 Consult our [Tutorials](https://4c-multiphysics.github.io/4C/documentation/tutorials/tutorials.html) to get an overview of the
 general workflow in 4C.
+Also have a look at related [projects/tools](https://4c-multiphysics.github.io/4C/documentation/tools/tools.html) that work with 4C, e.g., tools that help with input generatation or visualization.
 
 ## Contributing
 

--- a/doc/documentation/src/tools/tools.rst
+++ b/doc/documentation/src/tools/tools.rst
@@ -5,6 +5,7 @@ Tools
 =====
 
 A number of tools are available to work with |FOURC|.
+If you also have a tool for |FOURC| or a project that works with |FOURC| please open a PR to add it to this list.
 
 4C-Webviewer
 ~~~~~~~~~~~~
@@ -36,10 +37,11 @@ beamme
 `beamme <https://beamme-py.github.io/beamme/>`_ is a general purpose 3D beam finite element input generator written in Python.
 It contains advanced geometry creation and manipulation functions to create complex beam geometries, including a consistent handling of finite rotations.
 
+pipapo
+~~~~~~
+`pipapo <https://github.com/particles-pipapo/pipapo>`_ is a post-processing tool for particle simulations, e.g. to calculate the porosity or coordination number.
+
 QUEENS
 ~~~~~~
 
 `QUEENS <https://github.com/queens-py/queens>`_ (Quantification of Uncertain Effects in Engineering Systems) is a Python framework for solver-independent multi-query analyses of large-scale computational models.
-
-
-


### PR DESCRIPTION
I added a link to our related projects/tools to the README to point new users to these tools. I was prepared to create the list as well. But saw that the list already existed. I didn't know we already had it in the repo.

I also added [pipapo](https://github.com/particles-pipapo/pipapo) to the list. @gilrrei 