### PR TITLE
[solver] Recompute preconditioner due to linear solver stall

### DIFF
--- a/src/core/linear_solver/src/method/4C_linear_solver_method_input.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_input.cpp
@@ -91,8 +91,15 @@ namespace Core::LinearSolver
                             .default_value = 0}),
 
         parameter<int>("AZREUSE",
-            {.description = "The number specifying how often to recompute some preconditioners",
+            {.description = "Update preconditioner after this many nonlinear iterations. The "
+                            "preconditioner is recomputed at every start of a nonlinear solve.",
                 .default_value = 0}),
+
+        parameter<int>("REUSE_STALL_ITER",
+            {.description =
+                    "Maximum number of linear iterations that triggers a nonlinear iteration to "
+                    "be declared stalled and thus force recomputation of the preconditioner.",
+                .default_value = 50}),
 
         parameter<int>(
             "AZSUB", {.description = "The maximum size of the Krylov subspace used with \"GMRES\" "

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_linalg.cpp
@@ -281,6 +281,7 @@ Teuchos::ParameterList translate_four_c_to_belos(const Teuchos::ParameterList& i
 
   beloslist.set("reuse", inparams.get<int>("AZREUSE"));
   beloslist.set("ncall", 0);
+  beloslist.set("max linear iterations for stall", inparams.get<int>("REUSE_STALL_ITER"));
 
   beloslist.set("THROW_IF_UNCONVERGED", inparams.get<bool>("THROW_IF_UNCONVERGED"));
 

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -4121,6 +4121,7 @@ void FLD::XFluid::x_timint_reconstruct_ghost_values(
   solverlist.set("Solver Type", "GMRES");
   solverlist.set<double>("Convergence Tolerance", 1.0e-12);
   solverlist.set<int>("reuse", 0);
+  solverlist.set<int>("max linear iterations for stall", 50);
   solverparams.sublist("IFPACK Parameters");
 
   Core::LinAlg::Solver solver_gp(solverparams, discret_->get_comm(),

--- a/tests/input_files/beam3eb_static_beam_to_solid_volume_meshtying_cube.4C.yaml
+++ b/tests/input_files/beam3eb_static_beam_to_solid_volume_meshtying_cube.4C.yaml
@@ -21,6 +21,7 @@ SOLVER 1:
   AZTOL: 1e-06
   AZOUTPUT: 5
   AZREUSE: 3
+  REUSE_STALL_ITER: 5
   TEKO_XML_FILE: "xml/block_preconditioner/beam_solid.xml"
   NAME: "Structure_Solver"
 BEAM INTERACTION:


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
If a preconditioner is reused over several nonlinear iterations the linear solver might begin to stall, due to a change in nonlinearity / physical behavior. Stalling in this case means a rapid increase in linear iterations, which can be reduced by triggering a recomputation of the preconditioner.

This PR introduces a new input parameter, which can be used to define an upper bound for linear iterations. If the number of linear iterations go over this value, we assume it to be stalling, thus triggering a recomputation of the preconditioner.

Example of the adapted test case:

```terminal
*******************************************************
***** Belos Iterative Solver:  Block Gmres 
***** Maximum Iterations: 1000
***** Block Size: 1
***** Residual Test: 
*****   Test 1 : Belos::StatusTestImpResNorm<>: (2-Norm Res Vec) / (2-Norm Res0), tol = 2.64275e-06
*******************************************************
Iter    0, [ 1] :    1.000000e+00
Iter    5, [ 1] :    4.054261e-06
Iter    6, [ 1] :    4.780254e-07
************************************************************************
-- Status Test Results --
**...........OR Combination -> 
  **...........AND Combination -> 
    **...........AND Combination -> 
      **...........Structure-Update-Norm = 2.861e-05 < 1e-10
                   (Unscaled 2-Norm, Absolute)
                   (Min Step Size:  1.000e+00 >= 1)
                   (Max Lin Solv Tol:  0.000e+00 < 0.5)
      Converged....Structure-F-Norm = 9.879e-15 < 1.000e-08
                   (Unscaled 2-Norm, Absolute)
  **...........Number of Iterations = 4 < 50
************************************************************************

************************************************************************
-- Nonlinear Solver Step 4 -- 
||F|| = 9.87920e-15  step = 1.00000e+00  dx = 2.86051e-05
************************************************************************

*******************************************************
Recomputation due to linear solver stalling.
Compute preconditioner 
*******************************************************
```

This example is of course super artificial, but shows the principle.