### PR TITLE
Enable _GLIBCXX_ASSERTIONS in assert mode

### DIFF
--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -226,12 +226,23 @@ if(${FOUR_C_BUILD_TYPE_UPPER} MATCHES RELWITHDEBINFO)
   enable_compiler_flag_if_supported("-funroll-loops")
 endif()
 
-# Evaluate this option now to get the correct output in case it is force ON in DEBUG mode.
+# Evaluate this option now to get the correct output in case it is forced ON in DEBUG mode.
 four_c_process_global_option(
   FOUR_C_ENABLE_ASSERTIONS
-  "Turn on assertions and debug sections in code. Automatically turned on for DEBUG as CMAKE_BUILD_TYPE."
+  "Turn on assertions and debug sections in 4C code, and turn on assertions in the standard library."
+  "Automatically turned on for DEBUG as CMAKE_BUILD_TYPE."
   OFF
   )
+
+if(FOUR_C_ENABLE_ASSERTIONS)
+  # In case we enable assertions, ensure that we also enable the standard library assertions.
+  # Note that starting from GCC 15, they are turned on in unoptimized -O0 builds. Since we
+  # usually use optimization in testing, we need to explicitly turn them on when requesting
+  # 4C's own assertions.
+  # Note that we can happily define this libstdc++ macro regardless of the standard library
+  # implementation, as it will just be ignored by other implementations.
+  target_compile_options(four_c_private_compile_interface INTERFACE "-D_GLIBCXX_ASSERTIONS")
+endif()
 
 four_c_process_global_option(
   FOUR_C_ENABLE_METADATA_GENERATION

--- a/src/constraint/4C_constraint_penalty.cpp
+++ b/src/constraint/4C_constraint_penalty.cpp
@@ -157,18 +157,14 @@ void Constraints::ConstraintPenalty::evaluate(Teuchos::ParameterList& params,
     default:
       FOUR_C_THROW("Wrong constraint type to evaluate systemvector!");
   }
-  evaluate_constraint(
-      params, systemmatrix1, *systemmatrix2, systemvector1, *systemvector2, *systemvector3);
-  return;
+  evaluate_constraint(params, systemmatrix1, systemvector1);
 }
 
 /*-----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Constraints::ConstraintPenalty::evaluate_constraint(Teuchos::ParameterList& params,
     std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix1,
-    Core::LinAlg::SparseOperator& systemmatrix2,
-    std::shared_ptr<Core::LinAlg::Vector<double>> systemvector1,
-    Core::LinAlg::Vector<double>& systemvector2, Core::LinAlg::Vector<double>& systemvector3)
+    std::shared_ptr<Core::LinAlg::Vector<double>> systemvector1)
 {
   if (!(actdisc_->filled())) FOUR_C_THROW("fill_complete() was not called");
   if (!actdisc_->have_dofs()) FOUR_C_THROW("assign_degrees_of_freedom() was not called");

--- a/src/constraint/4C_constraint_penalty.hpp
+++ b/src/constraint/4C_constraint_penalty.hpp
@@ -102,23 +102,12 @@ namespace Constraints
 
 
     //! Evaluate constraint conditions and assemble the results
-    void evaluate_constraint(
-        Teuchos::ParameterList&
-            params,  ///< parameter list to communicate between elements and discretization
-        std::shared_ptr<Core::LinAlg::SparseOperator>
-            systemmatrix1,  ///< sparse matrix that may be filled by assembly of element
-                            ///< contributions
-        Core::LinAlg::SparseOperator&
-            systemmatrix2,  ///< sparse (rectangular) matrix that may be filled by assembly of
-                            ///< element contributions
-        std::shared_ptr<Core::LinAlg::Vector<double>>
-            systemvector1,                            ///< distributed vector that may be filled by
-                                                      ///< aasembly of element contributions
-        Core::LinAlg::Vector<double>& systemvector2,  ///< distributed vector that may be filled by
-                                                      ///< aasembly of element contributions
-        Core::LinAlg::Vector<double>& systemvector3   ///< distributed vector that may be filled
-                                                      ///< by aasembly of element contributions
-    );
+    void evaluate_constraint(Teuchos::ParameterList& params,
+        ///< parameter list to communicate between elements and discretization
+        std::shared_ptr<Core::LinAlg::SparseOperator> systemmatrix1,
+        ///< sparse (rectangular) matrix that may be filled by assembly of
+        ///< element contributions
+        std::shared_ptr<Core::LinAlg::Vector<double>> systemvector1);
 
     //! Compute and assemble initial constraint values (depending on user specific activation times)
     void evaluate_error(

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem.cpp
@@ -1938,7 +1938,7 @@ namespace Discret
             std::vector<double> dummy2;
 
             get_interface_jump_vectors(coupcond, coupling, ivelint_jump, itraction_jump,
-                proj_tangential, LB_proj_matrix, x_gp_lin, normal, *si, rst, kappa_m, kappa_s,
+                proj_tangential, LB_proj_matrix, x_gp_lin, normal, si.get(), rst, kappa_m, kappa_s,
                 visc_m, dummy1, dummy2);
 
             if (cond_type == Inpar::XFEM::CouplingCond_LEVELSET_NEUMANN or
@@ -3747,7 +3747,7 @@ namespace Discret
             lb_proj_matrix_.clear();
 
             get_interface_jump_vectors(coupcond, coupling, ivelint_jump_, itraction_jump_,
-                proj_tangential_, lb_proj_matrix_, x_gp_lin_, normal_, *si, rst_, kappa_m,
+                proj_tangential_, lb_proj_matrix_, x_gp_lin_, normal_, si.get(), rst_, kappa_m,
                 viscaf_master_, viscaf_slave_, rst_slave, eledisp, coupl_ele);
 
             double fulltraction = 0.0;
@@ -3983,7 +3983,7 @@ namespace Discret
             LB_proj_matrix,  ///< prescribed projection matrix for laplace-beltrami problems
         const Core::LinAlg::Matrix<nsd_, 1>& x,       ///< global coordinates of Gaussian point
         const Core::LinAlg::Matrix<nsd_, 1>& normal,  ///< normal vector at Gaussian point
-        Discret::Elements::XFLUID::SlaveElementInterface<distype>&
+        Discret::Elements::XFLUID::SlaveElementInterface<distype>*
             si,                                 ///< side implementation for cutter element
         Core::LinAlg::Matrix<3, 1>& rst,        ///< local coordinates of GP for bg element
         double& kappa_m,                        ///< fluid sided weighting
@@ -4017,7 +4017,7 @@ namespace Discret
           else
           {
             // evaluate function at nodes at current time
-            si.get_interface_jump_velnp(ivelint_jump);
+            si->get_interface_jump_velnp(ivelint_jump);
           }
 
           break;
@@ -4057,7 +4057,7 @@ namespace Discret
         case Inpar::XFEM::CouplingCond_SURF_FSI_PART:
         {
           // evaluate function at nodes at current time
-          si.get_interface_jump_velnp(ivelint_jump);
+          si->get_interface_jump_velnp(ivelint_jump);
           break;
         }
         case Inpar::XFEM::CouplingCond_SURF_FLUIDFLUID:
@@ -4090,7 +4090,7 @@ namespace Discret
 
           if (!eval_dirich_at_gp)
           {
-            si.get_interface_jump_velnp(ivelint_jump);
+            si->get_interface_jump_velnp(ivelint_jump);
           }
 
           break;
@@ -4104,13 +4104,6 @@ namespace Discret
               ->evaluate_coupling_conditions<distype>(ivelint_jump, itraction_jump, x, cond,
                   proj_tangential, my::eid_, my::funct_, my::derxy_, normal, eval_dirich_at_gp,
                   kappa_m, visc_m, visc_s);
-
-          //    if(!eval_dirich_at_gp)
-          //    {
-          //
-          //      si->get_interface_jump_velnp(ivelint_jump);
-          //
-          //    }
 
           break;
         }

--- a/src/fluid_ele/4C_fluid_ele_calc_xfem.hpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_xfem.hpp
@@ -235,7 +235,7 @@ namespace Discret
               LB_proj_matrix,  ///< prescribed projection matrix for laplace-beltrami problems
           const Core::LinAlg::Matrix<nsd_, 1>& x,       ///< global coordinates of Gaussian point
           const Core::LinAlg::Matrix<nsd_, 1>& normal,  ///< normal vector at Gaussian point
-          Discret::Elements::XFLUID::SlaveElementInterface<distype>&
+          Discret::Elements::XFLUID::SlaveElementInterface<distype>*
               si,                                       ///< side implementation for cutter element
           Core::LinAlg::Matrix<3, 1>& rst,              ///< local coordinates of GP for bg element
           double& kappa_m,                              ///< fluid sided weighting

--- a/src/fluid_ele/4C_fluid_ele_evaluate.cpp
+++ b/src/fluid_ele/4C_fluid_ele_evaluate.cpp
@@ -357,16 +357,18 @@ int Discret::Elements::Fluid::evaluate(Teuchos::ParameterList& params,
           {
             FLD::f3_calc_smag_const_lij_mij_and_mij_mij<8>(this, fldpara, *col_filtered_vel,
                 *col_filtered_reynoldsstress, *col_filtered_modeled_subgrid_stress,
-                *col_filtered_dens_vel, *col_filtered_dens, *col_filtered_dens_strainrate, LijMij,
-                MijMij, CI_numerator, CI_denominator, xcenter, ycenter, zcenter);
+                col_filtered_dens_vel.get(), col_filtered_dens.get(),
+                col_filtered_dens_strainrate.get(), LijMij, MijMij, CI_numerator, CI_denominator,
+                xcenter, ycenter, zcenter);
             break;
           }
           case Core::FE::CellType::tet4:
           {
             FLD::f3_calc_smag_const_lij_mij_and_mij_mij<4>(this, fldpara, *col_filtered_vel,
                 *col_filtered_reynoldsstress, *col_filtered_modeled_subgrid_stress,
-                *col_filtered_dens_vel, *col_filtered_dens, *col_filtered_dens_strainrate, LijMij,
-                MijMij, CI_numerator, CI_denominator, xcenter, ycenter, zcenter);
+                col_filtered_dens_vel.get(), col_filtered_dens.get(),
+                col_filtered_dens_strainrate.get(), LijMij, MijMij, CI_numerator, CI_denominator,
+                xcenter, ycenter, zcenter);
             break;
           }
           default:

--- a/src/fluid_ele/4C_fluid_ele_evaluate_utils.hpp
+++ b/src/fluid_ele/4C_fluid_ele_evaluate_utils.hpp
@@ -1328,9 +1328,9 @@ namespace FLD
       Core::LinAlg::MultiVector<double>& col_filtered_vel,
       Core::LinAlg::MultiVector<double>& col_filtered_reynoldsstress,
       Core::LinAlg::MultiVector<double>& col_filtered_modeled_subgrid_stress,
-      Core::LinAlg::MultiVector<double>& col_filtered_dens_vel,
-      Core::LinAlg::Vector<double>& col_filtered_dens,
-      Core::LinAlg::Vector<double>& col_filtered_dens_strainrate, double& LijMij, double& MijMij,
+      Core::LinAlg::MultiVector<double>* col_filtered_dens_vel,
+      Core::LinAlg::Vector<double>* col_filtered_dens,
+      Core::LinAlg::Vector<double>* col_filtered_dens_strainrate, double& LijMij, double& MijMij,
       double& CI_numerator, double& CI_denominator, double& xcenter, double& ycenter,
       double& zcenter)
   {
@@ -1368,12 +1368,12 @@ namespace FLD
       {
         int lid = (ele->nodes()[nn])->lid();
 
-        edens_hat(0, nn) = (col_filtered_dens)[lid];
-        edensstrainrate_hat(0, nn) = (col_filtered_dens_strainrate)[lid];
+        edens_hat(0, nn) = (*col_filtered_dens)[lid];
+        edensstrainrate_hat(0, nn) = (*col_filtered_dens_strainrate)[lid];
 
         for (int dimi = 0; dimi < 3; ++dimi)
         {
-          edensvel_hat(dimi, nn) = (((col_filtered_dens_vel)(dimi)))[lid];
+          edensvel_hat(dimi, nn) = (((*col_filtered_dens_vel)(dimi)))[lid];
         }
       }
     }

--- a/src/poroelast/4C_poroelast_monolithic.cpp
+++ b/src/poroelast/4C_poroelast_monolithic.cpp
@@ -575,7 +575,7 @@ void PoroElast::Monolithic::setup_rhs(bool firstcall)
   setup_vector(*rhs_, structure_field()->rhs(), fluid_field()->rhs());
 
   // add rhs terms due to no penetration condition
-  nopen_handle_->apply_cond_rhs(*iterinc_, *rhs_);
+  if (iterinc_) nopen_handle_->apply_cond_rhs(*iterinc_, *rhs_);
 }
 
 void PoroElast::Monolithic::prepare_time_step() { PoroBase::prepare_time_step(); }

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_lib.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_lib.hpp
@@ -751,14 +751,15 @@ namespace Discret::Elements
           dsolidpressure_ddisp)
   {
     // get volume fraction primary variables
-    std::vector<double> volfracphi(&fluidmultiphase_phiAtGP[numfluidphases],
-        &fluidmultiphase_phiAtGP[numfluidphases + numvolfrac]);
+    std::vector<double> volfracphi(fluidmultiphase_phiAtGP.data() + numfluidphases,
+        fluidmultiphase_phiAtGP.data() + numfluidphases + numvolfrac);
     double sumaddvolfrac = 0.0;
     for (int ivolfrac = 0; ivolfrac < numvolfrac; ivolfrac++) sumaddvolfrac += volfracphi[ivolfrac];
 
     // get volume fraction pressure at [numfluidphases+numvolfrac...nummultifluiddofpernode-1]
-    std::vector<double> volfracpressure(&fluidmultiphase_phiAtGP[numfluidphases + numvolfrac],
-        &fluidmultiphase_phiAtGP[nummultifluiddofpernode]);
+    std::vector<double> volfracpressure(
+        fluidmultiphase_phiAtGP.data() + numfluidphases + numvolfrac,
+        fluidmultiphase_phiAtGP.data() + nummultifluiddofpernode);
 
     // p_s = (porosity - sumaddvolfrac)/porosity * fluidpress
     //       + 1.0 / porosity sum_i=1^numvolfrac (volfrac_i*pressure_i)
@@ -790,8 +791,8 @@ namespace Discret::Elements
       const std::vector<double>& fluidmultiphase_phiAtGP)
   {
     // get volume fraction primary variables at [numfluidphases-1...numfluidphase-1+numvolfrac]
-    std::vector<double> volfracphi(&fluidmultiphase_phiAtGP[numfluidphases],
-        &fluidmultiphase_phiAtGP[numfluidphases + numvolfrac]);
+    std::vector<double> volfracphi(fluidmultiphase_phiAtGP.data() + numfluidphases,
+        fluidmultiphase_phiAtGP.data() + numfluidphases + numvolfrac);
     double sumaddvolfrac = 0.0;
     for (int ivolfrac = 0; ivolfrac < numvolfrac; ivolfrac++) sumaddvolfrac += volfracphi[ivolfrac];
 
@@ -801,8 +802,9 @@ namespace Discret::Elements
     press *= (porosity - sumaddvolfrac) / porosity;
 
     // get volfrac pressures at [numfluidphases+numvolfrac...nummultifluiddofpernode-1]
-    std::vector<double> volfracpressure(&fluidmultiphase_phiAtGP[numfluidphases + numvolfrac],
-        &fluidmultiphase_phiAtGP[nummultifluiddofpernode]);
+    std::vector<double> volfracpressure(
+        fluidmultiphase_phiAtGP.data() + numfluidphases + numvolfrac,
+        fluidmultiphase_phiAtGP.data() + nummultifluiddofpernode);
 
     // second part
     for (int ivolfrac = 0; ivolfrac < numvolfrac; ivolfrac++)
@@ -1902,7 +1904,7 @@ namespace Discret::Elements
     Core::LinAlg::SerialDenseMatrix satderiv(numfluidphases, numfluidphases, true);
     Core::LinAlg::SerialDenseMatrix pressderiv(numfluidphases, numfluidphases, true);
     std::vector<double> fluidphi(
-        &fluidmultiphase_phiAtGP[0], &fluidmultiphase_phiAtGP[numfluidphases]);
+        fluidmultiphase_phiAtGP.data(), fluidmultiphase_phiAtGP.data() + numfluidphases);
 
     // evaluate the pressures
     porofluidmat.evaluate_gen_pressure(genpress, fluidphi);
@@ -1965,7 +1967,7 @@ namespace Discret::Elements
     std::vector<double> sat(numfluidphases, 0.0);
     std::vector<double> press(numfluidphases, 0.0);
     std::vector<double> fluidphi(
-        &fluidmultiphase_phiAtGP[0], &fluidmultiphase_phiAtGP[numfluidphases]);
+        fluidmultiphase_phiAtGP.data(), fluidmultiphase_phiAtGP.data() + numfluidphases);
 
     // evaluate the pressures
     porofluidmat.evaluate_gen_pressure(genpress, fluidphi);
@@ -2000,8 +2002,8 @@ namespace Discret::Elements
       const double solidpressure, const double porosity, std::vector<double>& solidpressurederiv)
   {
     // get volume fraction primary variables
-    std::vector<double> volfracphi(&fluidmultiphase_phiAtGP[numfluidphases],
-        &fluidmultiphase_phiAtGP[numfluidphases + numvolfrac]);
+    std::vector<double> volfracphi(fluidmultiphase_phiAtGP.data() + numfluidphases,
+        fluidmultiphase_phiAtGP.data() + numfluidphases + numvolfrac);
     double sumaddvolfrac = 0.0;
     for (int ivolfrac = 0; ivolfrac < numvolfrac; ivolfrac++) sumaddvolfrac += volfracphi[ivolfrac];
 
@@ -2013,8 +2015,9 @@ namespace Discret::Elements
     for (int iphase = 0; iphase < numfluidphases; iphase++) solidpressurederiv[iphase] *= scale;
 
     // get volfrac pressures at [numfluidphases+numvolfrac...nummultifluiddofpernode-1]
-    std::vector<double> volfracpressure(&fluidmultiphase_phiAtGP[numfluidphases + numvolfrac],
-        &fluidmultiphase_phiAtGP[nummultifluiddofpernode]);
+    std::vector<double> volfracpressure(
+        fluidmultiphase_phiAtGP.data() + numfluidphases + numvolfrac,
+        fluidmultiphase_phiAtGP.data() + nummultifluiddofpernode);
 
     for (int ivolfrac = 0; ivolfrac < numvolfrac; ivolfrac++)
     {


### PR DESCRIPTION
Based on a discussion with @marksidoro, I think we should turn on standard library assertions. They already uncovered some UB, e.g. #1017. Note that starting from GCC 15, these assertions are turned on by [default for unoptimized builds](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112808), so we should start to fix these issues. Of course, we first need to fix all failures before this PR can be merged. Let's see what the fallout is going to be.

All issues are now fixed.