### PR TITLE
Rough surface contact: remove unused method, fix doxygen

### DIFF
--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.hpp
@@ -65,12 +65,7 @@ namespace CONTACT
           CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLawParams params);
 
       //! @name Access methods
-
-      /// return contact constitutive law type
-      CONTACT::CONSTITUTIVELAW::ConstitutiveLawType get_constitutive_law_type() const override
-      {
-        return CONTACT::CONSTITUTIVELAW::ConstitutiveLawType::colaw_brokenrational;
-      }
+      //@{
 
       /// Get scaling factor of the broken rational function
       double getdata() { return params_.getdata(); }
@@ -85,6 +80,7 @@ namespace CONTACT
       //@}
 
       //! @name Evaluation methods
+      //@{
 
       /// evaluate the constitutive law
       double evaluate(double gap, CONTACT::Node* cnode) override;

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.hpp
@@ -32,9 +32,6 @@ namespace CONTACT
     class ConstitutiveLaw
     {
      public:
-      /// return type of this constitutive law
-      virtual CONTACT::CONSTITUTIVELAW::ConstitutiveLawType get_constitutive_law_type() const = 0;
-
       /// Return quick accessible Contact Constitutive Law parameter data
       virtual const CONTACT::CONSTITUTIVELAW::Parameter* parameter() const = 0;
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.hpp
@@ -62,12 +62,7 @@ namespace CONTACT
       explicit CubicConstitutiveLaw(CONTACT::CONSTITUTIVELAW::CubicConstitutiveLawParams params);
 
       //! @name Access methods
-
-      /// contact constitutive law type
-      CONTACT::CONSTITUTIVELAW::ConstitutiveLawType get_constitutive_law_type() const override
-      {
-        return CONTACT::CONSTITUTIVELAW::ConstitutiveLawType::colaw_cubic;
-      }
+      //@{
 
       double getdata() { return params_.getdata(); }
       double get_b() { return params_.get_b(); }
@@ -80,6 +75,7 @@ namespace CONTACT
       //@}
 
       //! @name Evaluation methods
+      //!{
 
       /// Evaluate contact constitutive law
       double evaluate(double gap, CONTACT::Node* cnode) override;

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp
@@ -64,12 +64,7 @@ namespace CONTACT
       explicit LinearConstitutiveLaw(CONTACT::CONSTITUTIVELAW::LinearConstitutiveLawParams params);
 
       //! @name Access methods
-
-      /// contact constitutive law type
-      CONTACT::CONSTITUTIVELAW::ConstitutiveLawType get_constitutive_law_type() const override
-      {
-        return CONTACT::CONSTITUTIVELAW::ConstitutiveLawType::colaw_linear;
-      }
+      //@{
 
       /// Get slope of linear polynomial
       double getdata() { return params_.getdata(); }
@@ -78,6 +73,8 @@ namespace CONTACT
 
       /// Return quick accessible contact constitutive law parameter data
       const CONTACT::CONSTITUTIVELAW::Parameter* parameter() const override { return &params_; }
+
+      //@}
 
       //! @name Evaluation methods
       //@{

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
@@ -89,15 +89,12 @@ namespace CONTACT
       explicit MircoConstitutiveLaw(CONTACT::CONSTITUTIVELAW::MircoConstitutiveLawParams params);
 
       //! @name Access methods
-
-      /// contact constitutive law type
-      CONTACT::CONSTITUTIVELAW::ConstitutiveLawType get_constitutive_law_type() const override
-      {
-        return CONTACT::CONSTITUTIVELAW::ConstitutiveLawType::colaw_mirco;
-      }
+      //@{
 
       /// Return quick accessible contact constitutive law parameter data
       const CONTACT::CONSTITUTIVELAW::Parameter* parameter() const override { return &params_; }
+
+      //@}
 
       //! @name Evaluation methods
       //@{

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.hpp
@@ -64,12 +64,7 @@ namespace CONTACT
       explicit PowerConstitutiveLaw(CONTACT::CONSTITUTIVELAW::PowerConstitutiveLawParams params);
 
       //! @name Access methods
-
-      /// contact constitutive law type
-      CONTACT::CONSTITUTIVELAW::ConstitutiveLawType get_constitutive_law_type() const override
-      {
-        return CONTACT::CONSTITUTIVELAW::ConstitutiveLawType::colaw_power;
-      }
+      //@{
 
       /// Get scaling factor of power law
       double getdata() { return params_.getdata(); }
@@ -78,6 +73,7 @@ namespace CONTACT
 
       /// Return quick accessible contact constitutive law parameter data
       const CONTACT::CONSTITUTIVELAW::Parameter* parameter() const override { return &params_; }
+      //@}
 
       //! @name Evaluation methods
       //@{


### PR DESCRIPTION
## Description and Context

- Remove unused method from inheritance structure
- Fix groups in doxygen

## Related Issues and Pull Requests

Follows #1037 