### PR TITLE
Refactor contact constitutive law implementations

### DIFF
--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.cpp
@@ -57,7 +57,7 @@ double CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::evaluate(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::evaluate_deriv(
+double CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::evaluate_derivative(
     double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.cpp
@@ -11,8 +11,6 @@
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 
-#include <vector>
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.cpp
@@ -38,16 +38,14 @@ CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::BrokenRationalConstitut
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 double CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::evaluate(
-    double gap, CONTACT::Node* cnode)
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {
     FOUR_C_THROW("You should not be here. The Evaluate function is only tested for active nodes. ");
   }
-  double result = -1.0;
-  gap = -gap;
-  result *=
-      (params_.getdata() * 1. / (gap - params_.get_offset() - params_.get_b()) + params_.get_c());
+  const double result =
+      -(params_.getdata() * 1. / (-gap - params_.get_offset() - params_.get_b()) + params_.get_c());
   if (result > 0)
     FOUR_C_THROW(
         "The constitutive function you are using seems to be positive, even though the gap is "
@@ -58,16 +56,16 @@ double CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::evaluate(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 double CONTACT::CONSTITUTIVELAW::BrokenRationalConstitutiveLaw::evaluate_derivative(
-    double gap, CONTACT::Node* cnode)
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {
     FOUR_C_THROW("You should not be here. The Evaluate function is only tested for active nodes. ");
   }
-  gap = -gap;
+
   return (-params_.getdata() * 1. /
-          ((gap - params_.get_offset() - params_.get_b()) *
-              (gap - params_.get_offset() - params_.get_b())));
+          ((-gap - params_.get_offset() - params_.get_b()) *
+              (-gap - params_.get_offset() - params_.get_b())));
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.hpp
@@ -83,9 +83,9 @@ namespace CONTACT
       //@{
 
       /// evaluate the constitutive law
-      double evaluate(double gap, CONTACT::Node* cnode) override;
+      double evaluate(const double gap, CONTACT::Node* cnode) override;
       /// Evaluate derivative of the constitutive law
-      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(const double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_brokenrational_contactconstitutivelaw.hpp
@@ -85,7 +85,7 @@ namespace CONTACT
       /// evaluate the constitutive law
       double evaluate(double gap, CONTACT::Node* cnode) override;
       /// Evaluate derivative of the constitutive law
-      double evaluate_deriv(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_bundle.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_bundle.cpp
@@ -11,6 +11,8 @@
 #include "4C_contact_constitutivelaw_contactconstitutivelaw_parameter.hpp"
 #include "4C_utils_exceptions.hpp"
 
+#include <map>
+
 FOUR_C_NAMESPACE_OPEN
 /*----------------------------------------------------------------------*/
 CONTACT::CONSTITUTIVELAW::Bundle::Bundle() : readfromproblem_(0) {}
@@ -39,6 +41,9 @@ void CONTACT::CONSTITUTIVELAW::Bundle::make_parameters()
     [[maybe_unused]] auto _ = CONTACT::CONSTITUTIVELAW::ConstitutiveLaw::factory(id);
   }
 }
+
+/*----------------------------------------------------------------------*/
+int CONTACT::CONSTITUTIVELAW::Bundle::num() const { return map_.size(); }
 
 /*----------------------------------------------------------------------*/
 Core::IO::InputParameterContainer& CONTACT::CONSTITUTIVELAW::Bundle::by_id(const int id)

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_bundle.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_bundle.hpp
@@ -14,10 +14,6 @@
 
 #include "4C_io_input_parameter_container.hpp"
 
-#include <map>
-#include <memory>
-#include <vector>
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace CONTACT
@@ -55,7 +51,7 @@ namespace CONTACT
       void make_parameters();
 
       /// return number of defined materials
-      int num() const { return map_.size(); }
+      int num() const;
 
       /** return contact constitutive law by ID
        *

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.hpp
@@ -35,8 +35,8 @@ namespace CONTACT
       /// Return quick accessible Contact Constitutive Law parameter data
       virtual const CONTACT::CONSTITUTIVELAW::Parameter* parameter() const = 0;
 
-      virtual double evaluate(double gap, CONTACT::Node* cnode) = 0;
-      virtual double evaluate_derivative(double gap, CONTACT::Node* cnode) = 0;
+      virtual double evaluate(const double gap, CONTACT::Node* cnode) = 0;
+      virtual double evaluate_derivative(const double gap, CONTACT::Node* cnode) = 0;
 
       /* \brief create Contact ConstitutiveLaw object given the id of the constitutive law in the
        * input file

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw.hpp
@@ -36,7 +36,7 @@ namespace CONTACT
       virtual const CONTACT::CONSTITUTIVELAW::Parameter* parameter() const = 0;
 
       virtual double evaluate(double gap, CONTACT::Node* cnode) = 0;
-      virtual double evaluate_deriv(double gap, CONTACT::Node* cnode) = 0;
+      virtual double evaluate_derivative(double gap, CONTACT::Node* cnode) = 0;
 
       /* \brief create Contact ConstitutiveLaw object given the id of the constitutive law in the
        * input file

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw_parameter.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_contactconstitutivelaw_parameter.hpp
@@ -8,29 +8,16 @@
 #ifndef FOUR_C_CONTACT_CONSTITUTIVELAW_CONTACTCONSTITUTIVELAW_PARAMETER_HPP
 #define FOUR_C_CONTACT_CONSTITUTIVELAW_CONTACTCONSTITUTIVELAW_PARAMETER_HPP
 
-
-/*----------------------------------------------------------------------*/
-/* headers */
 #include "4C_config.hpp"
 
 #include "4C_io_input_parameter_container.hpp"
-#include "4C_linalg_vector.hpp"
-
-#include <memory>
 
 FOUR_C_NAMESPACE_OPEN
-
-/*----------------------------------------------------------------------*/
-/* forward declarations */
 
 namespace CONTACT::CONSTITUTIVELAW
 {
   class ConstitutiveLaw;
 }  // namespace CONTACT::CONSTITUTIVELAW
-
-/*----------------------------------------------------------------------*/
-/* declarations */
-
 
 namespace CONTACT::CONSTITUTIVELAW
 {

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.cpp
@@ -59,7 +59,7 @@ double CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::evaluate(double gap, CONT
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::evaluate_deriv(
+double CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::evaluate_derivative(
     double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.cpp
@@ -37,38 +37,43 @@ CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::CubicConstitutiveLaw(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::evaluate(double gap, CONTACT::Node* cnode)
+double CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::evaluate(
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {
     FOUR_C_THROW("You should not be here. The Evaluate function is only tested for active nodes. ");
   }
-  double result = 1.0;
-  gap = -gap;
-  result = -1.0;
-  result *= params_.getdata() * (gap - params_.get_offset()) * (gap - params_.get_offset()) *
-                (gap - params_.get_offset()) +
-            params_.get_b() * (gap - params_.get_offset()) * (gap - params_.get_offset()) +
-            params_.get_c() * (gap - params_.get_offset()) + params_.get_d();
+
+  const double negative_gap = -gap;
+
+  const double result = -params_.getdata() * (negative_gap - params_.get_offset()) *
+                            (negative_gap - params_.get_offset()) *
+                            (negative_gap - params_.get_offset()) -
+                        params_.get_b() * (negative_gap - params_.get_offset()) *
+                            (negative_gap - params_.get_offset()) -
+                        params_.get_c() * (negative_gap - params_.get_offset()) - params_.get_d();
+
   if (result > 0)
     FOUR_C_THROW(
         "The constitutive function you are using seems to be positive, even though the gap is "
         "negative. Please check your coefficients!");
+
   return result;
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 double CONTACT::CONSTITUTIVELAW::CubicConstitutiveLaw::evaluate_derivative(
-    double gap, CONTACT::Node* cnode)
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {
     FOUR_C_THROW("You should not be here. The Evaluate function is only tested for active nodes. ");
   }
-  gap = -gap;
-  return 3 * params_.getdata() * (gap - params_.get_offset()) * (gap - params_.get_offset()) +
-         2 * params_.get_b() * (gap - params_.get_offset()) + params_.get_c();
+
+  return 3 * params_.getdata() * (-gap - params_.get_offset()) * (-gap - params_.get_offset()) +
+         2 * params_.get_b() * (-gap - params_.get_offset()) + params_.get_c();
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.cpp
@@ -11,8 +11,6 @@
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 
-#include <vector>
-
 FOUR_C_NAMESPACE_OPEN
 
 /*----------------------------------------------------------------------*/

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.hpp
@@ -78,9 +78,9 @@ namespace CONTACT
       //!{
 
       /// Evaluate contact constitutive law
-      double evaluate(double gap, CONTACT::Node* cnode) override;
+      double evaluate(const double gap, CONTACT::Node* cnode) override;
       /// Evaluate derivative of the contact constitutive law
-      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(const double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_cubic_contactconstitutivelaw.hpp
@@ -80,7 +80,7 @@ namespace CONTACT
       /// Evaluate contact constitutive law
       double evaluate(double gap, CONTACT::Node* cnode) override;
       /// Evaluate derivative of the contact constitutive law
-      double evaluate_deriv(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_interface.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_interface.cpp
@@ -85,7 +85,7 @@ void CONTACT::ConstitutivelawInterface::assemble_reg_normal_forces(
       // Evaluate pressure
       const double pressure = coconstlaw_->evaluate(kappa * gap, cnode);
       // Evaluate pressure derivative
-      const double pressurederiv = coconstlaw_->evaluate_deriv(kappa * gap, cnode);
+      const double pressurederiv = coconstlaw_->evaluate_derivative(kappa * gap, cnode);
 
       localisincontact = true;
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.cpp
@@ -11,8 +11,6 @@
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 
-#include <vector>
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.cpp
@@ -36,7 +36,8 @@ CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::LinearConstitutiveLaw(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate(double gap, CONTACT::Node* cnode)
+double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate(
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {
@@ -48,7 +49,7 @@ double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate(double gap, CON
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate_derivative(
-    double gap, CONTACT::Node* cnode)
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.cpp
@@ -47,7 +47,7 @@ double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate(double gap, CON
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate_deriv(
+double CONTACT::CONSTITUTIVELAW::LinearConstitutiveLaw::evaluate_derivative(
     double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp
@@ -82,7 +82,7 @@ namespace CONTACT
       double evaluate(double gap, CONTACT::Node* cnode) override;
 
       /// Evaluate derivative of the constitutive law
-      double evaluate_deriv(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_linear_contactconstitutivelaw.hpp
@@ -79,10 +79,10 @@ namespace CONTACT
       //! @name Evaluation methods
       //@{
       /// Evaluate the constitutive law
-      double evaluate(double gap, CONTACT::Node* cnode) override;
+      double evaluate(const double gap, CONTACT::Node* cnode) override;
 
       /// Evaluate derivative of the constitutive law
-      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(const double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
@@ -145,7 +145,7 @@ double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate(double gap, CONT
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate_deriv(
+double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate_derivative(
     double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0.0)

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.cpp
@@ -119,7 +119,8 @@ void CONTACT::CONSTITUTIVELAW::MircoConstitutiveLawParams::set_parameters()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate(double gap, CONTACT::Node* cnode)
+double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate(
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0.0)
   {
@@ -146,7 +147,7 @@ double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate(double gap, CONT
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 double CONTACT::CONSTITUTIVELAW::MircoConstitutiveLaw::evaluate_derivative(
-    double gap, CONTACT::Node* cnode)
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0.0)
   {

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
@@ -117,7 +117,7 @@ namespace CONTACT
        * \param gap contact gap at the mortar node
        * \return Derivative of the pressure responses from MIRCO
        */
-      double evaluate_deriv(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_mirco_contactconstitutivelaw.hpp
@@ -106,7 +106,7 @@ namespace CONTACT
        * \param gap contact gap at the mortar node
        * \return The pressure response from MIRCO
        */
-      double evaluate(double gap, CONTACT::Node* cnode) override;
+      double evaluate(const double gap, CONTACT::Node* cnode) override;
 
       /** \brief Evaluate derivative of the constitutive law
        *
@@ -117,7 +117,7 @@ namespace CONTACT
        * \param gap contact gap at the mortar node
        * \return Derivative of the pressure responses from MIRCO
        */
-      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(const double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.cpp
@@ -38,34 +38,36 @@ CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::PowerConstitutiveLaw(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::evaluate(double gap, CONTACT::Node* cnode)
+double CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::evaluate(
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0)
   {
     FOUR_C_THROW("You should not be here. The Evaluate function is only tested for active nodes. ");
   }
-  double result = 1;
-  gap *= -1;
-  result = -1;
-  result *= (params_.getdata() * pow(gap - params_.get_offset(), params_.get_b()));
+
+  const double result = -(params_.getdata() * pow(-gap - params_.get_offset(), params_.get_b()));
+
   if (result > 0)
     FOUR_C_THROW(
         "The constitutive function you are using seems to be positive, even though the gap is "
         "negative. Please check your coefficients!");
+
   return result;
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 double CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::evaluate_derivative(
-    double gap, CONTACT::Node* cnode)
+    const double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0.0)
   {
     FOUR_C_THROW("You should not be here. The Evaluate function is only tested for active nodes. ");
   }
-  gap = -gap;
-  return params_.getdata() * params_.get_b() * pow(gap - params_.get_offset(), params_.get_b() - 1);
+
+  return params_.getdata() * params_.get_b() *
+         pow(-gap - params_.get_offset(), params_.get_b() - 1);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.cpp
@@ -57,7 +57,7 @@ double CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::evaluate(double gap, CONT
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-double CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::evaluate_deriv(
+double CONTACT::CONSTITUTIVELAW::PowerConstitutiveLaw::evaluate_derivative(
     double gap, CONTACT::Node* cnode)
 {
   if (gap + params_.get_offset() > 0.0)

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.cpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.cpp
@@ -13,8 +13,6 @@
 
 #include <math.h>
 
-#include <vector>
-
 FOUR_C_NAMESPACE_OPEN
 
 

--- a/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.hpp
+++ b/src/contact_constitutivelaw/4C_contact_constitutivelaw_power_contactconstitutivelaw.hpp
@@ -80,7 +80,7 @@ namespace CONTACT
       /// Evaluate the constitutive law
       double evaluate(double gap, CONTACT::Node* cnode) override;
       /// Evaluate derivative of the constitutive law
-      double evaluate_deriv(double gap, CONTACT::Node* cnode) override;
+      double evaluate_derivative(double gap, CONTACT::Node* cnode) override;
       //@}
 
      private:

--- a/unittests/contact_constitutivelaw/4C_brokenrational_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_brokenrational_contactconstitutivelaw_test.threads2.cpp
@@ -50,7 +50,7 @@ namespace
   //! test member function EvaluateDeriv
   TEST_F(BrokenrationalConstitutiveLawTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-2.5, cnode.get()), 0.5, 1.e-15);
-    EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
+    EXPECT_NEAR(coconstlaw_->evaluate_derivative(-2.5, cnode.get()), 0.5, 1.e-15);
+    EXPECT_ANY_THROW(coconstlaw_->evaluate_derivative(-0.25, cnode.get()));
   }
 }  // namespace

--- a/unittests/contact_constitutivelaw/4C_cubic_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_cubic_contactconstitutivelaw_test.threads2.cpp
@@ -51,7 +51,7 @@ namespace
   //! test member function EvaluateDeriv
   TEST_F(CubicConstitutiveLawTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-0.75, cnode.get()), 4.28125, 1.e-15);
-    EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
+    EXPECT_NEAR(coconstlaw_->evaluate_derivative(-0.75, cnode.get()), 4.28125, 1.e-15);
+    EXPECT_ANY_THROW(coconstlaw_->evaluate_derivative(-0.25, cnode.get()));
   }
 }  // namespace

--- a/unittests/contact_constitutivelaw/4C_linear_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_linear_contactconstitutivelaw_test.threads2.cpp
@@ -49,7 +49,7 @@ namespace
   //! test member function EvaluateDeriv
   TEST_F(LinearConstitutiveLawTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-0.75, cnode.get()), 1.5, 1.e-15);
-    EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
+    EXPECT_NEAR(coconstlaw_->evaluate_derivative(-0.75, cnode.get()), 1.5, 1.e-15);
+    EXPECT_ANY_THROW(coconstlaw_->evaluate_derivative(-0.25, cnode.get()));
   }
 }  // namespace

--- a/unittests/contact_constitutivelaw/4C_mirco_force_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_mirco_force_contactconstitutivelaw_test.threads2.cpp
@@ -116,8 +116,8 @@ namespace
   //! test member function EvaluateDeriv
   TEST_F(MircoConstitutiveLawForceTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-12.0, cnode.get()), 1.34284789678326e-04, 1.e-10);
-    EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
+    EXPECT_NEAR(coconstlaw_->evaluate_derivative(-12.0, cnode.get()), 1.34284789678326e-04, 1.e-10);
+    EXPECT_ANY_THROW(coconstlaw_->evaluate_derivative(-0.25, cnode.get()));
   }
 }  // namespace
 

--- a/unittests/contact_constitutivelaw/4C_mirco_pressure_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_mirco_pressure_contactconstitutivelaw_test.threads2.cpp
@@ -114,8 +114,8 @@ namespace
   //! test member function EvaluateDeriv
   TEST_F(MircoConstitutiveLawPressureTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-12.0, cnode.get()), 1.17161352338802e-04, 1.e-10);
-    EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
+    EXPECT_NEAR(coconstlaw_->evaluate_derivative(-12.0, cnode.get()), 1.17161352338802e-04, 1.e-10);
+    EXPECT_ANY_THROW(coconstlaw_->evaluate_derivative(-0.25, cnode.get()));
   }
 }  // namespace
 

--- a/unittests/contact_constitutivelaw/4C_power_contactconstitutivelaw_test.threads2.cpp
+++ b/unittests/contact_constitutivelaw/4C_power_contactconstitutivelaw_test.threads2.cpp
@@ -49,7 +49,7 @@ namespace
   //! test member function EvaluateDeriv
   TEST_F(PowerConstitutiveLawTest, TestEvaluateDeriv)
   {
-    EXPECT_NEAR(coconstlaw_->evaluate_deriv(-0.75, cnode.get()), 0.5625, 1.e-15);
-    EXPECT_ANY_THROW(coconstlaw_->evaluate_deriv(-0.25, cnode.get()));
+    EXPECT_NEAR(coconstlaw_->evaluate_derivative(-0.75, cnode.get()), 0.5625, 1.e-15);
+    EXPECT_ANY_THROW(coconstlaw_->evaluate_derivative(-0.25, cnode.get()));
   }
 }  // namespace


### PR DESCRIPTION
## Description and Context

- Pass gap values as `const`
- Remove unused header inclusions
- Avoid abbreviation in method name
