### PR TITLE
Enable dependabot for reusable actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,11 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    # Note that directory is relative to .github/workflows
-    directory: "/"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: ".github/actions"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
#327 enabled `dependabot`, but only for the `workflows` folder. Most of our dependencies are stored inside `actions`. This PR adds it.

Furthermore, `dependabot` so far wasn't able to create PRs since we disallow random branches in this repo. `dependabot` is now exempted from this rule. We should see some version bumps soon :robot: .