### PR TITLE
Remove obsolete correction and eigenvalues objects `NOX::Nln::Group`

### DIFF
--- a/src/contact/4C_contact_paramsinterface.hpp
+++ b/src/contact/4C_contact_paramsinterface.hpp
@@ -66,9 +66,6 @@ namespace CONTACT
     //! get the is_default_step indicator
     virtual bool is_default_step() const = 0;
 
-    //! get correction type
-    virtual NOX::Nln::CorrectionType get_correction_type() const = 0;
-
     //! get the current time step [derived]
     virtual double get_delta_time() const = 0;
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.cpp
@@ -25,7 +25,6 @@ NOX::Nln::Group::Group(Teuchos::ParameterList& printParams, Teuchos::ParameterLi
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
     : GroupBase(printParams, i, x, linSys),
       skipUpdateX_(false),
-      corr_type_(NOX::Nln::CorrectionType::vague),
       prePostOperatorPtr_(Teuchos::make_rcp<NOX::Nln::GROUP::PrePostOperator>(grpOptionParams))
 {
   // empty constructor
@@ -34,18 +33,13 @@ NOX::Nln::Group::Group(Teuchos::ParameterList& printParams, Teuchos::ParameterLi
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 NOX::Nln::Group::Group(const NOX::Nln::Group& source, ::NOX::CopyType type)
-    : GroupBase(source, type),
-      skipUpdateX_(false),
-      corr_type_(NOX::Nln::CorrectionType::vague),
-      prePostOperatorPtr_(source.prePostOperatorPtr_)
+    : GroupBase(source, type), skipUpdateX_(false), prePostOperatorPtr_(source.prePostOperatorPtr_)
 {
   switch (type)
   {
     case ::NOX::DeepCopy:
     {
       skipUpdateX_ = source.skipUpdateX_;
-      corr_type_ = source.corr_type_;
-      ev_ = source.ev_;
       break;
     }
     default:
@@ -76,20 +70,13 @@ Teuchos::RCP<::NOX::Abstract::Group> NOX::Nln::Group::clone(::NOX::CopyType type
   const NOX::Nln::Group& nln_src = dynamic_cast<const NOX::Nln::Group&>(source);
 
   this->skipUpdateX_ = nln_src.skipUpdateX_;
-  this->corr_type_ = nln_src.corr_type_;
-  this->ev_ = nln_src.ev_;
 
   return *this;
 }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void NOX::Nln::Group::resetIsValid()
-{
-  ::NOX::Epetra::Group::resetIsValid();
-  ev_.isvalid_ = false;
-  corr_type_ = NOX::Nln::CorrectionType::vague;
-}
+void NOX::Nln::Group::resetIsValid() { ::NOX::Epetra::Group::resetIsValid(); }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
@@ -517,30 +504,6 @@ void NOX::Nln::Group::throw_error(
   msg << "ERROR - NOX::Nln::Group::" << functionName << " - " << errorMsg << std::endl;
 
   FOUR_C_THROW("{}", msg.str());
-}
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-NOX::Nln::Group::Eigenvalues& NOX::Nln::Group::Eigenvalues::operator=(const Eigenvalues& src)
-{
-  if (not src.isvalid_)
-  {
-    this->isvalid_ = false;
-    return *this;
-  }
-
-  this->realpart_.resize(src.realpart_.length());
-  this->realpart_ = src.realpart_;
-
-  this->imaginarypart_.resize(src.imaginarypart_.length());
-  this->imaginarypart_ = src.imaginarypart_;
-
-  this->real_max_ = src.real_max_;
-  this->real_min_ = src.real_min_;
-
-  this->isvalid_ = src.isvalid_;
-
-  return *this;
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
@@ -208,37 +208,8 @@ namespace NOX
        *  need a multiplicative update of some beam elements' rotation (pseudo-)vector DOFs) */
       bool skipUpdateX_;
 
-      /// correction system type
-      NOX::Nln::CorrectionType corr_type_;
-
       //! pointer to an user defined wrapped NOX::Nln::Abstract::PrePostOperator object.
       Teuchos::RCP<NOX::Nln::GROUP::PrePostOperator> prePostOperatorPtr_;
-
-     private:
-      /// container for eigenvalue info
-      struct Eigenvalues
-      {
-        /// assign operator
-        Eigenvalues& operator=(const Eigenvalues& src);
-
-        /// real part of the eigenvalues
-        Core::LinAlg::SerialDenseVector realpart_;
-
-        /// imaginary part of the eigenvalues
-        Core::LinAlg::SerialDenseVector imaginarypart_;
-
-        /// maximal real part
-        double real_max_ = 0.0;
-
-        /// minimal real part
-        double real_min_ = 0.0;
-
-        /// Are the eigenvalues valid?
-        bool isvalid_ = false;
-      };
-
-      /// instance of the Eigenvalue container
-      Eigenvalues ev_;
     };  // class Group
   }  // namespace Nln
 }  // namespace NOX

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.cpp
@@ -151,8 +151,6 @@ bool Solid::IMPLICIT::Generic::apply_correction_system(const enum NOX::Nln::Corr
 
   reset_eval_params();
 
-  eval_data().set_correction_type(type);
-
   bool ok = false;
   switch (type)
   {
@@ -265,11 +263,6 @@ void NOX::Nln::PrePostOp::IMPLICIT::Generic::run_post_apply_jacobian_inverse(
       copy_to_our_vector(rhs), result_view, copy_to_our_vector(xold), grp);
 
   impl_.print_jacobian_in_matlab_format(grp);
-
-  // reset any possible set correction type at this point
-  const Solid::ModelEvaluator::Data& eval_data = impl_.eval_data();
-  const_cast<Solid::ModelEvaluator::Data&>(eval_data).set_correction_type(
-      NOX::Nln::CorrectionType::vague);
 }
 
 

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.cpp
@@ -171,7 +171,6 @@ Solid::ModelEvaluator::Data::Data()
       delta_time_(-1.0),
       step_length_(-1.0),
       is_default_step_(true),
-      corr_type_(NOX::Nln::CorrectionType::vague),
       timintfactor_disp_(-1.0),
       timintfactor_vel_(-1.0),
       stressdata_ptr_(nullptr),

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_data.hpp
@@ -263,13 +263,6 @@ namespace Solid
         return *model_ptr_;
       }
 
-      /// get the current non-linear solver correction type
-      NOX::Nln::CorrectionType get_correction_type() const
-      {
-        check_init_setup();
-        return corr_type_;
-      }
-
       //!@name set routines which can be called inside of the element [derived]
       //! @{
 
@@ -469,12 +462,6 @@ namespace Solid
       inline void set_is_default_step(const bool& is_default_step)
       {
         is_default_step_ = is_default_step;
-      }
-
-      /// set the current system correction type of the non-linear solver
-      inline void set_correction_type(const NOX::Nln::CorrectionType corr_type)
-      {
-        corr_type_ = corr_type;
       }
 
       //! set the total time for the evaluation call
@@ -878,10 +865,6 @@ namespace Solid
        *  Only important for the internal elementwise update. */
       bool is_default_step_;
 
-      /// system correction type (e.g. in case of a SOC step, see the
-      /// NOX::Nln::Inner::StatusTest::Filter method)
-      NOX::Nln::CorrectionType corr_type_;
-
       //!@}
 
       //! @name time integration parameters
@@ -1137,13 +1120,6 @@ namespace Solid
         check_init();
         return str_data_ptr_->is_predictor();
       };
-
-      /// derived
-      NOX::Nln::CorrectionType get_correction_type() const override
-      {
-        check_init();
-        return str_data_ptr_->get_correction_type();
-      }
 
       /*! \brief Get the current active predictor type
        *


### PR DESCRIPTION
## Description and Context

Remove the unused parts of `Nln::Group` and also some other dependent classes that use its interface.

## Related Issues and Pull Requests
#359
