### PR TITLE
Reserve container space when parsing YAML

### DIFF
--- a/src/core/io/src/4C_io_yaml.hpp
+++ b/src/core/io/src/4C_io_yaml.hpp
@@ -231,6 +231,7 @@ namespace Core::IO
   {
     FOUR_C_ASSERT_ALWAYS(node.node.is_map(), "Expected a map node for a map.");
     value.clear();
+    value.reserve(node.node.num_children());
     for (auto child : node.node.children())
     {
       FOUR_C_ASSERT_ALWAYS(child.has_key(), "Expected a key in the map node.");
@@ -252,6 +253,7 @@ namespace Core::IO
   {
     FOUR_C_ASSERT_ALWAYS(node.node.is_seq(), "Expected a sequence node for a vector.");
     value.clear();
+    value.reserve(node.node.num_children());
     for (auto child : node.node.children())
     {
       T v;


### PR DESCRIPTION
As discussed during the workshop, this might speed things up when parsing very large containers.

@maxfirmbach Could you give this a try on the large example?