### PR TITLE
Generalize norms evaluation for NOX vectors and reduce the use of `get_ref_of_epetra_vector()`

### DIFF
--- a/src/constraint/4C_constraint_lagpenconstraint_noxinterface.cpp
+++ b/src/constraint/4C_constraint_lagpenconstraint_noxinterface.cpp
@@ -94,16 +94,7 @@ double LAGPENCONSTRAINT::NoxInterface::get_constraint_rhs_norms(
   // no constraint contributions present
   if (!constrRhs) return 0.0;
 
-  const ::NOX::Epetra::Vector constrRhs_nox(
-      Teuchos::rcpFromRef(constrRhs->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
-
-
-  double constrNorm = -1.0;
-  constrNorm = constrRhs_nox.norm(type);
-  if (isScaled) constrNorm /= static_cast<double>(constrRhs_nox.length());
-
-  return constrNorm;
+  return NOX::Nln::Aux::calc_vector_norm(*constrRhs, type, isScaled);
 }
 
 /*----------------------------------------------------------------------------*
@@ -126,9 +117,6 @@ double LAGPENCONSTRAINT::NoxInterface::get_lagrange_multiplier_update_rms(
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_lag_pen_constraint, xNew_copy);
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
-  const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
 
   rms = NOX::Nln::Aux::root_mean_square_norm(
       aTol, rTol, *lagnew_ptr, *lagincr_ptr, disable_implicit_weighting);
@@ -155,17 +143,8 @@ double LAGPENCONSTRAINT::NoxInterface::get_lagrange_multiplier_update_norms(
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_lag_pen_constraint, xNew_copy);
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
-  const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
 
-  double updatenorm = -1.0;
-
-  updatenorm = lagincr_nox_ptr.norm(type);
-  // do scaling if desired
-  if (isScaled) updatenorm /= static_cast<double>(lagincr_nox_ptr.length());
-
-  return updatenorm;
+  return NOX::Nln::Aux::calc_vector_norm(*lagincr_ptr, type, isScaled);
 }
 
 /*----------------------------------------------------------------------------*
@@ -182,17 +161,7 @@ double LAGPENCONSTRAINT::NoxInterface::get_previous_lagrange_multiplier_norms(
   std::shared_ptr<Core::LinAlg::Vector<double>> lagold_ptr =
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_lag_pen_constraint, xOld_copy);
 
-  const ::NOX::Epetra::Vector lagold_nox_ptr(
-      Teuchos::rcpFromRef(lagold_ptr->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
-
-  double lagoldnorm = -1.0;
-
-  lagoldnorm = lagold_nox_ptr.norm(type);
-  // do scaling if desired
-  if (isScaled) lagoldnorm /= static_cast<double>(lagold_nox_ptr.length());
-
-  return lagoldnorm;
+  return NOX::Nln::Aux::calc_vector_norm(*lagold_ptr, type, isScaled);
 }
 
 

--- a/src/contact/4C_contact_meshtying_noxinterface.cpp
+++ b/src/contact/4C_contact_meshtying_noxinterface.cpp
@@ -58,15 +58,7 @@ double CONTACT::MtNoxInterface::get_constraint_rhs_norms(const Core::LinAlg::Vec
   // no constraint contributions present
   if (!constrRhs) return 0.0;
 
-  const ::NOX::Epetra::Vector constrRhs_nox(
-      Teuchos::rcpFromRef(constrRhs->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
-
-  double constrNorm = -1.0;
-  constrNorm = constrRhs_nox.norm(type);
-  if (isScaled) constrNorm /= static_cast<double>(constrRhs_nox.length());
-
-  return constrNorm;
+  return NOX::Nln::Aux::calc_vector_norm(*constrRhs, type, isScaled);
 }
 
 /*----------------------------------------------------------------------------*
@@ -87,9 +79,6 @@ double CONTACT::MtNoxInterface::get_lagrange_multiplier_update_rms(
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_meshtying, xNew);
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
-  const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
 
   rms = NOX::Nln::Aux::root_mean_square_norm(
       aTol, rTol, *lagnew_ptr, *lagincr_ptr, disable_implicit_weighting);
@@ -113,17 +102,8 @@ double CONTACT::MtNoxInterface::get_lagrange_multiplier_update_norms(
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_meshtying, xNew);
 
   lagincr_ptr->update(1.0, *lagnew_ptr, -1.0);
-  const ::NOX::Epetra::Vector lagincr_nox_ptr(
-      Teuchos::rcpFromRef(lagincr_ptr->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
 
-  double updatenorm = -1.0;
-
-  updatenorm = lagincr_nox_ptr.norm(type);
-  // do scaling if desired
-  if (isScaled) updatenorm /= static_cast<double>(lagincr_nox_ptr.length());
-
-  return updatenorm;
+  return NOX::Nln::Aux::calc_vector_norm(*lagincr_ptr, type, isScaled);
 }
 
 /*----------------------------------------------------------------------------*
@@ -138,17 +118,7 @@ double CONTACT::MtNoxInterface::get_previous_lagrange_multiplier_norms(
   std::shared_ptr<Core::LinAlg::Vector<double>> lagold_ptr =
       gstate_ptr_->extract_model_entries(Inpar::Solid::model_meshtying, xOld);
 
-  const ::NOX::Epetra::Vector lagold_nox_ptr(
-      Teuchos::rcpFromRef(lagold_ptr->get_ref_of_epetra_vector()),
-      ::NOX::Epetra::Vector::CreateView);
-
-  double lagoldnorm = -1.0;
-
-  lagoldnorm = lagold_nox_ptr.norm(type);
-  // do scaling if desired
-  if (isScaled) lagoldnorm /= static_cast<double>(lagold_nox_ptr.length());
-
-  return lagoldnorm;
+  return NOX::Nln::Aux::calc_vector_norm(*lagold_ptr, type, isScaled);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/fs3i/4C_fs3i_biofilm_fsi.cpp
+++ b/src/fs3i/4C_fs3i_biofilm_fsi.cpp
@@ -591,17 +591,17 @@ void FS3I::BiofilmFSI::inner_timeloop()
 
       if (avgrowth)
       {
-        (*((normtempinflux_.get_ref_of_epetra_vector())(0)))[lnodeid] += tempflux;
-        (*((normtemptraction_.get_ref_of_epetra_vector())(0)))[lnodeid] += abs(tempnormtrac);
-        (*((tangtemptractionone_.get_ref_of_epetra_vector())(0)))[lnodeid] += abs(temptangtracone);
-        (*((tangtemptractiontwo_.get_ref_of_epetra_vector())(0)))[lnodeid] += abs(temptangtractwo);
+        normtempinflux_[lnodeid] += tempflux;
+        normtemptraction_[lnodeid] += abs(tempnormtrac);
+        tangtemptractionone_[lnodeid] += abs(temptangtracone);
+        tangtemptractiontwo_[lnodeid] += abs(temptangtractwo);
       }
       else
       {
-        (*((norminflux_->get_ref_of_epetra_vector())(0)))[lnodeid] = tempflux;
-        (*((normtraction_->get_ref_of_epetra_vector())(0)))[lnodeid] = abs(tempnormtrac);
-        (*((tangtractionone_->get_ref_of_epetra_vector())(0)))[lnodeid] = abs(temptangtracone);
-        (*((tangtractiontwo_->get_ref_of_epetra_vector())(0)))[lnodeid] = abs(temptangtractwo);
+        (*norminflux_)[lnodeid] = tempflux;
+        (*normtraction_)[lnodeid] = abs(tempnormtrac);
+        (*tangtractionone_)[lnodeid] = abs(temptangtracone);
+        (*tangtractiontwo_)[lnodeid] = abs(temptangtractwo);
       }
     }
   }
@@ -621,15 +621,10 @@ void FS3I::BiofilmFSI::inner_timeloop()
       int gnodeid = condnodemap->gid(i);
       int lnodeid = strudis->node_row_map()->lid(gnodeid);
 
-      // Fix this.
-      (*((norminflux_->get_ref_of_epetra_vector())(0)))[lnodeid] =
-          (*((normtempinflux_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
-      (*((normtraction_->get_ref_of_epetra_vector())(0)))[lnodeid] =
-          (*((normtemptraction_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
-      (*((tangtractionone_->get_ref_of_epetra_vector())(0)))[lnodeid] =
-          (*((tangtemptractionone_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
-      (*((tangtractiontwo_->get_ref_of_epetra_vector())(0)))[lnodeid] =
-          (*((tangtemptractiontwo_.get_ref_of_epetra_vector())(0)))[lnodeid] / step_fsi_;
+      (*norminflux_)[lnodeid] = normtempinflux_[lnodeid] / step_fsi_;
+      (*normtraction_)[lnodeid] = normtemptraction_[lnodeid] / step_fsi_;
+      (*tangtractionone_)[lnodeid] = tangtemptractionone_[lnodeid] / step_fsi_;
+      (*tangtractiontwo_)[lnodeid] = tangtemptractiontwo_[lnodeid] / step_fsi_;
     }
   }
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.cpp
@@ -571,6 +571,33 @@ std::string NOX::Nln::Aux::get_direction_method_list_name(const Teuchos::Paramet
   }
 }
 
+template <typename T>
+T NOX::Nln::Aux::calc_vector_norm(const Core::LinAlg::Vector<T>& vector,
+    const ::NOX::Abstract::Vector::NormType type, const bool is_scaled)
+{
+  T value;
+
+  switch (type)
+  {
+    case ::NOX::Abstract::Vector::OneNorm:
+      vector.norm_1(&value);
+      break;
+    case ::NOX::Abstract::Vector::TwoNorm:
+      vector.norm_2(&value);
+      break;
+    case ::NOX::Abstract::Vector::MaxNorm:
+      vector.norm_inf(&value);
+      break;
+    default:
+      FOUR_C_THROW("The norm type is not supported");
+  }
+
+  // do the scaling if desired
+  if (is_scaled) value /= static_cast<T>(vector.global_length());
+
+  return value;
+}
+
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 template bool NOX::Nln::Aux::is_quantity<NOX::Nln::StatusTest::NormF>(
@@ -594,5 +621,7 @@ template int NOX::Nln::Aux::get_outer_status<NOX::Nln::StatusTest::NormWRMS>(
     const ::NOX::StatusTest::Generic& test);
 template int NOX::Nln::Aux::get_outer_status<NOX::Nln::StatusTest::ActiveSet>(
     const ::NOX::StatusTest::Generic& test);
+template double NOX::Nln::Aux::calc_vector_norm<double>(const Core::LinAlg::Vector<double>& vector,
+    const ::NOX::Abstract::Vector::NormType type, const bool is_scaled);
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_aux.hpp
@@ -137,6 +137,10 @@ namespace NOX
       /// return the name of the parameter list corresponding to the set direction method
       std::string get_direction_method_list_name(const Teuchos::ParameterList& p);
 
+      /// Wrapper to compute vector norms
+      template <typename T>
+      T calc_vector_norm(const Core::LinAlg::Vector<T>& vector,
+          const ::NOX::Abstract::Vector::NormType type, const bool is_scaled = false);
     }  // namespace Aux
   }  // namespace Nln
 }  // namespace NOX

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.cpp
@@ -203,7 +203,7 @@ double Solid::TimeInt::NoxInterface::get_primary_rhs_norms(const Epetra_Vector& 
 
       int_ptr_->remove_condensed_contributions_from_rhs(*rhs_ptr);
 
-      rhsnorm = calculate_norm(rhs_ptr->get_ref_of_epetra_vector(), type, isscaled);
+      rhsnorm = NOX::Nln::Aux::calc_vector_norm(*rhs_ptr, type, isscaled);
 
       break;
     }
@@ -212,7 +212,7 @@ double Solid::TimeInt::NoxInterface::get_primary_rhs_norms(const Epetra_Vector& 
       // export the model specific solution if necessary
       auto rhs_ptr = gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(F));
 
-      rhsnorm = calculate_norm(rhs_ptr->get_ref_of_epetra_vector(), type, isscaled);
+      rhsnorm = NOX::Nln::Aux::calc_vector_norm(*rhs_ptr, type, isscaled);
 
       break;
     }
@@ -311,7 +311,7 @@ double Solid::TimeInt::NoxInterface::get_primary_solution_update_norms(const Epe
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xnew));
 
       model_incr_ptr->update(1.0, *model_xnew_ptr, -1.0);
-      updatenorm = calculate_norm(model_incr_ptr->get_ref_of_epetra_vector(), type, isscaled);
+      updatenorm = NOX::Nln::Aux::calc_vector_norm(*model_incr_ptr, type, isscaled);
 
       break;
     }
@@ -324,7 +324,7 @@ double Solid::TimeInt::NoxInterface::get_primary_solution_update_norms(const Epe
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xnew));
 
       model_incr_ptr->update(1.0, *model_xnew_ptr, -1.0);
-      updatenorm = calculate_norm(model_incr_ptr->get_ref_of_epetra_vector(), type, isscaled);
+      updatenorm = NOX::Nln::Aux::calc_vector_norm(*model_incr_ptr, type, isscaled);
 
       break;
     }
@@ -372,7 +372,7 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(const E
       auto model_xold_ptr =
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xold));
 
-      xoldnorm = calculate_norm(model_xold_ptr->get_ref_of_epetra_vector(), type, isscaled);
+      xoldnorm = NOX::Nln::Aux::calc_vector_norm(*model_xold_ptr, type, isscaled);
 
       break;
     }
@@ -382,7 +382,7 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(const E
       auto model_xold_ptr =
           gstate_ptr_->extract_model_entries(mt, Core::LinAlg::Vector<double>(xold));
 
-      xoldnorm = calculate_norm(model_xold_ptr->get_ref_of_epetra_vector(), type, isscaled);
+      xoldnorm = NOX::Nln::Aux::calc_vector_norm(*model_xold_ptr, type, isscaled);
 
       break;
     }
@@ -407,20 +407,6 @@ double Solid::TimeInt::NoxInterface::get_previous_primary_solution_norms(const E
   return xoldnorm;
 }
 
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-double Solid::TimeInt::NoxInterface::calculate_norm(Epetra_Vector& quantity,
-    const ::NOX::Abstract::Vector::NormType type, const bool isscaled) const
-{
-  const ::NOX::Epetra::Vector quantity_nox(
-      Teuchos::rcpFromRef(quantity), ::NOX::Epetra::Vector::CreateView);
-
-  double norm = quantity_nox.norm(type);
-  // do the scaling if desired
-  if (isscaled) norm /= static_cast<double>(quantity_nox.length());
-
-  return norm;
-}
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_timint_noxinterface.hpp
@@ -169,10 +169,6 @@ namespace Solid
       void find_constraint_models(const ::NOX::Abstract::Group* grp,
           std::vector<Inpar::Solid::ModelType>& constraint_models) const;
 
-      //! calculate norm in Get*Norms functions
-      double calculate_norm(Epetra_Vector& quantity, const ::NOX::Abstract::Vector::NormType type,
-          const bool isscaled) const;
-
      protected:
       //! init flag
       bool isinit_;


### PR DESCRIPTION
## Description and Context
I have removed some obsolete creation of NOX vector views when computing the norms since our `LinAlg::Vector` can compute them itself. I also removed some other unnecessary calls to `get_ref_of_epetra_vector()`.

## Related Issues and Pull Requests
#359
