### PR TITLE
Remove some calls to `epetra_matrix()`

### DIFF
--- a/src/contact/4C_contact_lagrange_strategy_wear.cpp
+++ b/src/contact/4C_contact_lagrange_strategy_wear.cpp
@@ -4170,7 +4170,7 @@ void Wear::LagrangeStrategyWear::output_wear()
 
       // extract diagonal of data
       Core::LinAlg::Vector<double> diagD(*gactivedofs_);
-      data->epetra_matrix()->ExtractDiagonalCopy(diagD.get_ref_of_epetra_vector());
+      data->extract_diagonal_copy(diagD);
 
       // solve by dividing through diagonal elements of data. Do not divide by 0.
       for (int i = 0; i < lNumActiveDOFs; ++i)
@@ -4248,7 +4248,7 @@ void Wear::LagrangeStrategyWear::output_wear()
 
         // extract diagonal of d2ii
         Core::LinAlg::Vector<double> diagD(*wear2_vectori);
-        d2ii->epetra_matrix()->ExtractDiagonalCopy(diagD.get_ref_of_epetra_vector());
+        d2ii->extract_diagonal_copy(diagD);
 
         // solve by dividing through diagonal elements of data. Do not divide by 0.
         for (int i = 0; i < lNumActiveDOFs; ++i)

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -307,7 +307,7 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
     for (int c = 0; c < numcols; ++c)
     {
       if (block_mat(r, c).epetra_matrix()->GlobalMaxNumEntries() == 0 or
-          block_mat(r, c).epetra_matrix()->NormFrobenius() == 0.0)
+          block_mat(r, c).norm_frobenius() == 0.0)
         isempty[r][c] = true;
     }
 

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -429,10 +429,10 @@ void NOX::Nln::CONTACT::LinearSystem::apply_diagonal_inverse(Core::LinAlg::Spars
 
   Core::LinAlg::Vector<double> diag_mat(mat.range_map(), true);
   int err = mat.extract_diagonal_copy(diag_mat);
-  if (err) FOUR_C_THROW("ExtractDiagonalCopy failed! (err={})", err);
+  if (err) FOUR_C_THROW("extract_diagonal_copy failed with error code {}", err);
 
   err = lhs_block.reciprocal_multiply(1.0, diag_mat, rhs_block, 0.0);
-  if (err) FOUR_C_THROW("ReciprocalMultiply failed! (err={})", err);
+  if (err) FOUR_C_THROW("reciprocal_multiply failed with error code {}", err);
 
   Core::LinAlg::assemble_my_vector(0.0, lhs, 1.0, lhs_block);
 }

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -311,8 +311,7 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
         isempty[r][c] = true;
     }
 
-    if (block_mat(r, r).epetra_matrix()->NumGlobalDiagonals() ==
-            block_mat(r, r).num_global_nonzeros() &&
+    if (block_mat(r, r).num_global_diagonals() == block_mat(r, r).num_global_nonzeros() &&
         !isempty[r][r])
       isdiagonal[r] = true;
   }
@@ -418,7 +417,7 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
 void NOX::Nln::CONTACT::LinearSystem::apply_diagonal_inverse(Core::LinAlg::SparseMatrix& mat,
     Core::LinAlg::Vector<double>& lhs, const Core::LinAlg::Vector<double>& rhs) const
 {
-  if (mat.epetra_matrix()->NumGlobalDiagonals() != mat.num_global_nonzeros())
+  if (mat.num_global_diagonals() != mat.num_global_nonzeros())
     FOUR_C_THROW("The given matrix seems to be no diagonal matrix!");
 
   Core::LinAlg::Vector<double> lhs_block(mat.domain_map(), true);

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -312,7 +312,7 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
     }
 
     if (block_mat(r, r).epetra_matrix()->NumGlobalDiagonals() ==
-            block_mat(r, r).epetra_matrix()->NumGlobalNonzeros() &&
+            block_mat(r, r).num_global_nonzeros() &&
         !isempty[r][r])
       isdiagonal[r] = true;
   }
@@ -418,7 +418,7 @@ void NOX::Nln::CONTACT::LinearSystem::LinearSubProblem::extract_active_blocks(
 void NOX::Nln::CONTACT::LinearSystem::apply_diagonal_inverse(Core::LinAlg::SparseMatrix& mat,
     Core::LinAlg::Vector<double>& lhs, const Core::LinAlg::Vector<double>& rhs) const
 {
-  if (mat.epetra_matrix()->NumGlobalDiagonals() != mat.epetra_matrix()->NumGlobalNonzeros())
+  if (mat.epetra_matrix()->NumGlobalDiagonals() != mat.num_global_nonzeros())
     FOUR_C_THROW("The given matrix seems to be no diagonal matrix!");
 
   Core::LinAlg::Vector<double> lhs_block(mat.domain_map(), true);

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -303,7 +303,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::KrylovProjector::proje
   // here: matvec = A c_;
   std::shared_ptr<Core::LinAlg::MultiVector<double>> matvec =
       std::make_shared<Core::LinAlg::MultiVector<double>>(c_->get_map(), nsdim_, false);
-  A.epetra_matrix()->Multiply(false, *c_, *matvec);
+  A.multiply(false, *c_, *matvec);
 
   // compute serial dense matrix c^T A c
   std::shared_ptr<Core::LinAlg::SerialDenseMatrix> cTAc =
@@ -320,7 +320,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::KrylovProjector::proje
   {
     // put in brackets to delete mat2 immediately after being added to mat1
     // here: matvec = A^T c_;
-    A.epetra_matrix()->Multiply(true, *c_, *matvec);
+    A.multiply(true, *c_, *matvec);
     std::shared_ptr<Core::LinAlg::SparseMatrix> mat2 =
         multiply_multi_vector_multi_vector(w_invwTc, matvec, 2, true);
     mat1->add(*mat2, false, 1.0, 1.0);

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -382,7 +382,7 @@ void Core::LinAlg::KrylovProjector::create_projector(std::shared_ptr<Core::LinAl
     int err = P->insert_global_values(grid, 1, &one, &grid);
     if (err < 0)
     {
-      err = P->epetra_matrix()->SumIntoGlobalValues(grid, 1, &one, &grid);
+      err = P->sum_into_global_values(grid, 1, &one, &grid);
       if (err < 0)
       {
         FOUR_C_THROW("insertion error when trying to computekrylov projection matrix.");

--- a/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_krylov_projector.cpp
@@ -379,7 +379,7 @@ void Core::LinAlg::KrylovProjector::create_projector(std::shared_ptr<Core::LinAl
     const int grid = P->global_row_index(rr);
 
     // add identity matrix by adding 1 on diagonal entries
-    int err = P->epetra_matrix()->InsertGlobalValues(grid, 1, &one, &grid);
+    int err = P->insert_global_values(grid, 1, &one, &grid);
     if (err < 0)
     {
       err = P->epetra_matrix()->SumIntoGlobalValues(grid, 1, &one, &grid);
@@ -573,8 +573,7 @@ Core::LinAlg::KrylovProjector::multiply_multi_vector_multi_vector(
     }
 
     // insert values in mat
-    int err = mat->epetra_matrix()->InsertGlobalValues(
-        grid, indices.size(), rowvals.data(), indices.data());
+    int err = mat->insert_global_values(grid, indices.size(), rowvals.data(), indices.data());
     if (err < 0)
     {
       FOUR_C_THROW(

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1300,11 +1300,11 @@ void Core::LinAlg::SparseMatrix::apply_dirichlet_with_trafo(const Core::LinAlg::
         {
           // extract values of trafo at the inclined dbc dof
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-          int err = trafo.epetra_matrix()->ExtractGlobalRowCopy(
+          int err = trafo.extract_global_row_copy(
               row, trafomaxnumentries, trafonumentries, trafovalues.data(), trafoindices.data());
           if (err < 0) FOUR_C_THROW("Epetra_CrsMatrix::ExtractGlobalRowCopy returned err={}", err);
 #else
-          trafo.epetra_matrix()->ExtractGlobalRowCopy(
+          trafo.extract_global_row_copy(
               row, trafomaxnumentries, trafonumentries, trafovalues.data(), trafoindices.data());
 #endif
         }

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1690,6 +1690,14 @@ int Core::LinAlg::SparseMatrix::replace_my_values(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
+int Core::LinAlg::SparseMatrix::replace_global_values(
+    int global_row, int num_entries, const double* values, const int* indices) const
+{
+  return sysmat_->ReplaceGlobalValues(global_row, num_entries, values, indices);
+}
+
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
 int Core::LinAlg::SparseMatrix::insert_global_values(
     int global_row, int num_entries, const double* values, const int* indices) const
 {

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1369,11 +1369,11 @@ void Core::LinAlg::SparseMatrix::apply_dirichlet_with_trafo(const Core::LinAlg::
         if (diagonalblock)
         {
 #ifdef FOUR_C_ENABLE_ASSERTIONS
-          err = trafo.epetra_matrix()->ExtractMyRowCopy(
+          err = trafo.extract_my_row_copy(
               i, trafomaxnumentries, trafonumentries, trafovalues.data(), trafoindices.data());
           if (err < 0) FOUR_C_THROW("Epetra_CrsMatrix::ExtractGlobalRowCopy returned err={}", err);
 #else
-          trafo.epetra_matrix()->ExtractMyRowCopy(
+          trafo.extract_my_row_copy(
               i, trafomaxnumentries, trafonumentries, trafovalues.data(), trafoindices.data());
 #endif
 

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -578,6 +578,10 @@ namespace Core::LinAlg
     int replace_my_values(
         int my_row, int num_entries, const double* values, const int* indices) const;
 
+    /// Replaces values in a global row.
+    int replace_global_values(
+        int global_row, int num_entries, const double* values, const int* indices) const;
+
     /// Inserts values into a global row.
     int insert_global_values(
         int global_row, int num_entries, const double* values, const int* indices) const;

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -489,6 +489,10 @@ namespace Core::LinAlg
       return sysmat_->NumAllocatedGlobalEntries(global_row);
     }
 
+    /// Returns the number of global nonzero diagonal entries, based on global row/column index
+    /// comparisons.
+    int num_global_diagonals() const { return sysmat_->NumGlobalDiagonals(); };
+
     /// Returns the global row index for give local row index, returns IndexBase-1 if we don't have
     /// this local row.
     int global_row_index(int local_row_index) const { return sysmat_->GRID(local_row_index); }

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -218,8 +218,8 @@ void Core::LinAlg::matrix_put(const Core::LinAlg::SparseMatrix& A, const double 
     if (err) FOUR_C_THROW("ExtractGlobalRowCopy returned err={}", err);
     if (scalarA != 1.0)
       for (int j = 0; j < NumEntries; ++j) Values[j] *= scalarA;
-    err = B.epetra_matrix()->ReplaceGlobalValues(Row, NumEntries, Values.data(), Indices.data());
-    if (err) FOUR_C_THROW("ReplaceGlobalValues returned err={}", err);
+    err = B.replace_global_values(Row, NumEntries, Values.data(), Indices.data());
+    if (err) FOUR_C_THROW("replace_global_values() failed with error code {}", err);
   }
 }
 

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.cpp
@@ -403,7 +403,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::matrix_sparse_inverse(
     if (err != 0) FOUR_C_THROW("Error in serial QR solve.");
 
     // 6. set calculated row into Ainv
-    A_inverse->epetra_matrix()->ReplaceMyValues(k, localX.length(), localX.values(), Ik);
+    A_inverse->replace_my_values(k, localX.length(), localX.values(), Ik);
   }
   A_inverse->complete();
 

--- a/src/structure/4C_structure_timint_ab2.cpp
+++ b/src/structure/4C_structure_timint_ab2.cpp
@@ -239,7 +239,7 @@ int Solid::TimIntAB2::integrate_step()
       std::shared_ptr<Core::LinAlg::Vector<double>> diagonal =
           Core::LinAlg::create_vector(*dof_row_map_view(), true);
       int error = massmatrix->extract_diagonal_copy(*diagonal);
-      if (error != 0) FOUR_C_THROW("ERROR: ExtractDiagonalCopy went wrong");
+      if (error != 0) FOUR_C_THROW("extract_diagonal_copy failed with error code {}", error);
       accn_->reciprocal_multiply(1.0, *diagonal, *frimpn_, 0.0);
     }
   }

--- a/src/structure/4C_structure_timint_centrdiff.cpp
+++ b/src/structure/4C_structure_timint_centrdiff.cpp
@@ -222,7 +222,7 @@ int Solid::TimIntCentrDiff::integrate_step()
       std::shared_ptr<Core::LinAlg::Vector<double>> diagonal =
           Core::LinAlg::create_vector(*dof_row_map_view(), true);
       int error = massmatrix->extract_diagonal_copy(*diagonal);
-      if (error != 0) FOUR_C_THROW("ERROR: ExtractDiagonalCopy went wrong");
+      if (error != 0) FOUR_C_THROW("extract_diagonal_copy failed with error code {}", error);
       accn_->reciprocal_multiply(1.0, *diagonal, *frimpn_, 0.0);
     }
   }


### PR DESCRIPTION
## Description and Context

This PR reduces the number of calls to `epetra_matrix()`, i.e. reduce the access to Epetra objects. Instead, it uses existing wrappers in the `LinAlg::SparseMatrix` or adds missing wrappers.

## Related Issues and Pull Requests

Part of #764 