### PR TITLE
Allow documentation of enum values in input

### DIFF
--- a/src/core/io/src/4C_io_exodus.cpp
+++ b/src/core/io/src/4C_io_exodus.cpp
@@ -10,6 +10,7 @@
 #include "4C_fem_general_utils_local_connectivity_matrices.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_utils_enum.hpp"
+#include "4C_utils_std23_unreachable.hpp"
 
 #include <exodusII.h>
 #include <Teuchos_Time.hpp>
@@ -125,6 +126,25 @@ namespace
     }
   }
 }  // namespace
+
+
+std::string Core::IO::Exodus::describe(VerbosityLevel level)
+{
+  switch (level)
+  {
+    case VerbosityLevel::none:
+      return "no output";
+    case VerbosityLevel::summary:
+      return "output of summary for blocks and sets";
+    case VerbosityLevel::detailed_summary:
+      return "output of summary for each block and set";
+    case VerbosityLevel::detailed:
+      return "detailed output for each block and set";
+    case VerbosityLevel::full:
+      return "detailed output, even for nodes and element connectivities";
+  }
+  std23::unreachable();
+}
 
 
 Core::IO::Exodus::Mesh::Mesh(std::filesystem::path exodus_file, MeshParameters mesh_parameters)

--- a/src/core/io/src/4C_io_exodus.hpp
+++ b/src/core/io/src/4C_io_exodus.hpp
@@ -22,7 +22,7 @@ namespace Core::IO::Exodus
 {
   enum class VerbosityLevel : int
   {
-    none = 0,              ///< output of summary for blocks and sets,
+    none = 0,              ///< no output,
     summary = 1,           ///< output of summary for blocks and sets,
     detailed_summary = 2,  ///< output of summary for each block and set,
     detailed = 3,          ///< detailed output for each block and set,
@@ -32,6 +32,11 @@ namespace Core::IO::Exodus
   {
     return static_cast<int>(lhs) > static_cast<int>(rhs);
   }
+
+  /**
+   * Describe each of the VerbosityLevel options.
+   */
+  std::string describe(VerbosityLevel level);
 
 
   struct ElementBlock;

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -105,7 +105,19 @@ namespace
       C,
     };
 
-    auto spec = parameter<EnumClass>("enum");
+    const auto describe = [](EnumClass e) -> std::string
+    {
+      switch (e)
+      {
+        case EnumClass::A:
+          return "The option A";
+        default:
+          return "Other option";
+      }
+    };
+
+    auto spec = parameter<EnumClass>(
+        "enum", {.description = "An enum constant", .enum_value_description = describe});
 
     {
       SCOPED_TRACE("Valid enum constant");
@@ -135,11 +147,15 @@ namespace
 
       std::string expected = R"(name: enum
 type: enum
+description: "An enum constant"
 required: true
 choices:
   - name: A
+    description: "The option A"
   - name: B
+    description: "Other option"
   - name: C
+    description: "Other option"
 )";
       EXPECT_EQ(out.str(), expected);
     }

--- a/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
@@ -154,9 +154,12 @@ std::map<std::string, Core::IO::InputSpec> Global::valid_parameters()
                 "FILE", {.description = "Path to the exodus geometry file. Either absolute or "
                                         "relative to the input file."}),
             parameter<Core::IO::Exodus::VerbosityLevel>("SHOW_INFO",
-                {.description =
-                        "Print element, node and set info for the exodus file after reading.",
-                    .default_value = Core::IO::Exodus::VerbosityLevel::none}),
+                {
+                    .description = "Choose verbosity of reporting element, node and set info for "
+                                   "the exodus file after reading.",
+                    .enum_value_description = Core::IO::Exodus::describe,
+                    .default_value = Core::IO::Exodus::VerbosityLevel::none,
+                }),
 
             // Once we support more formats, we should add a "TYPE" parameter for the file format.
             list("ELEMENT_BLOCKS",

--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -181,7 +181,9 @@ def schema_from_enum(enum):
         dict: JSON schema data
     """
     # One could also do this using a oneOf where the choices are strings with constant values.
-    # This would allow to add a description for each option.
+    # This would allow to add a description for each option. However, at the time we tried
+    # this, good editor support was not available for this feature, i.e., editors only show
+    # either the description of the parameter or the description of the choice, but not both.
     schema = json_schema(
         schema_type=FOURC_BASE_TYPES_TO_JSON_SCHEMA_DICT["string"],
         title=enum.short_description(),

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -136,9 +136,16 @@ class Enum(Primitive):
 
     def __post_init__(self):
         super().__post_init__()
+        combined_description = ""
         for i, choice in enumerate(self.choices):
             if isinstance(choice, dict):
                 self.choices[i] = choice["name"]
+                if d := choice.get("description", None):
+                    combined_description += f"{choice['name']}: {d}\n"
+        if self.description is not NOTSET:
+            self.description += "\n" + combined_description
+        elif combined_description != "":
+            self.description = combined_description
 
 
 @dataclass


### PR DESCRIPTION
Requested by and implemented together with @ischeider 

FYI @c-p-schmidt, you also requested this feature a while ago