### PR TITLE
Replace `NOX::Epetra::Scaling` with a custom class

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.cpp
@@ -26,7 +26,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, iPrec, M,
           cloneVector, scalingObject)
 {
@@ -57,7 +57,7 @@ NOX::Nln::Cardiovascular0D::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector, scalingObject)
 {

--- a/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.hpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_nox_nln_linearsystem.hpp
@@ -33,7 +33,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
         LinearSystem(Teuchos::ParameterList& printParams,
@@ -54,7 +54,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without preconditioner and scaling object
         LinearSystem(Teuchos::ParameterList& printParams,

--- a/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.cpp
+++ b/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.cpp
@@ -28,7 +28,7 @@ NOX::Nln::LAGPENCONSTRAINT::LinearSystem::LinearSystem(Teuchos::ParameterList& p
     const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, iPrec, M,
           cloneVector, scalingObject),
       i_constr_(iConstr),

--- a/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.hpp
+++ b/src/constraint/4C_constraint_nox_nln_lagpenconstraint_linearsystem.hpp
@@ -36,7 +36,7 @@ namespace NOX
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
         LinearSystem(Teuchos::ParameterList& printParams,

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -31,7 +31,7 @@ NOX::Nln::CONTACT::LinearSystem::LinearSystem(Teuchos::ParameterList& printParam
     const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, iPrec, M,
           cloneVector, scalingObject),
       i_constr_(iConstr),

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.hpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.hpp
@@ -42,7 +42,7 @@ namespace NOX
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
         LinearSystem(Teuchos::ParameterList& printParams,

--- a/src/contact/4C_contact_nox_nln_meshtying_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_meshtying_linearsystem.cpp
@@ -30,7 +30,7 @@ NOX::Nln::MeshTying::LinearSystem::LinearSystem(Teuchos::ParameterList& printPar
     const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, iPrec, M,
           cloneVector, scalingObject),
       i_constr_(iConstr),

--- a/src/contact/4C_contact_nox_nln_meshtying_linearsystem.hpp
+++ b/src/contact/4C_contact_nox_nln_meshtying_linearsystem.hpp
@@ -42,7 +42,7 @@ namespace NOX
             const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
         LinearSystem(Teuchos::ParameterList& printParams,

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -29,7 +29,7 @@ NOX::FSI::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     Teuchos::ParameterList& linearSolverParams,
     const std::shared_ptr<::NOX::Epetra::Interface::Jacobian>& iJac,
     const std::shared_ptr<Epetra_Operator>& J, const ::NOX::Epetra::Vector& cloneVector,
-    std::shared_ptr<Core::LinAlg::Solver> solver, const Teuchos::RCP<::NOX::Epetra::Scaling> s)
+    std::shared_ptr<Core::LinAlg::Solver> solver, const std::shared_ptr<NOX::Nln::Scaling> s)
     : utils_(printParams),
       jac_interface_ptr_(iJac),
       jac_type_(EpetraOperator),
@@ -162,19 +162,6 @@ bool NOX::FSI::LinearSystem::applyRightPreconditioning(bool useTranspose,
   if (&result != &input) result = input;
 
   return true;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-Teuchos::RCP<::NOX::Epetra::Scaling> NOX::FSI::LinearSystem::getScaling() { return scaling_; }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void NOX::FSI::LinearSystem::resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject)
-{
-  scaling_ = scalingObject;
 }
 
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -10,6 +10,8 @@
 
 #include "4C_config.hpp"
 
+#include "4C_solver_nonlin_nox_linearsystem_base.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 #include <NOX.H>
@@ -18,8 +20,6 @@
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Preconditioner.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_LinearSystem.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_Time.hpp>
@@ -36,7 +36,7 @@ namespace Core::LinAlg
 
 namespace NOX::FSI
 {
-  class LinearSystem : public ::NOX::Epetra::LinearSystem
+  class LinearSystem : public NOX::Nln::LinearSystemBase
   {
    private:
     enum OperatorType
@@ -58,8 +58,8 @@ namespace NOX::FSI
         const ::NOX::Epetra::Vector& cloneVector,   ///< initial guess of the solution process
         std::shared_ptr<Core::LinAlg::Solver>
             structure_solver,  ///< (used-defined) linear algebraic solver
-        const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject =
-            Teuchos::null);  ///< scaling of the linear system
+        const std::shared_ptr<NOX::Nln::Scaling> scalingObject =
+            nullptr);  ///< scaling of the linear system
 
     /// provide storage pattern of tangent matrix, i.e. the operator
     OperatorType get_operator_type(const Epetra_Operator& Op);
@@ -83,12 +83,6 @@ namespace NOX::FSI
     /// Apply right preconditiong to the given input vector.
     bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
         const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
-    /// Get the scaling object.
-    Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() override;
-
-    /// Sets the diagonal scaling vector(s) used in scaling the linear system.
-    void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s) override;
 
     /// Evaluates the Jacobian based on the solution vector x.
     bool computeJacobian(const ::NOX::Epetra::Vector& x) override;
@@ -144,7 +138,7 @@ namespace NOX::FSI
     OperatorType jac_type_;
     mutable std::shared_ptr<Epetra_Operator> jac_ptr_;
     mutable std::shared_ptr<Epetra_Operator> prec_ptr_;
-    Teuchos::RCP<::NOX::Epetra::Scaling> scaling_;
+    std::shared_ptr<NOX::Nln::Scaling> scaling_;
     mutable std::shared_ptr<::NOX::Epetra::Vector> tmp_vector_ptr_;
 
     bool output_solve_details_;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -29,7 +29,7 @@ NOX::FSI::LinearSystemGCR::LinearSystemGCR(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Epetra_Operator>& jacobian, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> s)
+    const std::shared_ptr<NOX::Nln::Scaling> s)
     : utils(printParams),
       jacInterfacePtr(iJac),
       jacType(EpetraOperator),
@@ -103,16 +103,11 @@ bool NOX::FSI::LinearSystemGCR::applyJacobianInverse(
       jacPtr.get(), &(result.getEpetraVector()), &(nonConstInput.getEpetraVector()));
 
   // ************* Begin linear system scaling *******************
-  if (!!(scaling))
+  if (scaling)
   {
-    if (!manualScaling) scaling->computeScaling(Problem);
+    if (!manualScaling) scaling->compute_scaling(Problem);
 
-    scaling->scaleLinearSystem(Problem);
-
-    if (utils.isPrintType(::NOX::Utils::Details))
-    {
-      utils.out() << *scaling << std::endl;
-    }
+    scaling->scale_linear_system(Problem);
   }
   // ************* End linear system scaling *******************
 
@@ -136,7 +131,7 @@ bool NOX::FSI::LinearSystemGCR::applyJacobianInverse(
   }
 
   // Unscale the linear system
-  if (!!(scaling)) scaling->unscaleLinearSystem(Problem);
+  if (scaling) scaling->unscale_linear_system(Problem);
 
   // Set the output parameters in the "Output" sublist
   if (outputSolveDetails)
@@ -391,16 +386,6 @@ bool NOX::FSI::LinearSystemGCR::applyRightPreconditioning(bool useTranspose,
 {
   if (&result != &input) result = input;
   return true;
-}
-
-
-Teuchos::RCP<::NOX::Epetra::Scaling> NOX::FSI::LinearSystemGCR::getScaling() { return scaling; }
-
-
-void NOX::FSI::LinearSystemGCR::resetScaling(
-    const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject)
-{
-  scaling = scalingObject;
 }
 
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -10,13 +10,14 @@
 
 #include "4C_config.hpp"
 
+#include "4C_solver_nonlin_nox_linearsystem_base.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 #include <NOX_Common.H>
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_LinearSystem.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_Time.hpp>
@@ -35,7 +36,7 @@ namespace NOX
       No preconditioner supported.
       Reuse of internal search directions supported.
      */
-    class LinearSystemGCR : public ::NOX::Epetra::LinearSystem
+    class LinearSystemGCR : public NOX::Nln::LinearSystemBase
     {
      protected:
       //! List of types of epetra objects that can be used for the Jacobian and/or Preconditioner.
@@ -58,7 +59,7 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const Teuchos::RCP<Epetra_Operator>& J, const ::NOX::Epetra::Vector& cloneVector,
-          const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject = Teuchos::null);
+          const std::shared_ptr<NOX::Nln::Scaling> scalingObject = nullptr);
 
       //! Reset the linear solver parameters.
       virtual void reset(Teuchos::ParameterList& linearSolverParams);
@@ -122,17 +123,6 @@ namespace NOX
       */
       bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
           const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
-      //! Get the scaling object
-      Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() override;
-
-      /*!
-        \brief Sets the diagonal scaling vector(s) used in scaling the linear system.
-
-        See ::NOX::Epetra::Scaling for details on how to specify scaling
-        of the linear system.
-      */
-      void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s) override;
 
       //! Evaluates the Jacobian based on the solution vector x.
       bool computeJacobian(const ::NOX::Epetra::Vector& x) override;
@@ -255,7 +245,7 @@ namespace NOX
       mutable Teuchos::RCP<Epetra_Operator> jacPtr;
 
       //! Scaling object supplied by the user
-      Teuchos::RCP<::NOX::Epetra::Scaling> scaling;
+      std::shared_ptr<NOX::Nln::Scaling> scaling;
 
       //! An extra temporary vector, only allocated if needed.
       mutable std::shared_ptr<::NOX::Epetra::Vector> tmpVectorPtr;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_forward_decl.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_forward_decl.hpp
@@ -41,7 +41,6 @@ namespace NOX
   }  // namespace Direction
   namespace Epetra
   {
-    class Scaling;
     class Vector;
     class LinearSystem;
     namespace Interface

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.cpp
@@ -15,6 +15,7 @@
 #include "4C_solver_nonlin_nox_direction_factory.hpp"
 #include "4C_solver_nonlin_nox_linearsystem.hpp"
 #include "4C_solver_nonlin_nox_meritfunction_factory.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_solver_nonlin_nox_solver_prepostop_generic.hpp"
 #include "4C_utils_exceptions.hpp"
 
@@ -40,7 +41,7 @@ NOX::Nln::GlobalData::GlobalData(MPI_Comm comm, Teuchos::ParameterList& noxParam
     const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
     const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
     const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-    const Teuchos::RCP<::NOX::Epetra::Scaling>& iScale)
+    const std::shared_ptr<NOX::Nln::Scaling>& iScale)
     : comm_(comm),
       nlnparams_(Teuchos::rcpFromRef(noxParams)),
       opt_type_(type),
@@ -426,7 +427,7 @@ bool NOX::Nln::GlobalData::is_constrained() const { return is_constrained_; }
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-const Teuchos::RCP<::NOX::Epetra::Scaling>& NOX::Nln::GlobalData::get_scaling_object()
+const std::shared_ptr<NOX::Nln::Scaling>& NOX::Nln::GlobalData::get_scaling_object()
 {
   return i_scale_;
 }

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_globaldata.hpp
@@ -37,6 +37,8 @@ namespace NOX
       }  // namespace Interface
     }  // namespace CONSTRAINT
 
+    class Scaling;
+
     class GlobalData
     {
      public:
@@ -52,7 +54,7 @@ namespace NOX
           const OptimizationProblemType& type, const NOX::Nln::CONSTRAINT::ReqInterfaceMap& iConstr,
           const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
           const NOX::Nln::CONSTRAINT::PrecInterfaceMap& iConstrPrec,
-          const Teuchos::RCP<::NOX::Epetra::Scaling>& iscale);
+          const std::shared_ptr<NOX::Nln::Scaling>& iscale);
 
       /*! CONSTRAINED OPTIMIZATION
        * inclusive the constraint interfaces map
@@ -128,7 +130,7 @@ namespace NOX
       const NOX::Nln::CONSTRAINT::PrecInterfaceMap& get_constraint_prec_interfaces();
 
       //! return linear system scaling object
-      const Teuchos::RCP<::NOX::Epetra::Scaling>& get_scaling_object();
+      const std::shared_ptr<NOX::Nln::Scaling>& get_scaling_object();
 
      private:
       //! setup the nln_utils class
@@ -177,7 +179,7 @@ namespace NOX
       NOX::Nln::CONSTRAINT::PrecInterfaceMap i_constr_prec_;
 
       /// scaling object (for the linear system)
-      Teuchos::RCP<::NOX::Epetra::Scaling> i_scale_;
+      std::shared_ptr<NOX::Nln::Scaling> i_scale_;
 
       /// merit function pointer
       Teuchos::RCP<::NOX::MeritFunction::Generic> mrt_fct_ptr_;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -12,9 +12,9 @@
 
 #include "4C_solver_nonlin_nox_enum_lists.hpp"
 #include "4C_solver_nonlin_nox_forward_decl.hpp"
+#include "4C_solver_nonlin_nox_linearsystem_base.hpp"
 
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_LinearSystem.H>
 #include <Teuchos_Time.hpp>
 
 FOUR_C_NAMESPACE_OPEN
@@ -44,9 +44,10 @@ namespace NOX
     namespace LinSystem
     {
       class PrePostOperator;
-      class Scaling;
     }  // namespace LinSystem
-    class LinearSystem : public ::NOX::Epetra::LinearSystem
+    class Scaling;
+
+    class LinearSystem : public NOX::Nln::LinearSystemBase
     {
      public:
       using SolverMap = std::map<NOX::Nln::SolutionType, Teuchos::RCP<Core::LinAlg::Solver>>;
@@ -77,7 +78,7 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& preconditioner,
           const ::NOX::Epetra::Vector& cloneVector,
-          const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+          const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
       //! Constructor without scaling object
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
@@ -94,7 +95,7 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
           const ::NOX::Epetra::Vector& cloneVector,
-          const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+          const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
       //! Constructor without preconditioner and scaling object
       LinearSystem(Teuchos::ParameterList& printParams, Teuchos::ParameterList& linearSolverParams,
@@ -193,10 +194,6 @@ namespace NOX
       //! Set the jacobian operator of this class
       void set_jacobian_operator_for_solve(
           const Teuchos::RCP<const Core::LinAlg::SparseOperator>& solveJacOp);
-
-      Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() override;
-
-      void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject) override;
 
       bool destroyPreconditioner() const override;
 
@@ -348,7 +345,7 @@ namespace NOX
       PreconditionerMatrixSourceType precMatrixSource_;
 
       //! Scaling object supplied by the user
-      Teuchos::RCP<::NOX::Epetra::Scaling> scaling_;
+      std::shared_ptr<NOX::Nln::Scaling> scaling_;
 
       double conditionNumberEstimate_;
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.cpp
@@ -1,0 +1,28 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_solver_nonlin_nox_linearsystem_base.hpp"
+
+#include "4C_utils_exceptions.hpp"
+
+#include <NOX_Epetra_Scaling.H>
+
+FOUR_C_NAMESPACE_OPEN
+
+Teuchos::RCP<::NOX::Epetra::Scaling> NOX::Nln::LinearSystemBase::getScaling()
+{
+  FOUR_C_THROW("This is a mock and if you need it, most probably you are doing something wrong.");
+  return Teuchos::null;
+}
+
+void NOX::Nln::LinearSystemBase::resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s)
+{
+  (void)s;  // avoid unused parameter warning
+  FOUR_C_THROW("This is a mock and if you need it, most probably you are doing something wrong.");
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -1,0 +1,49 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_SOLVER_NONLIN_NOX_LINEARSYSTEM_BASE_HPP
+#define FOUR_C_SOLVER_NONLIN_NOX_LINEARSYSTEM_BASE_HPP
+
+#include "4C_config.hpp"
+
+#include <NOX_Epetra_LinearSystem.H>
+
+// forward declaration
+namespace NOX
+{
+  namespace Epetra
+  {
+    class Scaling;
+  }  // namespace Epetra
+}  // namespace NOX
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace NOX
+{
+  namespace Nln
+  {
+    class Scaling;
+
+    /*
+     * \brief Base class for NOX linear systems.
+     *
+     * This mocks the scaling related methods of the NOX::Epetra::LinearSystem class. Most probably,
+     * it will be removed as soon as Epetra is removed from 4C.
+     */
+    class LinearSystemBase : public ::NOX::Epetra::LinearSystem
+    {
+      Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() override;
+
+      void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s) override;
+    };
+  }  // namespace Nln
+}  // namespace NOX
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.cpp
@@ -14,6 +14,7 @@
 #include "4C_linalg_sparseoperator.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
 #include "4C_solver_nonlin_nox_globaldata.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_structure_new_nox_nln_str_linearsystem.hpp"
 #include "4C_utils_enum.hpp"
 #include "4C_utils_exceptions.hpp"
@@ -21,7 +22,6 @@
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Preconditioner.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <Teuchos_ParameterList.hpp>
 
@@ -40,7 +40,7 @@ Teuchos::RCP<::NOX::Epetra::LinearSystem> NOX::Nln::LinSystem::Factory::build_li
     const NOX::Nln::LinSystem::LinearSystemType& linsystype, NOX::Nln::GlobalData& noxNlnGlobalData,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, ::NOX::Epetra::Vector& cloneVector,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
-    const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject) const
+    const std::shared_ptr<NOX::Nln::Scaling>& scalingObject) const
 {
   Teuchos::RCP<::NOX::Epetra::LinearSystem> linSys = Teuchos::null;
 
@@ -136,7 +136,7 @@ Teuchos::RCP<::NOX::Epetra::LinearSystem> NOX::Nln::LinSystem::build_linear_syst
     const NOX::Nln::LinSystem::LinearSystemType& linsystype, NOX::Nln::GlobalData& noxNlnGlobalData,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, ::NOX::Epetra::Vector& cloneVector,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
-    const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling>& scalingObject)
 {
   Factory factory;
   return factory.build_linear_system(

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_factory.hpp
@@ -29,6 +29,8 @@ namespace NOX
   namespace Nln
   {
     class GlobalData;
+    class Scaling;
+
     namespace LinSystem
     {
       class Factory
@@ -44,7 +46,7 @@ namespace NOX
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac,
             ::NOX::Epetra::Vector& cloneVector,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
-            const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject) const;
+            const std::shared_ptr<NOX::Nln::Scaling>& scalingObject) const;
       };
 
       /*! \brief Nonmember helper function for the NOX::Nln::LinearSystem::Factory.
@@ -57,7 +59,7 @@ namespace NOX
           NOX::Nln::GlobalData& noxNlnGlobalData,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& jac, ::NOX::Epetra::Vector& cloneVector,
           const Teuchos::RCP<Core::LinAlg::SparseOperator>& precMat,
-          const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject);
+          const std::shared_ptr<NOX::Nln::Scaling>& scalingObject);
     }  // namespace LinSystem
   }  // namespace Nln
 }  // namespace NOX

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_problem.cpp
@@ -19,10 +19,10 @@
 #include "4C_solver_nonlin_nox_interface_jacobian.hpp"
 #include "4C_solver_nonlin_nox_linearsystem.hpp"
 #include "4C_solver_nonlin_nox_linearsystem_factory.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_solver_nonlin_nox_singlestep_group.hpp"
 
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_StatusTest_Generic.H>
 #include <Teuchos_ParameterList.hpp>
@@ -85,7 +85,7 @@ Teuchos::RCP<::NOX::Epetra::LinearSystem> NOX::Nln::Problem::create_linear_syste
 
   const NOX::Nln::LinSystem::LinearSystemType linsystype =
       NOX::Nln::Aux::get_linear_system_type(noxNlnGlobalData_->get_linear_solvers());
-  Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject = noxNlnGlobalData_->get_scaling_object();
+  std::shared_ptr<NOX::Nln::Scaling> scalingObject = noxNlnGlobalData_->get_scaling_object();
 
   // build the linear system --> factory call
   return NOX::Nln::LinSystem::build_linear_system(

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_scaling.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_scaling.hpp
@@ -1,0 +1,56 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_SOLVER_NONLIN_NOX_SCALING_HPP
+#define FOUR_C_SOLVER_NONLIN_NOX_SCALING_HPP
+
+#include "4C_config.hpp"
+
+#include <Epetra_LinearProblem.h>
+
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace NOX::Nln
+{
+  class Scaling
+  {
+   public:
+    //! Virtual destructor
+    virtual ~Scaling() = default;
+
+    /**
+     * @brief Compute the scaling for the linear system.
+     *
+     * This method is mainly to provide compatibility with the current pattern how scaling is
+     * applied: if flag manualScaling is set to false, then this method is called.
+     *
+     * @param problem The linear problem to be scaled.
+     */
+    virtual void compute_scaling(const Epetra_LinearProblem& problem) = 0;
+
+    /**
+     * @brief Scales the linear system.
+     *
+     * @param problem The linear problem to be scaled.
+     */
+    virtual void scale_linear_system(Epetra_LinearProblem& problem) = 0;
+
+    /**
+     * @brief Remove the scaling from the linear system.
+     *
+     * @param problem The linear problem to be unscaled.
+     */
+    virtual void unscale_linear_system(Epetra_LinearProblem& problem) = 0;
+  };
+}  // namespace NOX::Nln
+
+
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -33,7 +33,7 @@ NOX::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::shared_ptr<::NOX::Epetra::Interface::Jacobian>& iJac,
     const std::shared_ptr<Epetra_Operator>& J, const ::NOX::Epetra::Vector& cloneVector,
     std::shared_ptr<Core::LinAlg::Solver> structure_solver,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> s)
+    const std::shared_ptr<NOX::Nln::Scaling> s)
     : utils_(printParams),
       jacInterfacePtr_(iJac),
       jacType_(EpetraOperator),
@@ -180,20 +180,6 @@ bool NOX::Solid::LinearSystem::applyRightPreconditioning(bool useTranspose,
 {
   if (&result != &input) result = input;
   return true;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-Teuchos::RCP<::NOX::Epetra::Scaling> NOX::Solid::LinearSystem::getScaling() { return scaling_; }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void NOX::Solid::LinearSystem::resetScaling(
-    const Teuchos::RCP<::NOX::Epetra::Scaling>& scalingObject)
-{
-  scaling_ = scalingObject;
 }
 
 

--- a/src/structure/4C_structure_timint_noxlinsys.hpp
+++ b/src/structure/4C_structure_timint_noxlinsys.hpp
@@ -12,6 +12,8 @@
 /* headers */
 #include "4C_config.hpp"
 
+#include "4C_solver_nonlin_nox_linearsystem_base.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_utils_parameter_list.fwd.hpp"
 
 #include <NOX.H>
@@ -20,8 +22,6 @@
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Preconditioner.H>
 #include <NOX_Epetra_Interface_Required.H>
-#include <NOX_Epetra_LinearSystem.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
 #include <Teuchos_Time.hpp>
@@ -47,7 +47,7 @@ namespace NOX
     /// linear algebraic solver #Core::LinAlg::Solver.
     ///
 
-    class LinearSystem : public ::NOX::Epetra::LinearSystem
+    class LinearSystem : public NOX::Nln::LinearSystemBase
     {
      protected:
       /// kind of storage and access pattern of tangent matrix
@@ -71,7 +71,7 @@ namespace NOX
           const ::NOX::Epetra::Vector& cloneVector,
           std::shared_ptr<Core::LinAlg::Solver>
               structure_solver,  ///< (used-defined) linear algebraic solver
-          const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject = Teuchos::null);
+          const std::shared_ptr<NOX::Nln::Scaling> scalingObject = nullptr);
 
 
       /// provide storage pattern of tangent matrix, i.e. the operator
@@ -96,12 +96,6 @@ namespace NOX
       /// Apply right preconditiong to the given input vector.
       bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
           const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
-      /// Get the scaling object.
-      Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() override;
-
-      /// Sets the diagonal scaling vector(s) used in scaling the linear system.
-      void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s) override;
 
       /// Evaluates the Jacobian based on the solution vector x.
       bool computeJacobian(const ::NOX::Epetra::Vector& x) override;
@@ -160,7 +154,7 @@ namespace NOX
       OperatorType precType_;
       mutable std::shared_ptr<Epetra_Operator> jacPtr_;
       mutable std::shared_ptr<Epetra_Operator> precPtr_;
-      Teuchos::RCP<::NOX::Epetra::Scaling> scaling_;
+      std::shared_ptr<NOX::Nln::Scaling> scaling_;
       mutable std::shared_ptr<::NOX::Epetra::Vector> tmpVectorPtr_;
       mutable double conditionNumberEstimate_;
 

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.cpp
@@ -290,7 +290,14 @@ Solid::Nln::LinSystem::StcScaling::StcScaling(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Solid::Nln::LinSystem::StcScaling::scaleLinearSystem(Epetra_LinearProblem& problem)
+void Solid::Nln::LinSystem::StcScaling::compute_scaling(const Epetra_LinearProblem& problem)
+{
+  (void)problem;  // avoid unused parameter warning
+}
+
+/*----------------------------------------------------------------------*
+ *----------------------------------------------------------------------*/
+void Solid::Nln::LinSystem::StcScaling::scale_linear_system(Epetra_LinearProblem& problem)
 {
   // get stiffness matrix
   Epetra_CrsMatrix* stiffmat = dynamic_cast<Epetra_CrsMatrix*>(problem.GetMatrix());
@@ -324,7 +331,7 @@ void Solid::Nln::LinSystem::StcScaling::scaleLinearSystem(Epetra_LinearProblem& 
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Solid::Nln::LinSystem::StcScaling::unscaleLinearSystem(Epetra_LinearProblem& problem)
+void Solid::Nln::LinSystem::StcScaling::unscale_linear_system(Epetra_LinearProblem& problem)
 {
   std::shared_ptr<Core::LinAlg::Vector<double>> disisdc =
       std::make_shared<Core::LinAlg::Vector<double>>(problem.GetLHS()->Map(), true);

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.hpp
@@ -12,16 +12,7 @@
 
 #include "4C_inpar_structure.hpp"
 #include "4C_linalg_map.hpp"
-
-#include <NOX_Epetra_Scaling.H>
-
-namespace NOX
-{
-  namespace Epetra
-  {
-    class Scaling;
-  }
-}  // namespace NOX
+#include "4C_solver_nonlin_nox_scaling.hpp"
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -46,18 +37,21 @@ namespace Solid
   {
     namespace LinSystem
     {
-      class StcScaling : public ::NOX::Epetra::Scaling
+      class StcScaling : public NOX::Nln::Scaling
       {
        public:
         //! Constructor.
         StcScaling(const Solid::TimeInt::BaseDataSDyn& DataSDyn,
             Solid::TimeInt::BaseDataGlobalState& GState);
 
+        //! Compute scaling.
+        void compute_scaling(const Epetra_LinearProblem& problem) override;
+
         //! Scales the linear system.
-        void scaleLinearSystem(Epetra_LinearProblem& problem) override;
+        void scale_linear_system(Epetra_LinearProblem& problem) override;
 
         //! Remove the scaling from the linear system.
-        void unscaleLinearSystem(Epetra_LinearProblem& problem) override;
+        void unscale_linear_system(Epetra_LinearProblem& problem) override;
 
        private:
         //! stiffness matrix after scaling

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_solver_nox.cpp
@@ -13,6 +13,7 @@
 #include "4C_solver_nonlin_nox_group.hpp"
 #include "4C_solver_nonlin_nox_linearsystem.hpp"
 #include "4C_solver_nonlin_nox_problem.hpp"
+#include "4C_solver_nonlin_nox_scaling.hpp"
 #include "4C_solver_nonlin_nox_solver_factory.hpp"
 #include "4C_structure_new_timint_base.hpp"
 #include "4C_structure_new_timint_noxinterface.hpp"
@@ -20,7 +21,6 @@
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Epetra_LinearSystem.H>
-#include <NOX_Epetra_Scaling.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_Solver_Generic.H>
 #include <Teuchos_RCPStdSharedPtrConversions.hpp>
@@ -81,7 +81,7 @@ Solid::Nln::SOLVER::Nox::Nox(const Teuchos::ParameterList& default_params,
   Solid::Nln::create_constraint_preconditioner(iconstr_prec, integrator(), soltypes);
 
   // create object to scale linear system
-  Teuchos::RCP<::NOX::Epetra::Scaling> iscale = Teuchos::null;
+  std::shared_ptr<NOX::Nln::Scaling> iscale = nullptr;
   Solid::Nln::create_scaling(iscale, data_sdyn(), data_global_state());
 
   // handle NOX settings

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.cpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.cpp
@@ -26,7 +26,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
     const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& M, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(printParams, linearSolverParams, solvers, iReq, iJac, J, iPrec, M,
           cloneVector, scalingObject)
 {
@@ -57,7 +57,7 @@ NOX::Nln::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Core::LinAlg::SparseOperator>& J, const ::NOX::Epetra::Vector& cloneVector,
-    const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject)
+    const std::shared_ptr<NOX::Nln::Scaling> scalingObject)
     : NOX::Nln::LinearSystem(
           printParams, linearSolverParams, solvers, iReq, iJac, J, cloneVector, scalingObject)
 {

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nox_nln_str_linearsystem.hpp
@@ -33,7 +33,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Preconditioner>& iPrec,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& M,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without scaling object
         LinearSystem(Teuchos::ParameterList& printParams,
@@ -54,7 +54,7 @@ namespace NOX
             const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
             const Teuchos::RCP<Core::LinAlg::SparseOperator>& J,
             const ::NOX::Epetra::Vector& cloneVector,
-            const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject);
+            const std::shared_ptr<NOX::Nln::Scaling> scalingObject);
 
         //! Constructor without preconditioner and scaling object
         LinearSystem(Teuchos::ParameterList& printParams,

--- a/src/structure_new/src/utils/4C_structure_new_utils.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.cpp
@@ -362,11 +362,11 @@ void Solid::Nln::create_constraint_preconditioner(
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-void Solid::Nln::create_scaling(Teuchos::RCP<::NOX::Epetra::Scaling>& iscale,
+void Solid::Nln::create_scaling(std::shared_ptr<NOX::Nln::Scaling>& iscale,
     const Solid::TimeInt::BaseDataSDyn& DataSDyn, Solid::TimeInt::BaseDataGlobalState& GState)
 {
   if (DataSDyn.get_stc_algo_type() != Inpar::Solid::stc_inactive)
-    iscale = Teuchos::make_rcp<Solid::Nln::LinSystem::StcScaling>(DataSDyn, GState);
+    iscale = std::make_shared<Solid::Nln::LinSystem::StcScaling>(DataSDyn, GState);
 }
 
 void Solid::compute_generalized_alpha_parameters(Solid::IMPLICIT::GenAlpha::Coefficients& coeffs)

--- a/src/structure_new/src/utils/4C_structure_new_utils.hpp
+++ b/src/structure_new/src/utils/4C_structure_new_utils.hpp
@@ -17,16 +17,6 @@
 
 #include <set>
 
-// forward declaration
-
-namespace NOX
-{
-  namespace Epetra
-  {
-    class Scaling;
-  }
-}  // namespace NOX
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg
@@ -46,6 +36,8 @@ namespace NOX
         class Preconditioner;
       }  // namespace Interface
     }  // namespace CONSTRAINT
+
+    class Scaling;
   }  // namespace Nln
 }  // namespace NOX
 
@@ -160,7 +152,7 @@ namespace Solid
         Solid::Integrator& integrator, const std::vector<enum NOX::Nln::SolutionType>& soltypes);
 
     //! Create object to scale linear system
-    void create_scaling(Teuchos::RCP<::NOX::Epetra::Scaling>& iscale,
+    void create_scaling(std::shared_ptr<NOX::Nln::Scaling>& iscale,
         const Solid::TimeInt::BaseDataSDyn& DataSDyn, Solid::TimeInt::BaseDataGlobalState& GState);
   }  // namespace Nln
 }  // namespace Solid


### PR DESCRIPTION
## Description and Context
I do not like the last commit in #1071 (https://github.com/4C-multiphysics/4C/pull/1071/commits/9ba0d5afb205a418680e6dedbc39cc175f9c11db) as it introduces not a very elegant solution. It gets worse for the cases when scaling is actually used. A better solution would be to replace `Epetra_LinearProblem` with our own class. To do that, firstly, we need to replace `Epetra::Scaling` with our own implementation that provides a similar interface (though, reduced). That is what this PR doing.

## Related Issues and Pull Requests
#1071, #723
