### PR TITLE
Use array of Tensors for material derivative of shape functions

### DIFF
--- a/src/core/linalg/tests/4C_linalg_tensor_matrix_conversion_test.cpp
+++ b/src/core/linalg/tests/4C_linalg_tensor_matrix_conversion_test.cpp
@@ -175,6 +175,25 @@ namespace
     EXPECT_DOUBLE_EQ(tensor(2, 0), 7.0);
   }
 
+  TEST(TensorMatrixConversionTest, makeMatrixViewFromArray)
+  {
+    std::array<Core::LinAlg::Tensor<double, 2>, 3> array_of_tensors;
+    array_of_tensors[0] = {{1.0, 2.0}};
+    array_of_tensors[1] = {{3.0, 4.0}};
+    array_of_tensors[2] = {{5.0, 6.0}};
+
+    Core::LinAlg::Matrix<2, 3> matrix_view = Core::LinAlg::make_matrix_view(array_of_tensors);
+    EXPECT_DOUBLE_EQ(matrix_view(0, 0), 1.0);
+    EXPECT_DOUBLE_EQ(matrix_view(0, 1), 3.0);
+    EXPECT_DOUBLE_EQ(matrix_view(0, 2), 5.0);
+    EXPECT_DOUBLE_EQ(matrix_view(1, 0), 2.0);
+    EXPECT_DOUBLE_EQ(matrix_view(1, 1), 4.0);
+    EXPECT_DOUBLE_EQ(matrix_view(1, 2), 6.0);
+
+    matrix_view(1, 2) = 7.0;
+    EXPECT_DOUBLE_EQ(array_of_tensors[2](1), 7.0);
+  }
+
   TEST(TensorMatrixConversionTest, makeMatrixViewReinterpretation)
   {
     Core::LinAlg::Tensor<double, 3> tensor = {{1.0, 2.0, 3.0}};

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_displacement_based.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_displacement_based.hpp
@@ -86,15 +86,15 @@ namespace Discret::Elements
       // evaluate derivative w.r.t. displacements
       for (int i = 0; i < Core::FE::num_nodes(celltype); ++i)
       {
-        d_F_dd(0, Core::FE::dim<celltype> * i + 0) = jacobian_mapping.N_XYZ_(0, i);
-        d_F_dd(1, Core::FE::dim<celltype> * i + 1) = jacobian_mapping.N_XYZ_(1, i);
-        d_F_dd(2, Core::FE::dim<celltype> * i + 2) = jacobian_mapping.N_XYZ_(2, i);
-        d_F_dd(3, Core::FE::dim<celltype> * i + 0) = jacobian_mapping.N_XYZ_(1, i);
-        d_F_dd(4, Core::FE::dim<celltype> * i + 1) = jacobian_mapping.N_XYZ_(2, i);
-        d_F_dd(5, Core::FE::dim<celltype> * i + 0) = jacobian_mapping.N_XYZ_(2, i);
-        d_F_dd(6, Core::FE::dim<celltype> * i + 1) = jacobian_mapping.N_XYZ_(0, i);
-        d_F_dd(7, Core::FE::dim<celltype> * i + 2) = jacobian_mapping.N_XYZ_(1, i);
-        d_F_dd(8, Core::FE::dim<celltype> * i + 2) = jacobian_mapping.N_XYZ_(0, i);
+        d_F_dd(0, Core::FE::dim<celltype> * i + 0) = jacobian_mapping.N_XYZ[i](0);
+        d_F_dd(1, Core::FE::dim<celltype> * i + 1) = jacobian_mapping.N_XYZ[i](1);
+        d_F_dd(2, Core::FE::dim<celltype> * i + 2) = jacobian_mapping.N_XYZ[i](2);
+        d_F_dd(3, Core::FE::dim<celltype> * i + 0) = jacobian_mapping.N_XYZ[i](1);
+        d_F_dd(4, Core::FE::dim<celltype> * i + 1) = jacobian_mapping.N_XYZ[i](2);
+        d_F_dd(5, Core::FE::dim<celltype> * i + 0) = jacobian_mapping.N_XYZ[i](2);
+        d_F_dd(6, Core::FE::dim<celltype> * i + 1) = jacobian_mapping.N_XYZ[i](0);
+        d_F_dd(7, Core::FE::dim<celltype> * i + 2) = jacobian_mapping.N_XYZ[i](1);
+        d_F_dd(8, Core::FE::dim<celltype> * i + 2) = jacobian_mapping.N_XYZ[i](0);
       }
 
       return d_F_dd;
@@ -178,7 +178,8 @@ namespace Discret::Elements
           deriv2(Core::LinAlg::Initialization::zero);
       Core::FE::shape_function_deriv2<celltype>(xi, deriv2);
       Xsec.multiply_nt(1.0, deriv2, element_nodes.reference_coordinates, 0.0);
-      N_XYZ_Xsec.multiply_tt(1.0, jacobian_mapping.N_XYZ_, Xsec, 0.0);
+      N_XYZ_Xsec.multiply_tt(
+          1.0, Core::LinAlg::make_matrix_view(jacobian_mapping.N_XYZ), Xsec, 0.0);
 
       for (int i = 0; i < Core::FE::dim<celltype>; ++i)
       {
@@ -249,7 +250,7 @@ namespace Discret::Elements
       Discret::Elements::add_elastic_stiffness_matrix(
           linearization.Bop_, stress, integration_factor, stiffness_matrix);
       Discret::Elements::add_geometric_stiffness_matrix(
-          jacobian_mapping.N_XYZ_, stress, integration_factor, stiffness_matrix);
+          jacobian_mapping.N_XYZ, stress, integration_factor, stiffness_matrix);
     }
   };
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_eas.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_eas.hpp
@@ -159,7 +159,7 @@ namespace Discret::Elements
       add_elastic_stiffness_matrix(
           eas_kinematics.b_op, stress, integration_factor, stiffness_matrix);
       add_geometric_stiffness_matrix(
-          jacobian_mapping.N_XYZ_, stress, integration_factor, stiffness_matrix);
+          jacobian_mapping.N_XYZ, stress, integration_factor, stiffness_matrix);
     }
 
     static void reset_condensed_variable_integration(const Core::Elements::Element& ele,

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_fbar.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_fbar.hpp
@@ -85,8 +85,8 @@ namespace Discret::Elements
             linearization.Bop =
                 evaluate_strain_gradient(jacobian_mapping, spatial_material_mapping);
 
-            linearization.Hop = evaluate_fbar_h_operator(jacobian_mapping.N_XYZ_,
-                preparation_data.jacobian_mapping_centroid.N_XYZ_, spatial_material_mapping,
+            linearization.Hop = evaluate_fbar_h_operator(jacobian_mapping.N_XYZ,
+                preparation_data.jacobian_mapping_centroid.N_XYZ, spatial_material_mapping,
                 preparation_data.spatial_material_mapping_centroid);
 
             linearization.fbar_factor = fbar_factor;
@@ -182,7 +182,7 @@ namespace Discret::Elements
     {
       Discret::Elements::add_elastic_stiffness_matrix(linearization.Bop, stress,
           integration_factor * linearization.fbar_factor, stiffness_matrix);
-      Discret::Elements::add_geometric_stiffness_matrix(jacobian_mapping.N_XYZ_, stress,
+      Discret::Elements::add_geometric_stiffness_matrix(jacobian_mapping.N_XYZ, stress,
           integration_factor / linearization.fbar_factor, stiffness_matrix);
 
       // additional stiffness matrix needed for fbar method

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_fbar.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib_fbar.hpp
@@ -72,11 +72,10 @@ namespace Discret::Elements
    */
   template <Core::FE::CellType celltype>
   inline Core::LinAlg::Matrix<Core::FE::dim<celltype> * Core::FE::num_nodes(celltype), 1>
-  evaluate_fbar_h_operator(
-      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::num_nodes(celltype)>&
-          shape_function_derivs,
-      const Core::LinAlg::Matrix<Core::FE::dim<celltype>, Core::FE::num_nodes(celltype)>&
-          shape_function_derivs_centroid,
+  evaluate_fbar_h_operator(const std::array<Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>,
+                               Core::FE::num_nodes(celltype)>& shape_function_derivs,
+      const std::array<Core::LinAlg::Tensor<double, Core::FE::dim<celltype>>,
+          Core::FE::num_nodes(celltype)>& shape_function_derivs_centroid,
       const Discret::Elements::SpatialMaterialMapping<celltype>& spatial_material_mapping,
       const Discret::Elements::SpatialMaterialMapping<celltype>& spatial_material_mapping_centroid)
     requires(Core::FE::dim<celltype> == 3)
@@ -94,12 +93,13 @@ namespace Discret::Elements
         Core::LinAlg::Initialization::zero);
     for (int idof = 0; idof < Core::FE::dim<celltype> * Core::FE::num_nodes(celltype); idof++)
     {
+      const std::size_t node_id = idof / Core::FE::dim<celltype>;
       for (int idim = 0; idim < Core::FE::dim<celltype>; idim++)
       {
         Hop(idof) += invdefgrd_centroid(idim, idof % Core::FE::dim<celltype>) *
-                     shape_function_derivs_centroid(idim, idof / Core::FE::dim<celltype>);
-        Hop(idof) -= invdefgrd(idim, idof % Core::FE::dim<celltype>) *
-                     shape_function_derivs(idim, idof / Core::FE::dim<celltype>);
+                     shape_function_derivs_centroid[node_id](idim);
+        Hop(idof) -=
+            invdefgrd(idim, idof % Core::FE::dim<celltype>) * shape_function_derivs[node_id](idim);
       }
     }
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_mulf.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_mulf.hpp
@@ -112,7 +112,7 @@ namespace Discret::Elements
       Discret::Elements::add_elastic_stiffness_matrix(
           linearization.Bop, stress, integration_factor, stiffness_matrix);
       Discret::Elements::add_geometric_stiffness_matrix(
-          jacobian_mapping.N_XYZ_, stress, integration_factor, stiffness_matrix);
+          jacobian_mapping.N_XYZ, stress, integration_factor, stiffness_matrix);
     }
 
     static void pack(

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_based.cpp
@@ -160,7 +160,7 @@ void Discret::Elements::SolidPoroPressureBasedEleCalc<celltype>::evaluate_nonlin
           sfac.scale((-integration_factor * solidpressure *
                       spatial_material_mapping.determinant_deformation_gradient_));
 
-          update_geometric_stiffness_matrix<celltype>(sfac, jacobian_mapping.N_XYZ_, *stiff);
+          update_geometric_stiffness_matrix<celltype>(sfac, jacobian_mapping.N_XYZ, *stiff);
         }
       });
 }

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_calc_pressure_velocity_based.cpp
@@ -254,7 +254,7 @@ namespace
                 dInverseDeformationGradientTransposed_dDisp(
                     i * Discret::Elements::Internal::num_dim<celltype> + l, gid) +=
                     -spatial_material_mapping.inverse_deformation_gradient_(l, j) *
-                    jacobian_mapping.N_XYZ_(k, n) *
+                    jacobian_mapping.N_XYZ[n](k) *
                     spatial_material_mapping.inverse_deformation_gradient_(k, i);
           }
         }
@@ -421,11 +421,13 @@ void Discret::Elements::SolidPoroPressureVelocityBasedEleCalc<celltype,
 
         // material fluid velocity gradient at integration point
         Core::LinAlg::Matrix<num_dim_, num_dim_> fvelder(Core::LinAlg::Initialization::zero);
-        fvelder.multiply_nt(fluid_variables.fluidvel_nodal, jacobian_mapping.N_XYZ_);
+        fvelder.multiply_nt(
+            fluid_variables.fluidvel_nodal, Core::LinAlg::make_matrix_view(jacobian_mapping.N_XYZ));
 
         // pressure gradient at integration point
         Core::LinAlg::Matrix<num_dim_, 1> Gradp(Core::LinAlg::Initialization::zero);
-        Gradp.multiply(jacobian_mapping.N_XYZ_, fluid_variables.fluidpress_nodal);
+        Gradp.multiply(Core::LinAlg::make_matrix_view(jacobian_mapping.N_XYZ),
+            fluid_variables.fluidpress_nodal);
 
         // F^-1 * Grad p
         Core::LinAlg::Matrix<num_dim_, 1> FinvGradp(Core::LinAlg::Initialization::zero);
@@ -526,7 +528,7 @@ void Discret::Elements::SolidPoroPressureVelocityBasedEleCalc<celltype,
                   spatial_material_mapping.determinant_deformation_gradient_);
 
           update_geometric_stiffness_matrix<celltype>(
-              sfac, jacobian_mapping.N_XYZ_, *matrix_views.K_displacement_displacement);
+              sfac, jacobian_mapping.N_XYZ, *matrix_views.K_displacement_displacement);
 
           if (react_matrix.has_value())
           {
@@ -680,11 +682,12 @@ void Discret::Elements::SolidPoroPressureVelocityBasedEleCalc<celltype,
         Core::LinAlg::Matrix<num_dim_, num_dim_> fluid_velocity_gradient(
             Core::LinAlg::Initialization::zero);
         fluid_velocity_gradient.multiply_nt(
-            fluid_variables.fluidvel_nodal, jacobian_mapping.N_XYZ_);
+            fluid_variables.fluidvel_nodal, Core::LinAlg::make_matrix_view(jacobian_mapping.N_XYZ));
 
         // pressure gradient at integration point
         Core::LinAlg::Matrix<num_dim_, 1> pressure_gradient(Core::LinAlg::Initialization::zero);
-        pressure_gradient.multiply(jacobian_mapping.N_XYZ_, fluid_variables.fluidpress_nodal);
+        pressure_gradient.multiply(Core::LinAlg::make_matrix_view(jacobian_mapping.N_XYZ),
+            fluid_variables.fluidpress_nodal);
 
         const PorosityAndLinearizationOD porosity_and_linearization_od =
             compute_porosity_and_linearization_od<celltype, porosity_formulation>(porostructmat,
@@ -709,7 +712,7 @@ void Discret::Elements::SolidPoroPressureVelocityBasedEleCalc<celltype,
         Core::LinAlg::Matrix<num_dim_, num_nodes_> FinvNXYZ;
         FinvNXYZ.multiply_tn(
             Core::LinAlg::make_matrix_view(spatial_material_mapping.inverse_deformation_gradient_),
-            jacobian_mapping.N_XYZ_);
+            Core::LinAlg::make_matrix_view(jacobian_mapping.N_XYZ));
 
         Core::LinAlg::Matrix<num_dim_, num_dim_> reatensor(Core::LinAlg::Initialization::zero);
         Core::LinAlg::Matrix<num_dim_, num_dim_> linreac_dporosity(


### PR DESCRIPTION
It is more convinient to use a `std::array<Tensor<double, 3>, num_nodes>` to represent the material derivatives of the shape functions. This PR also provides a function that creates a Matrix-view of the corresponding data.

I will use this in #961 