### PR TITLE
Fix error in linear solver factory for new structure

### DIFF
--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -14,7 +14,6 @@
 #include "4C_global_data.hpp"
 #include "4C_inpar_cardiovascular0d.hpp"
 #include "4C_inpar_structure.hpp"
-#include "4C_io_control.hpp"
 #include "4C_linalg_utils_sparse_algebra_create.hpp"
 #include "4C_linear_solver_method.hpp"
 #include "4C_linear_solver_method_linalg.hpp"
@@ -24,14 +23,6 @@
 #include <Teuchos_ParameterList.hpp>
 
 FOUR_C_NAMESPACE_OPEN
-
-
-/*----------------------------------------------------------------------------*
- *----------------------------------------------------------------------------*/
-Solid::SOLVER::Factory::Factory()
-{
-  // empty
-}
 
 
 /*----------------------------------------------------------------------------*
@@ -123,6 +114,7 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_structure_li
     }
     case Core::LinearSolver::PreconditionerType::block_teko:
     {
+      const unsigned solid_dofset(0u);
       // Create the beam and solid maps
       std::vector<int> solid_dof_gids;
       std::vector<int> solid_node_gids;
@@ -133,11 +125,11 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_structure_li
         if (const Core::Nodes::Node* node = actdis.l_row_node(i);
             BeamInteraction::Utils::is_beam_node(*node))
         {
-          actdis.dof(node, beam_dof_gids);
+          actdis.dof(solid_dofset, node, beam_dof_gids);
         }
         else
         {
-          actdis.dof(node, solid_dof_gids);
+          actdis.dof(solid_dofset, node, solid_dof_gids);
           solid_node_gids.push_back(node->id());
         }
       }

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.hpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.hpp
@@ -55,7 +55,7 @@ namespace Solid
 
      public:
       //! constructor
-      Factory();
+      Factory() = default;
 
       //! destructor
       virtual ~Factory() = default;


### PR DESCRIPTION
## Description and Context
The implementation did not work in the debug mode if more than one dofset has been defined on the structure discretization. This is changed now by explicitly accessing the dofset 0, which is the intended behavior in these cases.

