### PR TITLE
Rename CMake function for clarification

### DIFF
--- a/cmake/functions/four_c_add_dependency.cmake
+++ b/cmake/functions/four_c_add_dependency.cmake
@@ -10,7 +10,7 @@ function(_four_c_internal_link_with_debug_message target link_type deps)
   target_link_libraries(${target} ${link_type} ${deps})
 endfunction()
 
-function(four_c_add_dependency target)
+function(four_c_add_internal_dependency target)
   # Internal target in the library
   if(TARGET ${target}_deps)
     foreach(_dep ${ARGN})

--- a/doc/documentation/src/developer_guide/developer_cmake.rst
+++ b/doc/documentation/src/developer_guide/developer_cmake.rst
@@ -160,7 +160,7 @@ When defining a module `module_name`:
 - Define a CMake `INTERFACE` target conventionally called `module_name_deps` which contains all the headers and usage requirements of
   the module.
 - If another module `module_other` is required for building `module_name`, this module is added as
-  `four_c_add_dependency(module_name module_other)`. This step encodes internal dependencies.
+  `four_c_add_internal_dependency(module_name module_other)`. This step encodes internal dependencies.
 - Define a CMake `OBJECT` target conventionally called `module_name_objs` which contains the source files. If a module is
   header-only, this target is not defined.
 - Add the `OBJECT` target to a central library which contains all compiled sources.

--- a/src/adapter/CMakeLists.txt
+++ b/src/adapter/CMakeLists.txt
@@ -46,7 +46,7 @@ set(_dependencies
     xfem
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 four_c_unity_build_compile_separately(${AUTO_DEFINED_MODULE_NAME} 4C_adapter_str_fsiwrapper.cpp)
 four_c_unity_build_compile_separately(

--- a/src/ale/CMakeLists.txt
+++ b/src/ale/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     mortar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/art_net/CMakeLists.txt
+++ b/src/art_net/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/beam3/CMakeLists.txt
+++ b/src/beam3/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/beamcontact/CMakeLists.txt
+++ b/src/beamcontact/CMakeLists.txt
@@ -21,4 +21,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/beaminteraction/src/CMakeLists.txt
+++ b/src/beaminteraction/src/CMakeLists.txt
@@ -25,4 +25,4 @@ set(_dependencies
     truss3
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/bele/CMakeLists.txt
+++ b/src/bele/CMakeLists.txt
@@ -15,4 +15,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/browniandyn/CMakeLists.txt
+++ b/src/browniandyn/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/cardiovascular0d/CMakeLists.txt
+++ b/src/cardiovascular0d/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/constraint/CMakeLists.txt
+++ b/src/constraint/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     truss3
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/constraint_framework/CMakeLists.txt
+++ b/src/constraint_framework/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/contact/CMakeLists.txt
+++ b/src/contact/CMakeLists.txt
@@ -23,4 +23,4 @@ set(_dependencies
     xfem
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/contact_constitutivelaw/CMakeLists.txt
+++ b/src/contact_constitutivelaw/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/coupling/src/adapter/CMakeLists.txt
+++ b/src/coupling/src/adapter/CMakeLists.txt
@@ -15,4 +15,4 @@ set(_dependencies
     mortar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/coupling/src/volmortar/CMakeLists.txt
+++ b/src/coupling/src/volmortar/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     mortar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/cut/CMakeLists.txt
+++ b/src/cut/CMakeLists.txt
@@ -15,4 +15,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/deal_ii/CMakeLists.txt
+++ b/src/deal_ii/CMakeLists.txt
@@ -8,4 +8,4 @@
 four_c_auto_define_module(NO_CYCLES)
 
 # deal.II support is a pure extension of the core module and may not depend on any other module
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} core)
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} core)

--- a/src/ehl/CMakeLists.txt
+++ b/src/ehl/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     mortar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/elch/CMakeLists.txt
+++ b/src/elch/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fbi/CMakeLists.txt
+++ b/src/fbi/CMakeLists.txt
@@ -21,4 +21,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fluid/CMakeLists.txt
+++ b/src/fluid/CMakeLists.txt
@@ -24,4 +24,4 @@ set(_dependencies
     red_airways
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fluid_ele/CMakeLists.txt
+++ b/src/fluid_ele/CMakeLists.txt
@@ -21,7 +21,7 @@ set(_dependencies
     xfem
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 # duplicate macros
 four_c_unity_build_compile_separately(${AUTO_DEFINED_MODULE_NAME} 4C_fluid_ele_calc_poro.cpp)

--- a/src/fluid_turbulence/CMakeLists.txt
+++ b/src/fluid_turbulence/CMakeLists.txt
@@ -21,4 +21,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fluid_xfluid/CMakeLists.txt
+++ b/src/fluid_xfluid/CMakeLists.txt
@@ -22,4 +22,4 @@ set(_dependencies
     xfem
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fpsi/CMakeLists.txt
+++ b/src/fpsi/CMakeLists.txt
@@ -24,4 +24,4 @@ set(_dependencies
     structure
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fs3i/CMakeLists.txt
+++ b/src/fs3i/CMakeLists.txt
@@ -28,4 +28,4 @@ set(_dependencies
     structure
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/CMakeLists.txt
+++ b/src/fsi/src/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/monolithic/CMakeLists.txt
+++ b/src/fsi/src/monolithic/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/monolithic/model_evaluator/CMakeLists.txt
+++ b/src/fsi/src/monolithic/model_evaluator/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/monolithic/nonlinear_solver/CMakeLists.txt
+++ b/src/fsi/src/monolithic/nonlinear_solver/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/partitioned/CMakeLists.txt
+++ b/src/fsi/src/partitioned/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/partitioned/model_evaluator/CMakeLists.txt
+++ b/src/fsi/src/partitioned/model_evaluator/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/partitioned/nonlinear_solver/CMakeLists.txt
+++ b/src/fsi/src/partitioned/nonlinear_solver/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/utils/CMakeLists.txt
+++ b/src/fsi/src/utils/CMakeLists.txt
@@ -29,4 +29,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi_xfem/CMakeLists.txt
+++ b/src/fsi_xfem/CMakeLists.txt
@@ -23,4 +23,4 @@ set(_dependencies
     xfem
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/geometry_pair/CMakeLists.txt
+++ b/src/geometry_pair/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/global_data/CMakeLists.txt
+++ b/src/global_data/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     particle_engine
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/global_legacy_module/CMakeLists.txt
+++ b/src/global_legacy_module/CMakeLists.txt
@@ -44,4 +44,4 @@ set(_dependencies
     w1
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/inpar/CMakeLists.txt
+++ b/src/inpar/CMakeLists.txt
@@ -17,5 +17,5 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 four_c_unity_build_compile_separately(${AUTO_DEFINED_MODULE_NAME} 4C_inpar_xfem.cpp)

--- a/src/levelset/CMakeLists.txt
+++ b/src/levelset/CMakeLists.txt
@@ -19,4 +19,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/loma/CMakeLists.txt
+++ b/src/loma/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/lubrication/src/CMakeLists.txt
+++ b/src/lubrication/src/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/mat/CMakeLists.txt
+++ b/src/mat/CMakeLists.txt
@@ -23,4 +23,4 @@ set(_dependencies
     tsi
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/membrane/CMakeLists.txt
+++ b/src/membrane/CMakeLists.txt
@@ -18,7 +18,7 @@ set(_dependencies
     thermo
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 # duplicate template instantiations
 four_c_unity_build_compile_separately(${AUTO_DEFINED_MODULE_NAME} 4C_membrane_evaluate.cpp)

--- a/src/mixture/CMakeLists.txt
+++ b/src/mixture/CMakeLists.txt
@@ -16,7 +16,7 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 four_c_unity_build_compile_separately(
   ${AUTO_DEFINED_MODULE_NAME} 4C_mixture_constituent_remodelfiber_expl.cpp

--- a/src/module_registry/CMakeLists.txt
+++ b/src/module_registry/CMakeLists.txt
@@ -13,4 +13,4 @@ set(_dependencies
     core
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/mortar/CMakeLists.txt
+++ b/src/mortar/CMakeLists.txt
@@ -21,4 +21,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/particle_algorithm/CMakeLists.txt
+++ b/src/particle_algorithm/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     particle_wall
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/particle_engine/CMakeLists.txt
+++ b/src/particle_engine/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     particle_algorithm
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/particle_interaction/CMakeLists.txt
+++ b/src/particle_interaction/CMakeLists.txt
@@ -19,4 +19,4 @@ set(_dependencies
     particle_wall
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/particle_rigidbody/CMakeLists.txt
+++ b/src/particle_rigidbody/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     particle_interaction
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/particle_wall/CMakeLists.txt
+++ b/src/particle_wall/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     particle_engine
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/pasi/CMakeLists.txt
+++ b/src/pasi/CMakeLists.txt
@@ -21,4 +21,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/poroelast/CMakeLists.txt
+++ b/src/poroelast/CMakeLists.txt
@@ -25,4 +25,4 @@ set(_dependencies
     w1
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/poroelast_scatra/CMakeLists.txt
+++ b/src/poroelast_scatra/CMakeLists.txt
@@ -23,4 +23,4 @@ set(_dependencies
     w1
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/porofluid_pressure_based/CMakeLists.txt
+++ b/src/porofluid_pressure_based/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     porofluid_pressure_based_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/porofluid_pressure_based_elast/CMakeLists.txt
+++ b/src/porofluid_pressure_based_elast/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     porofluid_pressure_based_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/porofluid_pressure_based_elast_scatra/CMakeLists.txt
+++ b/src/porofluid_pressure_based_elast_scatra/CMakeLists.txt
@@ -25,4 +25,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/porofluid_pressure_based_ele/CMakeLists.txt
+++ b/src/porofluid_pressure_based_ele/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/post/CMakeLists.txt
+++ b/src/post/CMakeLists.txt
@@ -13,4 +13,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/red_airways/CMakeLists.txt
+++ b/src/red_airways/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/reduced_lung/CMakeLists.txt
+++ b/src/reduced_lung/CMakeLists.txt
@@ -13,4 +13,4 @@ set(_dependencies
     global_data
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/rigidsphere/CMakeLists.txt
+++ b/src/rigidsphere/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/scatra/CMakeLists.txt
+++ b/src/scatra/CMakeLists.txt
@@ -23,4 +23,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/scatra_ele/CMakeLists.txt
+++ b/src/scatra_ele/CMakeLists.txt
@@ -19,4 +19,4 @@ set(_dependencies
     porofluid_pressure_based_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/shell7p/CMakeLists.txt
+++ b/src/shell7p/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/shell_kl_nurbs/src/CMakeLists.txt
+++ b/src/shell_kl_nurbs/src/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/solid_3D_ele/CMakeLists.txt
+++ b/src/solid_3D_ele/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/solid_poro_3D_ele/CMakeLists.txt
+++ b/src/solid_poro_3D_ele/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/solid_scatra_3D_ele/CMakeLists.txt
+++ b/src/solid_scatra_3D_ele/CMakeLists.txt
@@ -11,4 +11,4 @@ set(_dependencies
     # cmake-format: sortable
     solid_3D_ele
     )
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/solver_nonlin_nox/CMakeLists.txt
+++ b/src/solver_nonlin_nox/CMakeLists.txt
@@ -18,4 +18,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/ssi/CMakeLists.txt
+++ b/src/ssi/CMakeLists.txt
@@ -22,4 +22,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/ssti/CMakeLists.txt
+++ b/src/ssti/CMakeLists.txt
@@ -22,4 +22,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/sti/CMakeLists.txt
+++ b/src/sti/CMakeLists.txt
@@ -19,4 +19,4 @@ set(_dependencies
     scatra_ele
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/stru_multi/CMakeLists.txt
+++ b/src/stru_multi/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure/CMakeLists.txt
+++ b/src/structure/CMakeLists.txt
@@ -27,4 +27,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/CMakeLists.txt
+++ b/src/structure_new/src/CMakeLists.txt
@@ -21,7 +21,7 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 four_c_unity_build_compile_separately(
   ${AUTO_DEFINED_MODULE_NAME} 4C_structure_new_timint_basedataglobalstate.cpp

--- a/src/structure_new/src/explicit/CMakeLists.txt
+++ b/src/structure_new/src/explicit/CMakeLists.txt
@@ -15,4 +15,4 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/implicit/CMakeLists.txt
+++ b/src/structure_new/src/implicit/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/linear_solver/CMakeLists.txt
+++ b/src/structure_new/src/linear_solver/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/model_evaluator/CMakeLists.txt
+++ b/src/structure_new/src/model_evaluator/CMakeLists.txt
@@ -24,4 +24,4 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/nonlinear_solver/CMakeLists.txt
+++ b/src/structure_new/src/nonlinear_solver/CMakeLists.txt
@@ -16,7 +16,7 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 four_c_unity_build_compile_separately(
   ${AUTO_DEFINED_MODULE_NAME} 4C_structure_new_nox_nln_str_linearsystem.cpp

--- a/src/structure_new/src/output/CMakeLists.txt
+++ b/src/structure_new/src/output/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/predict/CMakeLists.txt
+++ b/src/structure_new/src/predict/CMakeLists.txt
@@ -15,4 +15,4 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/utils/CMakeLists.txt
+++ b/src/structure_new/src/utils/CMakeLists.txt
@@ -19,4 +19,4 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/thermo/src/CMakeLists.txt
+++ b/src/thermo/src/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/thermo/src/element/CMakeLists.txt
+++ b/src/thermo/src/element/CMakeLists.txt
@@ -16,4 +16,4 @@ set(_dependencies
     mat
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/thermo/src/implicit/CMakeLists.txt
+++ b/src/thermo/src/implicit/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     timestepping
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/thermo/src/utils/CMakeLists.txt
+++ b/src/thermo/src/utils/CMakeLists.txt
@@ -15,4 +15,4 @@ set(_dependencies
     inpar
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/timestepping/CMakeLists.txt
+++ b/src/timestepping/CMakeLists.txt
@@ -13,4 +13,4 @@ set(_dependencies
     core
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/torsion3/CMakeLists.txt
+++ b/src/torsion3/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/truss3/CMakeLists.txt
+++ b/src/truss3/CMakeLists.txt
@@ -17,4 +17,4 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/tsi/CMakeLists.txt
+++ b/src/tsi/CMakeLists.txt
@@ -20,4 +20,4 @@ set(_dependencies
     thermo
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/w1/CMakeLists.txt
+++ b/src/w1/CMakeLists.txt
@@ -20,7 +20,7 @@ set(_dependencies
     structure_new
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
 
 four_c_unity_build_compile_separately(${AUTO_DEFINED_MODULE_NAME} 4C_w1_poro_evaluate.cpp)
 four_c_unity_build_compile_separately(${AUTO_DEFINED_MODULE_NAME} 4C_w1_poro_p1_evaluate.cpp)

--- a/src/xfem/CMakeLists.txt
+++ b/src/xfem/CMakeLists.txt
@@ -23,4 +23,4 @@ set(_dependencies
     solver_nonlin_nox
     )
 
-four_c_add_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/unittests/common/unittest_utils/CMakeLists.txt
+++ b/unittests/common/unittest_utils/CMakeLists.txt
@@ -7,4 +7,4 @@
 
 add_library(unittests_common INTERFACE)
 target_include_directories(unittests_common INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
-four_c_add_dependency(unittests_common core)
+four_c_add_internal_dependency(unittests_common core)


### PR DESCRIPTION
After encountering the issue that I added my own external dependency through this function, resulting in a linker error, I renamed the function to clarify that it is used only for internal dependencies in accordance with a discussion with @sebproell. 