### PR TITLE
Remove unused header inclusions

### DIFF
--- a/unittests/mat/4C_druckerprager_test.cpp
+++ b/unittests/mat/4C_druckerprager_test.cpp
@@ -7,8 +7,6 @@
 
 #include <gtest/gtest.h>
 
-#include "4C_beam3_kirchhoff.hpp"
-#include "4C_beam3_reissner.hpp"
 #include "4C_comm_pack_buffer.hpp"
 #include "4C_global_data.hpp"
 #include "4C_linalg_FADmatrix_utils.hpp"


### PR DESCRIPTION
## Description and Context

The unit test for a solid material does not need to know about beams, so it should not include beam headers.