### PR TITLE
Attempt to join pull requests of dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: ".github/workflows"
-    schedule:
-      interval: "weekly"
-
-  - package-ecosystem: "github-actions"
     directories:
       - ".github/actions/**/*"
+      - ".github/workflows"
     schedule:
       interval: "weekly"
+    groups:
+      create-combined-pull-request:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description and Context
Yesterday, Dependabot opened several pull requests to update a single dependency (see #1076, #1078, #1079,#1080). According to the documentation https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups-- it should be possible to join those pull requests to a single one using `groups`, which is suggested in this PR.

## Related Issues and Pull Requests
Follows #1048, #1042, #327
