### PR TITLE
Replace `Epetra_LinearProblem` with a custom class

### DIFF
--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.cpp
@@ -149,23 +149,20 @@ Core::LinAlg::SolverParams NOX::Nln::CONTACT::LinearSystem::set_solver_options(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void NOX::Nln::CONTACT::LinearSystem::set_linear_problem_for_solve(
-    Epetra_LinearProblem& linear_problem, Core::LinAlg::SparseOperator& jac,
-    Core::LinAlg::Vector<double>& lhs, Core::LinAlg::Vector<double>& rhs) const
+NOX::Nln::LinearProblem NOX::Nln::CONTACT::LinearSystem::set_linear_problem_for_solve(
+    Core::LinAlg::SparseOperator& jac, Core::LinAlg::Vector<double>& lhs,
+    Core::LinAlg::Vector<double>& rhs) const
 {
   switch (jacType_)
   {
     case NOX::Nln::LinSystem::LinalgSparseMatrix:
-      NOX::Nln::LinearSystem::set_linear_problem_for_solve(linear_problem, jac, lhs, rhs);
+      return NOX::Nln::LinearSystem::set_linear_problem_for_solve(jac, lhs, rhs);
 
-      break;
     case NOX::Nln::LinSystem::LinalgBlockSparseMatrix:
     {
       p_lin_prob_.extract_active_blocks(jac, lhs, rhs);
-      NOX::Nln::LinearSystem::set_linear_problem_for_solve(
-          linear_problem, *p_lin_prob_.p_jac_, *p_lin_prob_.p_lhs_, *p_lin_prob_.p_rhs_);
-
-      break;
+      return NOX::Nln::LinearSystem::set_linear_problem_for_solve(
+          *p_lin_prob_.p_jac_, *p_lin_prob_.p_lhs_, *p_lin_prob_.p_rhs_);
     }
     default:
     {
@@ -178,7 +175,7 @@ void NOX::Nln::CONTACT::LinearSystem::set_linear_problem_for_solve(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void NOX::Nln::CONTACT::LinearSystem::complete_solution_after_solve(
-    const Epetra_LinearProblem& linProblem, Core::LinAlg::Vector<double>& lhs) const
+    const NOX::Nln::LinearProblem& linProblem, Core::LinAlg::Vector<double>& lhs) const
 {
   p_lin_prob_.insert_into_global_lhs(lhs);
   p_lin_prob_.reset();

--- a/src/contact/4C_contact_nox_nln_contact_linearsystem.hpp
+++ b/src/contact/4C_contact_nox_nln_contact_linearsystem.hpp
@@ -67,12 +67,11 @@ namespace NOX
             Teuchos::RCP<Core::LinAlg::Solver>& currSolver) override;
 
         //! derived
-        void set_linear_problem_for_solve(Epetra_LinearProblem& linear_problem,
-            Core::LinAlg::SparseOperator& jac, Core::LinAlg::Vector<double>& lhs,
-            Core::LinAlg::Vector<double>& rhs) const override;
+        NOX::Nln::LinearProblem set_linear_problem_for_solve(Core::LinAlg::SparseOperator& jac,
+            Core::LinAlg::Vector<double>& lhs, Core::LinAlg::Vector<double>& rhs) const override;
 
         //! Combine the linear solution parts [derived]
-        void complete_solution_after_solve(const Epetra_LinearProblem& linProblem,
+        void complete_solution_after_solve(const NOX::Nln::LinearProblem& linProblem,
             Core::LinAlg::Vector<double>& lhs) const override;
 
        private:

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -17,6 +17,7 @@
 #include <Epetra_Operator.h>
 #include <Epetra_RowMatrix.h>
 #include <Epetra_VbrMatrix.h>
+#include <NOX_Epetra_Scaling.H>
 #include <Teuchos_ParameterList.hpp>
 
 #include <vector>
@@ -29,7 +30,7 @@ NOX::FSI::LinearSystemGCR::LinearSystemGCR(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
     const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
     const Teuchos::RCP<Epetra_Operator>& jacobian, const ::NOX::Epetra::Vector& cloneVector,
-    const std::shared_ptr<NOX::Nln::Scaling> s)
+    const Teuchos::RCP<::NOX::Epetra::Scaling> s)
     : utils(printParams),
       jacInterfacePtr(iJac),
       jacType(EpetraOperator),
@@ -105,9 +106,14 @@ bool NOX::FSI::LinearSystemGCR::applyJacobianInverse(
   // ************* Begin linear system scaling *******************
   if (scaling)
   {
-    if (!manualScaling) scaling->compute_scaling(Problem);
+    if (!manualScaling) scaling->computeScaling(Problem);
 
-    scaling->scale_linear_system(Problem);
+    scaling->scaleLinearSystem(Problem);
+
+    if (utils.isPrintType(::NOX::Utils::Details))
+    {
+      utils.out() << *scaling << std::endl;
+    }
   }
   // ************* End linear system scaling *******************
 
@@ -131,7 +137,7 @@ bool NOX::FSI::LinearSystemGCR::applyJacobianInverse(
   }
 
   // Unscale the linear system
-  if (scaling) scaling->unscale_linear_system(Problem);
+  if (scaling) scaling->unscaleLinearSystem(Problem);
 
   // Set the output parameters in the "Output" sublist
   if (outputSolveDetails)

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -59,7 +59,7 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::Interface::Required>& iReq,
           const Teuchos::RCP<::NOX::Epetra::Interface::Jacobian>& iJac,
           const Teuchos::RCP<Epetra_Operator>& J, const ::NOX::Epetra::Vector& cloneVector,
-          const std::shared_ptr<NOX::Nln::Scaling> scalingObject = nullptr);
+          const Teuchos::RCP<::NOX::Epetra::Scaling> scalingObject = Teuchos::null);
 
       //! Reset the linear solver parameters.
       virtual void reset(Teuchos::ParameterList& linearSolverParams);
@@ -245,7 +245,7 @@ namespace NOX
       mutable Teuchos::RCP<Epetra_Operator> jacPtr;
 
       //! Scaling object supplied by the user
-      std::shared_ptr<NOX::Nln::Scaling> scaling;
+      Teuchos::RCP<::NOX::Epetra::Scaling> scaling;
 
       //! An extra temporary vector, only allocated if needed.
       mutable std::shared_ptr<::NOX::Epetra::Vector> tmpVectorPtr;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_forward_decl.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_forward_decl.hpp
@@ -17,7 +17,6 @@
 
 class Epetra_Operator;
 class Epetra_RowMatrix;
-class Epetra_LinearProblem;
 
 namespace FourC::Core::LinAlg
 {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearproblem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearproblem.hpp
@@ -1,0 +1,31 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_SOLVER_NONLIN_NOX_LINEARPROBLEM_HPP
+#define FOUR_C_SOLVER_NONLIN_NOX_LINEARPROBLEM_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_linalg_sparseoperator.hpp"
+#include "4C_linalg_vector.hpp"
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace NOX::Nln
+{
+  class LinearProblem
+  {
+   public:
+    std::shared_ptr<Core::LinAlg::SparseOperator> jac;
+    std::shared_ptr<Core::LinAlg::Vector<double>> lhs;
+    std::shared_ptr<Core::LinAlg::Vector<double>> rhs;
+  };
+}  // namespace NOX::Nln
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -12,6 +12,7 @@
 
 #include "4C_solver_nonlin_nox_enum_lists.hpp"
 #include "4C_solver_nonlin_nox_forward_decl.hpp"
+#include "4C_solver_nonlin_nox_linearproblem.hpp"
 #include "4C_solver_nonlin_nox_linearsystem_base.hpp"
 
 #include <NOX_Epetra_Interface_Required.H>
@@ -267,9 +268,8 @@ namespace NOX
           Teuchos::RCP<Core::LinAlg::Solver>& currSolver) = 0;
 
       //! Set-up the linear problem object
-      virtual void set_linear_problem_for_solve(Epetra_LinearProblem& linear_problem,
-          Core::LinAlg::SparseOperator& jac, Core::LinAlg::Vector<double>& lhs,
-          Core::LinAlg::Vector<double>& rhs) const;
+      virtual LinearProblem set_linear_problem_for_solve(Core::LinAlg::SparseOperator& jac,
+          Core::LinAlg::Vector<double>& lhs, Core::LinAlg::Vector<double>& rhs) const;
 
       /*! \brief Complete the solution vector after a linear solver attempt
        *
@@ -281,7 +281,7 @@ namespace NOX
        *
        *  */
       virtual void complete_solution_after_solve(
-          const Epetra_LinearProblem& linProblem, Core::LinAlg::Vector<double>& lhs) const;
+          const NOX::Nln::LinearProblem& linProblem, Core::LinAlg::Vector<double>& lhs) const;
 
       /// convert jacobian matrix to dense matrix
       void convert_jacobian_to_dense_matrix(Core::LinAlg::SerialDenseMatrix& dense) const;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_scaling.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_scaling.hpp
@@ -10,13 +10,13 @@
 
 #include "4C_config.hpp"
 
-#include <Epetra_LinearProblem.h>
-
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace NOX::Nln
 {
+  // Forward declaration
+  class LinearProblem;
+
   class Scaling
   {
    public:
@@ -31,21 +31,21 @@ namespace NOX::Nln
      *
      * @param problem The linear problem to be scaled.
      */
-    virtual void compute_scaling(const Epetra_LinearProblem& problem) = 0;
+    virtual void compute_scaling(const NOX::Nln::LinearProblem& problem) = 0;
 
     /**
      * @brief Scales the linear system.
      *
      * @param problem The linear problem to be scaled.
      */
-    virtual void scale_linear_system(Epetra_LinearProblem& problem) = 0;
+    virtual void scale_linear_system(NOX::Nln::LinearProblem& problem) = 0;
 
     /**
      * @brief Remove the scaling from the linear system.
      *
      * @param problem The linear problem to be unscaled.
      */
-    virtual void unscale_linear_system(Epetra_LinearProblem& problem) = 0;
+    virtual void unscale_linear_system(NOX::Nln::LinearProblem& problem) = 0;
   };
 }  // namespace NOX::Nln
 

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -16,7 +16,6 @@
 #include "4C_utils_enum.hpp"
 
 #include <Epetra_CrsMatrix.h>
-#include <Epetra_LinearProblem.h>
 #include <Epetra_Operator.h>
 #include <Epetra_RowMatrix.h>
 #include <Epetra_VbrMatrix.h>

--- a/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.hpp
+++ b/src/structure_new/src/nonlinear_solver/4C_structure_new_nln_linearsystem_scaling.hpp
@@ -31,6 +31,11 @@ namespace Core::LinAlg
   class SparseMatrix;
 }
 
+namespace NOX::Nln
+{
+  class LinearProblem;
+}
+
 namespace Solid
 {
   namespace Nln
@@ -45,13 +50,13 @@ namespace Solid
             Solid::TimeInt::BaseDataGlobalState& GState);
 
         //! Compute scaling.
-        void compute_scaling(const Epetra_LinearProblem& problem) override;
+        void compute_scaling(const NOX::Nln::LinearProblem& problem) override;
 
         //! Scales the linear system.
-        void scale_linear_system(Epetra_LinearProblem& problem) override;
+        void scale_linear_system(NOX::Nln::LinearProblem& problem) override;
 
         //! Remove the scaling from the linear system.
-        void unscale_linear_system(Epetra_LinearProblem& problem) override;
+        void unscale_linear_system(NOX::Nln::LinearProblem& problem) override;
 
        private:
         //! stiffness matrix after scaling


### PR DESCRIPTION
## Description and Context
The next step to proceed with #1071 is to get rid of `Epetra_LinearProblem`. It is now only used in `NOX::FSI::LinearSystemGCR` (see comment below) an in `Core::LinearSolver::DirectSolver` for older version of Trilinos.

## Exception `NOX::FSI::LinearSystemGCR`
I had also to bring back the use of `NOX::Epetra::Scaling` in `NOX::FSI::LinearSystemGCR` since this system implements its own GCR and GMRES solution algorithms, this was earlier removed in #1077. Surely, these manual algos should be replaced by the suitable Trilinos packages. So since this class requires significant refactoring anyway, I think it is OK to have both `NOX::Epetra::Scaling` and `Epetra_LinearProblem` still used there. Alternative solutions would be to either disable the scaling feature (in fact, it is not used currently) or to create a `SparseOperator`-like view wrapper around `Epetra_Operator` as similarly done for `Core::Linalg::Vector` and its view. However, I would prefer not to use this option if other alternatives are available.

## Related Issues and Pull Requests
#723, #1071, #1077
