### PR TITLE
Allow for monolithic partitioning on a single MPI rank

### DIFF
--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -601,6 +601,12 @@ namespace
         colmap = std::make_shared<Core::LinAlg::Map>(
             -1, graph->col_map().num_my_elements(), graph->col_map().my_global_elements(), 0, comm);
 
+        if (Core::Communication::num_mpi_ranks(comm) == 1)
+        {
+          // In the case of a single MPI rank we don't have to perform the redistribution.
+          break;
+        }
+
         discret.redistribute(*rowmap, *colmap, {.do_boundary_conditions = false});
 
         std::shared_ptr<const Core::LinAlg::Graph> enriched_graph =

--- a/tests/list_of_tests.cmake
+++ b/tests/list_of_tests.cmake
@@ -1920,6 +1920,7 @@ four_c_test(TEST_FILE xfsi_push_1D_1st_order.4C.yaml)
 four_c_test(TEST_FILE xfsi_push_1D_2nd_order.4C.yaml)
 
 if (FOUR_C_WITH_ARBORX)
+    four_c_test(TEST_FILE beam3eb_static_beam_to_solid_volume_meshtying_beam_to_beam_contact_boundingvolume.4C.yaml NP 1)
     four_c_test(TEST_FILE beam3eb_static_beam_to_solid_volume_meshtying_beam_to_beam_contact_boundingvolume.4C.yaml NP 2 RESTART_STEP 3)
     four_c_test(TEST_FILE beam3eb_static_beam_to_solid_volume_meshtying_monolithic_partitioning.4C.yaml NP 3)
     four_c_test(TEST_FILE beam3r_herm2line3_static_beam_to_solid_surface_coupling_gpts_reference_forced_boundingvolume.4C.yaml NP 3 RESTART_STEP 2)


### PR DESCRIPTION
## Description and Context

Currently setting
```yaml
MESH PARTITIONING:
  METHOD: monolithic
```
and running the simulation on a single MPI rank produces an error. This PR fixes this, by simply skipping the partitioning in case of a single MPI rank.