### PR TITLE
Give InputSpec shallow copy behavior

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -464,7 +464,7 @@ namespace Core::IO
         // Take the special spec of FUNCT<n> because it is the same for all function sections.
         // Make a copy and replace the name. This is a pretty insane hack and should be removed when
         // the input of the functions is restructured.
-        auto spec = pimpl_->valid_sections_.at("FUNCT<n>");
+        auto spec = InputSpec(pimpl_->valid_sections_.at("FUNCT<n>").impl().clone());
         spec.impl().data.name = name;
         dynamic_cast<Internal::InputSpecTypeErasedImplementation<Internal::ListSpec>&>(spec.impl())
             .wrapped.name = name;

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -18,22 +18,6 @@ Core::IO::InputSpec::InputSpec(std::unique_ptr<Internal::InputSpecImpl> pimpl)
 {
 }
 
-Core::IO::InputSpec::~InputSpec() = default;
-
-Core::IO::InputSpec::InputSpec(const InputSpec& other)
-    : pimpl_(other.pimpl_ ? other.pimpl_->clone() : nullptr)
-{
-}
-
-Core::IO::InputSpec& Core::IO::InputSpec::operator=(const InputSpec& other)
-{
-  if (this == &other) return *this;
-
-  pimpl_ = other.pimpl_ ? other.pimpl_->clone() : nullptr;
-
-  return *this;
-}
-
 void Core::IO::InputSpec::fully_parse(
     ValueParser& parser, Core::IO::InputParameterContainer& container) const
 {

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -46,15 +46,7 @@ namespace Core::IO
    public:
     InputSpec() = default;
 
-    ~InputSpec();
-
     InputSpec(std::unique_ptr<Internal::InputSpecImpl> pimpl);
-
-    InputSpec(const InputSpec& other);
-    InputSpec& operator=(const InputSpec& other);
-
-    InputSpec(InputSpec&&) noexcept = default;
-    InputSpec& operator=(InputSpec&&) noexcept = default;
 
     /**
      * Use the @p parser to parse whatever this InputSpec expects. The results are stored in the
@@ -103,7 +95,7 @@ namespace Core::IO
     [[nodiscard]] const Internal::InputSpecImpl& impl() const;
 
    private:
-    std::unique_ptr<Internal::InputSpecImpl> pimpl_;
+    std::shared_ptr<Internal::InputSpecImpl> pimpl_;
   };
 }  // namespace Core::IO
 

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -1166,9 +1166,12 @@ namespace
                   &spec.impl());
           nested && (!predicate || predicate(nested->wrapped)))
       {
-        for (auto&& sub_spec : nested->wrapped.specs)
+        // Copy the specs from the nested spec into the flattened list.
+        // Note that we do not move the internals out of the spec since more (internal) references
+        // to the spec may be held elsewhere.
+        for (const auto& sub_spec : nested->wrapped.specs)
         {
-          flattened_specs.emplace_back(std::move(sub_spec));
+          flattened_specs.emplace_back(sub_spec);
         }
       }
       else


### PR DESCRIPTION
So far, `InputSpec` has always made a copy. `InputSpec` has only const methods and cannot mutate its state after construction (at least the user-facing part cannot). Thus, we can internally share repeated parts of an InputSpec. This PR serves as preparation for a new feature that also exports the info about shared specs to the metadata and schema.

Note that no change in the user code is required. This PR demonstrates how `shared_ptr` is meant to be used (IMHO): as an implementation detail of classes, hidden from clients.