### PR TITLE
Let 4C emit a top-level all_of for metadata

### DIFF
--- a/doc/documentation/python/include_yaml.py
+++ b/doc/documentation/python/include_yaml.py
@@ -28,7 +28,7 @@ def load_meta_data():
         (PATH_TO_TESTS / ("../.." / pathlib.Path("4C_metadata.yaml"))).read_text()
     )
     section_dict = {}
-    for section in metafile_data["sections"]:
+    for section in metafile_data["sections"]["specs"]:
         params_avail = {}
         if "spec" in section:
             params_avail = section["spec"]["specs"]

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -573,13 +573,14 @@ namespace Core::IO
 
     {
       auto sections = root["sections"];
-      sections |= ryml::SEQ;
-      for (const auto& [name, spec] : pimpl_->valid_sections_)
-      {
-        auto section = sections.append_child();
-        YamlNodeRef spec_emitter{section, ""};
-        spec.emit_metadata(spec_emitter);
-      }
+      sections |= ryml::MAP;
+
+      auto all_sections = pimpl_->valid_sections_ | std::views::values;
+      auto combined_spec =
+          InputSpecBuilders::all_of(std::vector(all_sections.begin(), all_sections.end()));
+
+      YamlNodeRef spec_emitter{sections, ""};
+      combined_spec.emit_metadata(spec_emitter);
     }
 
     {

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -425,30 +425,30 @@ def metadata_object_from_file(metadata_4C_path):
         metadata_description = f"Schema for 4C\nCommit hash: {metadata['metadata']['commit_hash']}\nVersion: {metadata['metadata']['version']}"
 
         # Legacy section
-        sections = metadata["sections"]
-        legacy_sections = [
-            {
-                "name": name,
-                "description": name + " [legacy section] ",
-                "type": "vector",
-                "value_type": {"type": "string"},
-            }
-            for name in metadata["legacy_string_sections"]
-        ]
-
-        # Combine sections with legacy sections
-        all_of = All_Of(
-            description=metadata_description,
-            specs=sections + legacy_sections,
-            name="Sections",
+        sections = All_Of(**metadata["sections"])
+        legacy_sections = All_Of(
+            specs=[
+                {
+                    "name": name,
+                    "description": name + " [legacy section] ",
+                    "type": "vector",
+                    "value_type": {"type": "string"},
+                }
+                for name in metadata["legacy_string_sections"]
+            ]
         )
+
+        sections.specs.extend(legacy_sections.specs)
+        sections.description = metadata_description
+        sections.name = "Sections"
+
     except Exception as exception:
         raise ValueError(
             "Could not read the 4C metadata file.\nThis generally indicates that input parameters"
             " were added or modified in a non-conforming way."
         ) from exception
 
-    return all_of, description_section_name, metadata["metadata"]
+    return sections, description_section_name, metadata["metadata"]
 
 
 @dataclass


### PR DESCRIPTION
This PR makes more consistent use of the tools that InputSpec provides. A collection of specs is represented by `all_of`, so also use this on the top-level. 