### PR TITLE
Condense metadata by sharing duplicated information

### DIFF
--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -573,13 +573,14 @@ namespace Core::IO
 
     {
       auto sections = root["sections"];
-      sections |= ryml::SEQ;
-      for (const auto& [name, spec] : pimpl_->valid_sections_)
-      {
-        auto section = sections.append_child();
-        YamlNodeRef spec_emitter{section, ""};
-        spec.emit_metadata(spec_emitter);
-      }
+      sections |= ryml::MAP;
+
+      auto all_sections = pimpl_->valid_sections_ | std::views::values;
+      auto combined_spec =
+          InputSpecBuilders::all_of(std::vector(all_sections.begin(), all_sections.end()));
+
+      YamlNodeRef spec_emitter{sections, ""};
+      combined_spec.emit_metadata(spec_emitter);
     }
 
     {

--- a/src/core/io/src/4C_io_input_file.cpp
+++ b/src/core/io/src/4C_io_input_file.cpp
@@ -580,7 +580,7 @@ namespace Core::IO
           InputSpecBuilders::all_of(std::vector(all_sections.begin(), all_sections.end()));
 
       YamlNodeRef spec_emitter{sections, ""};
-      combined_spec.emit_metadata(spec_emitter);
+      combined_spec.emit_metadata(spec_emitter, {.condense_duplicated_specs_threshold = 5});
     }
 
     {

--- a/src/core/io/src/4C_io_input_spec.cpp
+++ b/src/core/io/src/4C_io_input_spec.cpp
@@ -102,11 +102,13 @@ void Core::IO::InputSpec::print_as_dat(std::ostream& stream) const
   pimpl_->print(stream, 0u);
 }
 
-void Core::IO::InputSpec::emit_metadata(YamlNodeRef yaml) const
+void Core::IO::InputSpec::emit_metadata(
+    YamlNodeRef yaml, InputSpecEmitMetadataOptions options) const
 {
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
 
-  pimpl_->emit_metadata(yaml);
+  Internal::EmitMetadataContext context{.options = options};
+  pimpl_->emit_metadata(yaml, context);
 }
 
 Core::IO::Internal::InputSpecImpl& Core::IO::InputSpec::impl()
@@ -120,5 +122,7 @@ const Core::IO::Internal::InputSpecImpl& Core::IO::InputSpec::impl() const
   FOUR_C_ASSERT(pimpl_, "InputSpec is empty.");
   return *pimpl_;
 }
+
+std::size_t Core::IO::InputSpec::use_count() const { return pimpl_.use_count(); }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_spec.hpp
+++ b/src/core/io/src/4C_io_input_spec.hpp
@@ -13,6 +13,8 @@
 #include <memory>
 #include <optional>
 
+#include <c++/14/limits>
+
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::IO
@@ -34,6 +36,33 @@ namespace Core::IO
      * to the default.
      */
     bool emit_defaulted_values{false};
+  };
+
+  struct InputSpecEmitMetadataOptions
+  {
+    /**
+     * If an InputSpec is duplicated more often than this number, condense all occurrences into a
+     * single shared reference in the metadata. This means that if multiple InputSpecs have the same
+     * content, they will not be emitted separately, but instead a single reference is created in
+     * the metadata and the place where the InputSpec is used will point to that reference.
+     *
+     * By default, this is set to the maximum value of an unsigned integer, which means that no
+     * condensation is done. A useful value is around 5, as a trade-off between condensing too
+     * much and not condensing enough.
+     */
+    unsigned condense_duplicated_specs_threshold{std::numeric_limits<unsigned>::max()};
+
+    /**
+     * The name under which the metadata of duplicated InputSpecs is stored as a shared reference in
+     * the metadata. This key will _always_ be placed in the root of the YAML tree.
+     */
+    std::string references_node_name{"$references"};
+
+    /**
+     * The key under which a reference to a shared InputSpec is stored in the YAML tree. This is the
+     * key used in place of the full InputSpec metadata when a shared reference is used.
+     */
+    std::string reference_key{"$ref"};
   };
 
   /**
@@ -86,7 +115,7 @@ namespace Core::IO
     /**
      * Emit metadata about the InputSpec to the @p yaml emitter.
      */
-    void emit_metadata(YamlNodeRef yaml) const;
+    void emit_metadata(YamlNodeRef yaml, InputSpecEmitMetadataOptions options = {}) const;
 
     /**
      * Access the opaque implementation class. This is used in the implementation files where the
@@ -101,6 +130,12 @@ namespace Core::IO
      * code.
      */
     [[nodiscard]] const Internal::InputSpecImpl& impl() const;
+
+    /**
+     * Returns the number of times this exact InputSpec is used. Since InputSpecs are copied
+     * shallowly, this function is useful to export knowledge about shared specs to the metadata.
+     */
+    [[nodiscard]] std::size_t use_count() const;
 
    private:
     std::unique_ptr<Internal::InputSpecImpl> pimpl_;

--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -175,6 +175,52 @@ namespace
     ryml::id_type num_children_before;
   };
 
+  /**
+   * This function emits metadata or inserts a reference to an already existing metadata node.
+   */
+  void emit_metadata_helper(const Core::IO::InputSpec& spec, Core::IO::YamlNodeRef node,
+      Core::IO::Internal::EmitMetadataContext& context)
+  {
+    if (spec.use_count() > context.options.condense_duplicated_specs_threshold &&
+        !context.currently_emitting_to_references &&
+        spec.impl().data.type == Core::IO::Internal::InputSpecType::group)
+    {
+      // We have not yet written the reference metadata for this spec, so create it first.
+      if (!context.emitted_specs.contains(&spec.impl()))
+      {
+        // Make a new reference node in the yaml tree and emit the metadata into it.
+        auto references_node =
+            node.node.tree()->rootref()[ryml::to_csubstr(context.options.references_node_name)];
+        // Ensure that the name of the reference node is serialized into the YAML tree.
+        references_node << ryml::key(context.options.references_node_name);
+        references_node |= ryml::MAP;
+
+
+        auto next_id = references_node.num_children();
+        std::string ref_name = std::to_string(next_id);
+        FOUR_C_ASSERT(!references_node.has_child(ryml::to_csubstr(ref_name)),
+            "Internal error: duplicate reference name {}.", ref_name);
+        auto target_node = references_node.append_child();
+        target_node << ryml::key(ref_name);
+        target_node |= ryml::MAP;
+
+        context.currently_emitting_to_references = true;
+        spec.impl().emit_metadata(node.wrap(target_node), context);
+        context.currently_emitting_to_references = false;
+
+        context.emitted_specs.emplace(&spec.impl(), ref_name);
+      }
+
+      // Use the reference instead of the full metadata.
+      auto dst = node.node.append_child();
+      dst << ryml::key(context.options.reference_key);
+      dst << context.emitted_specs[&spec.impl()];
+    }
+    else
+    {
+      spec.impl().emit_metadata(node, context);
+    }
+  }
 }  // namespace
 
 
@@ -727,7 +773,8 @@ void Core::IO::Internal::GroupSpec::print(std::ostream& stream, std::size_t inde
   spec.impl().print(stream, indent);
 }
 
-void Core::IO::Internal::GroupSpec::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::GroupSpec::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
   node.node["name"] << name;
@@ -742,7 +789,7 @@ void Core::IO::Internal::GroupSpec::emit_metadata(YamlNodeRef node) const
   {
     auto child = node.node["specs"].append_child();
     child |= ryml::MAP;
-    spec.impl().emit_metadata(node.wrap(child));
+    emit_metadata_helper(spec, node.wrap(child), context);
   }
 }
 
@@ -817,7 +864,8 @@ void Core::IO::Internal::AllOfSpec::print(std::ostream& stream, std::size_t inde
   }
 }
 
-void Core::IO::Internal::AllOfSpec::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::AllOfSpec::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
 
@@ -828,7 +876,7 @@ void Core::IO::Internal::AllOfSpec::emit_metadata(YamlNodeRef node) const
     {
       auto child = node.node["specs"].append_child();
       child |= ryml::MAP;
-      spec.impl().emit_metadata(node.wrap(child));
+      emit_metadata_helper(spec, node.wrap(child), context);
     }
   }
 }
@@ -969,7 +1017,8 @@ void Core::IO::Internal::OneOfSpec::print(std::ostream& stream, std::size_t inde
   }
 }
 
-void Core::IO::Internal::OneOfSpec::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::OneOfSpec::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
 
@@ -978,7 +1027,7 @@ void Core::IO::Internal::OneOfSpec::emit_metadata(YamlNodeRef node) const
   for (const auto& spec : specs)
   {
     auto child = node.node["specs"].append_child();
-    spec.impl().emit_metadata(node.wrap(child));
+    emit_metadata_helper(spec, node.wrap(child), context);
   }
 }
 
@@ -1104,7 +1153,8 @@ void Core::IO::Internal::ListSpec::print(std::ostream& stream, std::size_t inden
   spec.impl().print(stream, indent + 2);
 }
 
-void Core::IO::Internal::ListSpec::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::ListSpec::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
 
@@ -1118,7 +1168,7 @@ void Core::IO::Internal::ListSpec::emit_metadata(YamlNodeRef node) const
   emit_value_as_yaml(node.wrap(node.node["required"]), data.required);
   if (data.size > 0) node.node["size"] << data.size;
   node.node["spec"] |= ryml::MAP;
-  spec.impl().emit_metadata(node.wrap(node.node["spec"]));
+  emit_metadata_helper(spec, node.wrap(node.node["spec"]), context);
 }
 
 

--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -333,6 +333,26 @@ namespace Core::IO
       ConstYamlNodeRef node_;
     };
 
+    /**
+     * Track information about the metadata that is emitted for an InputSpec.
+     */
+    struct EmitMetadataContext
+    {
+      InputSpecEmitMetadataOptions options;
+
+      /**
+       * Track which specs that are duplicated have already been emitted and remember the reference
+       * name.
+       */
+      std::unordered_map<const InputSpecImpl*, std::string> emitted_specs{};
+
+      /**
+       * Track whether we are currently emitting into a reference node. This is used to avoid
+       * nesting references.
+       */
+      bool currently_emitting_to_references{false};
+    };
+
 
     /**
      * Distinguish between different types of specs in the implementation.
@@ -421,14 +441,12 @@ namespace Core::IO
 
       //! Emit metadata. This function always emits into a map, i.e., the implementation must
       //! insert keys and values into the yaml emitter.
-      virtual void emit_metadata(YamlNodeRef node) const = 0;
+      virtual void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const = 0;
 
       virtual bool emit(YamlNodeRef node, const InputParameterContainer&,
           const InputSpecEmitOptions& options) const = 0;
 
       [[nodiscard]] virtual std::string pretty_type_name() const = 0;
-
-      [[nodiscard]] virtual std::unique_ptr<InputSpecImpl> clone() const = 0;
 
       void print(std::ostream& stream, std::size_t indent) const { do_print(stream, indent); }
 
@@ -483,7 +501,10 @@ namespace Core::IO
         wrapped.set_default_value(container);
       }
 
-      void emit_metadata(YamlNodeRef node) const override { wrapped.emit_metadata(node); }
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const override
+      {
+        wrapped.emit_metadata(node, context);
+      }
 
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const override
@@ -532,11 +553,6 @@ namespace Core::IO
               "types that store a type.");
           return "unknown";
         }
-      }
-
-      [[nodiscard]] std::unique_ptr<InputSpecImpl> clone() const override
-      {
-        return std::make_unique<InputSpecTypeErasedImplementation<T>>(wrapped, data);
       }
 
       T wrapped;
@@ -940,7 +956,7 @@ namespace Core::IO
       void parse(ValueParser& parser, InputParameterContainer& container) const;
       bool match(ConstYamlNodeRef node, InputSpecBuilders::Storage& container,
           IO::Internal::MatchEntry& match_entry) const;
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
       void set_default_value(InputSpecBuilders::Storage& container) const;
@@ -969,7 +985,7 @@ namespace Core::IO
       bool match(ConstYamlNodeRef node, InputSpecBuilders::Storage& container,
           IO::Internal::MatchEntry& match_entry) const;
       void print(std::ostream& stream, std::size_t indent) const;
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
       void set_default_value(InputSpecBuilders::Storage& container) const;
@@ -996,7 +1012,7 @@ namespace Core::IO
       bool match(ConstYamlNodeRef node, InputSpecBuilders::Storage& container,
           IO::Internal::MatchEntry& match_entry) const;
       void print(std::ostream& stream, std::size_t indent) const;
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
       void set_default_value(InputSpecBuilders::Storage& container) const;
@@ -1011,7 +1027,7 @@ namespace Core::IO
           IO::Internal::MatchEntry& match_entry) const;
       void set_default_value(InputSpecBuilders::Storage& container) const;
       void print(std::ostream& stream, std::size_t indent) const;
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
     };
@@ -1036,7 +1052,7 @@ namespace Core::IO
           IO::Internal::MatchEntry& match_entry) const;
       void set_default_value(InputSpecBuilders::Storage& container) const;
       void print(std::ostream& stream, std::size_t indent) const;
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
     };
@@ -1059,7 +1075,7 @@ namespace Core::IO
 
       void print(std::ostream& stream, std::size_t indent) const;
 
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
     };
@@ -1078,7 +1094,7 @@ namespace Core::IO
           IO::Internal::MatchEntry& match_entry) const;
       void set_default_value(InputSpecBuilders::Storage& container) const;
       void print(std::ostream& stream, std::size_t indent) const;
-      void emit_metadata(YamlNodeRef node) const;
+      void emit_metadata(YamlNodeRef node, EmitMetadataContext& context) const;
       bool emit(YamlNodeRef node, const InputParameterContainer& container,
           const InputSpecEmitOptions& options) const;
     };
@@ -1845,7 +1861,8 @@ bool Core::IO::Internal::ParameterSpec<T>::match(ConstYamlNodeRef node,
 
 
 template <Core::IO::SupportedType T>
-void Core::IO::Internal::ParameterSpec<T>::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::ParameterSpec<T>::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
   node.node["name"] << name;
@@ -2120,7 +2137,8 @@ void Core::IO::Internal::DeprecatedSelectionSpec<T>::print(
 }
 
 template <typename T>
-void Core::IO::Internal::DeprecatedSelectionSpec<T>::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::DeprecatedSelectionSpec<T>::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
   node.node["name"] << name;
@@ -2321,7 +2339,8 @@ void Core::IO::Internal::SelectionSpec<T>::print(std::ostream& stream, std::size
 
 template <typename T>
   requires(std::is_enum_v<T>)
-void Core::IO::Internal::SelectionSpec<T>::emit_metadata(YamlNodeRef node) const
+void Core::IO::Internal::SelectionSpec<T>::emit_metadata(
+    YamlNodeRef node, EmitMetadataContext& context) const
 {
   node.node |= ryml::MAP;
   node.node["name"] << group_name;
@@ -2341,7 +2360,7 @@ void Core::IO::Internal::SelectionSpec<T>::emit_metadata(YamlNodeRef node) const
     auto entry = node.node["choices"].append_child();
     entry |= ryml::MAP;
     emit_value_as_yaml(node.wrap(entry["name"]), choice);
-    spec.impl().emit_metadata(node.wrap(entry["spec"]));
+    spec.impl().emit_metadata(node.wrap(entry["spec"]), context);
   }
 }
 

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -1042,6 +1042,77 @@ specs:
     }
   }
 
+
+  TEST(InputSpecTest, EmitMetadataCondense)
+  {
+    auto spec_inner = group("inner", {
+                                         parameter<int>("a", {.default_value = 42}),
+                                         parameter<double>("b"),
+                                     });
+    auto spec_outer = group("outer", {spec_inner});
+
+    // The outer group is duplicated and should be shared. The inner group is also duplicated
+    // but it will not be shared since it is part of the already shared outer group.
+    auto spec = all_of({
+        group("first", {spec_outer}),
+        group("second", {spec_outer}),
+    });
+
+
+    std::ostringstream out;
+    ryml::Tree tree = init_yaml_tree_with_exceptions();
+    ryml::NodeRef root = tree.rootref();
+    YamlNodeRef yaml(root, "");
+    spec.emit_metadata(yaml, {.condense_duplicated_specs_threshold = 1});
+    out << tree;
+
+    std::string expected = R"(type: all_of
+specs:
+  - name: first
+    type: group
+    required: true
+    specs:
+      - type: all_of
+        specs:
+          - $ref: 0
+  - name: second
+    type: group
+    required: true
+    specs:
+      - type: all_of
+        specs:
+          - $ref: 0
+$references:
+  0:
+    name: outer
+    type: group
+    required: true
+    specs:
+      - type: all_of
+        specs:
+          - name: inner
+            type: group
+            required: true
+            specs:
+              - type: all_of
+                specs:
+                  - name: a
+                    type: int
+                    required: false
+                    default: 42
+                  - name: b
+                    type: double
+                    required: true
+)";
+
+    std::cout << out.str() << std::endl;
+    EXPECT_EQ(out.str(), expected);
+
+    // Verify that the inner group is not duplicated.
+    std::ostringstream out_inner;
+    spec_inner.print_as_dat(out_inner);
+  }
+
   TEST(InputSpecTest, Copyable)
   {
     InputSpec spec;

--- a/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
@@ -147,31 +147,29 @@ std::map<std::string, Core::IO::InputSpec> Global::valid_parameters()
       {.required = false});
 
   const Core::Elements::ElementDefinition element_definition;
-  auto all_possible_elements_spec = element_definition.element_data_spec();
+  auto geometry_specs = all_of({
+      parameter<std::filesystem::path>(
+          "FILE", {.description = "Path to the exodus geometry file. Either absolute or "
+                                  "relative to the input file."}),
+      parameter<Core::IO::Exodus::VerbosityLevel>("SHOW_INFO",
+          {
+              .description = "Choose verbosity of reporting element, node and set info for "
+                             "the exodus file after reading.",
+              .enum_value_description = Core::IO::Exodus::describe,
+              .default_value = Core::IO::Exodus::VerbosityLevel::none,
+          }),
+
+      // Once we support more formats, we should add a "TYPE" parameter for the file format.
+      list("ELEMENT_BLOCKS",
+          all_of({
+              parameter<int>("ID", {.description = "ID of the element block in the exodus file."}),
+              element_definition.element_data_spec(),
+          })),
+  });
 
   const auto add_geometry_section = [&](auto& specs, const std::string& field_identifier)
   {
-    specs[field_identifier + " GEOMETRY"] = group(field_identifier + " GEOMETRY",
-        {
-            parameter<std::filesystem::path>(
-                "FILE", {.description = "Path to the exodus geometry file. Either absolute or "
-                                        "relative to the input file."}),
-            parameter<Core::IO::Exodus::VerbosityLevel>("SHOW_INFO",
-                {
-                    .description = "Choose verbosity of reporting element, node and set info for "
-                                   "the exodus file after reading.",
-                    .enum_value_description = Core::IO::Exodus::describe,
-                    .default_value = Core::IO::Exodus::VerbosityLevel::none,
-                }),
-
-            // Once we support more formats, we should add a "TYPE" parameter for the file format.
-            list("ELEMENT_BLOCKS",
-                all_of({
-                    parameter<int>(
-                        "ID", {.description = "ID of the element block in the exodus file."}),
-                    all_possible_elements_spec,
-                })),
-        },
+    specs[field_identifier + " GEOMETRY"] = group(field_identifier + " GEOMETRY", {geometry_specs},
         {.description = "Settings related to the geometry of discretization " + field_identifier,
             .required = false});
   };

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -425,30 +425,30 @@ def metadata_object_from_file(metadata_4C_path):
         metadata_description = f"Schema for 4C\nCommit hash: {metadata['metadata']['commit_hash']}\nVersion: {metadata['metadata']['version']}"
 
         # Legacy section
-        sections = metadata["sections"]
-        legacy_sections = [
-            {
-                "name": name,
-                "description": name + " [legacy section] ",
-                "type": "vector",
-                "value_type": {"type": "string"},
-            }
-            for name in metadata["legacy_string_sections"]
-        ]
-
-        # Combine sections with legacy sections
-        all_of = All_Of(
-            description=metadata_description,
-            specs=sections + legacy_sections,
-            name="Sections",
+        sections = All_Of(**metadata["sections"])
+        legacy_sections = All_Of(
+            specs=[
+                {
+                    "name": name,
+                    "description": name + " [legacy section] ",
+                    "type": "vector",
+                    "value_type": {"type": "string"},
+                }
+                for name in metadata["legacy_string_sections"]
+            ]
         )
+
+        sections.specs.extend(legacy_sections.specs)
+        sections.description = metadata_description
+        sections.name = "Sections"
+
     except Exception as exception:
         raise ValueError(
             "Could not read the 4C metadata file.\nThis generally indicates that input parameters"
             " were added or modified in a non-conforming way."
         ) from exception
 
-    return all_of, description_section_name, metadata["metadata"]
+    return sections, description_section_name, metadata["metadata"]
 
 
 @dataclass


### PR DESCRIPTION
Inspired by #1092, Depends on #1102 

Introduce a `$references` section in the metadata file that contains duplicated specs. These can be referred to by `$ref$. 

Just to be clear: this has nothing to do with how your input file looks. This is only useful for internal tooling.

