### PR TITLE
Reduce Epetra in Core::LinAlg::SparseMatrix

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -117,28 +117,6 @@ Core::LinAlg::SparseMatrix::SparseMatrix(const Core::LinAlg::Map& rowmap,
 }
 
 
-Core::LinAlg::SparseMatrix::SparseMatrix(const Epetra_Map& rowmap, std::vector<int>& numentries,
-    bool explicitdirichlet, bool savegraph, MatrixType matrixtype)
-    : graph_(nullptr),
-      dbcmaps_(nullptr),
-      explicitdirichlet_(explicitdirichlet),
-      savegraph_(savegraph),
-      matrixtype_(matrixtype)
-{
-  if (!rowmap.UniqueGIDs()) FOUR_C_THROW("Row map is not unique");
-
-  if ((int)(numentries.size()) != rowmap.NumMyElements())
-    FOUR_C_THROW("estimate for non zero entries per row does not match the size of row map");
-
-  if (matrixtype_ == CRS_MATRIX)
-    sysmat_ = std::make_shared<Epetra_CrsMatrix>(::Copy, rowmap, numentries.data(), false);
-  else if (matrixtype_ == FE_MATRIX)
-    sysmat_ = std::make_shared<Epetra_FECrsMatrix>(::Copy, rowmap, numentries.data(), false);
-  else
-    FOUR_C_THROW("matrix type is not correct");
-}
-
-
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Core::LinAlg::SparseMatrix::SparseMatrix(std::shared_ptr<Epetra_CrsMatrix> matrix,

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -183,7 +183,7 @@ namespace Core::LinAlg
     /// destroy the underlying Epetra objects
     virtual bool destroy(bool throw_exception = true);
 
-    /// assemble method for Epetra_CrsMatrices, if ONLY local values are assembled
+    /// assemble method, if ONLY local values are assembled
     void assemble(int eid, const std::vector<int>& lmstride,
         const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lm,
         const std::vector<int>& lmowner) override
@@ -191,19 +191,19 @@ namespace Core::LinAlg
       assemble(eid, lmstride, Aele, lm, lmowner, lm);
     }
 
-    /// assemble method for Epetra_CrsMatrices, if ONLY local values are assembled
+    /// assemble method, if ONLY local values are assembled
     virtual void assemble(int eid, const Core::LinAlg::SerialDenseMatrix& Aele,
         const std::vector<int>& lm, const std::vector<int>& lmowner)
     {
       assemble(eid, Aele, lm, lmowner, lm);
     }
 
-    /// assemble method for Epetra_CrsMatrices, if ONLY local values are assembled
+    /// assemble method, if ONLY local values are assembled
     void assemble(int eid, const std::vector<int>& lmstride,
         const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lmrow,
         const std::vector<int>& lmrowowner, const std::vector<int>& lmcol) override;
 
-    /// assemble method for Epetra_CrsMatrices, if ONLY local values are assembled
+    /// assemble method, if ONLY local values are assembled
     void assemble(int eid, const Core::LinAlg::SerialDenseMatrix& Aele,
         const std::vector<int>& lmrow, const std::vector<int>& lmrowowner,
         const std::vector<int>& lmcol);
@@ -213,9 +213,9 @@ namespace Core::LinAlg
 
 
     /*
-     * \brief Set a single value in a Epetra_FECrsMatrix
+     * \brief Set a single value
      *
-     * This method inserts a new entry in a EpetraFECrsMatrix if it does not yet exist. If the entry
+     * This method inserts a new entry if it does not yet exist. If the entry
      * already exists, it is overwritten.
      *
      * \params[in] val Value to insert
@@ -225,39 +225,42 @@ namespace Core::LinAlg
     void set_value(double val, int rgid, int cgid);
 
     /*!
-      Assemble method for an Epetra_FECrsMatrix.
-      This method is also able to handle the assembly of nonlocal values.
-      It sets the doGlobalAssemble-flag to true and causes the
-      GlobalAssemble() method to redistribute the non-local
-      values to their owning procs, such that fill_complete can be safely
-      called on this matrix.
-
-      NOTE: This methods checks if rowowner == myrank. Only in this case
-      values are set. This is needed if the method is called in a loop over
-      column elements (which is the standard in 4C) to avoid multiple same entries.
+     * \brief Assemble method for an FE-style sparse matrix
+     *
+     * This method is also able to handle the assembly of nonlocal values.
+     * It sets the doGlobalAssemble-flag to true and causes the
+     * GlobalAssemble() method to redistribute the non-local
+     * values to their owning procs, such that fill_complete can be safely
+     * called on this matrix.
+     *
+     * \note This methods checks if rowowner == myrank. Only in this case
+     * values are set. This is needed if the method is called in a loop over
+     * column elements (which is the standard in 4C) to avoid multiple same entries.
      */
     void fe_assemble(const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lmrow,
         const std::vector<int>& lmrowowner, const std::vector<int>& lmcol);
 
     /*!
-      Assemble method for an Epetra_FECrsMatrices.
-      This method is also able to handle the assembly of nonlocal values.
-      It sets the doGlobalAssemble-flag to true and causes the
-      GlobalAssemble() method to redistribute the non-local
-      values to their owning procs, such that fill_complete can be safely
-      called on this matrix.
+     * \brief Assemble method for an FE-style sparse matrix
+     *
+     * This method is also able to handle the assembly of nonlocal values.
+     * It sets the doGlobalAssemble-flag to true and causes the
+     * GlobalAssemble() method to redistribute the non-local
+     * values to their owning procs, such that fill_complete can be safely
+     * called on this matrix.
      */
     void fe_assemble(const Core::LinAlg::SerialDenseMatrix& Aele, const std::vector<int>& lmrow,
         const std::vector<int>& lmcol);
 
     /*!
-      Assemble method for an Epetra_FECrsMatrices.
-      This method is also able
-      to handle the assembly of nonlocal values.
-      It sets the doGlobalAssemble-flag to true and causes the
-      GlobalAssemble -method() to redistribute the non-local
-      values to their owning procs, such that fill_complete can be safely
-      called on this matrix.
+     * \brief Assemble method for an FE-style sparse matrix
+     *
+     * This method is also able
+     * to handle the assembly of nonlocal values.
+     * It sets the doGlobalAssemble-flag to true and causes the
+     * GlobalAssemble -method() to redistribute the non-local
+     * values to their owning procs, such that fill_complete can be safely
+     * called on this matrix.
      */
     void fe_assemble(double val, int rgid, int cgid);
 

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -111,10 +111,6 @@ namespace Core::LinAlg
     SparseMatrix(const Epetra_Map& rowmap, const int npr, bool explicitdirichlet = true,
         bool savegraph = false, MatrixType matrixtype = CRS_MATRIX);
 
-    // TODO remove Epetra_Map here
-    SparseMatrix(const Epetra_Map& rowmap, std::vector<int>& numentries,
-        bool explicitdirichlet = true, bool savegraph = false, MatrixType matrixtype = CRS_MATRIX);
-
     /// construction of sparse matrix
     /*!
        Makes either a deep copy of the Epetra_CrsMatrix or Epetra_FECrsMatrix.

--- a/src/core/rebalance/src/4C_rebalance_graph_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_graph_based.cpp
@@ -121,8 +121,7 @@ Core::Rebalance::build_weights(const Core::FE::Discretization& dis)
 {
   const Core::LinAlg::Map* noderowmap = dis.node_row_map();
 
-  auto crs_ge_weights =
-      std::make_shared<Core::LinAlg::SparseMatrix>(noderowmap->get_epetra_map(), 15);
+  auto crs_ge_weights = std::make_shared<Core::LinAlg::SparseMatrix>(*noderowmap, 15);
   std::shared_ptr<Core::LinAlg::Vector<double>> vweights =
       Core::LinAlg::create_vector(*noderowmap, true);
 


### PR DESCRIPTION
## Description and Context

Reduce the use and mentions of Epetra in `Core::LinAlg::SparseMatrix`.

## Related Issues and Pull Requests

Part of #863