### PR TITLE
Remove Epetra_BlockMap from constructors

### DIFF
--- a/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_superconvergent_patch_recovery.cpp
@@ -152,7 +152,7 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::compute_superconver
 
   // step 2: use precalculated (velocity) gradient for patch-recovery of gradient
   // solution vector based on reduced node row map
-  Core::LinAlg::FEVector<double> nodevec(noderowmap.get_epetra_block_map(), numvec, false);
+  Core::LinAlg::FEVector<double> nodevec(noderowmap, numvec, false);
 
   std::vector<const Core::Conditions::Condition*> conds;
   dis.get_condition("SPRboundary", conds);

--- a/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
+++ b/src/core/io/src/4C_io_discretization_visualization_writer_mesh.cpp
@@ -496,8 +496,7 @@ namespace Core::IO
     const int my_proc = Core::Communication::my_mpi_rank(comm);
 
     // Create Vectors to store the ghosting information.
-    LinAlg::FEVector<double> ghosting_information(
-        discretization.element_row_map()->get_epetra_block_map(), n_proc, false);
+    LinAlg::FEVector<double> ghosting_information(*discretization.element_row_map(), n_proc, false);
 
     // Get elements ghosted by this rank.
     std::vector<int> my_ghost_elements;

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.cpp
@@ -23,16 +23,11 @@ Core::LinAlg::FEVector<T>::FEVector(const Map& Map, bool zeroOut)
 {
 }
 
-template <typename T>
-Core::LinAlg::FEVector<T>::FEVector(const Epetra_BlockMap& Map, bool zeroOut)
-    : vector_(Utils::make_owner<Epetra_FEVector>(Map, zeroOut))
-{
-}
 
 template <typename T>
-Core::LinAlg::FEVector<T>::FEVector(
-    const Epetra_BlockMap& Map, int numVectors, bool ignoreNonLocalEntries)
-    : vector_(Utils::make_owner<Epetra_FEVector>(Map, numVectors, ignoreNonLocalEntries))
+Core::LinAlg::FEVector<T>::FEVector(const Map& Map, int numVectors, bool ignoreNonLocalEntries)
+    : vector_(Utils::make_owner<Epetra_FEVector>(
+          Map.get_epetra_block_map(), numVectors, ignoreNonLocalEntries))
 {
 }
 

--- a/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_fevector.hpp
@@ -33,9 +33,8 @@ namespace Core::LinAlg
 
    public:
     /// Basic vector constructor to create vector based on a map and initialize memory with zeros
-    explicit FEVector(const Epetra_BlockMap& Map, bool zeroOut = true);
 
-    explicit FEVector(const Epetra_BlockMap& Map, int numVectors, bool ignoreNonLocalEntries);
+    explicit FEVector(const Map& Map, int numVectors, bool ignoreNonLocalEntries);
 
     explicit FEVector(const Map& Map, bool zeroOut = true);
 

--- a/src/core/linalg/src/sparse/4C_linalg_graph.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.cpp
@@ -22,17 +22,6 @@ Core::LinAlg::Graph::Graph(const Epetra_FECrsGraph& Source)
 {
 }
 
-Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Epetra_BlockMap& RowMap,
-    const int* NumIndicesPerRow, bool StaticProfile, GraphType graphtype)
-    : graphtype_(graphtype)
-{
-  if (graphtype_ == CRS_GRAPH)
-    graph_ = std::make_unique<Epetra_CrsGraph>(CV, RowMap, NumIndicesPerRow, StaticProfile);
-  else if (graphtype_ == FE_GRAPH)
-    graph_ = std::make_unique<Epetra_FECrsGraph>(
-        CV, RowMap, const_cast<int*>(NumIndicesPerRow), StaticProfile);
-}
-
 Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Map& RowMap, const int* NumIndicesPerRow,
     bool StaticProfile, GraphType graphtype)
     : graphtype_(graphtype)
@@ -43,16 +32,6 @@ Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Map& RowMap, const int* N
   else if (graphtype_ == FE_GRAPH)
     graph_ = std::make_unique<Epetra_FECrsGraph>(
         CV, RowMap.get_epetra_block_map(), const_cast<int*>(NumIndicesPerRow), StaticProfile);
-}
-
-Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Epetra_BlockMap& RowMap,
-    int NumIndicesPerRow, bool StaticProfile, GraphType graphtype)
-    : graphtype_(graphtype)
-{
-  if (graphtype_ == CRS_GRAPH)
-    graph_ = std::make_unique<Epetra_CrsGraph>(CV, RowMap, NumIndicesPerRow, StaticProfile);
-  else if (graphtype_ == FE_GRAPH)
-    graph_ = std::make_unique<Epetra_FECrsGraph>(CV, RowMap, NumIndicesPerRow, StaticProfile);
 }
 
 Core::LinAlg::Graph::Graph(Epetra_DataAccess CV, const Map& RowMap, int NumIndicesPerRow,

--- a/src/core/linalg/src/sparse/4C_linalg_graph.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.hpp
@@ -36,13 +36,6 @@ namespace Core::LinAlg
       FE_GRAPH
     };
 
-    //! Creates a Epetra_CrsGraph object and allocates storage.
-    Graph(Epetra_DataAccess CV, const Epetra_BlockMap& RowMap, const int* NumIndicesPerRow,
-        bool StaticProfile = false, GraphType graphtype = CRS_GRAPH);
-
-    Graph(Epetra_DataAccess CV, const Epetra_BlockMap& RowMap, int NumIndicesPerRow,
-        bool StaticProfile = false, GraphType graphtype = CRS_GRAPH);
-
     Graph(Epetra_DataAccess CV, const Core::LinAlg::Map& RowMap, const int* NumIndicesPerRow,
         bool StaticProfile = false, GraphType graphtype = CRS_GRAPH);
 

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_linebased.cpp
@@ -335,10 +335,10 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingLineBasedAlgorithm::
   // If the above quantity is bigger than zero, a 1D element protrudes.
 
   // initialize the unaffected and current lengths
-  unaffected_artery_segment_lengths_ = std::make_shared<Core::LinAlg::FEVector<double>>(
-      artery_dis_->dof_row_map(1)->get_epetra_map(), true);
-  current_artery_segment_lengths_ = std::make_shared<Core::LinAlg::FEVector<double>>(
-      artery_dis_->dof_row_map(1)->get_epetra_map());
+  unaffected_artery_segment_lengths_ =
+      std::make_shared<Core::LinAlg::FEVector<double>>(*artery_dis_->dof_row_map(1), true);
+  current_artery_segment_lengths_ =
+      std::make_shared<Core::LinAlg::FEVector<double>>(*artery_dis_->dof_row_map(1));
 
   // set segment ID on coupling pairs and fill the unaffected artery length
   for (int iele = 0; iele < artery_dis_->element_col_map()->num_my_elements(); ++iele)
@@ -410,7 +410,7 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingLineBasedAlgorithm::
     fill_unaffected_integrated_diameter() const
 {
   Core::LinAlg::FEVector<double> unaffected_artery_diameters_row(
-      artery_dis_->element_row_map()->get_epetra_map(), true);
+      *artery_dis_->element_row_map(), true);
 
   for (int i = 0; i < artery_dis_->element_row_map()->num_my_elements(); ++i)
   {
@@ -514,8 +514,8 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingLineBasedAlgorithm::
   // set up the required vectors
   if (has_variable_diameter_)
   {
-    integrated_artery_diameters_row_ = std::make_shared<Core::LinAlg::FEVector<double>>(
-        artery_dis_->element_row_map()->get_epetra_map(), true);
+    integrated_artery_diameters_row_ =
+        std::make_shared<Core::LinAlg::FEVector<double>>(*artery_dis_->element_row_map(), true);
     unaffected_integrated_artery_diameters_col_ =
         std::make_shared<Core::LinAlg::Vector<double>>(*artery_dis_->element_col_map(), true);
     integrated_artery_diameters_col_ =

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_artery_coupling_nonconforming.cpp
@@ -88,8 +88,8 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
       *(artery_dis_->dof_row_map()), 27, false, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
   mortar_matrix_m_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *(artery_dis_->dof_row_map()), 27, false, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
-  mortar_kappa_inv_ = std::make_shared<Core::LinAlg::FEVector<double>>(
-      artery_dis_->dof_row_map()->get_epetra_map(), true);
+  mortar_kappa_inv_ =
+      std::make_shared<Core::LinAlg::FEVector<double>>(*artery_dis_->dof_row_map(), true);
 
   // full map of homogenized and artery dofs
   std::vector<std::shared_ptr<const Core::LinAlg::Map>> maps;
@@ -104,8 +104,7 @@ void PoroPressureBased::PorofluidElastScatraArteryCouplingNonConformingAlgorithm
   coupling_matrix_ = std::make_shared<Core::LinAlg::SparseMatrix>(
       *fullmap_, 81, true, true, Core::LinAlg::SparseMatrix::FE_MATRIX);
 
-  coupling_rhs_vector_ =
-      std::make_shared<Core::LinAlg::FEVector<double>>(fullmap_->get_epetra_map());
+  coupling_rhs_vector_ = std::make_shared<Core::LinAlg::FEVector<double>>(*fullmap_);
 
   global_extractor_->check_for_valid_map_extractor();
 }

--- a/src/thermo/src/implicit/4C_thermo_timint_impl.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint_impl.cpp
@@ -74,8 +74,7 @@ Thermo::TimIntImpl::TimIntImpl(const Teuchos::ParameterList& ioparams,
   auto material = std::dynamic_pointer_cast<Mat::Fourier>(discret_->l_row_element(0)->material());
   const size_t columns = material->conductivity(discret_->l_row_element(0)->id()).size();
   Core::LinAlg::FEVector<double> overlapping_element_material_vector =
-      Core::LinAlg::FEVector<double>(
-          discret_->element_col_map()->get_epetra_block_map(), columns, true);
+      Core::LinAlg::FEVector<double>(*discret_->element_col_map(), columns, true);
 
   auto get_element_material_vector = [&](Core::Elements::Element& ele)
   {


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
As the title indicates this MR substitutes the `Epetra_BlockMap` with the Map interface for the FEVector interface and the graph interface. 

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
