### PR TITLE
Remove unused code from partitioned FSI

### DIFF
--- a/src/adapter/4C_adapter_ale.cpp
+++ b/src/adapter/4C_adapter_ale.cpp
@@ -188,8 +188,7 @@ void Adapter::AleBaseAlgorithm::setup_ale(
                coupling == fsi_iter_stagg_CHEB_rel_param or coupling == fsi_iter_stagg_MFNK_FD or
                coupling == fsi_iter_stagg_MFNK_FSI or coupling == fsi_iter_stagg_MPE or
                coupling == fsi_iter_stagg_NLCG or coupling == fsi_iter_stagg_Newton_FD or
-               coupling == fsi_iter_stagg_Newton_I or coupling == fsi_iter_stagg_RRE or
-               coupling == fsi_iter_stagg_fixed_rel_param or
+               coupling == fsi_iter_stagg_Newton_I or coupling == fsi_iter_stagg_fixed_rel_param or
                coupling == fsi_iter_stagg_steep_desc or coupling == fsi_iter_stagg_steep_desc_force)
       {
         ale_ = std::make_shared<Adapter::AleFluidWrapper>(ale);
@@ -220,8 +219,7 @@ void Adapter::AleBaseAlgorithm::setup_ale(
                coupling == fsi_iter_stagg_CHEB_rel_param or coupling == fsi_iter_stagg_MFNK_FD or
                coupling == fsi_iter_stagg_MFNK_FSI or coupling == fsi_iter_stagg_MPE or
                coupling == fsi_iter_stagg_NLCG or coupling == fsi_iter_stagg_Newton_FD or
-               coupling == fsi_iter_stagg_Newton_I or coupling == fsi_iter_stagg_RRE or
-               coupling == fsi_iter_stagg_fixed_rel_param or
+               coupling == fsi_iter_stagg_Newton_I or coupling == fsi_iter_stagg_fixed_rel_param or
                coupling == fsi_iter_stagg_steep_desc or coupling == fsi_iter_stagg_steep_desc_force)
       {
         ale_ = std::make_shared<Adapter::AleFluidWrapper>(ale);

--- a/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
+++ b/src/fsi/src/partitioned/4C_fsi_partitioned.cpp
@@ -309,47 +309,6 @@ void FSI::Partitioned::set_default_parameters(
       lineSearchParams.sublist("Full Step").set("Full Step", 1.0);
       break;
     }
-    case fsi_iter_stagg_RRE:
-    {
-      // reduced rank extrapolation
-      set_method("ITERATIVE STAGGERED SCHEME WITH REDUCED RANK EXTRAPOLATION");
-
-      nlParams.set("Jacobian", "None");
-      dirParams.set("Method", "User Defined");
-
-      Teuchos::RCP<::NOX::Direction::UserDefinedFactory> factory =
-          Teuchos::make_rcp<NOX::FSI::MinimalPolynomialFactory>();
-      dirParams.set("User Defined Direction Factory", factory);
-
-      Teuchos::ParameterList& exParams = dirParams.sublist("Extrapolation");
-      exParams.set("Tolerance", fsipart.get<double>("BASETOL"));
-      exParams.set("omega", fsipart.get<double>("RELAX"));
-      exParams.set("kmax", 25);
-      exParams.set("Method", "RRE");
-
-      // lsParams.set("Preconditioner","None");
-
-      lineSearchParams.set("Method", "Full Step");
-      lineSearchParams.sublist("Full Step").set("Full Step", 1.0);
-      break;
-    }
-    case fsi_basic_sequ_stagg:
-    {
-      // sequential coupling (no iteration!)
-      set_method("BASIC SEQUENTIAL STAGGERED SCHEME");
-
-      nlParams.set("Jacobian", "None");
-      nlParams.set("Max Iterations", 1);
-
-      dirParams.set("Method", "User Defined");
-      Teuchos::RCP<::NOX::Direction::UserDefinedFactory> fixpointfactory =
-          Teuchos::make_rcp<NOX::FSI::FixPointFactory>();
-      dirParams.set("User Defined Direction Factory", fixpointfactory);
-
-      lineSearchParams.set("Method", "Full Step");
-      lineSearchParams.sublist("Full Step").set("Full Step", 1.0);
-      break;
-    }
     default:
     {
       FOUR_C_THROW("Coupling method type {} unsupported",

--- a/src/inpar/4C_inpar_fsi.cpp
+++ b/src/inpar/4C_inpar_fsi.cpp
@@ -21,7 +21,6 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
 
           deprecated_selection<FsiCoupling>("COUPALGO",
               {
-                  {"basic_sequ_stagg", fsi_basic_sequ_stagg},
                   {"iter_stagg_fixed_rel_param", fsi_iter_stagg_fixed_rel_param},
                   {"iter_stagg_AITKEN_rel_param", fsi_iter_stagg_AITKEN_rel_param},
                   {"iter_stagg_steep_desc", fsi_iter_stagg_steep_desc},
@@ -29,7 +28,6 @@ void Inpar::FSI::set_valid_parameters(std::map<std::string, Core::IO::InputSpec>
                   {"iter_stagg_MFNK_FD", fsi_iter_stagg_MFNK_FD},
                   {"iter_stagg_MFNK_FSI", fsi_iter_stagg_MFNK_FSI},
                   {"iter_stagg_MPE", fsi_iter_stagg_MPE},
-                  {"iter_stagg_RRE", fsi_iter_stagg_RRE},
                   {"iter_monolithicfluidsplit", fsi_iter_monolithicfluidsplit},
                   {"iter_monolithicstructuresplit", fsi_iter_monolithicstructuresplit},
                   {"iter_xfem_monolithic", fsi_iter_xfem_monolithic},

--- a/src/inpar/4C_inpar_fsi.hpp
+++ b/src/inpar/4C_inpar_fsi.hpp
@@ -30,7 +30,6 @@ enum FsiCoupling
 {
   fsi_coupling_freesurface = -1,
   fsi_coupling_undefined = 0,
-  fsi_basic_sequ_stagg = 1,            /*< sequential coupling (no iteration!) */
   fsi_iter_stagg_fixed_rel_param = 4,  /*!< fixed-point solver with fixed relaxation parameter */
   fsi_iter_stagg_AITKEN_rel_param = 5, /*!< fixed-point solver with Aitken relaxation parameter */
   fsi_iter_stagg_steep_desc = 6, /* fixed-point solver with steepest descent relaxation parameter */
@@ -49,7 +48,6 @@ enum FsiCoupling
   fsi_iter_stagg_MFNK_FD,  /*!< matrix free Newton Krylov with finite difference Jacobian */
   fsi_iter_stagg_MFNK_FSI, /*!< matrix free Newton Krylov with FSI specific Jacobian */
   fsi_iter_stagg_MPE,      /*!< minimal polynomial extrapolation */
-  fsi_iter_stagg_RRE,      /*!< reduced rank extrapolation */
   fsi_iter_fluidfluid_monolithicstructuresplit,
   fsi_iter_fluidfluid_monolithicfluidsplit,
   fsi_iter_fluidfluid_monolithicstructuresplit_nonox,


### PR DESCRIPTION
## Description and Context

This PR removes some unused and untested code paths from the partitioned FSI solvers. ~At its core, it deletes the `NOX::FSI::LinearSystemGCR` class.~

## Related Issues and Pull Requests

- Related to findings in PR #1098 