### PR TITLE
Switch ordering of blocks in block systems

### DIFF
--- a/tests/input_files/ssi_mono_3D_27hex8_scatra_BGS-AMG_2x2.xml
+++ b/tests/input_files/ssi_mono_3D_27hex8_scatra_BGS-AMG_2x2.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu_Struct"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_2x2.xml
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_2x2.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu_Struct"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_3x3.xml
+++ b/tests/input_files/ssi_mono_3D_2blocks_hex8_nonmatching_nitsche_contact_scatra_s2i_constperm_BGS-AMG_3x3.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu,MueLu_Struct"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmer_grain_boundary_meshtying_BGS-AMG_5x5.4C.yaml
+++ b/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmer_grain_boundary_meshtying_BGS-AMG_5x5.4C.yaml
@@ -303,7 +303,7 @@ RESULT DESCRIPTION:
   - SSI:
       SPECIAL: true
       QUANTITY: "numiterlastlinearsolve"
-      VALUE: 2
+      VALUE: 1
       TOLERANCE: 1e-16
   - SSI:
       SPECIAL: true

--- a/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmer_grain_boundary_meshtying_BGS-AMG_5x5.xml
+++ b/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmer_grain_boundary_meshtying_BGS-AMG_5x5.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2),(3),(4)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu,MueLu,MueLu_Struct,MueLu"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu,MueLu,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1,1,1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmercapacity_BGS-AMG_4x4.xml
+++ b/tests/input_files/ssi_mono_3D_hex8_elch_s2i_butlervolmercapacity_BGS-AMG_4x4.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2),(3)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu,MueLu,MueLu_Struct"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1,1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_11x11.xml
+++ b/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_11x11.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu_Struct,MueLu,MueLu,MueLu,MueLu"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1,1,1,1,1,1,1,1,1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_3x3.xml
+++ b/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_3x3.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu_Struct,MueLu"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_6x6.xml
+++ b/tests/input_files/ssi_mono_3D_tet4_elch_s2i_butlervolmer_manifold_BGS-AMG_6x6.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2),(3),(4),(5)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu,MueLu,MueLu_Struct,MueLu,MueLu"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu,MueLu,MueLu,MueLu"/>
       <Parameter name="local sweeps" type="string" value="1,1,1,1,1,1"/>
     </ParameterList>
   </ParameterList>


### PR DESCRIPTION
## Description and Context
While working on removing the AMGnxn within the SSI module, we found together with @maxfirmbach that the ordering of dofs within the blocks of the block system needs to be ascending. This was not the case and has been changed within this PR as a preparation for the switch to Teko (which internally uses Thyra, where this requirement seems to originate from).

## Related Issues and Pull Requests
part of #754 
