### PR TITLE
Switch ordering of blocks in SSTI block systems

### DIFF
--- a/src/ssti/4C_ssti_monolithic.cpp
+++ b/src/ssti/4C_ssti_monolithic.cpp
@@ -634,21 +634,17 @@ std::vector<int> SSTI::SSTIMono::get_block_positions(Subproblem subproblem) cons
   {
     case Subproblem::structure:
     {
-      if (scatra_field()->matrix_type() == Core::LinAlg::MatrixType::sparse)
-        block_position.emplace_back(1);
-      else
-        block_position.emplace_back(scatra_field()->block_maps()->num_maps());
+      block_position.emplace_back(0);
       break;
     }
     case Subproblem::scalar_transport:
     {
       if (scatra_field()->matrix_type() == Core::LinAlg::MatrixType::sparse)
-        block_position.emplace_back(0);
+        block_position.emplace_back(1);
       else
-
       {
-        for (int i = 0; i < static_cast<int>(scatra_field()->block_maps()->num_maps()); ++i)
-          block_position.emplace_back(i);
+        for (int i = 0; i < scatra_field()->block_maps()->num_maps(); ++i)
+          block_position.emplace_back(i + 1);
       }
       break;
     }
@@ -658,7 +654,7 @@ std::vector<int> SSTI::SSTIMono::get_block_positions(Subproblem subproblem) cons
         block_position.emplace_back(2);
       else
       {
-        for (int i = 0; i < static_cast<int>(thermo_field()->block_maps()->num_maps()); ++i)
+        for (int i = 0; i < thermo_field()->block_maps()->num_maps(); ++i)
           block_position.emplace_back(scatra_field()->block_maps()->num_maps() + 1 + i);
       }
       break;
@@ -666,7 +662,6 @@ std::vector<int> SSTI::SSTIMono::get_block_positions(Subproblem subproblem) cons
     default:
     {
       FOUR_C_THROW("Unknown type of subproblem");
-      break;
     }
   }
 
@@ -675,7 +670,7 @@ std::vector<int> SSTI::SSTIMono::get_block_positions(Subproblem subproblem) cons
 
 /*--------------------------------------------------------------------------------------*
  *--------------------------------------------------------------------------------------*/
-int SSTI::SSTIMono::get_problem_position(Subproblem subproblem) const
+int SSTI::SSTIMono::get_problem_position(const Subproblem subproblem) const
 {
   int position = -1;
 
@@ -683,12 +678,12 @@ int SSTI::SSTIMono::get_problem_position(Subproblem subproblem) const
   {
     case Subproblem::structure:
     {
-      position = 1;
+      position = 0;
       break;
     }
     case Subproblem::scalar_transport:
     {
-      position = 0;
+      position = 1;
       break;
     }
     case Subproblem::thermo:
@@ -699,7 +694,6 @@ int SSTI::SSTIMono::get_problem_position(Subproblem subproblem) const
     default:
     {
       FOUR_C_THROW("Unknown type of subproblem");
-      break;
     }
   }
 
@@ -708,7 +702,7 @@ int SSTI::SSTIMono::get_problem_position(Subproblem subproblem) const
 
 /*--------------------------------------------------------------------------------------*
  *--------------------------------------------------------------------------------------*/
-std::vector<Core::LinAlg::EquilibrationMethod> SSTI::SSTIMono::get_block_equilibration()
+std::vector<Core::LinAlg::EquilibrationMethod> SSTI::SSTIMono::get_block_equilibration() const
 {
   std::vector<Core::LinAlg::EquilibrationMethod> equilibration_method_vector;
   switch (matrixtype_)
@@ -759,7 +753,6 @@ std::vector<Core::LinAlg::EquilibrationMethod> SSTI::SSTIMono::get_block_equilib
     default:
     {
       FOUR_C_THROW("Invalid matrix type associated with system matrix field!");
-      break;
     }
   }
 

--- a/src/ssti/4C_ssti_monolithic.hpp
+++ b/src/ssti/4C_ssti_monolithic.hpp
@@ -71,11 +71,20 @@ namespace SSTI
   {
    public:
     explicit SSTIMono(MPI_Comm comm, const Teuchos::ParameterList& globaltimeparams);
-    //! get vector containing positions within system matrix for specific subproblem
-    std::vector<int> get_block_positions(Subproblem subproblem) const;
 
-    //! get position within global dof map for specific subproblem
-    int get_problem_position(Subproblem subproblem) const;
+    /*!
+     * @brief get a vector containing positions within system matrix for the specific subproblem
+     *
+     * @note the subblocks are ordered such that the dof gid ranges constituting the individual
+     * subblocks are larger for later blocks, i.e.,
+     * block 1: dof gids 1 to m
+     * block 2: dof gids m+1 to n
+     * and so on.
+     */
+    [[nodiscard]] std::vector<int> get_block_positions(Subproblem subproblem) const;
+
+    //! get position within global dof map for the specific subproblem
+    [[nodiscard]] int get_problem_position(Subproblem subproblem) const;
 
     //! Setup of algorithm
     //@{
@@ -121,7 +130,7 @@ namespace SSTI
     std::shared_ptr<Core::LinAlg::Vector<double>> extract_sub_increment(Subproblem sub);
 
     // build and return vector of equilibration methods for each block of system matrix
-    std::vector<Core::LinAlg::EquilibrationMethod> get_block_equilibration();
+    std::vector<Core::LinAlg::EquilibrationMethod> get_block_equilibration() const;
 
     //! evaluate time step using Newton-Raphson iteration
     void newton_loop();

--- a/tests/input_files/ssti_mono_3D_6hex8_elch_s2i_butlervolmerthermo_BGS-AMG_3x3.xml
+++ b/tests/input_files/ssti_mono_3D_6hex8_elch_s2i_butlervolmerthermo_BGS-AMG_3x3.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu_Struct,MueLu_Thermo"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu_Thermo"/>
       <Parameter name="local sweeps" type="string" value="1,1,1"/>
     </ParameterList>
   </ParameterList>

--- a/tests/input_files/ssti_mono_3D_tet4_batt_with_anode_plate_and_current_collectors_elch_s2i_butlervolmer_BGS_AMG_11x11.4C.yaml
+++ b/tests/input_files/ssti_mono_3D_tet4_batt_with_anode_plate_and_current_collectors_elch_s2i_butlervolmer_BGS_AMG_11x11.4C.yaml
@@ -66,6 +66,7 @@ SOLVER 1:
   SOLVER: "Belos"
   AZPREC: "AMGnxn"
   AZSUB: 10
+  AZTOL: 1.0e-10
   AMGNXN_TYPE: "XML"
   AMGNXN_XML_FILE: "ssti_mono_3D_tet4_batt_with_anode_plate_and_current_collectors_elch_s2i_butlervolmer_BGS_AMG_11x11.xml"
 SOLVER 2:
@@ -373,7 +374,7 @@ RESULT DESCRIPTION:
       DIS: "scatra"
       NODE: 4
       QUANTITY: "phi2"
-      VALUE: 0.006853490261494826
+      VALUE: 6.85349056391118278e-03
       TOLERANCE: 6.9e-11
   - STRUCTURE:
       DIS: "structure"

--- a/tests/input_files/ssti_mono_3D_tet4_batt_with_anode_plate_and_current_collectors_elch_s2i_butlervolmer_BGS_AMG_11x11.xml
+++ b/tests/input_files/ssti_mono_3D_tet4_batt_with_anode_plate_and_current_collectors_elch_s2i_butlervolmer_BGS_AMG_11x11.xml
@@ -13,7 +13,7 @@
     <Parameter name="type" type="string" value="BGS"/>
     <ParameterList name="parameters">
       <Parameter name="blocks" type="string" value="(0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10)"/>
-      <Parameter name="smoothers" type="string" value="MueLu,MueLu,MueLu,MueLu,MueLu,MueLu_Struct,MueLu_Thermo,MueLu_Thermo,MueLu_Thermo,MueLu_Thermo,MueLu_Thermo"/>
+      <Parameter name="smoothers" type="string" value="MueLu_Struct,MueLu,MueLu,MueLu,MueLu,MueLu,MueLu_Thermo,MueLu_Thermo,MueLu_Thermo,MueLu_Thermo,MueLu_Thermo"/>
       <Parameter name="local sweeps" type="string" value="1,1,1,1,1,1,1,1,1,1,1"/>
     </ParameterList>
   </ParameterList>


### PR DESCRIPTION
## Description and Context
While working on removing the AMGnxn within the SSTI module, we found together with @maxfirmbach that the ordering of dof gids within the blocks of the block system needs to be ascending. This was not the case and has been changed within this PR as a preparation for the switch to Teko (which internally uses Thyra, where this requirement seems to originate from).

## Related Issues and Pull Requests
part of #754 
following #1123
