### PR TITLE
Cmake: move internal dependencies to module root

### DIFF
--- a/src/beaminteraction/CMakeLists.txt
+++ b/src/beaminteraction/CMakeLists.txt
@@ -6,3 +6,23 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    beam3
+    beamcontact
+    config
+    core
+    geometry_pair
+    global_data
+    inpar
+    mat
+    rigidsphere
+    solid_3D_ele
+    structure
+    structure_new
+    timestepping
+    truss3
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/beaminteraction/src/CMakeLists.txt
+++ b/src/beaminteraction/src/CMakeLists.txt
@@ -6,23 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    beam3
-    beamcontact
-    config
-    core
-    geometry_pair
-    global_data
-    inpar
-    mat
-    rigidsphere
-    solid_3D_ele
-    structure
-    structure_new
-    timestepping
-    truss3
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/coupling/CMakeLists.txt
+++ b/src/coupling/CMakeLists.txt
@@ -6,3 +6,16 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    config
+    constraint_framework
+    core
+    cut
+    global_data
+    inpar
+    mortar
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/coupling/src/adapter/CMakeLists.txt
+++ b/src/coupling/src/adapter/CMakeLists.txt
@@ -6,13 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    inpar
-    mortar
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/CMakeLists.txt
+++ b/src/fsi/CMakeLists.txt
@@ -6,3 +6,27 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    adapter
+    ale
+    config
+    constraint
+    core
+    fbi
+    fluid
+    fluid_xfluid
+    fsi_xfem
+    global_data
+    inpar
+    mat
+    mortar
+    poroelast
+    solver_nonlin_nox
+    structure
+    structure_new
+    timestepping
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/fsi/src/CMakeLists.txt
+++ b/src/fsi/src/CMakeLists.txt
@@ -6,27 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    adapter
-    ale
-    config
-    constraint
-    core
-    fbi
-    fluid
-    fluid_xfluid
-    fsi_xfem
-    global_data
-    inpar
-    mat
-    mortar
-    poroelast
-    solver_nonlin_nox
-    structure
-    structure_new
-    timestepping
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/lubrication/CMakeLists.txt
+++ b/src/lubrication/CMakeLists.txt
@@ -6,3 +6,16 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    adapter
+    config
+    core
+    fluid_ele
+    global_data
+    inpar
+    mat
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/lubrication/src/CMakeLists.txt
+++ b/src/lubrication/src/CMakeLists.txt
@@ -6,16 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    adapter
-    config
-    core
-    fluid_ele
-    global_data
-    inpar
-    mat
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/mixture/CMakeLists.txt
+++ b/src/mixture/CMakeLists.txt
@@ -6,3 +6,14 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    config
+    core
+    global_data
+    inpar
+    mat
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/mixture/src/CMakeLists.txt
+++ b/src/mixture/src/CMakeLists.txt
@@ -7,17 +7,6 @@
 
 four_c_auto_define_module()
 
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    global_data
-    inpar
-    mat
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
-
 four_c_unity_build_compile_separately(
   ${AUTO_DEFINED_MODULE_NAME} 4C_mixture_constituent_remodelfiber_expl.cpp
   )

--- a/src/shell_kl_nurbs/CMakeLists.txt
+++ b/src/shell_kl_nurbs/CMakeLists.txt
@@ -6,3 +6,15 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    config
+    core
+    global_data
+    inpar
+    mat
+    structure_new
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/shell_kl_nurbs/src/CMakeLists.txt
+++ b/src/shell_kl_nurbs/src/CMakeLists.txt
@@ -6,15 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    global_data
-    inpar
-    mat
-    structure_new
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/CMakeLists.txt
+++ b/src/structure_new/CMakeLists.txt
@@ -6,3 +6,20 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    adapter
+    beam3
+    beaminteraction
+    browniandyn
+    config
+    contact
+    core
+    global_data
+    inpar
+    solver_nonlin_nox
+    timestepping
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/CMakeLists.txt
+++ b/src/structure_new/src/CMakeLists.txt
@@ -7,22 +7,6 @@
 
 four_c_auto_define_module()
 
-set(_dependencies
-    # cmake-format: sortable
-    adapter
-    beam3
-    beaminteraction
-    config
-    contact
-    core
-    global_data
-    inpar
-    solver_nonlin_nox
-    timestepping
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
-
 four_c_unity_build_compile_separately(
   ${AUTO_DEFINED_MODULE_NAME} 4C_structure_new_timint_basedataglobalstate.cpp
   )

--- a/src/structure_new/src/explicit/CMakeLists.txt
+++ b/src/structure_new/src/explicit/CMakeLists.txt
@@ -6,13 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    global_data
-    solver_nonlin_nox
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/implicit/CMakeLists.txt
+++ b/src/structure_new/src/implicit/CMakeLists.txt
@@ -6,14 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    global_data
-    inpar
-    solver_nonlin_nox
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/linear_solver/CMakeLists.txt
+++ b/src/structure_new/src/linear_solver/CMakeLists.txt
@@ -6,15 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    beam3
-    beaminteraction
-    config
-    core
-    global_data
-    inpar
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/model_evaluator/CMakeLists.txt
+++ b/src/structure_new/src/model_evaluator/CMakeLists.txt
@@ -6,22 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    beam3
-    beamcontact
-    beaminteraction
-    browniandyn
-    cardiovascular0d
-    config
-    constraint
-    constraint_framework
-    contact
-    core
-    global_data
-    inpar
-    solver_nonlin_nox
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/nonlinear_solver/CMakeLists.txt
+++ b/src/structure_new/src/nonlinear_solver/CMakeLists.txt
@@ -7,17 +7,6 @@
 
 four_c_auto_define_module()
 
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    global_data
-    inpar
-    solver_nonlin_nox
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})
-
 four_c_unity_build_compile_separately(
   ${AUTO_DEFINED_MODULE_NAME} 4C_structure_new_nox_nln_str_linearsystem.cpp
   )

--- a/src/structure_new/src/output/CMakeLists.txt
+++ b/src/structure_new/src/output/CMakeLists.txt
@@ -6,14 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    beam3
-    config
-    core
-    global_data
-    inpar
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/predict/CMakeLists.txt
+++ b/src/structure_new/src/predict/CMakeLists.txt
@@ -6,13 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    inpar
-    solver_nonlin_nox
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/structure_new/src/utils/CMakeLists.txt
+++ b/src/structure_new/src/utils/CMakeLists.txt
@@ -6,17 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    constraint
-    contact
-    core
-    global_data
-    inpar
-    mat
-    solver_nonlin_nox
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/thermo/CMakeLists.txt
+++ b/src/thermo/CMakeLists.txt
@@ -6,3 +6,14 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
+
+set(_dependencies
+    # cmake-format: sortable
+    config
+    core
+    global_data
+    inpar
+    mat
+    )
+
+four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})

--- a/src/thermo/src/CMakeLists.txt
+++ b/src/thermo/src/CMakeLists.txt
@@ -6,14 +6,3 @@
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
 four_c_auto_define_module()
-
-set(_dependencies
-    # cmake-format: sortable
-    config
-    core
-    global_data
-    inpar
-    mat
-    )
-
-four_c_add_internal_dependency(${AUTO_DEFINED_MODULE_NAME} ${_dependencies})


### PR DESCRIPTION
As discussed in #1096, this PR moves internal dependencies higher up. The old way also worked, but the new way is more intuitive.