### PR TITLE
CMake: document FOUR_C_CXX_ variables

### DIFF
--- a/cmake/functions/four_c_process_global_option.cmake
+++ b/cmake/functions/four_c_process_global_option.cmake
@@ -67,5 +67,9 @@ function(four_c_process_cache_variable variable_name)
       "${_parsed_DEFAULT}"
       CACHE ${_parsed_TYPE} "${_parsed_DESCRIPTION} (default: ${_parsed_DEFAULT})"
       )
-  message(STATUS "Cache variable ${variable_name} = ${${variable_name}}")
+  if(${variable_name} STREQUAL "")
+    message(STATUS "Cache variable ${variable_name} not set")
+  else()
+    message(STATUS "Cache variable ${variable_name} = ${${variable_name}}")
+  endif()
 endfunction()

--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -254,16 +254,35 @@ four_c_process_global_option(
 # Add potential user flags at the very end
 ##
 
+four_c_process_cache_variable(
+  FOUR_C_CXX_FLAGS
+  TYPE
+  STRING
+  DESCRIPTION
+  "Expert setting. Additional C++ compiler flags to use for all 4C targets.
+  Note that these flags are added at the very end and can override various other flags."
+  DEFAULT
+  ""
+  )
+four_c_process_cache_variable(
+  FOUR_C_CXX_LINKER_FLAGS
+  TYPE
+  STRING
+  DESCRIPTION
+  "Expert setting. Additional C++ linker flags to use for all 4C targets.
+  Note that these flags are added at the very end and can override various other flags."
+  DEFAULT
+  ""
+  )
+
 # Compiler
 separate_arguments(_split UNIX_COMMAND ${FOUR_C_CXX_FLAGS})
-target_compile_options(four_c_private_compile_interface INTERFACE ${_split})
-separate_arguments(_split UNIX_COMMAND ${FOUR_C_CXX_FLAGS_${FOUR_C_BUILD_TYPE_UPPER}})
 target_compile_options(four_c_private_compile_interface INTERFACE ${_split})
 
 # Linker
 separate_arguments(_split UNIX_COMMAND ${FOUR_C_CXX_LINKER_FLAGS})
 target_link_options(four_c_private_compile_interface INTERFACE ${_split})
-separate_arguments(_split UNIX_COMMAND ${FOUR_C_CXX_LINKER_FLAGS_${FOUR_C_BUILD_TYPE_UPPER}})
-target_link_options(four_c_private_compile_interface INTERFACE ${_split})
 
 ### Do not add any more flags here! User flags have already been added.
+
+message(STATUS "") # Separate output with empty line


### PR DESCRIPTION
Part of #1073

I decided to remove the `FOUR_C_CXX_DEBUG_FLAGS` etc. since they aren't useful if we don't do multi-configuration builds. Technically, a breaking change, but I doubt that anybody uses these.