### PR TITLE
Add pattern validator for input strings

### DIFF
--- a/src/core/io/src/4C_io_input_spec_validators.cpp
+++ b/src/core/io/src/4C_io_input_spec_validators.cpp
@@ -1,0 +1,29 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_io_input_spec_validators.hpp"
+
+#include <regex>
+
+FOUR_C_NAMESPACE_OPEN
+
+Core::IO::InputSpecBuilders::Validators::Validator<std::string>
+Core::IO::InputSpecBuilders::Validators::pattern(std::string pattern)
+{
+  return Validator<std::string>([re = std::regex(pattern, std::regex::ECMAScript)](
+                                    const std::string& v) { return std::regex_search(v, re); },
+      [pattern](std::ostream& os) { os << "pattern{" << pattern << "}"; },
+      [pattern](YamlNodeRef yaml)
+      {
+        auto& node = yaml.node;
+        node |= ryml::MAP;
+        node["pattern"] |= ryml::MAP;
+        node["pattern"]["pattern"] << pattern;
+      });
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_input_spec_validators.hpp
+++ b/src/core/io/src/4C_io_input_spec_validators.hpp
@@ -240,6 +240,18 @@ namespace Core::IO::InputSpecBuilders::Validators
    */
   template <typename T>
   [[nodiscard]] Validator<std::optional<T>> null_or(Validator<T> validator);
+
+
+  /**
+   * A validator that ensures a string matches a given regular expression @p pattern.
+   * Note that the pattern is expected to be a valid regular expression in the modified ECMAScript
+   * regex syntax.
+   *
+   * @note The validator internally will match any string that contains the @p pattern
+   * _anywhere_ in the string. To achieve a full match, surround the @p pattern with `^` and `$`.
+   */
+  [[nodiscard]] Validator<std::string> pattern(std::string pattern);
+
 }  // namespace Core::IO::InputSpecBuilders::Validators
 
 // --- template definitions --- //

--- a/src/core/io/tests/4C_io_input_spec_validators_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_validators_test.cpp
@@ -76,4 +76,15 @@ namespace
     EXPECT_EQ(ss.str(), "all_elements{in_range[1,4]}");
   }
 
+  TEST(InputSpecValidators, Pattern)
+  {
+    using namespace std::string_literals;
+    const auto validator = pattern(R"(\d-\d-\d)");
+    EXPECT_TRUE(validator("1-2-3"s));
+    // This works since the regex performs a search and not a full match
+    EXPECT_TRUE(validator("1-2-3-4"s));
+
+    EXPECT_FALSE(validator("1-a-2"s));
+  }
+
 }  // namespace

--- a/src/inpar/4C_inpar_scatra.cpp
+++ b/src/inpar/4C_inpar_scatra.cpp
@@ -166,9 +166,12 @@ void Inpar::ScaTra::set_valid_parameters(std::map<std::string, Core::IO::InputSp
                   .default_value = true}),
 
           parameter<std::string>("WRITEFLUX_IDS",
-              {.description = "Write diffusive/total flux vector fields for these scalar "
-                              "fields only (starting with 1)",
-                  .default_value = "-1"}),
+              {
+                  .description = "Write diffusive/total flux vector fields for these scalar "
+                                 "fields only (starting with 1)",
+                  .default_value = "-1",
+                  .validator = Validators::pattern(R"(^(-?\d+)(\s+-?\d+)*$)"),
+              }),
 
 
           deprecated_selection<Inpar::ScaTra::OutputScalarType>("OUTPUTSCALARS",

--- a/utilities/create_json_schema.py
+++ b/utilities/create_json_schema.py
@@ -26,6 +26,7 @@ from metadata_utils import (
     One_Of,
     Primitive,
     RangeValidator,
+    PatternValidator,
     Selection,
     Vector,
     metadata_object_from_file,
@@ -65,6 +66,9 @@ def validator_to_schema(validator):
                 data["maximum"] = validator.maximum
 
             return data
+
+        case PatternValidator():
+            return {"pattern": validator.pattern}
 
         case _:
             if validator is not None:

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -472,6 +472,12 @@ class RangeValidator(Validator):
 
 
 @dataclass
+class PatternValidator(Validator):
+    allowed_types: ClassVar[tuple] = ("string",)
+    pattern: str
+
+
+@dataclass
 class AllElementsValidator(Validator):
     inner_validator: object
 
@@ -489,5 +495,7 @@ def validator_from_dict(validator_dict):
             return RangeValidator(**validator_settings)
         case "all_elements":
             return AllElementsValidator(validator_from_dict(validator_settings))
+        case "pattern":
+            return PatternValidator(**validator_settings)
         case _:
             raise ValueError("Validator '{}' not known.".format(validator_type))


### PR DESCRIPTION
Allows specifying a regex pattern for strings. I don't anticipate a lot of uses for this case, but it is exactly what we need for validating the version number within #74. It is trivial to add the pattern in a general way, so I went for this option rather than special hackery for certain fields.