### PR TITLE
Initialize more 2D-3D beam-to-solid pairs

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_2d-3d_mortar.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_2d-3d_mortar.cpp
@@ -600,38 +600,76 @@ void BeamInteraction::BeamToSolidVolumeMeshtyingPair2D3DMortar<Beam, Solid,
 /**
  *
  */
-std::shared_ptr<BeamInteraction::BeamContactPair>
+std::unique_ptr<BeamInteraction::BeamContactPair>
 BeamInteraction::create_beam_to_solid_volume_pair_mortar_cross_section(
     const Core::FE::CellType shape,
     const Inpar::BeamToSolid::BeamToSolidMortarShapefunctions mortar_shape_function,
     const int n_fourier_modes)
 {
-  switch (mortar_shape_function)
+  using namespace GeometryPair;
+
+  // Function to create the mortar pair for a given solid type
+  auto make_mortar_pair =
+      []<typename Solid>(Inpar::BeamToSolid::BeamToSolidMortarShapefunctions mortar_shape_function,
+          int n_fourier_modes) -> std::unique_ptr<BeamInteraction::BeamContactPair>
   {
-    case Inpar::BeamToSolid::BeamToSolidMortarShapefunctions::line2:
+    switch (mortar_shape_function)
     {
-      switch (n_fourier_modes)
-      {
-        case 0:
-          return std::make_shared<BeamToSolidVolumeMeshtyingPair2D3DMortar<GeometryPair::t_hermite,
-              GeometryPair::t_hex8, GeometryPair::t_line2_fourier_0>>();
-        case 1:
-          return std::make_shared<BeamToSolidVolumeMeshtyingPair2D3DMortar<GeometryPair::t_hermite,
-              GeometryPair::t_hex8, GeometryPair::t_line2_fourier_1>>();
-        case 2:
-          return std::make_shared<BeamToSolidVolumeMeshtyingPair2D3DMortar<GeometryPair::t_hermite,
-              GeometryPair::t_hex8, GeometryPair::t_line2_fourier_2>>();
-        case 3:
-          return std::make_shared<BeamToSolidVolumeMeshtyingPair2D3DMortar<GeometryPair::t_hermite,
-              GeometryPair::t_hex8, GeometryPair::t_line2_fourier_3>>();
-        default:
-          FOUR_C_THROW("Got wrong number of fourier mortar modes {}.", n_fourier_modes);
-      }
+      case Inpar::BeamToSolid::BeamToSolidMortarShapefunctions::line2:
+        switch (n_fourier_modes)
+        {
+          case 0:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 0>>>();
+          case 1:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 1>>>();
+          case 2:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 2>>>();
+          case 3:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 3>>>();
+          case 4:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 4>>>();
+          case 5:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 5>>>();
+          case 6:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 6>>>();
+          case 7:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 7>>>();
+          case 8:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 8>>>();
+          case 9:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 9>>>();
+          case 10:
+            return std::make_unique<BeamToSolidVolumeMeshtyingPair2D3DMortar<t_hermite, Solid,
+                FourierDiscretization<t_line2_scalar, 10>>>();
+          default:
+            FOUR_C_THROW("Got wrong number of fourier mortar modes {}.", n_fourier_modes);
+        }
+      default:
+        FOUR_C_THROW("Wrong mortar shape function.");
     }
+  };
+
+  switch (shape)
+  {
+    case Core::FE::CellType::hex8:
+      return make_mortar_pair.operator()<t_hex8>(mortar_shape_function, n_fourier_modes);
+    case Core::FE::CellType::hex27:
+      return make_mortar_pair.operator()<t_hex27>(mortar_shape_function, n_fourier_modes);
     default:
-      FOUR_C_THROW("Wrong mortar shape function.");
+      FOUR_C_THROW("Got unexpected FE shape function");
   }
 }
+
 
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_2d-3d_mortar.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_volume_meshtying_pair_2d-3d_mortar.hpp
@@ -36,6 +36,9 @@ namespace GeometryPair
   class FourierDiscretization
   {
    public:
+    // Mark this as a Fourier type element.
+    using fourier_tag = void;
+
     // Discretization of the 1D part
     using curve_discretization_ = CurveDiscretization;
 
@@ -65,50 +68,18 @@ namespace GeometryPair
         ElementDiscretizationToGeometryType<discretization_>::geometry_type_;
   };
 
-  //! Fourier types
-  using t_line2_fourier_0 = FourierDiscretization<t_line2_scalar, 0>;
-  using t_line2_fourier_1 = FourierDiscretization<t_line2_scalar, 1>;
-  using t_line2_fourier_2 = FourierDiscretization<t_line2_scalar, 2>;
-  using t_line2_fourier_3 = FourierDiscretization<t_line2_scalar, 3>;
-
-
   /**
-   * \brief Compile time struct to check if an element type is based on Fourier shape functions
+   * \brief This allows for an easy overload of the EvaluateShapeFunction struct for Fourier shape
+   * functions.
    */
-  template <typename ElementType>
-  struct IsFourierElement
-  {
-    static const bool value_ = false;
-  };
-
-  template <>
-  struct IsFourierElement<t_line2_fourier_0>
-  {
-    static const bool value_ = true;
-  };
-  template <>
-  struct IsFourierElement<t_line2_fourier_1>
-  {
-    static const bool value_ = true;
-  };
-  template <>
-  struct IsFourierElement<t_line2_fourier_2>
-  {
-    static const bool value_ = true;
-  };
-  template <>
-  struct IsFourierElement<t_line2_fourier_3>
-  {
-    static const bool value_ = true;
-  };
-
+  template <class T>
+  concept FourierElement = requires { typename T::fourier_tag; };
 
   /**
    * \brief Specialization for Fourier elements
    */
-  template <typename ElementType>
-  struct EvaluateShapeFunction<ElementType,
-      typename std::enable_if<IsFourierElement<ElementType>::value_>::type>
+  template <FourierElement ElementType>
+  struct EvaluateShapeFunction<ElementType>
   {
     /**
      * \brief Evaluate the shape functions of the element.
@@ -272,7 +243,7 @@ namespace BeamInteraction
   /**
    * \brief Factory for the mortar cross section pair
    */
-  std::shared_ptr<BeamContactPair> create_beam_to_solid_volume_pair_mortar_cross_section(
+  std::unique_ptr<BeamContactPair> create_beam_to_solid_volume_pair_mortar_cross_section(
       const Core::FE::CellType shape,
       const Inpar::BeamToSolid::BeamToSolidMortarShapefunctions mortar_shape_function,
       const int n_fourier_modes);


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

Add more variants to the 2D-3D beam-to-solid volume mortar pairs. We can now create coupling pairs for hex8 and hex27 and up to 10 Fourier modes.