### PR TITLE
Mock preconditioner related member methods for linear systems

### DIFF
--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -155,17 +155,6 @@ bool NOX::FSI::LinearSystem::applyJacobianInverse(
   return true;
 }
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::applyRightPreconditioning(bool useTranspose,
-    Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
-    ::NOX::Epetra::Vector& result) const
-{
-  if (&result != &input) result = input;
-
-  return true;
-}
-
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
@@ -174,48 +163,6 @@ bool NOX::FSI::LinearSystem::computeJacobian(const ::NOX::Epetra::Vector& x)
   bool success = jac_interface_ptr_->computeJacobian(x.getEpetraVector(), *jac_ptr_);
   return success;
 }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::createPreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p, bool recomputeGraph) const
-{
-  return false;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::destroyPreconditioner() const { return false; }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::recomputePreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const
-{
-  return false;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-NOX::FSI::LinearSystem::PreconditionerReusePolicyType
-NOX::FSI::LinearSystem::getPreconditionerPolicy(bool advanceReuseCounter)
-{
-  return PRPT_REBUILD;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::isPreconditionerConstructed() const { return false; }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::FSI::LinearSystem::hasPreconditioner() const { return false; }
 
 
 /*----------------------------------------------------------------------*
@@ -236,22 +183,6 @@ Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystem::getJacobianOperator()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-Teuchos::RCP<const Epetra_Operator> NOX::FSI::LinearSystem::getGeneratedPrecOperator() const
-{
-  return Teuchos::null;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystem::getGeneratedPrecOperator()
-{
-  return Teuchos::null;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void NOX::FSI::LinearSystem::setJacobianOperatorForSolve(
     const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
 {
@@ -260,14 +191,6 @@ void NOX::FSI::LinearSystem::setJacobianOperatorForSolve(
   jac_type_ = get_operator_type(*solveJacOp);
 }
 
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void NOX::FSI::LinearSystem::setPrecOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solvePrecOp)
-{
-  throw_error("setPrecOperatorForSolve", "no preconditioner supported");
-}
 
 
 /*----------------------------------------------------------------------*

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -19,7 +19,6 @@
 #include <NOX_Common.H>
 #include <NOX_Epetra_Group.H>
 #include <NOX_Epetra_Interface_Jacobian.H>
-#include <NOX_Epetra_Interface_Preconditioner.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_Utils.H>
@@ -82,33 +81,8 @@ namespace NOX::FSI
     bool applyJacobianInverse(Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
         ::NOX::Epetra::Vector& result) override;
 
-    /// Apply right preconditiong to the given input vector.
-    bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
-        const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
     /// Evaluates the Jacobian based on the solution vector x.
     bool computeJacobian(const ::NOX::Epetra::Vector& x) override;
-
-    /// Explicitly constructs a preconditioner based on the solution vector x and the parameter
-    /// list p.
-    bool createPreconditioner(const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
-        bool recomputeGraph) const override;
-
-    /// Deletes the preconditioner.
-    bool destroyPreconditioner() const override;
-
-    /// Recalculates the preconditioner using an already allocated graph.
-    bool recomputePreconditioner(
-        const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const override;
-
-    /// Evaluates the preconditioner policy at the current state.
-    PreconditionerReusePolicyType getPreconditionerPolicy(bool advanceReuseCounter = true) override;
-
-    /// Indicates whether a preconditioner has been constructed.
-    bool isPreconditionerConstructed() const override;
-
-    /// Indicates whether the linear system has a preconditioner.
-    bool hasPreconditioner() const override;
 
     /// Return Jacobian operator.
     Teuchos::RCP<const Epetra_Operator> getJacobianOperator() const override;
@@ -116,18 +90,9 @@ namespace NOX::FSI
     /// Return Jacobian operator.
     Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-    /// Return preconditioner operator.
-    Teuchos::RCP<const Epetra_Operator> getGeneratedPrecOperator() const override;
-
-    /// Return preconditioner operator.
-    Teuchos::RCP<Epetra_Operator> getGeneratedPrecOperator() override;
-
     /// Set Jacobian operator for solve.
     void setJacobianOperatorForSolve(
         const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
-    /// Set preconditioner operator for solve.
-    void setPrecOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solvePrecOp) override;
 
    private:
     /// throw an error
@@ -136,10 +101,8 @@ namespace NOX::FSI
     ::NOX::Utils utils_;
 
     std::shared_ptr<::NOX::Epetra::Interface::Jacobian> jac_interface_ptr_;
-    std::shared_ptr<::NOX::Epetra::Interface::Preconditioner> prec_interface_ptr_;
     OperatorType jac_type_;
     mutable std::shared_ptr<Epetra_Operator> jac_ptr_;
-    mutable std::shared_ptr<Epetra_Operator> prec_ptr_;
     mutable std::shared_ptr<Core::LinAlg::SparseOperator> operator_;
     std::shared_ptr<NOX::Nln::Scaling> scaling_;
     mutable std::shared_ptr<::NOX::Epetra::Vector> tmp_vector_ptr_;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -386,50 +386,11 @@ void NOX::FSI::LinearSystemGCR::apply_plane_rotation(double& dx, double& dy, dou
 }
 
 
-bool NOX::FSI::LinearSystemGCR::applyRightPreconditioning(bool useTranspose,
-    Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
-    ::NOX::Epetra::Vector& result) const
-{
-  if (&result != &input) result = input;
-  return true;
-}
-
-
 bool NOX::FSI::LinearSystemGCR::computeJacobian(const ::NOX::Epetra::Vector& x)
 {
   bool success = jacInterfacePtr->computeJacobian(x.getEpetraVector(), *jacPtr);
   return success;
 }
-
-
-bool NOX::FSI::LinearSystemGCR::createPreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p, bool recomputeGraph) const
-{
-  return false;
-}
-
-
-bool NOX::FSI::LinearSystemGCR::destroyPreconditioner() const { return false; }
-
-
-bool NOX::FSI::LinearSystemGCR::recomputePreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const
-{
-  return false;
-}
-
-
-NOX::FSI::LinearSystemGCR::PreconditionerReusePolicyType
-NOX::FSI::LinearSystemGCR::getPreconditionerPolicy(bool advanceReuseCounter)
-{
-  return PRPT_REBUILD;
-}
-
-
-bool NOX::FSI::LinearSystemGCR::isPreconditionerConstructed() const { return false; }
-
-
-bool NOX::FSI::LinearSystemGCR::hasPreconditioner() const { return false; }
 
 
 Teuchos::RCP<const Epetra_Operator> NOX::FSI::LinearSystemGCR::getJacobianOperator() const
@@ -444,30 +405,11 @@ Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystemGCR::getJacobianOperator()
 }
 
 
-Teuchos::RCP<const Epetra_Operator> NOX::FSI::LinearSystemGCR::getGeneratedPrecOperator() const
-{
-  return Teuchos::null;
-}
-
-
-Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystemGCR::getGeneratedPrecOperator()
-{
-  return Teuchos::null;
-}
-
-
 void NOX::FSI::LinearSystemGCR::setJacobianOperatorForSolve(
     const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
 {
   jacPtr = Teuchos::rcp_const_cast<Epetra_Operator>(solveJacOp);
   jacType = get_operator_type(*solveJacOp);
-}
-
-
-void NOX::FSI::LinearSystemGCR::setPrecOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solvePrecOp)
-{
-  throw_error("setPrecOperatorForSolve", "no preconditioner supported");
 }
 
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -102,72 +102,8 @@ namespace NOX
       bool applyJacobianInverse(Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
           ::NOX::Epetra::Vector& result) override;
 
-      /*!
-        \brief Apply right preconditiong to the given input vector
-
-        Let \f$M\f$ be a right preconditioner for the Jacobian \f$J\f$; in
-        other words, \f$M\f$ is a matrix such that
-        \f[ JM \approx I. \f]
-
-        Compute
-        \f[ u = M^{-1} v, \f]
-        where \f$u\f$ is the input vector and \f$v\f$ is the result vector.
-
-        If <em>useTranspose</em> is true, then the transpose of the
-        preconditioner is applied:
-        \f[ u = {M^{-1}}^T v, \f]
-        The transpose preconditioner is currently only required for
-        Tensor methods.
-
-        The parameter list contains the linear solver options.
-      */
-      bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
       //! Evaluates the Jacobian based on the solution vector x.
       bool computeJacobian(const ::NOX::Epetra::Vector& x) override;
-
-      /*!
-        \brief Explicitly constructs a preconditioner based on the solution vector x and the
-        parameter list p.
-
-        The user has the option of recomputing the graph when a new preconditioner is created. The
-        Group controls the isValid flag for the preconditioner and will control when to call this.
-      */
-      bool createPreconditioner(const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
-          bool recomputeGraph) const override;
-
-      /*!
-        \brief Deletes the preconditioner.
-
-        The Group controls the isValid flag for the preconditioner and will control when to call
-        this.
-      */
-      bool destroyPreconditioner() const override;
-
-      /*! \brief Recalculates the preconditioner using an already allocated graph.
-
-      Use this to compute a new preconditioner while using the same
-      graph for the preconditioner.  This avoids deleting and
-      reallocating the memory required for the preconditioner and
-      results in a big speed-up for large-scale jobs.
-      */
-      bool recomputePreconditioner(const ::NOX::Epetra::Vector& x,
-          Teuchos::ParameterList& linearSolverParams) const override;
-
-      /*! \brief  Evaluates the preconditioner policy at the current state.
-
-      NOTE: This can change values between nonlienar iterations.  It is
-      not a static value.
-      */
-      PreconditionerReusePolicyType getPreconditionerPolicy(
-          bool advanceReuseCounter = true) override;
-
-      //! Indicates whether a preconditioner has been constructed
-      bool isPreconditionerConstructed() const override;
-
-      //! Indicates whether the linear system has a preconditioner
-      bool hasPreconditioner() const override;
 
       //! Return Jacobian operator
       Teuchos::RCP<const Epetra_Operator> getJacobianOperator() const override;
@@ -175,24 +111,9 @@ namespace NOX
       //! Return Jacobian operator
       Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-      //! Return preconditioner operator
-      /*!
-       * Note:  This should only be called if hasPreconditioner() returns true.
-       */
-      Teuchos::RCP<const Epetra_Operator> getGeneratedPrecOperator() const override;
-
-      //! Return preconditioner operator
-      Teuchos::RCP<Epetra_Operator> getGeneratedPrecOperator() override;
-
       //! Set Jacobian operator for solve
       void setJacobianOperatorForSolve(
           const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
-      //! Set preconditioner operator for solve
-      /*!
-       * Note:  This should only be called if hasPreconditioner() returns true.
-       */
-      void setPrecOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solvePrecOp) override;
 
       //! Returns the type of operator that is passed into the group constructors.
       /*! Uses dynamic casting to identify the underlying object type. */

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -54,7 +54,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       scaling_(scalingObject),
       conditionNumberEstimate_(0.0),
       timer_("", true),
-      timeCreatePreconditioner_(0.0),
       timeApplyJacbianInverse_(0.0),
       resNorm2_(0.0),
       prePostOperatorPtr_(Teuchos::null),
@@ -89,7 +88,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       scaling_(nullptr),
       conditionNumberEstimate_(0.0),
       timer_("", true),
-      timeCreatePreconditioner_(0.0),
       timeApplyJacbianInverse_(0.0),
       resNorm2_(0.0),
       prePostOperatorPtr_(Teuchos::null),
@@ -123,7 +121,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       scaling_(scalingObject),
       conditionNumberEstimate_(0.0),
       timer_("", true),
-      timeCreatePreconditioner_(0.0),
       timeApplyJacbianInverse_(0.0),
       resNorm2_(0.0),
       prePostOperatorPtr_(Teuchos::null),
@@ -156,7 +153,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       scaling_(nullptr),
       conditionNumberEstimate_(0.0),
       timer_("", true),
-      timeCreatePreconditioner_(0.0),
       timeApplyJacbianInverse_(0.0),
       resNorm2_(0.0),
       prePostOperatorPtr_(Teuchos::null),
@@ -360,15 +356,6 @@ bool NOX::Nln::LinearSystem::applyJacobianInverse(Teuchos::ParameterList& linear
   return (linsol_status == 0);
 }
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::applyRightPreconditioning(bool useTranspose,
-    Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
-    ::NOX::Epetra::Vector& result) const
-{
-  if (&result != &input) result = input;
-  return true;
-}
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
@@ -580,65 +567,6 @@ void NOX::Nln::LinearSystem::set_jacobian_operator_for_solve(
     throw_error("set_jacobian_operator_for_solve", "wrong operator type!");
 
   jac_ptr_ = Teuchos::rcp_const_cast<Core::LinAlg::SparseOperator>(solveJacOp);
-  return;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::createPreconditioner(const ::NOX::Epetra::Vector& x,
-    Teuchos::ParameterList& linearSolverParams, bool recomputeGraph) const
-{
-  return false;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::destroyPreconditioner() const { return false; }
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::recomputePreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const
-{
-  return false;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-::NOX::Epetra::LinearSystem::PreconditionerReusePolicyType
-NOX::Nln::LinearSystem::getPreconditionerPolicy(bool advanceReuseCounter)
-{
-  return PRPT_REBUILD;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::isPreconditionerConstructed() const { return false; }
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Nln::LinearSystem::hasPreconditioner() const { return false; }
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-Teuchos::RCP<const Epetra_Operator> NOX::Nln::LinearSystem::getGeneratedPrecOperator() const
-{
-  return Teuchos::null;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-Teuchos::RCP<Epetra_Operator> NOX::Nln::LinearSystem::getGeneratedPrecOperator()
-{
-  return Teuchos::null;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void NOX::Nln::LinearSystem::setPrecOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solvePrecOp)
-{
-  throw_error("setPrecOperatorForSolve", "no preconditioner supported");
   return;
 }
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -134,12 +134,6 @@ namespace NOX
       bool applyJacobianInverse(Teuchos::ParameterList& linearSolverParams,
           const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) override;
 
-      bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& linearSolverParams,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
-      bool createPreconditioner(const ::NOX::Epetra::Vector& x,
-          Teuchos::ParameterList& linearSolverParams, bool recomputeGraph) const override;
-
       //! adjust the pseudo time step (using a least squares approximation)
       void adjust_pseudo_time_step(double& delta, const double& stepSize,
           const ::NOX::Epetra::Vector& dir, const ::NOX::Epetra::Vector& rhs,
@@ -195,24 +189,6 @@ namespace NOX
       //! Set the jacobian operator of this class
       void set_jacobian_operator_for_solve(
           const Teuchos::RCP<const Core::LinAlg::SparseOperator>& solveJacOp);
-
-      bool destroyPreconditioner() const override;
-
-      bool recomputePreconditioner(const ::NOX::Epetra::Vector& x,
-          Teuchos::ParameterList& linearSolverParams) const override;
-
-      ::NOX::Epetra::LinearSystem::PreconditionerReusePolicyType getPreconditionerPolicy(
-          bool advanceReuseCounter) override;
-
-      bool isPreconditionerConstructed() const override;
-
-      bool hasPreconditioner() const override;
-
-      Teuchos::RCP<const Epetra_Operator> getGeneratedPrecOperator() const override;
-
-      Teuchos::RCP<Epetra_Operator> getGeneratedPrecOperator() override;
-
-      void setPrecOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solvePrecOp) override;
 
       //! destroy the jacobian ptr
       bool destroy_jacobian();
@@ -351,9 +327,6 @@ namespace NOX
 
       //! Teuchos::Time object
       Teuchos::Time timer_;
-
-      //! Total time spent in createPreconditioner (sec.).
-      double timeCreatePreconditioner_;
 
       //! Total time spent in applyJacobianInverse (sec.).
       double timeApplyJacbianInverse_;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.cpp
@@ -25,4 +25,67 @@ void NOX::Nln::LinearSystemBase::resetScaling(const Teuchos::RCP<::NOX::Epetra::
   FOUR_C_THROW("This is a mock and if you need it, most probably you are doing something wrong.");
 }
 
+void NOX::Nln::LinearSystemBase::setPrecOperatorForSolve(
+    const Teuchos::RCP<const Epetra_Operator>& solvePrecOp)
+{
+  (void)solvePrecOp;
+
+  FOUR_C_THROW("setPrecOperatorForSolve() is not implemented for NOX::Nln::LinearSystemBase.");
+}
+
+bool NOX::Nln::LinearSystemBase::isPreconditionerConstructed() const { return false; }
+
+bool NOX::Nln::LinearSystemBase::hasPreconditioner() const { return false; }
+
+Teuchos::RCP<const Epetra_Operator> NOX::Nln::LinearSystemBase::getGeneratedPrecOperator() const
+{
+  return Teuchos::null;
+}
+
+Teuchos::RCP<Epetra_Operator> NOX::Nln::LinearSystemBase::getGeneratedPrecOperator()
+{
+  return Teuchos::null;
+}
+
+bool NOX::Nln::LinearSystemBase::createPreconditioner(
+    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p, bool recomputeGraph) const
+{
+  (void)x;
+  (void)p;
+  (void)recomputeGraph;
+
+  return false;
+}
+
+bool NOX::Nln::LinearSystemBase::destroyPreconditioner() const { return false; }
+
+bool NOX::Nln::LinearSystemBase::recomputePreconditioner(
+    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const
+{
+  (void)x;
+  (void)linearSolverParams;
+
+  return false;
+}
+
+::NOX::Epetra::LinearSystem::PreconditionerReusePolicyType
+NOX::Nln::LinearSystemBase::getPreconditionerPolicy(bool advanceReuseCounter)
+{
+  (void)advanceReuseCounter;
+
+  return ::NOX::Epetra::LinearSystem::PRPT_REBUILD;
+}
+
+bool NOX::Nln::LinearSystemBase::applyRightPreconditioning(bool useTranspose,
+    Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
+    ::NOX::Epetra::Vector& result) const
+{
+  (void)useTranspose;
+  (void)params;
+
+  if (&result != &input) result = input;
+
+  return true;
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -29,17 +29,103 @@ namespace NOX
   {
     class Scaling;
 
-    /*
+    /**
      * \brief Base class for NOX linear systems.
      *
-     * This mocks the scaling related methods of the NOX::Epetra::LinearSystem class. Most probably,
-     * it will be removed as soon as Epetra is removed from 4C.
+     * Currently, this class is a temporary base to proceed with a smooth step-by-step clean up of
+     * the Epetra related interface methods. Most probably, it will be removed as soon as Epetra is
+     * removed from 4C.
      */
     class LinearSystemBase : public ::NOX::Epetra::LinearSystem
     {
-      Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() override;
+      /**
+       * \brief Get native Epetra scaling object.
+       *
+       * This method throws an exception and is a temporary mock.
+       */
+      Teuchos::RCP<::NOX::Epetra::Scaling> getScaling() final;
 
-      void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s) override;
+      /**
+       * \brief Get native Epetra scaling object.
+       *
+       * This method throws an exception and is a temporary mock.
+       */
+      void resetScaling(const Teuchos::RCP<::NOX::Epetra::Scaling>& s) final;
+
+      /**
+       * \brief Set preconditioner operator for solve.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      void setPrecOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solvePrecOp) final;
+
+      /**
+       * \brief Indicates whether a preconditioner has been constructed.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      bool isPreconditionerConstructed() const final;
+
+      /**
+       * \brief Indicates whether the linear system has a preconditioner.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      bool hasPreconditioner() const final;
+
+      /**
+       * \brief Return preconditioner operator.
+       *
+       * This method returns null and is a temporary mock.
+       */
+      Teuchos::RCP<const Epetra_Operator> getGeneratedPrecOperator() const final;
+
+      /**
+       * \brief Return preconditioner operator.
+       *
+       * This method returns null and is a temporary mock.
+       */
+      Teuchos::RCP<Epetra_Operator> getGeneratedPrecOperator() final;
+
+      /**
+       * \brief Explicitly constructs a preconditioner based on the solution vector x and the
+       * parameter list p.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      bool createPreconditioner(const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
+          bool recomputeGraph) const final;
+
+      /**
+       * \brief Deletes the preconditioner.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      bool destroyPreconditioner() const final;
+
+      /**
+       * \brief Recalculates the preconditioner using an already allocated graph.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      bool recomputePreconditioner(
+          const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const final;
+
+      /**
+       * \brief Evaluates the preconditioner policy at the current state.
+       *
+       * This method returns a value and is a temporary mock.
+       */
+      ::NOX::Epetra::LinearSystem::PreconditionerReusePolicyType getPreconditionerPolicy(
+          bool advanceReuseCounter = true) final;
+
+      /**
+       * \brief Apply right preconditiong to the given input vector.
+       *
+       * This method does nothing and is a temporary mock.
+       */
+      bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
+          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const final;
     };
   }  // namespace Nln
 }  // namespace NOX

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -171,16 +171,6 @@ bool NOX::Solid::LinearSystem::applyJacobianInverse(
   return true;
 }
 
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Solid::LinearSystem::applyRightPreconditioning(bool useTranspose,
-    Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
-    ::NOX::Epetra::Vector& result) const
-{
-  if (&result != &input) result = input;
-  return true;
-}
-
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
@@ -189,48 +179,6 @@ bool NOX::Solid::LinearSystem::computeJacobian(const ::NOX::Epetra::Vector& x)
   bool success = jacInterfacePtr_->computeJacobian(x.getEpetraVector(), *jacPtr_);
   return success;
 }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Solid::LinearSystem::createPreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p, bool recomputeGraph) const
-{
-  return false;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Solid::LinearSystem::destroyPreconditioner() const { return false; }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Solid::LinearSystem::recomputePreconditioner(
-    const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& linearSolverParams) const
-{
-  return false;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-NOX::Solid::LinearSystem::PreconditionerReusePolicyType
-NOX::Solid::LinearSystem::getPreconditionerPolicy(bool advanceReuseCounter)
-{
-  return PRPT_REBUILD;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Solid::LinearSystem::isPreconditionerConstructed() const { return false; }
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-bool NOX::Solid::LinearSystem::hasPreconditioner() const { return false; }
 
 
 /*----------------------------------------------------------------------*
@@ -251,36 +199,11 @@ Teuchos::RCP<Epetra_Operator> NOX::Solid::LinearSystem::getJacobianOperator()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-Teuchos::RCP<const Epetra_Operator> NOX::Solid::LinearSystem::getGeneratedPrecOperator() const
-{
-  return Teuchos::null;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-Teuchos::RCP<Epetra_Operator> NOX::Solid::LinearSystem::getGeneratedPrecOperator()
-{
-  return Teuchos::null;
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void NOX::Solid::LinearSystem::setJacobianOperatorForSolve(
     const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
 {
   jacPtr_ = Core::Utils::shared_ptr_from_ref(*Teuchos::rcp_const_cast<Epetra_Operator>(solveJacOp));
   jacType_ = get_operator_type(*solveJacOp);
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void NOX::Solid::LinearSystem::setPrecOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solvePrecOp)
-{
-  throw_error("setPrecOperatorForSolve", "no preconditioner supported");
 }
 
 

--- a/src/structure/4C_structure_timint_noxlinsys.hpp
+++ b/src/structure/4C_structure_timint_noxlinsys.hpp
@@ -93,34 +93,8 @@ namespace NOX
       bool applyJacobianInverse(Teuchos::ParameterList& params, const ::NOX::Epetra::Vector& input,
           ::NOX::Epetra::Vector& result) override;
 
-      /// Apply right preconditiong to the given input vector.
-      bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
-
       /// Evaluates the Jacobian based on the solution vector x.
       bool computeJacobian(const ::NOX::Epetra::Vector& x) override;
-
-      /// Explicitly constructs a preconditioner based on the solution vector x and the parameter
-      /// list p.
-      bool createPreconditioner(const ::NOX::Epetra::Vector& x, Teuchos::ParameterList& p,
-          bool recomputeGraph) const override;
-
-      /// Deletes the preconditioner.
-      bool destroyPreconditioner() const override;
-
-      /// Recalculates the preconditioner using an already allocated graph.
-      bool recomputePreconditioner(const ::NOX::Epetra::Vector& x,
-          Teuchos::ParameterList& linearSolverParams) const override;
-
-      /// Evaluates the preconditioner policy at the current state.
-      PreconditionerReusePolicyType getPreconditionerPolicy(
-          bool advanceReuseCounter = true) override;
-
-      /// Indicates whether a preconditioner has been constructed.
-      bool isPreconditionerConstructed() const override;
-
-      /// Indicates whether the linear system has a preconditioner.
-      bool hasPreconditioner() const override;
 
       /// Return Jacobian operator.
       Teuchos::RCP<const Epetra_Operator> getJacobianOperator() const override;
@@ -128,18 +102,9 @@ namespace NOX
       /// Return Jacobian operator.
       Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-      /// Return preconditioner operator.
-      Teuchos::RCP<const Epetra_Operator> getGeneratedPrecOperator() const override;
-
-      /// Return preconditioner operator.
-      Teuchos::RCP<Epetra_Operator> getGeneratedPrecOperator() override;
-
       /// Set Jacobian operator for solve.
       void setJacobianOperatorForSolve(
           const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
-      /// Set preconditioner operator for solve.
-      void setPrecOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solvePrecOp) override;
 
      protected:
       /// throw an error


### PR DESCRIPTION
## Description and Context
These methods of the `NOX::Epetra::LinearSystem` are not used by any of our linear systems and do just dummy work. I have mocked all of them just in one place.

These changes are yet another preliminary work for replacing ultimately `NOX::Epetra::Group`.

## Related Issues and Pull Requests
#1077, #1098
