### PR TITLE
Consistently name CMake options

### DIFF
--- a/cmake/checks/01_detect_linkers.cmake
+++ b/cmake/checks/01_detect_linkers.cmake
@@ -10,18 +10,29 @@
 #
 
 # The following options may be disabled by users. In this case, we do not search for a linker and use the user flags.
-option(FOUR_C_DETECT_LINKER "Detect a fast linker" ON)
+four_c_process_global_option(
+  FOUR_C_ENABLE_LINKER_DETECTION
+  DESCRIPTION
+  "Detect a fast linker"
+  DEFAULT
+  ON
+  DEPRECATED_NAMES
+  "FOUR_C_DETECT_LINKER"
+  )
 
-if(FOUR_C_DETECT_LINKER)
+if(FOUR_C_ENABLE_LINKER_DETECTION)
   # The order of the linkers here is the order in which we prefer to use the linkers.
   # As soon as a linker works, skip the rest.
   set(_linkers "mold" "lld" "gold" "bfd")
   set(_no_linker_found True)
   foreach(_linker_name ${_linkers})
     # Check that the linker exists
-    find_program(FOUR_C_HAVE_LINKER_PROGRAM_${_linker_name} "ld.${_linker_name}")
+    find_program(
+      FOUR_C_LINKER_PROGRAM_${_linker_name} "ld.${_linker_name}"
+      DOC "Path to the ${_linker_name} linker. Auto-detected when FOUR_C_ENABLE_LINKER_DETECTION is ON."
+      )
 
-    if(FOUR_C_HAVE_LINKER_PROGRAM_${_linker_name})
+    if(FOUR_C_LINKER_PROGRAM_${_linker_name})
       # Check if the linker works out of the box.
       four_c_check_compiles(
         FOUR_C_LINKER_FUNCTIONAL_${_linker_name}

--- a/cmake/configure/configure_ArborX.cmake
+++ b/cmake/configure/configure_ArborX.cmake
@@ -5,7 +5,13 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-option(FOUR_C_ARBORX_FIND_INSTALLED "Use installed ARBORX instead of fetching sources" OFF)
+four_c_process_global_option(
+  FOUR_C_ARBORX_FIND_INSTALLED
+  DESCRIPTION
+  "Use installed ARBORX instead of fetching sources"
+  DEFAULT
+  OFF
+  )
 if(FOUR_C_ARBORX_FIND_INSTALLED)
   message(STATUS "FOUR_C_ARBORX_FIND_INSTALLED is enabled")
 

--- a/cmake/configure/configure_MIRCO.cmake
+++ b/cmake/configure/configure_MIRCO.cmake
@@ -5,7 +5,13 @@
 #
 # SPDX-License-Identifier: LGPL-3.0-or-later
 
-option(FOUR_C_MIRCO_FIND_INSTALLED "Use installed MIRCO instead of fetching sources" OFF)
+four_c_process_global_option(
+  FOUR_C_MIRCO_FIND_INSTALLED
+  DESCRIPTION
+  "Use installed MIRCO instead of fetching sources"
+  DEFAULT
+  OFF
+  )
 if(FOUR_C_MIRCO_FIND_INSTALLED)
 
   message(STATUS "FOUR_C_MIRCO_FIND_INSTALLED is enabled")

--- a/cmake/functions/four_c_configure_dependency.cmake
+++ b/cmake/functions/four_c_configure_dependency.cmake
@@ -231,7 +231,11 @@ function(four_c_configure_dependency _package_name)
 
   # Add a cache entry to turn the option ON or OFF.
   four_c_process_global_option(
-    FOUR_C_WITH_${_package_name_sanitized} "Build 4C with ${_package_name}" ${_parsed_DEFAULT}
+    FOUR_C_WITH_${_package_name_sanitized}
+    DESCRIPTION
+    "Build 4C with ${_package_name}"
+    DEFAULT
+    ${_parsed_DEFAULT}
     )
   # Add a cache entry to set the root directory of the package.
   four_c_process_cache_variable(

--- a/cmake/setup_global_options.cmake
+++ b/cmake/setup_global_options.cmake
@@ -47,7 +47,11 @@ if(NOT DEFINED FOUR_C_BUILD_SHARED_LIBS AND DEFINED BUILD_SHARED_LIBS)
 endif()
 
 four_c_process_global_option(
-  FOUR_C_BUILD_SHARED_LIBS "Build shared libraries instead of static ones" ON
+  FOUR_C_BUILD_SHARED_LIBS
+  DESCRIPTION
+  "Build shared libraries instead of static ones"
+  DEFAULT
+  ON
   )
 set(BUILD_SHARED_LIBS
     ${FOUR_C_BUILD_SHARED_LIBS}
@@ -59,7 +63,9 @@ set(BUILD_SHARED_LIBS
 
 four_c_process_global_option(
   FOUR_C_ENABLE_DEVELOPER_MODE
+  DESCRIPTION
   "Enable developer mode (tries to optimize setup for iterative development cycles)"
+  DEFAULT
   OFF
   )
 
@@ -93,19 +99,35 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 endif()
 
 four_c_process_global_option(
-  FOUR_C_ENABLE_WARNINGS_AS_ERRORS "Treat warnings as errors when compiling" OFF
+  FOUR_C_ENABLE_WARNINGS_AS_ERRORS
+  DESCRIPTION
+  "Treat warnings as errors when compiling"
+  DEFAULT
+  OFF
   )
 if(FOUR_C_ENABLE_WARNINGS_AS_ERRORS)
   enable_compiler_flag_if_supported("-Werror")
 endif()
 
-four_c_process_global_option(FOUR_C_ENABLE_NATIVE_OPTIMIZATIONS "Optimize for current hardware" OFF)
+four_c_process_global_option(
+  FOUR_C_ENABLE_NATIVE_OPTIMIZATIONS
+  DESCRIPTION
+  "Optimize for current hardware"
+  DEFAULT
+  OFF
+  )
 if(FOUR_C_ENABLE_NATIVE_OPTIMIZATIONS)
   enable_compiler_flag_if_supported("-march=native")
 endif()
 
 # If enabled, build all targets with address sanitizer
-four_c_process_global_option(FOUR_C_ENABLE_ADDRESS_SANITIZER "Compile with address sanitizer" OFF)
+four_c_process_global_option(
+  FOUR_C_ENABLE_ADDRESS_SANITIZER
+  DESCRIPTION
+  "Compile with address sanitizer"
+  DEFAULT
+  OFF
+  )
 if(FOUR_C_ENABLE_ADDRESS_SANITIZER)
   # We get better stack traces in ASAN with this flag.
   enable_compiler_flag_if_supported("-fno-omit-frame-pointer")
@@ -131,7 +153,9 @@ endif()
 
 four_c_process_global_option(
   FOUR_C_ENABLE_COVERAGE
+  DESCRIPTION
   "Set up a build to gather coverage information with LLVM source based coverage"
+  DEFAULT
   OFF
   )
 if(FOUR_C_ENABLE_COVERAGE)
@@ -155,10 +179,20 @@ if(FOUR_C_ENABLE_COVERAGE)
   endif()
 endif()
 
-four_c_process_global_option(FOUR_C_ENABLE_CORE_DUMP "Uncaught exceptions create a core file" OFF)
+four_c_process_global_option(
+  FOUR_C_ENABLE_CORE_DUMP
+  DESCRIPTION
+  "Uncaught exceptions create a core file"
+  DEFAULT
+  OFF
+  )
 
 four_c_process_global_option(
-  FOUR_C_ENABLE_FE_TRAPPING "Crash the program if a nan or inf would occur" ON
+  FOUR_C_ENABLE_FE_TRAPPING
+  DESCRIPTION
+  "Crash the program if a nan or inf would occur"
+  DEFAULT
+  ON
   )
 # We need to let the compiler know that we intend to use the floating-point trapping mechanism.
 if(FOUR_C_ENABLE_FE_TRAPPING)
@@ -176,7 +210,13 @@ else()
   enable_compiler_flag_if_supported("-fno-trapping-math")
 endif()
 
-four_c_process_global_option(FOUR_C_ENABLE_IWYU "Enable include-what-you-use" OFF)
+four_c_process_global_option(
+  FOUR_C_ENABLE_IWYU
+  DESCRIPTION
+  "Enable include-what-you-use"
+  DEFAULT
+  OFF
+  )
 if(FOUR_C_ENABLE_IWYU)
   find_program(FOUR_C_IWYU_EXECUTABLE NAMES include-what-you-use iwyu)
   if(NOT FOUR_C_IWYU_EXECUTABLE)
@@ -229,8 +269,9 @@ endif()
 # Evaluate this option now to get the correct output in case it is forced ON in DEBUG mode.
 four_c_process_global_option(
   FOUR_C_ENABLE_ASSERTIONS
-  "Turn on assertions and debug sections in 4C code, and turn on assertions in the standard library."
-  "Automatically turned on for DEBUG as CMAKE_BUILD_TYPE."
+  DESCRIPTION
+  "Turn on assertions and debug sections in 4C code, and turn on assertions in the standard library. Automatically turned on for DEBUG as CMAKE_BUILD_TYPE."
+  DEFAULT
   OFF
   )
 
@@ -246,7 +287,9 @@ endif()
 
 four_c_process_global_option(
   FOUR_C_ENABLE_METADATA_GENERATION
+  DESCRIPTION
   "Generate metadata after building 4C. Requires python and invokes 4C."
+  DEFAULT
   ON
   )
 
@@ -259,8 +302,7 @@ four_c_process_cache_variable(
   TYPE
   STRING
   DESCRIPTION
-  "Expert setting. Additional C++ compiler flags to use for all 4C targets.
-  Note that these flags are added at the very end and can override various other flags."
+  "Expert setting. Additional C++ compiler flags to use for all 4C targets. Note that these flags are added at the very end and can override various other flags."
   DEFAULT
   ""
   )
@@ -269,8 +311,7 @@ four_c_process_cache_variable(
   TYPE
   STRING
   DESCRIPTION
-  "Expert setting. Additional C++ linker flags to use for all 4C targets.
-  Note that these flags are added at the very end and can override various other flags."
+  "Expert setting. Additional C++ linker flags to use for all 4C targets. Note that these flags are added at the very end and can override various other flags."
   DEFAULT
   ""
   )

--- a/cmake/setup_tests.cmake
+++ b/cmake/setup_tests.cmake
@@ -34,7 +34,13 @@ four_c_process_cache_variable(
   )
 
 # Fetch GoogleTest and setup the unit tests if option is enabled
-four_c_process_global_option(FOUR_C_WITH_GOOGLETEST "Use GoogleTest for unit testing" ON)
+four_c_process_global_option(
+  FOUR_C_WITH_GOOGLETEST
+  DESCRIPTION
+  "Use GoogleTest for unit testing"
+  DEFAULT
+  ON
+  )
 if(FOUR_C_WITH_GOOGLETEST)
   # Define a convenience target for all unit tests and add it to 'full'
   # All unit test executables should add themselves as a dependency to 'unittests'
@@ -65,7 +71,11 @@ endif()
 
 # Fetch Google Benchmark and setup benchmark tests if option is enabled
 four_c_process_global_option(
-  FOUR_C_WITH_GOOGLE_BENCHMARK "Use Google Benchmark for micro benchmark tests" OFF
+  FOUR_C_WITH_GOOGLE_BENCHMARK
+  DESCRIPTION
+  "Use Google Benchmark for micro benchmark tests"
+  DEFAULT
+  OFF
   )
 if(FOUR_C_WITH_GOOGLE_BENCHMARK)
   # Define a convenience target for all benchmark tests and add it to 'full'

--- a/doc/documentation/CMakeLists.txt
+++ b/doc/documentation/CMakeLists.txt
@@ -8,7 +8,13 @@
 #
 # Set up the main documentation based on Sphinx
 
-four_c_process_global_option(FOUR_C_BUILD_DOCUMENTATION "Build the documentation" OFF)
+four_c_process_global_option(
+  FOUR_C_BUILD_DOCUMENTATION
+  DESCRIPTION
+  "Build the documentation"
+  DEFAULT
+  OFF
+  )
 if(FOUR_C_BUILD_DOCUMENTATION)
 
   if(NOT FOUR_C_WITH_PYTHON)

--- a/doc/documentation/CMakeLists.txt
+++ b/doc/documentation/CMakeLists.txt
@@ -9,16 +9,18 @@
 # Set up the main documentation based on Sphinx
 
 four_c_process_global_option(
-  FOUR_C_BUILD_DOCUMENTATION
+  FOUR_C_ENABLE_DOCUMENTATION
   DESCRIPTION
   "Build the documentation"
   DEFAULT
   OFF
+  DEPRECATED_NAMES
+  "FOUR_C_BUILD_DOCUMENTATION"
   )
-if(FOUR_C_BUILD_DOCUMENTATION)
+if(FOUR_C_ENABLE_DOCUMENTATION)
 
   if(NOT FOUR_C_WITH_PYTHON)
-    message(FATAL_ERROR "FOUR_C_BUILD_DOCUMENTATION requires FOUR_C_WITH_PYTHON to be enabled.")
+    message(FATAL_ERROR "FOUR_C_ENABLE_DOCUMENTATION requires FOUR_C_WITH_PYTHON to be enabled.")
   endif()
 
   # add doc-specific cmake modules

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -7,8 +7,20 @@
 
 #
 # Build routine/test for doxygen documentation
-four_c_process_global_option(FOUR_C_BUILD_DOXYGEN "Build doxygen documentation" OFF)
-four_c_process_global_option(FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX "Use local MathJax installation" OFF)
+four_c_process_global_option(
+  FOUR_C_BUILD_DOXYGEN
+  DESCRIPTION
+  "Build doxygen documentation"
+  DEFAULT
+  OFF
+  )
+four_c_process_global_option(
+  FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX
+  DESCRIPTION
+  "Use local MathJax installation"
+  DEFAULT
+  OFF
+  )
 four_c_process_cache_variable(
   FOUR_C_DOXYGEN_LOCAL_MATHJAX_BASEPATH
   TYPE

--- a/doc/doxygen/CMakeLists.txt
+++ b/doc/doxygen/CMakeLists.txt
@@ -8,11 +8,13 @@
 #
 # Build routine/test for doxygen documentation
 four_c_process_global_option(
-  FOUR_C_BUILD_DOXYGEN
+  FOUR_C_ENABLE_DOXYGEN
   DESCRIPTION
   "Build doxygen documentation"
   DEFAULT
   OFF
+  DEPRECATED_NAMES
+  "FOUR_C_BUILD_DOXYGEN"
   )
 four_c_process_global_option(
   FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX
@@ -30,7 +32,7 @@ four_c_process_cache_variable(
   DEFAULT
   ""
   )
-if(FOUR_C_BUILD_DOXYGEN)
+if(FOUR_C_ENABLE_DOXYGEN)
 
   # add doc-specific cmake modules
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)


### PR DESCRIPTION
This PR 

- improves the `four_c_process_global_option` function to use argument parsing
- provides backward compatible warnings that an options is now named differently
- renames the options that are not in the `FOUR_C_ENABLE` style


Q: What would be a good time frame to remove the deprecated option names? Maybe leave it in the next release, and remove it after the one after that?

Addresses #1073 