### PR TITLE
Support std::pair as an InputSpec type

### DIFF
--- a/src/core/io/src/4C_io_input_types.hpp
+++ b/src/core/io/src/4C_io_input_types.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <optional>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -168,10 +169,11 @@ namespace Core::IO
   /**
    * Determine the rank of a type, i.e., how many levels of nested containers are present.
    */
-  template <SupportedType T>
+  template <typename T>
+    requires SupportedType<std::decay_t<T>>
   constexpr std::size_t rank()
   {
-    return Internal::RankHelper<T>::value;
+    return Internal::RankHelper<std::decay_t<T>>::value;
   }
 
   /**

--- a/src/core/io/src/4C_io_input_types.hpp
+++ b/src/core/io/src/4C_io_input_types.hpp
@@ -77,6 +77,18 @@ namespace Core::IO
     {
     };
 
+    template <typename... Ts>
+    struct SupportedTypeHelper<std::tuple<Ts...>>
+        : std::bool_constant<(SupportedTypeHelper<Ts>::value && ...)>
+    {
+    };
+
+    template <typename T1, typename T2>
+    struct SupportedTypeHelper<std::pair<T1, T2>>
+        : std::bool_constant<SupportedTypeHelper<T1>::value && SupportedTypeHelper<T2>::value>
+    {
+    };
+
     template <typename U>
     struct SupportedTypeHelper<std::map<std::string, U>> : SupportedTypeHelper<U>
     {
@@ -103,6 +115,18 @@ namespace Core::IO
     struct RankHelper<std::map<std::string, T>>
     {
       static constexpr std::size_t value = 1 + RankHelper<T>::value;
+    };
+
+    template <typename... Ts>
+    struct RankHelper<std::tuple<Ts...>>
+    {
+      static constexpr std::size_t value = (RankHelper<Ts>::value + ...);
+    };
+
+    template <typename T1, typename T2>
+    struct RankHelper<std::pair<T1, T2>>
+    {
+      static constexpr std::size_t value = RankHelper<T1>::value + RankHelper<T2>::value;
     };
 
     template <typename T>
@@ -162,6 +186,8 @@ namespace Core::IO
    * - `std::optional<T>`, where `T` is one of the supported types
    * - `std::vector<T>`, where `T` is one of the supported types
    * - `std::map<std::string, T>`, where `T` is one of the supported types
+   * - `std::tuple<Ts...>`, where all `Ts` are one of the supported types
+   * - `std::pair<T1, T2>`, where `T1` and `T2` are both one of the supported types
    */
   template <typename T>
   concept SupportedType = Internal::SupportedTypeHelper<T>::value;

--- a/src/core/io/src/4C_io_value_parser.hpp
+++ b/src/core/io/src/4C_io_value_parser.hpp
@@ -210,7 +210,7 @@ namespace Core::IO
       }
     }
 
-    template <typename T, typename... SizeInfo>
+    template <typename T>
     void read_internal(std::optional<T>& value)
     {
       auto next = peek();
@@ -225,7 +225,7 @@ namespace Core::IO
       }
     }
 
-    template <typename T, typename... SizeInfo>
+    template <typename T>
     void read_internal(std::vector<T>& value)
     {
       const std::size_t my_size = size_info_[0];
@@ -238,7 +238,7 @@ namespace Core::IO
       size_info_--;
     }
 
-    template <typename T, std::size_t n, typename... SizeInfo>
+    template <typename T, std::size_t n>
     void read_internal(std::array<T, n>& value)
     {
       for (std::size_t i = 0; i < n; ++i)
@@ -247,7 +247,7 @@ namespace Core::IO
       }
     }
 
-    template <typename U, typename... SizeInfo>
+    template <typename U>
     void read_internal(std::map<std::string, U>& value)
     {
       const std::size_t my_size = size_info_[0];

--- a/src/core/io/src/4C_io_value_parser.hpp
+++ b/src/core/io/src/4C_io_value_parser.hpp
@@ -23,6 +23,7 @@
 #include <stack>
 #include <string>
 #include <string_view>
+#include <tuple>
 #include <vector>
 
 FOUR_C_NAMESPACE_OPEN
@@ -245,6 +246,19 @@ namespace Core::IO
       {
         read_internal(value[i]);
       }
+    }
+
+    template <typename... Ts>
+    void read_internal(std::tuple<Ts...>& value)
+    {
+      std::apply([this](auto&... val) { (this->read_internal(val), ...); }, value);
+    }
+
+    template <typename T1, typename T2>
+    void read_internal(std::pair<T1, T2>& value)
+    {
+      read_internal(value.first);
+      read_internal(value.second);
     }
 
     template <typename U>

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -2092,7 +2092,7 @@ parameters:
       SCOPED_TRACE("Invalid input");
       ryml::Tree tree = init_yaml_tree_with_exceptions();
       ryml::NodeRef root = tree.rootref();
-      ryml::parse_in_arena(R"(v: [-1, null])", root);
+      ryml::parse_in_arena(R"(v: [-1, null, 4])", root);
       ConstYamlNodeRef node(root, "");
       InputParameterContainer container;
       FOUR_C_EXPECT_THROW_WITH_MESSAGE(spec.match(node, container), Core::Exception,

--- a/utilities/metadata_utils.py
+++ b/utilities/metadata_utils.py
@@ -8,8 +8,9 @@
 """Utilities to handle 4C metadata files."""
 from dataclasses import dataclass, field
 from pathlib import Path
-from ruamel.yaml import YAML
 from typing import ClassVar
+
+from ruamel.yaml import YAML
 
 
 # In order to allow None as defaults
@@ -126,6 +127,20 @@ class Map(Primitive):
         # If dict create object
         if isinstance(self.value_type, dict):
             self.value_type = _metadata_object_from_dict(self.value_type)
+
+
+@dataclass
+class Tuple(Primitive):
+    """Tuple parameter."""
+
+    size: int = None
+    value_types: list = field(default_factory=list)
+
+    def __post_init__(self):
+        # If dict create object
+        for i, vt in enumerate(self.value_types):
+            if isinstance(vt, dict):
+                self.value_types[i] = _metadata_object_from_dict(vt)
 
 
 @dataclass
@@ -382,6 +397,8 @@ def _metadata_object_from_dict(metadata_dict):
             cls = Vector
         case "map":
             cls = Map
+        case "tuple":
+            cls = Tuple
         # Collections
         case "selection":
             cls = Selection


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
Extend InputSpecs to support std::pair as a supported type. This includes extending the schema generation functionalities and YAML read/write toolings to support std::pair. The first commit adds a compile-time check in SizeChecker to catch missing template implementations for types where rank != 0. 

## Related Issues and Pull Requests
Preparation for #1139