### PR TITLE
[LinAlg] Refactor matrix complete call

### DIFF
--- a/src/core/comm/tests/4C_comm_utils_test.np3.cpp
+++ b/src/core/comm/tests/4C_comm_utils_test.np3.cpp
@@ -129,9 +129,7 @@ namespace
         }
       }
 
-      // TODO: we are not allowed to optimize data storage here, otherwise results in the second
-      //       run won't fit
-      matrix_->epetra_matrix()->FillComplete(false);
+      matrix_->complete({.optimize_data_storage = false});
     }
 
     void TearDown() override { Core::IO::cout.close(); }
@@ -255,9 +253,7 @@ namespace
 
     matrix_->insert_my_values(myLastLid[0], 1, &value[0], &myLastLid[0]);
 
-    // TODO: we are not allowed to optimize data storage here, otherwise results from the first
-    //       run won't fit
-    matrix_->epetra_matrix()->FillComplete(false);
+    matrix_->complete({.enforce_complete = true, .optimize_data_storage = false});
 
     EXPECT_THROW(Core::Communication::are_distributed_sparse_matrices_identical(
                      *communicators_, *matrix_, "matrix"),

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.cpp
@@ -122,13 +122,13 @@ void Core::LinAlg::BlockSparseMatrixBase::reset()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::LinAlg::BlockSparseMatrixBase::complete(bool enforce_complete)
+void Core::LinAlg::BlockSparseMatrixBase::complete(OptionsMatrixComplete options_matrix_complete)
 {
   for (int r = 0; r < rows(); ++r)
   {
     for (int c = 0; c < cols(); ++c)
     {
-      matrix(r, c).complete(domain_map(c), range_map(r), enforce_complete);
+      matrix(r, c).complete(domain_map(c), range_map(r), options_matrix_complete);
     }
   }
 
@@ -158,8 +158,8 @@ void Core::LinAlg::BlockSparseMatrixBase::complete(bool enforce_complete)
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::LinAlg::BlockSparseMatrixBase::complete(
-    const Core::LinAlg::Map& domainmap, const Core::LinAlg::Map& rangemap, bool enforce_complete)
+void Core::LinAlg::BlockSparseMatrixBase::complete(const Core::LinAlg::Map& domainmap,
+    const Core::LinAlg::Map& rangemap, OptionsMatrixComplete options_matrix_complete)
 {
   FOUR_C_THROW("Complete with arguments not supported for block matrices");
 }

--- a/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_blocksparsematrix.hpp
@@ -89,10 +89,10 @@ namespace Core::LinAlg
     void zero() override;
     void reset() override;
 
-    void complete(bool enforce_complete = false) override;
+    void complete(OptionsMatrixComplete options_matrix_complete = {}) override;
 
     void complete(const Core::LinAlg::Map& domainmap, const Core::LinAlg::Map& rangemap,
-        bool enforce_complete = false) override;
+        OptionsMatrixComplete options_matrix_complete = {}) override;
 
     void un_complete() override;
 
@@ -321,7 +321,7 @@ namespace Core::LinAlg
      */
     void assemble(double val, int rgid, int cgid) override { Strategy::assemble(val, rgid, cgid); }
 
-    void complete(bool enforce_complete = false) override;
+    void complete(OptionsMatrixComplete options_matrix_complete = {}) override;
 
    private:
     /** \brief internal clone method which provides the possibility to clone only
@@ -511,10 +511,11 @@ Core::LinAlg::BlockSparseMatrix<Strategy>::clone(DataAccess access,
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 template <class Strategy>
-void Core::LinAlg::BlockSparseMatrix<Strategy>::complete(bool enforce_complete)
+void Core::LinAlg::BlockSparseMatrix<Strategy>::complete(
+    OptionsMatrixComplete options_matrix_complete)
 {
   Strategy::complete();
-  BlockSparseMatrixBase::complete(enforce_complete);
+  BlockSparseMatrixBase::complete(options_matrix_complete);
 }
 
 

--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -264,35 +264,20 @@ namespace Core::LinAlg
      */
     void fe_assemble(double val, int rgid, int cgid);
 
-
     /*!
       The GlobalAssembleMethod() distributes nonlocal values to their owning procs
       for Epetra_FECrsMatrices.
       Afterwards Fillcomplete is called such as for Epetra_CrsMatrices.
-
-      @param enforce_complete Enforce fill_complete() even though the matrix might already be filled
      */
-    void complete(bool enforce_complete = false) override;
+    void complete(OptionsMatrixComplete options_matrix_complete = {}) override;
 
     /*!
       The GlobalAssembleMethod() distributes nonlocal values to their owning procs
       for Epetra_FECrsMatrices.
       Afterwards Fillcomplete is called such as for Epetra_CrsMatrices.
-
-      @param enforce_complete Enforce fill_complete() even though the matrix might already be filled
      */
     void complete(const Core::LinAlg::Map& domainmap, const Core::LinAlg::Map& rangemap,
-        bool enforce_complete = false) override;
-
-    // The following three interfaces needs so be merged into one.
-    void complete(const Core::LinAlg::Map& domainmap, const Epetra_Map& rangemap,
-        bool enforce_complete = false);
-
-    void complete(const Epetra_Map& domainmap, const Core::LinAlg::Map& rangemap,
-        bool enforce_complete = false);
-
-    void complete(
-        const Epetra_Map& domainmap, const Epetra_Map& rangemap, bool enforce_complete = false);
+        OptionsMatrixComplete options_matrix_complete = {}) override;
 
     void un_complete() override;
 

--- a/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparseoperator.hpp
@@ -67,6 +67,17 @@ namespace Core::LinAlg
                             each 'original' block is divided into 2 blocks. */
   };
 
+  //! \brief Options for matrix completion
+  struct OptionsMatrixComplete
+  {
+    //! enforce a lightweight fill_complete() even though the matrix might already have been filled
+    bool enforce_complete = false;
+
+    //! make consecutive row index sections contiguous, minimize internal storage used for
+    //! constructing graph
+    bool optimize_data_storage = true;
+  };
+
   /// Linear operator interface enhanced for use in FE simulations
   /*!
 
@@ -184,15 +195,11 @@ namespace Core::LinAlg
     virtual bool filled() const = 0;
 
     /// Call fill_complete on a matrix
-    /*!
-     * @param enforce_complete Enforce fill_complete() even though the matrix might already be
-     * filled
-     */
-    virtual void complete(bool enforce_complete = false) = 0;
+    virtual void complete(OptionsMatrixComplete options_matrix_complete = {}) = 0;
 
     /// Call fill_complete on a matrix (for rectangular and square matrices)
     virtual void complete(const Core::LinAlg::Map& domainmap, const Core::LinAlg::Map& rangemap,
-        bool enforce_complete = false) = 0;
+        OptionsMatrixComplete options_matrix_complete = {}) = 0;
 
     /// Undo a previous Complete() call
     virtual void un_complete() = 0;

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_manipulation.cpp
@@ -808,7 +808,7 @@ std::shared_ptr<Core::LinAlg::SparseMatrix> Core::LinAlg::matrix_col_transform(
   std::shared_ptr<Core::LinAlg::SparseMatrix> outmat =
       std::make_shared<Core::LinAlg::SparseMatrix>(inmat);
 
-  outmat->complete(newdomainmap, inmat.row_map(), true);
+  outmat->complete(newdomainmap, inmat.row_map(), {.enforce_complete = true});
 
   return outmat;
 }

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit.cpp
@@ -853,7 +853,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
   (*aigtransform_)(a->full_row_map(), a->full_col_map(), aig, 1.,
       Coupling::Adapter::CouplingSlaveConverter(interface_fluid_ale_coupling()), *laig);
 
-  laig->complete(f->matrix(1, 1).domain_map(), aii.range_map(), true);
+  laig->complete(f->matrix(1, 1).domain_map(), aii.range_map(), {.enforce_complete = true});
   std::shared_ptr<Core::LinAlg::SparseMatrix> llaig =
       matrix_multiply(*laig, false, *mortarp, false, false, false, true);
   laig = std::make_shared<Core::LinAlg::SparseMatrix>(llaig->row_map(), 81, false);
@@ -920,7 +920,7 @@ void FSI::MortarMonolithicFluidSplit::setup_system_matrix(Core::LinAlg::BlockSpa
         Coupling::Adapter::CouplingMasterConverter(coupfa), *lfmgi, false);
 
     // ---------Addressing contribution to block (2,4)
-    lfmgi->complete(aii.domain_map(), mortarp->range_map(), true);
+    lfmgi->complete(aii.domain_map(), mortarp->range_map(), {.enforce_complete = true});
     std::shared_ptr<Core::LinAlg::SparseMatrix> llfmgi =
         matrix_multiply(*mortarp, true, *lfmgi, false, false, false, true);
     lfmgi = std::make_shared<Core::LinAlg::SparseMatrix>(s->row_map(), 81, false);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_fluidsplit_sp.cpp
@@ -860,7 +860,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   aux_fluidblock.add(fluid_interf_inner, false, 1.0, 1.0);
   aux_fluidblock.add(fluid_inner_interf, false, 1.0, 1.0);
   aux_fluidblock.add(fluid_interf_interf, false, 1.0, 1.0);
-  aux_fluidblock.complete(fluidblock->full_domain_map(), fluidblock->full_range_map(), true);
+  aux_fluidblock.complete(
+      fluidblock->full_domain_map(), fluidblock->full_range_map(), {.enforce_complete = true});
 
   // ---------Addressing contribution to block (5,4)
   std::shared_ptr<Core::LinAlg::SparseMatrix> aux_ale_inner_interf =
@@ -871,7 +872,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
       *aux_ale_inner_interf);
 
   aux_ale_inner_interf->scale(1. / fluid_timescale);
-  aux_ale_inner_interf->complete(fluidblock->domain_map(), aux_ale_inner_interf->range_map(), true);
+  aux_ale_inner_interf->complete(
+      fluidblock->domain_map(), aux_ale_inner_interf->range_map(), {.enforce_complete = true});
 
   mat.assign(2, 1, Core::LinAlg::DataAccess::View, *aux_ale_inner_interf);
 
@@ -881,7 +883,7 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   // ---------Addressing contribution to block (6,2)
   std::shared_ptr<Core::LinAlg::SparseMatrix> aux_mortar_m =
       Core::LinAlg::matrix_row_transform_gids(*mortar_m, *lag_mult_dof_map_);
-  aux_mortar_m->complete(solidblock->domain_map(), *lag_mult_dof_map_, true);
+  aux_mortar_m->complete(solidblock->domain_map(), *lag_mult_dof_map_, {.enforce_complete = true});
 
   mat.assign(3, 0, Core::LinAlg::DataAccess::View, *aux_mortar_m);
 
@@ -889,7 +891,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   aux_mortar_m = Core::LinAlg::matrix_row_transform_gids(*mortar_m, *lag_mult_dof_map_);
   Core::LinAlg::SparseMatrix aux_mortar_m_trans(solidblock->row_map(), 81, false);
   aux_mortar_m_trans.add(*aux_mortar_m, true, -1.0 * (1.0 - solid_time_int_param), 0.0);
-  aux_mortar_m_trans.complete(*lag_mult_dof_map_, solidblock->range_map(), true);
+  aux_mortar_m_trans.complete(
+      *lag_mult_dof_map_, solidblock->range_map(), {.enforce_complete = true});
 
   mat.assign(0, 3, Core::LinAlg::DataAccess::View, aux_mortar_m_trans);
 
@@ -898,7 +901,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
       Core::LinAlg::matrix_row_transform_gids(*mortar_d, *lag_mult_dof_map_);
 
   aux_mortar_d->scale(-1.0 / fluid_timescale);
-  aux_mortar_d->complete(fluidblock->full_domain_map(), *lag_mult_dof_map_, true);
+  aux_mortar_d->complete(
+      fluidblock->full_domain_map(), *lag_mult_dof_map_, {.enforce_complete = true});
 
   mat.assign(3, 1, Core::LinAlg::DataAccess::View, *aux_mortar_d);
 
@@ -907,7 +911,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
   Core::LinAlg::SparseMatrix aux_mortar_d_trans(fluidblock->full_row_map(), 81, false);
   aux_mortar_d_trans.add(
       *aux_mortar_d, true, 1.0 * (1.0 - fluid_time_int_param) / fluid_res_scale, 0.0);
-  aux_mortar_d_trans.complete(*lag_mult_dof_map_, fluidblock->full_range_map(), true);
+  aux_mortar_d_trans.complete(
+      *lag_mult_dof_map_, fluidblock->full_range_map(), {.enforce_complete = true});
 
   mat.assign(1, 3, Core::LinAlg::DataAccess::View, aux_mortar_d_trans);
 
@@ -927,8 +932,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
     Core::LinAlg::SparseMatrix aux_fluid_mesh_inner_interf(
         fluid_mesh_inner_interf.row_map(), 81, false);
     aux_fluid_mesh_inner_interf.add(fluid_mesh_inner_interf, false, 1.0, 0.0);
-    aux_fluid_mesh_inner_interf.complete(
-        fluidblock->domain_map(), aux_fluid_mesh_inner_interf.range_map(), true);
+    aux_fluid_mesh_inner_interf.complete(fluidblock->domain_map(),
+        aux_fluid_mesh_inner_interf.range_map(), {.enforce_complete = true});
     aux_fluidblock.add(aux_fluid_mesh_inner_interf, false, 1. / fluid_timescale, 1.0);
 
     // Addressing contribution to block (3,5)
@@ -940,8 +945,8 @@ void FSI::MortarMonolithicFluidSplitSaddlePoint::setup_system_matrix(
     Core::LinAlg::SparseMatrix aux_fluid_mesh_interf_interf(
         fluid_mesh_interf_interf.row_map(), 81, false);
     aux_fluid_mesh_interf_interf.add(fluid_mesh_interf_interf, false, 1.0, 0.0);
-    aux_fluid_mesh_interf_interf.complete(
-        fluidblock->domain_map(), aux_fluid_mesh_interf_interf.range_map(), true);
+    aux_fluid_mesh_interf_interf.complete(fluidblock->domain_map(),
+        aux_fluid_mesh_interf_interf.range_map(), {.enforce_complete = true});
     aux_fluidblock.add(aux_fluid_mesh_interf_interf, false, 1. / fluid_timescale, 1.0);
 
     // Addressing contribution to block (4,5)


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR refactors the matrix `complete()` call by introducing a struct for the different options to handle. This also removes some specific `epetra_matrix()->FillComplete(false)` calls. Also some unused `complete()` calls based on `Epetra` input variables are removed.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Closes #764.