### PR TITLE
[LinAlg] Refactor matrix add and multiply methods

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.cpp
@@ -1709,7 +1709,7 @@ void Core::LinAlg::SparseMatrix::add(const Core::LinAlg::SparseOperator& A, cons
 void Core::LinAlg::SparseMatrix::add(const Core::LinAlg::SparseMatrix& A, const bool transposeA,
     const double scalarA, const double scalarB)
 {
-  Core::LinAlg::add(*A.epetra_matrix(), transposeA, scalarA, *this, scalarB);
+  Core::LinAlg::add(A, transposeA, scalarA, *this, scalarB);
 }
 
 /*----------------------------------------------------------------------*
@@ -1717,8 +1717,7 @@ void Core::LinAlg::SparseMatrix::add(const Core::LinAlg::SparseMatrix& A, const 
 void Core::LinAlg::SparseMatrix::add_other(Core::LinAlg::SparseMatrix& B, const bool transposeA,
     const double scalarA, const double scalarB) const
 {
-  // B.add(*this, transposeA, scalarA, scalarB);
-  Core::LinAlg::add(*sysmat_, transposeA, scalarA, B, scalarB);
+  B.add(*this, transposeA, scalarA, scalarB);
 }
 
 /*----------------------------------------------------------------------*

--- a/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_utils_sparse_algebra_math.hpp
@@ -11,10 +11,8 @@
 #include "4C_config.hpp"
 
 #include "4C_linalg_blocksparsematrix.hpp"
-#include "4C_linalg_fixedsizematrix.hpp"
 #include "4C_linalg_graph.hpp"
 #include "4C_linalg_map.hpp"
-#include "4C_linalg_serialdensematrix.hpp"
 
 #include <Epetra_CrsMatrix.h>
 
@@ -25,9 +23,15 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core::LinAlg
 {
   /*!
-   \brief Add a (transposed) Epetra_CrsMatrix to another: B = B*scalarB + A(^T)*scalarA
+   \brief Add a (transposed) Epetra_CrsMatrix to a Core::LinAlg::SparseMatrix: B = B*scalarB +
+   A(^T)*scalarA
 
    Add one matrix to another.
+
+   As opposed to the other Add() functions, this method can handle both the case where
+   matrix B is fill-completed (for performance reasons) but does not have to.
+   If B is completed and new matrix elements are detected, the matrix is un-completed and
+   rebuild internally (expensive).
 
    The matrix B may or may not be completed. If B is completed, no new elements can be
    inserted and the addition only succeeds in case the sparsity pattern of B is a superset of
@@ -50,34 +54,7 @@ namespace Core::LinAlg
    \param B          (in/out) : Matrix to be added to (must have Filled()==false)
    \param scalarB    (in)     : scaling factor for B
    */
-  void add(const Epetra_CrsMatrix& A, const bool transposeA, const double scalarA,
-      Epetra_CrsMatrix& B, const double scalarB);
-
-  /*!
-   \brief Add a (transposed) Epetra_CrsMatrix to a Core::LinAlg::SparseMatrix: B = B*scalarB +
-   A(^T)*scalarA
-
-   Add one matrix to another.
-
-   As opposed to the other Add() functions, this method can handle both the case where
-   matrix B is fill-completed (for performance reasons) but does not have to.
-   If B is completed and new matrix elements are detected, the matrix is un-completed and
-   rebuild internally (expensive).
-
-   Sparsity patterns of A and B need not match and A and B can be
-   nonsymmetric in value and pattern.
-
-   Row map of A has to be a processor-local subset of the row map of B.
-
-   Note that this is a true parallel add, even in the transposed case!
-
-   \param A          (in)     : Matrix to add to B (must have Filled()==true)
-   \param transposeA (in)     : flag indicating whether transposed of A should be used
-   \param scalarA    (in)     : scaling factor for A
-   \param B          (in/out) : Matrix to be added to (must have Filled()==false)
-   \param scalarB    (in)     : scaling factor for B
-   */
-  void add(const Epetra_CrsMatrix& A, const bool transposeA, const double scalarA,
+  void add(const Core::LinAlg::SparseMatrix& A, const bool transposeA, const double scalarA,
       Core::LinAlg::SparseMatrix& B, const double scalarB);
 
   /*!


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR switches the data types of our internal matrix addition method from `Epetra_CrsMatrix` to `Core::LinAlg::SparseMatrix`. In addition several places, which need a matrix transpose now use `matrix_transpose()` instead of direct calls to `Epetra`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #136