### PR TITLE
Minor cleanup in Knotvectors

### DIFF
--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_knotvector.cpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_knotvector.cpp
@@ -73,7 +73,7 @@ Core::FE::Nurbs::Knotvector::Knotvector(const int dim, const int npatches)
     (knot_values_[rr]).resize(dim_);
 
     // initialize interpolation type
-    for (int mm = 0; mm < dim_; ++mm) (interpolation_[rr])[mm] = knotvector_is_not_defined;
+    for (int mm = 0; mm < dim_; ++mm) (interpolation_[rr])[mm] = KnotvectorType::Undefined;
   }
 
   return;
@@ -543,11 +543,11 @@ void Core::FE::Nurbs::Knotvector::set_knots(const int& direction, const int& npa
   // set the type
   if (knotvectortype == "Interpolated")
   {
-    (interpolation_[npatch])[direction] = knotvector_is_interpolating;
+    (interpolation_[npatch])[direction] = KnotvectorType::Interpolated;
   }
   else if (knotvectortype == "Periodic")
   {
-    (interpolation_[npatch])[direction] = knotvector_is_periodic;
+    (interpolation_[npatch])[direction] = KnotvectorType::Periodic;
   }
   else
   {
@@ -651,11 +651,11 @@ void Core::FE::Nurbs::Knotvector::finish_knots(const int smallest_gid_in_dis)
       }
 
       // is interpolation/periodicity assigned correctly?
-      if ((interpolation_[np])[rr] == knotvector_is_not_defined)
+      if ((interpolation_[np])[rr] == KnotvectorType::Undefined)
       {
         FOUR_C_THROW("undefined knotvector type\n");
       }
-      else if ((interpolation_[np])[rr] == knotvector_is_interpolating)
+      else if ((interpolation_[np])[rr] == KnotvectorType::Interpolated)
       {
         // for interpolating knot vectors, the first and last
         // knots have to be repeated degree+1 times
@@ -675,7 +675,7 @@ void Core::FE::Nurbs::Knotvector::finish_knots(const int smallest_gid_in_dis)
           }
         }
       }
-      else if ((interpolation_[np])[rr] == knotvector_is_periodic)
+      else if ((interpolation_[np])[rr] == KnotvectorType::Periodic)
       {
         // for periodic knot vectors, distances between the
         // degree+1 first and last nodes have to be equal

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_knotvector.hpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_knotvector.hpp
@@ -460,11 +460,11 @@ namespace Core::FE
 
      private:
       //! Knotvector types
-      enum KnotvectorType
+      enum class KnotvectorType
       {
-        knotvector_is_interpolating,
-        knotvector_is_periodic,
-        knotvector_is_not_defined
+        Undefined,
+        Interpolated,
+        Periodic,
       };
 
       //! Spatial dimension

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_knotvector.hpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_knotvector.hpp
@@ -51,9 +51,6 @@ namespace Core::FE
     class Knotvector : public Core::Communication::ParObject
     {
      public:
-      //! @name Construction, destruction and copying
-      //! @{
-
       /*!
       \brief standard constructor
 
@@ -68,14 +65,6 @@ namespace Core::FE
        */
       Knotvector();
 
-      /*!
-      \brief copy constructor
-
-      \param old const Knotvector (i)
-      */
-      Knotvector(const Knotvector& old);
-
-      //! @}
 
       //! @name Access methods for shapefunction evaluation
       //! @{
@@ -274,7 +263,7 @@ namespace Core::FE
       */
       void set_knots(const int& direction, const int& npatch, const int& degree,
           const int& numknots, const std::string& knotvectortype,
-          std::shared_ptr<std::vector<double>> directions_knots);
+          const std::vector<double>& directions_knots);
 
       //! @}
 
@@ -501,7 +490,7 @@ namespace Core::FE
       std::vector<int> offsets_;
 
       //! the actual values
-      std::vector<std::vector<std::shared_ptr<std::vector<double>>>> knot_values_;
+      std::vector<std::vector<std::vector<double>>> knot_values_;
 
       //! @}
     };

--- a/src/core/io/src/4C_io_input_file_utils.hpp
+++ b/src/core/io/src/4C_io_input_file_utils.hpp
@@ -81,15 +81,15 @@ namespace Core::IO
           get_discretization);
 
   /**
-   * \brief read the knotvector section (for isogeometric analysis)
+   * @brief Read the knot vector section (for isogeometric analysis)
    *
-   * \param  reader         (in ): InputFile object
-   * \param  name           (in ): Name/type of discretisation
-   * \param  disknots       (out): node vector coordinates
+   * @param  input         (in ): InputFile object
+   * @param  name           (in ): Name/type of discretisation
    *
+   * @return The Knotvector object read from the input file.
    */
-  void read_knots(InputFile& input, const std::string& name,
-      std::shared_ptr<Core::FE::Nurbs::Knotvector>& disknots);
+  std::unique_ptr<Core::FE::Nurbs::Knotvector> read_knots(
+      InputFile& input, const std::string& name);
 
 }  // namespace Core::IO
 

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1718,11 +1718,8 @@ void Global::read_knots(Global::Problem& problem, Core::IO::InputFile& input)
       if (nurbsdis == nullptr)
         FOUR_C_THROW("discretization {} is not a NurbsDiscretization! Panic.", dis->name());
 
-      // define an empty knot vector object
-      std::shared_ptr<Core::FE::Nurbs::Knotvector> disknots = nullptr;
-
       // read the knotvector data from the input
-      Core::IO::read_knots(input, dis->name(), disknots);
+      auto disknots = Core::IO::read_knots(input, dis->name());
 
       if (disknots == nullptr)
       {
@@ -1746,7 +1743,7 @@ void Global::read_knots(Global::Problem& problem, Core::IO::InputFile& input)
       disknots->finish_knots(smallest_gid_in_dis);
 
       // add knots to discretisation
-      nurbsdis->set_knot_vector(disknots);
+      nurbsdis->set_knot_vector(std::move(disknots));
     }
   }  // loop fields
 }

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_volume_segmentation_geometry_functions_test.hpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_volume_segmentation_geometry_functions_test.hpp
@@ -504,15 +504,13 @@ namespace
     const std::string knotvectortype = "Interpolated";
     for (unsigned int dir = 0; dir < 3; dir++)
     {
-      std::shared_ptr<std::vector<double>> directions_knots =
-          std::make_shared<std::vector<double>>();
-      directions_knots->clear();
-      directions_knots->push_back(0.);
-      directions_knots->push_back(0.);
-      directions_knots->push_back(0.);
-      directions_knots->push_back(1.);
-      directions_knots->push_back(1.);
-      directions_knots->push_back(1.);
+      std::vector<double> directions_knots;
+      directions_knots.push_back(0.);
+      directions_knots.push_back(0.);
+      directions_knots.push_back(0.);
+      directions_knots.push_back(1.);
+      directions_knots.push_back(1.);
+      directions_knots.push_back(1.);
       knot_vector->set_knots(dir, 0, 2, 6, knotvectortype, directions_knots);
     }
     knot_vector->finish_knots(0);


### PR DESCRIPTION
The `KNOTVECTORS` sections are legacy sections that should become nested YAML. While looking through the code to see how this can be achieved, I performed a little cleanup.