### PR TITLE
Improve beaminteraction checks

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -342,24 +342,24 @@ void Solid::ModelEvaluator::BeamInteraction::set_sub_model_types()
 
   // Ensure that no point coupling condition connects two beams that are possibly in contact with
   // each other.
-  for (auto bpcc : beampenaltycouplingconditions)
+  for (auto beam_point_coupling_condition : beampenaltycouplingconditions)
   {
     // get all nodes of beam to beam point coupling condition
-    const std::vector<int>& nodes = *(bpcc->get_nodes());
+    const std::vector<int>& nodes = *(beam_point_coupling_condition->get_nodes());
     if (nodes.size() != 2)
       FOUR_C_THROW("Beam-to-beam point coupling condition should contain exactly two nodes.");
-    for (auto btbcc : beamtobeamcontactconditions)
+    for (auto beam_to_beam_contact_condition : beamtobeamcontactconditions)
     {
-      if (btbcc->contains_node(nodes[0]) and btbcc->contains_node(nodes[1]))
+      if (beam_to_beam_contact_condition->contains_node(nodes[0]) and
+          beam_to_beam_contact_condition->contains_node(nodes[1]))
       {
-        btbcc->print(std::cout);
-        bpcc->print(std::cout);
         FOUR_C_THROW(
             "It is not possible to use beam-to-beam contact in combination with "
             "beam-to-beam point coupling for the same node pair. Please reconsider the specified "
             "interaction conditions with the ids {} and {}, since they are intersecting at the "
             "nodes with ids {} and {}",
-            btbcc->id(), bpcc->id(), nodes[0], nodes[1]);
+            beam_to_beam_contact_condition->id(), beam_point_coupling_condition->id(), nodes[0],
+            nodes[1]);
       }
     }
   }

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -340,28 +340,26 @@ void Solid::ModelEvaluator::BeamInteraction::set_sub_model_types()
   std::vector<const Core::Conditions::Condition*> beamtobeamcontactconditions;
   discret_ptr_->get_condition("BeamToBeamContact", beamtobeamcontactconditions);
 
-  // ensure that no beam to beam contact condition is specified
-  // with a penalty point coupling condition
+  // Ensure that no point coupling condition connects two beams that are possibly in contact with
+  // each other.
   for (auto bpcc : beampenaltycouplingconditions)
   {
-    // get all nodes of beam to beam contact condition
-    const std::vector<int>* nodes = bpcc->get_nodes();
+    // get all nodes of beam to beam point coupling condition
+    const std::vector<int>& nodes = *(bpcc->get_nodes());
+    if (nodes.size() != 2)
+      FOUR_C_THROW("Beam-to-beam point coupling condition should contain exactly two nodes.");
     for (auto btbcc : beamtobeamcontactconditions)
     {
-      for (auto node : *nodes)
+      if (btbcc->contains_node(nodes[0]) and btbcc->contains_node(nodes[1]))
       {
-        if (btbcc->contains_node(node))
-        {
-          btbcc->print(std::cout);
-          bpcc->print(std::cout);
-          FOUR_C_THROW(
-              "It is not possible to use beam-to-beam contact in combination with "
-              "beam-to-beam point coupling for the same node. Please reconsider the specified "
-              "interaction conditions with the ids {} and {}, since they are intersecting at the "
-              "node with id "
-              "{}",
-              btbcc->id(), bpcc->id(), node);
-        }
+        btbcc->print(std::cout);
+        bpcc->print(std::cout);
+        FOUR_C_THROW(
+            "It is not possible to use beam-to-beam contact in combination with "
+            "beam-to-beam point coupling for the same node pair. Please reconsider the specified "
+            "interaction conditions with the ids {} and {}, since they are intersecting at the "
+            "nodes with ids {} and {}",
+            btbcc->id(), bpcc->id(), nodes[0], nodes[1]);
       }
     }
   }


### PR DESCRIPTION
## Description and Context

#1086 introduces a nice check for the compatibility of beam-to-beam point couplings and beam-to-beam contact pairs. This check is extended in such a way, that we don't allow point couplings between two beams that are potentially in contact with each other. Point couplings between two beams that are possibly in contact with other beams are OK.