### PR TITLE
Add logical operators to symbolic expressions

### DIFF
--- a/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
+++ b/src/core/utils/src/functions/4C_utils_symbolic_expression.cpp
@@ -7,7 +7,6 @@
 
 #include "4C_utils_symbolic_expression.hpp"
 
-
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::Utils::SymbolicExpressionDetails
@@ -32,14 +31,8 @@ namespace Core::Utils::SymbolicExpressionDetails
     }
   }
 
-  /*----------------------------------------------------------------------*/
-  /*!
-  \brief Identify current token
-         type: tok_,
-         value: integer_, real_,
-         operator name: str_
-  */
-  void Lexer::lexan()
+
+  void Lexer::advance()
   {
     for (;;)
     {
@@ -171,6 +164,90 @@ namespace Core::Utils::SymbolicExpressionDetails
         else if (t == ',')
         {
           tok_ = Lexer::tok_comma;
+          return;
+        }
+        else if (t == '>')
+        {
+          t = get_next();
+          if (t == '=')
+          {
+            tok_ = Lexer::tok_ge;
+            return;
+          }
+          if (t != EOF)
+          {
+            pos_--;
+          }
+          tok_ = Lexer::tok_gt;
+          return;
+        }
+        else if (t == '<')
+        {
+          t = get_next();
+          if (t == '=')
+          {
+            tok_ = Lexer::tok_le;
+            return;
+          }
+          if (t != EOF)
+          {
+            pos_--;
+          }
+          tok_ = Lexer::tok_lt;
+          return;
+        }
+        else if (t == '=')
+        {
+          t = get_next();
+          if (t == '=')
+          {
+            tok_ = Lexer::tok_eq;
+            return;
+          }
+          else
+          {
+            FOUR_C_THROW("unexpected char '{}' at pos {}", t, pos_);
+          }
+        }
+        else if (t == '&')
+        {
+          t = get_next();
+          if (t == '&')
+          {
+            tok_ = Lexer::tok_and;
+            return;
+          }
+          else
+          {
+            FOUR_C_THROW("unexpected char '{}' at pos {}", t, pos_);
+          }
+        }
+        else if (t == '|')
+        {
+          t = get_next();
+          if (t == '|')
+          {
+            tok_ = Lexer::tok_or;
+            return;
+          }
+          else
+          {
+            FOUR_C_THROW("unexpected char '{}' at pos {}", t, pos_);
+          }
+        }
+        else if (t == '!')
+        {
+          t = get_next();
+          if (t == '=')
+          {
+            tok_ = Lexer::tok_ne;
+            return;
+          }
+          if (t != EOF)
+          {
+            pos_--;
+          }
+          tok_ = Lexer::tok_bang;
           return;
         }
         else

--- a/src/core/utils/src/functions/4C_utils_symbolic_expression.hpp
+++ b/src/core/utils/src/functions/4C_utils_symbolic_expression.hpp
@@ -27,10 +27,12 @@ namespace Core::Utils
    * The class constructs a SymbolicExpression from an expression string. The expression must only
    * contain supported functions ("acos", "asin", "atan", "cos", "sin", "tan", "cosh", "sinh",
    * "tanh", "exp", "log", "log10", "sqrt", "heaviside", "fabs", "atan2") literals
-   * ('1.0', 'pi', 'e', 'E', etc) and supported operators ("+", "-", "*", "/", "^"). In
-   * addition, an arbitrary number of variables can be contained. Any substring that is not a number
-   * or supported function is parsed as a variable. When calling value(), first_derivative() or
-   * second_derivative(), the variables that have been parsed need to be supplied with a value.
+   * ('1.0', 'pi', 'e', 'E', etc) and supported operators ("+", "-", "*", "/", "^", ">", "<", "!",
+   * "&&", "||"). In addition, an arbitrary number of variables can be contained. Any substring that
+   * is not a number or supported function is parsed as a variable. When calling value(),
+   * first_derivative() or second_derivative(), the variables that have been parsed need to be
+   * supplied with a value. Note that the expression is parsed and compiled only once, so evaluating
+   * the same expression multiple times is efficient.
    *
    * There are two ways to use this class:
    *
@@ -59,7 +61,8 @@ namespace Core::Utils
    * expression only needs to be parsed and compiled once.
    *
    * @tparam Number: Only an arithmetic type is allowed for template parameter. So far only double
-   * is supported.
+   * is supported. In case you use logical operators like ">" or "<" in the expression, you will
+   * obtain 1.0 for true and 0.0 for false.
    */
 
   template <typename Number, CompileTimeString... variables>

--- a/src/core/utils/tests/functions/4C_utils_symbolic_expression_test.cpp
+++ b/src/core/utils/tests/functions/4C_utils_symbolic_expression_test.cpp
@@ -229,6 +229,46 @@ namespace
     EXPECT_DOUBLE_EQ(value, 16.0);
   }
 
+  TEST(SymbolicExpressionTest, Comparison)
+  {
+    Core::Utils::SymbolicExpression<double, "x", "y"> expr("x*y > 0");
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(2.0), Core::Utils::var<"y">(3.0)), 1.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(2.0), Core::Utils::var<"y">(-3.0)), 0.0);
+  }
+
+  TEST(SymbolicExpressionTest, Equality)
+  {
+    Core::Utils::SymbolicExpression<double, "x", "y"> expr("x == 2^2*y");
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(4.0), Core::Utils::var<"y">(1.0)), 1.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(0.0), Core::Utils::var<"y">(-3.0)), 0.0);
+  }
+
+  TEST(SymbolicExpressionTest, NotEqual)
+  {
+    Core::Utils::SymbolicExpression<double, "x", "y"> expr("x != 2^2*y");
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(4.0), Core::Utils::var<"y">(1.0)), 0.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(0.0), Core::Utils::var<"y">(-3.0)), 1.0);
+  }
+
+  TEST(SymbolicExpressionTest, SumOfComparisons)
+  {
+    Core::Utils::SymbolicExpression<double, "x", "y"> expr("(x*y > 0) + (x >= y)");
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(2.0), Core::Utils::var<"y">(1.0)), 2.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(0.0), Core::Utils::var<"y">(0.0)), 1.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(0.0), Core::Utils::var<"y">(1.0)), 0.0);
+  }
+
+  TEST(SymbolicExpressionTest, LogicalOperators)
+  {
+    // Note that || has lower precedence than &&
+    Core::Utils::SymbolicExpression<double, "x", "y"> expr(
+        "(x > 1.0 - 1.0) && (y > sin(0)) || (x <= !2) && !(y > 0)");
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(2.0), Core::Utils::var<"y">(3.0)), 1.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(-2.0), Core::Utils::var<"y">(-3.0)), 1.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(2.0), Core::Utils::var<"y">(-3.0)), 0.0);
+    EXPECT_DOUBLE_EQ(expr.value(Core::Utils::var<"x">(0.0), Core::Utils::var<"y">(3.0)), 0.0);
+  }
+
 
 }  // namespace
 FOUR_C_NAMESPACE_CLOSE


### PR DESCRIPTION
In order to implement https://github.com/4C-multiphysics/4C/issues/571#issuecomment-3214966458 but also as a general extension, this PR adds comparison operators (`>`, `>-=`, `<`, `<=`, `==`, `!=`) and logical operators (`!`, `&&` and `||`) to the SymbolicExpression.

I think this basically makes the `heaviside` function that was implemented before obsolete, because theses conditions are more powerful and readable. Compare e.g.

```
f(x) = 2*H(3 - x) + (2 + (x - 3))*(H(x - 3) - H(x - 7)) + 6*H(x - 7)
```

vs.

```
f(x) = (x < 3)*2 + ((x >= 3) && (x < 7))*(2 + (x - 3)) + (x >= 7)*6
```