### PR TITLE
Mock method `NOX::Epetra::LinearSystem::setJacobianOperatorForSolve()`

### DIFF
--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -183,18 +183,6 @@ Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystem::getJacobianOperator()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void NOX::FSI::LinearSystem::setJacobianOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
-{
-  jac_ptr_ =
-      Core::Utils::shared_ptr_from_ref(*Teuchos::rcp_const_cast<Epetra_Operator>(solveJacOp));
-  jac_type_ = get_operator_type(*solveJacOp);
-}
-
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void NOX::FSI::LinearSystem::throw_error(
     const std::string& functionName, const std::string& errorMsg) const
 {

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -90,10 +90,6 @@ namespace NOX::FSI
     /// Return Jacobian operator.
     Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-    /// Set Jacobian operator for solve.
-    void setJacobianOperatorForSolve(
-        const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
    private:
     /// throw an error
     void throw_error(const std::string& functionName, const std::string& errorMsg) const;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -405,14 +405,6 @@ Teuchos::RCP<Epetra_Operator> NOX::FSI::LinearSystemGCR::getJacobianOperator()
 }
 
 
-void NOX::FSI::LinearSystemGCR::setJacobianOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
-{
-  jacPtr = Teuchos::rcp_const_cast<Epetra_Operator>(solveJacOp);
-  jacType = get_operator_type(*solveJacOp);
-}
-
-
 void NOX::FSI::LinearSystemGCR::throw_error(
     const std::string& functionName, const std::string& errorMsg) const
 {

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -111,10 +111,6 @@ namespace NOX
       //! Return Jacobian operator
       Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-      //! Set Jacobian operator for solve
-      void setJacobianOperatorForSolve(
-          const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
       //! Returns the type of operator that is passed into the group constructors.
       /*! Uses dynamic casting to identify the underlying object type. */
       virtual OperatorType get_operator_type(const Epetra_Operator& o);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -519,20 +519,6 @@ const enum NOX::Nln::LinSystem::OperatorType& NOX::Nln::LinearSystem::get_jacobi
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void NOX::Nln::LinearSystem::setJacobianOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
-{
-  const Teuchos::RCP<const Core::LinAlg::SparseOperator>& linalgSprOp =
-      Teuchos::rcp_dynamic_cast<const Core::LinAlg::SparseOperator>(solveJacOp);
-  if (linalgSprOp.is_null())
-    throw_error("setJacobianOperatorForSolve", "dynamic_cast to LINALG_SparseOperator failed!");
-
-  set_jacobian_operator_for_solve(linalgSprOp);
-  return;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void NOX::Nln::LinearSystem::set_jacobian_operator_for_solve(
     const Teuchos::RCP<const Core::LinAlg::SparseOperator>& solveJacOp)
 {

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -158,11 +158,6 @@ namespace NOX
       //! Returns the operator type of the jacobian
       const enum NOX::Nln::LinSystem::OperatorType& get_jacobian_operator_type() const;
 
-      //! Set the jacobian operator
-      //! Derived function: Check if the input operator is a LINALG_SparseOperator
-      void setJacobianOperatorForSolve(
-          const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
       //! Set the jacobian operator of this class
       void set_jacobian_operator_for_solve(
           const Teuchos::RCP<const Core::LinAlg::SparseOperator>& solveJacOp);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.cpp
@@ -88,4 +88,10 @@ bool NOX::Nln::LinearSystemBase::applyRightPreconditioning(bool useTranspose,
   return true;
 }
 
+void NOX::Nln::LinearSystemBase::setJacobianOperatorForSolve(
+    const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
+{
+  (void)solveJacOp;
+}
+
 FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -126,6 +126,21 @@ namespace NOX
        */
       bool applyRightPreconditioning(bool useTranspose, Teuchos::ParameterList& params,
           const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const final;
+
+      /**
+       * \brief Set Jacobian operator for solve.
+       *
+       * This method is in fact does nothing, because the only (strange) use of this method in
+       * Trilinos, which is relevant for 4C, is the following call inside NOX::Epetra::Group
+       *
+       * sharedLinearSystem.getObject(this)->setJacobianOperatorForSolve(
+       *   sharedLinearSystem.getObject(this)->getJacobianOperator());
+       *
+       * We could have implemented this method to covert the Teuchos::RCP to a std::shared_ptr, but
+       * that would loose the ownership information, and for the use pattern shown above it can be
+       * quite dangerous as the wrapped object might get deleted.
+       */
+      void setJacobianOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solveJacOp) final;
     };
   }  // namespace Nln
 }  // namespace NOX

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -198,16 +198,6 @@ Teuchos::RCP<Epetra_Operator> NOX::Solid::LinearSystem::getJacobianOperator()
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void NOX::Solid::LinearSystem::setJacobianOperatorForSolve(
-    const Teuchos::RCP<const Epetra_Operator>& solveJacOp)
-{
-  jacPtr_ = Core::Utils::shared_ptr_from_ref(*Teuchos::rcp_const_cast<Epetra_Operator>(solveJacOp));
-  jacType_ = get_operator_type(*solveJacOp);
-}
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
 void NOX::Solid::LinearSystem::throw_error(
     const std::string& functionName, const std::string& errorMsg) const
 {

--- a/src/structure/4C_structure_timint_noxlinsys.hpp
+++ b/src/structure/4C_structure_timint_noxlinsys.hpp
@@ -101,10 +101,6 @@ namespace NOX
       /// Return Jacobian operator.
       Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-      /// Set Jacobian operator for solve.
-      void setJacobianOperatorForSolve(
-          const Teuchos::RCP<const Epetra_Operator>& solveJacOp) override;
-
      protected:
       /// throw an error
       virtual void throw_error(const std::string& functionName, const std::string& errorMsg) const;


### PR DESCRIPTION
## Description and Context
This method is used in a single place and does there quite a strange thing: https://github.com/trilinos/Trilinos/blob/8cea8978b961ed2c52ab41c223d9268d6348e40b/packages/nox/src-epetra/NOX_Epetra_Group.C#L388-L391. So we can just mock it for all our linear systems.

## Related Issues and Pull Requests
#1077, #1098