### PR TITLE
ASAN: only suppress report on specific memory leaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,9 +171,13 @@ four_c_process_cache_variable(
 set(_mpiexec_all_args_for_testing ${FOUR_C_MPIEXEC_ARGS_FOR_TESTING})
 
 if(FOUR_C_ENABLE_ADDRESS_SANITIZER)
+  set(_suppressions_file ${PROJECT_BINARY_DIR}/tests/asan_leak_suppressions.txt)
+  configure_file(tests/asan_leak_suppressions.txt ${_suppressions_file} COPYONLY)
   # Do not detect leaks, we only care about UB inducing memory issues
-  string(APPEND _mpiexec_all_args_for_testing " -x LSAN_OPTIONS=detect_leaks=0")
-  set(FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS "LSAN_OPTIONS=detect_leaks=0")
+  string(APPEND _mpiexec_all_args_for_testing " -x LSAN_OPTIONS=suppressions=${_suppressions_file}")
+  set(FOUR_C_ENABLE_ADDRESS_SANITIZER_TEST_OPTIONS
+      "LSAN_OPTIONS=suppressions=${_suppressions_file}"
+      )
 endif()
 
 set(FOUR_C_EXECUTABLE_NAME 4C)

--- a/tests/asan_leak_suppressions.txt
+++ b/tests/asan_leak_suppressions.txt
@@ -1,0 +1,26 @@
+# Known memory leaks to suppress for AddressSanitizer leak detection
+
+###
+# Leaks from other libraries (not our fault)
+###
+
+# MPI
+# Note: this list was done for OpenMPI which we use in CI
+leak:MPI_Init
+leak:libevent
+leak:event_base_loop
+# MPI_Finalize does not necessarily show up in the stack trace, but this destructor does
+leak:~CleanUpMPI
+
+# CLN
+# leak:base/cl_malloc.cc
+
+# Catch all remaining leaks from other libraries
+# A more specific suppression would be better, but the originating function or lib names are not symbolized.
+# At least it is better to only ignore leaks coming from strdup, than ignoring all leaks.
+leak:strdup
+
+
+###
+# Leaks from our code that we have chosen to ignore (including link to respective GitHub issue or reason)
+###


### PR DESCRIPTION
Way back when I introduced AddressSanitizer (ASAN) years ago on Gitlab, we had enough to do to fix the serious memory errors. Memory leak reports were always suppressed since then. This PR makes the various suppressions explicit. Draft for now, maybe I can fix a few leaks right away.

Related to #413 