### PR TITLE
Remove some Jacobian types handling

### DIFF
--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.cpp
@@ -33,7 +33,6 @@ NOX::FSI::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::shared_ptr<NOX::Nln::Scaling> s)
     : utils_(printParams),
       jac_interface_ptr_(iJac),
-      jac_type_(EpetraOperator),
       jac_ptr_(J),
       operator_(J),
       scaling_(s),
@@ -43,36 +42,7 @@ NOX::FSI::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
 {
   tmp_vector_ptr_ = std::make_shared<::NOX::Epetra::Vector>(cloneVector);
 
-  jac_type_ = get_operator_type(*jac_ptr_);
-
   reset(linearSolverParams);
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-NOX::FSI::LinearSystem::OperatorType NOX::FSI::LinearSystem::get_operator_type(
-    const Epetra_Operator& Op)
-{
-  // check via dynamic cast, which type of Jacobian was broadcast
-  const Epetra_Operator* testOperator = nullptr;
-
-  testOperator = dynamic_cast<
-      const Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>*>(&Op);
-  if (testOperator != nullptr) return BlockSparseMatrix;
-
-  testOperator = dynamic_cast<const Core::LinAlg::SparseMatrix*>(&Op);
-  if (testOperator != nullptr) return SparseMatrix;
-
-  testOperator = dynamic_cast<const Epetra_CrsMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraCrsMatrix;
-
-  testOperator = dynamic_cast<const Epetra_VbrMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraVbrMatrix;
-
-  testOperator = dynamic_cast<const Epetra_RowMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraRowMatrix;
-
-  return EpetraOperator;
 }
 
 

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -38,17 +38,6 @@ namespace NOX::FSI
 {
   class LinearSystem : public NOX::Nln::LinearSystemBase
   {
-   private:
-    enum OperatorType
-    {
-      EpetraOperator,
-      EpetraRowMatrix,
-      EpetraVbrMatrix,
-      EpetraCrsMatrix,
-      SparseMatrix,
-      BlockSparseMatrix
-    };
-
    public:
     LinearSystem(Teuchos::ParameterList& printParams,  ///< printing parameters
         Teuchos::ParameterList& linearSolverParams,    ///< parameters for linear solution
@@ -61,9 +50,6 @@ namespace NOX::FSI
             structure_solver,  ///< (used-defined) linear algebraic solver
         const std::shared_ptr<NOX::Nln::Scaling> scalingObject =
             nullptr);  ///< scaling of the linear system
-
-    /// provide storage pattern of tangent matrix, i.e. the operator
-    OperatorType get_operator_type(const Epetra_Operator& Op);
 
     ///
     void reset(Teuchos::ParameterList& linearSolverParams);
@@ -97,7 +83,6 @@ namespace NOX::FSI
     ::NOX::Utils utils_;
 
     std::shared_ptr<::NOX::Epetra::Interface::Jacobian> jac_interface_ptr_;
-    OperatorType jac_type_;
     mutable std::shared_ptr<Epetra_Operator> jac_ptr_;
     mutable std::shared_ptr<Core::LinAlg::SparseOperator> operator_;
     std::shared_ptr<NOX::Nln::Scaling> scaling_;

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.cpp
@@ -43,9 +43,6 @@ NOX::FSI::LinearSystemGCR::LinearSystemGCR(Teuchos::ParameterList& printParams,
   // Allocate solver
   tmpVectorPtr = std::make_shared<::NOX::Epetra::Vector>(cloneVector);
 
-  // Jacobian operator is supplied
-  jacType = get_operator_type(*jacPtr);
-
   reset(linearSolverParams);
 }
 
@@ -415,30 +412,5 @@ void NOX::FSI::LinearSystemGCR::throw_error(
   throw "NOX Error";
 }
 
-
-NOX::FSI::LinearSystemGCR::OperatorType NOX::FSI::LinearSystemGCR::get_operator_type(
-    const Epetra_Operator& Op)
-{
-  //***************
-  //*** NOTE: The order in which the following tests occur is important!
-  //***************
-
-  const Epetra_Operator* testOperator = nullptr;
-
-  // Is it an Epetra_CrsMatrix ?
-  testOperator = dynamic_cast<const Epetra_CrsMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraCrsMatrix;
-
-  // Is it an Epetra_VbrMatrix ?
-  testOperator = dynamic_cast<const Epetra_VbrMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraVbrMatrix;
-
-  // Is it an Epetra_RowMatrix ?
-  testOperator = dynamic_cast<const Epetra_RowMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraRowMatrix;
-
-  // Otherwise it must be an Epetra_Operator!
-  return EpetraOperator;
-}
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem_gcr.hpp
@@ -111,10 +111,6 @@ namespace NOX
       //! Return Jacobian operator
       Teuchos::RCP<Epetra_Operator> getJacobianOperator() override;
 
-      //! Returns the type of operator that is passed into the group constructors.
-      /*! Uses dynamic casting to identify the underlying object type. */
-      virtual OperatorType get_operator_type(const Epetra_Operator& o);
-
      protected:
       /// generalized conjugate residual solver
       /*!

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.cpp
@@ -44,7 +44,7 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       solvers_(solvers),
       reqInterfacePtr_(iReq),
       jacInterfacePtr_(iJac),
-      jacType_(NOX::Nln::LinSystem::LinalgSparseOperator),
+      jacType_(NOX::Nln::Aux::get_operator_type(*jacobian_op)),
       scaling_(scalingObject),
       conditionNumberEstimate_(0.0),
       timer_("", true),
@@ -53,9 +53,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       prePostOperatorPtr_(Teuchos::null),
       jac_ptr_(jacobian_op)
 {
-  // Jacobian operator is supplied
-  jacType_ = NOX::Nln::Aux::get_operator_type(jacobian());
-
   reset(linearSolverParams);
 }
 
@@ -73,7 +70,7 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       solvers_(solvers),
       reqInterfacePtr_(iReq),
       jacInterfacePtr_(iJac),
-      jacType_(NOX::Nln::LinSystem::LinalgSparseOperator),
+      jacType_(NOX::Nln::Aux::get_operator_type(*jacobian_op)),
       scaling_(nullptr),
       conditionNumberEstimate_(0.0),
       timer_("", true),
@@ -82,9 +79,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       prePostOperatorPtr_(Teuchos::null),
       jac_ptr_(jacobian_op)
 {
-  // Jacobian operator is supplied
-  jacType_ = NOX::Nln::Aux::get_operator_type(jacobian());
-
   reset(linearSolverParams);
 }
 
@@ -102,7 +96,7 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       solvers_(solvers),
       reqInterfacePtr_(iReq),
       jacInterfacePtr_(iJac),
-      jacType_(NOX::Nln::LinSystem::LinalgSparseOperator),
+      jacType_(NOX::Nln::Aux::get_operator_type(*jacobian_op)),
       scaling_(scalingObject),
       conditionNumberEstimate_(0.0),
       timer_("", true),
@@ -111,9 +105,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       prePostOperatorPtr_(Teuchos::null),
       jac_ptr_(jacobian_op)
 {
-  // Jacobian operator is supplied
-  jacType_ = NOX::Nln::Aux::get_operator_type(jacobian());
-
   reset(linearSolverParams);
 }
 
@@ -130,7 +121,7 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       solvers_(solvers),
       reqInterfacePtr_(iReq),
       jacInterfacePtr_(iJac),
-      jacType_(NOX::Nln::LinSystem::LinalgSparseOperator),
+      jacType_(NOX::Nln::Aux::get_operator_type(*jacobian_op)),
       scaling_(nullptr),
       conditionNumberEstimate_(0.0),
       timer_("", true),
@@ -139,9 +130,6 @@ NOX::Nln::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
       prePostOperatorPtr_(Teuchos::null),
       jac_ptr_(jacobian_op)
 {
-  // Jacobian operator is supplied
-  jacType_ = NOX::Nln::Aux::get_operator_type(jacobian());
-
   reset(linearSolverParams);
 }
 
@@ -515,18 +503,6 @@ const enum NOX::Nln::LinSystem::OperatorType& NOX::Nln::LinearSystem::get_jacobi
     const
 {
   return jacType_;
-}
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-void NOX::Nln::LinearSystem::set_jacobian_operator_for_solve(
-    const Teuchos::RCP<const Core::LinAlg::SparseOperator>& solveJacOp)
-{
-  if (jacType_ != NOX::Nln::Aux::get_operator_type(*solveJacOp))
-    throw_error("set_jacobian_operator_for_solve", "wrong operator type!");
-
-  jac_ptr_ = Teuchos::rcp_const_cast<Core::LinAlg::SparseOperator>(solveJacOp);
-  return;
 }
 
 /*----------------------------------------------------------------------*

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem.hpp
@@ -158,10 +158,6 @@ namespace NOX
       //! Returns the operator type of the jacobian
       const enum NOX::Nln::LinSystem::OperatorType& get_jacobian_operator_type() const;
 
-      //! Set the jacobian operator of this class
-      void set_jacobian_operator_for_solve(
-          const Teuchos::RCP<const Core::LinAlg::SparseOperator>& solveJacOp);
-
       //! destroy the jacobian ptr
       bool destroy_jacobian();
 

--- a/src/structure/4C_structure_timint_noxlinsys.cpp
+++ b/src/structure/4C_structure_timint_noxlinsys.cpp
@@ -35,7 +35,6 @@ NOX::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
     const std::shared_ptr<NOX::Nln::Scaling> s)
     : utils_(printParams),
       jacInterfacePtr_(iJac),
-      jacType_(EpetraOperator),
       jacPtr_(J),
       scaling_(s),
       conditionNumberEstimate_(0.0),
@@ -48,41 +47,7 @@ NOX::Solid::LinearSystem::LinearSystem(Teuchos::ParameterList& printParams,
 
   // std::cout << "STRUCTURE SOLVER: " << *structureSolver_ << " " << structureSolver_ << std::endl;
 
-  // Jacobian operator is supplied.
-  // get type of it
-  jacType_ = get_operator_type(*jacPtr_);
-
   reset(linearSolverParams);
-}
-
-
-
-/*----------------------------------------------------------------------*
- *----------------------------------------------------------------------*/
-NOX::Solid::LinearSystem::OperatorType NOX::Solid::LinearSystem::get_operator_type(
-    const Epetra_Operator& Op)
-{
-  // check per dynamik cast, which type of Jacobian was broadcast
-
-  const Epetra_Operator* testOperator = nullptr;
-
-  testOperator = dynamic_cast<
-      const Core::LinAlg::BlockSparseMatrix<Core::LinAlg::DefaultBlockMatrixStrategy>*>(&Op);
-  if (testOperator != nullptr) return BlockSparseMatrix;
-
-  testOperator = dynamic_cast<const Core::LinAlg::SparseMatrix*>(&Op);
-  if (testOperator != nullptr) return SparseMatrix;
-
-  testOperator = dynamic_cast<const Epetra_CrsMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraCrsMatrix;
-
-  testOperator = dynamic_cast<const Epetra_VbrMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraVbrMatrix;
-
-  testOperator = dynamic_cast<const Epetra_RowMatrix*>(&Op);
-  if (testOperator != nullptr) return EpetraRowMatrix;
-
-  return EpetraOperator;
 }
 
 
@@ -133,23 +98,19 @@ bool NOX::Solid::LinearSystem::applyJacobianInverse(
   double tol = p.get("Tolerance", 1.0e-10);
 
   // Structure
-  if (jacType_ == SparseMatrix)
-  {
-    std::shared_ptr<Core::LinAlg::Vector<double>> fres =
-        std::make_shared<Core::LinAlg::Vector<double>>(input.getEpetraVector());
-    Core::LinAlg::View result_view(result.getEpetraVector());
-    Core::LinAlg::SparseMatrix* J = dynamic_cast<Core::LinAlg::SparseMatrix*>(jacPtr_.get());
-    Core::LinAlg::SolverParams solver_params;
-    solver_params.refactor = true;
-    solver_params.reset = callcount_ == 0;
-    structureSolver_->solve(Core::Utils::shared_ptr_from_ref(*J),
-        Core::Utils::shared_ptr_from_ref(result_view.underlying()), fres, solver_params);
-    callcount_ += 1;
-  }
-  else
-  {
-    FOUR_C_THROW("Cannot deal with Epetra_Operator of type {}", jacType_);
-  }
+  std::shared_ptr<Core::LinAlg::Vector<double>> fres =
+      std::make_shared<Core::LinAlg::Vector<double>>(input.getEpetraVector());
+  Core::LinAlg::View result_view(result.getEpetraVector());
+  Core::LinAlg::SparseOperator* J = dynamic_cast<Core::LinAlg::SparseOperator*>(jacPtr_.get());
+
+  FOUR_C_ASSERT(J, "NOX::Solid::LinearSystem works only with Core::LinAlg::SparseOperator");
+
+  Core::LinAlg::SolverParams solver_params;
+  solver_params.refactor = true;
+  solver_params.reset = callcount_ == 0;
+  structureSolver_->solve(Core::Utils::shared_ptr_from_ref(*J),
+      Core::Utils::shared_ptr_from_ref(result_view.underlying()), fres, solver_params);
+  callcount_ += 1;
 
   // Set the output parameters in the "Output" sublist
   if (outputSolveDetails_)

--- a/src/structure/4C_structure_timint_noxlinsys.hpp
+++ b/src/structure/4C_structure_timint_noxlinsys.hpp
@@ -72,10 +72,6 @@ namespace NOX
               structure_solver,  ///< (used-defined) linear algebraic solver
           const std::shared_ptr<NOX::Nln::Scaling> scalingObject = nullptr);
 
-
-      /// provide storage pattern of tangent matrix, i.e. the operator
-      virtual OperatorType get_operator_type(const Epetra_Operator& Op);
-
       ///
       virtual void reset(Teuchos::ParameterList& linearSolverParams);
 
@@ -109,7 +105,6 @@ namespace NOX
       ::NOX::Utils utils_;
 
       std::shared_ptr<::NOX::Epetra::Interface::Jacobian> jacInterfacePtr_;
-      OperatorType jacType_;
       mutable std::shared_ptr<Epetra_Operator> jacPtr_;
       std::shared_ptr<NOX::Nln::Scaling> scaling_;
       mutable std::shared_ptr<::NOX::Epetra::Vector> tmpVectorPtr_;


### PR DESCRIPTION
## Description and Context
In certain parts of the code there are some objects which carry the so-called Jacobian type information based on whether the pointer was successfully dynamic casted to a particular type. I think this pattern should not be used at all, as it breaks the whole idea of polymorphism and is a clear hack for overcoming the limitations of the original design desicions. A couple of places `jacType`s still remain, they need a bit more work to get removed, so this is to be performed in a follow up PR.

## Related Issues and Pull Requests
#1077, #1098, #1146