### PR TITLE
[solver] Replace Epetra_Operator with SparseOperator in preconditioner setup

### DIFF
--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.cpp
@@ -44,12 +44,11 @@ std::shared_ptr<Epetra_Operator> Core::LinearSolver::AmGnxnPreconditioner::prec_
 /*------------------------------------------------------------------------------*/
 /*------------------------------------------------------------------------------*/
 
-void Core::LinearSolver::AmGnxnPreconditioner::setup(Epetra_Operator* matrix,
-    Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
+void Core::LinearSolver::AmGnxnPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
+    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
 {
   // Check whether this is a block sparse matrix
-  Core::LinAlg::BlockSparseMatrixBase* A_bl =
-      dynamic_cast<Core::LinAlg::BlockSparseMatrixBase*>(matrix);
+  auto* A_bl = dynamic_cast<Core::LinAlg::BlockSparseMatrixBase*>(&matrix);
   if (A_bl == nullptr)
     FOUR_C_THROW(
         "The AMGnxn preconditioner works only for BlockSparseMatrixBase or derived classes");

--- a/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.hpp
+++ b/src/core/linear_solver/src/amgnxn/4C_linear_solver_amgnxn_preconditioner.hpp
@@ -35,8 +35,8 @@ namespace Core::LinearSolver
    public:
     AmGnxnPreconditioner(Teuchos::ParameterList& params);
 
-    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
-        Core::LinAlg::MultiVector<double>* b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
+        Core::LinAlg::MultiVector<double>& b) override;
 
     virtual void setup(std::shared_ptr<Core::LinAlg::BlockSparseMatrixBase> A);
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_iterative.cpp
@@ -72,7 +72,7 @@ void Core::LinearSolver::IterativeSolver::setup(std::shared_ptr<Core::LinAlg::Sp
       std::cout << "*******************************************************" << std::endl;
     }
 
-    preconditioner_->setup(&a_->epetra_operator(), x_.get(), b_.get());
+    preconditioner_->setup(*a_, *x_, *b_);
   }
   else
   {

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_ifpack.hpp
@@ -29,8 +29,8 @@ namespace Core::LinearSolver
     IFPACKPreconditioner(Teuchos::ParameterList& ifpacklist, Teuchos::ParameterList& solverlist);
 
     //! Setup
-    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
-        Core::LinAlg::MultiVector<double>* b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
+        Core::LinAlg::MultiVector<double>& b) override;
 
     /// linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const override { return prec_; }

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.cpp
@@ -22,10 +22,10 @@ Core::LinearSolver::KrylovProjectionPreconditioner::KrylovProjectionPrecondition
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::KrylovProjectionPreconditioner::setup(Epetra_Operator* matrix,
-    Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
+void Core::LinearSolver::KrylovProjectionPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
+    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
 {
-  projector_->apply_pt(*b);
+  projector_->apply_pt(b);
 
   // setup wrapped preconditioner
   preconditioner_->setup(matrix, x, b);

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_krylovprojection.hpp
@@ -30,8 +30,8 @@ namespace Core::LinearSolver
     KrylovProjectionPreconditioner(std::shared_ptr<PreconditionerTypeBase> preconditioner,
         std::shared_ptr<Core::LinAlg::KrylovProjector> projector);
 
-    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
-        Core::LinAlg::MultiVector<double>* b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
+        Core::LinAlg::MultiVector<double>& b) override;
 
     /// linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const override { return p_; }

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.cpp
@@ -49,23 +49,22 @@ Core::LinearSolver::MueLuPreconditioner::MueLuPreconditioner(Teuchos::ParameterL
 
 //----------------------------------------------------------------------------------
 //----------------------------------------------------------------------------------
-void Core::LinearSolver::MueLuPreconditioner::setup(Epetra_Operator* matrix,
-    Core::LinAlg::MultiVector<double>* x, Core::LinAlg::MultiVector<double>* b)
+void Core::LinearSolver::MueLuPreconditioner::setup(Core::LinAlg::SparseOperator& matrix,
+    const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b)
 {
   using EpetraCrsMatrix = Xpetra::EpetraCrsMatrixT<GO, NO>;
   using EpetraMap = Xpetra::EpetraMapT<GO, NO>;
   using EpetraMultiVector = Xpetra::EpetraMultiVectorT<GO, NO>;
 
   Teuchos::RCP<Core::LinAlg::BlockSparseMatrixBase> A =
-      Teuchos::rcp_dynamic_cast<Core::LinAlg::BlockSparseMatrixBase>(Teuchos::rcpFromRef(*matrix));
+      Teuchos::rcp_dynamic_cast<Core::LinAlg::BlockSparseMatrixBase>(Teuchos::rcpFromRef(matrix));
 
   if (A.is_null())
   {
-    Teuchos::RCP<Epetra_CrsMatrix> crsA =
-        Teuchos::rcp_dynamic_cast<Epetra_CrsMatrix>(Teuchos::rcpFromRef(*matrix));
+    auto crsA = Teuchos::rcp_dynamic_cast<Core::LinAlg::SparseMatrix>(Teuchos::rcpFromRef(matrix));
 
     Teuchos::RCP<Xpetra::CrsMatrix<SC, LO, GO, NO>> mueluA =
-        Teuchos::make_rcp<EpetraCrsMatrix>(crsA);
+        Teuchos::make_rcp<EpetraCrsMatrix>(Teuchos::rcpFromRef(crsA->epetra_matrix()));
     pmatrix_ = Xpetra::MatrixFactory<SC, LO, GO, NO>::BuildCopy(
         Teuchos::make_rcp<Xpetra::CrsMatrixWrap<SC, LO, GO, NO>>(mueluA));
 

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_muelu.hpp
@@ -56,8 +56,8 @@ namespace Core::LinearSolver
      * @param x Solution of the linear system
      * @param b Right-hand side of the linear system
      */
-    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
-        Core::LinAlg::MultiVector<double>* b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
+        Core::LinAlg::MultiVector<double>& b) override;
 
     //! linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const final

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_teko.hpp
@@ -33,8 +33,8 @@ namespace Core::LinearSolver
    public:
     TekoPreconditioner(Teuchos::ParameterList& tekolist);
 
-    void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
-        Core::LinAlg::MultiVector<double>* b) override;
+    void setup(Core::LinAlg::SparseOperator& matrix, const Core::LinAlg::MultiVector<double>& x,
+        Core::LinAlg::MultiVector<double>& b) override;
 
     /// linear operator used for preconditioning
     std::shared_ptr<Epetra_Operator> prec_operator() const override { return p_; }

--- a/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
+++ b/src/core/linear_solver/src/preconditioner/4C_linear_solver_preconditioner_type.hpp
@@ -10,6 +10,7 @@
 
 #include "4C_config.hpp"
 
+#include "4C_linalg_sparseoperator.hpp"
 #include "4C_linalg_vector.hpp"
 
 #include <Epetra_Operator.h>
@@ -39,8 +40,8 @@ namespace Core::LinearSolver
     virtual ~PreconditionerTypeBase() = default;
 
     /// Setup preconditioner with a given linear system.
-    virtual void setup(Epetra_Operator* matrix, Core::LinAlg::MultiVector<double>* x,
-        Core::LinAlg::MultiVector<double>* b) = 0;
+    virtual void setup(Core::LinAlg::SparseOperator& matrix,
+        const Core::LinAlg::MultiVector<double>& x, Core::LinAlg::MultiVector<double>& b) = 0;
 
     /// linear operator used for preconditioning
     virtual std::shared_ptr<Epetra_Operator> prec_operator() const = 0;


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR modifies the preconditioner setup function such that it takes a `Core::LinAlg::SparseOperator` as input instead of an `Epetra_Operator`.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #863 