### PR TITLE
Add workflow to test fourcipp

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -309,3 +309,43 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+
+  test_fourcipp:
+    runs-on: ubuntu-latest
+    needs: clang18_build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          repository: 4C-multiphysics/fourcipp
+      - name: Set up virtual environment
+        uses: conda-incubator/setup-miniconda@v3.2.0
+        with:
+          auto-update-conda: true
+          conda-remove-defaults: true
+          activate-environment: fourcipp
+          python-version: 3.12
+      - name: Install requirements from FourCIPP
+        shell: bash -el {0}
+        run: |
+          pip install .
+      - name: Download schema file from current pull request
+        uses: actions/download-artifact@v5
+        with:
+          name: clang18_build-schema
+          path: ${{ github.workspace }}/latest_metadata_schema/
+
+      - name: Download metadata file from current pull request
+        uses: actions/download-artifact@v5
+        with:
+          name: clang18_build-metadata
+          path: ${{ github.workspace }}/latest_metadata_schema/
+      - name: Move current metadata and schema file into FourCIPP (continue to use default profile)
+        shell: bash -el {0}
+        run: |
+          mv ${{ github.workspace }}/latest_metadata_schema/4C_metadata.json ${{ github.workspace }}/src/fourcipp/config/4C_metadata.json
+          mv ${{ github.workspace }}/latest_metadata_schema/4C_schema.json ${{ github.workspace }}/src/fourcipp/config/4C_schema.json
+      - name: Run pytest
+        shell: bash -el {0}
+        run: |
+          pytest --color=yes -v --no-cov


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

First part of #973.

Some points to discuss:

- We definitely need the metadata/schema file from the clang18 build of each PR. Currently, the `fourcipp_test` is executed after `buildtest` completed. Ideally, it should start after the clang18 build is finished and not the entire workflow. Unfortunately, as far as I know it is not possible to start a workflow based on an individual job from another workflow. We could move the `fourcipp_test` to the `buildtest` but I do not really like this idea. @amgebauer any tips/tricks/ideas?
    
- We should also lint the 4C input files with FourCIPP as @gilrrei stated in https://github.com/4C-multiphysics/4C/issues/973#issuecomment-3056277376. @gilrrei what is your vision there? Is this necessary if we already validate all input files against the latest schema in the clang18 build?

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->

#973