### PR TITLE
Generalize external mesh input

### DIFF
--- a/src/core/io/src/4C_io_exodus.hpp
+++ b/src/core/io/src/4C_io_exodus.hpp
@@ -11,6 +11,7 @@
 #include "4C_config.hpp"
 
 #include "4C_fem_general_element.hpp"
+#include "4C_io_mesh.hpp"
 
 #include <filesystem>
 #include <string>
@@ -20,29 +21,6 @@ FOUR_C_NAMESPACE_OPEN
 
 namespace Core::IO::Exodus
 {
-  enum class VerbosityLevel : int
-  {
-    none = 0,              ///< no output,
-    summary = 1,           ///< output of summary for blocks and sets,
-    detailed_summary = 2,  ///< output of summary for each block and set,
-    detailed = 3,          ///< detailed output for each block and set,
-    full = 4               ///< detailed output, even for nodes and element connectivities
-  };
-  constexpr bool operator>(VerbosityLevel lhs, VerbosityLevel rhs)
-  {
-    return static_cast<int>(lhs) > static_cast<int>(rhs);
-  }
-
-  /**
-   * Describe each of the VerbosityLevel options.
-   */
-  std::string describe(VerbosityLevel level);
-
-
-  struct ElementBlock;
-  struct NodeSet;
-  struct SideSet;
-
   /**
    * Additional parameters that are used in the constructor.
    */
@@ -55,156 +33,8 @@ namespace Core::IO::Exodus
     int node_start_id{1};
   };
 
-  /**
-   * A class that stores the mesh information read from an Exodus file.
-   */
-  class Mesh
-  {
-   public:
-    /**
-     * @brief Read a mesh from an Exodus file.
-     *
-     * Read the data from the Exodus file and store it in the class. The optional @p
-     * mesh_data can be used to set options documented in the MeshParameters struct.
-     */
-    Mesh(std::filesystem::path exodus_file, MeshParameters mesh_parameters = {});
-
-    /** Print mesh info
-     *  parameter:
-     *  os (std::ostream): output stream
-     *  verbose (VerbosityLevel): verbosity
-     */
-    void print(std::ostream& os, VerbosityLevel verbose) const;
-
-    //! Get number of nodes in mesh
-    [[nodiscard]] std::size_t get_num_nodes() const { return nodes_.size(); }
-
-    //! Get number of elements in mesh
-    [[nodiscard]] std::size_t get_num_elements() const { return num_elem_; }
-
-    //! Get ElementBlock map
-    [[nodiscard]] const std::map<int, ElementBlock>& get_element_blocks() const
-    {
-      return element_blocks_;
-    }
-
-    //! Get Number of ElementBlocks
-    [[nodiscard]] std::size_t get_num_element_blocks() const { return element_blocks_.size(); }
-
-    //! Get one ElementBlock
-    [[nodiscard]] const ElementBlock& get_element_block(const int id) const;
-
-    //! Get NodeSet map
-    [[nodiscard]] const std::map<int, NodeSet>& get_node_sets() const { return node_sets_; }
-
-    //! Get one NodeSet
-    [[nodiscard]] NodeSet get_node_set(const int id) const;
-
-    //! Get SideSet map
-    [[nodiscard]] std::map<int, SideSet> get_side_sets() const { return side_sets_; }
-
-    //! Get one SideSet
-    [[nodiscard]] const SideSet& get_side_set(const int id) const;
-
-    //! Get Node map
-    [[nodiscard]] const std::map<int, std::vector<double>>& get_nodes() const { return nodes_; }
-
-    //! Get one nodal coords
-    [[nodiscard]] const std::vector<double>& get_node(const int node_id) const;
-
-   private:
-    MeshParameters mesh_parameters_;
-
-    std::map<int, std::vector<double>> nodes_;
-
-    std::map<int, ElementBlock> element_blocks_;
-
-    std::map<int, NodeSet> node_sets_;
-
-    std::map<int, SideSet> side_sets_;
-
-    //! Number of spatial dimensions in the mesh file.
-    int spatial_dimension_{};
-
-    //! number of elements
-    std::size_t num_elem_{};
-
-    //! title
-    std::string title_;
-
-    //! exodus filename
-    std::filesystem::path exodus_filename_;
-  };
-
-
-  /**
-   * An EXODUS element block. This encodes a collection of elements of the same type.
-   */
-  struct ElementBlock
-  {
-    /**
-     * The type of the elements in the element block.
-     */
-    FE::CellType cell_type;
-
-    /**
-     * Elements in this block. The keys are the element IDs, and the values are the IDs of the nodes
-     * making up the element.
-     */
-    std::map<int, std::vector<int>> elements;
-
-    /**
-     * The name of the element block. This may be an empty string.
-     */
-    std::string name;
-
-    /**
-     * Pretty-print information about the element block.
-     */
-    void print(std::ostream& os, VerbosityLevel verbose = VerbosityLevel::none) const;
-  };
-
-  /**
-   * An EXODUS node set. This encodes a collection of nodes.
-   */
-  struct NodeSet
-  {
-    /**
-     *  The IDs of the nodes in the node set.
-     */
-    std::vector<int> node_ids;
-
-    /**
-     * The name of the node set. This may be an empty string.
-     */
-    std::string name;
-
-    /**
-     * Pretty-print information about the node set.
-     */
-    void print(std::ostream& os, VerbosityLevel verbose = VerbosityLevel::none) const;
-  };
-
-  /**
-   * An EXODUS side set. This encodes a collection of sides/faces of elements.
-   */
-  struct SideSet
-  {
-    /**
-     * The IDs of the nodes making up the sides of the side set.
-     */
-    std::map<int, std::vector<int>> sides;
-
-    /**
-     * The name of the side set. This may be an empty string.
-     */
-    std::string name;
-
-    /**
-     * Pretty-print information about the side set.
-     */
-    void print(std::ostream& os, VerbosityLevel verbose = VerbosityLevel::none) const;
-  };
+  MeshInput::Mesh read_exodus_file(
+      const std::filesystem::path& exodus_file, MeshParameters mesh_parameters = {});
 }  // namespace Core::IO::Exodus
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_mesh.cpp
+++ b/src/core/io/src/4C_io_mesh.cpp
@@ -1,0 +1,188 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "4C_io_mesh.hpp"
+
+#include "4C_utils_enum.hpp"
+#include "4C_utils_std23_unreachable.hpp"
+
+
+
+FOUR_C_NAMESPACE_OPEN
+
+std::string Core::IO::MeshInput::describe(VerbosityLevel level)
+{
+  switch (level)
+  {
+    case VerbosityLevel::none:
+      return "no output";
+    case VerbosityLevel::summary:
+      return "output of summary for blocks and sets";
+    case VerbosityLevel::detailed_summary:
+      return "output of summary for each block and set";
+    case VerbosityLevel::detailed:
+      return "detailed output for each block and set";
+    case VerbosityLevel::full:
+      return "detailed output, even for nodes and element connectivities";
+  }
+  std23::unreachable();
+}
+
+void Core::IO::MeshInput::print(const Mesh& mesh, std::ostream& os, VerbosityLevel verbose)
+{
+  if (verbose >= VerbosityLevel::summary)
+  {
+    auto num_elements = std::accumulate(mesh.cell_blocks.begin(), mesh.cell_blocks.end(), 0,
+        [](int sum, const auto& block) { return sum + block.second.cell_connectivities.size(); });
+
+    os << "  consists of " << mesh.points.size() << " points and " << num_elements << " cells; \n"
+       << "  organized in " << mesh.cell_blocks.size() << " cell-blocks, ";
+    os << mesh.point_sets.size() << " point-sets and ";
+    os << mesh.side_sets.size() << " side-sets. ";
+    os << std::endl << std::endl;
+  }
+  if (verbose >= VerbosityLevel::detailed_summary)
+  {
+    if (verbose == VerbosityLevel::full)
+    {
+      for (const auto& [point_id, coords] : mesh.points)
+      {
+        os << "Point " << point_id << ": ";
+        for (const auto& coord : coords)
+        {
+          os << std::format("{:10.6g},", coord);
+        }
+        os << "\n";
+      }
+      os << std::endl;
+    }
+    os << "cell-blocks:\n";
+    os << "------------\n";
+    for (const auto& [id, connectivity] : mesh.cell_blocks)
+    {
+      os << "cell-block " << id << ": ";
+      print(connectivity, os, verbose);
+    }
+
+    os << "\nside-sets:\n";
+    os << "-----------\n";
+    for (const auto& [ss_id, ss] : mesh.side_sets)
+    {
+      os << "side-set " << ss_id << ": ";
+      print(ss, os, verbose);
+    }
+
+    os << "\nline-sets:\n";
+    os << "----------\n";
+    for (const auto& [ls_id, ls] : mesh.line_sets)
+    {
+      os << "line-set " << ls_id << ": ";
+      print(ls, os, verbose);
+    }
+
+    os << "\npoint-sets:\n";
+    os << "-------------\n";
+    for (const auto& [ps_id, ps] : mesh.point_sets)
+    {
+      os << "point-set " << ps_id << ": ";
+      print(ps, os, verbose);
+    }
+  }
+}
+
+void Core::IO::MeshInput::print(const CellBlock& block, std::ostream& os, VerbosityLevel verbose)
+{
+  using EnumTools::operator<<;
+
+  os << block.cell_connectivities.size() << " Cells of shape " << block.cell_type;
+  os << std::endl;
+
+  if (verbose == VerbosityLevel::detailed)
+  {
+    int nline = 0;
+    os << "cells:";
+    for (const auto& [id, connectivity] : block.cell_connectivities)
+    {
+      if (nline++ % 12 == 0) os << "\n  ";
+      os << id << ",";
+    }
+    if (nline % 12 != 0) os << std::endl;
+    os << std::endl;
+  }
+  else if (verbose == VerbosityLevel::full)
+  {
+    for (const auto& [id, conn] : block.cell_connectivities)
+    {
+      os << "  cell " << id << ": ";
+      for (const auto& point_id : conn)
+      {
+        os << point_id << ",";
+      }
+      os << std::endl;
+    }
+    os << std::endl;
+  }
+}
+
+void Core::IO::MeshInput::print(const SideSet& side_set, std::ostream& os, VerbosityLevel verbose)
+{
+  os << " contains " << side_set.sides.size() << " sides";
+  if (verbose == VerbosityLevel::full)
+  {
+    os << ": ";
+    int nline = 0;
+    for (const auto& [id, _] : side_set.sides)
+    {
+      if (nline++ % 12 == 0) os << "\n  ";
+      os << std::setw(5) << id << ",";
+    }
+    if (nline % 12 != 0) os << std::endl;
+  }
+  else
+    os << "\n";
+}
+
+void Core::IO::MeshInput::print(const LineSet& line_set, std::ostream& os, VerbosityLevel verbose)
+{
+  os << " contains " << line_set.lines.size() << " lines";
+  if (verbose == VerbosityLevel::full)
+  {
+    os << ": ";
+    int nline = 0;
+    for (const auto& [id, _] : line_set.lines)
+    {
+      if (nline++ % 12 == 0) os << "\n  ";
+      os << std::setw(5) << id << ",";
+    }
+    if (nline % 12 != 0) os << std::endl;
+  }
+  else
+    os << "\n";
+}
+
+void Core::IO::MeshInput::print(const PointSet& point_set, std::ostream& os, VerbosityLevel verbose)
+{
+  os << " contains " << point_set.point_ids.size() << " points";
+  if (verbose == VerbosityLevel::full)
+  {
+    os << ": ";
+    int nline = 0;
+    int nodelength =
+        std::to_string(*std::max_element(point_set.point_ids.begin(), point_set.point_ids.end()))
+            .size();
+    for (const int id : point_set.point_ids)
+    {
+      if (nline++ % 12 == 0) os << "\n  ";
+      os << std::setw(nodelength) << id << ",";
+    }
+    if (nline % 12 != 0) os << std::endl;
+  }
+  else
+    os << "\n";
+}
+
+FOUR_C_NAMESPACE_CLOSE

--- a/src/core/io/src/4C_io_mesh.hpp
+++ b/src/core/io/src/4C_io_mesh.hpp
@@ -1,0 +1,167 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef FOUR_C_IO_MESH_HPP
+#define FOUR_C_IO_MESH_HPP
+
+#include "4C_config.hpp"
+
+#include "4C_fem_general_element.hpp"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+FOUR_C_NAMESPACE_OPEN
+
+namespace Core::IO::MeshInput
+{
+  enum class VerbosityLevel : int
+  {
+    none = 0,              ///< no output,
+    summary = 1,           ///< output of summary for blocks and sets,
+    detailed_summary = 2,  ///< output of summary for each block and set,
+    detailed = 3,          ///< detailed output for each block and set,
+    full = 4               ///< detailed output, even for nodes and element connectivities
+  };
+  constexpr bool operator>(VerbosityLevel lhs, VerbosityLevel rhs)
+  {
+    return static_cast<int>(lhs) > static_cast<int>(rhs);
+  }
+
+  /**
+   * Describe each of the VerbosityLevel options.
+   */
+  std::string describe(VerbosityLevel level);
+
+
+  struct CellBlock;
+  struct SideSet;
+  struct LineSet;
+  struct PointSet;
+
+  /*!
+   * @brief An intermediate representation of finite element meshes
+   *
+   * 4C will read meshes into this basic representation of the mesh and generate its internal
+   * Discretization from it.
+   *
+   */
+  struct Mesh
+  {
+    /**
+     * The points in the mesh. The keys are the point IDs, and the values are the coordinates of the
+     * points.
+     */
+    std::map<int, std::vector<double>> points;
+
+    /**
+     * The cell blocks in the mesh. The keys are the cell block IDs, and the values are the cell
+     * blocks.
+     *
+     * The mesh is organized into cell blocks, each containing a collection of cells. Each
+     * cell-block is required to have the same cell-type. 4C can solve different equations on each
+     * block.
+     */
+    std::map<int, CellBlock> cell_blocks;
+
+    /**
+     * The sides in the mesh. The keys are the side-set IDs, and the values are the side-sets.
+     */
+    std::map<int, SideSet> side_sets;
+
+    /**
+     * The lines in the mesh. The keys are the line-set IDs, and the values are the line-sets.
+     */
+    std::map<int, LineSet> line_sets;
+
+    /**
+     * The points in the mesh. The keys are the point-set IDs, and the values are the point-sets.
+     */
+    std::map<int, PointSet> point_sets;
+  };
+
+
+  /**
+   * A cell-block. This encodes a collection of cells of the same type.
+   */
+  struct CellBlock
+  {
+    /**
+     * The type of the cells in the cell block.
+     */
+    FE::CellType cell_type;
+
+    /**
+     * Cells in this block. The keys are the cell-IDs, and the values are the IDs of the points
+     * making up the cell. The ordering of the points are important for the cell connectivity.
+     */
+    std::map<int, std::vector<int>> cell_connectivities;
+  };
+
+  /**
+   * A point set. This encodes a collection of points.
+   */
+  struct PointSet
+  {
+    /**
+     *  The IDs of the points in the point set.
+     */
+    std::vector<int> point_ids;
+  };
+
+  /**
+   * An side set. This encodes a collection of sides/faces of elements.
+   */
+  struct SideSet
+  {
+    /**
+     * The IDs of the nodes making up the sides of the side set.
+     */
+    std::map<int, std::vector<int>> sides;
+  };
+
+  /**
+   * An line set. This encodes a collection of lines/edges of elements.
+   */
+  struct LineSet
+  {
+    /**
+     * The IDs of the nodes making up the lines of the line set.
+     */
+    std::map<int, std::vector<int>> lines;
+  };
+
+  /**
+   * Print a summary of the mesh to the given output stream (details according to @p verbose )
+   */
+  void print(const Mesh& mesh, std::ostream& os, VerbosityLevel verbose);
+
+  /**
+   * Print a summary of the cell block to the given output stream (details according to @p verbose )
+   */
+  void print(const CellBlock& block, std::ostream& os, VerbosityLevel verbose);
+
+  /**
+   * Print a summary of the side set to the given output stream (details according to @p verbose )
+   */
+  void print(const SideSet& side_set, std::ostream& os, VerbosityLevel verbose);
+
+  /**
+   * Print a summary of the line set to the given output stream (details according to @p verbose )
+   */
+  void print(const LineSet& line_set, std::ostream& os, VerbosityLevel verbose);
+
+  /**
+   * Print a summary of the point set to the given output stream (details according to @p verbose )
+   */
+  void print(const PointSet& point_set, std::ostream& os, VerbosityLevel verbose);
+}  // namespace Core::IO::MeshInput
+
+FOUR_C_NAMESPACE_CLOSE
+
+#endif

--- a/src/core/io/src/4C_io_meshreader.hpp
+++ b/src/core/io/src/4C_io_meshreader.hpp
@@ -25,14 +25,14 @@ namespace Core::IO
 {
   class InputFile;
 
-  namespace Exodus
+  namespace MeshInput
   {
-    class Mesh;
+    struct Mesh;
   }
 
   namespace Internal
   {
-    struct ExodusReader;
+    struct MeshReader;
   }
 
 
@@ -100,17 +100,17 @@ namespace Core::IO
     [[nodiscard]] MPI_Comm get_comm() const;
 
     /**
-     * Access the exodus mesh on rank 0. This is only available if an exodus file was actually read.
-     * On ranks other than 0, this will always return a nullptr.
+     * Access the external mesh on rank 0. This is only available if an external mesh was actually
+     * read. On ranks other than 0, this will always return a nullptr.
      */
-    [[nodiscard]] const Exodus::Mesh* get_exodus_mesh_on_rank_zero() const;
+    [[nodiscard]] const MeshInput::Mesh* get_external_mesh_on_rank_zero() const;
 
    private:
     /// Communicator for this mesh reader.
     MPI_Comm comm_;
 
-    /// Internal exodus readers.
-    std::vector<std::unique_ptr<Internal::ExodusReader>> exodus_readers_;
+    /// Internal mesh readers.
+    std::vector<std::unique_ptr<Internal::MeshReader>> mesh_readers_;
 
     /// The input file to read the mesh from.
     const Core::IO::InputFile& input_;

--- a/src/core/io/tests/4C_io_exodus_test.cpp
+++ b/src/core/io/tests/4C_io_exodus_test.cpp
@@ -17,25 +17,26 @@ namespace
 
   TEST(Exodus, MeshCubeHex)
   {
-    Core::IO::Exodus::Mesh mesh(TESTING::get_support_file_path("test_files/exodus/cube.exo"));
+    Core::IO::MeshInput::Mesh mesh = Core::IO::Exodus::read_exodus_file(
+        TESTING::get_support_file_path("test_files/exodus/cube.exo"));
 
-    EXPECT_EQ(mesh.get_num_element_blocks(), 2);
-    EXPECT_EQ(mesh.get_node_sets().size(), 1);
-    EXPECT_EQ(mesh.get_side_sets().size(), 1);
-    EXPECT_EQ(mesh.get_num_nodes(), 27);
-    EXPECT_EQ(mesh.get_num_elements(), 8);
-    EXPECT_EQ(mesh.get_element_block(1).elements.size(), 4);
-    EXPECT_EQ(mesh.get_element_block(2).elements.size(), 4);
+    EXPECT_EQ(mesh.cell_blocks.size(), 2);
+    EXPECT_EQ(mesh.point_sets.size(), 1);
+    EXPECT_EQ(mesh.side_sets.size(), 1);
+    EXPECT_EQ(mesh.points.size(), 27);
+    EXPECT_EQ(mesh.cell_blocks[1].cell_connectivities.size(), 4);
+    EXPECT_EQ(mesh.cell_blocks[2].cell_connectivities.size(), 4);
 
-    mesh.print(std::cout, Core::IO::Exodus::VerbosityLevel::none);
+    Core::IO::MeshInput::print(mesh, std::cout, Core::IO::MeshInput::VerbosityLevel::none);
   }
 
   TEST(Exodus, NodeOffset)
   {
-    Core::IO::Exodus::Mesh mesh(TESTING::get_support_file_path("test_files/exodus/cube.exo"),
+    Core::IO::MeshInput::Mesh mesh = Core::IO::Exodus::read_exodus_file(
+        TESTING::get_support_file_path("test_files/exodus/cube.exo"),
         Core::IO::Exodus::MeshParameters{.node_start_id = 100});
-    EXPECT_EQ(mesh.get_node(100), (std::vector<double>{-5.0, 0.0, 0.0}));
-    EXPECT_EQ(mesh.get_element_block(1).elements.at(1),
+    EXPECT_EQ(mesh.points[100], (std::vector<double>{-5.0, 0.0, 0.0}));
+    EXPECT_EQ(mesh.cell_blocks[1].cell_connectivities.at(1),
         (std::vector<int>{108, 100, 103, 109, 110, 104, 107, 111}));
   }
 }  // namespace

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1470,13 +1470,12 @@ namespace
     // Data is available on rank zero: bring it into the right shape and broadcast it.
     if (my_rank == 0)
     {
-      auto* exodus_mesh = mesh_reader.get_exodus_mesh_on_rank_zero();
-      if (exodus_mesh)
+      if (const auto* external_mesh = mesh_reader.get_external_mesh_on_rank_zero(); external_mesh)
       {
-        const auto& node_sets_from_mesh = exodus_mesh->get_node_sets();
+        const auto& node_sets_from_mesh = external_mesh->point_sets;
         for (const auto& [id, node_set] : node_sets_from_mesh)
         {
-          const auto& set = node_set.node_ids;
+          const auto& set = node_set.point_ids;
           node_sets[id] = std::vector<int>(set.begin(), set.end());
         }
       }
@@ -1497,14 +1496,13 @@ namespace
     // Data is available on rank zero: bring it into the right shape and broadcast it.
     if (my_rank == 0)
     {
-      auto* exodus_mesh = mesh_reader.get_exodus_mesh_on_rank_zero();
-      if (exodus_mesh)
+      if (const auto* external_mesh = mesh_reader.get_external_mesh_on_rank_zero(); external_mesh)
       {
-        const auto& element_blocks = exodus_mesh->get_element_blocks();
+        const auto& element_blocks = external_mesh->cell_blocks;
         for (const auto& [id, eb] : element_blocks)
         {
           std::set<int> nodes;
-          for (const auto& connectivity : eb.elements | std::views::values)
+          for (const auto& connectivity : eb.cell_connectivities | std::views::values)
           {
             nodes.insert(connectivity.begin(), connectivity.end());
           }

--- a/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validparameters.cpp
@@ -53,10 +53,10 @@
 #include "4C_inpar_volmortar.hpp"
 #include "4C_inpar_wear.hpp"
 #include "4C_inpar_xfem.hpp"
-#include "4C_io_exodus.hpp"
 #include "4C_io_gridgenerator.hpp"
 #include "4C_io_input_file_utils.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_io_mesh.hpp"
 #include "4C_io_pstream.hpp"
 #include "4C_linear_solver_method_input.hpp"
 #include "4C_lubrication_input.hpp"
@@ -156,14 +156,14 @@ std::map<std::string, Core::IO::InputSpec> Global::valid_parameters()
     specs[field_identifier + " GEOMETRY"] = group(field_identifier + " GEOMETRY",
         {
             parameter<std::filesystem::path>(
-                "FILE", {.description = "Path to the exodus geometry file. Either absolute or "
+                "FILE", {.description = "Path to the external geometry file. Either absolute or "
                                         "relative to the input file."}),
-            parameter<Core::IO::Exodus::VerbosityLevel>("SHOW_INFO",
+            parameter<Core::IO::MeshInput::VerbosityLevel>("SHOW_INFO",
                 {
                     .description = "Choose verbosity of reporting element, node and set info for "
                                    "the exodus file after reading.",
-                    .enum_value_description = Core::IO::Exodus::describe,
-                    .default_value = Core::IO::Exodus::VerbosityLevel::none,
+                    .enum_value_description = Core::IO::MeshInput::describe,
+                    .default_value = Core::IO::MeshInput::VerbosityLevel::none,
                 }),
 
             // Once we support more formats, we should add a "TYPE" parameter for the file format.


### PR DESCRIPTION
These changes generalize the exodus intermediate input representation so that it can also be used for other mesh formats. The data structure now contains all the data, the mesh reader expects to build the 4C discretization.

I have a small draft for vtu file input, which are a couple of lines then (using the vtk c++ library).

Part of #825