### PR TITLE
[Rebalance] Add unit tests for some edge cases

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_graph.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_graph.hpp
@@ -107,6 +107,9 @@ namespace Core::LinAlg
     //! Returns the number of matrix rows on this processor.
     int num_local_rows() const { return graph_->NumMyRows(); }
 
+    //! Returns the number of indices in the local graph.
+    int num_local_nonzeros() const { return graph_->NumMyNonzeros(); }
+
     //! Returns the number of indices in the global graph.
     int num_global_nonzeros() const { return graph_->NumGlobalNonzeros(); }
 

--- a/src/core/rebalance/tests/4C_rebalance_graph_test.cpp
+++ b/src/core/rebalance/tests/4C_rebalance_graph_test.cpp
@@ -1,0 +1,77 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_rebalance_graph_based.hpp"
+
+#include <Teuchos_ParameterList.hpp>
+
+namespace
+{
+  using namespace FourC;
+
+  class RebalanceGraph : public ::testing::Test
+  {
+   public:
+    RebalanceGraph()
+    {
+      verbosity_ = Core::IO::minimal;
+
+      map_ = std::make_shared<Core::LinAlg::Map>(NumGlobalElements, 0, comm_);
+    }
+
+   protected:
+    std::shared_ptr<Core::LinAlg::Map> map_;
+
+    int NumGlobalElements = 20;
+    MPI_Comm comm_{MPI_COMM_WORLD};
+    Core::IO::Verbositylevel verbosity_;
+  };
+
+  /**
+   * Checks serial rebalancing, where input and output graph should be the same.
+   */
+  TEST_F(RebalanceGraph, RebalanceGraphSerial)
+  {
+    Core::LinAlg::Graph graph(Copy, *map_, 3);
+
+    for (int row = 0; row < map_->num_my_elements(); row++)
+    {
+      if (row == 0)
+      {
+        std::array<int, 2> indices{row, row + 1};
+        graph.insert_global_indices(row, 2, indices.data());
+      }
+      else if (row == map_->num_my_elements() - 1)
+      {
+        std::array<int, 2> indices{row - 1, row};
+        graph.insert_global_indices(row, 2, indices.data());
+      }
+      else
+      {
+        std::array<int, 3> indices{row - 1, row, row + 1};
+        graph.insert_global_indices(row, 3, indices.data());
+      }
+    }
+
+    graph.fill_complete();
+    graph.optimize_storage();
+
+    Teuchos::ParameterList rebalance_params;
+    rebalance_params.set("partitioning method", "hypergraph");
+
+    auto rebalanced_graph = Core::Rebalance::rebalance_graph(graph, rebalance_params);
+
+    EXPECT_EQ(rebalanced_graph->num_global_nonzeros(), graph.num_global_nonzeros());
+    EXPECT_EQ(rebalanced_graph->num_local_nonzeros(), graph.num_local_nonzeros());
+    EXPECT_EQ(rebalanced_graph->num_global_nonzeros(), rebalanced_graph->num_local_nonzeros());
+  }
+}  // namespace

--- a/src/core/rebalance/tests/4C_rebalance_graph_test.np2.cpp
+++ b/src/core/rebalance/tests/4C_rebalance_graph_test.np2.cpp
@@ -1,0 +1,126 @@
+// This file is part of 4C multiphysics licensed under the
+// GNU Lesser General Public License v3.0 or later.
+//
+// See the LICENSE.md file in the top-level for license information.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include <gtest/gtest.h>
+
+#include "4C_config.hpp"
+
+#include "4C_fem_discretization.hpp"
+#include "4C_rebalance_graph_based.hpp"
+
+#include <Teuchos_ParameterList.hpp>
+
+namespace
+{
+  using namespace FourC;
+
+  class RebalanceGraph : public ::testing::Test
+  {
+   public:
+    RebalanceGraph()
+    {
+      verbosity_ = Core::IO::minimal;
+
+      testdis_ = std::make_shared<Core::FE::Discretization>("dummy", comm_, 3);
+    }
+
+   protected:
+    std::shared_ptr<Core::FE::Discretization> testdis_;
+
+    MPI_Comm comm_{MPI_COMM_WORLD};
+    Core::IO::Verbositylevel verbosity_;
+  };
+
+  /**
+   * Checks the rebalancing of an empty graph, which should throw.
+   */
+  TEST_F(RebalanceGraph, RebalanceEmptyGraph)
+  {
+    Core::LinAlg::Map map(20, 0, comm_);
+
+    Core::LinAlg::Graph empty_graph(Copy, map, 3);
+
+    EXPECT_EQ(false, empty_graph.filled());
+
+    Teuchos::ParameterList rebalance_params;
+    rebalance_params.set("partitioning method", "hypergraph");
+
+    EXPECT_ANY_THROW(Core::Rebalance::rebalance_graph(empty_graph, rebalance_params));
+  }
+
+  /**
+   * Checks parallel rebalancing, where the initial graph only exists on one processor.
+   * After rebalancing the graph is equally split over two processors.
+   */
+  TEST_F(RebalanceGraph, RebalanceGraphEmptyProc)
+  {
+    const int num_global_elements = 20;
+    int num_local_elements;
+
+    if (Core::Communication::my_mpi_rank(comm_) == 0)
+      num_local_elements = num_global_elements;
+    else
+      num_local_elements = 0;
+
+    Core::LinAlg::Map map(num_global_elements, num_local_elements, 0, comm_);
+
+    Core::LinAlg::Graph graph(Copy, map, 3);
+
+    if (Core::Communication::my_mpi_rank(comm_) == 0)
+    {
+      for (int row = 0; row < map.num_my_elements(); row++)
+      {
+        if (row == 0)
+        {
+          std::array<int, 2> indices{row, row + 1};
+          graph.insert_global_indices(row, 2, indices.data());
+        }
+        else if (row == map.num_my_elements() - 1)
+        {
+          std::array<int, 2> indices{row - 1, row};
+          graph.insert_global_indices(row, 2, indices.data());
+        }
+        else
+        {
+          std::array<int, 3> indices{row - 1, row, row + 1};
+          graph.insert_global_indices(row, 3, indices.data());
+        }
+      }
+    }
+
+    graph.fill_complete();
+    graph.optimize_storage();
+
+    Teuchos::ParameterList rebalance_params;
+    rebalance_params.set("partitioning method", "hypergraph");
+
+    auto rebalanced_graph = Core::Rebalance::rebalance_graph(graph, rebalance_params);
+
+    EXPECT_EQ(rebalanced_graph->row_map().num_global_elements(), 20);
+    EXPECT_EQ(rebalanced_graph->row_map().num_my_elements(), 10);
+    EXPECT_EQ(rebalanced_graph->num_local_nonzeros(), 29);
+  }
+
+  /**
+   * Checks the construction of a monolithic graph of an empty discretization, which should throw.
+   */
+  TEST_F(RebalanceGraph, BuildMonolithicGraphEmptyDiscretization)
+  {
+    EXPECT_EQ(false, testdis_->filled());
+
+    Teuchos::ParameterList geometric_search_params;
+    geometric_search_params.set("BEAM_RADIUS_EXTENSION_FACTOR", 1.0);
+    geometric_search_params.set("SPHERE_RADIUS_EXTENSION_FACTOR", 1.0);
+    geometric_search_params.set("WRITE_GEOMETRIC_SEARCH_VISUALIZATION", false);
+    Teuchos::ParameterList io_params;
+    io_params.set("VERBOSITY", verbosity_);
+
+    Core::GeometricSearch::GeometricSearchParams search_params(geometric_search_params, io_params);
+
+    EXPECT_ANY_THROW(Core::Rebalance::build_monolithic_node_graph(*testdis_, search_params));
+  }
+}  // namespace

--- a/src/core/rebalance/tests/CMakeLists.txt
+++ b/src/core/rebalance/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+# This file is part of 4C multiphysics licensed under the
+# GNU Lesser General Public License v3.0 or later.
+#
+# See the LICENSE.md file in the top-level for license information.
+#
+# SPDX-License-Identifier: LGPL-3.0-or-later
+
+four_c_auto_define_tests()


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR adds some unit testing for edge cases that might happen during graph rebalancing, e.g.:
- Serial case: input graph should be equal to output graph (we should not guard with myrank == 0)
- One processor holds the full graph with others beeing empty: after rebalancing the empty procs should be populated
- Empty graph: should throw before rebalancing
- Empty discretization: should throw before building a monolithic graph

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Part of #594 