### PR TITLE
[beaminteraction] Small cleanup of the saddle point case

### DIFF
--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -724,7 +724,6 @@ bool Solid::ModelEvaluator::BeamInteraction::evaluate_force_stiff()
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-
 bool Solid::ModelEvaluator::BeamInteraction::have_lagrange_dofs() const
 {
   bool lagrange_flag = false;
@@ -747,20 +746,25 @@ bool Solid::ModelEvaluator::BeamInteraction::have_lagrange_dofs() const
     }
   }
 
-
   return lagrange_flag;
 }
 
-
+/*----------------------------------------------------------------------------*
+ *----------------------------------------------------------------------------*/
 bool Solid::ModelEvaluator::BeamInteraction::assemble_force(
     Core::LinAlg::Vector<double>& f, const double& timefac_np) const
 {
   check_init_setup();
 
   Core::LinAlg::assemble_my_vector(1.0, f, timefac_np, *force_beaminteraction_);
+
   if (have_lagrange_dofs())
   {
-    (*me_vec_ptr_)[0]->assemble_force(f);
+    auto beam_contact_model =
+        std::dynamic_pointer_cast<FourC::BeamInteraction::SubmodelEvaluator::BeamContact const>(
+            (*me_vec_ptr_)[0]);
+
+    beam_contact_model->assemble_force(f);
   }
 
   return true;
@@ -778,9 +782,12 @@ bool Solid::ModelEvaluator::BeamInteraction::assemble_jacobian(
 
   if (have_lagrange_dofs())
   {
-    (*me_vec_ptr_)[0]->assemble_stiff(jac);
-  }
+    auto beam_contact_model =
+        std::dynamic_pointer_cast<FourC::BeamInteraction::SubmodelEvaluator::BeamContact const>(
+            (*me_vec_ptr_)[0]);
 
+    beam_contact_model->assemble_stiff(jac);
+  }
 
   // no need to keep it
   stiff_beaminteraction_->zero();
@@ -1134,7 +1141,11 @@ Solid::ModelEvaluator::BeamInteraction::get_block_dof_row_map_ptr() const
 
   if (have_lagrange_dofs())
   {
-    return (*me_vec_ptr_)[0]->get_lagrange_map();
+    auto beam_contact_model =
+        std::dynamic_pointer_cast<FourC::BeamInteraction::SubmodelEvaluator::BeamContact const>(
+            (*me_vec_ptr_)[0]);
+
+    return beam_contact_model->get_lagrange_map();
   }
   else
   {

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_beamcontact.hpp
@@ -175,17 +175,17 @@ namespace BeamInteraction
       /**
        * \brief Return the dof rowmap of the lagrange multipliers.
        */
-      std::shared_ptr<const FourC::Core::LinAlg::Map> get_lagrange_map() const override;
+      std::shared_ptr<const FourC::Core::LinAlg::Map> get_lagrange_map() const;
 
       /**
        * \brief Method used to assemble the force vector when using Lagrange Multipliers
        */
-      void assemble_force(Core::LinAlg::Vector<double>& f) const override;
+      void assemble_force(Core::LinAlg::Vector<double>& f) const;
 
       /**
        * \brief Method used to assemble the stiffness matrix when using Lagrange Multipliers
        */
-      void assemble_stiff(Core::LinAlg::SparseOperator& jac) const override;
+      void assemble_stiff(Core::LinAlg::SparseOperator& jac) const;
 
       //! @}
 

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_generic.hpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_generic.hpp
@@ -240,28 +240,6 @@ namespace BeamInteraction
       std::shared_ptr<BeamInteraction::Utils::MapExtractor>& ele_type_map_extractor_ptr();
       BeamInteraction::Utils::MapExtractor const& ele_type_map_extractor() const;
 
-      //! \brief returns the dof row map of the Lagrange Multipliers
-      virtual std::shared_ptr<const FourC::Core::LinAlg::Map> get_lagrange_map() const
-      {
-        FOUR_C_THROW("get_lagrange_map() called, but no Lagrange multiplier map is available.");
-      }
-
-      //! \brief Method used to assemble the force vector while using Lagrange Multipliers
-      virtual void assemble_force(Core::LinAlg::Vector<double>& f) const
-      {
-        FOUR_C_THROW(
-            "assemble_force called, but this submodel does not implement Lagrange multiplier force "
-            "assembly.");
-      };
-
-      //! \brief Method used to assemble the stiffness matrix while using Lagrange Multipliers
-      virtual void assemble_stiff(Core::LinAlg::SparseOperator& jac) const
-      {
-        FOUR_C_THROW(
-            "assemble_stiff called, but this submodel does not implement Lagrange multiplier "
-            "stiffness assembly.");
-      };
-
       //! @}
      protected:
       //! init flag


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Removes methods specific  to the beam-contact module evaluator from the generic class. We should not put random methods in "almost" abstract classes. Does some tiny cleanup on the way.

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
Follows #637