### PR TITLE
Replace deprecated cmake-flags with current ones

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -33,7 +33,7 @@ jobs:
           build-targets: doxygen
           build-directory: ${{ github.workspace }}/build
           use-ccache: "false"
-          additional-cmake-flags: -DFOUR_C_BUILD_DOXYGEN="ON"
+          additional-cmake-flags: -DFOUR_C_ENABLE_DOXYGEN="ON"
       - name: Upload doxygen
         uses: actions/upload-artifact@v4
         with:

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,10 +1,16 @@
 # Documentation
-On every change of the `main` branch, we automatically build a new version of our general documentation and the Doxygen documentation. Sometimes, it is necessary to build the documentation locally. Here, we give instructions on how to do it.
+
+On every change of the `main` branch, we automatically build a new version of our general documentation and the Doxygen
+documentation. Sometimes, it is necessary to build the documentation locally. Here, we give instructions on how to do
+it.
 
 ## Build the documentation
-To build the documentation, you need the required dependencies (see the [README](../README.md)) and a `CMakeUserPresets.json` with the configured paths. For simplicity, the `docker` preset is used here.
+
+To build the documentation, you need the required dependencies (see the [README](../README.md)) and a
+`CMakeUserPresets.json` with the configured paths. For simplicity, the `docker` preset is used here.
 
 ### General documentation
+
 ```
 cd <build-dir>
 cmake <source-dir> --fresh --preset=docker
@@ -12,8 +18,9 @@ cmake --build . --target documentation
 ```
 
 ### Doxygen
+
 ```
 cd <build-dir>
-cmake <source-dir> --fresh --preset=docker -DFOUR_C_BUILD_DOXYGEN="ON"
+cmake <source-dir> --fresh --preset=docker -DFOUR_C_ENABLE_DOXYGEN="ON"
 cmake --build . --target doxygen
 ```

--- a/doc/documentation/CMakeLists.txt
+++ b/doc/documentation/CMakeLists.txt
@@ -91,17 +91,17 @@ if(FOUR_C_ENABLE_DOCUMENTATION)
     COMMAND
       ${CMAKE_COMMAND} -E copy_if_different ${_sphinx_TEST_INPUT_FILES}
       "${_sphinx_OUT_DIR}/testfiles"
-    # Copy tutorial files
+      # Copy tutorial files
     COMMAND
       ${CMAKE_COMMAND} -E copy_directory "${PROJECT_SOURCE_DIR}/tests/tutorials"
       "${_sphinx_OUT_DIR}/testfiles"
-    # Run 4C to generate a help file
+      # Run 4C to generate a help file
     COMMAND ${FOUR_C_EXECUTABLE_NAME} -h > ${_sphinx_OUT_DIR}/reference_docs/4C-help.txt
     # Generate a cmake preset list which is used in the documentation
     COMMAND
       ${CMAKE_COMMAND} ${PROJECT_SOURCE_DIR} --list-presets >
       ${_sphinx_OUT_DIR}/reference_docs/4C-cmake-presets.txt
-    # A list of cmake variables will also be given in the documentation.
+      # A list of cmake variables will also be given in the documentation.
     COMMAND
       bash ${CMAKE_CURRENT_SOURCE_DIR}/scripts/extract_cmake_variables.sh
       ${PROJECT_BINARY_DIR}/CMakeCache.txt >

--- a/doc/documentation/src/developer_guide/developer_cmake.rst
+++ b/doc/documentation/src/developer_guide/developer_cmake.rst
@@ -55,8 +55,8 @@ Such a local preset could look like this::
             "CMAKE_CXX_COMPILER": "g++",
             "CMAKE_CXX_COMPILER_LAUNCHER": "ccache",
             "FOUR_C_WITH_GOOGLETEST": "OFF",
-            "FOUR_C_BUILD_DOCUMENTATION": "ON",
-            "FOUR_C_BUILD_DOXYGEN": "ON",
+            "FOUR_C_ENABLE_DOCUMENTATION": "ON",
+            "FOUR_C_ENABLE_DOXYGEN": "ON",
             "FOUR_C_ENABLE_DEVELOPER_MODE": "ON",
           }
         }

--- a/doc/documentation/src/installation/installation.rst
+++ b/doc/documentation/src/installation/installation.rst
@@ -539,8 +539,8 @@ Executables:
 
 Documentation (for the documentation to be generated, you have to set the respective cmake variables in the presets file described :ref:`above<installation_configure>`):
 
-- ``documentation`` create the main documentation (set ``FOUR_C_BUILD_DOCUMENTATION=ON`` in the presets)
-- ``doxygen`` create the (developer-oriented) Doxygen documentation (set ``FOUR_C_BUILD_DOXYGEN=ON`` in the presets)
+- ``documentation`` create the main documentation (set ``FOUR_C_ENABLE_DOCUMENTATION=ON`` in the presets)
+- ``doxygen`` create the (developer-oriented) Doxygen documentation (set ``FOUR_C_ENABLE_DOXYGEN=ON`` in the presets)
 
 .. note::
 

--- a/presets/docker/CMakePresets.json
+++ b/presets/docker/CMakePresets.json
@@ -17,8 +17,8 @@
         "FOUR_C_PVPYTHON": "/opt/4C-dependencies-testing/ParaView-5.5.2-Qt5-MPI-Linux-64bit/bin/pvpython",
         "FOUR_C_BUILD_SHARED_LIBS": "ON",
         "FOUR_C_WITH_GOOGLETEST": "ON",
-        "FOUR_C_BUILD_DOXYGEN": "OFF",
-        "FOUR_C_BUILD_DOCUMENTATION": "ON",
+        "FOUR_C_ENABLE_DOXYGEN": "OFF",
+        "FOUR_C_ENABLE_DOCUMENTATION": "ON",
         "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "ON",
         "FOUR_C_DOXYGEN_LOCAL_MATHJAX_BASEPATH": "/opt/4C-dependencies-testing/MathJax-2.7.9",
         "FOUR_C_WITH_ARBORX": "ON",
@@ -48,7 +48,7 @@
       ],
       "cacheVariables": {
         "FOUR_C_ENABLE_ASSERTIONS": "ON",
-        "FOUR_C_BUILD_DOCUMENTATION": "OFF"
+        "FOUR_C_ENABLE_DOCUMENTATION": "OFF"
       }
     },
     {
@@ -86,7 +86,7 @@
         "FOUR_C_ENABLE_WARNINGS_AS_ERRORS": "OFF",
         "FOUR_C_ENABLE_ASSERTIONS": "ON",
         "CMAKE_CXX_COMPILER": "clang++",
-        "FOUR_C_BUILD_DOCUMENTATION": "OFF",
+        "FOUR_C_ENABLE_DOCUMENTATION": "OFF",
         "CMAKE_UNITY_BUILD": "ON",
         "FOUR_C_WITH_GOOGLE_BENCHMARK": "OFF"
       }
@@ -116,8 +116,8 @@
         "FOUR_C_PVPYTHON": "",
         "FOUR_C_WITH_GOOGLETEST": "OFF",
         "FOUR_C_WITH_GOOGLE_BENCHMARK": "OFF",
-        "FOUR_C_BUILD_DOXYGEN": "OFF",
-        "FOUR_C_BUILD_DOCUMENTATION": "OFF",
+        "FOUR_C_ENABLE_DOXYGEN": "OFF",
+        "FOUR_C_ENABLE_DOCUMENTATION": "OFF",
         "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "OFF"
       }
     },
@@ -136,7 +136,7 @@
         "FOUR_C_WITH_PYTHON": "OFF",
         "FOUR_C_WITH_PYBIND11": "OFF",
         "FOUR_C_ENABLE_METADATA_GENERATION": "OFF",
-        "FOUR_C_BUILD_DOCUMENTATION": "OFF",
+        "FOUR_C_ENABLE_DOCUMENTATION": "OFF",
         "FOUR_C_WITH_VTK": "OFF"
       }
     }

--- a/presets/imcs/cluster/CMakePresets.json
+++ b/presets/imcs/cluster/CMakePresets.json
@@ -6,7 +6,7 @@
       "hidden": true,
       "generator": "Ninja",
       "cacheVariables": {
-        "FOUR_C_BUILD_DOXYGEN": "OFF",
+        "FOUR_C_ENABLE_DOXYGEN": "OFF",
         "FOUR_C_ENABLE_METADATA_GENERATION": "OFF",
         "FOUR_C_ENABLE_NATIVE_OPTIMIZATIONS": "ON",
         "FOUR_C_WITH_ARBORX": "ON",

--- a/presets/imcs/workstation/CMakePresets.json
+++ b/presets/imcs/workstation/CMakePresets.json
@@ -16,7 +16,7 @@
         "FOUR_C_PVPYTHON": "/imcs/public/compsim/opt/ParaView-5.6.0-MPI-Linux-64bit/bin/pvpython",
         "FOUR_C_DOXYGEN_USE_LOCAL_MATHJAX": "ON",
         "FOUR_C_DOXYGEN_LOCAL_MATHJAX_BASEPATH": "/imcs/public/compsim/opt/mathjax-2.7.9",
-        "FOUR_C_BUILD_DOXYGEN": "ON",
+        "FOUR_C_ENABLE_DOXYGEN": "ON",
         "FOUR_C_WITH_GOOGLETEST": "ON",
         "FOUR_C_WITH_ARBORX": "ON",
         "FOUR_C_WITH_MIRCO": "ON",

--- a/presets/lnm/cluster/CMakePresets.json
+++ b/presets/lnm/cluster/CMakePresets.json
@@ -9,7 +9,7 @@
         "CMAKE_BUILD_TYPE": "RELEASE",
         "FOUR_C_ENABLE_NATIVE_OPTIMIZATIONS": "ON",
         "FOUR_C_WITH_GOOGLETEST": "OFF",
-        "FOUR_C_BUILD_DOXYGEN": "OFF",
+        "FOUR_C_ENABLE_DOXYGEN": "OFF",
         "FOUR_C_CLN_ROOT": "/lnm/packages/cln/1-3-4",
         "FOUR_C_QHULL_ROOT": "/lnm/packages/qhull/2012-1",
         "FOUR_C_TRILINOS_ROOT": "/lnm/packages/trilinos/16-1-0_v2/release",


### PR DESCRIPTION
## Description and Context
After #1147 there have been several occurrences of the deprecated cmake flags in our doc and presets. These have been changed to the current ones in this PR to not guide users to deprecated things.

However, the deprecated flags are still accepted, so this behavior is unchanged compared to #1147.

## Related Issues and Pull Requests
follows #1147
