### PR TITLE
[beam] Update error message in neuman boundary evaluation

### DIFF
--- a/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
@@ -235,7 +235,10 @@ int Discret::Elements::Beam3eb::evaluate_neumann(Teuchos::ParameterList& params,
   // get element displacements
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement new");
-  if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
+  if (disp == nullptr)
+    FOUR_C_THROW(
+        "Cannot get state vector 'displacement new'. "
+        "No linearization provided for load (add 'LOADLIN: true' to input file)");
   std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
 #ifndef INEXTENSIBLE

--- a/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
+++ b/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
@@ -2125,7 +2125,10 @@ int Discret::Elements::Beam3k::evaluate_neumann(Teuchos::ParameterList& params,
   // get element displacements
   std::shared_ptr<const Core::LinAlg::Vector<double>> disp =
       discretization.get_state("displacement new");
-  if (disp == nullptr) FOUR_C_THROW("Cannot get state vector 'displacement new'");
+  if (disp == nullptr)
+    FOUR_C_THROW(
+        "Cannot get state vector 'displacement new'. "
+        "No linearization provided for load (add 'LOADLIN: true' to input file)");
   std::vector<double> mydisp = Core::FE::extract_values(*disp, lm);
 
   Core::LinAlg::Matrix<6 * nnodecl + BEAM3K_COLLOCATION_POINTS, 1, double> disp_totlag(


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
Somehow the neumann load for `beam3eb` and `beam3k` can only be evaluated, when load linearization is done. The error message was quite unspecific, thus this PR adds a hint that `LOADLIN: true` has to be set.

I don't understand why a load linearization is necessary ... but otherwise the new displacement state is not retrievable. In the new structure model evaluator the new displacement state is explicitly only set for load linearization, otherwise not.

Actually `beam3r` calculates the neumann load completely different ... which is also strange ...