### PR TITLE
Evaluate initial acceleration with full RHS vector

### DIFF
--- a/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
+++ b/src/cardiovascular0d/4C_cardiovascular0d_structure_new_model_evaluator.cpp
@@ -158,11 +158,7 @@ bool Solid::ModelEvaluator::Cardiovascular0D::assemble_force(
         "the structural part indicates, that 0D cardiovascular model contributions \n"
         "are present!");
 
-  const int elements_f = f.get_map().num_global_elements();
-  const int max_gid = get_block_dof_row_map_ptr()->max_all_gid();
-  // only call when f is the full rhs of the coupled problem (not for structural
-  // equilibriate initial state call)
-  if (elements_f == max_gid + 1) Core::LinAlg::assemble_my_vector(1.0, f, 1.0, *block_vec_ptr);
+  Core::LinAlg::assemble_my_vector(1.0, f, 1.0, *block_vec_ptr);
 
   return true;
 }

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_lagpenconstraint.cpp
@@ -162,12 +162,7 @@ bool Solid::ModelEvaluator::LagPenConstraint::assemble_force(
           "the structural part indicates, that constraint contributions \n"
           "are present!");
 
-    const int elements_f = f.get_map().num_global_elements();
-    const int max_gid = get_block_dof_row_map_ptr()->max_all_gid();
-    // only call when f is the rhs of the full problem (not for structural
-    // equilibriate initial state call)
-    if (elements_f == max_gid + 1)
-      Core::LinAlg::assemble_my_vector(1.0, f, timefac_np, *block_vec_ptr);
+    Core::LinAlg::assemble_my_vector(1.0, f, timefac_np, *block_vec_ptr);
   }
 
   return true;

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.cpp
@@ -112,12 +112,10 @@ void Solid::ModelEvaluatorManager::setup_multi_map_extractor()
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
 bool Solid::ModelEvaluatorManager::initialize_inertia_and_damping(
-    const Core::LinAlg::Vector<double>& x, Core::LinAlg::SparseOperator& jac)
+    const Core::LinAlg::Vector<double>& x)
 {
   check_init_setup();
 
-  // initialize stiffness matrix to zero
-  jac.zero();
   // get structural model evaluator
   Solid::ModelEvaluator::Structure& str_model =
       dynamic_cast<Solid::ModelEvaluator::Structure&>(evaluator(Inpar::Solid::model_structure));

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_manager.hpp
@@ -114,8 +114,7 @@ namespace Solid
     //! @name General evaluate routines
     //!@{
 
-    bool initialize_inertia_and_damping(
-        const Core::LinAlg::Vector<double>& x, Core::LinAlg::SparseOperator& jac);
+    bool initialize_inertia_and_damping(const Core::LinAlg::Vector<double>& x);
 
     bool apply_initial_force(
         const Core::LinAlg::Vector<double>& x, Core::LinAlg::Vector<double>& f);


### PR DESCRIPTION
During the setup of the new structural framework, we evaluate the RHS to compute the initial accelerations. The vector we created previously was only large enough to accommodate the solid RHS. However, for cardiovascular0D-BCs and Lagrange constraints, this vector was too short to assemble their RHS. In these modules, we had a peculiar check to determine whether to assemble their RHS, which depended on the node numbering at input.

This issue has now been resolved: we create an RHS of the appropriate size and assemble the entire RHS.

I also removed unnecessary pointers on the way.

Related to #733