### PR TITLE
Validate muscle and St. Venant Kirchhoff material input via InputSpecBuilders::Validators

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.hpp
+++ b/src/core/io/src/4C_io_input_spec_builders.hpp
@@ -1384,7 +1384,7 @@ namespace Core::IO
      * The remaining parameterization options follow the same rules as for the parameter() function.
      *
      * @note If you want to store the choices as strings and not map them to another type, use the
-     * other selection() function.
+     * other deprecated_selection() function.
      *
      * @deprecated If you want to select from a set of enum constants use the parameter() function
      * with the enum type.
@@ -1398,8 +1398,8 @@ namespace Core::IO
 
 
     /**
-     * Like the other selection() function, but the choices are stored as strings and not mapped
-     * to another type.
+     * Like the other deprecated_selection() function, but the choices are stored as strings and not
+     * mapped to another type.
      *
      * @note Although this function only works with strings, you still need to provide a type for
      * the first template parameter for consistency with the other functions.

--- a/src/core/io/src/4C_io_input_spec_validators.hpp
+++ b/src/core/io/src/4C_io_input_spec_validators.hpp
@@ -363,6 +363,14 @@ namespace Core::IO::InputSpecBuilders::Validators
   template <Internal::Numeric T>
   [[nodiscard]] auto positive();
 
+  /**
+   * A shorthand for creating a Validator that checks if a value is in the range [0, max].
+   *
+   * @note You need to specify the type of the value to be checked explicitly, since there are no
+   * arguments to deduce the type from.
+   */
+  template <Internal::Numeric T>
+  [[nodiscard]] auto positive_or_zero();
 
   /**
    * A validator that checks if all elements in a range-like object satisfy the given @p validator:
@@ -456,6 +464,12 @@ template <Core::IO::InputSpecBuilders::Validators::Internal::Numeric T>
 [[nodiscard]] auto Core::IO::InputSpecBuilders::Validators::positive()
 {
   return in_range(excl(static_cast<T>(0)), std::numeric_limits<T>::max());
+}
+
+template <Core::IO::InputSpecBuilders::Validators::Internal::Numeric T>
+[[nodiscard]] auto Core::IO::InputSpecBuilders::Validators::positive_or_zero()
+{
+  return in_range(static_cast<T>(0), std::numeric_limits<T>::max());
 }
 
 template <typename T>

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -1044,10 +1044,14 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   /*--------------------------------------------------------------------*/
   // St.Venant--Kirchhoff
   {
+    using namespace Core::IO::InputSpecBuilders::Validators;
+
     known_materials[Core::Materials::m_stvenant] = group("MAT_Struct_StVenantKirchhoff",
         {
-            parameter<double>("YOUNG", {.description = "Young's modulus"}),
-            parameter<double>("NUE", {.description = "Poisson's ratio"}),
+            parameter<double>(
+                "YOUNG", {.description = "Young's modulus", .validator = positive<double>()}),
+            parameter<double>("NUE",
+                {.description = "Poisson's ratio", .validator = in_range<double>(-1.0, excl(0.5))}),
             parameter<double>("DENS", {.description = "mass density"}),
         },
         {.description = "St.Venant--Kirchhoff material"});

--- a/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
+++ b/src/global_legacy_module/4C_global_legacy_module_validmaterials.cpp
@@ -12,6 +12,7 @@
 #include "4C_io_file_reader.hpp"
 #include "4C_io_input_field.hpp"
 #include "4C_io_input_spec_builders.hpp"
+#include "4C_io_input_spec_validators.hpp"
 #include "4C_mat_electrode.hpp"
 #include "4C_mat_micromaterial.hpp"
 #include "4C_mat_muscle_combo.hpp"
@@ -402,48 +403,65 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   /*----------------------------------------------------------------------*/
   // Weickenmeier muscle material
   {
+    using namespace Core::IO::InputSpecBuilders::Validators;
+
     known_materials[Core::Materials::m_muscle_weickenmeier] = group("MAT_Muscle_Weickenmeier",
         {
-            parameter<double>("ALPHA", {.description = "experimentally fitted material parameter"}),
-            parameter<double>("BETA", {.description = "experimentally fitted material parameter"}),
-            parameter<double>("GAMMA", {.description = "experimentally fitted material parameter"}),
+            parameter<double>("ALPHA", {.description = "experimentally fitted material parameter",
+                                           .validator = positive<double>()}),
+            parameter<double>("BETA", {.description = "experimentally fitted material parameter",
+                                          .validator = positive<double>()}),
+            parameter<double>("GAMMA", {.description = "experimentally fitted material parameter",
+                                           .validator = positive<double>()}),
             parameter<double>(
                 "KAPPA", {.description = "material parameter for coupled volumetric contribution"}),
             parameter<double>(
-                "OMEGA0", {.description = "weighting factor for isotropic tissue constituents"}),
+                "OMEGA0", {.description = "weighting factor for isotropic tissue constituents",
+                              .validator = in_range<double>(0.0, 1.0)}),
             parameter<double>("ACTMUNUM",
                 {.description =
-                        "number of active motor units per undeformed muscle cross-sectional area"}),
+                        "number of active motor units per undeformed muscle cross-sectional area",
+                    .validator = positive_or_zero<double>()}),
             parameter<int>("MUTYPESNUM", {.description = "number of motor unit types"}),
             parameter<std::vector<double>>(
                 "INTERSTIM", {.description = "interstimulus interval",
+                                 .validator = all_elements(positive_or_zero<double>()),
                                  .size = from_parameter<int>("MUTYPESNUM")}),
             parameter<std::vector<double>>(
                 "FRACACTMU", {.description = "fraction of motor unit type",
+                                 .validator = all_elements(positive_or_zero<double>()),
                                  .size = from_parameter<int>("MUTYPESNUM")}),
             parameter<std::vector<double>>(
                 "FTWITCH", {.description = "twitch force of motor unit type",
+                               .validator = all_elements(positive_or_zero<double>()),
                                .size = from_parameter<int>("MUTYPESNUM")}),
             parameter<std::vector<double>>(
                 "TTWITCH", {.description = "twitch contraction time of motor unit type",
+                               .validator = all_elements(positive_or_zero<double>()),
                                .size = from_parameter<int>("MUTYPESNUM")}),
-            parameter<double>("LAMBDAMIN", {.description = "minimal active fiber stretch"}),
+            parameter<double>("LAMBDAMIN",
+                {.description = "minimal active fiber stretch", .validator = positive<double>()}),
             parameter<double>("LAMBDAOPT",
                 {.description =
-                        "optimal active fiber stretch related to active nominal stress maximum"}),
+                        "optimal active fiber stretch related to active nominal stress maximum",
+                    .validator = positive<double>()}),
             parameter<double>("DOTLAMBDAMIN", {.description = "minimal stretch rate"}),
             parameter<double>(
                 "KE", {.description = "parameter controlling the curvature of the velocity "
-                                      "dependent activation function in the eccentric case"}),
+                                      "dependent activation function in the eccentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<double>(
                 "KC", {.description = "parameter controlling the curvature of the velocity "
-                                      "dependent activation function in the concentric case"}),
+                                      "dependent activation function in the concentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<double>(
                 "DE", {.description = "parameter controlling the amplitude of the velocity "
-                                      "dependent activation function in the eccentric case"}),
+                                      "dependent activation function in the eccentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<double>(
                 "DC", {.description = "parameter controlling the amplitude of the velocity "
-                                      "dependent activation function in the concentric case"}),
+                                      "dependent activation function in the concentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<int>("ACTTIMESNUM",
                 {.description = "number of time boundaries to prescribe activation"}),
             parameter<std::vector<double>>(
@@ -454,7 +472,8 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<std::vector<double>>("ACTVALUES",
                 {.description = "scaling factor in intervals (1=full activation, 0=no activation)",
                     .size = from_parameter<int>("ACTINTERVALSNUM")}),
-            parameter<double>("DENS", {.description = "density"}),
+            parameter<double>(
+                "DENS", {.description = "density", .validator = positive_or_zero<double>()}),
         },
         {.description = "Weickenmeier muscle material"});
   }
@@ -462,20 +481,29 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   /*----------------------------------------------------------------------*/
   // Combo muscle material
   {
+    using namespace Core::IO::InputSpecBuilders::Validators;
+
     known_materials[Core::Materials::m_muscle_combo] = group("MAT_Muscle_Combo",
         {
-            parameter<double>("ALPHA", {.description = "experimentally fitted material parameter"}),
-            parameter<double>("BETA", {.description = "experimentally fitted material parameter"}),
-            parameter<double>("GAMMA", {.description = "experimentally fitted material parameter"}),
+            parameter<double>("ALPHA", {.description = "experimentally fitted material parameter",
+                                           .validator = positive<double>()}),
+            parameter<double>("BETA", {.description = "experimentally fitted material parameter",
+                                          .validator = positive<double>()}),
+            parameter<double>("GAMMA", {.description = "experimentally fitted material parameter",
+                                           .validator = positive<double>()}),
             parameter<double>(
                 "KAPPA", {.description = "material parameter for coupled volumetric contribution"}),
             parameter<double>(
-                "OMEGA0", {.description = "weighting factor for isotropic tissue constituents"}),
-            parameter<double>("POPT", {.description = "tetanised optimal (maximal) active stress"}),
-            parameter<double>("LAMBDAMIN", {.description = "minimal active fiber stretch"}),
+                "OMEGA0", {.description = "weighting factor for isotropic tissue constituents",
+                              .validator = in_range<double>(0.0, 1.0)}),
+            parameter<double>("POPT", {.description = "tetanised optimal (maximal) active stress",
+                                          .validator = positive_or_zero<double>()}),
+            parameter<double>("LAMBDAMIN",
+                {.description = "minimal active fiber stretch", .validator = positive<double>()}),
             parameter<double>("LAMBDAOPT",
                 {.description =
-                        "optimal active fiber stretch related to active nominal stress maximum"}),
+                        "optimal active fiber stretch related to active nominal stress maximum",
+                    .validator = positive<double>()}),
             one_of({
                 parameter<int>("ACTIVATION_FUNCTION_ID",
                     {.description =
@@ -485,7 +513,8 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
                                     "elementwise-defined discrete values "
                                     "for time- and space-dependency of muscle activation"}),
             }),
-            parameter<double>("DENS", {.description = "density"}),
+            parameter<double>(
+                "DENS", {.description = "density", .validator = positive_or_zero<double>()}),
         },
         {.description = "Combo muscle material"});
   }
@@ -493,48 +522,65 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   /*----------------------------------------------------------------------*/
   // Active strain Giantesio muscle material
   {
+    using namespace Core::IO::InputSpecBuilders::Validators;
+
     known_materials[Core::Materials::m_muscle_giantesio] = group("MAT_Muscle_Giantesio",
         {
-            parameter<double>("ALPHA", {.description = "experimentally fitted material parameter"}),
-            parameter<double>("BETA", {.description = "experimentally fitted material parameter"}),
-            parameter<double>("GAMMA", {.description = "experimentally fitted material parameter"}),
+            parameter<double>("ALPHA", {.description = "experimentally fitted material parameter",
+                                           .validator = positive<double>()}),
+            parameter<double>("BETA", {.description = "experimentally fitted material parameter",
+                                          .validator = positive<double>()}),
+            parameter<double>("GAMMA", {.description = "experimentally fitted material parameter",
+                                           .validator = positive<double>()}),
             parameter<double>(
                 "KAPPA", {.description = "material parameter for coupled volumetric contribution"}),
             parameter<double>(
-                "OMEGA0", {.description = "weighting factor for isotropic tissue constituents"}),
+                "OMEGA0", {.description = "weighting factor for isotropic tissue constituents",
+                              .validator = in_range<double>(0.0, 1.0)}),
             parameter<double>("ACTMUNUM",
                 {.description =
-                        "number of active motor units per undeformed muscle cross-sectional area"}),
+                        "number of active motor units per undeformed muscle cross-sectional area",
+                    .validator = positive_or_zero<double>()}),
             parameter<int>("MUTYPESNUM", {.description = "number of motor unit types"}),
             parameter<std::vector<double>>(
                 "INTERSTIM", {.description = "interstimulus interval",
+                                 .validator = all_elements(positive_or_zero<double>()),
                                  .size = from_parameter<int>("MUTYPESNUM")}),
             parameter<std::vector<double>>(
                 "FRACACTMU", {.description = "fraction of motor unit type",
+                                 .validator = all_elements(positive_or_zero<double>()),
                                  .size = from_parameter<int>("MUTYPESNUM")}),
             parameter<std::vector<double>>(
                 "FTWITCH", {.description = "twitch force of motor unit type",
+                               .validator = all_elements(positive_or_zero<double>()),
                                .size = from_parameter<int>("MUTYPESNUM")}),
             parameter<std::vector<double>>(
                 "TTWITCH", {.description = "twitch contraction time of motor unit type",
+                               .validator = all_elements(positive_or_zero<double>()),
                                .size = from_parameter<int>("MUTYPESNUM")}),
-            parameter<double>("LAMBDAMIN", {.description = "minimal active fiber stretch"}),
+            parameter<double>("LAMBDAMIN",
+                {.description = "minimal active fiber stretch", .validator = positive<double>()}),
             parameter<double>("LAMBDAOPT",
                 {.description =
-                        "optimal active fiber stretch related to active nominal stress maximum"}),
+                        "optimal active fiber stretch related to active nominal stress maximum",
+                    .validator = positive<double>()}),
             parameter<double>("DOTLAMBDAMIN", {.description = "minimal stretch rate"}),
             parameter<double>(
                 "KE", {.description = "parameter controlling the curvature of the velocity "
-                                      "dependent activation function in the eccentric case"}),
+                                      "dependent activation function in the eccentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<double>(
                 "KC", {.description = "parameter controlling the curvature of the velocity "
-                                      "dependent activation function in the concentric case"}),
+                                      "dependent activation function in the concentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<double>(
                 "DE", {.description = "parameter controlling the amplitude of the velocity "
-                                      "dependent activation function in the eccentric case"}),
+                                      "dependent activation function in the eccentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<double>(
                 "DC", {.description = "parameter controlling the amplitude of the velocity "
-                                      "dependent activation function in the concentric case"}),
+                                      "dependent activation function in the concentric case",
+                          .validator = positive_or_zero<double>()}),
             parameter<int>("ACTTIMESNUM",
                 {.description = "number of time boundaries to prescribe activation"}),
             parameter<std::vector<double>>(
@@ -545,7 +591,8 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
             parameter<std::vector<double>>("ACTVALUES",
                 {.description = "scaling factor in intervals (1=full activation, 0=no activation)",
                     .size = from_parameter<int>("ACTINTERVALSNUM")}),
-            parameter<double>("DENS", {.description = "density"}),
+            parameter<double>(
+                "DENS", {.description = "density", .validator = positive_or_zero<double>()}),
         },
         {.description = "Giantesio active strain muscle material"});
   }
@@ -1866,24 +1913,35 @@ std::unordered_map<Core::Materials::MaterialType, Core::IO::InputSpec> Global::v
   /*--------------------------------------------------------------------*/
   // isochoric anisotropic material with one exponential fiber family
   {
+    using namespace Core::IO::InputSpecBuilders::Validators;
+
     known_materials[Core::Materials::mes_isomuscleblemker] = group("ELAST_IsoMuscle_Blemker",
         {
-            parameter<double>("G1", {.description = "muscle along fiber shear modulus"}),
-            parameter<double>("G2", {.description = "muscle cross fiber shear modulus"}),
-            parameter<double>("P1",
-                {.description = "linear material parameter for passive along-fiber response"}),
+            parameter<double>("G1", {.description = "muscle along fiber shear modulus",
+                                        .validator = positive_or_zero<double>()}),
+            parameter<double>("G2", {.description = "muscle cross fiber shear modulus",
+                                        .validator = positive_or_zero<double>()}),
+            parameter<double>(
+                "P1", {.description = "linear material parameter for passive along-fiber response",
+                          .validator = positive<double>()}),
             parameter<double>("P2",
-                {.description = "exponential material parameter for passive along-fiber response"}),
-            parameter<double>("SIGMAMAX", {.description = "maximal active isometric stress"}),
-            parameter<double>("LAMBDAOFL", {.description = "optimal fiber stretch"}),
+                {.description = "exponential material parameter for passive along-fiber response",
+                    .validator = positive<double>()}),
+            parameter<double>("SIGMAMAX", {.description = "maximal active isometric stress",
+                                              .validator = positive_or_zero<double>()}),
+            parameter<double>("LAMBDAOFL",
+                {.description = "optimal fiber stretch", .validator = positive<double>()}),
             parameter<double>("LAMBDASTAR",
                 {.description =
-                        "stretch at which the normalized passive fiber force becomes linear"}),
-            parameter<double>("ALPHA", {.description = "tetanised activation level,"}),
+                        "stretch at which the normalized passive fiber force becomes linear",
+                    .validator = positive<double>()}),
+            parameter<double>("ALPHA", {.description = "tetanised activation level,",
+                                           .validator = positive_or_zero<double>()}),
             parameter<double>(
-                "BETA", {.description = "constant scaling tanh-type activation function"}),
-            parameter<double>(
-                "ACTSTARTTIME", {.description = "starting time of muscle activation"}),
+                "BETA", {.description = "constant scaling tanh-type activation function",
+                            .validator = positive_or_zero<double>()}),
+            parameter<double>("ACTSTARTTIME", {.description = "starting time of muscle activation",
+                                                  .validator = positive_or_zero<double>()}),
         },
         {.description = "anisotropic Blemker muscle material"});
   }

--- a/src/mat/4C_mat_muscle_combo.cpp
+++ b/src/mat/4C_mat_muscle_combo.cpp
@@ -112,25 +112,6 @@ Mat::PAR::MuscleCombo::MuscleCombo(const Core::Mat::PAR::Parameter::Data& matdat
       activationParams_(get_activation_params(matdata)),
       density_(matdata.parameters.get<double>("DENS"))
 {
-  // error handling for parameter ranges
-  // passive material parameters
-  if (alpha_ <= 0.0) FOUR_C_THROW("Material parameter ALPHA must be greater zero");
-  if (beta_ <= 0.0) FOUR_C_THROW("Material parameter BETA must be greater zero");
-  if (gamma_ <= 0.0) FOUR_C_THROW("Material parameter GAMMA must be greater zero");
-  if (omega0_ < 0.0 || omega0_ > 1.0) FOUR_C_THROW("Material parameter OMEGA0 must be in [0;1]");
-
-  // active material parameters
-  if (Popt_ < 0.0)
-  {
-    FOUR_C_THROW("Material parameter POPT must be positive or zero");
-  }
-
-  // stretch dependent parameters
-  if (lambdaMin_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDAMIN must be positive");
-  if (lambdaOpt_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDAOPT must be positive");
-
-  // density
-  if (density_ < 0.0) FOUR_C_THROW("DENS should be positive");
 }
 
 std::shared_ptr<Core::Mat::Material> Mat::PAR::MuscleCombo::create_material()

--- a/src/mat/4C_mat_muscle_giantesio.cpp
+++ b/src/mat/4C_mat_muscle_giantesio.cpp
@@ -241,42 +241,15 @@ Mat::PAR::MuscleGiantesio::MuscleGiantesio(const Core::Mat::PAR::Parameter::Data
       actValues_((matdata.parameters.get<std::vector<double>>("ACTVALUES"))),
       density_(matdata.parameters.get<double>("DENS"))
 {
-  // error handling for parameter ranges
-  // passive material parameters
-  if (alpha_ <= 0.0) FOUR_C_THROW("Material parameter ALPHA must be greater zero");
-  if (beta_ <= 0.0) FOUR_C_THROW("Material parameter BETA must be greater zero");
-  if (gamma_ <= 0.0) FOUR_C_THROW("Material parameter GAMMA must be greater zero");
-  if (omega0_ < 0.0 || omega0_ > 1.0) FOUR_C_THROW("Material parameter OMEGA0 must be in [0;1]");
-
   // active material parameters
   // stimulation frequency dependent parameters
-  if (Na_ < 0.0)
-  {
-    FOUR_C_THROW("Material parameter ACTMUNUM must be positive or zero");
-  }
-
   double sumrho = 0.0;
   for (int iMU = 0; iMU < muTypesNum_; ++iMU)
   {
-    if (I_[iMU] < 0.0) FOUR_C_THROW("Material parameter INTERSTIM must be positive or zero");
-    if (rho_[iMU] < 0.0) FOUR_C_THROW("Material parameter FRACACTMU must be positive or zero");
-
     sumrho += rho_[iMU];
-    if (F_[iMU] < 0.0) FOUR_C_THROW("Material parameter FTWITCH must be positive or zero");
-    if (T_[iMU] < 0.0) FOUR_C_THROW("Material parameter TTWITCH must be positive or zero");
   }
 
   if (muTypesNum_ > 1 && sumrho != 1.0) FOUR_C_THROW("Sum of fractions of MU types must equal one");
-
-  // stretch dependent parameters
-  if (lambdaMin_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDAMIN must be positive");
-  if (lambdaOpt_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDAOPT must be positive");
-
-  // velocity dependent parameters
-  if (ke_ < 0.0) FOUR_C_THROW("Material parameter KE should be positive or zero");
-  if (kc_ < 0.0) FOUR_C_THROW("Material parameter KC should be positive or zero");
-  if (de_ < 0.0) FOUR_C_THROW("Material parameter DE should be positive or zero");
-  if (dc_ < 0.0) FOUR_C_THROW("Material parameter DC should be positive or zero");
 
   // prescribed activation in time intervals
   if (actTimesNum_ != int(actTimes_.size()))
@@ -285,9 +258,6 @@ Mat::PAR::MuscleGiantesio::MuscleGiantesio(const Core::Mat::PAR::Parameter::Data
     FOUR_C_THROW("Number of activation values ACTVALUES must equal ACTINTERVALSNUM");
   if (actTimesNum_ != actIntervalsNum_ + 1)
     FOUR_C_THROW("ACTTIMESNUM must be one smaller than ACTINTERVALSNUM");
-
-  // density
-  if (density_ < 0.0) FOUR_C_THROW("DENS should be positive");
 }
 
 std::shared_ptr<Core::Mat::Material> Mat::PAR::MuscleGiantesio::create_material()

--- a/src/mat/4C_mat_muscle_weickenmeier.cpp
+++ b/src/mat/4C_mat_muscle_weickenmeier.cpp
@@ -49,42 +49,15 @@ Mat::PAR::MuscleWeickenmeier::MuscleWeickenmeier(const Core::Mat::PAR::Parameter
       actValues_((matdata.parameters.get<std::vector<double>>("ACTVALUES"))),
       density_(matdata.parameters.get<double>("DENS"))
 {
-  // error handling for parameter ranges
-  // passive material parameters
-  if (alpha_ <= 0.0) FOUR_C_THROW("Material parameter ALPHA must be greater zero");
-  if (beta_ <= 0.0) FOUR_C_THROW("Material parameter BETA must be greater zero");
-  if (gamma_ <= 0.0) FOUR_C_THROW("Material parameter GAMMA must be greater zero");
-  if (omega0_ < 0.0 || omega0_ > 1.0) FOUR_C_THROW("Material parameter OMEGA0 must be in [0;1]");
-
   // active material parameters
   // stimulation frequency dependent parameters
-  if (Na_ < 0.0)
-  {
-    FOUR_C_THROW("Material parameter ACTMUNUM must be positive or zero");
-  }
-
   double sumrho = 0.0;
   for (int iMU = 0; iMU < muTypesNum_; ++iMU)
   {
-    if (I_[iMU] < 0.0) FOUR_C_THROW("Material parameter INTERSTIM must be positive or zero");
-    if (rho_[iMU] < 0.0) FOUR_C_THROW("Material parameter FRACACTMU must be positive or zero");
-
     sumrho += rho_[iMU];
-    if (F_[iMU] < 0.0) FOUR_C_THROW("Material parameter FTWITCH must be positive or zero");
-    if (T_[iMU] < 0.0) FOUR_C_THROW("Material parameter TTWITCH must be positive or zero");
   }
 
   if (muTypesNum_ > 1 && sumrho != 1.0) FOUR_C_THROW("Sum of fractions of MU types must equal one");
-
-  // stretch dependent parameters
-  if (lambdaMin_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDAMIN must be positive");
-  if (lambdaOpt_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDAOPT must be positive");
-
-  // velocity dependent parameters
-  if (ke_ < 0.0) FOUR_C_THROW("Material parameter KE should be positive or zero");
-  if (kc_ < 0.0) FOUR_C_THROW("Material parameter KC should be positive or zero");
-  if (de_ < 0.0) FOUR_C_THROW("Material parameter DE should be positive or zero");
-  if (dc_ < 0.0) FOUR_C_THROW("Material parameter DC should be positive or zero");
 
   // prescribed activation in time intervals
   if (actTimesNum_ != int(actTimes_.size()))
@@ -93,9 +66,6 @@ Mat::PAR::MuscleWeickenmeier::MuscleWeickenmeier(const Core::Mat::PAR::Parameter
     FOUR_C_THROW("Number of activation values ACTVALUES must equal ACTINTERVALSNUM");
   if (actTimesNum_ != actIntervalsNum_ + 1)
     FOUR_C_THROW("ACTTIMESNUM must be one smaller than ACTINTERVALSNUM");
-
-  // density
-  if (density_ < 0.0) FOUR_C_THROW("DENS should be positive");
 }
 
 std::shared_ptr<Core::Mat::Material> Mat::PAR::MuscleWeickenmeier::create_material()

--- a/src/mat/4C_mat_stvenantkirchhoff.cpp
+++ b/src/mat/4C_mat_stvenantkirchhoff.cpp
@@ -25,9 +25,6 @@ Mat::PAR::StVenantKirchhoff::StVenantKirchhoff(const Core::Mat::PAR::Parameter::
       poissonratio_(matdata.parameters.get<double>("NUE")),
       density_(matdata.parameters.get<double>("DENS"))
 {
-  if (youngs_ <= 0.) FOUR_C_THROW("Young's modulus must be greater zero");
-  if (poissonratio_ >= 0.5 || poissonratio_ < -1.)
-    FOUR_C_THROW("Poisson's ratio must be in [-1;0.5)");
 }
 
 std::shared_ptr<Core::Mat::Material> Mat::PAR::StVenantKirchhoff::create_material()

--- a/src/mat/elast/4C_mat_elast_isomuscle_blemker.cpp
+++ b/src/mat/elast/4C_mat_elast_isomuscle_blemker.cpp
@@ -35,16 +35,6 @@ Mat::Elastic::PAR::IsoMuscleBlemker::IsoMuscleBlemker(
       beta_(matdata.parameters.get<double>("BETA")),
       t_act_start_(matdata.parameters.get<double>("ACTSTARTTIME"))
 {
-  // error handling for parameter ranges
-  if (G1_ < 0.0) FOUR_C_THROW("Material parameter G1 must be positive or zero");
-  if (G2_ < 0.0) FOUR_C_THROW("Material parameter G2 must be positive or zero");
-  if (P1_ <= 0.0) FOUR_C_THROW("Material parameter P1 must be greater zero");
-  if (P2_ <= 0.0) FOUR_C_THROW("Material parameter P2 must be greater zero");
-  if (sigma_max_ < 0.0) FOUR_C_THROW("Material parameter SIGMA_MAX must be positive or zero");
-  if (lambda_ofl_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDA_OFL must be greater zero");
-  if (lambda_star_ <= 0.0) FOUR_C_THROW("Material parameter LAMBDA_STAR must be greater zero");
-  if (alpha_ < 0.0) FOUR_C_THROW("Material parameter ALPHA must be positive or zero");
-  if (beta_ < 0.0) FOUR_C_THROW("Material parameter BETA must be positive or zero");
 }
 
 


### PR DESCRIPTION
## Description and Context
- Use `Core::IO::InputSpecBuilders::Validators` to validate:
  - **St. Venant–Kirchhoff material model** (commit 1)  
  - **All muscle materials** (commits 2 + 3, to be squashed/merged together)  
- Fix a documentation error in `Core::IO::InputSpecBuilders::deprecated_selection` (commit 4).  

## Open Question
I often use:  
```cpp
using namespace Core::IO::InputSpecBuilders::Validators;
auto positive_or_zero_validator =
    in_range<double>(0.0, std::numeric_limits<double>::max());
```

Should we introduce a `positive_or_zero()` helper just as we have the `positive()` helper function?