### PR TITLE
Fix typo and doc link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To ensure a high quality of the repository, we enforce some pre-commit hooks in 
 
 ### 3. Code development
 
-Add your changes to the codebase. Please add unit tests or input-file tests that capture your changes. For further information, see our documentation on [testing](https://4c-multiphysics.github.io/4C/documentation/4Ctesting.html).
+Add your changes to the codebase. Please add unit tests or input-file tests that capture your changes. For further information, see our documentation on [testing](https://4c-multiphysics.github.io/4C/documentation/developer_guide/testing.html).
 
 #### Coding style
 Your changes are checked for a number of coding style conventions when creating a commit. These conventions are also verified when you submit a pull request. Please annotate your C++ source code with [Doxygen](https://doxygen.nl/index.html) comments.
@@ -44,7 +44,7 @@ Your changes are checked for a number of coding style conventions when creating 
 Please provide meaningful commit messages.
 
 ### 5. Submit a pull request
-Once you submitted your pull request, checks will run automatically to verify that you changes do not break existing functionality. We will review your changes before it can be merged into the `main` branch.
+Once you submitted your pull request, checks will run automatically to verify that your changes do not break existing functionality. We will review your changes before it can be merged into the `main` branch.
 We desire a clean commit history. This may require rebasing the commits before merging.
 
 ## Documentation


### PR DESCRIPTION
<!--
* Title: Provide a general summary of your changes in the Title above.

* Assignees:  If you know anyone who should likely handle bringing this pull request (PR) to completion -- that's usually yourself -- select them from the Assignees drop-down on the right.

* Labels: Update the label of the issue(s) addressed by this pull request to "Under Review".
-->

## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->

As the title states.
The link to the documentation of testing was obsolete. I think this new link is supposed to be the target.
[https://4c-multiphysics.github.io/4C/documentation/developer_guide/testing.html](https://4c-multiphysics.github.io/4C/documentation/developer_guide/testing.html)

## Related Issues and Pull Requests
<!--
If applicable, let us know how this pull request is related to any other open issues or pull requests by linking to them here.
Some suggestion for keywords:
Closes (will automatically close mentioned issue if merged), Blocks, Related to
-->
