### PR TITLE
Provide adjacent elements in Node as refs

### DIFF
--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -155,7 +155,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
     // bounding boxes.
     auto correct_node = [](const Core::Nodes::Node& node) -> decltype(auto)
     {
-      const Core::Elements::Element* element = node.elements()[0];
+      const Core::Elements::Element* element = node.adjacent_elements()[0].user_element();
       const auto* beamelement = dynamic_cast<const Discret::Elements::Beam3Base*>(element);
       if (beamelement != nullptr && !beamelement->is_centerline_node(node))
         return *element->nodes()[0];

--- a/src/beam3/4C_beam3_euler_bernoulli.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli.cpp
@@ -91,7 +91,8 @@ Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3ebType::compute_null_spa
   const auto& x = node.x();
 
   // getting pointer at current element
-  const auto* beam3eb = dynamic_cast<const Discret::Elements::Beam3eb*>(node.elements()[0]);
+  const auto* beam3eb =
+      dynamic_cast<const Discret::Elements::Beam3eb*>(node.adjacent_elements()[0].user_element());
   if (!beam3eb) FOUR_C_THROW("Cannot cast to Beam3eb");
 
   // Compute tangent vector with unit length from nodal coordinates.

--- a/src/beamcontact/4C_beamcontact_beam3contact.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact.cpp
@@ -5165,7 +5165,8 @@ std::vector<int> CONTACT::Beam3contact<numnodes, numnodalvalues>::get_global_dof
   // this loop is not entered in case of numnodalvalues=1
   for (int k = 3; k < 3 * numnodalvalues; ++k)
   {
-    if ((node->elements()[0])->element_type() != Discret::Elements::Beam3rType::instance())
+    if ((node->adjacent_elements()[0].user_element())->element_type() !=
+        Discret::Elements::Beam3rType::instance())
       pdofs[k] = (dofoffsetmap_.find(cdofs[k]))->second;
     else
       pdofs[k] = (dofoffsetmap_.find(cdofs[k + 3]))->second;

--- a/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_octtree.cpp
@@ -265,8 +265,8 @@ bool Beam3ContactOctTree::intersect_b_boxes_with(
   octants.clear();
   // get the octants for two bounding boxes (element) GIDs adjacent to each given node LID
   for (int i = 0; i < nodeLID.numRows(); i++)
-    octants.push_back(
-        in_which_octant_lies(searchdis_.l_col_node((int)nodeLID(i, 0))->elements()[0]->id()));
+    octants.push_back(in_which_octant_lies(
+        searchdis_.l_col_node((int)nodeLID(i, 0))->adjacent_elements()[0].global_id()));
 
   // intersection of given bounding box with all other bounding boxes in given octant
   for (int ibox = 0; ibox < (int)octants.size(); ibox++)

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_tangentsmoothing.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_contact_tangentsmoothing.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_beaminteraction_beam_to_beam_contact_tangentsmoothing.hpp"
 
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_node.hpp"
 #include "4C_fem_general_utils_fem_shapefunctions.hpp"
@@ -61,25 +62,16 @@ BeamInteraction::Beam3TangentSmoothing::determine_neighbors(const Core::Elements
         "per node");
   }
 
-  // loop over all elements adjacent to the left node of element 1
-  for (int y = 0; y < (**(element1->nodes())).num_element(); ++y)
+  // Loop over all elements adjacent to the left node of element1
+  for (auto neighbor_element : element1->nodes()[0]->adjacent_elements())
   {
-    globalneighborId = (*((**(element1->nodes())).elements() + y))->id();
-
-    if (globalneighborId != element1->id())
+    if (neighbor_element.global_id() != element1->id())
     {
-      left_neighbor = (*((**(element1->nodes())).elements() + y));
+      left_neighbor = neighbor_element.user_element();
 
-      // if node 1 of the left neighbor is the connecting node:
-      if (*((*((**(element1->nodes())).elements() + y))->node_ids()) == globalnodeId)
-      {
-        connecting_node_left = 0;
-      }
-      // otherwise node n_right of the left neighbor is the connecting node
-      else
-      {
-        connecting_node_left = n_right;
-      }
+      // Determine the connecting node
+      connecting_node_left =
+          (neighbor_element.user_element()->node_ids()[0] == globalnodeId) ? 0 : n_right;
     }
   }
 
@@ -94,22 +86,21 @@ BeamInteraction::Beam3TangentSmoothing::determine_neighbors(const Core::Elements
         "per node");
   }
 
-  // loop over all elements adjacent to the right node of element 1
-  for (int y = 0; y < (**(element1->nodes() + n_right)).num_element(); ++y)
+  // loop over all elements adjacent to the right node of element1
+  const auto rightNode = element1->nodes()[n_right];
+  for (auto neighbor : rightNode->adjacent_elements())
   {
-    globalneighborId = (*((**(element1->nodes() + n_right)).elements() + y))->id();
+    globalneighborId = neighbor.global_id();
 
     if (globalneighborId != element1->id())
     {
-      right_neighbor = (*((**(element1->nodes() + n_right)).elements() + y));
+      right_neighbor = neighbor.user_element();
 
-      // if node 1 of the right neighbor is the connecting node:
-      if (*((*((**(element1->nodes() + n_right)).elements() + y))->node_ids()) == globalnodeId)
+      // if node 0 of the right neighbor is the connecting node:
+      if (neighbor.user_element()->node_ids()[0] == globalnodeId)
       {
         connecting_node_right = 0;
       }
-
-      // otherwise node n_right of the right neighbor is the connecting node
       else
       {
         connecting_node_right = n_right;

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_point_coupling_pair_condition.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_beam_point_coupling_pair_condition.cpp
@@ -83,7 +83,7 @@ void BeamInteraction::BeamToBeamPointCouplingCondition::build_id_sets(
 
     Core::Nodes::Node* node = discretization->g_node(node_id);
 
-    Core::Elements::Element* element = node->elements()[0];
+    Core::Elements::Element* element = node->adjacent_elements()[0].user_element();
     element_ids[i - 1] = element->id();
     if (element->node_ids()[0] == node_id)
       position_in_parameter_space[i - 1] = -1;

--- a/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_conditions.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_beam_to_solid_conditions.cpp
@@ -495,10 +495,9 @@ void BeamInteraction::BeamToSolidConditionSurface::setup(
     for (int i_node = 0; i_node < face_element_iterator.second->get_element()->num_node(); i_node++)
     {
       // Loop over the elements connected to that node and check if they are in this condition.
-      const Core::Elements::Element* const* elements = nodes[i_node]->elements();
-      for (int i_element = 0; i_element < nodes[i_node]->num_element(); i_element++)
+      for (auto ele : nodes[i_node]->adjacent_elements())
       {
-        const int element_id = elements[i_element]->id();
+        const int element_id = ele.global_id();
         auto find_in_condition = surface_ids_.find(element_id);
         if (find_in_condition != surface_ids_.end())
         {

--- a/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_calc_utils.cpp
@@ -60,9 +60,9 @@ namespace BeamInteraction
       bool beameles = false;
       bool othereles = false;
 
-      for (int i = 0; i < static_cast<int>(node.num_element()); ++i)
+      for (auto ele : node.adjacent_elements())
       {
-        if (is_beam_element(*(node.elements())[i]))
+        if (is_beam_element(*ele.user_element()))
           beameles = true;
         else
           othereles = true;
@@ -83,10 +83,10 @@ namespace BeamInteraction
       bool beamclnode = false;
 
       // TODO: actually we would have to check all elements of all processors!!! Gather?
-      for (int i = 0; i < static_cast<int>(node.num_element()); ++i)
+      for (auto ele : node.adjacent_elements())
       {
         const Discret::Elements::Beam3Base* beamele =
-            dynamic_cast<const Discret::Elements::Beam3Base*>(node.elements()[i]);
+            dynamic_cast<const Discret::Elements::Beam3Base*>(ele.user_element());
 
         if (beamele != nullptr and beamele->is_centerline_node(node)) beamclnode = true;
       }
@@ -101,9 +101,9 @@ namespace BeamInteraction
       bool othereles = false;
 
       // TODO: actually we would have to check all elements of all processors!!! Gather?
-      for (int i = 0; i < node.num_element(); ++i)
+      for (auto ele : node.adjacent_elements())
       {
-        if (is_rigid_sphere_element(*(node.elements())[i]))
+        if (is_rigid_sphere_element(*ele.user_element()))
           sphereele = true;
         else
           othereles = true;
@@ -359,7 +359,7 @@ namespace BeamInteraction
           // insert element cloud of current node
           Core::Nodes::Node* currnode = discret.g_node(requirednodes[i]);
           for (int j = 0; j < currnode->num_element(); ++j)
-            sdata.insert(currnode->elements()[j]->id());
+            sdata.insert(currnode->adjacent_elements()[j].global_id());
         }
 
         // gather and store information on iproc
@@ -430,15 +430,15 @@ namespace BeamInteraction
       {
         // insert element cloud of current node
         Core::Nodes::Node* node = discret.g_node((*nodeids)[nodei]);
-        for (int j = 0; j < node->num_element(); ++j)
+        for (auto ele : node->adjacent_elements())
         {
           // only if element has not yet been added to the filaments elements
-          if (std::find(sortedfilamenteles.begin(), sortedfilamenteles.end(),
-                  node->elements()[j]) != sortedfilamenteles.end())
+          if (std::find(sortedfilamenteles.begin(), sortedfilamenteles.end(), ele.user_element()) !=
+              sortedfilamenteles.end())
             continue;
 
           Discret::Elements::Beam3Base* currbeamele =
-              dynamic_cast<Discret::Elements::Beam3Base*>(node->elements()[j]);
+              dynamic_cast<Discret::Elements::Beam3Base*>(ele.user_element());
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
           if (currbeamele == nullptr)
@@ -448,7 +448,7 @@ namespace BeamInteraction
           // add element reference length of new element to filament reference length
           filreflength += currbeamele->ref_length();
           // add element
-          sortedfilamenteles.push_back(node->elements()[j]);
+          sortedfilamenteles.push_back(ele.user_element());
         }
       }
     }

--- a/src/beaminteraction/src/4C_beaminteraction_crosslinker_handler.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_crosslinker_handler.cpp
@@ -538,7 +538,8 @@ std::shared_ptr<std::list<int>> BeamInteraction::BeamCrosslinkerHandler::transfe
 #endif
 
     Core::FE::MeshFree::MeshfreeMultiBin* currbin =
-        dynamic_cast<Core::FE::MeshFree::MeshfreeMultiBin*>(currlinker->elements()[0]);
+        dynamic_cast<Core::FE::MeshFree::MeshfreeMultiBin*>(
+            currlinker->adjacent_elements()[0].user_element());
     // as checked above, there is only one element in currele array
     const int binId = currbin->id();
     const int rlid = binstrategy_->bin_discret()->element_row_map()->lid(binId);

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -160,7 +160,7 @@ void Solid::ModelEvaluator::BeamInteraction::setup()
 
   auto correct_node = [](const Core::Nodes::Node& node) -> decltype(auto)
   {
-    const Core::Elements::Element* element = node.elements()[0];
+    const Core::Elements::Element* element = node.adjacent_elements()[0].user_element();
     const auto* beamelement = dynamic_cast<const Discret::Elements::Beam3Base*>(element);
     if (beamelement != nullptr && !beamelement->is_centerline_node(node))
       return *element->nodes()[0];

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
@@ -268,8 +268,8 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::set_filament_types()
 
     for (int i = 0; i < currnode->num_element(); ++i)
     {
-      Discret::Elements::Beam3Base* beamele =
-          dynamic_cast<Discret::Elements::Beam3Base*>(currnode->elements()[i]);
+      Discret::Elements::Beam3Base* beamele = dynamic_cast<Discret::Elements::Beam3Base*>(
+          currnode->adjacent_elements()[i].user_element());
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
       if (beamele == nullptr)
@@ -2279,7 +2279,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::find_potential_binding_ev
 #endif
 
     // get bin that contains this crosslinker (can only be one)
-    Core::Elements::Element* currentbin = currcrosslinker->elements()[0];
+    Core::Elements::Element* currentbin = currcrosslinker->adjacent_elements()[0].user_element();
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     if (currentbin->id() < 0) FOUR_C_THROW(" negative bin id number {} ", currentbin->id());

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -529,8 +529,8 @@ void Constraints::SpringDashpot::evaluate_robin(std::shared_ptr<Core::LinAlg::Sp
         // get adjacent element of this node and check if it's just one -> get this element and cast
         // it to truss element
         if (node->num_element() != 1) FOUR_C_THROW("Node may only have one element");
-        auto* ele = node->elements();
-        auto* truss_ele = dynamic_cast<Discret::Elements::Truss3*>(ele[0]);
+        auto* truss_ele =
+            dynamic_cast<Discret::Elements::Truss3*>(node->adjacent_elements()[0].user_element());
         if (truss_ele == nullptr)
         {
           FOUR_C_THROW(

--- a/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
+++ b/src/constraint_framework/4C_constraint_framework_embeddedmesh_solid_to_solid_mortar_manager.cpp
@@ -589,7 +589,7 @@ bool Constraints::EmbeddedMesh::SolidToSolidMortarManager::is_cut_node(
   {
     bool is_node_in_cut_ele =
         std::find(cut_elements_col_vector_.begin(), cut_elements_col_vector_.end(),
-            node.elements()[num_ele]) != cut_elements_col_vector_.end();
+            node.adjacent_elements()[num_ele].user_element()) != cut_elements_col_vector_.end();
     if (is_node_in_cut_ele) is_cut_node = true;
   }
 

--- a/src/contact/src/4C_contact_friction_node.cpp
+++ b/src/contact/src/4C_contact_friction_node.cpp
@@ -10,6 +10,7 @@
 #include "4C_comm_pack_helpers.hpp"
 #include "4C_contact_defines.hpp"
 #include "4C_contact_element.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -539,15 +540,12 @@ void CONTACT::FriNode::initialize_data_container()
 {
   // get maximum size of lin vectors
   linsize_ = 0;
-  for (int i = 0; i < num_element(); ++i)
-    for (int j = 0; j < elements()[i]->num_node(); ++j)
-      linsize_ += elements()[i]->num_dof_per_node(*(elements()[i]->nodes()[j]));
+  for (auto ele : adjacent_elements())
+    for (auto node : ele.nodes())
+      linsize_ += ele.user_element()->num_dof_per_node(*node.user_node());
 
   // get maximum size of lin vectors
-  dentries_ = 0;
-  for (int i = 0; i < num_element(); ++i)
-    for (int j = 0; j < elements()[i]->num_node(); ++j)
-      dentries_ += elements()[i]->num_dof_per_node(*(elements()[i]->nodes()[j]));
+  dentries_ = linsize_;
 
   // only initialize if not yet done
   if (modata_ == nullptr && codata_ == nullptr && fridata_ == nullptr)

--- a/src/contact/src/4C_contact_interface_assemble.cpp
+++ b/src/contact/src/4C_contact_interface_assemble.cpp
@@ -1531,7 +1531,8 @@ void CONTACT::Interface::assemble_g(Core::LinAlg::Vector<double>& gglobal)
         bool node_has_quad_element = false;
         for (int i = 0; i < cnode->num_element(); i++)
         {
-          if (dynamic_cast<Mortar::Element*>(cnode->elements()[i])->is_quad() == true)
+          if (dynamic_cast<Mortar::Element*>(cnode->adjacent_elements()[i].user_element())
+                  ->is_quad() == true)
           {
             node_has_quad_element = true;
             break;

--- a/src/contact/src/4C_contact_interpolator.cpp
+++ b/src/contact/src/4C_contact_interpolator.cpp
@@ -11,6 +11,7 @@
 #include "4C_contact_element.hpp"
 #include "4C_contact_friction_node.hpp"
 #include "4C_contact_integrator.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_linalg_serialdensematrix.hpp"
 #include "4C_linalg_serialdensevector.hpp"
 #include "4C_mortar_defines.hpp"
@@ -104,13 +105,10 @@ void NTS::Interpolator::interpolate_2d(Mortar::Node& snode, std::vector<Mortar::
 
   // calculate area -- simplified version
   double area = 0.0;
-  //  for (int ele=0;ele<snode.NumElement();++ele)
-  //    area+=dynamic_cast<CONTACT::Element*>(snode.Elements()[ele])->MoData().Area();
-  //
-  //  area=area/snode.NumElement();
 
   // get first element (this is a dummy to use established algorithms)
-  Mortar::Element* sele = dynamic_cast<Mortar::Element*>(snode.elements()[0]);
+  Mortar::Element* sele =
+      dynamic_cast<Mortar::Element*>(snode.adjacent_elements()[0].user_element());
 
   CONTACT::Node& mynode = dynamic_cast<CONTACT::Node&>(snode);
 
@@ -247,7 +245,8 @@ bool NTS::Interpolator::interpolate_3d(Mortar::Node& snode, std::vector<Mortar::
   bool kink_projection = false;
 
   // get first element (this is a dummy to use established algorithms)
-  Mortar::Element* sele = dynamic_cast<Mortar::Element*>(snode.elements()[0]);
+  Mortar::Element* sele =
+      dynamic_cast<Mortar::Element*>(snode.adjacent_elements()[0].user_element());
 
   CONTACT::Node& mynode = dynamic_cast<CONTACT::Node&>(snode);
 
@@ -1896,7 +1895,8 @@ void NTS::MTInterpolatorCalc<distype_m>::interpolate_3d(
   double sxi[2] = {0.0, 0.0};
 
   // get local id
-  Mortar::Element* sele = dynamic_cast<Mortar::Element*>(snode.elements()[0]);
+  Mortar::Element* sele =
+      dynamic_cast<Mortar::Element*>(snode.adjacent_elements()[0].user_element());
 
   int lid = -1;
   for (int i = 0; i < sele->num_node(); ++i)

--- a/src/contact/src/4C_contact_selfcontact_binarytree.cpp
+++ b/src/contact/src/4C_contact_selfcontact_binarytree.cpp
@@ -806,18 +806,11 @@ void CONTACT::SelfBinaryTree::calculate_dual_graph(
       Core::Nodes::Node* node = nodes[j];
       if (!node) FOUR_C_THROW("Null pointer!");
 
-      // adjacent elements of current node
-      int numE = node->num_element();
-      Core::Elements::Element** adjElements = node->elements();
-      if (!adjElements) FOUR_C_THROW("Null pointer!");
-
       // loop over all adjacent elements of current node
-      for (int k = 0; k < numE; ++k)
+      for (auto ele : node->adjacent_elements())
       {
-        Core::Elements::Element* adjElementk = adjElements[k];
-
         calculate_adjacent_tree_nodes_and_dual_edges(
-            possadjids, gid, adjElementk, node1, adjtreenodes, adjdualedges);
+            possadjids, gid, ele.user_element(), node1, adjtreenodes, adjdualedges);
       }  // all adjacent elements
     }  // all nodes
 

--- a/src/contact/src/4C_contact_selfcontact_binarytree_unbiased.cpp
+++ b/src/contact/src/4C_contact_selfcontact_binarytree_unbiased.cpp
@@ -108,22 +108,14 @@ void CONTACT::UnbiasedSelfBinaryTree::calculate_proc_specific_dual_graph(
       Core::Nodes::Node* node = nodes[j];
       if (!node) FOUR_C_THROW("Null pointer!");
 
-      // adjacent elements of current node
-      int numE = node->num_element();
-      Core::Elements::Element** adjElements = node->elements();
-      if (!adjElements) FOUR_C_THROW("Null pointer!");
-
       // loop over all adjacent elements of current node
-      for (int k = 0; k < numE; ++k)
+      for (auto ele : node->adjacent_elements())
       {
-        // get k-th adjacent element
-        Core::Elements::Element* adjElementk = adjElements[k];
-
         // we only need to collect information if current adjacent element is owned by processor p
-        if (adjElementk->owner() != p) continue;
+        if (ele.owner() != p) continue;
 
         calculate_adjacent_tree_nodes_and_dual_edges(
-            possadjids, gid, adjElementk, node1, adjtreenodes, adjdualedges);
+            possadjids, gid, ele.user_element(), node1, adjtreenodes, adjdualedges);
       }  // all adjacent elements
     }  // all nodes
 

--- a/src/contact/src/4C_contact_strategy_factory.cpp
+++ b/src/contact/src/4C_contact_strategy_factory.cpp
@@ -846,10 +846,11 @@ void CONTACT::STRATEGY::Factory::build_interfaces(const Teuchos::ParameterList& 
               node->id());
         }
 
-        const bool nurbs = Core::FE::is_nurbs_celltype(node->elements()[0]->shape());
-        for (unsigned elid = 0; elid < static_cast<unsigned>(node->num_element()); ++elid)
+        const bool nurbs =
+            Core::FE::is_nurbs_celltype(node->adjacent_elements()[0].user_element()->shape());
+        for (auto ele : node->adjacent_elements())
         {
-          const Core::Elements::Element* adj_ele = node->elements()[elid];
+          const Core::Elements::Element* adj_ele = ele.user_element();
           if (nurbs != Core::FE::is_nurbs_celltype(adj_ele->shape()))
           {
             FOUR_C_THROW(

--- a/src/contact/src/4C_contact_tsi_interface.cpp
+++ b/src/contact/src/4C_contact_tsi_interface.cpp
@@ -366,7 +366,8 @@ void CONTACT::TSIInterface::assemble_dual_mass_lumped(
             "some inconsistency: for lagmult_const every slave node may only have one element "
             "attached (it's the center-node!)");
 
-      CONTACT::Element* coele = dynamic_cast<CONTACT::Element*>(conode->elements()[0]);
+      CONTACT::Element* coele =
+          dynamic_cast<CONTACT::Element*>(conode->adjacent_elements()[0].user_element());
       if (!coele) FOUR_C_THROW("this should be a contact element");
 
       Core::Gen::Pairedvector<int, double> derivArea(coele->num_node() * n_dim());

--- a/src/contact/src/4C_contact_wear_interface.cpp
+++ b/src/contact/src/4C_contact_wear_interface.cpp
@@ -3196,13 +3196,15 @@ bool Wear::WearInterface::build_active_set_master()
     for (int u = 0; u < (int)frinode->num_element(); ++u)
     {
       // all found MASTER elements:
-      for (int k = 0; k < (int)dynamic_cast<Mortar::Element*>(frinode->elements()[u])
-                              ->mo_data()
-                              .num_search_elements();
+      for (int k = 0;
+          k < (int)dynamic_cast<Mortar::Element*>(frinode->adjacent_elements()[u].user_element())
+                  ->mo_data()
+                  .num_search_elements();
           ++k)
       {
-        int gid2 =
-            dynamic_cast<Mortar::Element*>(frinode->elements()[u])->mo_data().search_elements()[k];
+        int gid2 = dynamic_cast<Mortar::Element*>(frinode->adjacent_elements()[u].user_element())
+                       ->mo_data()
+                       .search_elements()[k];
         Core::Elements::Element* ele2 = discret().g_element(gid2);
         if (!ele2) FOUR_C_THROW("Cannot find master element with gid %", gid2);
         Mortar::Element* celement = dynamic_cast<Mortar::Element*>(ele2);

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -696,7 +696,7 @@ void Core::Binstrategy::BinningStrategy::write_bin_output(int const step, double
   for (int i = 0; i < bindis_->num_my_col_elements(); ++i)
   {
     Core::Elements::Element* ele = bindis_->l_col_element(i);
-    if (!ele) FOUR_C_THROW("Cannot find element with lid %", i);
+    if (!ele) FOUR_C_THROW("Cannot find element with local id {}", i);
 
     // get corner position as node positions
     const int numcorner = 8;
@@ -1772,9 +1772,8 @@ void Core::Binstrategy::BinningStrategy::transfer_nodes_and_elements(
         // set new owner of node
         currnode->set_owner(hostbinowner);
         // in case myrank is owner of associated element, add it to set
-        Core::Elements::Element** curreles = currnode->elements();
-        for (int j = 0; j < currnode->num_element(); ++j)
-          if (curreles[j]->owner() == myrank_) elestoupdate.insert(curreles[j]);
+        for (auto ele : currnode->adjacent_elements())
+          if (ele.owner() == myrank_) elestoupdate.insert(ele.user_element());
       }
     }
     /*else: in this case myrank was not owner of node and a corresponding element had and

--- a/src/core/fem/benchmark_tests/discretization/4C_fem_discretization_benchmark.cpp
+++ b/src/core/fem/benchmark_tests/discretization/4C_fem_discretization_benchmark.cpp
@@ -81,6 +81,7 @@ namespace
   }
   BENCHMARK(discretization_loop_user_pointer);
 
+
   void discretization_loop_reference_nested(benchmark::State& state)
   {
     auto comm = MPI_COMM_WORLD;
@@ -95,6 +96,7 @@ namespace
         for (auto element : node.adjacent_elements())
         {
           count += element.local_id();
+          count += element.global_id();
         }
       }
       benchmark::DoNotOptimize(count);
@@ -117,11 +119,11 @@ namespace
       {
         const auto* node = discret.l_row_node(i);
         {
-          const int n_elements = node->num_element();
-          const auto* elements = node->elements();
-          for (int j = 0; j < n_elements; ++j)
+          // Use the new interface which return a range of ElementRef objects
+          for (auto ele : node->adjacent_elements())
           {
-            count += elements[j]->lid();
+            count += ele.local_id();
+            count += ele.global_id();
           }
         }
       }

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -1203,9 +1203,8 @@ void Core::Conditions::PeriodicBoundaryConditions::balance_load()
       double weight = 1.0;
 
       // loop over adjacent elements of this node and find element with highest cost
-      Core::Elements::Element** surrele = node->elements();
-      for (int k = 0; k < node->num_element(); ++k)
-        weight = std::max(weight, surrele[k]->evaluation_cost());
+      for (auto ele : node->adjacent_elements())
+        weight = std::max(weight, ele.user_element()->evaluation_cost());
 
       node_weights->replace_local_value(node_lid, weight);
     }

--- a/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_evaluate.cpp
@@ -299,13 +299,9 @@ void Core::FE::Discretization::evaluate_neumann(Teuchos::ParameterList& params,
       Core::Nodes::Node* actnode = g_node(nodeid);
       if (!actnode) FOUR_C_THROW("Cannot find global node {}", nodeid);
 
-      // get elements attached to global node
-      Core::Elements::Element** curreleptr = actnode->elements();
-
-      // find element from pointer
       // please note, that external force will be applied to the first element [0] attached to a
       // node this needs to be done, otherwise it will be applied several times on several elements.
-      Core::Elements::Element* currele = curreleptr[0];
+      auto currele = actnode->adjacent_elements()[0].user_element();
 
       // get information from location
       currele->location_vector(*this, lm, lmowner, lmstride);

--- a/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
@@ -266,7 +266,6 @@ void Core::FE::Discretization::build_node_to_element_pointers()
 {
   for (const auto& node : node_ | std::views::values)
   {
-    node->clear_my_element_topology();
     node->discretization_ = this;
   }
 
@@ -282,7 +281,6 @@ void Core::FE::Discretization::build_node_to_element_pointers()
       FOUR_C_ASSERT_ALWAYS(
           node, "Node {} is not on this proc {}", j, Core::Communication::my_mpi_rank(get_comm()));
 
-      node->add_element_ptr(ele.get());
       node_to_element_ids[node->lid()].push_back(ele->lid());
     }
   }

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
@@ -82,11 +82,14 @@ void Core::FE::do_initial_field(const Core::Utils::FunctionManager& function_man
     // Get native number of dofs at this node. There might be multiple dofsets
     // (in xfem cases), thus the size of the dofs vector might be a multiple
     // of this.
-    auto* const myeles = node->elements();
-    auto* ele_with_max_dof = std::max_element(myeles, myeles + node->num_element(),
-        [&](Core::Elements::Element* a, Core::Elements::Element* b)
-        { return a->num_dof_per_node(*node) < b->num_dof_per_node(*node); });
-    const int numdof = (*ele_with_max_dof)->num_dof_per_node(*node);
+    auto elements = node->adjacent_elements();
+    auto ele_with_max_dof = std::ranges::max_element(elements,
+        [&](ElementRef a, ElementRef b)
+        {
+          return a.user_element()->num_dof_per_node(*node) <
+                 b.user_element()->num_dof_per_node(*node);
+        });
+    const int numdof = ele_with_max_dof->user_element()->num_dof_per_node(*node);
 
     if ((total_numdof % numdof) != 0) FOUR_C_THROW("illegal dof set number");
 

--- a/src/core/fem/src/general/node/4C_fem_general_node.cpp
+++ b/src/core/fem/src/general/node/4C_fem_general_node.cpp
@@ -8,6 +8,7 @@
 #include "4C_fem_general_node.hpp"
 
 #include "4C_comm_pack_helpers.hpp"
+#include "4C_fem_discretization.hpp"
 #include "4C_utils_exceptions.hpp"
 
 FOUR_C_NAMESPACE_OPEN
@@ -50,6 +51,23 @@ std::ostream& operator<<(std::ostream& os, const Core::Nodes::Node& node)
 {
   node.print(os);
   return os;
+}
+
+
+int Core::Nodes::Node::num_element() const { return adjacent_elements().size(); }
+
+
+Core::FE::IteratorRange<Core::FE::DiscretizationIterator<Core::FE::ElementRef>>
+Core::Nodes::Node::adjacent_elements()
+{
+  return FE::NodeRef(discretization_, lid_).adjacent_elements();
+}
+
+
+Core::FE::IteratorRange<Core::FE::DiscretizationIterator<Core::FE::ConstElementRef>>
+Core::Nodes::Node::adjacent_elements() const
+{
+  return FE::ConstNodeRef(discretization_, lid_).adjacent_elements();
 }
 
 

--- a/src/core/fem/src/general/node/4C_fem_general_node.hpp
+++ b/src/core/fem/src/general/node/4C_fem_general_node.hpp
@@ -13,6 +13,7 @@
 
 #include "4C_comm_parobject.hpp"
 #include "4C_comm_parobjectfactory.hpp"
+#include "4C_fem_discretization_iterator.hpp"
 
 #include <memory>
 
@@ -31,6 +32,8 @@ namespace Core::Conditions
 
 namespace Core::FE
 {
+  class ConstElementRef;
+  class ElementRef;
   class Discretization;
 }  // namespace Core::FE
 
@@ -140,33 +143,21 @@ namespace Core::Nodes
     */
     inline int n_dim() const { return x_.size(); }
 
-    /*!
-    \brief Return processor-local number of elements adjacent to this node
-    */
-    inline int num_element() const { return element_.size(); }
+    /**
+     * Return the number of elements adjacent to this node.
+     */
+    [[nodiscard]] int num_element() const;
 
-    /*!
-    \brief Return ptr to vector of element ptrs
-    */
-    inline Core::Elements::Element** elements()
-    {
-      if (num_element())
-        return element_.data();
-      else
-        return nullptr;
-    }
+    /**
+     * A range containing a ElementRef to all elements adjacent to this node.
+     */
+    [[nodiscard]] FE::IteratorRange<FE::DiscretizationIterator<FE::ElementRef>> adjacent_elements();
 
-    /*!
-    \brief Return const ptr to vector of const element ptrs
-    */
-    inline const Core::Elements::Element* const* elements() const
-    {
-      if (num_element())
-        return (const Core::Elements::Element* const*)(element_.data());
-      else
-        return nullptr;
-    }
-
+    /**
+     * A range containing a ConstElementRef to all elements adjacent to this node.
+     */
+    [[nodiscard]] FE::IteratorRange<FE::DiscretizationIterator<FE::ConstElementRef>>
+    adjacent_elements() const;
 
     /*!
     \brief Print this node
@@ -238,24 +229,6 @@ namespace Core::Nodes
      */
     virtual bool vis_data(const std::string& name, std::vector<double>& data);
 
-    /*!
-    \brief Clear vector of pointers to my elements
-
-    */
-    inline void clear_my_element_topology() { element_.clear(); }
-
-    /*!
-    \brief Add an element to my vector of pointers to elements
-
-    Resizes the element ptr vector and adds ptr at the end of vector
-    */
-    inline void add_element_ptr(Core::Elements::Element* eleptr)
-    {
-      const int size = element_.size();
-      element_.resize(size + 1);
-      element_[size] = eleptr;
-    }
-
     /**
      * Access the discretization managing this node. This may be a nullptr if the node is not
      * part of a discretization.
@@ -272,8 +245,6 @@ namespace Core::Nodes
     int owner_;
     //! nodal coords
     std::vector<double> x_;
-    //! pointers to adjacent elements
-    std::vector<Core::Elements::Element*> element_;
 
     //! Refer to discretization managing this node
     FE::Discretization* discretization_{};

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -132,7 +132,7 @@ Core::FE::DiscretizationCreatorBase::create_matching_discretization(
   for (int i = 0; i < sourcedis.node_col_map()->num_my_elements(); ++i)
   {
     Core::Nodes::Node* node = sourcedis.l_col_node(i);
-    if (!node) FOUR_C_THROW("Cannot find node with lid %", i);
+    if (!node) FOUR_C_THROW("Cannot find node with local id {}", i);
     std::shared_ptr<Core::Nodes::Node> newnode(node->clone());
     targetdis->add_node(newnode);
   }
@@ -141,7 +141,7 @@ Core::FE::DiscretizationCreatorBase::create_matching_discretization(
   for (int i = 0; i < sourcedis.element_col_map()->num_my_elements(); ++i)
   {
     Core::Elements::Element* ele = sourcedis.l_col_element(i);
-    if (!ele) FOUR_C_THROW("Cannot find element with lid %", i);
+    if (!ele) FOUR_C_THROW("Cannot find element with local id {}", i);
     std::shared_ptr<Core::Elements::Element> newele(ele->clone());
     targetdis->add_element(newele);
   }

--- a/src/core/fem/src/geometry/4C_fem_geometry_searchtree_service.cpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_searchtree_service.cpp
@@ -226,8 +226,8 @@ std::map<int, std::set<int>> Core::Geo::get_elements_in_radius(const Core::FE::D
 
       if (distance < (radius + Core::Geo::TOL7))
       {
-        for (int i = 0; i < dis.g_node(*nodeIter)->num_element(); i++)
-          elementMap[labelIter->first].insert(dis.g_node(*nodeIter)->elements()[i]->id());
+        for (auto ele : dis.g_node(*nodeIter)->adjacent_elements())
+          elementMap[labelIter->first].insert(ele.global_id());
       }
     }
 
@@ -427,7 +427,8 @@ int Core::Geo::nearest_3d_object_in_node(const Core::FE::Discretization& dis,
         min_distance = distance;
         nearestObject.set_node_object_type(
             *nodeIter, labelIter->first, currentpositions.find(node->id())->second);
-        surfid = node->elements()[0]->id();  // surf id of any of the adjacent elements
+        surfid =
+            node->adjacent_elements()[0].global_id();  // surf id of any of the adjacent elements
       }
     }
 

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -59,7 +59,8 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
         if (localIndex == -1) continue;
 
         Core::Elements::Element* dwele = dis.l_row_element(localIndex);
-        actnode->elements()[0]->element_type().nodal_block_information(dwele, numdf, dimns);
+        actnode->adjacent_elements()[0].user_element()->element_type().nodal_block_information(
+            dwele, numdf, dimns);
         break;
       }
     }

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -741,7 +741,8 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_consistent_interpolation()
     Core::Nodes::Node* anode = dis1_->g_node(gid);
 
     // get found elements from other discr.
-    std::vector<int> found = search(*anode->elements()[0], SearchTreeB, CurrentDOPsB);
+    std::vector<int> found =
+        search(*anode->adjacent_elements()[0].user_element(), SearchTreeB, CurrentDOPsB);
 
     assemble_consistent_interpolation_p12(anode, found);
   }  // end node loop
@@ -754,7 +755,8 @@ void Coupling::VolMortar::VolMortarCoupl::evaluate_consistent_interpolation()
     Core::Nodes::Node* bnode = dis2_->g_node(gid);
 
     // get found elements from other discr.
-    std::vector<int> found = search(*bnode->elements()[0], SearchTreeA, CurrentDOPsA);
+    std::vector<int> found =
+        search(*bnode->adjacent_elements()[0].user_element(), SearchTreeA, CurrentDOPsA);
 
     assemble_consistent_interpolation_p21(bnode, found);
   }  // end node loop

--- a/src/cut/4C_cut_parentintersection.cpp
+++ b/src/cut/4C_cut_parentintersection.cpp
@@ -64,12 +64,9 @@ void Cut::ParentIntersection::create_nodal_dof_set(
     {
       Core::Nodes::Node* node = dis.g_node(n_gid);
 
-      // get adjacent elements for this node
-      const Core::Elements::Element* const* adjelements = node->elements();
-
-      for (int iele = 0; iele < node->num_element(); iele++)
+      for (auto ele : node->adjacent_elements())
       {
-        int adj_eid = adjelements[iele]->id();
+        int adj_eid = ele.global_id();
 
         // get its elementhandle
         Cut::ElementHandle* e = get_element(adj_eid);

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -377,7 +377,8 @@ void EHL::Base::add_couette_force(
     const double p = lubrication_->lubrication_field()->prenp()->operator[](
         lubrication_->lubrication_field()->prenp()->get_map().lid(lub_dis.dof(0, lnode, 0)));
 
-    std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
+    std::shared_ptr<Core::Mat::Material> mat =
+        lnode->adjacent_elements()[0].user_element()->material(0);
     if (!mat) FOUR_C_THROW("null pointer");
     std::shared_ptr<Mat::LubricationMat> lmat = std::dynamic_pointer_cast<Mat::LubricationMat>(mat);
     const double visc = lmat->compute_viscosity(p);
@@ -512,7 +513,7 @@ void EHL::Base::setup_unprojectable_dbc()
     {
       for (int e = 0; e < cnode->num_element(); ++e)
       {
-        Core::Elements::Element* ele = cnode->elements()[e];
+        Core::Elements::Element* ele = cnode->adjacent_elements()[e].user_element();
         for (int nn = 0; nn < ele->num_node(); ++nn)
         {
           CONTACT::Node* cnn = dynamic_cast<CONTACT::Node*>(ele->nodes()[nn]);
@@ -802,7 +803,8 @@ void EHL::Base::output(bool forced_writerestart)
       const double p = lubrication_->lubrication_field()->prenp()->operator[](
           lubrication_->lubrication_field()->prenp()->get_map().lid(
               lubrication_->lubrication_field()->discretization()->dof(0, lnode, 0)));
-      std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
+      std::shared_ptr<Core::Mat::Material> mat =
+          lnode->adjacent_elements()[0].user_element()->material(0);
       if (!mat) FOUR_C_THROW("null pointer");
       std::shared_ptr<Mat::LubricationMat> lmat =
           std::dynamic_pointer_cast<Mat::LubricationMat>(mat);

--- a/src/ehl/4C_ehl_monolithic.cpp
+++ b/src/ehl/4C_ehl_monolithic.cpp
@@ -1679,7 +1679,8 @@ void EHL::Monolithic::lin_couette_force_disp(
     const double p = lubrication_->lubrication_field()->prenp()->operator[](
         lubrication_->lubrication_field()->prenp()->get_map().lid(lub_dis.dof(0, lnode, 0)));
 
-    std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
+    std::shared_ptr<Core::Mat::Material> mat =
+        lnode->adjacent_elements()[0].user_element()->material(0);
     if (!mat) FOUR_C_THROW("null pointer");
     std::shared_ptr<Mat::LubricationMat> lmat = std::dynamic_pointer_cast<Mat::LubricationMat>(mat);
     const double visc = lmat->compute_viscosity(p);
@@ -1829,7 +1830,8 @@ void EHL::Monolithic::lin_couette_force_pres(
     const double p = lubrication_->lubrication_field()->prenp()->operator[](
         lubrication_->lubrication_field()->prenp()->get_map().lid(lub_dis.dof(0, lnode, 0)));
 
-    std::shared_ptr<Core::Mat::Material> mat = lnode->elements()[0]->material(0);
+    std::shared_ptr<Core::Mat::Material> mat =
+        lnode->adjacent_elements()[0].user_element()->material(0);
     if (!mat) FOUR_C_THROW("null pointer");
     std::shared_ptr<Mat::LubricationMat> lmat = std::dynamic_pointer_cast<Mat::LubricationMat>(mat);
     const double visc = lmat->compute_viscosity(p);

--- a/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
+++ b/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
@@ -100,12 +100,9 @@ std::shared_ptr<std::map<int, std::vector<int>>> FBI::FBIGeometryCoupler::search
         closefluideles != closeeles.end(); closefluideles++)
     {
       const Core::Nodes::Node* const beamnode = discretizations[0]->g_node(beamnodeiterator->first);
-      const Core::Elements::Element* const* beamelements = beamnode->elements();
-
       // loop over the set of beam elements adjacent to the current beam node (this leads to
       // duplicate pairs)
-      for (int beamelementsnumber = 0; beamelementsnumber < beamnode->num_element();
-          beamelementsnumber++)
+      for (auto ele : beamnode->adjacent_elements())
       {
         // loop over the gids of the fluid elements
         for (std::set<int>::const_iterator fluideleIter = (closefluideles->second).begin();
@@ -116,7 +113,7 @@ std::shared_ptr<std::map<int, std::vector<int>>> FBI::FBIGeometryCoupler::search
           {
             // store pairs because we have to create them on the beam element owner and we are
             // currently on the fluid element owner
-            (*pairids)[beamelements[beamelementsnumber]->id()].push_back(*fluideleIter);
+            (*pairids)[ele.global_id()].push_back(*fluideleIter);
           }
         }
       }

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -4581,8 +4581,8 @@ void FLD::XFluid::set_initial_flow_field(
     // arbitrarily take first node on this proc
     Core::Nodes::Node* lnode = discret_->l_row_node(0);
     // get list of adjacent elements of the first node
-    Core::Elements::Element** elelist = lnode->elements();
-    Core::Elements::Element* ele = elelist[0];  // (arbitrary!) first element
+    Core::Elements::Element* ele =
+        lnode->adjacent_elements()[0].user_element();  // (arbitrary!) first element
     // get material from first (arbitrary!) element adjacent to this node
     const std::shared_ptr<Core::Mat::Material> material = ele->material();
 #ifdef FOUR_C_ENABLE_ASSERTIONS

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -379,7 +379,7 @@ std::shared_ptr<Coupling::Adapter::MortarVolCoupl> FS3I::PartFS3I::create_vol_mo
 
   auto correct_node = [](const Core::Nodes::Node& node) -> decltype(auto)
   {
-    const Core::Elements::Element* element = node.elements()[0];
+    const Core::Elements::Element* element = node.adjacent_elements()[0].user_element();
     const auto* beamelement = dynamic_cast<const Discret::Elements::Beam3Base*>(element);
     if (beamelement != nullptr && !beamelement->is_centerline_node(node))
       return *element->nodes()[0];

--- a/src/fsi/src/4C_fsi_dyn.cpp
+++ b/src/fsi/src/4C_fsi_dyn.cpp
@@ -236,7 +236,7 @@ void fsi_immersed_drt()
 
   auto correct_node = [](const Core::Nodes::Node& node) -> decltype(auto)
   {
-    const Core::Elements::Element* element = node.elements()[0];
+    const Core::Elements::Element* element = node.adjacent_elements()[0].user_element();
     const auto* beamelement = dynamic_cast<const Discret::Elements::Beam3Base*>(element);
     if (beamelement != nullptr && !beamelement->is_centerline_node(node))
       return *element->nodes()[0];
@@ -375,7 +375,7 @@ void fsi_ale_drt()
   // We rely on this ordering in certain non-intuitive places!
   auto correct_node = [](const Core::Nodes::Node& node) -> decltype(auto)
   {
-    const Core::Elements::Element* element = node.elements()[0];
+    const Core::Elements::Element* element = node.adjacent_elements()[0].user_element();
     const auto* beamelement = dynamic_cast<const Discret::Elements::Beam3Base*>(element);
     if (beamelement != nullptr && !beamelement->is_centerline_node(node))
       return *element->nodes()[0];

--- a/src/geometry_pair/4C_geometry_pair_element_faces.cpp
+++ b/src/geometry_pair/4C_geometry_pair_element_faces.cpp
@@ -164,20 +164,20 @@ void GeometryPair::FaceElementPatchTemplate<Surface, ScalarType>::setup(
   {
     // Loop over all elements connected to a node of this face.
     const Core::Nodes::Node* node = this->core_element_->nodes()[i_node];
-    for (int i_element = 0; i_element < node->num_element(); i_element++)
+    for (auto element : node->adjacent_elements())
     {
-      const Core::Elements::Element* element = node->elements()[i_element];
+      auto element_id = element.global_id();
 
-      if (element->id() == element_uid) continue;
+      if (element_id == element_uid) continue;
 
       // Check if the element was already searched for.
-      if (connected_faces_.find(element->id()) == connected_faces_.end())
+      if (connected_faces_.find(element_id) == connected_faces_.end())
       {
         temp_connected_face.node_lid_map_.clear();
         temp_connected_face.my_node_patch_lid_.clear();
 
         // Check if the element is part of the surface condition.
-        auto find_in_faces = face_elements.find(element->id());
+        auto find_in_faces = face_elements.find(element_id);
         if (find_in_faces != face_elements.end())
         {
           // Add the node GIDs of this element.
@@ -226,7 +226,7 @@ void GeometryPair::FaceElementPatchTemplate<Surface, ScalarType>::setup(
           }
 
           // Add this element to the already searched connected elements.
-          connected_faces_[element->id()] = temp_connected_face;
+          connected_faces_[element_id] = temp_connected_face;
         }
       }
     }

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -323,19 +323,16 @@ void ScaTra::LevelSetAlgorithm::apply_contact_point_boundary_condition()
         // which are only available for nodes belonging to the this proc
         if (actnode->owner() == myrank_)
         {
-          // get adjacent elements
-          const Core::Elements::Element* const* adjelements = actnode->elements();
-
           // initialize vector for averaged center velocity
           // note: velocity in scatra algorithm has three components (see also basic constructor)
           std::vector<double> averagedvel(3);
           for (int rr = 0; rr < 3; rr++) averagedvel[rr] = 0.0;
 
           // loop all adjacent elements
-          for (int iele = 0; iele < actnode->num_element(); iele++)
+          for (auto adj_ele : actnode->adjacent_elements())
           {
             // get discretization type
-            if ((adjelements[iele])->shape() != Core::FE::CellType::hex8)
+            if (adj_ele.user_element()->shape() != Core::FE::CellType::hex8)
               FOUR_C_THROW("Currently only hex8 supported");
             const Core::FE::CellType distype = Core::FE::CellType::hex8;
 
@@ -348,7 +345,7 @@ void ScaTra::LevelSetAlgorithm::apply_contact_point_boundary_condition()
 
               // get nodal values of velocity field from secondary dofset
               Core::Elements::LocationArray la(discret_->num_dof_sets());
-              adjelements[iele]->location_vector(*discret_, la);
+              adj_ele.user_element()->location_vector(*discret_, la);
               const std::vector<int>& lmvel = la[nds_vel()].lm_;
               std::vector<double> myconvel(lmvel.size());
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -50,10 +50,9 @@ namespace
       for (auto const nodeid : *ArteryNodeIds)
       {
         Core::Nodes::Node* artnode = artsearchdis.g_node(nodeid);
-        Core::Elements::Element** artele = artnode->elements();
         // get Id of corresponding element; Note: in lung modeling only most distal nodes
         // are coupled, so coupling nodes can only belong to one element
-        const int elementID = artele[0]->id();
+        const int elementID = artnode->adjacent_elements()[0].global_id();
         // safety check if assertion is true
         FOUR_C_ASSERT(elementID >= 0, "It is not possible to have a negative element ID!");
         artEleGIDs_help.push_back(elementID);

--- a/src/reduced_lung/src/4C_reduced_lung_main.cpp
+++ b/src/reduced_lung/src/4C_reduced_lung_main.cpp
@@ -190,9 +190,9 @@ namespace ReducedLung
     std::map<int, std::vector<int>> ele_ids_per_node;
     for (const auto& node : actdis->my_row_node_range())
     {
-      for (int i = 0; i < node.user_node()->num_element(); i++)
+      for (auto ele : node.adjacent_elements())
       {
-        ele_ids_per_node[node.global_id()].push_back(node.user_node()->elements()[i]->id());
+        ele_ids_per_node[node.global_id()].push_back(ele.global_id());
       }
     }
     auto merge_maps =

--- a/src/scatra/4C_scatra_timint_elch.cpp
+++ b/src/scatra/4C_scatra_timint_elch.cpp
@@ -1101,7 +1101,7 @@ ScaTra::ScaTraTimIntElch::evaluate_single_electrode_info_point(
     }
 
     // get element attached to node
-    Core::Elements::Element* element = node->elements()[0];
+    Core::Elements::Element* element = node->adjacent_elements()[0].user_element();
 
     // determine location information
     Core::Elements::LocationArray la(discret_->num_dof_sets());
@@ -2697,7 +2697,7 @@ void ScaTra::ScaTraTimIntElch::evaluate_electrode_boundary_kinetics_point_condit
       }
 
       // get element attached to node
-      Core::Elements::Element* element = node->elements()[0];
+      Core::Elements::Element* element = node->adjacent_elements()[0].user_element();
 
       // determine location information
       Core::Elements::LocationArray la(discret_->num_dof_sets());

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -3433,7 +3433,8 @@ void ScaTra::ScaTraTimIntImpl::evaluate_macro_micro_coupling()
             {
               // access material of electrode
               std::shared_ptr<const Mat::Electrode> matelectrode =
-                  std::dynamic_pointer_cast<const Mat::Electrode>(node->elements()[0]->material());
+                  std::dynamic_pointer_cast<const Mat::Electrode>(
+                      node->adjacent_elements()[0].user_element()->material());
               if (matelectrode == nullptr)
                 FOUR_C_THROW("Invalid electrode material for multi-scale coupling!");
 

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i.cpp
@@ -1702,7 +1702,8 @@ void ScaTra::MeshtyingStrategyS2I::evaluate_nts(
     if (slavenode == nullptr) FOUR_C_THROW("Couldn't extract slave-side node from discretization!");
 
     // extract first slave-side element associated with current slave-side node
-    auto* const slaveelement = dynamic_cast<Mortar::Element* const>(slavenode->elements()[0]);
+    auto* const slaveelement =
+        dynamic_cast<Mortar::Element* const>(slavenode->adjacent_elements()[0].user_element());
     if (!slaveelement) FOUR_C_THROW("Invalid slave-side mortar element!");
 
     // extract master-side element associated with current slave-side node
@@ -2442,7 +2443,8 @@ void ScaTra::MeshtyingStrategyS2I::setup_meshtying()
             // element
             (*islavenodesimpltypes)[inode] = dynamic_cast<Discret::Elements::Transport*>(
                 std::dynamic_pointer_cast<Core::Elements::FaceElement>(
-                    kinetics_slave_cond.second->geometry().at(slavenode->elements()[0]->id()))
+                    kinetics_slave_cond.second->geometry().at(
+                        slavenode->adjacent_elements()[0].user_element()->id()))
                     ->parent_element())
                                                  ->impl_type();
           }

--- a/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
+++ b/src/scatra/4C_scatra_timint_meshtying_strategy_s2i_elch.cpp
@@ -210,8 +210,8 @@ void ScaTra::MeshtyingStrategyS2IElch::evaluate_point_coupling()
       case Inpar::S2I::kinetics_butlervolmerreduced:
       {
         // access material of electrode
-        auto matelectrode =
-            std::dynamic_pointer_cast<const Mat::Electrode>(slave_node->elements()[0]->material());
+        auto matelectrode = std::dynamic_pointer_cast<const Mat::Electrode>(
+            slave_node->adjacent_elements()[0].user_element()->material());
         if (matelectrode == nullptr)
           FOUR_C_THROW("Invalid electrode material for multi-scale coupling!");
 

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -59,7 +59,8 @@ void Discret::Elements::Shell7pType::nodal_block_information(
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Shell7pType::compute_null_space(
     Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
 {
-  auto* shell = dynamic_cast<Discret::Elements::Shell7p*>(node.elements()[0]);
+  auto* shell =
+      dynamic_cast<Discret::Elements::Shell7p*>(node.adjacent_elements()[0].user_element());
   if (!shell) FOUR_C_THROW("Cannot cast to Shell7p");
   int j;
   for (j = 0; j < shell->num_node(); ++j)

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -163,7 +163,8 @@ int Discret::Elements::Shell7pScatraType::initialize(Core::FE::Discretization& d
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Shell7pScatraType::compute_null_space(
     Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
 {
-  auto* shell = dynamic_cast<Discret::Elements::Shell7pScatra*>(node.elements()[0]);
+  auto* shell =
+      dynamic_cast<Discret::Elements::Shell7pScatra*>(node.adjacent_elements()[0].user_element());
   if (!shell) FOUR_C_THROW("Cannot cast to Shell");
   int j;
   for (j = 0; j < shell->num_node(); ++j)

--- a/src/shell7p/4C_shell7p_utils.cpp
+++ b/src/shell7p/4C_shell7p_utils.cpp
@@ -509,10 +509,9 @@ void Solid::Utils::Shell::Director::export_director_map_from_row_to_col_map(
   {
     auto curr = director_map.find(actnode.global_id());
     FOUR_C_ASSERT(curr != director_map.end(), "Cannot find director map entry");
-    for (int j = 0; j < actnode.user_node()->num_element(); ++j)
+    for (auto ele : actnode.adjacent_elements())
     {
-      Core::Elements::Element* tmpele = actnode.user_node()->elements()[j];
-      if (!tmpele) continue;
+      auto* tmpele = ele.user_element();
       if (tmpele->element_type() != eletype) continue;
       if (auto* scatra_ele = dynamic_cast<Discret::Elements::Shell7pScatra*>(tmpele))
       {
@@ -555,9 +554,9 @@ void Solid::Utils::Shell::Director::average_directors_at_nodes(
   for (const auto& act_node : dis.my_row_node_range())
   {
     int num_directors = 0;
-    for (int j = 0; j < act_node.user_node()->num_element(); ++j)
+    for (auto ele : act_node.adjacent_elements())
     {
-      const Core::Elements::Element* tmpele = act_node.user_node()->elements()[j];
+      auto* tmpele = ele.user_element();
       if (tmpele->element_type() != eletype) continue;
       if (auto* scatra_ele = dynamic_cast<const Discret::Elements::Shell7pScatra*>(tmpele))
       {

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -511,7 +511,8 @@ void Solid::TimeInt::BaseDataGlobalState::setup_rot_vec_map_extractor(
     Core::Nodes::Node* nodeptr = discret_->l_row_node(i);
 
     const Discret::Elements::Beam3Base* beameleptr =
-        dynamic_cast<const Discret::Elements::Beam3Base*>(nodeptr->elements()[0]);
+        dynamic_cast<const Discret::Elements::Beam3Base*>(
+            nodeptr->adjacent_elements()[0].user_element());
 
     std::vector<int> nodaladditdofs;
     std::vector<int> nodalrotvecdofs;

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -376,20 +376,14 @@ void XFEM::MeshVolCoupling::redistribute_embedded_discretization()
     // a subset!)
     const Core::Nodes::Node* cond_node = cond_dis_->g_node(cond_node_gid);
 
-    // get associated elements
-    const Core::Elements::Element* const* cond_eles = cond_node->elements();
-    const int num_cond_ele = cond_node->num_element();
-
     // loop over associated elements
-    for (int ie = 0; ie < num_cond_ele; ++ie)
+    for (auto ele : cond_node->adjacent_elements())
     {
-      if (cond_eles[ie]->owner() == mypid) adj_eles_row.insert(cond_eles[ie]->id());
+      if (ele.owner() == mypid) adj_eles_row.insert(ele.global_id());
 
-      const int* node_ids = cond_eles[ie]->node_ids();
-      for (int in = 0; in < cond_eles[ie]->num_node(); ++in)
+      for (auto node : ele.nodes())
       {
-        if (cond_dis_->g_node(node_ids[in])->owner() == mypid)
-          adj_ele_nodes_row.insert(node_ids[in]);
+        if (node.owner() == mypid) adj_ele_nodes_row.insert(node.global_id());
       }
     }
   }

--- a/src/xfem/4C_xfem_xfluid_timeInt.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt.cpp
@@ -860,17 +860,11 @@ std::map<int, std::set<int>>& XFEM::XFluidTimeInt::get_node_to_dof_map_for_recon
 // -------------------------------------------------------------------
 bool XFEM::XFluidTimeInt::non_intersected_elements(Core::Nodes::Node* n, Cut::CutWizard& wizard)
 {
-  const int numele = n->num_element();
-
-  Core::Elements::Element** elements = n->elements();
-
   // loop surrounding elements
-  for (int i = 0; i < numele; i++)
+  for (auto ele : n->adjacent_elements())
   {
-    Core::Elements::Element* e = elements[i];
-
     // we have to check elements and its sub-elements in case of quadratic elements
-    Cut::ElementHandle* ehandle = wizard.get_element(e);
+    Cut::ElementHandle* ehandle = wizard.get_element(ele.user_element());
 
     // elements which do not have an element-handle are non-intersected anyway
     if (ehandle == nullptr) continue;

--- a/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_base.cpp
@@ -202,15 +202,9 @@ bool XFEM::XfluidTimeintBase::changed_side_same_time(
           break;
         }
 
-        const int numele = n->num_element();
-
-        Core::Elements::Element** elements = n->elements();
-
-        for (int e_it = 0; e_it < numele; e_it++)
+        for (auto ele : n->adjacent_elements())
         {
-          Core::Elements::Element* ele = elements[e_it];
-
-          eids.insert(ele->id());
+          eids.insert(ele.global_id());
 
 #ifdef DEBUG_TIMINT_STD
           Core::IO::cout << "\n\t\t\t\t\t add element " << ele->Id() << Core::IO::endl;
@@ -660,27 +654,6 @@ void XFEM::XfluidTimeintBase::add_pb_celements(
     const Core::Nodes::Node* node, std::vector<const Core::Elements::Element*>& eles) const
 {
   FOUR_C_THROW("what to do in add_pb_celements?");
-
-  const Core::Elements::Element* const* elements = node->elements();  // element around current node
-
-  for (int iele = 0; iele < node->num_element(); iele++) eles.push_back(elements[iele]);
-
-  // get pbcnode
-  bool pbcnodefound = false;  // boolean indicating whether this node is a pbc node
-  Core::Nodes::Node* pbcnode = nullptr;
-  find_pbc_node(node, pbcnode, pbcnodefound);
-
-  // add elements located around the coupled pbc node
-  if (pbcnodefound)
-  {
-    // get adjacent elements of this node
-    const Core::Elements::Element* const* pbcelements = pbcnode->elements();
-    // add elements to list
-    for (int iele = 0; iele < pbcnode->num_element(); iele++)  // = ptToNode->Elements();
-    {
-      eles.push_back(pbcelements[iele]);
-    }
-  }  // end if pbcnode true
 }
 
 
@@ -1506,10 +1479,9 @@ void XFEM::XfluidStd::project_and_trackback(TimeIntData& data)
 
         for (int i = 0; i < side_1->num_node(); i++)
         {
-          Core::Elements::Element** surr_sides = nodes[i]->elements();
-          for (int s = 0; s < nodes[i]->num_element(); s++)
+          for (auto ele : nodes[i]->adjacent_elements())
           {
-            neighbor_sides.insert(surr_sides[s]->id());
+            neighbor_sides.insert(ele.global_id());
           }
         }
 
@@ -1638,13 +1610,11 @@ void XFEM::XfluidStd::project_and_trackback(TimeIntData& data)
     // get the node
     Core::Nodes::Node* node = boundarydis_->g_node(proj_nid_np);
 
-    // get all surrounding sides
-    Core::Elements::Element** node_sides = node->elements();
 
-    for (int s = 0; s < node->num_element(); s++)
+    for (auto ele : node->adjacent_elements())
     {
       // side geometry at initial state t^0
-      Core::Elements::Element* side = node_sides[s];
+      Core::Elements::Element* side = ele.user_element();
       const int numnodes = side->num_node();
       Core::Nodes::Node** nodes = side->nodes();
       Core::LinAlg::SerialDenseMatrix side_xyze(3, numnodes);

--- a/src/xfem/4C_xfem_xfluid_timeInt_std_SemiLagrange.cpp
+++ b/src/xfem/4C_xfem_xfluid_timeInt_std_SemiLagrange.cpp
@@ -1026,22 +1026,20 @@ void XFEM::XfluidSemiLagrange::new_iteration_nodal_data(
     }
 
     // check all surrounding elements
-    int numele = node->num_element();
-    Core::Elements::Element** eles = node->elements();
-
     // add surrounding std uncut elements for that no elementhandle is available
-    for (int i = 0; i < numele; i++)
+    for (auto ele : node->adjacent_elements())
     {
-      Cut::ElementHandle* eh = wizard_new_->get_element(eles[i]);
+      auto ele_ptr = ele.user_element();
+      Cut::ElementHandle* eh = wizard_new_->get_element(ele_ptr);
 
       if (eh != nullptr)
         continue;  // element and the right nds-vec should have been found using the for-loop before
 
       // if we are here, then the element is a standard uncut element
       // and it is ensured that it has not been added to eles_avg yet
-      std::vector<int> std_nds(eles[i]->num_node(), 0);
+      std::vector<int> std_nds(ele.num_nodes(), 0);
 
-      eles_avg.push_back(eles[i]);
+      eles_avg.push_back(ele_ptr);
       eles_avg_nds.push_back(std_nds);
     }
 
@@ -1452,22 +1450,20 @@ void XFEM::XfluidSemiLagrange::back_tracking(
     }
 
     // check all surrounding elements
-    int numele = node->num_element();
-    Core::Elements::Element** eles = node->elements();
-
     // add surrounding std uncut elements for that no elementhandle is available
-    for (int i = 0; i < numele; i++)
+    for (auto ele : node->adjacent_elements())
     {
-      Cut::ElementHandle* eh = wizard_old_->get_element(eles[i]);
+      auto ele_ptr = ele.user_element();
+      Cut::ElementHandle* eh = wizard_old_->get_element(ele_ptr);
 
       if (eh != nullptr)
         continue;  // element and the right nds-vec should have been found using the for-loop before
 
       // if we are here, then the element is a standard uncut element
       // and it is ensured that it has not been added to eles_avg yet
-      std::vector<int> std_nds(eles[i]->num_node(), 0);
+      std::vector<int> std_nds(ele.num_nodes(), 0);
 
-      eles_avg.push_back(eles[i]);
+      eles_avg.push_back(ele_ptr);
       eles_avg_nds.push_back(std_nds);
     }
 

--- a/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
+++ b/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
@@ -85,12 +85,11 @@ namespace
       nullspace_ref(4, 4) = -0.912870929175277;
       nullspace_ref(5, 3) = 0.866666666666667;
 
-      const auto node = testele_->nodes()[0];
       int numdof, dimnsp;
 
-      testele_->element_type().nodal_block_information(node->elements()[0], numdof, dimnsp);
+      testele_->element_type().nodal_block_information(testele_.get(), numdof, dimnsp);
       Core::LinAlg::SerialDenseMatrix nullspace = testele_->element_type().compute_null_space(
-          *node, std::vector{0.0, 0.0, 0.0}.data(), numdof, dimnsp);
+          *testele_->nodes()[0], std::vector{0.0, 0.0, 0.0}.data(), numdof, dimnsp);
 
       FOUR_C_EXPECT_NEAR(nullspace, nullspace_ref, testTolerance);
     }
@@ -108,12 +107,11 @@ namespace
       nullspace_ref(4, 4) = -0.912870929175277;
       nullspace_ref(5, 3) = 0.866666666666667;
 
-      const auto node = testele_->nodes()[0];
       int numdof, dimnsp;
 
-      testele_->element_type().nodal_block_information(node->elements()[0], numdof, dimnsp);
+      testele_->element_type().nodal_block_information(testele_.get(), numdof, dimnsp);
       Core::LinAlg::SerialDenseMatrix nullspace = testele_->element_type().compute_null_space(
-          *node, std::vector{-0.05, 0.05, 0.3}.data(), numdof, dimnsp);
+          *testele_->nodes()[0], std::vector{-0.05, 0.05, 0.3}.data(), numdof, dimnsp);
 
       FOUR_C_EXPECT_NEAR(nullspace, nullspace_ref, testTolerance);
     }


### PR DESCRIPTION
This PR updates the Node class API to provide adjacent elements as references instead of raw pointers, replacing the legacy pointer-based interface with a modern range-based approach using `adjacent_elements()` that returns IteratorRange objects.

Key Changes:

  -  Added new adjacent_elements() methods returning iterator ranges for both const and non-const access
   - Updated all code to use the new iterator-based API `adjacent_elements()` instead of direct pointer access; removed `elements()`
   - Replaced manual loops with range-based for loops and standard library algorithms


Part of #1228