### PR TITLE
Make SparseMatrix movable and move-assignable

### DIFF
--- a/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_sparsematrix.hpp
@@ -151,6 +151,9 @@ namespace Core::LinAlg
     /// Assignment operator. Makes a deep copy.
     SparseMatrix& operator=(const SparseMatrix& mat);
 
+    SparseMatrix(SparseMatrix&&) noexcept = default;
+    SparseMatrix& operator=(SparseMatrix&&) noexcept = default;
+
     /// Assignment method. Deep copy or view on matrix.
     /*!
       Explicit method for the assignment operator. You can make an explicit

--- a/src/core/linalg/src/sparse/4C_linalg_view.hpp
+++ b/src/core/linalg/src/sparse/4C_linalg_view.hpp
@@ -132,8 +132,8 @@ namespace Core::LinAlg
     View(const View& other) = default;
     View& operator=(const View& other) = default;
 
-    View(View&& other) = default;
-    View& operator=(View&& other) = default;
+    View(View&& other) noexcept = default;
+    View& operator=(View&& other) noexcept = default;
 
     ~View() = default;
 


### PR DESCRIPTION
We currently fall back to a deep copy, which is quite expensive.