### PR TITLE
Use Discretization dim for nodes

### DIFF
--- a/src/art_net/4C_art_net_artery_ele_calc.cpp
+++ b/src/art_net/4C_art_net_artery_ele_calc.cpp
@@ -31,7 +31,7 @@ double Discret::Elements::ArteryEleCalc<distype>::calculate_ele_length(Artery* e
     const auto& x = nodes[inode]->x();
     xyze(0, inode) = x[0];
     xyze(1, inode) = x[1];
-    xyze(2, inode) = x[2];
+    if (x.size() > 2) xyze(2, inode) = x[2];
   }
 
   // Calculate the length of artery element

--- a/src/contact/src/4C_contact_interface.cpp
+++ b/src/contact/src/4C_contact_interface.cpp
@@ -333,11 +333,12 @@ void CONTACT::Interface::set_cn_ct_values(const int& iter)
 
     pos1[0] = dynamic_cast<Node*>(cele->nodes()[0])->x()[0];
     pos1[1] = dynamic_cast<Node*>(cele->nodes()[0])->x()[1];
-    pos1[2] = dynamic_cast<Node*>(cele->nodes()[0])->x()[2];
+
+    if (dim_ == 3) pos1[2] = dynamic_cast<Node*>(cele->nodes()[0])->x()[2];
 
     pos2[0] = dynamic_cast<Node*>(cele->nodes()[1])->x()[0];
     pos2[1] = dynamic_cast<Node*>(cele->nodes()[1])->x()[1];
-    pos2[2] = dynamic_cast<Node*>(cele->nodes()[1])->x()[2];
+    if (dim_ == 3) pos2[2] = dynamic_cast<Node*>(cele->nodes()[1])->x()[2];
 
     vec[0] = pos1[0] - pos2[0];
     vec[1] = pos1[1] - pos2[1];
@@ -4202,10 +4203,10 @@ double CONTACT::Interface::compute_cpp_normal_2d(const Mortar::Node& mrtrnode,
     std::array<double, 3> Posnp = {0.0, 0.0, 0.0};
     Posn[0] = mrtrnode.x()[0] + mrtrnode.uold()[0];
     Posn[1] = mrtrnode.x()[1] + mrtrnode.uold()[1];
-    Posn[2] = mrtrnode.x()[2] + mrtrnode.uold()[2];
+    if (dim_ == 3) Posn[2] = mrtrnode.x()[2] + mrtrnode.uold()[2];
     Posnp[0] = mrtrnode.xspatial()[0];
     Posnp[1] = mrtrnode.xspatial()[1];
-    Posnp[2] = mrtrnode.xspatial()[2];
+    if (dim_ == 3) Posnp[2] = mrtrnode.xspatial()[2];
 
     vect[0] = Posnp[0] - Posn[0];
     vect[1] = Posnp[1] - Posn[1];
@@ -4391,10 +4392,10 @@ double CONTACT::Interface::compute_cpp_normal_3d(Mortar::Node& mrtrnode,
 
   Posn[0] = mrtrnode.x()[0] + mrtrnode.uold()[0];
   Posn[1] = mrtrnode.x()[1] + mrtrnode.uold()[1];
-  Posn[2] = mrtrnode.x()[2] + mrtrnode.uold()[2];
+  if (dim_ == 3) Posn[2] = mrtrnode.x()[2] + mrtrnode.uold()[2];
   Posnp[0] = mrtrnode.xspatial()[0];
   Posnp[1] = mrtrnode.xspatial()[1];
-  Posnp[2] = mrtrnode.xspatial()[2];
+  if (dim_ == 3) Posnp[2] = mrtrnode.xspatial()[2];
 
   vect[0] = Posnp[0] - Posn[0];
   vect[1] = Posnp[1] - Posn[1];

--- a/src/contact/src/4C_contact_meshtying_abstract_strategy.cpp
+++ b/src/contact/src/4C_contact_meshtying_abstract_strategy.cpp
@@ -509,7 +509,7 @@ void CONTACT::MtAbstractStrategy::mesh_initialization(
       Mortar::Node* mtnode = dynamic_cast<Mortar::Node*>(node);
 
       // new nodal position and problem dimension
-      std::vector<double> Xnew(3, 0.0);
+      std::vector<double> Xnew(n_dim(), 0.0);
 
       //******************************************************************
       // compute new nodal position

--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -245,6 +245,7 @@ namespace Core::Binstrategy::Utils
   void get_current_node_pos(const Core::FE::Discretization& discret, Core::Nodes::Node const* node,
       std::shared_ptr<const Core::LinAlg::Vector<double>> const disnp, double* currpos)
   {
+    const auto x = node->x();
     if (disnp != nullptr)
     {
       const int gid = discret.dof(node, 0);
@@ -254,14 +255,16 @@ namespace Core::Binstrategy::Utils
             "Your displacement is incomplete (need to be based on a column map"
             " as this function is also called from a loop over elements and "
             "each proc does (usually) not own all nodes of its row elements ");
-      for (int dim = 0; dim < 3; ++dim)
+      for (size_t dim = 0; dim < x.size(); ++dim)
       {
-        currpos[dim] = node->x()[dim] + (*disnp)[lid + dim];
+        currpos[dim] = x[dim] + (*disnp)[lid + dim];
       }
+      for (size_t dim = x.size(); dim < 3; ++dim) currpos[dim] = 0.0;
     }
     else
     {
-      for (int dim = 0; dim < 3; ++dim) currpos[dim] = node->x()[dim];
+      for (size_t dim = 0; dim < x.size(); ++dim) currpos[dim] = x[dim];
+      for (size_t dim = x.size(); dim < 3; ++dim) currpos[dim] = 0.0;
     }
   }
 }  // namespace Core::Binstrategy::Utils

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -66,15 +66,17 @@ void Core::FE::Discretization::check_filled_globally()
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Core::FE::Discretization::add_node(
-    std::span<const double, 3> x, GlobalIndexType gid, std::shared_ptr<Core::Nodes::Node> user_node)
+    std::span<const double> x, GlobalIndexType gid, std::shared_ptr<Core::Nodes::Node> user_node)
 {
+  FOUR_C_ASSERT(x.size() == n_dim_, "Node coordinate dimension mismatch in discretization.");
+
   // As long as user nodes are required, we need to ensure that a node exists, so we create one.
   // Once we can live without user nodes, this fixup may be removed.
   if (user_node == nullptr)
     user_node = std::make_shared<Core::Nodes::Node>(gid, x, Communication::my_mpi_rank(comm_));
 
   node_[gid] = user_node;
-  FOUR_C_ASSERT(node_gid_.size() * 3 == node_coordinates_.size(),
+  FOUR_C_ASSERT(node_gid_.size() * n_dim_ == node_coordinates_.size(),
       "Internal error: mismatch in size of node data.");
 
   node_gid_.emplace_back() = gid;

--- a/src/core/fem/src/discretization/4C_fem_discretization.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.cpp
@@ -75,6 +75,21 @@ void Core::FE::Discretization::add_node(
   if (user_node == nullptr)
     user_node = std::make_shared<Core::Nodes::Node>(gid, x, Communication::my_mpi_rank(comm_));
 
+#ifdef FOUR_C_ENABLE_ASSERTIONS
+  FOUR_C_ASSERT(user_node->id() == gid,
+      "Node GID mismatch in discretization (user node). Expected {}, got {}.", gid,
+      user_node->id());
+
+  const auto user_x = user_node->x();
+  FOUR_C_ASSERT(
+      user_x.size() == n_dim_, "Node coordinate dimension mismatch in discretization (user node).");
+  for (unsigned int i = 0; i < n_dim_; i++)
+    FOUR_C_ASSERT(user_x[i] == x[i],
+        "Node coordinate mismatch in discretization (user node). Expected {}, got {}.", x[i],
+        user_x[i]);
+
+#endif
+
   node_[gid] = user_node;
   FOUR_C_ASSERT(node_gid_.size() * n_dim_ == node_coordinates_.size(),
       "Internal error: mismatch in size of node data.");

--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -119,11 +119,10 @@ namespace Core::FE
     /**
      * Return the spatial coordinates of the node.
      */
-    [[nodiscard]] std::span<const double, 3> x() const
+    [[nodiscard]] std::span<const double> x() const
     {
       const auto& coord = discretization_->nodecolptr_[local_id_]->x();
-      FOUR_C_ASSERT(coord.size() == 3, "NodeRef only supports 3D coordinates");
-      return std::span<const double, 3>(coord.data(), 3);
+      return coord;
     }
 
     /**
@@ -1286,7 +1285,7 @@ namespace Core::FE
 
     \note Sets Filled()=false
     */
-    void add_node(std::span<const double, 3> x, GlobalIndexType gid,
+    void add_node(std::span<const double> x, GlobalIndexType gid,
         std::shared_ptr<Core::Nodes::Node> user_node);
 
     /**

--- a/src/core/fem/src/discretization/4C_fem_discretization_nullspace.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_nullspace.cpp
@@ -37,8 +37,11 @@ namespace Core::FE
     {
       // for rigid body rotations compute nodal center of the discretization
       std::array<double, 3> x0send = {0.0, 0.0, 0.0};
-      for (int i = 0; i < dis.num_my_row_nodes(); ++i)
-        for (int j = 0; j < 3; ++j) x0send[j] += dis.l_row_node(i)->x()[j];
+      for (auto node : dis.my_row_node_range())
+      {
+        auto x = node.x();
+        for (size_t j = 0; j < x.size(); ++j) x0send[j] += x[j];
+      }
 
       std::array<double, 3> x0;
       Core::Communication::sum_all(x0send.data(), x0.data(), 3, dis.get_comm());

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -211,8 +211,11 @@ void Core::FE::Discretization::export_row_elements(
 
   exporter.do_export(element_);
 
-  // update ownerships and kick out everything that's not in newmap
-  for (curr = element_.begin(); curr != element_.end(); ++curr) curr->second->set_owner(myrank);
+  for (auto& ele : element_ | std::views::values)
+  {
+    ele->set_owner(myrank);
+    ele->discretization_ = this;
+  }
 
   // maps and pointers are no longer correct and need rebuilding
   reset(killdofs, killcond);

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -310,8 +310,14 @@ std::shared_ptr<Core::LinAlg::MultiVector<double>> Core::FE::Discretization::bui
   for (int lid = 0; lid < noderowmap->num_my_elements(); ++lid)
   {
     if (!node_.contains(noderowmap->gid(lid))) continue;
-    for (int dim = 0; dim < 3; ++dim)
-      coordinates->ReplaceMyValue(lid, dim, node_.at(noderowmap->gid(lid))->x()[dim]);
+    auto x = node_.at(noderowmap->gid(lid))->x();
+    for (size_t dim = 0; dim < 3; ++dim)
+    {
+      if (dim >= n_dim())
+        coordinates->ReplaceMyValue(lid, dim, 0.0);
+      else
+        coordinates->ReplaceMyValue(lid, dim, x[dim]);
+    }
   }
 
   return coordinates;

--- a/src/core/fem/src/general/element/4C_fem_general_element.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.cpp
@@ -623,6 +623,20 @@ int Core::Elements::Element::num_face() const
 }
 
 
+Core::FE::IteratorRange<Core::FE::DiscretizationIterator<Core::FE::NodeRef>>
+Core::Elements::Element::node_range()
+{
+  return FE::ElementRef(discretization_, lid_).nodes();
+}
+
+
+Core::FE::IteratorRange<Core::FE::DiscretizationIterator<Core::FE::ConstNodeRef>>
+Core::Elements::Element::node_range() const
+{
+  return FE::ConstElementRef(discretization_, lid_).nodes();
+}
+
+
 /*----------------------------------------------------------------------*
  |  set faces (public)                                 kronbichler 05/13|
  *----------------------------------------------------------------------*/

--- a/src/core/fem/src/general/element/4C_fem_general_element.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element.hpp
@@ -12,6 +12,7 @@
 #include "4C_config.hpp"
 
 #include "4C_comm_parobject.hpp"
+#include "4C_fem_discretization_iterator.hpp"
 #include "4C_fem_general_cell_type.hpp"
 #include "4C_fem_general_cell_type_traits.hpp"
 #include "4C_fem_general_elements_paramsinterface.hpp"
@@ -48,6 +49,8 @@ namespace Core::FE::MeshFree
 
 namespace Core::FE
 {
+  class ConstNodeRef;
+  class NodeRef;
   class Discretization;
   class DiscretizationHDG;
 }  // namespace Core::FE
@@ -331,6 +334,17 @@ namespace Core::Elements
       else
         return nullptr;
     }
+
+    /**
+     * Return the nodes of this element as a range of NodeRef objects.
+     */
+    [[nodiscard]] FE::IteratorRange<FE::DiscretizationIterator<FE::NodeRef>> node_range();
+
+    /**
+     * Return the nodes of this element as a range of NodeRef objects.
+     */
+    [[nodiscard]] FE::IteratorRange<FE::DiscretizationIterator<FE::ConstNodeRef>> node_range()
+        const;
 
     /*!
     \brief Get vector of std::shared_ptrs to the lines of this element

--- a/src/core/fem/src/general/element/4C_fem_general_element_center.cpp
+++ b/src/core/fem/src/general/element/4C_fem_general_element_center.cpp
@@ -7,6 +7,7 @@
 
 #include "4C_fem_general_element_center.hpp"
 
+#include "4C_fem_discretization.hpp"
 #include "4C_fem_general_element.hpp"
 #include "4C_fem_general_node.hpp"
 
@@ -15,21 +16,22 @@ FOUR_C_NAMESPACE_OPEN
 std::vector<double> Core::FE::element_center_refe_coords(const Core::Elements::Element& ele)
 {
   // get nodes of element
-  const Core::Nodes::Node* const* nodes = ele.nodes();
   const int numnodes = ele.num_node();
   const double invnumnodes = 1.0 / numnodes;
 
   // calculate mean of node coordinates
   std::vector<double> centercoords(3, 0.0);
-  for (int i = 0; i < 3; ++i)
+  for (auto node : ele.node_range())
   {
-    double var = 0.0;
-    for (int j = 0; j < numnodes; ++j)
+    const auto x = node.x();
+    for (size_t i = 0; i < x.size(); ++i)
     {
-      const auto& x = nodes[j]->x();
-      var += x[i];
+      centercoords[i] += x[i];
     }
-    centercoords[i] = var * invnumnodes;
+  }
+  for (double& centercoord : centercoords)
+  {
+    centercoord *= invnumnodes;
   }
 
   return centercoords;

--- a/src/core/fem/src/general/node/4C_fem_general_node.cpp
+++ b/src/core/fem/src/general/node/4C_fem_general_node.cpp
@@ -34,8 +34,6 @@ Core::Communication::ParObject* Core::Nodes::NodeType::create(
 Core::Nodes::Node::Node(const int id, std::span<const double> coords, const int owner)
     : ParObject(), id_(id), lid_(-1), owner_(owner), x_(coords.begin(), coords.end())
 {
-  FOUR_C_ASSERT(
-      x_.size() == 3, "Node coordinates vector has size {}, but should have size 3", x_.size());
 }
 
 

--- a/src/core/fem/src/general/node/4C_fem_general_node.hpp
+++ b/src/core/fem/src/general/node/4C_fem_general_node.hpp
@@ -136,7 +136,7 @@ namespace Core::Nodes
     /*!
     \brief Return coordinates vector
     */
-    inline std::span<const double, 3> x() const { return std::span<const double, 3>(x_.data(), 3); }
+    inline std::span<const double> x() const { return std::span<const double>(x_); }
 
     /*!
     \brief return spatial dimension of node coordinates

--- a/src/core/fem/src/geometry/4C_fem_geometry_searchtree_service.cpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_searchtree_service.cpp
@@ -103,9 +103,10 @@ Core::LinAlg::Matrix<3, 2> Core::Geo::get_xaab_bof_dis(const Core::FE::Discretiz
   {
     const Core::Nodes::Node* node = dis.l_col_node(lid);
     Core::LinAlg::Matrix<3, 1> currpos;
-    currpos(0) = node->x()[0];
-    currpos(1) = node->x()[1];
-    currpos(2) = node->x()[2];
+    auto x = node->x();
+    currpos(0) = x[0];
+    currpos(1) = x[1];
+    if (x.size() > 2) currpos(2) = x[2];
     currentpositions[node->id()] = currpos;
   }
 

--- a/src/core/geometric_search/src/4C_geometric_search_matchingoctree.hpp
+++ b/src/core/geometric_search/src/4C_geometric_search_matchingoctree.hpp
@@ -49,6 +49,13 @@ namespace Core::GeometricSearch
   class MatchingOctree
   {
    public:
+    /// Data structure to hold entity id and position regardless of entity type
+    struct Entity
+    {
+      int gid;
+      std::array<double, 3> position;
+    };
+
     //! Constructor
     MatchingOctree();
 
@@ -131,13 +138,9 @@ namespace Core::GeometricSearch
     //! returns true if entity is owned by calling proc
     virtual bool check_entity_owner(const Core::FE::Discretization* dis, const int id) = 0;
 
-    //! pack entity to PackPuffer
+    //! Write data as Entity to PackPuffer
     virtual void pack_entity(Core::Communication::PackBuffer& data,
         const Core::FE::Discretization* dis, const int id) = 0;
-
-    //! unpack entity to PackPuffer
-    virtual void unpack_entity(
-        Core::Communication::UnpackBuffer& buffer, std::vector<char>& data) = 0;
 
     //! check if unpacked type is correct
     virtual int check_valid_entity_type(std::shared_ptr<Core::Communication::ParObject> o) = 0;
@@ -300,9 +303,6 @@ namespace Core::GeometricSearch
     void pack_entity(Core::Communication::PackBuffer& data, const Core::FE::Discretization* dis,
         const int id) override;
 
-    //! unpack node from PackPuffer
-    void unpack_entity(Communication::UnpackBuffer& buffer, std::vector<char>& data) override;
-
     //! check if unpacked type is correct
     int check_valid_entity_type(std::shared_ptr<Core::Communication::ParObject> o) override;
 
@@ -337,9 +337,6 @@ namespace Core::GeometricSearch
     //! pack element to PackPuffer
     void pack_entity(Core::Communication::PackBuffer& data, const Core::FE::Discretization* dis,
         const int id) override;
-
-    //! unpack element from PackPuffer
-    void unpack_entity(Communication::UnpackBuffer& buffer, std::vector<char>& data) override;
 
     //! check if unpacked type is correct
     int check_valid_entity_type(std::shared_ptr<Core::Communication::ParObject> o) override;

--- a/src/core/io/src/4C_io_element_append_visualization.hpp
+++ b/src/core/io/src/4C_io_element_append_visualization.hpp
@@ -41,11 +41,11 @@ namespace Core::IO
     cell_types.push_back(vtk_cell_info.first);
 
     // Add each node to the output.
-    const Core::Nodes::Node* const* nodes = ele.nodes();
+    auto nodes = ele.node_range();
 
-    for (int inode = 0; inode < ele.num_node(); ++inode)
+    for (auto node : numbering | std::views::transform([&](int i) { return nodes[i]; }))
       for (unsigned int idim = 0; idim < num_spatial_dimensions; ++idim)
-        point_coordinates.push_back(nodes[numbering[inode]]->x()[idim]);
+        point_coordinates.push_back(node.x()[idim]);
 
     // Return the number of added points.
     return ele.num_node();

--- a/src/core/io/src/4C_io_element_append_visualization.hpp
+++ b/src/core/io/src/4C_io_element_append_visualization.hpp
@@ -45,7 +45,13 @@ namespace Core::IO
 
     for (auto node : numbering | std::views::transform([&](int i) { return nodes[i]; }))
       for (unsigned int idim = 0; idim < num_spatial_dimensions; ++idim)
-        point_coordinates.push_back(node.x()[idim]);
+      {
+        const auto x = node.x();
+        if (idim < x.size())
+          point_coordinates.push_back(x[idim]);
+        else
+          point_coordinates.push_back(0.0);
+      }
 
     // Return the number of added points.
     return ele.num_node();
@@ -110,7 +116,8 @@ namespace Core::IO
           ++i_controlpoint)
       {
         const Core::Nodes::Node* controlpoint = ele.nodes()[i_controlpoint];
-        for (int i_dim = 0; i_dim < dim_output; ++i_dim)
+        const auto size = controlpoint->x().size();
+        for (size_t i_dim = 0; i_dim < size; ++i_dim)
           pos_controlpoints(dim_output * i_controlpoint + i_dim) = controlpoint->x()[i_dim];
       }
 

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -314,9 +314,10 @@ std::shared_ptr<Core::Geo::SearchTree> Coupling::VolMortar::VolMortarCoupl::init
       Core::Nodes::Node* node = sele->nodes()[k];
       Core::LinAlg::Matrix<3, 1> currpos;
 
-      currpos(0) = node->x()[0];
-      currpos(1) = node->x()[1];
-      currpos(2) = node->x()[2];
+      const auto x = node->x();
+      currpos(0) = x[0];
+      currpos(1) = x[1];
+      if (x.size() > 2) currpos(2) = x[2];
 
       currentpositions[node->id()] = currpos;
     }
@@ -3762,7 +3763,8 @@ void Coupling::VolMortar::VolMortarCoupl::define_vertices_slave(
   for (int i = 0; i < nnodes; ++i)
   {
     // compute projection
-    for (int k = 0; k < 3; ++k) vertices[k] = mynodes[i]->x()[k];
+    const auto x = mynodes[i]->x();
+    for (size_t k = 0; k < x.size(); ++k) vertices[k] = x[k];
 
     // get node id, too
     snodeids[0] = mynodes[i]->id();
@@ -3792,7 +3794,8 @@ void Coupling::VolMortar::VolMortarCoupl::define_vertices_master(
   for (int i = 0; i < nnodes; ++i)
   {
     // compute projection
-    for (int k = 0; k < 3; ++k) vertices[k] = mynodes[i]->x()[k];
+    const auto x = mynodes[i]->x();
+    for (size_t k = 0; k < x.size(); ++k) vertices[k] = x[k];
 
     // get node id, too
     snodeids[0] = mynodes[i]->id();

--- a/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar_integrator.cpp
@@ -1965,7 +1965,16 @@ void Coupling::VolMortar::ConsInterpolator::interpolate(Core::Nodes::Node* node,
   if (node->owner() != Core::Communication::my_mpi_rank(nodediscret.get_comm())) return;
 
   // map gp into A and B para space
-  double nodepos[3] = {node->x()[0], node->x()[1], node->x()[2]};
+  double nodepos[3];
+
+  const auto node_x = node->x();
+  nodepos[0] = node_x[0];
+  nodepos[1] = node_x[1];
+  if (node_x.size() > 2)
+    nodepos[2] = node_x[2];
+  else
+    nodepos[2] = 0.0;
+
   double dist = 1.0e12;
   int eleid = 0;
   double AuxXi[3] = {0.0, 0.0, 0.0};

--- a/src/coupling/src/volmortar/4C_coupling_volmortar_shape.hpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar_shape.hpp
@@ -339,10 +339,11 @@ namespace Coupling::VolMortar
           // build basis vectors gxi and geta
           for (int i = 0; i < nn; ++i)
           {
+            const auto x = ele.nodes()[i]->x();
             // first local basis vector
-            gxi[0] += deriv(0, i) * ele.nodes()[i]->x()[0];
-            gxi[1] += deriv(0, i) * ele.nodes()[i]->x()[1];
-            gxi[2] += deriv(0, i) * ele.nodes()[i]->x()[2];
+            gxi[0] += deriv(0, i) * x[0];
+            gxi[1] += deriv(0, i) * x[1];
+            if (x.size() == 3) gxi[2] += deriv(0, i) * x[2];
           }
 
           // second local basis vector
@@ -372,15 +373,16 @@ namespace Coupling::VolMortar
           // build basis vectors gxi and geta
           for (int i = 0; i < nn; ++i)
           {
+            const auto x = ele.nodes()[i]->x();
             // first local basis vector
-            gxi[0] += deriv(0, i) * ele.nodes()[i]->x()[0];
-            gxi[1] += deriv(0, i) * ele.nodes()[i]->x()[1];
-            gxi[2] += deriv(0, i) * ele.nodes()[i]->x()[2];
+            gxi[0] += deriv(0, i) * x[0];
+            gxi[1] += deriv(0, i) * x[1];
+            if (x.size() == 3) gxi[2] += deriv(0, i) * x[2];
 
             // second local basis vector
-            geta[0] += deriv(1, i) * ele.nodes()[i]->x()[0];
-            geta[1] += deriv(1, i) * ele.nodes()[i]->x()[1];
-            geta[2] += deriv(1, i) * ele.nodes()[i]->x()[2];
+            geta[0] += deriv(1, i) * x[0];
+            geta[1] += deriv(1, i) * x[1];
+            if (x.size() == 3) geta[2] += deriv(1, i) * x[2];
           }
 
           // cross product of gxi and geta
@@ -422,9 +424,10 @@ namespace Coupling::VolMortar
             const Core::Nodes::Node* const* nodes = ele.nodes();
             if (!nodes) FOUR_C_THROW("Nodes() returned null pointer");
 
-            xrefe(i, 0) = nodes[i]->x()[0];
-            xrefe(i, 1) = nodes[i]->x()[1];
-            xrefe(i, 2) = nodes[i]->x()[2];
+            const auto x = nodes[i]->x();
+            xrefe(i, 0) = x[0];
+            xrefe(i, 1) = x[1];
+            if (x.size() == 3) xrefe(i, 2) = x[2];
           }
 
           Core::LinAlg::Matrix<ndim, ndim> invJ;

--- a/src/fpsi/4C_fpsi_utils.cpp
+++ b/src/fpsi/4C_fpsi_utils.cpp
@@ -239,11 +239,11 @@ void FPSI::InterfaceUtils::setup_local_interface_facing_element_map(
     {
       const Core::Nodes::Node* const* currslavenode = curr->second->nodes();
 
-      std::vector<double> temploc;
-      temploc.assign(3, 0.0);
-      temploc[0] = currslavenode[nodenum]->x()[0];
-      temploc[1] = currslavenode[nodenum]->x()[1];
-      temploc[2] = currslavenode[nodenum]->x()[2];
+      std::vector<double> temploc(3);
+      auto x = currslavenode[nodenum]->x();
+      temploc[0] = x[0];
+      temploc[1] = x[1];
+      if (x.size() > 2) temploc[2] = x[2];
       for (int dim = 0; dim < 3; dim++)
       {
         slaveloc[dim] = slaveloc[dim] + temploc[dim];
@@ -337,11 +337,11 @@ void FPSI::InterfaceUtils::setup_local_interface_facing_element_map(
         {
           const Core::Nodes::Node* const* currmasternode = curr->second->nodes();
 
-          std::vector<double> temploc;
-          temploc.assign(3, 0.0);
-          temploc[0] = currmasternode[nodenum]->x()[0];
-          temploc[1] = currmasternode[nodenum]->x()[1];
-          temploc[2] = currmasternode[nodenum]->x()[2];
+          std::vector<double> temploc(3);
+          auto x = currmasternode[nodenum]->x();
+          temploc[0] = x[0];
+          temploc[1] = x[1];
+          if (x.size() > 2) temploc[2] = x[2];
           for (int dim = 0; dim < 3; dim++)
           {
             masterloc[dim] = masterloc[dim] + temploc[dim];

--- a/src/mortar/src/4C_mortar_element.cpp
+++ b/src/mortar/src/4C_mortar_element.cpp
@@ -845,7 +845,7 @@ void Mortar::Element::get_nodal_coords_old(
 
     coord(0, i) = mymrtrnode->x()[0] + mymrtrnode->uold()[0];
     coord(1, i) = mymrtrnode->x()[1] + mymrtrnode->uold()[1];
-    coord(2, i) = mymrtrnode->x()[2] + mymrtrnode->uold()[2];
+    if (n_dim() == 3) coord(2, i) = mymrtrnode->x()[2] + mymrtrnode->uold()[2];
   }
 }
 

--- a/src/mortar/src/4C_mortar_interface.cpp
+++ b/src/mortar/src/4C_mortar_interface.cpp
@@ -2043,7 +2043,9 @@ void Mortar::Interface::set_state(
         if (mydisp.size() < 3) mydisp.resize(3);
 
         // set current configuration
-        for (int j = 0; j < 3; ++j) node->xspatial()[j] = node->x()[j] + mydisp[j];
+        auto x = node->x();
+        for (size_t j = 0; j < x.size(); ++j) node->xspatial()[j] = x[j] + mydisp[j];
+        for (size_t j = x.size(); j < 3; ++j) node->xspatial()[j] = 0.0;
       }
 
       // compute element areas

--- a/src/mortar/src/4C_mortar_node.cpp
+++ b/src/mortar/src/4C_mortar_node.cpp
@@ -107,6 +107,13 @@ Mortar::Node::Node(int id, std::span<const double> coords, const int owner,
     xspatial()[i] = x()[i];
     dbcdofs_[i] = false;
   }
+  // For 2D problems, initialize the unused third coordinate to zero
+  for (std::size_t i = coords.size(); i < 3; ++i)
+  {
+    uold()[i] = 0.0;
+    xspatial()[i] = 0.0;
+    dbcdofs_[i] = false;
+  }
 }
 
 

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -441,9 +441,10 @@ std::map<int, Core::LinAlg::Matrix<3, 1>> PoroPressureBased::get_nodal_positions
     const Core::Nodes::Node* node = dis.g_node(nodemap->gid(lid));
     Core::LinAlg::Matrix<3, 1> currpos;
 
-    currpos(0) = node->x()[0];
-    currpos(1) = node->x()[1];
-    currpos(2) = node->x()[2];
+    auto x = node->x();
+    currpos(0) = x[0];
+    currpos(1) = x[1];
+    if (x.size() > 2) currpos(2) = x[2];
 
     positions[node->id()] = currpos;
   }
@@ -467,7 +468,7 @@ double PoroPressureBased::get_max_nodal_distance(
     static Core::LinAlg::Matrix<3, 1> pos0;
     pos0(0) = node0->x()[0];
     pos0(1) = node0->x()[1];
-    pos0(2) = node0->x()[2];
+    if (node0->x().size() > 2) pos0(2) = node0->x()[2];
 
     // loop over second node to numnode to compare distances with first node
     for (int jnode = inode + 1; jnode < ele->num_node(); jnode++)
@@ -478,7 +479,7 @@ double PoroPressureBased::get_max_nodal_distance(
       static Core::LinAlg::Matrix<3, 1> pos1;
       pos1(0) = node1->x()[0];
       pos1(1) = node1->x()[1];
-      pos1(2) = node1->x()[2];
+      if (node1->x().size() > 2) pos1(2) = node1->x()[2];
 
       static Core::LinAlg::Matrix<3, 1> dist;
       dist.update(1.0, pos0, -1.0, pos1, 0.0);

--- a/src/post/4C_post_ensight_writer.cpp
+++ b/src/post/4C_post_ensight_writer.cpp
@@ -2324,8 +2324,6 @@ void EnsightWriter::write_coordinates_for_polynomial_shapefunctions(std::ofstrea
   // distributed among all procs
   std::shared_ptr<Core::LinAlg::MultiVector<double>> nodecoords;
 
-  const int NSD = 3;  // number of space dimensions
-
   const Core::LinAlg::Map* nodemap = dis.node_row_map();
   const int numnp = nodemap->num_my_elements();
   nodecoords = std::make_shared<Core::LinAlg::MultiVector<double>>(*nodemap, 3);
@@ -2335,10 +2333,10 @@ void EnsightWriter::write_coordinates_for_polynomial_shapefunctions(std::ofstrea
   {
     int gid = nodemap->gid(inode);
     const Core::Nodes::Node* actnode = dis.g_node(gid);
-    for (int isd = 0; isd < NSD; ++isd)
+    auto x = actnode->x();
+    for (size_t isd = 0; isd < x.size(); ++isd)
     {
-      double val = ((actnode->x())[isd]);
-      nodecoords->ReplaceMyValue(inode, isd, val);
+      nodecoords->ReplaceMyValue(inode, isd, x[isd]);
     }
   }
 

--- a/src/scatra/4C_scatra_functions.cpp
+++ b/src/scatra/4C_scatra_functions.cpp
@@ -190,7 +190,7 @@ std::array<double, 3> ScaTra::CylinderMagnetFunction::global_to_cylinder_coordin
   // translate coordinates to the magnet's coordinate system
   const double x_translated = x[0] - parameters_.magnet_position[0];
   const double y_translated = x[1] - parameters_.magnet_position[1];
-  const double z_translated = x[2] - parameters_.magnet_position[2];
+  const double z_translated = (x.size() > 2) ? x[2] - parameters_.magnet_position[2] : 0.0;
 
   // rotate coordinates to the magnet's coordinate system
   const double xi = x_translated * std::cos(beta) +

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1317,8 +1317,7 @@ void ScaTra::ScaTraTimIntImpl::set_external_force() const
 
     std::vector<double> external_force_vector(3);
     problem_->function_by_id<Core::Utils::FunctionOfSpaceTime>(external_force_function_id)
-        .evaluate_vector(std::span<const double, 3>(current_node->x().begin(), 3), time_,
-            std::span<double, 3>(external_force_vector));
+        .evaluate_vector(current_node->x(), time_, external_force_vector);
 
     for (int spatial_dimension = 0; spatial_dimension < nsd_; ++spatial_dimension)
     {

--- a/src/solid_3D_ele/4C_solid_3D_ele_nullspace.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_nullspace.hpp
@@ -27,7 +27,7 @@ namespace Discret::Elements
   template <unsigned dim>
     requires(dim == 2 || dim == 3)
   Core::LinAlg::SerialDenseMatrix compute_solid_null_space(
-      std::span<const double, 3> node_coordinates, const double* x0)
+      std::span<const double> node_coordinates, const double* x0)
   {
     if constexpr (dim == 2)
     {

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -898,7 +898,7 @@ void Solid::TimInt::apply_mesh_initialization(
 
     // get degrees of freedom associated with this fluid/structure node
     std::vector<int> nodedofs = discret_->dof(0, mynode);
-    std::vector<double> nvector(3, 0.0);
+    std::vector<double> nvector(numdim, 0.0);
 
     // create new position vector
     for (int i = 0; i < numdim; ++i)

--- a/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
+++ b/src/structure_new/src/model_evaluator/4C_structure_new_model_evaluator_meshtying.cpp
@@ -430,7 +430,7 @@ void Solid::ModelEvaluator::Meshtying::apply_mesh_initialization(
 
     // get degrees of freedom associated with this fluid/structure node
     std::vector<int> nodedofs = discret_ptr()->dof(0, mynode);
-    std::vector<double> nvector(3, 0.0);
+    std::vector<double> nvector(numdim, 0.0);
 
     // create new position vector
     for (int i = 0; i < numdim; ++i)

--- a/tests/input_files/one_d_3_artery_network.4C.yaml
+++ b/tests/input_files/one_d_3_artery_network.4C.yaml
@@ -1,7 +1,7 @@
 TITLE:
   - "baby arterial network"
 PROBLEM SIZE:
-  DIM: 1
+  DIM: 3
   ELEMENTS: 2
   NODES: 3
   MATERIALS: 1


### PR DESCRIPTION
Reverts the fixed dimension == 3 from #1279

Use the known runtime (not yet compile-time) dimension of the Discretization and ensure that nndes have the correct number of coordinates.

#1228