### PR TITLE
[InputSpec] Fix: condense one_ofs with all_ofs

### DIFF
--- a/src/core/io/src/4C_io_input_spec_builders.cpp
+++ b/src/core/io/src/4C_io_input_spec_builders.cpp
@@ -1161,6 +1161,15 @@ namespace
     std::vector<Core::IO::InputSpec> flattened_specs;
     for (auto&& spec : specs)
     {
+      // Strip of redundant all_of wrappers with only one spec.
+      if (auto* all_of_spec =
+              dynamic_cast<Core::IO::Internal::InputSpecTypeErasedImplementation<AllOfSpec>*>(
+                  &spec.impl());
+          all_of_spec && all_of_spec->wrapped.specs.size() == 1)
+      {
+        spec = all_of_spec->wrapped.specs[0];
+      }
+
       if (auto* nested =
               dynamic_cast<Core::IO::Internal::InputSpecTypeErasedImplementation<InputSpecType>*>(
                   &spec.impl());

--- a/src/core/io/tests/4C_io_input_spec_test.cpp
+++ b/src/core/io/tests/4C_io_input_spec_test.cpp
@@ -689,6 +689,65 @@ specs:
     EXPECT_EQ(out.str(), expected);
   }
 
+  TEST(InputSpecTest, NestedOneOfsWithAllOfs)
+  {
+    auto spec = one_of({
+        all_of({
+            one_of({
+                parameter<int>("a"),
+                parameter<int>("b"),
+            }),
+            one_of({
+                parameter<std::string>("c"),
+            }),
+        }),
+        all_of({
+            one_of({
+                parameter<int>("c"),
+                parameter<int>("d"),
+            }),
+        }),
+    });
+
+    std::ostringstream out;
+    ryml::Tree tree = init_yaml_tree_with_exceptions();
+    ryml::NodeRef root = tree.rootref();
+    YamlNodeRef yaml(root, "");
+    spec.emit_metadata(yaml);
+    out << tree;
+
+    std::string expected = R"(type: one_of
+specs:
+  - type: all_of
+    specs:
+      - name: a
+        type: int
+        required: true
+      - name: c
+        type: string
+        required: true
+  - type: all_of
+    specs:
+      - name: b
+        type: int
+        required: true
+      - name: c
+        type: string
+        required: true
+  - type: all_of
+    specs:
+      - name: c
+        type: int
+        required: true
+  - type: all_of
+    specs:
+      - name: d
+        type: int
+        required: true
+)";
+    EXPECT_EQ(out.str(), expected);
+  }
+
   TEST(InputSpecTest, PrintAsDat)
   {
     enum class Options


### PR DESCRIPTION
Small inconsistency where a few specs were not condensed as much as possible