### PR TITLE
Add node IDs as yaml data in DBC monitor output

### DIFF
--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -239,10 +239,6 @@ void Solid::MonitorDbc::setup()
         information_node << ryml::key("dbc monitor condition");
         information_node |= ryml::MAP;
         {
-          std::ostringstream of;
-          write_condition_header(of, OS_WIDTH, rcond_ptr);
-          information_node["condition information"] << of.str();
-
           auto node_gids = information_node.append_child();
           node_gids << ryml::key("node gids");
           node_gids |= ryml::SEQ;

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -237,13 +237,20 @@ void Solid::MonitorDbc::setup()
         root |= ryml::MAP;
         auto information_node = root.append_child();
         information_node << ryml::key("dbc monitor condition");
-        information_node |= ryml::SEQ;
+        information_node |= ryml::MAP;
         {
           std::ostringstream of;
           write_condition_header(of, OS_WIDTH, rcond_ptr);
-          auto first_entry = information_node.append_child();
-          first_entry |= ryml::MAP;
-          first_entry["condition information"] << of.str();
+          information_node["condition information"] << of.str();
+
+          auto node_gids = information_node.append_child();
+          node_gids << ryml::key("node gids");
+          node_gids |= ryml::SEQ;
+          const auto* node_ids = rcond_ptr->get_nodes();
+          for (const auto node_id : *node_ids)
+          {
+            node_gids.append_child() << node_id;
+          }
         }
 
         // add the data node to be appended later

--- a/tests/input_files/ref/beam3r_herm2line3_beam_to_beam_penalty_point_coupling_restart-101_monitor_dbc.yaml
+++ b/tests/input_files/ref/beam3r_herm2line3_beam_to_beam_penalty_point_coupling_restart-101_monitor_dbc.yaml
@@ -1,6 +1,7 @@
 dbc monitor condition:
-  - condition information: "Condition 100 Tagged elements: ONOFF : 1 1 0 0 0 0 0 0 0 \nNodes of this condition:
-      2\n\n\n"
+  condition information: "Condition 100 Tagged elements: ONOFF : 1 1 0 0 0 0 0 0 0 \nNodes of this condition:
+    2\n\n\n"
+  node gids: [2]
 dbc monitor condition data:
   - step: 0
     time: 0

--- a/tests/input_files/ref/beam3r_herm2line3_beam_to_beam_penalty_point_coupling_restart-101_monitor_dbc.yaml
+++ b/tests/input_files/ref/beam3r_herm2line3_beam_to_beam_penalty_point_coupling_restart-101_monitor_dbc.yaml
@@ -1,6 +1,4 @@
 dbc monitor condition:
-  condition information: "Condition 100 Tagged elements: ONOFF : 1 1 0 0 0 0 0 0 0 \nNodes of this condition:
-    2\n\n\n"
   node gids: [2]
 dbc monitor condition data:
   - step: 0


### PR DESCRIPTION
## Description and Context

Following #1211 , this PR adds the node ids as a yaml list instead of a string.