### PR TITLE
Implement `GroupBase` to replace `NOX::Epetra::Group`

### DIFF
--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_group.cpp
@@ -32,7 +32,6 @@ void NOX::FSI::Group::capture_system_state()
   mfsi_.setup_rhs(rhs_view, true);
   mfsi_.setup_system_matrix();
 
-  sharedLinearSystem.getObject(this);
   isValidJacobian = true;
   isValidRHS = true;
 }
@@ -48,7 +47,6 @@ void NOX::FSI::Group::capture_system_state()
     if (not isValidJacobian)
     {
       mfsi_.setup_system_matrix();
-      sharedLinearSystem.getObject(this);
       isValidJacobian = true;
     }
   }

--- a/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
+++ b/src/fsi/src/monolithic/nonlinear_solver/4C_fsi_nox_linearsystem.hpp
@@ -17,7 +17,6 @@
 
 #include <NOX.H>
 #include <NOX_Common.H>
-#include <NOX_Epetra_Group.H>
 #include <NOX_Epetra_Interface_Jacobian.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Vector.H>

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_mpe.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_mpe.cpp
@@ -14,7 +14,6 @@
 #include "4C_linalg_vector.hpp"
 
 #include <NOX_Abstract_Group.H>
-#include <NOX_Epetra_Group.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_GlobalData.H>
 #include <Teuchos_ParameterList.hpp>

--- a/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_sd.cpp
+++ b/src/fsi/src/partitioned/nonlinear_solver/4C_fsi_nox_sd.cpp
@@ -11,11 +11,11 @@
 #include "4C_global_data.hpp"
 #include "4C_io_control.hpp"
 #include "4C_linalg_vector.hpp"
+#include "4C_solver_nonlin_nox_group.hpp"
 
 #include <NOX_Abstract_Group.H>
 #include <NOX_Abstract_Vector.H>
 #include <NOX_Common.H>
-#include <NOX_Epetra_Group.H>
 #include <NOX_Epetra_Interface_Required.H>
 #include <NOX_Epetra_Vector.H>
 #include <NOX_GlobalData.H>
@@ -54,7 +54,7 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
   }
 
   const ::NOX::Abstract::Group& oldgrp = s.getPreviousSolutionGroup();
-  ::NOX::Epetra::Group& egrp = dynamic_cast<::NOX::Epetra::Group&>(newgrp);
+  auto& grp = dynamic_cast<NOX::Nln::GroupBase&>(newgrp);
 
   // Perform single-step linesearch
 
@@ -63,7 +63,7 @@ bool NOX::FSI::SDRelaxation::compute(::NOX::Abstract::Group& newgrp, double& ste
 
   double numerator = oldgrp.getF().innerProduct(dir);
   double denominator =
-      compute_directional_derivative(dir, *egrp.getRequiredInterface()).innerProduct(dir);
+      compute_directional_derivative(dir, *grp.get_required_interface()).innerProduct(dir);
 
   step = -numerator / denominator;
   utils_->out() << "          RELAX = " << std::setw(5) << step << "\n";

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.cpp
@@ -47,7 +47,7 @@ Teuchos::RCP<::NOX::Abstract::Group> NOX::Nln::CONSTRAINT::Group::clone(::NOX::C
 
 /*----------------------------------------------------------------------------*
  *----------------------------------------------------------------------------*/
-::NOX::Abstract::Group& NOX::Nln::CONSTRAINT::Group::operator=(const ::NOX::Epetra::Group& source)
+::NOX::Abstract::Group& NOX::Nln::CONSTRAINT::Group::operator=(const ::NOX::Abstract::Group& source)
 {
   NOX::Nln::Group::operator=(source);
 

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_constraint_group.hpp
@@ -52,7 +52,7 @@ namespace NOX
         //! generate a clone of the given object concerning the given \c CopyType
         Teuchos::RCP<::NOX::Abstract::Group> clone(::NOX::CopyType type) const override;
 
-        ::NOX::Abstract::Group& operator=(const ::NOX::Epetra::Group& source) override;
+        ::NOX::Abstract::Group& operator=(const ::NOX::Abstract::Group& source) override;
 
         //! Returns the interface map
         const ReqInterfaceMap& get_constraint_interfaces() const;

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group.hpp
@@ -67,7 +67,6 @@ namespace NOX
 
       /// assign operator
       ::NOX::Abstract::Group& operator=(const ::NOX::Abstract::Group& source) override;
-      ::NOX::Abstract::Group& operator=(const ::NOX::Epetra::Group& source) override;
 
       Teuchos::RCP<::NOX::Abstract::Group> clone(
           ::NOX::CopyType type = ::NOX::DeepCopy) const override;
@@ -80,7 +79,7 @@ namespace NOX
       ::NOX::Abstract::Group::ReturnType computeF() override;
 
       ::NOX::Abstract::Group::ReturnType applyJacobianInverse(Teuchos::ParameterList& p,
-          const ::NOX::Epetra::Vector& input, ::NOX::Epetra::Vector& result) const override;
+          const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const override;
 
       //! Compute and store \f$F(x)\f$ and the jacobian \f$\frac{\partial F(x)}{\partial x}\f$ at
       //! the same time. This can result in a huge performance gain in some special cases, e.g.
@@ -194,13 +193,11 @@ namespace NOX
       inline void set_is_valid_rhs(const bool value) { isValidRHS = value; };
 #endif
 
-     protected:
-      //! resets the isValid flags to false
-      void resetIsValid() override;
-
      private:
       //! Throw an NOX_error
       void throw_error(const std::string& functionName, const std::string& errorMsg) const;
+
+      mutable Teuchos::RCP<Epetra_Vector> tmp_vector_ptr_;
 
      protected:
       /*! flag whether update of x vector should be skipped

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.cpp
@@ -7,18 +7,280 @@
 
 #include "4C_solver_nonlin_nox_group_base.hpp"
 
+#include "4C_utils_exceptions.hpp"
+
+#include <NOX_SolverStats.hpp>
+#include <Teuchos_ParameterList.hpp>
+
 FOUR_C_NAMESPACE_OPEN
 
 NOX::Nln::GroupBase::GroupBase(Teuchos::ParameterList& printParams,
     const Teuchos::RCP<::NOX::Epetra::Interface::Required>& i, const ::NOX::Epetra::Vector& x,
     const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys)
-    : ::NOX::Epetra::Group(printParams, i, x, linSys)
+    : utils(printParams),
+      xVector(x, ::NOX::DeepCopy),
+      RHSVector(x, ::NOX::ShapeCopy),
+      gradVector(x, ::NOX::ShapeCopy),
+      NewtonVector(x, ::NOX::ShapeCopy),
+      linearSystemPtr(linSys),
+      userInterfacePtr(i),
+      lastLinearSolveConverged(false),
+      lastNumIterations(-1),
+      lastAchievedTol(-1.0)
 {
+  reset_is_valid();
 }
 
-NOX::Nln::GroupBase::GroupBase(const NOX::Nln::GroupBase& source, ::NOX::CopyType type)
-    : ::NOX::Epetra::Group(source, type)
+NOX::Nln::GroupBase::GroupBase(const GroupBase& source, ::NOX::CopyType type)
+    : utils(source.utils),
+      xVector(source.xVector, type),
+      RHSVector(source.RHSVector, type),
+      gradVector(source.gradVector, type),
+      NewtonVector(source.NewtonVector, type),
+      linearSystemPtr(source.linearSystemPtr),
+      userInterfacePtr(source.userInterfacePtr),
+      lastLinearSolveConverged(source.lastLinearSolveConverged),
+      lastNumIterations(source.lastNumIterations),
+      lastAchievedTol(source.lastAchievedTol)
 {
+  FOUR_C_ASSERT(type == ::NOX::DeepCopy || type == ::NOX::ShapeCopy,
+      "NOX::Nln::GroupBase::GroupBase() - invalid copy type provided");
+
+  switch (type)
+  {
+    case ::NOX::DeepCopy:
+      isValidRHS = source.isValidRHS;
+      isValidJacobian = source.isValidJacobian;
+      isValidGrad = source.isValidGrad;
+      isValidNewton = source.isValidNewton;
+      break;
+
+    case ::NOX::ShapeCopy:
+      reset_is_valid();
+      break;
+  }
+}
+
+void NOX::Nln::GroupBase::reset_is_valid()
+{
+  isValidRHS = false;
+  isValidJacobian = false;
+  isValidGrad = false;
+  isValidNewton = false;
+}
+
+Teuchos::RCP<::NOX::Abstract::Group> NOX::Nln::GroupBase::clone(::NOX::CopyType type) const
+{
+  Teuchos::RCP<::NOX::Abstract::Group> newgrp = Teuchos::rcp(new GroupBase(*this, type));
+  return newgrp;
+}
+
+::NOX::Abstract::Group& NOX::Nln::GroupBase::operator=(const Group& source_abs)
+{
+  const auto& source = dynamic_cast<const GroupBase&>(source_abs);
+
+  // Copy the xVector
+  xVector = source.xVector;
+
+  // Update the isValid flags
+  isValidRHS = source.isValidRHS;
+  isValidGrad = source.isValidGrad;
+  isValidNewton = source.isValidNewton;
+  isValidJacobian = source.isValidJacobian;
+
+  // Only copy vectors that are valid
+  if (isValidRHS) RHSVector = source.RHSVector;
+  if (isValidGrad) gradVector = source.gradVector;
+  if (isValidNewton) NewtonVector = source.NewtonVector;
+
+  lastLinearSolveConverged = source.lastLinearSolveConverged;
+  lastNumIterations = source.lastNumIterations;
+  lastAchievedTol = source.lastAchievedTol;
+
+  return *this;
+}
+
+Teuchos::RCP<const ::NOX::Abstract::Vector> NOX::Nln::GroupBase::getXPtr() const
+{
+  FOUR_C_THROW("Not implemented.");
+}
+
+Teuchos::RCP<const ::NOX::Abstract::Vector> NOX::Nln::GroupBase::getFPtr() const
+{
+  FOUR_C_THROW("Not implemented.");
+}
+
+Teuchos::RCP<const ::NOX::Abstract::Vector> NOX::Nln::GroupBase::getGradientPtr() const
+{
+  FOUR_C_THROW("Not implemented.");
+}
+
+Teuchos::RCP<const ::NOX::Abstract::Vector> NOX::Nln::GroupBase::getNewtonPtr() const
+{
+  FOUR_C_THROW("Not implemented.");
+}
+
+void NOX::Nln::GroupBase::setX(const ::NOX::Abstract::Vector& y)
+{
+  reset_is_valid();
+  xVector = dynamic_cast<const ::NOX::Epetra::Vector&>(y);
+}
+
+void NOX::Nln::GroupBase::computeX(
+    const ::NOX::Abstract::Group& grp, const ::NOX::Abstract::Vector& d, double step)
+{
+  const auto& grp_base = dynamic_cast<const GroupBase&>(grp);
+  const auto& epetra_d = dynamic_cast<const ::NOX::Epetra::Vector&>(d);
+
+  reset_is_valid();
+  xVector.update(1.0, grp_base.xVector, step, epetra_d);
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::computeF()
+{
+  if (isF()) return ::NOX::Abstract::Group::Ok;
+
+  isValidRHS = userInterfacePtr->computeF(xVector.getEpetraVector(), RHSVector.getEpetraVector(),
+      ::NOX::Epetra::Interface::Required::Residual);
+
+  FOUR_C_ASSERT(isValidRHS, "NOX::Nln::GroupBase::computeF() - failed");
+
+  return ::NOX::Abstract::Group::Ok;
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::computeJacobian()
+{
+  if (isJacobian()) return ::NOX::Abstract::Group::Ok;
+
+  isValidJacobian = linearSystemPtr->computeJacobian(xVector);
+
+  FOUR_C_ASSERT(isValidJacobian, "NOX::Nln::GroupBase::computeJacobian() - failed");
+
+  return ::NOX::Abstract::Group::Ok;
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::computeGradient()
+{
+  if (isGradient()) return ::NOX::Abstract::Group::Ok;
+
+  FOUR_C_ASSERT(isF(), "NOX::Nln::GroupBase::computeGradient() - RHS is out of date wrt X!");
+  FOUR_C_ASSERT(
+      isJacobian(), "NOX::Nln::GroupBase::computeGradient() - Jacobian is out of date wrt X!");
+
+  isValidGrad = linearSystemPtr->applyJacobianTranspose(RHSVector, gradVector);
+
+  return ::NOX::Abstract::Group::Ok;
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::computeNewton(Teuchos::ParameterList& p)
+{
+  if (isNewton()) return ::NOX::Abstract::Group::Ok;
+
+  FOUR_C_ASSERT(isF(), "NOX::Nln::GroupBase::computeNewton() - RHS is out of date wrt X!");
+  FOUR_C_ASSERT(
+      isJacobian(), "NOX::Nln::GroupBase::computeNewton() - Jacobian is out of date wrt X!");
+
+  ::NOX::Abstract::Group::ReturnType status;
+
+  NewtonVector.init(0.0);
+
+  status = applyJacobianInverse(p, RHSVector, NewtonVector);
+
+  // Scale by -1
+  NewtonVector.scale(-1.0);
+
+  // Update state even if linear solve failed since we may still want top use the vector
+  isValidNewton = true;
+
+  return status;
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::applyJacobian(
+    const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const
+{
+  const auto& epetra_input = dynamic_cast<const ::NOX::Epetra::Vector&>(input);
+  auto& epetra_result = dynamic_cast<::NOX::Epetra::Vector&>(result);
+
+  if (!isJacobian()) return ::NOX::Abstract::Group::BadDependency;
+
+  const bool status = linearSystemPtr->applyJacobian(epetra_input, epetra_result);
+
+  return status ? ::NOX::Abstract::Group::Ok : ::NOX::Abstract::Group::Failed;
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::applyJacobianInverse(
+    Teuchos::ParameterList& p, const ::NOX::Abstract::Vector& input,
+    ::NOX::Abstract::Vector& result) const
+{
+  const auto& epetra_input = dynamic_cast<const ::NOX::Epetra::Vector&>(input);
+  auto& epetra_result = dynamic_cast<::NOX::Epetra::Vector&>(result);
+
+  if (!isJacobian()) return ::NOX::Abstract::Group::BadDependency;
+
+  // Save linear solve stats
+  lastLinearSolveConverged = linearSystemPtr->applyJacobianInverse(p, epetra_input, epetra_result);
+  lastNumIterations = p.sublist("Output").get("Number of Linear Iterations", 0);
+  lastAchievedTol = p.sublist("Output").get("Achieved Tolerance", 0.0);
+
+  return lastLinearSolveConverged ? ::NOX::Abstract::Group::Ok
+                                  : ::NOX::Abstract::Group::NotConverged;
+}
+
+::NOX::Abstract::Group::ReturnType NOX::Nln::GroupBase::applyJacobianTranspose(
+    const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const
+{
+  const auto& epetra_input = dynamic_cast<const ::NOX::Epetra::Vector&>(input);
+  auto& epetra_result = dynamic_cast<::NOX::Epetra::Vector&>(result);
+
+  if (!isJacobian()) return ::NOX::Abstract::Group::BadDependency;
+
+  const bool status = linearSystemPtr->applyJacobianTranspose(epetra_input, epetra_result);
+
+  return status ? ::NOX::Abstract::Group::Ok : ::NOX::Abstract::Group::Failed;
+}
+
+bool NOX::Nln::GroupBase::isF() const { return isValidRHS; }
+
+bool NOX::Nln::GroupBase::isJacobian() const { return isValidJacobian; }
+
+bool NOX::Nln::GroupBase::isGradient() const { return isValidGrad; }
+
+bool NOX::Nln::GroupBase::isNewton() const { return isValidNewton; }
+
+const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getX() const { return xVector; }
+
+const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getF() const { return RHSVector; }
+
+const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getGradient() const { return gradVector; }
+
+const ::NOX::Abstract::Vector& NOX::Nln::GroupBase::getNewton() const { return NewtonVector; }
+
+double NOX::Nln::GroupBase::getNormF() const
+{
+  FOUR_C_ASSERT(isF(), "NOX::Nln::GroupBase::getNormF() - invalid RHS");
+
+  return RHSVector.norm();
+}
+
+Teuchos::RCP<::NOX::Epetra::Interface::Required> NOX::Nln::GroupBase::get_required_interface()
+{
+  return userInterfacePtr;
+}
+
+Teuchos::RCP<const ::NOX::Epetra::LinearSystem> NOX::Nln::GroupBase::get_linear_system() const
+{
+  return linearSystemPtr;
+}
+
+Teuchos::RCP<::NOX::Epetra::LinearSystem> NOX::Nln::GroupBase::get_linear_system()
+{
+  return linearSystemPtr;
+}
+
+void NOX::Nln::GroupBase::logLastLinearSolveStats(::NOX::SolverStats& stats) const
+{
+  stats.linearSolve.logLinearSolve(
+      lastLinearSolveConverged, lastNumIterations, lastAchievedTol, 0.0, 0.0);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_group_base.hpp
@@ -10,7 +10,12 @@
 
 #include "4C_config.hpp"
 
-#include <NOX_Epetra_Group.H>
+#include <NOX_Abstract_Group.H>
+#include <NOX_Epetra_Interface_Required.H>
+#include <NOX_Epetra_LinearSystem.H>
+#include <NOX_Epetra_Vector.H>
+#include <NOX_Utils.H>
+#include <Teuchos_RCP.hpp>
 
 FOUR_C_NAMESPACE_OPEN
 
@@ -18,7 +23,7 @@ namespace NOX
 {
   namespace Nln
   {
-    class GroupBase : public ::NOX::Epetra::Group
+    class GroupBase : public ::NOX::Abstract::Group
     {
      public:
       GroupBase(Teuchos::ParameterList& printParams,
@@ -26,6 +31,140 @@ namespace NOX
           const Teuchos::RCP<::NOX::Epetra::LinearSystem>& linSys);
 
       GroupBase(const NOX::Nln::GroupBase& source, ::NOX::CopyType type);
+
+      ::NOX::Abstract::Group& operator=(const ::NOX::Abstract::Group& source) override;
+
+      //! Clone the group (deep or shallow copy).
+      Teuchos::RCP<::NOX::Abstract::Group> clone(
+          ::NOX::CopyType type = ::NOX::DeepCopy) const override;
+
+      /** @name Compute functions. */
+      //@{
+
+      void setX(const ::NOX::Abstract::Vector& y) override;
+
+      void computeX(const ::NOX::Abstract::Group& grp, const ::NOX::Abstract::Vector& d,
+          double step) override;
+
+      ::NOX::Abstract::Group::ReturnType computeF() override;
+
+      ::NOX::Abstract::Group::ReturnType computeJacobian() override;
+
+      ::NOX::Abstract::Group::ReturnType computeGradient() override;
+
+      ::NOX::Abstract::Group::ReturnType computeNewton(Teuchos::ParameterList& params) override;
+
+      //@}
+
+      /** @name Jacobian operations. */
+      //@{
+
+      ::NOX::Abstract::Group::ReturnType applyJacobian(
+          const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const override;
+
+      ::NOX::Abstract::Group::ReturnType applyJacobianTranspose(
+          const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const override;
+
+      ::NOX::Abstract::Group::ReturnType applyJacobianInverse(Teuchos::ParameterList& params,
+          const ::NOX::Abstract::Vector& input, ::NOX::Abstract::Vector& result) const override;
+
+      //@}
+
+      /** @name These functions check if various objects have been computed.
+       */
+      //@{
+
+      bool isF() const override;
+      bool isJacobian() const override;
+      bool isGradient() const override;
+      bool isNewton() const override;
+
+      //@}
+
+      /** @name Get functions.
+       *
+       * Note that these function do not check whether or not the vectors are valid. Distinctly from
+       * the original Epetra group, all of these function to do not check that the corresponding
+       * object has been evaluated.
+       */
+      //@{
+
+      const ::NOX::Abstract::Vector& getX() const override;
+
+      const ::NOX::Abstract::Vector& getF() const override;
+
+      const ::NOX::Abstract::Vector& getGradient() const override;
+
+      const ::NOX::Abstract::Vector& getNewton() const override;
+
+      Teuchos::RCP<const ::NOX::Abstract::Vector> getXPtr() const override;
+
+      Teuchos::RCP<const ::NOX::Abstract::Vector> getFPtr() const override;
+
+      Teuchos::RCP<const ::NOX::Abstract::Vector> getGradientPtr() const override;
+
+      Teuchos::RCP<const ::NOX::Abstract::Vector> getNewtonPtr() const override;
+
+      double getNormF() const override;
+
+      //@}
+
+      //! Return the user interface object.
+      Teuchos::RCP<::NOX::Epetra::Interface::Required> get_required_interface();
+
+      //! Return the Linear System.
+      Teuchos::RCP<const ::NOX::Epetra::LinearSystem> get_linear_system() const;
+
+      //! Return the Linear System.
+      Teuchos::RCP<::NOX::Epetra::LinearSystem> get_linear_system();
+
+     protected:
+      //! Resets the isValid flags to false
+      void reset_is_valid();
+
+      //! Write last linear solve stats into the provided NOX::SolverStats object
+      void logLastLinearSolveStats(::NOX::SolverStats& stats) const override;
+
+     protected:
+      //! Printing Utilities object
+      const ::NOX::Utils utils;
+
+      /** @name Vectors */
+      //@{
+      //! Solution vector.
+      ::NOX::Epetra::Vector xVector;
+      //! Right-hand-side vector (function evaluation).
+      ::NOX::Epetra::Vector RHSVector;
+      //! Gradient vector (steepest descent vector).
+      ::NOX::Epetra::Vector gradVector;
+      //! Newton direction vector.
+      ::NOX::Epetra::Vector NewtonVector;
+      //@}
+
+      /** @name IsValid flags
+       *
+       * True if a particular object is up-to-date with respect to the
+       * current xVector. */
+      //@{
+      bool isValidRHS;
+      bool isValidJacobian;
+      bool isValidGrad;
+      bool isValidNewton;
+      //@}
+
+      /** @name Operators */
+      //@{
+      //! Pointer to Jacobian matrix
+      Teuchos::RCP<::NOX::Epetra::LinearSystem> linearSystemPtr;
+
+      //! Pointer to the user supplied interface functions
+      Teuchos::RCP<::NOX::Epetra::Interface::Required> userInterfacePtr;
+      //@}
+
+      // Linear solver stats
+      mutable bool lastLinearSolveConverged;
+      mutable int lastNumIterations;
+      mutable double lastAchievedTol;
     };  // class GroupBase
   }  // namespace Nln
 }  // namespace NOX

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_linearsystem_base.hpp
@@ -130,15 +130,7 @@ namespace NOX
       /**
        * \brief Set Jacobian operator for solve.
        *
-       * This method is in fact does nothing, because the only (strange) use of this method in
-       * Trilinos, which is relevant for 4C, is the following call inside NOX::Epetra::Group
-       *
-       * sharedLinearSystem.getObject(this)->setJacobianOperatorForSolve(
-       *   sharedLinearSystem.getObject(this)->getJacobianOperator());
-       *
-       * We could have implemented this method to covert the Teuchos::RCP to a std::shared_ptr, but
-       * that would loose the ownership information, and for the use pattern shown above it can be
-       * quite dangerous as the wrapped object might get deleted.
+       * This method does nothing and is a temporary mock.
        */
       void setJacobianOperatorForSolve(const Teuchos::RCP<const Epetra_Operator>& solveJacOp) final;
     };

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_singlestep_group.cpp
@@ -60,9 +60,7 @@ void NOX::Nln::SINGLESTEP::Group::computeX(
   Core::LinAlg::View d_view(const_cast<Epetra_Vector&>(d.getEpetraVector()));
   prePostOperatorPtr_->run_pre_compute_x(grp, d_view, step, *this);
 
-  if (isPreconditioner()) sharedLinearSystem.getObject(this)->destroyPreconditioner();
-
-  resetIsValid();
+  reset_is_valid();
 
   step = 1.0;
   xVector.update(-1.0, d, step, grp.xVector);

--- a/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
+++ b/src/solver_nonlin_nox/4C_solver_nonlin_nox_solver_ptc.cpp
@@ -139,11 +139,9 @@ void NOX::Nln::Solver::PseudoTransient::create_scaling_operator()
     case NOX::Nln::Solver::PseudoTransient::scale_op_identity:
     {
       // identity matrix
-      Teuchos::RCP<const ::NOX::Epetra::Vector> epetraXPtr =
-          Teuchos::rcp_dynamic_cast<const ::NOX::Epetra::Vector>(solnPtr->getXPtr());
-      if (epetraXPtr.is_null()) FOUR_C_THROW("Cast to ::NOX::Epetra::Vector failed!");
+      const auto& epetraXPtr = dynamic_cast<const ::NOX::Epetra::Vector&>(solnPtr->getX());
       scalingDiagOpPtr_ = Teuchos::make_rcp<Core::LinAlg::Vector<double>>(
-          epetraXPtr->getEpetraVector().Map(), false);
+          epetraXPtr.getEpetraVector().Map(), false);
 
       scalingDiagOpPtr_->put_scalar(1.0);
 
@@ -260,8 +258,8 @@ void NOX::Nln::Solver::PseudoTransient::create_group_pre_post_operator()
     ::NOX::Abstract::Group::ReturnType rtype = solnPtr->computeF();
     if (rtype != ::NOX::Abstract::Group::Ok)
     {
-      utilsPtr->out() << "::NOX::Solver::PseudoTransient::init - "
-                      << "Unable to compute F" << std::endl;
+      utilsPtr->out() << "::NOX::Solver::PseudoTransient::init - " << "Unable to compute F"
+                      << std::endl;
       throw "NOX Error";
     }
 
@@ -273,8 +271,8 @@ void NOX::Nln::Solver::PseudoTransient::create_group_pre_post_operator()
                       << "The solution passed into the solver (either "
                       << "through constructor or reset method) "
                       << "is already converged! The solver will not "
-                      << "attempt to solve this system since status is "
-                      << "flagged as converged." << std::endl;
+                      << "attempt to solve this system since status is " << "flagged as converged."
+                      << std::endl;
     }
     printUpdate();
   }
@@ -317,11 +315,6 @@ void NOX::Nln::Solver::PseudoTransient::create_group_pre_post_operator()
    * See the NOX::Nln::LinSystem::PrePostOP::PseudoTransient class for
    * more information. */
   bool ok = directionPtr->compute(*dirPtr, soln, *this);
-
-  // Show the linear solver residual || Ax-b ||_2
-  //  double lin_residual = 0.0;
-  //  soln.getNormLastLinearSolveResidual(lin_residual);
-  //  utilsPtr->out() << "Linear Solver Residual (L2-norm): " << lin_residual << std::endl;
 
   if (not ok)
   {

--- a/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
+++ b/src/structure_new/src/4C_structure_new_timint_basedataglobalstate.cpp
@@ -1179,7 +1179,10 @@ void NOX::Nln::GROUP::PrePostOp::TimeInt::RotVecUpdater::run_pre_compute_x(
 
   // now replace the rotvec entries by the correct value computed before
   Core::LinAlg::assemble_my_vector(0.0, *xnew, 1.0, x_rotvec);
-  curr_grp_mutable.setX(Teuchos::rcpFromRef(xnew->get_ref_of_epetra_vector()));
+
+  ::NOX::Epetra::Vector wrapper(Teuchos::make_rcp<Epetra_Vector>(xnew->get_ref_of_epetra_vector()),
+      ::NOX::Epetra::Vector::CreateView);
+  curr_grp_mutable.setX(wrapper);
 
   /* tell the NOX::Nln::Group that the x vector has already been updated in
    * this preComputeX operator call */

--- a/src/structure_new/src/implicit/4C_structure_new_impl_generic.hpp
+++ b/src/structure_new/src/implicit/4C_structure_new_impl_generic.hpp
@@ -267,7 +267,7 @@ namespace NOX
            *  \note The result vector is the actual result vector of the internal
            *  linear solver and, accordingly, due to the used sign convention in NOX,
            *  the NEGATIVE direction vector. The sign will be changed again in the
-           *  ::NOX::Epetra::Group::computeNewton method.
+           *  NOX::Nln::GroupBase::computeNewton method.
            *
            *  \param rhs    : read-only access to the rhs vector
            *  \param result : full access to the result vector

--- a/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
+++ b/src/structure_new/src/implicit/4C_structure_new_timint_implicit.cpp
@@ -491,7 +491,7 @@ void Solid::TimeInt::Implicit::print_jacobian_in_matlab_format(
   if (get_data_global_state().get_my_rank() == 0)
     std::cout << "Writing structural jacobian to \"" << filename.str() << "\"\n";
 
-  Teuchos::RCP<const ::NOX::Epetra::LinearSystem> linear_system = curr_grp.getLinearSystem();
+  Teuchos::RCP<const ::NOX::Epetra::LinearSystem> linear_system = curr_grp.get_linear_system();
 
   Teuchos::RCP<const NOX::Nln::LinearSystem> nln_lin_system =
       Teuchos::rcp_dynamic_cast<const NOX::Nln::LinearSystem>(linear_system, true);

--- a/src/structure_new/src/predict/4C_structure_new_predict_tangdis.cpp
+++ b/src/structure_new/src/predict/4C_structure_new_predict_tangdis.cpp
@@ -193,7 +193,7 @@ void NOX::Nln::GROUP::PrePostOp::TangDis::run_post_compute_f(
   if (dbc_incr_nrm2 == 0.0) return;
 
   /* Alternatively, it's also possible to get a const pointer on the jacobian
-   * by calling grp.getLinearSystem()->getJacobianOperator()... */
+   * by calling grp.get_linear_system()->getJacobianOperator()... */
   std::shared_ptr<const Core::LinAlg::SparseMatrix> stiff_ptr =
       tang_predict_ptr_->global_state().get_jacobian_displ_block();
 


### PR DESCRIPTION
## Description and Context
This PR implements our own group class `GroupBase` that replaces `NOX::Epetra::Group` from Trilinos. Effectively, it reproduces functionality of the latter with the following essential modifications:
- Remove method `getNormLastLinearSolveResidual()` - it is mainly used in the single place of NOX, inside `NOX::Direction::ModifiedNewton::rescueBadNewtonSolve()` which attempts to proceed to the next time step even if the convergence tests failed but the "accuracy" measure was not so bad. We have never used this option, and in general, it does not look robust to me.
- Remove everything related to preconditioners since we build them outside of the group.
- Remove method computeNormNewtonSolveResidual() as it mainly provides information for `getNormLastLinearSolveResidual()`.
- Remove data fields related to normNewtonSolveResidual for the above reason.
- Remove `SharedObject` wrapper for the linear system and required interface objects. In general, this pattern is very confusing, especially if one tries to guess why it is even needed provided we use shared pointers. To my understanding, this wrapper was used in the original `NOX::Epetra::Group` in order to keep the object status with the flags `isValidSolverJacOp` and `isValidJacobian` such that they would mean meaningful things. It looks that for our use cases this concern is not a problem. However, if later we need something similar, a different strategy should be implemented. For instance, the status flags should be stored together with the linear system object inside some other wrapper.
- Remove flag `isValidSolverJacOp` which gets obsolete after removing the aforementioned shared object pattern.

Later this class will be further modified to remove `NOX::Epetra::Vector` and switch to `Core::LinAlg::Vector`.

## Related Issues and Pull Requests
#359, #198