### PR TITLE
Let Function framework take spatial position as a span

### DIFF
--- a/src/ale/4C_ale.cpp
+++ b/src/ale/4C_ale.cpp
@@ -152,7 +152,7 @@ void ALE::Ale::set_initial_displacement(const ALE::InitialDisp init, const int s
           // evaluate component d of function
           double initialval = Global::Problem::instance()
                                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                  .evaluate(lnode.x().data(), 0, d);
+                                  .evaluate(lnode.x(), 0, d);
 
           int err = dispn_->replace_local_value(doflid, initialval);
           if (err != 0) FOUR_C_THROW("dof not on proc");

--- a/src/art_net/4C_art_net_impl_stationary.cpp
+++ b/src/art_net/4C_art_net_impl_stationary.cpp
@@ -714,7 +714,7 @@ void Arteries::ArtNetImplStationary::set_initial_field(
           // evaluate component k of spatial function
           double initialval = Global::Problem::instance()
                                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                  .evaluate(lnode.x().data(), time_, k);
+                                  .evaluate(lnode.x(), time_, k);
           int err = pressurenp_->replace_local_value(doflid, initialval);
           if (err != 0) FOUR_C_THROW("dof not on proc");
         }

--- a/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli_evaluate.cpp
@@ -497,7 +497,7 @@ int Discret::Elements::Beam3eb::evaluate_neumann(Teuchos::ParameterList& params,
           functionfac =
               Global::Problem::instance()
                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(tmp_funct[dof].value())
-                  .evaluate(X_ref.data(), time, dof);
+                  .evaluate(X_ref, time, dof);
         }
         else
           functionfac = 1.0;

--- a/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
+++ b/src/beam3/4C_beam3_kirchhoff_evaluate.cpp
@@ -2639,7 +2639,7 @@ void Discret::Elements::Beam3k::evaluate_line_neumann_forces(
         functionfac =
             Global::Problem::instance()
                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(function_numbers[idof].value())
-                .evaluate(X_ref.data(), time, idof);
+                .evaluate(X_ref, time, idof);
       }
       else
         functionfac = 1.0;

--- a/src/beam3/4C_beam3_reissner_evaluate.cpp
+++ b/src/beam3/4C_beam3_reissner_evaluate.cpp
@@ -642,7 +642,7 @@ int Discret::Elements::Beam3r::evaluate_neumann(Teuchos::ParameterList& params,
       if (functions[dof].has_value() && functions[dof].value() > 0)
         functionfac = Global::Problem::instance()
                           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[dof].value())
-                          .evaluate(X_ref.data(), time, dof);
+                          .evaluate(X_ref, time, dof);
       else
         functionfac = 1.0;
 

--- a/src/constraint/4C_constraint_springdashpot.cpp
+++ b/src/constraint/4C_constraint_springdashpot.cpp
@@ -379,11 +379,11 @@ void Constraints::SpringDashpot::evaluate_robin(std::shared_ptr<Core::LinAlg::Sp
                   std::numeric_limits<double>::infinity(), std::numeric_limits<double>::infinity()};
               displ[i] = delta_displacement;
 
-              const double force = nonlinear_spring.evaluate(displ.data(), total_time, 0) +
-                                   dashpot_viscosity * velocity;
+              const double force =
+                  nonlinear_spring.evaluate(displ, total_time, 0) + dashpot_viscosity * velocity;
 
               const double force_derivative_wrt_displ =
-                  nonlinear_spring.evaluate_spatial_derivative(displ.data(), total_time, 0)[i];
+                  nonlinear_spring.evaluate_spatial_derivative(displ, total_time, 0)[i];
 
               return {force, force_derivative_wrt_displ, dashpot_viscosity};
             };
@@ -593,12 +593,12 @@ void Constraints::SpringDashpot::evaluate_robin(std::shared_ptr<Core::LinAlg::Sp
             force_disp = Global::Problem::instance()
                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
                                  (numfuncnonlinstiff)[dof] - 1)
-                             .evaluate(displ.data(), total_time, 0);
+                             .evaluate(displ, total_time, 0);
 
             force_disp_deriv = (Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
                         (numfuncnonlinstiff)[dof] - 1)
-                    .evaluate_spatial_derivative(displ.data(), total_time, 0))[dof];
+                    .evaluate_spatial_derivative(displ, total_time, 0))[dof];
           }
 
           // velocity related forces and derivatives

--- a/src/contact/src/4C_contact_rough_node.cpp
+++ b/src/contact/src/4C_contact_rough_node.cpp
@@ -55,11 +55,11 @@ CONTACT::RoughNode::RoughNode(int id, std::span<const double> coords, const int 
   {
     hurstExponent_ = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(hurstexponentfunction_)
-                         .evaluate(this->x().data(), 1, this->n_dim());
+                         .evaluate(this->x(), 1, this->n_dim());
     initialTopologyStdDeviation_ =
         Global::Problem::instance()
             ->function_by_id<Core::Utils::FunctionOfSpaceTime>(initialtopologystddeviationfunction_)
-            .evaluate(this->x().data(), 1, this->n_dim());
+            .evaluate(this->x(), 1, this->n_dim());
 
     const int N = pow(2, resolution_);
     topology_.shape(N + 1, N + 1);

--- a/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_locsys.cpp
@@ -214,14 +214,14 @@ void Core::Conditions::LocsysManager::update(const double time,
                   // Evaluate function with current node position
                   functfac = (function_manager.function_by_id<Core::Utils::FunctionOfSpaceTime>(
                                   (funct)[j].value()))
-                                 .evaluate(currPos.data(), time, j);
+                                 .evaluate(currPos, time, j);
                 }
                 else
                 {
                   // Evaluate function with reference node position
                   functfac = (function_manager.function_by_id<Core::Utils::FunctionOfSpaceTime>(
                                   (funct)[j].value()))
-                                 .evaluate(node->x().data(), time, j);
+                                 .evaluate(node->x(), time, j);
                 }
               }
               currotangle(j) = (rotangle)[j] * functfac;

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils.cpp
@@ -109,7 +109,7 @@ void Core::FE::do_initial_field(const Core::Utils::FunctionManager& function_man
           const double functfac =
               funct_num > 0
                   ? function_manager.function_by_id<Core::Utils::FunctionOfSpaceTime>(funct_num)
-                        .evaluate(node->x().data(), time, localdof)
+                        .evaluate(node->x(), time, localdof)
                   : 0.0;
 
           // assign value

--- a/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_utils_dbc.cpp
@@ -340,7 +340,7 @@ void Core::FE::Dbc::read_dirichlet_condition(const Teuchos::ParameterList& param
         {
           functfac = params.get<const Core::Utils::FunctionManager*>("function_manager")
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[onesetj].value())
-                         .evaluate(actnode->x().data(), time, onesetj);
+                         .evaluate(actnode->x(), time, onesetj);
         }
 
         const double value = val[onesetj] * functfac;
@@ -539,7 +539,7 @@ void Core::FE::Dbc::do_dirichlet_condition(const Teuchos::ParameterList& params,
         functimederivfac =
             params.get<const Core::Utils::FunctionManager*>("function_manager")
                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[onesetj].value())
-                .evaluate_time_derivative(actnode->x().data(), time, deg, onesetj);
+                .evaluate_time_derivative(actnode->x(), time, deg, onesetj);
       }
 
       // apply factors to Dirichlet value

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization.cpp
@@ -614,7 +614,7 @@ void Core::FE::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_boundary(
         // important: position has to have always three components!!
         functimederivfac =
             function_manager.function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[rr].value())
-                .evaluate_time_derivative(position.values(), time, deg, rr);
+                .evaluate_time_derivative(std::span(position.values(), 3), time, deg, rr);
       }
 
       // apply factors to Dirichlet value
@@ -764,11 +764,11 @@ void Core::FE::DbcNurbs::fill_matrix_and_rhs_for_ls_dirichlet_domain(
         // important: position has to have always three components!!
         functimederivfac =
             function_manager.function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[rr].value())
-                .evaluate_time_derivative(position.values(), time, deg, rr);
+                .evaluate_time_derivative(std::span(position.values(), 3), time, deg, rr);
 
         functfac =
             function_manager.function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[rr].value())
-                .evaluate(position.values(), time, rr);
+                .evaluate(std::span(position.values(), 3), time, rr);
       }
 
       // apply factors to Dirichlet value

--- a/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_initial_condition.cpp
+++ b/src/core/fem/src/nurbs_discretization/4C_fem_nurbs_discretization_initial_condition.cpp
@@ -337,7 +337,8 @@ namespace
                 for (int rr = 0; rr < dofblock; ++rr)
                 {
                   // important: position has to have always three components!!
-                  initialval(rr) = start_function.evaluate(position.values(), 0.0, rr);
+                  initialval(rr) =
+                      start_function.evaluate(std::span(position.values(), 3), 0.0, rr);
                 }
 
 
@@ -462,7 +463,8 @@ namespace
                 for (int rr = 0; rr < dofblock; ++rr)
                 {
                   // important: position has to have always three components!!
-                  initialval(rr) = start_function.evaluate(position.values(), 0.0, rr);
+                  initialval(rr) =
+                      start_function.evaluate(std::span(position.values(), 3), 0.0, rr);
                 }
 
                 // check for degenerated elements

--- a/src/core/linalg/src/dense/4C_linalg_fixedsizematrix.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_fixedsizematrix.hpp
@@ -2004,12 +2004,14 @@ namespace Core::LinAlg
     /// set to 512 bytes (or 64 entries for double matrices).
     static constexpr bool allocatesmemory_ = rows * cols * sizeof(ValueType) > 512;
 
+    static constexpr size_t size_ = rows * cols;
+
     /// the pointer holding the data
     ValueType* data_;
 
     /// for small sizes of the matrix, avoid expensive memory allocation by storing
     /// the matrix on the stack
-    ValueType datafieldsmall_[allocatesmemory_ ? 1 : rows * cols];
+    ValueType datafieldsmall_[allocatesmemory_ ? 1 : size_];
 
     /// whether we are a view to some other matrix
     bool isview_;
@@ -2156,6 +2158,27 @@ namespace Core::LinAlg
       FOUR_C_ASSERT((not isreadonly_), "No write access to read-only data!");
       return data_;
     }
+
+    /// Return a std::span for easy access to the data as a 1D array.
+    ///
+    /// This is only available for vectors (rows==1 or cols==1).
+    [[nodiscard]] std::span<const ValueType, size_> as_span() const
+      requires(rows == 1 || cols == 1)
+    {
+      return std::span<ValueType, size_>(data_, size_);
+    }
+
+    /// Return a std::span for easy access to the data as a 1D array.
+    ///
+    /// This is only available for vectors (rows==1 or cols==1).
+    [[nodiscard]] std::span<ValueType, size_> as_span()
+      requires(rows == 1 || cols == 1)
+    {
+      FOUR_C_ASSERT((not isreadonly_), "No write access to read-only data!");
+      return std::span<ValueType, size_>(data_, size_);
+    }
+
+
     /// Return the number of rows
     static constexpr unsigned int m() { return num_rows(); }
     /// Return the number of columns

--- a/src/core/linalg/src/dense/4C_linalg_serialdensevector.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_serialdensevector.hpp
@@ -13,6 +13,8 @@
 
 #include <Teuchos_SerialDenseVector.hpp>
 
+#include <c++/13/span>
+
 FOUR_C_NAMESPACE_OPEN
 
 namespace Core::LinAlg
@@ -39,6 +41,19 @@ namespace Core::LinAlg
     //! @note This function exists because of a design decision in Trilinos where a vector is
     //! implemented as a matrix with one column.
     [[nodiscard]] int num_cols() const { return this->numCols(); }
+
+    /**
+     * Get the vector as a std::span.
+     */
+    [[nodiscard]] std::span<const double> as_span() const
+    {
+      return std::span(this->values(), this->length());
+    }
+
+    /**
+     * Get the vector as a std::span.
+     */
+    [[nodiscard]] std::span<double> as_span() { return std::span(this->values(), this->length()); }
   };
 
   // type definition for serial integer vector

--- a/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
+++ b/src/core/linalg/src/dense/4C_linalg_tensor_internals.hpp
@@ -193,6 +193,28 @@ namespace Core::LinAlg
 
     TensorInternal(ContainerType&& data) : data_(std::move(data)) {}
 
+    /**
+     * @brief Access the underlying raw data of the tensor as a std::span.
+     *
+     * This only works for rank-1 tensors (i.e., vectors).
+     */
+    [[nodiscard]] constexpr std::span<Number, size_> as_span()
+      requires(rank_ == 1)
+    {
+      return data_;
+    }
+
+    /**
+     * @brief Access the underlying raw data of the tensor as a std::span.
+     *
+     * This only works for rank-1 tensors (i.e., vectors).
+     */
+    [[nodiscard]] constexpr std::span<const Number, size_> as_span() const
+      requires(rank_ == 1)
+    {
+      return data_;
+    }
+
     /*!
      * @brief Access to the underlying raw data of the tensor
      *

--- a/src/core/utils/src/functions/4C_utils_function.cpp
+++ b/src/core/utils/src/functions/4C_utils_function.cpp
@@ -66,19 +66,27 @@ namespace
     // define Fad object for evaluation
     using FAD = Sacado::Fad::DFad<Sacado::Fad::DFad<double>>;
 
+    const auto safe_coordinate = [&x](size_t i) -> double
+    {
+      if (i < x.size())
+        return x[i];
+      else
+        return 0.0;
+    };
+
     // define FAD variables
     // arguments are: x, y, z, and t
     const int number_of_arguments = 4;
     // we consider a function of the type F = F ( x, y, z, t, v1(t), ..., vn(t) )
     const int fad_size = number_of_arguments + static_cast<int>(variables.size());
-    FAD xfad(fad_size, 0, x[0]);
-    FAD yfad(fad_size, 1, x[1]);
-    FAD zfad(fad_size, 2, x[2]);
+    FAD xfad(fad_size, 0, safe_coordinate(0));
+    FAD yfad(fad_size, 1, safe_coordinate(1));
+    FAD zfad(fad_size, 2, safe_coordinate(2));
     FAD tfad(fad_size, 3, t);
 
-    xfad.val() = Sacado::Fad::DFad<double>(fad_size, 0, x[0]);
-    yfad.val() = Sacado::Fad::DFad<double>(fad_size, 1, x[1]);
-    zfad.val() = Sacado::Fad::DFad<double>(fad_size, 2, x[2]);
+    xfad.val() = Sacado::Fad::DFad<double>(fad_size, 0, safe_coordinate(0));
+    yfad.val() = Sacado::Fad::DFad<double>(fad_size, 1, safe_coordinate(1));
+    zfad.val() = Sacado::Fad::DFad<double>(fad_size, 2, safe_coordinate(2));
     tfad.val() = Sacado::Fad::DFad<double>(fad_size, 3, t);
 
     std::vector<FAD> fadvectvars(variables.size());
@@ -401,8 +409,10 @@ double Core::Utils::SymbolicFunctionOfSpaceTime::evaluate(
 
   // set spatial variables
   variable_values.emplace("x", x[0]);
-  variable_values.emplace("y", x[1]);
-  variable_values.emplace("z", x[2]);
+  if (x.size() > 1) variable_values.emplace("y", x[1]);
+  if (x.size() > 2) variable_values.emplace("z", x[2]);
+  if (x.size() > 3)
+    FOUR_C_THROW("The function can only be evaluated in 1D, 2D or 3D space, but got {}D", x.size());
 
   // set temporal variable
   variable_values.emplace("t", t);

--- a/src/core/utils/src/functions/4C_utils_function.cpp
+++ b/src/core/utils/src/functions/4C_utils_function.cpp
@@ -59,8 +59,8 @@ namespace
 
   /// sets the values of the variables in second derivative of expression
   void set_values_in_expression_second_deriv(
-      const std::vector<std::shared_ptr<Core::Utils::FunctionVariable>>& variables, const double* x,
-      const double t,
+      const std::vector<std::shared_ptr<Core::Utils::FunctionVariable>>& variables,
+      std::span<const double> x, const double t,
       std::map<std::string, Sacado::Fad::DFad<Sacado::Fad::DFad<double>>>& variable_values)
   {
     // define Fad object for evaluation
@@ -354,6 +354,24 @@ Core::Utils::try_create_symbolic_function_of_space_time(
   return std::make_shared<SymbolicFunctionOfSpaceTime>(functstring, functvarvector);
 }
 
+void Core::Utils::FunctionOfSpaceTime::evaluate_vector(
+    std::span<const double> x, double t, std::span<double> values) const
+{
+  for (std::size_t i = 0; i < number_components(); ++i) values[i] = evaluate(x, t, i);
+}
+
+std::vector<double> Core::Utils::FunctionOfSpaceTime::evaluate_spatial_derivative(
+    std::span<const double> x, double t, std::size_t component) const
+{
+  FOUR_C_THROW("The evaluation of the derivative is not implemented for this function");
+}
+
+std::vector<double> Core::Utils::FunctionOfSpaceTime::evaluate_time_derivative(
+    std::span<const double> x, double t, unsigned deg, std::size_t component) const
+{
+  FOUR_C_THROW("The evaluation of the time derivative is not implemented for this function");
+}
+
 Core::Utils::SymbolicFunctionOfSpaceTime::SymbolicFunctionOfSpaceTime(
     const std::vector<std::string>& expressions,
     std::vector<std::shared_ptr<FunctionVariable>> variables)
@@ -370,7 +388,7 @@ Core::Utils::SymbolicFunctionOfSpaceTime::SymbolicFunctionOfSpaceTime(
 }
 
 double Core::Utils::SymbolicFunctionOfSpaceTime::evaluate(
-    const double* x, const double t, const std::size_t component) const
+    std::span<const double> x, const double t, const std::size_t component) const
 {
   std::size_t component_mod = find_modified_component(component, expr_);
 
@@ -400,7 +418,7 @@ double Core::Utils::SymbolicFunctionOfSpaceTime::evaluate(
 }
 
 std::vector<double> Core::Utils::SymbolicFunctionOfSpaceTime::evaluate_spatial_derivative(
-    const double* x, const double t, const std::size_t component) const
+    std::span<const double> x, const double t, const std::size_t component) const
 {
   std::size_t component_mod = find_modified_component(component, expr_);
 
@@ -422,7 +440,8 @@ std::vector<double> Core::Utils::SymbolicFunctionOfSpaceTime::evaluate_spatial_d
 }
 
 std::vector<double> Core::Utils::SymbolicFunctionOfSpaceTime::evaluate_time_derivative(
-    const double* x, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> x, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // result vector
   std::vector<double> res(deg + 1);

--- a/src/core/utils/src/functions/4C_utils_function.hpp
+++ b/src/core/utils/src/functions/4C_utils_function.hpp
@@ -47,7 +47,7 @@ namespace Core::Utils
      *                      which should be evaluated
      * @return function value
      */
-    virtual double evaluate(const double* x, double t, std::size_t component) const = 0;
+    virtual double evaluate(std::span<const double> x, double t, std::size_t component) const = 0;
 
     /*!
      * @brief Vector-valued evaluation of time and space dependent function
@@ -60,10 +60,7 @@ namespace Core::Utils
      * @param values function values
      */
     virtual void evaluate_vector(
-        const std::span<const double, 3> x, double t, std::span<double> values) const
-    {
-      for (std::size_t i = 0; i < number_components(); ++i) values[i] = evaluate(x.data(), t, i);
-    }
+        std::span<const double> x, double t, std::span<double> values) const;
 
 
     /*!
@@ -76,10 +73,7 @@ namespace Core::Utils
      * \return first spatial derivative of function
      */
     virtual std::vector<double> evaluate_spatial_derivative(
-        const double* x, double t, std::size_t component) const
-    {
-      FOUR_C_THROW("The evaluation of the derivative is not implemented for this function");
-    };
+        std::span<const double> x, double t, std::size_t component) const;
 
     /*!
      * \brief Evaluation of time derivatives and value of the time and space dependent function
@@ -95,10 +89,7 @@ namespace Core::Utils
      * @return vector containing value and time derivative(s)
      */
     virtual std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const
-    {
-      FOUR_C_THROW("The evaluation of the time derivative is not implemented for this function");
-    };
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const;
 
     /// Return number of components of function
     [[nodiscard]] virtual std::size_t number_components() const = 0;
@@ -124,13 +115,13 @@ namespace Core::Utils
     SymbolicFunctionOfSpaceTime(const std::vector<std::string>& expressions,
         std::vector<std::shared_ptr<FunctionVariable>> variables);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_spatial_derivative(
-        const double* x, double t, std::size_t component) const override;
+        std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     [[nodiscard]] std::size_t number_components() const override { return (expr_.size()); }
 

--- a/src/fluid/4C_fluid_functions.cpp
+++ b/src/fluid/4C_fluid_functions.cpp
@@ -394,7 +394,7 @@ FLD::BeltramiFunction::BeltramiFunction(double c1) : c1_(c1) {}
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::BeltramiFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double a = std::numbers::pi / 4.0;
   double d = std::numbers::pi / 2.0;
@@ -442,8 +442,8 @@ double FLD::BeltramiFunction::evaluate(
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::BeltramiFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::BeltramiFunction::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   double a = std::numbers::pi / 4.0;
   double d = std::numbers::pi / 2.0;
@@ -559,7 +559,7 @@ std::vector<double> FLD::BeltramiFunction::evaluate_time_derivative(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::ChannelWeaklyCompressibleFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   int id = Global::Problem::instance()->materials()->first_id_by_type(
       Core::Materials::m_fluid_murnaghantait);
@@ -770,7 +770,8 @@ double FLD::ChannelWeaklyCompressibleFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::ChannelWeaklyCompressibleFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -802,7 +803,7 @@ std::vector<double> FLD::ChannelWeaklyCompressibleFunction::evaluate_time_deriva
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::CorrectionTermChannelWeaklyCompressibleFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   int id = Global::Problem::instance()->materials()->first_id_by_type(
       Core::Materials::m_fluid_murnaghantait);
@@ -928,7 +929,8 @@ double FLD::CorrectionTermChannelWeaklyCompressibleFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::CorrectionTermChannelWeaklyCompressibleFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -973,7 +975,7 @@ FLD::WeaklyCompressiblePoiseuilleFunction::WeaklyCompressiblePoiseuilleFunction(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressiblePoiseuilleFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -1035,7 +1037,8 @@ double FLD::WeaklyCompressiblePoiseuilleFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressiblePoiseuilleFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -1079,7 +1082,7 @@ FLD::WeaklyCompressiblePoiseuilleForceFunction::WeaklyCompressiblePoiseuilleForc
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressiblePoiseuilleForceFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -1125,7 +1128,8 @@ double FLD::WeaklyCompressiblePoiseuilleForceFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressiblePoiseuilleForceFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -1167,7 +1171,7 @@ FLD::WeaklyCompressibleManufacturedFlowFunction::WeaklyCompressibleManufacturedF
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleManufacturedFlowFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -1294,7 +1298,8 @@ double FLD::WeaklyCompressibleManufacturedFlowFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleManufacturedFlowFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -1337,7 +1342,7 @@ FLD::WeaklyCompressibleManufacturedFlowForceFunction::
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleManufacturedFlowForceFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -1690,7 +1695,8 @@ double FLD::WeaklyCompressibleManufacturedFlowForceFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleManufacturedFlowForceFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -1731,7 +1737,7 @@ FLD::WeaklyCompressibleEtienneCFDFunction::WeaklyCompressibleEtienneCFDFunction(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleEtienneCFDFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -1844,7 +1850,8 @@ double FLD::WeaklyCompressibleEtienneCFDFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleEtienneCFDFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -1883,7 +1890,7 @@ FLD::WeaklyCompressibleEtienneCFDForceFunction::WeaklyCompressibleEtienneCFDForc
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleEtienneCFDForceFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -2260,7 +2267,8 @@ double FLD::WeaklyCompressibleEtienneCFDForceFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleEtienneCFDForceFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -2298,7 +2306,7 @@ FLD::WeaklyCompressibleEtienneCFDViscosityFunction::WeaklyCompressibleEtienneCFD
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleEtienneCFDViscosityFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -2322,7 +2330,8 @@ double FLD::WeaklyCompressibleEtienneCFDViscosityFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleEtienneCFDViscosityFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -2375,7 +2384,7 @@ FLD::WeaklyCompressibleEtienneFSIFluidFunction::WeaklyCompressibleEtienneFSIFlui
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleEtienneFSIFluidFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -2772,7 +2781,8 @@ double FLD::WeaklyCompressibleEtienneFSIFluidFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleEtienneFSIFluidFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -2825,7 +2835,7 @@ FLD::WeaklyCompressibleEtienneFSIFluidForceFunction::WeaklyCompressibleEtienneFS
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleEtienneFSIFluidForceFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -7814,7 +7824,8 @@ double FLD::WeaklyCompressibleEtienneFSIFluidForceFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> FLD::WeaklyCompressibleEtienneFSIFluidForceFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -7868,7 +7879,7 @@ FLD::WeaklyCompressibleEtienneFSIFluidViscosityFunction::
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::WeaklyCompressibleEtienneFSIFluidViscosityFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -8047,7 +8058,8 @@ double FLD::WeaklyCompressibleEtienneFSIFluidViscosityFunction::evaluate(
 /*----------------------------------------------------------------------*/
 std::vector<double>
 FLD::WeaklyCompressibleEtienneFSIFluidViscosityFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -8082,7 +8094,7 @@ FLD::BeltramiUP::BeltramiUP(const Mat::PAR::NewtonianFluid& fparams) : density_(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::BeltramiUP::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8116,8 +8128,8 @@ double FLD::BeltramiUP::evaluate(
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::BeltramiUP::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::BeltramiUP::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -8174,7 +8186,7 @@ FLD::BeltramiGradU::BeltramiGradU(const Mat::PAR::NewtonianFluid& fparams) {}
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::BeltramiGradU::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8217,8 +8229,8 @@ double FLD::BeltramiGradU::evaluate(
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::BeltramiGradU::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::BeltramiGradU::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -8288,7 +8300,7 @@ FLD::BeltramiRHS::BeltramiRHS(const Mat::PAR::NewtonianFluid& fparams, bool is_s
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::BeltramiRHS::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8339,8 +8351,8 @@ double FLD::BeltramiRHS::evaluate(
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::BeltramiRHS::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::BeltramiRHS::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -8399,7 +8411,8 @@ FLD::KimMoinUP::KimMoinUP(const Mat::PAR::NewtonianFluid& fparams, bool is_stati
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-double FLD::KimMoinUP::evaluate(const double* xp, const double t, const std::size_t component) const
+double FLD::KimMoinUP::evaluate(
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8439,8 +8452,8 @@ double FLD::KimMoinUP::evaluate(const double* xp, const double t, const std::siz
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::KimMoinUP::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::KimMoinUP::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8547,7 +8560,7 @@ FLD::KimMoinGradU::KimMoinGradU(const Mat::PAR::NewtonianFluid& fparams, bool is
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::KimMoinGradU::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // double visc = 1.0;
 
@@ -8598,8 +8611,8 @@ double FLD::KimMoinGradU::evaluate(
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::KimMoinGradU::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::KimMoinGradU::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   // double visc = 1.0;
 
@@ -8736,7 +8749,7 @@ FLD::KimMoinRHS::KimMoinRHS(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::KimMoinRHS::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8798,8 +8811,8 @@ double FLD::KimMoinRHS::evaluate(
 }
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
-std::vector<double> FLD::KimMoinRHS::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+std::vector<double> FLD::KimMoinRHS::evaluate_time_derivative(std::span<const double> xp,
+    const double t, const unsigned deg, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -8937,7 +8950,7 @@ FLD::KimMoinStress::KimMoinStress(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double FLD::KimMoinStress::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // double visc = 1.0;
 

--- a/src/fluid/4C_fluid_functions.hpp
+++ b/src/fluid/4C_fluid_functions.hpp
@@ -38,10 +38,10 @@ namespace FLD
    public:
     BeltramiUP(const Mat::PAR::NewtonianFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -61,10 +61,10 @@ namespace FLD
    public:
     BeltramiGradU(const Mat::PAR::NewtonianFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -82,10 +82,10 @@ namespace FLD
    public:
     KimMoinUP(const Mat::PAR::NewtonianFluid& fparams, bool is_stationary);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -108,10 +108,10 @@ namespace FLD
    public:
     KimMoinGradU(const Mat::PAR::NewtonianFluid& fparams, bool is_stationary);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -132,10 +132,10 @@ namespace FLD
    public:
     BeltramiFunction(double c1);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -153,10 +153,10 @@ namespace FLD
   class ChannelWeaklyCompressibleFunction : public Core::Utils::FunctionOfSpaceTime
   {
    public:
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -171,10 +171,10 @@ namespace FLD
   class CorrectionTermChannelWeaklyCompressibleFunction : public Core::Utils::FunctionOfSpaceTime
   {
    public:
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (1); };
   };
@@ -186,10 +186,10 @@ namespace FLD
     WeaklyCompressiblePoiseuilleFunction(
         const Mat::PAR::WeaklyCompressibleFluid& fparams, double L, double R, double U);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (6); };
 
@@ -210,10 +210,10 @@ namespace FLD
     WeaklyCompressiblePoiseuilleForceFunction(
         const Mat::PAR::WeaklyCompressibleFluid& fparams, double L, double R, double U);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (3); };
 
@@ -232,10 +232,10 @@ namespace FLD
    public:
     WeaklyCompressibleManufacturedFlowFunction(const Mat::PAR::WeaklyCompressibleFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (6); };
 
@@ -253,10 +253,10 @@ namespace FLD
     WeaklyCompressibleManufacturedFlowForceFunction(
         const Mat::PAR::WeaklyCompressibleFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (3); };
 
@@ -273,10 +273,10 @@ namespace FLD
    public:
     WeaklyCompressibleEtienneCFDFunction(const Mat::PAR::WeaklyCompressibleFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (6); };
 
@@ -292,10 +292,10 @@ namespace FLD
    public:
     WeaklyCompressibleEtienneCFDForceFunction(const Mat::PAR::WeaklyCompressibleFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (3); };
 
@@ -309,10 +309,10 @@ namespace FLD
    public:
     WeaklyCompressibleEtienneCFDViscosityFunction(const Mat::PAR::WeaklyCompressibleFluid& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (1); };
   };
@@ -325,10 +325,10 @@ namespace FLD
         const Mat::PAR::WeaklyCompressibleFluid& fparams_fluid,
         const Mat::PAR::StVenantKirchhoff& fparams_struct);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (6); };
 
@@ -349,10 +349,10 @@ namespace FLD
         const Mat::PAR::WeaklyCompressibleFluid& fparams_fluid,
         const Mat::PAR::StVenantKirchhoff& fparams_struct);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (3); };
 
@@ -373,10 +373,10 @@ namespace FLD
         const Mat::PAR::WeaklyCompressibleFluid& fparams_fluid,
         const Mat::PAR::StVenantKirchhoff& fparams_struct);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     std::size_t number_components() const override { return (1); };
 
@@ -395,10 +395,10 @@ namespace FLD
    public:
     BeltramiRHS(const Mat::PAR::NewtonianFluid& fparams, bool is_stokes);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -419,10 +419,10 @@ namespace FLD
    public:
     KimMoinRHS(const Mat::PAR::NewtonianFluid& fparams, bool is_stationary, bool is_stokes);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     /*!
      * \brief Return the number of components of this spatial function (This is a vector-valued
@@ -446,7 +446,7 @@ namespace FLD
     KimMoinStress(
         const Mat::PAR::NewtonianFluid& fparams, bool is_stationary, double amplitude = 1.0);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::size_t number_components() const override { return (6); };
 

--- a/src/fluid/4C_fluid_implicit_integration.cpp
+++ b/src/fluid/4C_fluid_implicit_integration.cpp
@@ -2640,7 +2640,7 @@ void FLD::FluidImplicitTimeInt::ale_update(std::string condName)
             (*nodeNormals).get_values()[dofsLocalInd[i]] =
                 (Global::Problem::instance()->function_by_id<Core::Utils::FunctionOfSpaceTime>(
                      nodeNormalFunct))
-                    .evaluate(currPos.data(), 0.0, i);
+                    .evaluate(currPos, 0.0, i);
           }
         }
       }
@@ -4145,7 +4145,7 @@ void FLD::FluidImplicitTimeInt::set_initial_flow_field(
 
         double initialval = Global::Problem::instance()
                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                .evaluate(lnode.x().data(), time_, index);
+                                .evaluate(lnode.x(), time_, index);
 
         velnp_->replace_global_value(gid, initialval);
       }

--- a/src/fluid/4C_fluid_timint_poro.cpp
+++ b/src/fluid/4C_fluid_timint_poro.cpp
@@ -120,7 +120,7 @@ void FLD::TimIntPoro::set_initial_porosity_field(
         int numdofs = nodedofset.size();
         double initialval = Global::Problem::instance()
                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                .evaluate(lnode.x().data(), time_, 0);
+                                .evaluate(lnode.x(), time_, 0);
 
         // check whether there are invalid values of porosity
         if (initialval < 1e-15) FOUR_C_THROW("zero or negative initial porosity");

--- a/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_calc.cpp
@@ -370,8 +370,6 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
     coordgp3D[2] = 0.0;
     for (int i = 0; i < nsd_; i++) coordgp3D[i] = coordgp(i);
 
-    const double* coordgpref = coordgp3D;  // needed for function evaluation
-
     for (int idim = 0; idim < (nsd_); ++idim)
     {
       if (*type == "Live")
@@ -383,11 +381,11 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
             // evaluate function at current gauss point
             functfac = Global::Problem::instance()
                            ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[idim].value())
-                           .evaluate(coordgpref, time, idim);
+                           .evaluate(coordgp3D, time, idim);
             if (fldparatimint_->is_new_ost_implementation())
               functfacn = Global::Problem::instance()
                               ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[idim].value())
-                              .evaluate(coordgpref, time - fldparatimint_->dt(), idim);
+                              .evaluate(coordgp3D, time - fldparatimint_->dt(), idim);
           }
           else
           {
@@ -421,11 +419,11 @@ int Discret::Elements::FluidBoundaryImpl<distype>::evaluate_neumann(
             // evaluate function at current gauss point
             functfac = Global::Problem::instance()
                            ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[0].value())
-                           .evaluate(coordgpref, time, idim);
+                           .evaluate(coordgp3D, time, idim);
             if (fldparatimint_->is_new_ost_implementation())
               functfacn = Global::Problem::instance()
                               ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[0].value())
-                              .evaluate(coordgpref, time - fldparatimint_->dt(), idim);
+                              .evaluate(coordgp3D, time - fldparatimint_->dt(), idim);
           }
           else
           {

--- a/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_boundary_parent_calc.cpp
@@ -2194,7 +2194,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::evaluate_weak_dbc(
         // (important: requires 3D position vector)
         functionfac(idim) = Global::Problem::instance()
                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[idim])
-                                .evaluate(coordgp.data(), time, idim);
+                                .evaluate(coordgp.as_span(), time, idim);
       }
       else
         functionfac(idim) = 1.0;
@@ -4863,7 +4863,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
             functionfac(dim) =
                 Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[dim].value())
-                    .evaluate(coordgp.data(), time, dim);
+                    .evaluate(coordgp.as_span(), time, dim);
           }
           else
           {
@@ -5231,7 +5231,7 @@ void Discret::Elements::FluidBoundaryParent<distype>::mix_hyb_dirichlet(
           functionfac(dim) =
               Global::Problem::instance()
                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[dim].value())
-                  .evaluate(coordgp.data(), time, dim);
+                  .evaluate(coordgp.as_span(), time, dim);
         }
         else
         {

--- a/src/fluid_ele/4C_fluid_ele_calc.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc.cpp
@@ -1457,7 +1457,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::body_force(Discret::Elem
             functionfac =
                 Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[isd].value())
-                    .evaluate((ele->nodes()[jnode])->x().data(), time, isd);
+                    .evaluate((ele->nodes()[jnode])->x(), time, isd);
           }
           else
             functionfac = 1.0;
@@ -1485,7 +1485,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::body_force(Discret::Elem
             functionfac =
                 Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[isd].value())
-                    .evaluate((ele->nodes()[jnode])->x().data(), time, isd);
+                    .evaluate((ele->nodes()[jnode])->x(), time, isd);
           }
           else
             functionfac = 1.0;
@@ -1568,7 +1568,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::correction_term(
   {
     ecorrectionterm(i) = Global::Problem::instance()
                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum)
-                             .evaluate((ele->nodes()[i])->x().data(), 0.0, 0);
+                             .evaluate((ele->nodes()[i])->x(), 0.0, 0);
   }
 }
 
@@ -1826,7 +1826,7 @@ void Discret::Elements::FluidEleCalc<distype, enrtype>::set_advective_vel_oseen(
     const double time = fldparatimint_->time();
     for (int jnode = 0; jnode < nen_; ++jnode)
     {
-      const double* jx = ele->nodes()[jnode]->x().data();
+      const auto jx = ele->nodes()[jnode]->x();
       for (int idim = 0; idim < nsd_; ++idim)
         eadvvel_(idim, jnode) = Global::Problem::instance()
                                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg.cpp
@@ -608,7 +608,7 @@ int Discret::Elements::FluidEleCalcHDG<distype>::project_field(Discret::Elements
           if (funct_num > 0)
             u(d) = Global::Problem::instance()
                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct_num)
-                       .evaluate(xyz.data(), *time, d);
+                       .evaluate(xyz.as_span(), *time, d);
         }
       }
 
@@ -1288,13 +1288,13 @@ void Discret::Elements::FluidEleCalcHDG<distype>::evaluate_all(const int startfu
     {
       FLD::ChannelWeaklyCompressibleFunction* channelfunc =
           new FLD::ChannelWeaklyCompressibleFunction;
-      u(0) = channelfunc->evaluate(xyz.data(), 0, 0);
-      u(1) = channelfunc->evaluate(xyz.data(), 0, 1);
-      p = channelfunc->evaluate(xyz.data(), 0, 2);
-      grad(0, 0) = channelfunc->evaluate(xyz.data(), 0, 3);
-      grad(0, 1) = channelfunc->evaluate(xyz.data(), 0, 4);
-      grad(1, 0) = channelfunc->evaluate(xyz.data(), 0, 5);
-      grad(1, 1) = channelfunc->evaluate(xyz.data(), 0, 6);
+      u(0) = channelfunc->evaluate(xyz.as_span(), 0, 0);
+      u(1) = channelfunc->evaluate(xyz.as_span(), 0, 1);
+      p = channelfunc->evaluate(xyz.as_span(), 0, 2);
+      grad(0, 0) = channelfunc->evaluate(xyz.as_span(), 0, 3);
+      grad(0, 1) = channelfunc->evaluate(xyz.as_span(), 0, 4);
+      grad(1, 0) = channelfunc->evaluate(xyz.as_span(), 0, 5);
+      grad(1, 1) = channelfunc->evaluate(xyz.as_span(), 0, 6);
     }
     break;
 
@@ -1304,10 +1304,10 @@ void Discret::Elements::FluidEleCalcHDG<distype>::evaluate_all(const int startfu
       for (unsigned int index = 0; index < nsd_; ++index)
         u(index) = Global::Problem::instance()
                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfunc)
-                       .evaluate(xyz.data(), 0, index);
+                       .evaluate(xyz.as_span(), 0, index);
       p = Global::Problem::instance()
               ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfunc)
-              .evaluate(xyz.data(), 0, nsd_);
+              .evaluate(xyz.as_span(), 0, nsd_);
     }
     break;
 

--- a/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_hdg_weak_comp.cpp
@@ -841,17 +841,17 @@ void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::evaluate_all(const int
 {
   r = Global::Problem::instance()
           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)
-          .evaluate(xyz.data(), t, 0);
+          .evaluate(xyz.as_span(), t, 0);
 
   for (unsigned int d = 0; d < nsd_; ++d)
     w(d) = Global::Problem::instance()
                ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)
-               .evaluate(xyz.data(), t, 1 + d);
+               .evaluate(xyz.as_span(), t, 1 + d);
 
   for (unsigned int m = 0; m < msd_; ++m)
     L(m) = Global::Problem::instance()
                ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)
-               .evaluate(xyz.data(), t, 1 + nsd_ + m);
+               .evaluate(xyz.as_span(), t, 1 + nsd_ + m);
 }
 
 
@@ -863,12 +863,12 @@ void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::evaluate_density_momen
 {
   r = Global::Problem::instance()
           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)
-          .evaluate(xyz.data(), t, 0);
+          .evaluate(xyz.as_span(), t, 0);
 
   for (unsigned int d = 0; d < nsd_; ++d)
     w(d) = Global::Problem::instance()
                ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)
-               .evaluate(xyz.data(), t, 1 + d);
+               .evaluate(xyz.as_span(), t, 1 + d);
 }
 
 
@@ -1082,7 +1082,7 @@ void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::LocalSolver::compute_m
     // get viscosity
     double mu = Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(varviscfuncnum)
-                    .evaluate(xyz.data(), time, 0);
+                    .evaluate(xyz.as_span(), time, 0);
 
     // evaluate Dw
     for (unsigned int d = 0; d < nsd_; ++d) Dw(d, d) = 2.0 * mu;
@@ -1200,7 +1200,7 @@ void Discret::Elements::FluidEleCalcHDGWeakComp<distype>::LocalSolver::compute_i
         for (unsigned int dmod = 0; dmod < (1 + nsd_); ++dmod)
           feg(dmod, q) = Global::Problem::instance()
                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(forcefuncnum)
-                             .evaluate(xyzeg.data(), time, dmod);
+                             .evaluate(xyzeg.as_span(), time, dmod);
 
       drdteg(q) += N(i, q) * drdte(i);
 

--- a/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_intfaces_stab.cpp
@@ -839,7 +839,7 @@ int Discret::Elements::FluidInternalSurfaceStab<distype, pdistype,
     // parent element
     for (int jnode = 0; jnode < piel; ++jnode)
     {
-      const double* jx = pele->nodes()[jnode]->x().data();
+      const auto jx = pele->nodes()[jnode]->x();
       for (int idim = 0; idim < nsd_; ++idim)
         peconvvelaf_(idim, jnode) = Global::Problem::instance()
                                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)
@@ -849,7 +849,7 @@ int Discret::Elements::FluidInternalSurfaceStab<distype, pdistype,
     // neighbor element
     for (int jnode = 0; jnode < niel; ++jnode)
     {
-      const double* jx = nele->nodes()[jnode]->x().data();
+      const auto jx = nele->nodes()[jnode]->x();
       for (int idim = 0; idim < nsd_; ++idim)
         neconvvelaf_(idim, jnode) = Global::Problem::instance()
                                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funcnum)

--- a/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
+++ b/src/fluid_ele/4C_fluid_ele_calc_poro.cpp
@@ -6359,13 +6359,13 @@ int Discret::Elements::FluidEleCalcPoro<distype>::compute_error(Discret::Element
         {
           const double u_exact_x = Global::Problem::instance()
                                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                       .evaluate(position.data(), t, 0);
+                                       .evaluate(position, t, 0);
           const double u_exact_y = Global::Problem::instance()
                                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                       .evaluate(position.data(), t, 1);
+                                       .evaluate(position, t, 1);
           const double p_exact = Global::Problem::instance()
                                      ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                     .evaluate(position.data(), t, 2);
+                                     .evaluate(position, t, 2);
 
           u(0) = u_exact_x;
           u(1) = u_exact_y;
@@ -6375,16 +6375,16 @@ int Discret::Elements::FluidEleCalcPoro<distype>::compute_error(Discret::Element
         {
           const double u_exact_x = Global::Problem::instance()
                                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                       .evaluate(position.data(), t, 0);
+                                       .evaluate(position, t, 0);
           const double u_exact_y = Global::Problem::instance()
                                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                       .evaluate(position.data(), t, 1);
+                                       .evaluate(position, t, 1);
           const double u_exact_z = Global::Problem::instance()
                                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                       .evaluate(position.data(), t, 2);
+                                       .evaluate(position, t, 2);
           const double p_exact = Global::Problem::instance()
                                      ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                                     .evaluate(position.data(), t, 3);
+                                     .evaluate(position, t, 3);
 
           u(0) = u_exact_x;
           u(1) = u_exact_y;

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -4463,7 +4463,7 @@ void FLD::XFluid::set_initial_flow_field(
 
           double initialval = Global::Problem::instance()
                                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                  .evaluate(lnode.x().data(), time_, dof % 4);
+                                  .evaluate(lnode.x(), time_, dof % 4);
           state_->velnp_->replace_global_values(1, &initialval, &gid);
         }
       }

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions.cpp
@@ -264,7 +264,7 @@ void Discret::Utils::add_valid_xfluid_functions(Core::Utils::FunctionManager& fu
 Discret::Utils::GerstenbergerForwardfacingStep::GerstenbergerForwardfacingStep() {}
 
 double Discret::Utils::GerstenbergerForwardfacingStep::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   //  //cube_Gerstenberger:
   //  //1.6x1.6
@@ -368,7 +368,7 @@ Discret::Utils::MovingLevelSetCylinder::MovingLevelSetCylinder(std::vector<doubl
 }
 
 double Discret::Utils::MovingLevelSetCylinder::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // d = L/2 * sin(f*t-PI/2)
   // v = L*f/2 * cos(f*t-PI/2) = maxspeed * cos( (maxspeed*2/L)*t-PI/2 )
@@ -504,7 +504,7 @@ Discret::Utils::MovingLevelSetTorus::MovingLevelSetTorus(std::vector<double>* or
 }
 
 double Discret::Utils::MovingLevelSetTorus::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // d = L/2 * sin(f*t-PI/2)
   // v = L*f/2 * cos(f*t-PI/2) = maxspeed * cos( (maxspeed*2/L)*t-PI/2 )
@@ -617,7 +617,7 @@ Discret::Utils::MovingLevelSetTorusVelocity::MovingLevelSetTorusVelocity(
 }
 
 double Discret::Utils::MovingLevelSetTorusVelocity::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // d = L/2 * sin(f*t-PI/2)
   // v = L*f/2 * cos(f*t-PI/2) = maxspeed * cos( (maxspeed*2/L)*t-PI/2 )
@@ -747,7 +747,7 @@ Discret::Utils::MovingLevelSetTorusSliplength::MovingLevelSetTorusSliplength(
 }
 
 double Discret::Utils::MovingLevelSetTorusSliplength::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // coefficient for sinus.
   double dist;
@@ -934,7 +934,7 @@ Discret::Utils::TaylorCouetteFlow::TaylorCouetteFlow(double radius_inner, double
 }
 
 double Discret::Utils::TaylorCouetteFlow::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double radius = std::sqrt(xp[0] * xp[0] + xp[1] * xp[1]);
 
@@ -961,7 +961,7 @@ double Discret::Utils::TaylorCouetteFlow::evaluate(
 }
 
 std::vector<double> Discret::Utils::TaylorCouetteFlow::evaluate_spatial_derivative(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // u_x = -(c1_*r + c2_/r)*y/r = -(c1_*y + c2_*y/(x^2+y^2))
   // d u_x /dx = c2_ * 2*x*y/((x^2+y^2)^2)
@@ -1063,7 +1063,7 @@ Discret::Utils::UrquizaBoxFlow::UrquizaBoxFlow(double lengthx, double lengthy, d
 }
 
 double Discret::Utils::UrquizaBoxFlow::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // CASE 1:
   //  u =
@@ -1215,7 +1215,7 @@ double Discret::Utils::UrquizaBoxFlow::evaluate(
 }
 
 std::vector<double> Discret::Utils::UrquizaBoxFlow::evaluate_spatial_derivative(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   //  CASE 1:
   //  du_i/dx_j =
@@ -1316,7 +1316,7 @@ Discret::Utils::UrquizaBoxFlowForce::UrquizaBoxFlowForce(double lengthx, double 
 }
 
 double Discret::Utils::UrquizaBoxFlowForce::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double x = xp[0];
   double y = xp[1];
@@ -1470,7 +1470,7 @@ Discret::Utils::UrquizaBoxFlowTraction::UrquizaBoxFlowTraction(double lengthx, d
 }
 
 double Discret::Utils::UrquizaBoxFlowTraction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   double tol = 1e-13;
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions.hpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions.hpp
@@ -38,7 +38,7 @@ namespace Discret
       /// ctor
       GerstenbergerForwardfacingStep();
 
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       [[nodiscard]] std::size_t number_components() const override
       {
@@ -62,7 +62,7 @@ namespace Discret
       MovingLevelSetCylinder(std::vector<double>* origin, double radius,
           std::vector<double>* direction, double distance, double maxspeed);
 
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       [[nodiscard]] std::size_t number_components() const override
       {
@@ -188,7 +188,7 @@ namespace Discret
           double maxspeed, std::vector<double>* rotvector, double rotspeed, double rotramptime);
 
       /// evaluate function at given position in space
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
     };
 
     class MovingLevelSetTorusVelocity : public MovingLSTorus
@@ -201,7 +201,7 @@ namespace Discret
           std::vector<double>* rotvector, double rotspeed, double rotramptime);
 
       /// evaluate function at given position in space
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       /*!
        * @brief Return the number of components of this spatial function (This is a vector-valued
@@ -222,7 +222,7 @@ namespace Discret
           std::vector<double>* rotvector, double rotspeed, double rotramptime, int slipfunct);
 
       /// evaluate function at given position in space
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
      private:
       int slipfunct_;
@@ -242,10 +242,10 @@ namespace Discret
 
       /// evaluate function at given position in space,
       /// here: evaluation of Taylor-Couette analytical solution
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       std::vector<double> evaluate_spatial_derivative(
-          const double* x, double t, std::size_t component) const override;
+          std::span<const double> x, double t, std::size_t component) const override;
 
       [[nodiscard]] std::size_t number_components() const override
       {
@@ -275,10 +275,10 @@ namespace Discret
       UrquizaBoxFlow(double lengthx, double lengthy, double rotation, double viscosity,
           double density, int functno, std::vector<double> lincomb);
 
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       std::vector<double> evaluate_spatial_derivative(
-          const double* x, double t, std::size_t component) const override;
+          std::span<const double> x, double t, std::size_t component) const override;
 
       [[nodiscard]] std::size_t number_components() const override
       {
@@ -308,10 +308,10 @@ namespace Discret
           double density, int functno, std::vector<double> lincomb);
 
       /// evaluate function at given position in space
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       std::vector<double> evaluate_spatial_derivative(
-          const double* x, const double t, const std::size_t component) const override
+          std::span<const double> x, const double t, const std::size_t component) const override
       {
         FOUR_C_THROW("Derivative not implemented for UrquizaBoxFlowForce");
         return {};
@@ -329,10 +329,10 @@ namespace Discret
           double density, int functno, std::vector<double> lincomb);
 
       /// evaluate function at given position in space
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       std::vector<double> evaluate_spatial_derivative(
-          const double* x, const double t, const std::size_t component) const override
+          std::span<const double> x, const double t, const std::size_t component) const override
       {
         FOUR_C_THROW("Derivative not implemented for UrquizaBoxFlowTraction");
         return {};

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.cpp
@@ -55,7 +55,7 @@ void Discret::Utils::add_valid_combust_functions(Core::Utils::FunctionManager& f
 
 
 double Discret::Utils::ZalesaksDiskFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // the disk consists of 3 lines and a part of a circle and four points
   // decide if the orthogonal projection of the current point lies on the lines and the circle (four
@@ -128,7 +128,7 @@ double Discret::Utils::ZalesaksDiskFunction::evaluate(
 
 
 double Discret::Utils::CollapsingWaterColumnFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // here calculation of distance (sign is already taken in consideration)
   double distance = 0.0;

--- a/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.hpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_functions_combust.hpp
@@ -38,7 +38,7 @@ namespace Discret
     class ZalesaksDiskFunction : public Core::Utils::FunctionOfSpaceTime
     {
      public:
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       [[nodiscard]] std::size_t number_components() const override
       {
@@ -50,7 +50,7 @@ namespace Discret
     class CollapsingWaterColumnFunction : public Core::Utils::FunctionOfSpaceTime
     {
      public:
-      double evaluate(const double* x, double t, std::size_t component) const override;
+      double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
       [[nodiscard]] std::size_t number_components() const override
       {

--- a/src/levelset/4C_levelset_algorithm_utils.cpp
+++ b/src/levelset/4C_levelset_algorithm_utils.cpp
@@ -240,7 +240,7 @@ void ScaTra::LevelSetAlgorithm::evaluate_error_compared_to_analytical_sol()
             // evaluate component k of spatial function
             double initialval =
                 problem_->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                    .evaluate(lnode.x().data(), time_, k);
+                    .evaluate(lnode.x(), time_, k);
             int err = phiref.replace_local_value(doflid, initialval);
             if (err != 0) FOUR_C_THROW("dof not on proc");
           }

--- a/src/lubrication/src/4C_lubrication_timint_implicit.cpp
+++ b/src/lubrication/src/4C_lubrication_timint_implicit.cpp
@@ -284,7 +284,7 @@ void Lubrication::TimIntImpl::set_height_field_pure_lub(const int nds)
     {
       double heightfuncvalue = Global::Problem::instance()
                                    ->function_by_id<Core::Utils::FunctionOfSpaceTime>(heightfuncno)
-                                   .evaluate(lnode.x().data(), time_, index);
+                                   .evaluate(lnode.x(), time_, index);
 
       // get global and local dof IDs
       const int gid = nodedofs[index];
@@ -324,7 +324,7 @@ void Lubrication::TimIntImpl::set_average_velocity_field_pure_lub(const int nds)
     {
       double velfuncvalue = Global::Problem::instance()
                                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(velfuncno)
-                                .evaluate(lnode.x().data(), time_, index);
+                                .evaluate(lnode.x(), time_, index);
 
       // get global and local dof IDs
       const int gid = nodedofs[index];

--- a/src/mat/4C_mat_muscle_utils.cpp
+++ b/src/mat/4C_mat_muscle_utils.cpp
@@ -370,7 +370,7 @@ double Mat::Utils::Muscle::evaluate_time_space_dependent_active_stress_by_funct(
   const std::vector<double> x_vec{x(0), x(1), x(2)};
 
   // compute time-dependency ft
-  const double ft = activation_function.evaluate(&x_vec.front(), t_current, 0);
+  const double ft = activation_function.evaluate(x_vec, t_current, 0);
 
   // ft needs to be in interval [0, 1]
   if (ft < 0.00 || ft > 1.00)

--- a/src/mat/elast/4C_mat_elast_anisoactivestress_evolution.cpp
+++ b/src/mat/elast/4C_mat_elast_anisoactivestress_evolution.cpp
@@ -138,7 +138,7 @@ void Mat::Elastic::AnisoActiveStressEvolution::add_stress_aniso_principal(
     activationFunction =
         Global::Problem::instance()
             ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->sourceactiv_)
-            .evaluate(element_center_coordinates_ref.data(), totaltime, 0);
+            .evaluate(element_center_coordinates_ref.as_span(), totaltime, 0);
   }
 
   double lambda = 0.0;

--- a/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
+++ b/src/mat/elast/4C_mat_elast_coupanisoneohooke_VarProp.cpp
@@ -140,7 +140,7 @@ void Mat::Elastic::CoupAnisoNeoHookeVarProp::add_stress_aniso_principal(
       params.get<Core::LinAlg::Tensor<double, 3>>("elecenter_coords_ref");
   double stressFact_ = Global::Problem::instance()
                            ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->sourceactiv_)
-                           .evaluate(element_center_coordinates_ref.data(), time_, 0);
+                           .evaluate(element_center_coordinates_ref.as_span(), time_, 0);
 
 
   // double stressFact_=params.get<double>("scalar");

--- a/src/membrane/4C_membrane_line_evaluate.cpp
+++ b/src/membrane/4C_membrane_line_evaluate.cpp
@@ -132,12 +132,11 @@ int Discret::Elements::MembraneLine<distype>::evaluate_neumann(Teuchos::Paramete
               // write coordinates in another datatype
               double gp_coord2[noddof_];
               for (int k = 0; k < noddof_; k++) gp_coord2[k] = gp_coord(k, 0);
-              const double* coordgpref = gp_coord2;  // needed for function evaluation
 
               // evaluate function at current gauss point
               functfac = Global::Problem::instance()
                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(spa_func[i].value())
-                             .evaluate(coordgpref, time, i);
+                             .evaluate(gp_coord2, time, i);
             }
 
             const double fac = val[i] * gpweight * dL * functfac;

--- a/src/mixture/src/4C_mixture_constituent_elasthyper_damage.cpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper_damage.cpp
@@ -91,7 +91,7 @@ void Mixture::MixtureConstituentElastHyperDamage::update(
   current_reference_growth_[gp] =
       Global::Problem::instance()
           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->damage_function_id_)
-          .evaluate(reference_coordinates.data(), totaltime, 0);
+          .evaluate(reference_coordinates.as_span(), totaltime, 0);
 
   MixtureConstituentElastHyperBase::update(defgrd, params, gp, eleGID);
 }

--- a/src/mixture/src/4C_mixture_constituent_elasthyper_elastin_membrane.cpp
+++ b/src/mixture/src/4C_mixture_constituent_elasthyper_elastin_membrane.cpp
@@ -228,7 +228,7 @@ void Mixture::MixtureConstituentElastHyperElastinMembrane::update(
   current_reference_growth_[gp] =
       Global::Problem::instance()
           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(params_->damage_function_id_)
-          .evaluate(reference_coordinates.data(), totaltime, 0);
+          .evaluate(reference_coordinates.as_span(), totaltime, 0);
 
   MixtureConstituentElastHyperBase::update(defgrd, params, gp, eleGID);
 

--- a/src/mixture/src/4C_mixture_rule_function.cpp
+++ b/src/mixture/src/4C_mixture_rule_function.cpp
@@ -100,7 +100,7 @@ void Mixture::FunctionMixtureRule::evaluate(const Core::LinAlg::Tensor<double, 3
 
     // evaluate the mass fraction function at the gauss point reference coordinates and current time
     const double massfrac =
-        mass_fractions_functions_[i]->evaluate(reference_coordinates.data(), time, 0);
+        mass_fractions_functions_[i]->evaluate(reference_coordinates.container(), time, 0);
     sum += massfrac;
     double constituent_density = params_->initial_reference_density_ * massfrac;
 

--- a/src/particle_algorithm/4C_particle_algorithm_dirichlet_bc.cpp
+++ b/src/particle_algorithm/4C_particle_algorithm_dirichlet_bc.cpp
@@ -145,8 +145,8 @@ void PARTICLEALGORITHM::DirichletBoundaryConditionHandler::evaluate_dirichlet_bo
       for (int dim = 0; dim < statedim; ++dim)
       {
         // evaluate function, first and second time derivative
-        functtimederiv =
-            function.evaluate_time_derivative(&(refpos[statedim * i]), evaltime, deg, dim);
+        functtimederiv = function.evaluate_time_derivative(
+            std::span(&(refpos[statedim * i]), 3), evaltime, deg, dim);
 
         // set position state
         if (evalpos)

--- a/src/particle_algorithm/4C_particle_algorithm_initial_field.cpp
+++ b/src/particle_algorithm/4C_particle_algorithm_initial_field.cpp
@@ -115,7 +115,8 @@ void PARTICLEALGORITHM::InitialFieldHandler::set_initial_fields()
       {
         // evaluate function to set initial field
         for (int dim = 0; dim < statedim; ++dim)
-          state[statedim * i + dim] = function.evaluate(&(pos[posstatedim * i]), 0.0, dim);
+          state[statedim * i + dim] =
+              function.evaluate(std::span(&(pos[posstatedim * i]), 3), 0.0, dim);
       }
     }
   }

--- a/src/particle_algorithm/4C_particle_algorithm_temperature_bc.cpp
+++ b/src/particle_algorithm/4C_particle_algorithm_temperature_bc.cpp
@@ -125,7 +125,7 @@ void PARTICLEALGORITHM::TemperatureBoundaryConditionHandler::
     for (int i = 0; i < particlestored; ++i)
     {
       // evaluate function
-      temp[i] = function.evaluate(&(refpos[statedim * i]), evaltime, 0);
+      temp[i] = function.evaluate(std::span(&(refpos[statedim * i]), 3), evaltime, 0);
     }
   }
 }

--- a/src/particle_interaction/4C_particle_interaction_sph_heatsource.cpp
+++ b/src/particle_interaction/4C_particle_interaction_sph_heatsource.cpp
@@ -136,7 +136,7 @@ void ParticleInteraction::SPHHeatSourceVolume::evaluate_heat_source(const double
       double* tempdot_i = container_i->get_ptr_to_state(PARTICLEENGINE::TemperatureDot, particle_i);
 
       // evaluate function defining heat source
-      funct = function.evaluate_time_derivative(pos_i, evaltime, 0, 0);
+      funct = function.evaluate_time_derivative(std::span(pos_i, 3), evaltime, 0, 0);
 
       // add contribution of heat source
       tempdot_i[0] += thermomaterial_i->thermalAbsorptivity_ * funct[0] *
@@ -326,7 +326,7 @@ void ParticleInteraction::SPHHeatSourceSurface::evaluate_heat_source(const doubl
       double* tempdot_i = container_i->get_ptr_to_state(PARTICLEENGINE::TemperatureDot, particle_i);
 
       // evaluate function defining heat source
-      funct = function.evaluate_time_derivative(pos_i, evaltime, 0, 0);
+      funct = function.evaluate_time_derivative(std::span(pos_i, 3), evaltime, 0, 0);
 
       // add contribution of heat source
       tempdot_i[0] += f_i_proj * thermomaterial_i->thermalAbsorptivity_ * funct[0] *

--- a/src/particle_interaction/4C_particle_interaction_sph_open_boundary.cpp
+++ b/src/particle_interaction/4C_particle_interaction_sph_open_boundary.cpp
@@ -303,7 +303,8 @@ void ParticleInteraction::SPHOpenBoundaryDirichlet::prescribe_open_boundary_stat
     double* vel_i = container_i->get_ptr_to_state(PARTICLEENGINE::Velocity, particle_i);
 
     // evaluate function to set velocity
-    Utils::vec_set_scale(vel_i, -function.evaluate(pos_i, evaltime, 0), outwardnormal_.data());
+    Utils::vec_set_scale(
+        vel_i, -function.evaluate(std::span(pos_i, 3), evaltime, 0), outwardnormal_.data());
   }
 }
 
@@ -513,7 +514,7 @@ void ParticleInteraction::SPHOpenBoundaryNeumann::prescribe_open_boundary_states
       double* press_i = container_i->get_ptr_to_state(PARTICLEENGINE::Pressure, particle_i);
 
       // evaluate function to set pressure
-      press_i[0] = function.evaluate(pos_i, evaltime, 0);
+      press_i[0] = function.evaluate(std::span(pos_i, 3), evaltime, 0);
     }
   }
   else

--- a/src/particle_rigidbody/4C_particle_rigidbody_initial_field.cpp
+++ b/src/particle_rigidbody/4C_particle_rigidbody_initial_field.cpp
@@ -71,7 +71,7 @@ void ParticleRigidBody::set_initial_fields(const Teuchos::ParameterList& params,
       // evaluate function to set initial field
       for (int dim = 0; dim < statedim; ++dim)
       {
-        state[rigidbody_k][dim] = function.evaluate(pos_k, 0.0, dim);
+        state[rigidbody_k][dim] = function.evaluate(std::span(pos_k, 3), 0.0, dim);
       }
     }
   }

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_algorithm.cpp
@@ -1083,7 +1083,7 @@ void PoroPressureBased::PorofluidAlgorithm::apply_starting_dbc()
               const double dbc_value = Global::Problem::instance()
                                            ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
                                                starting_dbc_funct_[dof_idx])
-                                           .evaluate(current_node->x().data(), time_, 0);
+                                           .evaluate(current_node->x(), time_, 0);
               phinp_->replace_global_value(gid, dbc_value);
             }
           }
@@ -2016,7 +2016,7 @@ void PoroPressureBased::PorofluidAlgorithm::set_initial_field(
           // evaluate component k of spatial function
           double initialval = Global::Problem::instance()
                                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                  .evaluate(lnode.x().data(), time_, k);
+                                  .evaluate(lnode.x(), time_, k);
           int err = phin_->replace_local_value(doflid, initialval);
           if (err != 0) FOUR_C_THROW("dof not on proc");
         }

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_boundary_calc.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele_boundary_calc.cpp
@@ -214,8 +214,6 @@ int Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<distype>::evaluate_neu
     Core::LinAlg::Matrix<nsd_vol_ele, 1> coordgp;  // coordinate has always to be given in 3D!
     coordgp.multiply_nn(xyze_, funct_);
 
-    const double* coordgpref = &coordgp(0);  // needed for function evaluation
-
     for (int dof = 0; dof < numdofpernode_; ++dof)
     {
       if (onoff[dof])  // is this dof activated?
@@ -226,7 +224,7 @@ int Discret::Elements::PoroFluidMultiPhaseEleBoundaryCalc<distype>::evaluate_neu
           // evaluate function at current Gauss point (provide always 3D coordinates!)
           functfac = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[dof].value())
-                         .evaluate(coordgpref, time, dof);
+                         .evaluate(coordgp.as_span(), time, dof);
         }
         else
           functfac = 1.;

--- a/src/red_airways/4C_red_airways_acinus_impl.cpp
+++ b/src/red_airways/4C_red_airways_acinus_impl.cpp
@@ -354,7 +354,7 @@ void Discret::Elements::AcinusImpl<distype>::evaluate_terminal_bc(RedAcinus* ele
             functionfac =
                 Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[0].value())
-                    .evaluate((ele->nodes()[i])->x().data(), time, 0);
+                    .evaluate((ele->nodes()[i])->x(), time, 0);
           }
 
           // Get factor of second CURVE

--- a/src/red_airways/4C_red_airways_airway_impl.cpp
+++ b/src/red_airways/4C_red_airways_airway_impl.cpp
@@ -109,7 +109,7 @@ namespace
         {
           functionfac = Global::Problem::instance()
                             ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum)
-                            .evaluate(node->x().data(), time, 0);
+                            .evaluate(node->x(), time, 0);
         }
         // get curve2
         double curve2fac = 1.0;
@@ -975,7 +975,7 @@ void Discret::Elements::AirwayImpl<distype>::evaluate_terminal_bc(RedAirway* ele
                       return Global::Problem::instance()
                           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
                               (*functions)[0].value())
-                          .evaluate((ele->nodes()[i])->x().data(), time, 0);
+                          .evaluate((ele->nodes()[i])->x(), time, 0);
                     else
                       return 0.0;
                   }

--- a/src/red_airways/4C_red_airways_interacinardep_impl.cpp
+++ b/src/red_airways/4C_red_airways_interacinardep_impl.cpp
@@ -232,7 +232,7 @@ void Discret::Elements::InterAcinarDepImpl<distype>::evaluate_terminal_bc(RedInt
             functionfac =
                 Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[0].value())
-                    .evaluate((ele->nodes()[i])->x().data(), time, 0);
+                    .evaluate((ele->nodes()[i])->x(), time, 0);
           }
 
           // Get factor of second CURVE

--- a/src/scatra/4C_scatra_functions.cpp
+++ b/src/scatra/4C_scatra_functions.cpp
@@ -163,16 +163,16 @@ ScaTra::CylinderMagnetFunction::CylinderMagnetFunction(const CylinderMagnetParam
 
 
 double ScaTra::CylinderMagnetFunction::evaluate(
-    const double* x, double t, std::size_t component) const
+    std::span<const double> x, double t, std::size_t component) const
 {
-  const std::span<const double, 3> position(x, 3);
-  const auto force_vector = evaluate_magnetic_force(position);
+  FOUR_C_ASSERT(x.size() == 3, "Input position must be a 3D point");
+  const auto force_vector = evaluate_magnetic_force(x);
   return force_vector[component];
 }
 
 
 void ScaTra::CylinderMagnetFunction::evaluate_vector(
-    const std::span<const double, 3> x, double t, std::span<double> values) const
+    const std::span<const double> x, double t, std::span<double> values) const
 {
   auto force = evaluate_magnetic_force(x);
   FOUR_C_ASSERT(force.size() == 3, "Internal error: force vector has wrong size");
@@ -181,7 +181,7 @@ void ScaTra::CylinderMagnetFunction::evaluate_vector(
 
 
 std::array<double, 3> ScaTra::CylinderMagnetFunction::global_to_cylinder_coordinates(
-    const std::span<const double, 3> x) const
+    const std::span<const double> x) const
 {
   // convert rotation angles to radians
   const double gamma = parameters_.magnet_rotation.x_axis * std::numbers::pi / 180;
@@ -245,7 +245,7 @@ std::array<double, 3> ScaTra::CylinderMagnetFunction::cylinder_to_global_coordin
 
 
 std::array<double, 3> ScaTra::CylinderMagnetFunction::evaluate_magnetic_field(
-    const std::span<const double, 3> x) const
+    const std::span<const double> x) const
 {
   const double radius_magnet = parameters_.magnet_radius;
   // half-length L in Caciagli et al. (2018)
@@ -322,7 +322,7 @@ std::array<double, 3> ScaTra::CylinderMagnetFunction::evaluate_magnetic_field(
 
 
 double ScaTra::CylinderMagnetFunction::evaluate_magnetization_model(
-    const std::span<const double, 3> x) const
+    const std::span<const double> x) const
 {
   const auto magnetic_field = evaluate_magnetic_field(x);
   const auto magnetic_field_magnitude =
@@ -367,7 +367,7 @@ double ScaTra::CylinderMagnetFunction::evaluate_magnetization_model(
 
 
 std::array<double, 3> ScaTra::CylinderMagnetFunction::evaluate_magnetic_force(
-    const std::span<const double, 3> x) const
+    const std::span<const double> x) const
 {
   // magnet parameters
   const double radius_magnet = parameters_.magnet_radius;

--- a/src/scatra/4C_scatra_functions.hpp
+++ b/src/scatra/4C_scatra_functions.hpp
@@ -105,7 +105,7 @@ namespace ScaTra
      * @param component index of the function-component which should be evaluated
      * @return function value
      */
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     /**
      * Evaluate the function at a given position x and time t and return the vector of all
@@ -116,7 +116,7 @@ namespace ScaTra
      * @param values function values
      */
     void evaluate_vector(
-        std::span<const double, 3> x, double t, std::span<double> values) const override;
+        std::span<const double> x, double t, std::span<double> values) const override;
 
     /**
      * Number of components of the function (3 for the cylinder magnet)
@@ -139,7 +139,7 @@ namespace ScaTra
      * @param x global cartesian coordinates (X,Y,Z) of the point x
      * @return magnetic field vector
      */
-    [[nodiscard]] std::array<double, 3> evaluate_magnetic_field(std::span<const double, 3> x) const;
+    [[nodiscard]] std::array<double, 3> evaluate_magnetic_field(std::span<const double> x) const;
 
     /*!
      * @brief evaluate demagnetization factor f(|H|) as part of the magnetization model at a given
@@ -148,7 +148,7 @@ namespace ScaTra
      * @param x global cartesian coordinates (X,Y,Z) of the point x
      * @return magnetization model
      */
-    [[nodiscard]] double evaluate_magnetization_model(std::span<const double, 3> x) const;
+    [[nodiscard]] double evaluate_magnetization_model(std::span<const double> x) const;
 
     /*!
      * @brief evaluate magnetic force at a given position (X,Y,Z)
@@ -161,7 +161,7 @@ namespace ScaTra
      * @param x global cartesian coordinates (X,Y,Z) of the point x
      * @return magnetic force vector
      */
-    [[nodiscard]] std::array<double, 3> evaluate_magnetic_force(std::span<const double, 3> x) const;
+    [[nodiscard]] std::array<double, 3> evaluate_magnetic_force(std::span<const double> x) const;
 
 
     /*!
@@ -173,7 +173,7 @@ namespace ScaTra
      * @return cylindrical coordinates (rho, phi, z)
      */
     [[nodiscard]] std::array<double, 3> global_to_cylinder_coordinates(
-        std::span<const double, 3> x) const;
+        std::span<const double> x) const;
 
     /*!
      * \brief transform the cylindrical coordinates of a result vector to global cartesian

--- a/src/scatra/4C_scatra_timint_implicit.cpp
+++ b/src/scatra/4C_scatra_timint_implicit.cpp
@@ -1254,7 +1254,7 @@ void ScaTra::ScaTraTimIntImpl::set_velocity_field_from_function()
         {
           double value =
               problem_->function_by_id<Core::Utils::FunctionOfSpaceTime>(velfuncno).evaluate(
-                  lnode->x().data(), time_, index);
+                  lnode->x(), time_, index);
 
           // get global and local dof IDs
           const int gid = nodedofs[index];
@@ -1325,7 +1325,7 @@ void ScaTra::ScaTraTimIntImpl::set_external_force() const
       const double external_force_value = external_force_vector[spatial_dimension];
       const double intrinsic_mobility_value =
           problem_->function_by_id<Core::Utils::FunctionOfSpaceTime>(intrinsic_mobility_function_id)
-              .evaluate(current_node->x().data(), time_, spatial_dimension);
+              .evaluate(current_node->x(), time_, spatial_dimension);
       const double force_velocity_value = external_force_value * intrinsic_mobility_value;
 
       const int gid = nodedofs[spatial_dimension];
@@ -1933,7 +1933,7 @@ void ScaTra::ScaTraTimIntImpl::set_initial_field(
           // evaluate component k of spatial function
           double initialval =
               problem_->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                  .evaluate(lnode.x().data(), time_, k);
+                  .evaluate(lnode.x(), time_, k);
           int err = phin_->replace_local_value(doflid, initialval);
           if (err != 0) FOUR_C_THROW("dof not on proc");
         }

--- a/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_boundary_calc.cpp
@@ -523,8 +523,6 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_neumann
     Core::LinAlg::Matrix<nsd_, 1> coordgp;  // coordinate has always to be given in 3D!
     coordgp.multiply_nn(xyze_, funct_);
 
-    const double* coordgpref = &coordgp(0);  // needed for function evaluation
-
     for (int dof = 0; dof < numdofpernode_; ++dof)
     {
       if (onoff[dof])  // is this dof activated?
@@ -535,7 +533,7 @@ int Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::evaluate_neumann
           // evaluate function at current Gauss point (provide always 3D coordinates!)
           functfac = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[dof].value())
-                         .evaluate(coordgpref, time, dof);
+                         .evaluate(coordgp.as_span(), time, dof);
         }
         else
           functfac = 1.;
@@ -2573,7 +2571,7 @@ void Discret::Elements::ScaTraEleBoundaryCalc<distype, probdim>::weak_dirichlet(
 
       functfac = Global::Problem::instance()
                      ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[0].value())
-                     .evaluate(coordgp3D.data(), time, 0);
+                     .evaluate(coordgp3D, time, 0);
     }
     else
       functfac = 1.0;

--- a/src/scatra_ele/4C_scatra_ele_calc.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc.cpp
@@ -877,10 +877,9 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::body_force(
 
         if (funct[idof].has_value() && funct[idof].value() > 0)
         {
-          functfac =
-              Global::Problem::instance()
-                  ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[idof].value())
-                  .evaluate((ele->nodes()[jnode])->x().data(), scatraparatimint_->time(), idof);
+          functfac = Global::Problem::instance()
+                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[idof].value())
+                         .evaluate((ele->nodes()[jnode])->x(), scatraparatimint_->time(), idof);
         }
 
         (bodyforce_[idof])(jnode) = onoff[idof] * val[idof] * functfac;

--- a/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_hdg.cpp
@@ -1291,8 +1291,6 @@ void Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::LocalSolver::compute
     double coordgp[3];  // we always need three coordinates for function evaluation!
     for (int i = 0; i < 3; ++i) coordgp[i] = shapesface_->xyzreal(i, iquad);
 
-    const double* coordgpref = coordgp;  // needed for function evaluation
-
     if (onoff[0])  // is this dof activated?
     {
       // factor given by spatial function
@@ -1301,7 +1299,7 @@ void Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::LocalSolver::compute
         // evaluate function at current Gauss point (provide always 3D coordinates!)
         functfac = Global::Problem::instance()
                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[0].value())
-                       .evaluate(coordgpref, time, 0);
+                       .evaluate(coordgp, time, 0);
       }
       else
         functfac = 1.;
@@ -1600,11 +1598,11 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::set_initial_field(
 
       phi = Global::Problem::instance()
                 ->function_by_id<Core::Utils::FunctionOfSpaceTime>(*start_func)
-                .evaluate(xyz.data(), 0, 0);
+                .evaluate(xyz, 0, 0);
       for (unsigned int i = 0; i < nsd_; ++i)
         gradphi[i] = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(*start_func)
-                         .evaluate(xyz.data(), 0, 1 + i);
+                         .evaluate(xyz, 0, 1 + i);
 
       // now fill the components in the one-sided mass matrix and the right hand side
       for (unsigned int i = 0; i < shapes_->ndofs_; ++i)
@@ -1658,7 +1656,7 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::set_initial_field(
       double trphi;
       trphi = Global::Problem::instance()
                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(*start_func)
-                  .evaluate(xyz.data(), 0, nsd_ + 1);
+                  .evaluate(xyz, 0, nsd_ + 1);
 
       // now fill the components in the mass matrix and the right hand side
       for (unsigned int i = 0; i < shapesface_->nfdofs_; ++i)
@@ -2141,10 +2139,10 @@ int Discret::Elements::ScaTraEleCalcHDG<distype, probdim>::calc_error(
     for (unsigned int idim = 0; idim < nsd_; idim++) xsi(idim) = highshapes.xyzreal(idim, q);
     double funct = Global::Problem::instance()
                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func)
-                       .evaluate(xsi.data(), time, 0);
+                       .evaluate(xsi.as_span(), time, 0);
     std::vector<double> deriv = Global::Problem::instance()
                                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func)
-                                    .evaluate_spatial_derivative(xsi.data(), time, 0);
+                                    .evaluate_spatial_derivative(xsi.as_span(), time, 0);
 
     error_phi += std::pow((funct - phi), 2) * highshapes.jfac(q);
     exact_phi += std::pow(funct, 2) * highshapes.jfac(q);

--- a/src/scatra_ele/4C_scatra_ele_calc_service_stabilization.cpp
+++ b/src/scatra_ele/4C_scatra_ele_calc_service_stabilization.cpp
@@ -989,10 +989,9 @@ void Discret::Elements::ScaTraEleCalc<distype, probdim>::calc_subgr_velocity(
             // evaluation at the integration point. However, we need a node
             // based element bodyforce vector for prescribed pressure gradients
             // in some fancy turbulance stuff.
-            functfac =
-                Global::Problem::instance()
-                    ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[isd].value())
-                    .evaluate((ele->nodes()[jnode])->x().data(), scatraparatimint_->time(), isd);
+            functfac = Global::Problem::instance()
+                           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[isd].value())
+                           .evaluate((ele->nodes()[jnode])->x(), scatraparatimint_->time(), isd);
           }
           else
             FOUR_C_THROW("Negative time value in body force calculation: time = {}",

--- a/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
+++ b/src/shell7p/4C_shell7p_ele_neumann_evaluator.cpp
@@ -222,7 +222,7 @@ void Discret::Elements::Shell::evaluate_neumann(Core::Elements::Element& ele,
           function_scale_factors[dim] =
               Global::Problem::instance()
                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(function_ids[dim].value())
-                  .evaluate(gauss_point_reference_coordinates.data(), total_time, dim);
+                  .evaluate(gauss_point_reference_coordinates.as_span(), total_time, dim);
         }
       }
     }

--- a/src/shell7p/4C_shell7p_line_evaluate.cpp
+++ b/src/shell7p/4C_shell7p_line_evaluate.cpp
@@ -97,12 +97,11 @@ int Discret::Elements::Shell7pLine::evaluate_neumann(Teuchos::ParameterList& par
           // calculate reference position of gaussian point
           Core::LinAlg::SerialDenseVector gp_coord(num_dim_);
           Core::LinAlg::multiply_tn(gp_coord, x, shape_functions);
-          const double* coordgpref = gp_coord.values();  // needed for function evaluation
 
           // evaluate function at current gauss point
           functfac = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(spa_func[i].value())
-                         .evaluate(coordgpref, time, i);
+                         .evaluate(gp_coord.as_span(), time, i);
         }
 
         const double fac = val[i] * intpoints.qwgt[gp] * dL * functfac;

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs_evaluate.cpp
@@ -169,7 +169,8 @@ int Discret::Elements::KirchhoffLoveShellNurbs::evaluate_neumann(Teuchos::Parame
     {
       if (onoff[i_dof] == 1 and funct_id[i_dof] > 0)
       {
-        force(i_dof) = val[i_dof] * functions[i_dof]->evaluate(reference_position, time, i_dof);
+        force(i_dof) =
+            val[i_dof] * functions[i_dof]->evaluate(std::span(reference_position, 3), time, i_dof);
       }
       else if (onoff[i_dof] == 1)
       {

--- a/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_calc_lib.hpp
@@ -1148,7 +1148,7 @@ namespace Discret::Elements
           for (int i_dim = 0; i_dim < 3; i_dim++)
           {
             analytical_solution(i_dim) = analytical_displacements_function.evaluate(
-                gauss_point_reference_coordinates.data(), 0.0, i_dim);
+                gauss_point_reference_coordinates.as_span(), 0.0, i_dim);
           }
 
           // The data that will be added to the element_force_vector will be summed up for all

--- a/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_neumann_evaluator.cpp
@@ -95,7 +95,7 @@ void Discret::Elements::evaluate_neumann(Core::Elements::Element& element,
                     ? Global::Problem::instance()
                           ->function_by_id<Core::Utils::FunctionOfSpaceTime>(
                               function_ids[i].value())
-                          .evaluate(gauss_point_reference_coordinates.data(), total_time, i)
+                          .evaluate(gauss_point_reference_coordinates.as_span(), total_time, i)
                     : 1.0;
 
             const double value_times_integration_factor =

--- a/src/solid_3D_ele/4C_solid_3D_ele_surface_evaluate.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_surface_evaluate.cpp
@@ -296,13 +296,11 @@ int Discret::Elements::SolidSurface::evaluate_neumann(Teuchos::ParameterList& pa
                 {
                   gp_coord2[i] = gp_coord(0, i);
                 }
-                const double* coordgpref = gp_coord2;  // needed for function evaluation
-
                 // evaluate function at current gauss point
                 functfac =
                     Global::Problem::instance()
                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>((*spa_func)[dof].value())
-                        .evaluate(coordgpref, time, dof);
+                        .evaluate(gp_coord2, time, dof);
               }
             }
             else
@@ -344,13 +342,12 @@ int Discret::Elements::SolidSurface::evaluate_neumann(Teuchos::ParameterList& pa
             {
               gp_coord2[i] = gp_coord(0, i);
             }
-            const double* coordgpref = gp_coord2;  // needed for function evaluation
 
             // evaluate function at current gauss point
             functfac =
                 Global::Problem::instance()
                     ->function_by_id<Core::Utils::FunctionOfSpaceTime>((*spa_func)[0].value())
-                    .evaluate(coordgpref, time, 0);
+                    .evaluate(gp_coord2, time, 0);
           }
         }
 

--- a/src/structure_new/src/4C_structure_new_integrator.cpp
+++ b/src/structure_new/src/4C_structure_new_integrator.cpp
@@ -134,7 +134,7 @@ void Solid::Integrator::set_initial_displacement(
           const double initialval =
               Global::Problem::instance()
                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                  .evaluate(lnode->x().data(), global_state().get_time_n(), d);
+                  .evaluate(lnode->x(), global_state().get_time_n(), d);
 
           const int err = global_state().get_dis_n()->replace_local_value(doflid, initialval);
           if (err != 0) FOUR_C_THROW("dof not on proc");

--- a/src/structure_new/src/utils/4C_structure_new_functions.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_functions.cpp
@@ -109,7 +109,7 @@ Solid::WeaklyCompressibleEtienneFSIStructureFunction::WeaklyCompressibleEtienneF
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double Solid::WeaklyCompressibleEtienneFSIStructureFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -140,7 +140,8 @@ double Solid::WeaklyCompressibleEtienneFSIStructureFunction::evaluate(
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 std::vector<double> Solid::WeaklyCompressibleEtienneFSIStructureFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);
@@ -210,7 +211,7 @@ Solid::WeaklyCompressibleEtienneFSIStructureForceFunction::
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/
 double Solid::WeaklyCompressibleEtienneFSIStructureForceFunction::evaluate(
-    const double* xp, const double t, const std::size_t component) const
+    std::span<const double> xp, const double t, const std::size_t component) const
 {
   // ease notation
   double x = xp[0];
@@ -262,7 +263,8 @@ double Solid::WeaklyCompressibleEtienneFSIStructureForceFunction::evaluate(
 /*----------------------------------------------------------------------*/
 std::vector<double>
 Solid::WeaklyCompressibleEtienneFSIStructureForceFunction::evaluate_time_derivative(
-    const double* xp, const double t, const unsigned deg, const std::size_t component) const
+    std::span<const double> xp, const double t, const unsigned deg,
+    const std::size_t component) const
 {
   // resulting vector holding
   std::vector<double> res(deg + 1);

--- a/src/structure_new/src/utils/4C_structure_new_functions.hpp
+++ b/src/structure_new/src/utils/4C_structure_new_functions.hpp
@@ -35,10 +35,10 @@ namespace Solid
    public:
     WeaklyCompressibleEtienneFSIStructureFunction(const Mat::PAR::StVenantKirchhoff& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     [[nodiscard]] std::size_t number_components() const override { return (2); };
   };
@@ -49,10 +49,10 @@ namespace Solid
    public:
     WeaklyCompressibleEtienneFSIStructureForceFunction(const Mat::PAR::StVenantKirchhoff& fparams);
 
-    double evaluate(const double* x, double t, std::size_t component) const override;
+    double evaluate(std::span<const double> x, double t, std::size_t component) const override;
 
     std::vector<double> evaluate_time_derivative(
-        const double* x, double t, unsigned deg, std::size_t component) const override;
+        std::span<const double> x, double t, unsigned deg, std::size_t component) const override;
 
     [[nodiscard]] std::size_t number_components() const override { return (2); };
 

--- a/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_boundary_impl.cpp
@@ -541,8 +541,6 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate_neumann(const Core::Elements::
     Core::LinAlg::Matrix<nsd_vol_ele, 1> coordgp;  // coordinate has always to be given in 3D!
     coordgp.multiply_nn(xyze_, funct_);
 
-    const double* coordgpref = &coordgp(0);
-
     for (int dof = 0; dof < numdofpernode_; dof++)
     {
       if (onoff[dof])  // is this dof activated?
@@ -553,7 +551,7 @@ int Thermo::TemperBoundaryImpl<distype>::evaluate_neumann(const Core::Elements::
           // evaluate function at current gauss point
           functfac = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func[dof].value())
-                         .evaluate(coordgpref, time, dof);
+                         .evaluate(coordgp.as_span(), time, dof);
         }
         else
           functfac = 1.0;

--- a/src/thermo/src/element/4C_thermo_ele_impl.cpp
+++ b/src/thermo/src/element/4C_thermo_ele_impl.cpp
@@ -2583,7 +2583,7 @@ void Discret::Elements::TemperImpl<distype>::radiation(
       // evaluate function at current gauss point (3D position vector required!)
       functfac = Global::Problem::instance()
                      ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[0].value())
-                     .evaluate(xrefegp.data(), time, 0);
+                     .evaluate(xrefegp.as_span(), time, 0);
 
     // get values and switches from the condition
     const auto onoff = myneumcond[0]->parameters().get<std::vector<int>>("ONOFF");

--- a/src/thermo/src/implicit/4C_thermo_timint.cpp
+++ b/src/thermo/src/implicit/4C_thermo_timint.cpp
@@ -888,7 +888,7 @@ void Thermo::TimInt::set_initial_field(const Thermo::InitialField init, const in
           // evaluate component k of spatial function
           double initialval = Global::Problem::instance()
                                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(startfuncno)
-                                  .evaluate(lnode.x().data(), 0.0, k);
+                                  .evaluate(lnode.x(), 0.0, k);
           // extract temperature vector at time t_n (temp_ contains various vectors of
           // old(er) temperatures and is of type TimIntMStep<Core::LinAlg::Vector<double>>)
           int err1 = temp_(0)->replace_local_value(doflid, initialval);

--- a/src/w1/4C_w1_evaluate.cpp
+++ b/src/w1/4C_w1_evaluate.cpp
@@ -519,12 +519,11 @@ int Discret::Elements::Wall1::evaluate_neumann(Teuchos::ParameterList& params,
         for (int k = 0; k < numdim_; k++) gp_coord2[k] = gp_coord(0, k);
         for (int k = numdim_; k < 3; k++)  // set a zero value for the remaining spatial directions
           gp_coord2[k] = 0.0;
-        const double* coordgpref = gp_coord2;  // needed for function evaluation
 
         // evaluate function at current gauss point
         functfac = Global::Problem::instance()
                        ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[i].value())
-                       .evaluate(coordgpref, time, i);
+                       .evaluate(gp_coord2, time, i);
       }
 
       ar[i] = fac * onoff[i] * val[i] * functfac;

--- a/src/w1/4C_w1_line_evaluate.cpp
+++ b/src/w1/4C_w1_line_evaluate.cpp
@@ -221,12 +221,11 @@ int Discret::Elements::Wall1Line::evaluate_neumann(Teuchos::ParameterList& param
               for (int k = numdim; k < 3;
                   k++)  // set a zero value for the remaining spatial directions
                 gp_coord2[k] = 0.0;
-              const double* coordgpref = gp_coord2;  // needed for function evaluation
 
               // evaluate function at current gauss point
               functfac = Global::Problem::instance()
                              ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum)
-                             .evaluate(coordgpref, time, i);
+                             .evaluate(gp_coord2, time, i);
             }
             else
               functfac = 1.0;
@@ -277,12 +276,11 @@ int Discret::Elements::Wall1Line::evaluate_neumann(Teuchos::ParameterList& param
           for (int k = 0; k < numdim; k++) gp_coord2[k] = gp_coord(0, k);
           for (int k = numdim; k < 3; k++)  // set a zero value for the remaining spatial directions
             gp_coord2[k] = 0.0;
-          const double* coordgpref = gp_coord2;  // needed for function evaluation
 
           // evaluate function at current gauss point
           functfac = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum)
-                         .evaluate(coordgpref, time, 0);
+                         .evaluate(gp_coord2, time, 0);
         }
 
         // constant factor for integration

--- a/src/w1/4C_w1_poro_p1_evaluate.cpp
+++ b/src/w1/4C_w1_poro_p1_evaluate.cpp
@@ -963,12 +963,11 @@ int Discret::Elements::Wall1PoroP1<distype>::evaluate_neumann(Teuchos::Parameter
           for (int k = Base::numdim_; k < 3;
               k++)  // set a zero value for the remaining spatial directions
             gp_coord2[k] = 0.0;
-          const double* coordgpref = gp_coord2.data();  // needed for function evaluation
 
           // evaluate function at current gauss point
           functfac = Global::Problem::instance()
                          ->function_by_id<Core::Utils::FunctionOfSpaceTime>(funct[i].value())
-                         .evaluate(coordgpref, time, i);
+                         .evaluate(gp_coord2, time, i);
         }
 
         ar[i] = fac * val[i] * functfac;

--- a/src/xfem/4C_xfem_coupling_base.cpp
+++ b/src/xfem/4C_xfem_coupling_base.cpp
@@ -583,7 +583,7 @@ void XFEM::CouplingBase::evaluate_function(std::vector<double>& final_values, co
     {
       functionfac = Global::Problem::instance()
                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functions[dof].value())
-                        .evaluate(x, time, dof % numdof);
+                        .evaluate(std::span(x, 3), time, dof % numdof);
     }
 
     // uniformly distributed noise
@@ -630,7 +630,7 @@ void XFEM::CouplingBase::evaluate_scalar_function(double& final_values, const do
     {
       functionfac = Global::Problem::instance()
                         ->function_by_id<Core::Utils::FunctionOfSpaceTime>(functnum)
-                        .evaluate(x, time, dof % numdof);
+                        .evaluate(std::span(x, 3), time, dof % numdof);
     }
 
     // uniformly distributed noise

--- a/src/xfem/4C_xfem_coupling_levelset.cpp
+++ b/src/xfem/4C_xfem_coupling_levelset.cpp
@@ -395,7 +395,7 @@ bool XFEM::LevelSetCoupling::set_level_set_field(const double time)
     {
       value = Global::Problem::instance()
                   ->function_by_id<Core::Utils::FunctionOfSpaceTime>(func_no)
-                  .evaluate(lnode->x().data(), time, 0);
+                  .evaluate(lnode->x(), time, 0);
     }
     else
       FOUR_C_THROW("invalid function no. to set level-set field!");


### PR DESCRIPTION
A few of our linear algebra data structures now provide their data as spans as well. This is safer than a raw pointer and works nicely with the functions taking such a span.

Needed for #1283 but useful on its own.