### PR TITLE
Refactor nodal nullspace input types

### DIFF
--- a/src/ale/4C_ale_ale2.cpp
+++ b/src/ale/4C_ale_ale2.cpp
@@ -70,7 +70,7 @@ void Discret::Elements::Ale2Type::nodal_block_information(
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Ale2Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<2>(node.x(), x0);
 }

--- a/src/ale/4C_ale_ale2.hpp
+++ b/src/ale/4C_ale_ale2.hpp
@@ -54,7 +54,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -491,7 +491,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/ale/4C_ale_ale3.cpp
+++ b/src/ale/4C_ale_ale3.cpp
@@ -69,7 +69,7 @@ void Discret::Elements::Ale3Type::nodal_block_information(
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Ale3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/ale/4C_ale_ale3.hpp
+++ b/src/ale/4C_ale_ale3.hpp
@@ -125,7 +125,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -567,7 +567,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/ale/4C_ale_ale3_nurbs.cpp
+++ b/src/ale/4C_ale_ale3_nurbs.cpp
@@ -64,7 +64,7 @@ void Discret::Elements::Nurbs::Ale3NurbsType::nodal_block_information(
 /*----------------------------------------------------------------------------*/
 /*----------------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Nurbs::Ale3NurbsType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/ale/4C_ale_ale3_nurbs.hpp
+++ b/src/ale/4C_ale_ale3_nurbs.hpp
@@ -40,7 +40,7 @@ namespace Discret
             Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
         Core::LinAlg::SerialDenseMatrix compute_null_space(
-            Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+            Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
         void setup_element_definition(
             std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/art_net/4C_art_net_artery.hpp
+++ b/src/art_net/4C_art_net_artery.hpp
@@ -53,15 +53,18 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         switch (numdof)
         {
+          case 1:
+            // trivial artery
+            return FLD::compute_fluid_null_space<1>();
           case 3:
-            // 2D lubrication
+            // 2D artery
             return FLD::compute_fluid_null_space<3>();
           case 4:
-            // 3D lubrication
+            // 3D artery
             return FLD::compute_fluid_null_space<4>();
           default:
             FOUR_C_THROW(

--- a/src/beam3/4C_beam3_euler_bernoulli.cpp
+++ b/src/beam3/4C_beam3_euler_bernoulli.cpp
@@ -71,19 +71,13 @@ void Discret::Elements::Beam3ebType::nodal_block_information(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3ebType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   if (numdof != 6)
     FOUR_C_THROW(
         "The computation of the euler-bernoulli beam nullspace in three dimensions requires six"
         "DOFs per node, however the current node carries {} DOFs.",
         numdof);
-
-  if (dimnsp != 5)
-    FOUR_C_THROW(
-        "The computation of the euler-bernoulli beam nullspace in three dimensions requires five"
-        " nullspace vectors per node, however the current node carries {} vectors.",
-        dimnsp);
 
   constexpr std::size_t spacedim = 3;
 
@@ -163,7 +157,7 @@ Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3ebType::compute_null_spa
   rotTangOne.cross_product(omegaOne, tangent);
   rotTangTwo.cross_product(omegaTwo, tangent);
 
-  Core::LinAlg::SerialDenseMatrix nullspace(numdof, dimnsp);
+  Core::LinAlg::SerialDenseMatrix nullspace(numdof, 5);
   // x-modes
   nullspace(0, 0) = 1.0;
   nullspace(0, 1) = 0.0;

--- a/src/beam3/4C_beam3_euler_bernoulli.hpp
+++ b/src/beam3/4C_beam3_euler_bernoulli.hpp
@@ -93,7 +93,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     void setup_element_definition(
         std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/beam3/4C_beam3_kirchhoff.cpp
+++ b/src/beam3/4C_beam3_kirchhoff.cpp
@@ -80,7 +80,7 @@ void Discret::Elements::Beam3kType::nodal_block_information(
 /*------------------------------------------------------------------------------------------------*
  *------------------------------------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3kType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented for element type beam3k!");

--- a/src/beam3/4C_beam3_kirchhoff.hpp
+++ b/src/beam3/4C_beam3_kirchhoff.hpp
@@ -101,8 +101,8 @@ namespace Discret
 
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
-      Core::LinAlg::SerialDenseMatrix compute_null_space(Core::Nodes::Node& actnode,
-          const double* x0, const int numdof, const int dimnsp) override;
+      Core::LinAlg::SerialDenseMatrix compute_null_space(
+          Core::Nodes::Node& actnode, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/beam3/4C_beam3_reissner.cpp
+++ b/src/beam3/4C_beam3_reissner.cpp
@@ -90,7 +90,7 @@ void Discret::Elements::Beam3rType::nodal_block_information(
 /*------------------------------------------------------------------------------------------------*
  *------------------------------------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3rType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   // getting pointer at current element
   const auto* beam3r =
@@ -113,12 +113,6 @@ Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3rType::compute_null_spac
           "DOFs per node, however the current node carries {} DOFs.",
           numdof);
   }
-
-  if (dimnsp != 6)
-    FOUR_C_THROW(
-        "The computation of the Simo-Reissner beam nullspace in three dimensions requires six "
-        "nullspace vectors per node, however the current node carries {} vectors.",
-        dimnsp);
 
   constexpr std::size_t spacedim = 3;
 
@@ -163,7 +157,7 @@ Core::LinAlg::SerialDenseMatrix Discret::Elements::Beam3rType::compute_null_spac
   rotTangTwo.cross_product(e2, tangent);
   rotTangThree.cross_product(e3, tangent);
 
-  Core::LinAlg::SerialDenseMatrix nullspace(numdof, dimnsp);
+  Core::LinAlg::SerialDenseMatrix nullspace(numdof, 6);
   if (beam3r->is_centerline_node(node))
   {
     // x-modes

--- a/src/beam3/4C_beam3_reissner.hpp
+++ b/src/beam3/4C_beam3_reissner.hpp
@@ -67,8 +67,8 @@ namespace Discret
 
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
-      Core::LinAlg::SerialDenseMatrix compute_null_space(Core::Nodes::Node& actnode,
-          const double* x0, const int numdof, const int dimnsp) override;
+      Core::LinAlg::SerialDenseMatrix compute_null_space(
+          Core::Nodes::Node& actnode, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/bele/4C_bele_bele3.cpp
+++ b/src/bele/4C_bele_bele3.cpp
@@ -82,7 +82,7 @@ void Discret::Elements::Bele3Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Bele3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/bele/4C_bele_bele3.hpp
+++ b/src/bele/4C_bele_bele3.hpp
@@ -49,7 +49,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -272,7 +272,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented for element type bele3!");

--- a/src/bele/4C_bele_vele3.cpp
+++ b/src/bele/4C_bele_vele3.cpp
@@ -56,7 +56,7 @@ void Discret::Elements::Vele3Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Vele3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented for element type vele3!");

--- a/src/bele/4C_bele_vele3.hpp
+++ b/src/bele/4C_bele_vele3.hpp
@@ -49,7 +49,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -306,7 +306,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented for element type vele3!");
@@ -458,7 +458,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented for element type vele3!");

--- a/src/constraint/4C_constraint_element2.cpp
+++ b/src/constraint/4C_constraint_element2.cpp
@@ -58,7 +58,7 @@ void Discret::Elements::ConstraintElement2Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::ConstraintElement2Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/constraint/4C_constraint_element2.hpp
+++ b/src/constraint/4C_constraint_element2.hpp
@@ -52,7 +52,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
      private:
       static ConstraintElement2Type instance_;

--- a/src/constraint/4C_constraint_element3.cpp
+++ b/src/constraint/4C_constraint_element3.cpp
@@ -58,7 +58,7 @@ void Discret::Elements::ConstraintElement3Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::ConstraintElement3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/constraint/4C_constraint_element3.hpp
+++ b/src/constraint/4C_constraint_element3.hpp
@@ -51,7 +51,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
      private:
       static ConstraintElement3Type instance_;

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_nullspace.cpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_nullspace.cpp
@@ -64,7 +64,8 @@ Constraints::SubmodelEvaluator::NullspaceConstraintManager::NullspaceConstraintM
   // just grab the block information on the first element that appears and check with given number
   Core::Elements::Element* dwele = discret_ptr->l_row_element(0);
   int nullspace_dimension;
-  dwele->element_type().nodal_block_information(dwele, number_of_dofs_, nullspace_dimension);
+  int number_of_dofs;
+  dwele->element_type().nodal_block_information(dwele, number_of_dofs, nullspace_dimension);
 
   if (nullspace_dimension_ != nullspace_dimension)
   {
@@ -119,8 +120,7 @@ void Constraints::SubmodelEvaluator::NullspaceConstraintManager::evaluate_coupli
     Solid::TimeInt::BaseDataGlobalState& gstate)
 {
   auto dof_map = discret_ptr_->dof_row_map();
-  auto nullspace =
-      Core::FE::compute_null_space(*discret_ptr_, number_of_dofs_, nullspace_dimension_, *dof_map);
+  auto nullspace = Core::FE::compute_null_space(*discret_ptr_, nullspace_dimension_, *dof_map);
 
   Core::LinAlg::MultiVector<double> constraint_space(*dof_map, active_mode_ids_.size());
 

--- a/src/constraint_framework/4C_constraint_framework_submodelevaluator_nullspace.hpp
+++ b/src/constraint_framework/4C_constraint_framework_submodelevaluator_nullspace.hpp
@@ -74,9 +74,6 @@ namespace Constraints::SubmodelEvaluator
     //! Row map of the additional constraint degrees of freedom
     std::shared_ptr<Core::LinAlg::Map> constraint_map_;
 
-    //! Number of degrees of freedom per node in the discretization
-    int number_of_dofs_;
-
     //! Dimension of the nullspace used for constraint enforcement
     int nullspace_dimension_;
 

--- a/src/contact/src/4C_contact_element.cpp
+++ b/src/contact/src/4C_contact_element.cpp
@@ -40,7 +40,7 @@ void CONTACT::ElementType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix CONTACT::ElementType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/contact/src/4C_contact_element.hpp
+++ b/src/contact/src/4C_contact_element.hpp
@@ -34,7 +34,7 @@ namespace CONTACT
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
    private:
     static ElementType instance_;

--- a/src/core/binstrategy/4C_binstrategy_meshfree_multibin.hpp
+++ b/src/core/binstrategy/4C_binstrategy_meshfree_multibin.hpp
@@ -50,7 +50,7 @@ namespace Core::FE::MeshFree
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override {}
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
     {
       Core::LinAlg::SerialDenseMatrix nullspace;
       FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/core/fem/src/discretization/4C_fem_discretization_nullspace.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_nullspace.cpp
@@ -20,100 +20,92 @@ FOUR_C_NAMESPACE_OPEN
 namespace Core::FE
 {
   std::shared_ptr<Core::LinAlg::MultiVector<double>> compute_null_space(
-      const Core::FE::Discretization& dis, const int numdf, const int dimns,
-      const Core::LinAlg::Map& dofmap)
+      const Core::FE::Discretization& dis, const int dimns, const Core::LinAlg::Map& dofmap)
   {
-    if (dimns > 10) FOUR_C_THROW("Nullspace size only up to 10 supported!");
-
     std::shared_ptr<Core::LinAlg::MultiVector<double>> nullspace =
         std::make_shared<Core::LinAlg::MultiVector<double>>(dofmap, dimns, true);
 
-    if (dimns == 1 && numdf == 1)
+    // TODO: Early exit.
+    // For two scatra dof-split cases we have the weird situation that the nullspace dimension is
+    // given with dimension 1, same holds true for the number of degrees of freedom. But in the
+    // discretization the number of degrees of freedom per node is actually 2 not 1. This mismatch
+    // later on breaks things ...
+    if (dimns == 1)
     {
-      // compute nullspace for simple case: vector of ones
       nullspace->PutScalar(1.0);
+      return nullspace;
     }
-    else
+
+    // for rigid body rotations compute nodal center of the discretization
+    std::array<double, 3> x0send{};
+    for (auto node : dis.my_row_node_range())
     {
-      // for rigid body rotations compute nodal center of the discretization
-      std::array<double, 3> x0send = {0.0, 0.0, 0.0};
-      for (auto node : dis.my_row_node_range())
+      auto x = node.x();
+      for (size_t j = 0; j < x.size(); ++j) x0send[j] += x[j];
+    }
+
+    std::array<double, 3> x0;
+    Core::Communication::sum_all(x0send.data(), x0.data(), 3, dis.get_comm());
+
+    for (int i = 0; i < 3; ++i) x0[i] /= dis.num_global_nodes();
+
+    // assembly process of the nodalNullspace into the actual nullspace
+    for (int node = 0; node < dis.num_my_row_nodes(); ++node)
+    {
+      Core::Nodes::Node* actnode = dis.l_row_node(node);
+      std::vector<int> dofs = dis.dof(0, actnode);
+      const int number_of_dofs = dofs.size();
+
+      // check if degrees of freedom are zero
+      if (number_of_dofs == 0) continue;
+
+      // check if dof is existing as index
+      if (dofmap.lid(dofs[0]) == -1) continue;
+
+      // Here we check the first element type of the node. One node can be owned by several
+      // elements we restrict the routine, that a node is only owned by elements with the same
+      // physics
+      auto adjacent_elements = actnode->adjacent_elements();
+      if (adjacent_elements.size() > 1)
       {
-        auto x = node.x();
-        for (size_t j = 0; j < x.size(); ++j) x0send[j] += x[j];
+        // strip of the first element and compare the rest with it
+        ElementRef first = *adjacent_elements.begin();
+        auto& type_first = first.user_element()->element_type();
+        int numdof_first;
+        int dimnsp_first;
+        type_first.nodal_block_information(first.user_element(), numdof_first, dimnsp_first);
+
+        for (auto ele : adjacent_elements | std::views::drop(1))
+        {
+          auto* other = ele.user_element();
+          auto& type_other = other->element_type();
+          if (type_first != type_other)
+          {
+            int numdof_other;
+            int dimnsp_other;
+            type_other.nodal_block_information(other, numdof_other, dimnsp_other);
+            if (numdof_first != numdof_other || dimnsp_first != dimnsp_other)
+              FOUR_C_THROW(
+                  "Node is owned by different element types, nullspace calculation aborted!");
+          }
+        }
       }
 
-      std::array<double, 3> x0;
-      Core::Communication::sum_all(x0send.data(), x0.data(), 3, dis.get_comm());
+      Core::LinAlg::SerialDenseMatrix nodalNullspace =
+          adjacent_elements[0].user_element()->element_type().compute_null_space(
+              *actnode, x0, number_of_dofs);
 
-      for (int i = 0; i < 3; ++i) x0[i] /= dis.num_global_nodes();
-
-      // assembly process of the nodalNullspace into the actual nullspace
-      for (int node = 0; node < dis.num_my_row_nodes(); ++node)
+      for (int dim = 0; dim < dimns; ++dim)
       {
-        Core::Nodes::Node* actnode = dis.l_row_node(node);
-        std::vector<int> dofs = dis.dof(0, actnode);
-        const int localLength = dofs.size();
+        double** arrayOfPointers;
+        nullspace->ExtractView(&arrayOfPointers);
+        double* data = arrayOfPointers[dim];
+        Teuchos::ArrayRCP<double> dataVector(data, dofmap.lid(dofs[0]), number_of_dofs, false);
 
-        // check if degrees of freedom are zero
-        if (localLength == 0) continue;
-
-        // check if dof is existing as index
-        if (dofmap.lid(dofs[0]) == -1) continue;
-
-        // check size of degrees of freedom
-        if (localLength != numdf)
+        for (int j = 0; j < number_of_dofs; ++j)
         {
-          Core::IO::cout(Core::IO::debug)
-              << "Warning: At local node " << node << " : nullspace degrees of freedom ( " << numdf
-              << " ) and rowmap degrees of freedom ( " << localLength << " ) are not consistent.\n";
-        }
-
-        // Here we check the first element type of the node. One node can be owned by several
-        // elements we restrict the routine, that a node is only owned by elements with the same
-        // physics
-        auto adjacent_elements = actnode->adjacent_elements();
-        if (adjacent_elements.size() > 1)
-        {
-          // strip of the first element and compare the rest with it
-          ElementRef first = *adjacent_elements.begin();
-          auto& type_first = first.user_element()->element_type();
-          int numdof_first;
-          int dimnsp_first;
-          type_first.nodal_block_information(first.user_element(), numdof_first, dimnsp_first);
-
-          for (auto ele : adjacent_elements | std::views::drop(1))
-          {
-            auto* other = ele.user_element();
-            auto& type_other = other->element_type();
-            if (type_first != type_other)
-            {
-              int numdof_other;
-              int dimnsp_other;
-              type_other.nodal_block_information(other, numdof_other, dimnsp_other);
-              if (numdof_first != numdof_other || dimnsp_first != dimnsp_other)
-                FOUR_C_THROW(
-                    "Node is owned by different element types, nullspace calculation aborted!");
-            }
-          }
-        }
-
-        Core::LinAlg::SerialDenseMatrix nodalNullspace =
-            adjacent_elements[0].user_element()->element_type().compute_null_space(
-                *actnode, x0.data(), localLength, dimns);
-
-        for (int dim = 0; dim < dimns; ++dim)
-        {
-          double** arrayOfPointers;
-          nullspace->ExtractView(&arrayOfPointers);
-          double* data = arrayOfPointers[dim];
-          Teuchos::ArrayRCP<double> dataVector(data, dofmap.lid(dofs[0]), localLength, false);
-
-          for (int j = 0; j < localLength; ++j)
-          {
-            const int lid = dofmap.lid(dofs[j]);
-            dataVector[lid] = nodalNullspace(j, dim);
-          }
+          const int lid = dofmap.lid(dofs[j]);
+          dataVector[lid] = nodalNullspace(j, dim);
         }
       }
     }

--- a/src/core/fem/src/discretization/4C_fem_discretization_nullspace.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_nullspace.hpp
@@ -27,13 +27,11 @@ namespace Core::FE
           in the respective variable.
 
      \param dis (in): discretization
-     \param numdf (in): number of degrees of freedom
      \param dimns (in): nullspace dimension
      \param map (in): nullspace map
       */
   std::shared_ptr<Core::LinAlg::MultiVector<double>> compute_null_space(
-      const Core::FE::Discretization& dis, const int numdf, const int dimns,
-      const Core::LinAlg::Map& dofmap);
+      const Core::FE::Discretization& dis, const int dimns, const Core::LinAlg::Map& dofmap);
 }  // namespace Core::FE
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/general/element/4C_fem_general_elementtype.hpp
+++ b/src/core/fem/src/general/element/4C_fem_general_elementtype.hpp
@@ -85,7 +85,7 @@ namespace Core::Elements
 
     /// do the null space computation
     virtual Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) = 0;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) = 0;
   };
 
 }  // namespace Core::Elements

--- a/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
+++ b/src/core/linear_solver/src/method/4C_linear_solver_method_parameters.cpp
@@ -96,7 +96,7 @@ void Core::LinearSolver::Parameters::compute_solver_parameters(
       nullspace_dof_map = std::make_shared<Core::LinAlg::Map>(*dis.dof_row_map());
     }
 
-    const auto nullspace = Core::FE::compute_null_space(dis, numdf, dimns, *nullspace_dof_map);
+    const auto nullspace = Core::FE::compute_null_space(dis, dimns, *nullspace_dof_map);
 
     solverlist.set<std::shared_ptr<Core::LinAlg::MultiVector<double>>>("nullspace", nullspace);
   }

--- a/src/fluid_ele/4C_fluid_ele.cpp
+++ b/src/fluid_ele/4C_fluid_ele.cpp
@@ -61,7 +61,7 @@ void Discret::Elements::FluidType::nodal_block_information(
 
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::FluidType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/fluid_ele/4C_fluid_ele.hpp
+++ b/src/fluid_ele/4C_fluid_ele.hpp
@@ -58,7 +58,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -410,7 +410,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");
@@ -706,7 +706,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/fluid_ele/4C_fluid_ele_hdg.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.cpp
@@ -75,8 +75,8 @@ void Discret::Elements::FluidHDGType::nodal_block_information(
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Discret::Elements::FluidHDGType::compute_null_space(
-    Core::FE::Discretization& dis, std::vector<double>& ns, const double* x0, int numdf, int dimns)
+void Discret::Elements::FluidHDGType::compute_null_space(Core::FE::Discretization& dis,
+    std::vector<double>& ns, std::span<const double> x0, int numdf, int dimns)
 {
   if (Core::FE::DiscretizationFaces* facedis = dynamic_cast<Core::FE::DiscretizationFaces*>(&dis))
   {

--- a/src/fluid_ele/4C_fluid_ele_hdg.hpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg.hpp
@@ -43,7 +43,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       virtual void compute_null_space(Core::FE::Discretization& dis, std::vector<double>& ns,
-          const double* x0, int numdf, int dimns);
+          std::span<const double> x0, int numdf, int dimns);
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.cpp
@@ -75,7 +75,7 @@ void Discret::Elements::FluidHDGWeakCompType::nodal_block_information(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 void Discret::Elements::FluidHDGWeakCompType::compute_null_space(
-    Core::FE::Discretization& dis, std::vector<double>& ns, const double* x0, int numdf, int dimns)
+    Core::FE::Discretization& dis, std::vector<double>& ns, std::span<const double> x0, int numdf)
 {
 }
 

--- a/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.hpp
+++ b/src/fluid_ele/4C_fluid_ele_hdg_weak_comp.hpp
@@ -44,7 +44,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       virtual void compute_null_space(Core::FE::Discretization& dis, std::vector<double>& ns,
-          const double* x0, int numdf, int dimns);
+          std::span<const double> x0, int numdf);
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/fluid_ele/4C_fluid_ele_xwall.cpp
+++ b/src/fluid_ele/4C_fluid_ele_xwall.cpp
@@ -56,7 +56,7 @@ void Discret::Elements::FluidXWallType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::FluidXWallType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/fluid_ele/4C_fluid_ele_xwall.hpp
+++ b/src/fluid_ele/4C_fluid_ele_xwall.hpp
@@ -38,7 +38,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/lubrication/src/4C_lubrication_ele.cpp
+++ b/src/lubrication/src/4C_lubrication_ele.cpp
@@ -62,7 +62,7 @@ void Discret::Elements::LubricationType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::LubricationType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/lubrication/src/4C_lubrication_ele.hpp
+++ b/src/lubrication/src/4C_lubrication_ele.hpp
@@ -37,7 +37,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -285,7 +285,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented");

--- a/src/membrane/4C_membrane.hpp
+++ b/src/membrane/4C_membrane.hpp
@@ -516,7 +516,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");
@@ -544,7 +544,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/membrane/4C_membrane_eletypes.cpp
+++ b/src/membrane/4C_membrane_eletypes.cpp
@@ -61,7 +61,7 @@ void Discret::Elements::MembraneTri3Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::MembraneTri3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }
@@ -134,7 +134,7 @@ void Discret::Elements::MembraneTri6Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::MembraneTri6Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<2>(node.x(), x0);
 }
@@ -207,7 +207,7 @@ void Discret::Elements::MembraneQuad4Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::MembraneQuad4Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<2>(node.x(), x0);
 }
@@ -280,7 +280,7 @@ void Discret::Elements::MembraneQuad9Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::MembraneQuad9Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<2>(node.x(), x0);
 }

--- a/src/membrane/4C_membrane_eletypes.hpp
+++ b/src/membrane/4C_membrane_eletypes.hpp
@@ -46,7 +46,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -78,7 +78,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -110,7 +110,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -142,7 +142,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/mortar/src/4C_mortar_element.cpp
+++ b/src/mortar/src/4C_mortar_element.cpp
@@ -47,7 +47,7 @@ void Mortar::ElementType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Mortar::ElementType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/mortar/src/4C_mortar_element.hpp
+++ b/src/mortar/src/4C_mortar_element.hpp
@@ -53,7 +53,7 @@ namespace Mortar
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
    private:
     static ElementType instance_;

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.cpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.cpp
@@ -68,7 +68,7 @@ void Discret::Elements::PoroFluidMultiPhaseType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::PoroFluidMultiPhaseType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.hpp
+++ b/src/porofluid_pressure_based_ele/4C_porofluid_pressure_based_ele.hpp
@@ -44,7 +44,7 @@ namespace Discret
 
       /// do the null space computation
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       /// setup the input file input line definitions for this type of element
       void setup_element_definition(
@@ -325,7 +325,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented");

--- a/src/red_airways/4C_red_airways_elementbase.hpp
+++ b/src/red_airways/4C_red_airways_elementbase.hpp
@@ -57,7 +57,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented");
@@ -402,7 +402,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented");
@@ -748,7 +748,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented");

--- a/src/rigidsphere/4C_rigidsphere.cpp
+++ b/src/rigidsphere/4C_rigidsphere.cpp
@@ -78,7 +78,7 @@ void Discret::Elements::RigidsphereType::nodal_block_information(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::RigidsphereType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/rigidsphere/4C_rigidsphere.hpp
+++ b/src/rigidsphere/4C_rigidsphere.hpp
@@ -60,7 +60,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/scatra_ele/4C_scatra_ele.cpp
+++ b/src/scatra_ele/4C_scatra_ele.cpp
@@ -73,10 +73,12 @@ void Discret::Elements::TransportType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::TransportType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {
+    case 1:
+      return FLD::compute_fluid_null_space<1>();
     case 2:
       return FLD::compute_fluid_null_space<2>();
     case 3:

--- a/src/scatra_ele/4C_scatra_ele.hpp
+++ b/src/scatra_ele/4C_scatra_ele.hpp
@@ -50,7 +50,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -388,7 +388,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/scatra_ele/4C_scatra_ele_hdg.cpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.cpp
@@ -100,7 +100,7 @@ void Discret::Elements::ScaTraHDGType::nodal_block_information(
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Discret::Elements::ScaTraHDGType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   Core::LinAlg::SerialDenseMatrix nullspace;
   FOUR_C_THROW("method ComputeNullSpace not implemented right now!");

--- a/src/scatra_ele/4C_scatra_ele_hdg.hpp
+++ b/src/scatra_ele/4C_scatra_ele_hdg.hpp
@@ -44,7 +44,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -382,7 +382,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");
@@ -656,7 +656,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/shell7p/4C_shell7p_ele.cpp
+++ b/src/shell7p/4C_shell7p_ele.cpp
@@ -57,7 +57,7 @@ void Discret::Elements::Shell7pType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Shell7pType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   auto* shell =
       dynamic_cast<Discret::Elements::Shell7p*>(node.adjacent_elements()[0].user_element());

--- a/src/shell7p/4C_shell7p_ele.hpp
+++ b/src/shell7p/4C_shell7p_ele.hpp
@@ -63,7 +63,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       static Shell7pType& instance();
 

--- a/src/shell7p/4C_shell7p_ele_scatra.cpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.cpp
@@ -161,7 +161,7 @@ int Discret::Elements::Shell7pScatraType::initialize(Core::FE::Discretization& d
 
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Shell7pScatraType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   auto* shell =
       dynamic_cast<Discret::Elements::Shell7pScatra*>(node.adjacent_elements()[0].user_element());

--- a/src/shell7p/4C_shell7p_ele_scatra.hpp
+++ b/src/shell7p/4C_shell7p_ele_scatra.hpp
@@ -48,7 +48,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     static Shell7pScatraType& instance();
 

--- a/src/shell7p/4C_shell7p_line.hpp
+++ b/src/shell7p/4C_shell7p_line.hpp
@@ -32,7 +32,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override {}
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
     {
       FOUR_C_THROW("method ComputeNullSpace not implemented!");
     }

--- a/src/shell7p/4C_shell7p_utils.cpp
+++ b/src/shell7p/4C_shell7p_utils.cpp
@@ -330,7 +330,7 @@ namespace
 }  // namespace
 
 Core::LinAlg::SerialDenseMatrix Solid::Utils::Shell::compute_shell_null_space(
-    Core::Nodes::Node& node, const double* x0, const Core::LinAlg::Matrix<3, 1>& dir)
+    Core::Nodes::Node& node, std::span<const double> x0, const Core::LinAlg::Matrix<3, 1>& dir)
 {
   const auto& x = node.x();
 

--- a/src/shell7p/4C_shell7p_utils.hpp
+++ b/src/shell7p/4C_shell7p_utils.hpp
@@ -93,7 +93,7 @@ namespace Solid::Utils::Shell
    *  rotational (around x,y,z) nullspace contribution for given node
    */
   Core::LinAlg::SerialDenseMatrix compute_shell_null_space(
-      Core::Nodes::Node& node, const double* x0, const Core::LinAlg::Matrix<3, 1>& dir);
+      Core::Nodes::Node& node, std::span<const double> x0, const Core::LinAlg::Matrix<3, 1>& dir);
 
   void nodal_block_information_shell(Core::Elements::Element* dwele, int& numdf, int& dimns);
 

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.cpp
@@ -80,7 +80,7 @@ void Discret::Elements::KirchhoffLoveShellNurbsType::nodal_block_information(
  *
  */
 Core::LinAlg::SerialDenseMatrix Discret::Elements::KirchhoffLoveShellNurbsType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, int const numdof, int const dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, int const numdof)
 {
   FOUR_C_THROW("ComputeNullSpace not implemented");
 }

--- a/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.hpp
+++ b/src/shell_kl_nurbs/src/4C_shell_kl_nurbs.hpp
@@ -51,7 +51,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, int const numdof, int const dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, int const numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/solid_3D_ele/4C_solid_3D_ele.cpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.cpp
@@ -143,7 +143,7 @@ void Discret::Elements::SolidType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::SolidType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/solid_3D_ele/4C_solid_3D_ele.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele.hpp
@@ -51,7 +51,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     static SolidType& instance();
 

--- a/src/solid_3D_ele/4C_solid_3D_ele_line.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_line.hpp
@@ -38,7 +38,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override {}
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
     {
       FOUR_C_THROW("Computation of nullspace is not possible for solid-line element.");
     }

--- a/src/solid_3D_ele/4C_solid_3D_ele_nullspace.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_nullspace.hpp
@@ -27,7 +27,7 @@ namespace Discret::Elements
   template <unsigned dim>
     requires(dim == 2 || dim == 3)
   Core::LinAlg::SerialDenseMatrix compute_solid_null_space(
-      std::span<const double> node_coordinates, const double* x0)
+      std::span<const double> node_coordinates, std::span<const double> x0)
   {
     if constexpr (dim == 2)
     {

--- a/src/solid_3D_ele/4C_solid_3D_ele_surface.hpp
+++ b/src/solid_3D_ele/4C_solid_3D_ele_surface.hpp
@@ -37,7 +37,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override {}
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
     {
       Core::LinAlg::SerialDenseMatrix nullspace;
       FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.cpp
@@ -117,7 +117,7 @@ void Discret::Elements::SolidPoroPressureBasedType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::SolidPoroPressureBasedType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_based.hpp
@@ -58,7 +58,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     static SolidPoroPressureBasedType& instance();
 

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.cpp
@@ -141,7 +141,7 @@ void Discret::Elements::SolidPoroPressureVelocityBasedType::nodal_block_informat
 
 Core::LinAlg::SerialDenseMatrix
 Discret::Elements::SolidPoroPressureVelocityBasedType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based.hpp
@@ -59,7 +59,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     static SolidPoroPressureVelocityBasedType& instance();
 

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.cpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.cpp
@@ -137,7 +137,7 @@ void Discret::Elements::SolidPoroPressureVelocityBasedP1Type::nodal_block_inform
 
 Core::LinAlg::SerialDenseMatrix
 Discret::Elements::SolidPoroPressureVelocityBasedP1Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.hpp
+++ b/src/solid_poro_3D_ele/4C_solid_poro_3D_ele_pressure_velocity_based_p1.hpp
@@ -62,7 +62,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     static SolidPoroPressureVelocityBasedP1Type& instance();
 

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.cpp
@@ -110,7 +110,7 @@ void Discret::Elements::SolidScatraType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::SolidScatraType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.hpp
+++ b/src/solid_scatra_3D_ele/4C_solid_scatra_3D_ele.hpp
@@ -46,7 +46,7 @@ namespace Discret::Elements
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     static SolidScatraType& instance();
 

--- a/src/structure/4C_structure_timint_impl.cpp
+++ b/src/structure/4C_structure_timint_impl.cpp
@@ -790,7 +790,7 @@ void Solid::TimIntImpl::update_krylov_space_projection()
 
   Core::LinAlg::Map nullspaceMap(*discret_->dof_row_map());
   std::shared_ptr<Core::LinAlg::MultiVector<double>> nullspace =
-      Core::FE::compute_null_space(*discret_, 3, 6, nullspaceMap);
+      Core::FE::compute_null_space(*discret_, 6, nullspaceMap);
   if (nullspace == nullptr) FOUR_C_THROW("nullspace not successfully computed");
 
   // sort vector of nullspace data into kernel vector c_

--- a/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
+++ b/src/structure_new/src/linear_solver/4C_structure_new_solver_factory.cpp
@@ -178,7 +178,7 @@ std::shared_ptr<Core::LinAlg::Solver> Solid::SOLVER::Factory::build_structure_li
           dwele->element_type().nodal_block_information(dwele, numdof, dimns);
         }
         std::shared_ptr<Core::LinAlg::MultiVector<double>> nullspace =
-            Core::FE::compute_null_space(actdis, numdof, dimns, nullspace_map);
+            Core::FE::compute_null_space(actdis, dimns, nullspace_map);
         if (nullspace == nullptr) FOUR_C_THROW("Nullspace could not be computed successfully.");
 
         // sort vector of nullspace data into kernel vector c_

--- a/src/thermo/src/element/4C_thermo_element.cpp
+++ b/src/thermo/src/element/4C_thermo_element.cpp
@@ -77,10 +77,11 @@ void Thermo::ElementType::nodal_block_information(
  | ctor (public)                                             dano 08/12 |
  *----------------------------------------------------------------------*/
 Core::LinAlg::SerialDenseMatrix Thermo::ElementType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
-  Core::LinAlg::SerialDenseMatrix nullspace;
-  FOUR_C_THROW("method ComputeNullSpace not implemented!");
+  Core::LinAlg::SerialDenseMatrix nullspace(1, 1);
+  nullspace.put_scalar(1.0);
+
   return nullspace;
 }
 

--- a/src/thermo/src/element/4C_thermo_element.hpp
+++ b/src/thermo/src/element/4C_thermo_element.hpp
@@ -49,7 +49,7 @@ namespace Thermo
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
     void setup_element_definition(
         std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -370,10 +370,11 @@ namespace Thermo
     void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override {}
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
     {
-      Core::LinAlg::SerialDenseMatrix nullspace;
-      FOUR_C_THROW("method ComputeNullSpace not implemented");
+      Core::LinAlg::SerialDenseMatrix nullspace(1, 1);
+      nullspace.put_scalar(1.0);
+
       return nullspace;
     }
 

--- a/src/torsion3/4C_torsion3.cpp
+++ b/src/torsion3/4C_torsion3.cpp
@@ -62,7 +62,7 @@ void Discret::Elements::Torsion3Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Torsion3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/torsion3/4C_torsion3.hpp
+++ b/src/torsion3/4C_torsion3.hpp
@@ -51,7 +51,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)

--- a/src/truss3/4C_truss3.cpp
+++ b/src/truss3/4C_truss3.cpp
@@ -61,7 +61,7 @@ void Discret::Elements::Truss3Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Truss3Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<3>(node.x(), x0);
 }

--- a/src/truss3/4C_truss3.hpp
+++ b/src/truss3/4C_truss3.hpp
@@ -36,7 +36,7 @@ namespace Discret
     {
      public:
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       Core::Communication::ParObject* create(Core::Communication::UnpackBuffer& buffer) override;
 

--- a/src/w1/4C_w1.cpp
+++ b/src/w1/4C_w1.cpp
@@ -60,7 +60,7 @@ void Discret::Elements::Wall1Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Wall1Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, int const numdof, int const dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, int const numdof)
 {
   return compute_solid_null_space<2>(node.x(), x0);
 }

--- a/src/w1/4C_w1.hpp
+++ b/src/w1/4C_w1.hpp
@@ -60,7 +60,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, int const numdof, int const dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, int const numdof) override;
 
       void setup_element_definition(
           std::map<std::string, std::map<Core::FE::CellType, Core::IO::InputSpec>>& definitions)
@@ -742,7 +742,7 @@ namespace Discret
       }
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& actnode, const double* x0, const int numdof, const int dimnsp) override
+          Core::Nodes::Node& actnode, std::span<const double> x0, const int numdof) override
       {
         Core::LinAlg::SerialDenseMatrix nullspace;
         FOUR_C_THROW("method ComputeNullSpace not implemented!");

--- a/src/w1/4C_w1_nurbs.cpp
+++ b/src/w1/4C_w1_nurbs.cpp
@@ -57,7 +57,7 @@ void Discret::Elements::Nurbs::Wall1NurbsType::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::Nurbs::Wall1NurbsType::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   return compute_solid_null_space<2>(node.x(), x0);
 }

--- a/src/w1/4C_w1_nurbs.hpp
+++ b/src/w1/4C_w1_nurbs.hpp
@@ -42,7 +42,7 @@ namespace Discret
             Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
         Core::LinAlg::SerialDenseMatrix compute_null_space(
-            Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+            Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
        private:
         static Wall1NurbsType instance_;

--- a/src/w1/4C_w1_poro_p1_eletypes.cpp
+++ b/src/w1/4C_w1_poro_p1_eletypes.cpp
@@ -76,7 +76,7 @@ void Discret::Elements::WallQuad4PoroP1Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::WallQuad4PoroP1Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {
@@ -167,7 +167,7 @@ void Discret::Elements::WallQuad9PoroP1Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::WallQuad9PoroP1Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {
@@ -259,7 +259,7 @@ void Discret::Elements::WallTri3PoroP1Type::nodal_block_information(
 }
 
 Core::LinAlg::SerialDenseMatrix Discret::Elements::WallTri3PoroP1Type::compute_null_space(
-    Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp)
+    Core::Nodes::Node& node, std::span<const double> x0, const int numdof)
 {
   switch (numdof)
   {

--- a/src/w1/4C_w1_poro_p1_eletypes.hpp
+++ b/src/w1/4C_w1_poro_p1_eletypes.hpp
@@ -43,7 +43,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       int initialize(Core::FE::Discretization& dis) override;
 
@@ -75,7 +75,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       int initialize(Core::FE::Discretization& dis) override;
 
@@ -107,7 +107,7 @@ namespace Discret
       void nodal_block_information(Core::Elements::Element* dwele, int& numdf, int& dimns) override;
 
       Core::LinAlg::SerialDenseMatrix compute_null_space(
-          Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override;
+          Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override;
 
       int initialize(Core::FE::Discretization& dis) override;
 

--- a/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
+++ b/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
@@ -88,7 +88,7 @@ namespace
 
       testele_->element_type().nodal_block_information(testele_.get(), numdof, dimnsp);
       Core::LinAlg::SerialDenseMatrix nullspace = testele_->element_type().compute_null_space(
-          *testele_->nodes()[0], std::vector{0.0, 0.0, 0.0}.data(), numdof, dimnsp);
+          *testele_->nodes()[0], std::array{0.0, 0.0, 0.0}, numdof);
 
       FOUR_C_EXPECT_NEAR(nullspace, nullspace_ref, testTolerance);
     }
@@ -110,7 +110,7 @@ namespace
 
       testele_->element_type().nodal_block_information(testele_.get(), numdof, dimnsp);
       Core::LinAlg::SerialDenseMatrix nullspace = testele_->element_type().compute_null_space(
-          *testele_->nodes()[0], std::vector{-0.05, 0.05, 0.3}.data(), numdof, dimnsp);
+          *testele_->nodes()[0], std::array{-0.05, 0.05, 0.3}, numdof);
 
       FOUR_C_EXPECT_NEAR(nullspace, nullspace_ref, testTolerance);
     }

--- a/unittests/beam3/4C_beam3_reissner_test.cpp
+++ b/unittests/beam3/4C_beam3_reissner_test.cpp
@@ -225,8 +225,7 @@ namespace
     int numdof, dimnsp;
     testele_->element_type().nodal_block_information(testele_.get(), numdof, dimnsp);
 
-    const auto B =
-        Core::FE::compute_null_space(*testdis_, numdof, dimnsp, *testdis_->dof_row_map());
+    const auto B = Core::FE::compute_null_space(*testdis_, dimnsp, *testdis_->dof_row_map());
     Core::LinAlg::MultiVector<double> zero(*testdis_->dof_row_map(), 6);
 
     A.multiply(false, *B, zero);

--- a/unittests/common/unittest_utils/4C_unittest_utils_create_discretization_helper_test.hpp
+++ b/unittests/common/unittest_utils/4C_unittest_utils_create_discretization_helper_test.hpp
@@ -51,7 +51,7 @@ namespace TESTING
     }
 
     Core::LinAlg::SerialDenseMatrix compute_null_space(
-        Core::Nodes::Node& node, const double* x0, const int numdof, const int dimnsp) override
+        Core::Nodes::Node& node, std::span<const double> x0, const int numdof) override
     {
       FOUR_C_THROW("Not implemented.");
     }


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR replaces the `const double*` with a `std::array` for the discretization centroid coordinates. In addition the unused `dimns` input parameter is removed from the nodal null space.