### PR TITLE
Update documentation on Trilinos versioning

### DIFF
--- a/doc/documentation/src/installation/installation.rst
+++ b/doc/documentation/src/installation/installation.rst
@@ -84,7 +84,9 @@ See the `ArborX repository <https://github.com/arborx/ArborX>`_ for details and 
 **Trilinos**
 
 This external dependency can be downloaded from the `Trilinos Github repository <https://github.com/trilinos/Trilinos>`_ .
-Currently supported versions are listed in ``<4C_sourceDir>/dependencies/supported_version/Trilinos.txt``.
+Currently supported versions are listed in ``<4C_sourceDir>/dependencies/supported_version/Trilinos.txt``. An older supported version will be supported for at least six months after its introduction. Afterwards, the version may be dropped at any time.
+
+.. note:: As 4C is still depending on Epetra based Trilinos code, the last official update will for now happen with the last available Trilinos hash still supporting Epetra.
 
 .. _4Cinstallation:
 


### PR DESCRIPTION
## Description and Context
<!--
Provide a brief and concise description of your proposed change. Questions you should think about:
* Why is this change required?  What problem does it solve?
* Is there a bigger picture? Is this PR a part of a larger set of changes? Which further steps are planned after merging this PR, if any?
* How has the proposed implementation been verified and tested?

Keep the description of the PR always up-to-date and concise.
-->
This PR adds some more details on the Trilinos versioning. We try to update Trilinos in 4C every ~6 months and thus by that restrict / delete supported versions. From 21st October 2025 we are not able to update anymore as we still depend on `Epetra` based Trilinos code.
