### PR TITLE
Improve Discretization::redistribute and fill_complete

### DIFF
--- a/src/adapter/4C_adapter_fld_base_algorithm.cpp
+++ b/src/adapter/4C_adapter_fld_base_algorithm.cpp
@@ -103,7 +103,7 @@ void Adapter::FluidBaseAlgorithm::setup_fluid(const Teuchos::ParameterList& prbd
     if (probtype == Core::ProblemType::fsi_xfem or probtype == Core::ProblemType::fluid_xfem or
         (probtype == Core::ProblemType::fpsi_xfem and disname == "fluid"))
     {
-      actdis->fill_complete(false, false, false);
+      actdis->fill_complete(Core::FE::OptionsFillComplete::none());
     }
     else
     {

--- a/src/adapter/4C_adapter_str_structure_new.cpp
+++ b/src/adapter/4C_adapter_str_structure_new.cpp
@@ -148,7 +148,7 @@ void Adapter::StructureBaseAlgorithmNew::setup_tim_int()
     Core::Utils::add_enum_class_to_parameter_list<Core::FE::ShapeFunctionType>(
         "spatial_approximation_type", Global::Problem::instance()->spatial_approximation_type(),
         binning_params);
-    actdis_vec[0]->fill_complete(false, false, false);
+    actdis_vec[0]->fill_complete(Core::FE::OptionsFillComplete::none());
 
     // Different types of structural elements may be present, so we need to help the binning
     // strategy understand their different shapes by providing the correct points to compute

--- a/src/art_net/4C_art_net_dyn_drt.cpp
+++ b/src/art_net/4C_art_net_dyn_drt.cpp
@@ -112,7 +112,11 @@ std::shared_ptr<Adapter::ArtNet> dyn_art_net_drt(bool CoupledTo3D)
     if (scatradis->add_dof_set(arterydofset) != 1)
       FOUR_C_THROW("unexpected dof sets in scatra field");
 
-    scatradis->fill_complete(true, false, false);
+    scatradis->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
   }
   else
   {

--- a/src/art_net/4C_art_net_explicitintegration.cpp
+++ b/src/art_net/4C_art_net_explicitintegration.cpp
@@ -89,8 +89,8 @@ void Arteries::ArtNetExplicitTimeInt::init(const Teuchos::ParameterList& globalt
   // reduce the node row map into processor 0
   const Core::LinAlg::Map noderowmap_1_proc =
       *Core::LinAlg::allreduce_e_map(*discret_->node_row_map(), 0);
-  // update the discetization by redistributing the new row map
-  discret_->redistribute(noderowmap_1_proc, noderowmap_1_proc);
+  // update the discretization by redistributing the new row map
+  discret_->redistribute({noderowmap_1_proc, noderowmap_1_proc});
 
   // -------------------------------------------------------------------
   // get a vector layout from the discretization to construct matching

--- a/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
+++ b/src/beamcontact/4C_beamcontact_beam3contact_manager.cpp
@@ -681,7 +681,7 @@ void CONTACT::Beam3cmanager::init_beam_contact_discret()
 
   // build maps but do not assign dofs yet, we'll do this below
   // after shuffling around of nodes and elements (saves time)
-  bt_sol_discret().fill_complete(false, false, false);
+  bt_sol_discret().fill_complete(Core::FE::OptionsFillComplete::none());
 
   // store the node and element row and column maps into this manager
   noderowmap_ = std::make_shared<Core::LinAlg::Map>(*(bt_sol_discret().node_row_map()));
@@ -760,7 +760,11 @@ void CONTACT::Beam3cmanager::init_beam_contact_discret()
   // complete beam contact discretization based on the new column maps
   // (this also assign new degrees of freedom what we actually do not
   // want, thus we have to introduce a dof mapping next)
-  bt_sol_discret().fill_complete(true, false, false);
+  bt_sol_discret().fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // communicate the map nodedofs to all proccs
   Core::Communication::Exporter ex(

--- a/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_str_model_evaluator.cpp
@@ -852,7 +852,7 @@ void Solid::ModelEvaluator::BeamInteraction::read_restart(Core::IO::Discretizati
   // read correct nodes
   Core::IO::DiscretizationReader bin_reader(bindis_, input_control_file, stepn);
   bin_reader.read_nodes_only(stepn);
-  bindis_->fill_complete(false, false, false);
+  bindis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
   // need to read step next (as it was written next, do safety check)
   if (stepn != ia_reader.read_int("step") or stepn != bin_reader.read_int("step"))

--- a/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
+++ b/src/beaminteraction/src/4C_beaminteraction_submodel_evaluator_crosslinking.cpp
@@ -149,7 +149,7 @@ bool BeamInteraction::SubmodelEvaluator::Crosslinking::post_partition_problem()
   set_all_possible_initial_double_bonded_crosslinker(newlinker, mynewdbondcl);
 
   // set row map of newly created linker discretization
-  bin_discret_ptr()->fill_complete(false, false, false);
+  bin_discret_ptr()->fill_complete(Core::FE::OptionsFillComplete::none());
 
   // init crosslinker data container
   crosslinker_data_.clear();
@@ -752,7 +752,7 @@ void BeamInteraction::SubmodelEvaluator::Crosslinking::add_crosslinker_to_bin_di
   }
 
   // set row map of newly created linker discretization
-  bin_discret_ptr()->fill_complete(false, false, false);
+  bin_discret_ptr()->fill_complete(Core::FE::OptionsFillComplete::none());
 }
 
 /*-------------------------------------------------------------------------------*

--- a/src/constraint/4C_constraint_multipointconstraint2.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint2.cpp
@@ -37,7 +37,7 @@ Constraints::MPConstraint2::MPConstraint2(std::shared_ptr<Core::FE::Discretizati
         actdisc_, constrcond_, "ConstrDisc", "CONSTRELE2", dummy);
     std::shared_ptr<Core::LinAlg::Map> newcolnodemap =
         Core::Rebalance::compute_node_col_map(*actdisc_, *constraintdis_.find(0)->second);
-    actdisc_->redistribute(*(actdisc_->node_row_map()), *newcolnodemap);
+    actdisc_->redistribute({*actdisc_->node_row_map(), *newcolnodemap});
     std::shared_ptr<Core::DOFSets::DofSet> newdofset =
         std::make_shared<Core::DOFSets::TransparentDofSet>(actdisc_);
     (constraintdis_.find(0)->second)->replace_dof_set(newdofset);
@@ -223,7 +223,7 @@ Constraints::MPConstraint2::create_discretization_from_condition(
 
   constraintnodecolvec.clear();
 
-  newdis->redistribute(constraintnoderowmap, constraintnodecolmap);
+  newdis->redistribute({constraintnoderowmap, constraintnodecolmap});
 
   std::map<int, std::shared_ptr<Core::FE::Discretization>> newdismap;
   newdismap[startID] = newdis;

--- a/src/constraint/4C_constraint_multipointconstraint3.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3.cpp
@@ -52,7 +52,7 @@ Constraints::MPConstraint3::MPConstraint3(std::shared_ptr<Core::FE::Discretizati
       // ReplaceNumDof(actdisc_,discriter->second);
       std::shared_ptr<Core::LinAlg::Map> newcolnodemap =
           Core::Rebalance::compute_node_col_map(*actdisc_, *discriter->second);
-      actdisc_->redistribute(*(actdisc_->node_row_map()), *newcolnodemap);
+      actdisc_->redistribute({*actdisc_->node_row_map(), *newcolnodemap});
       std::shared_ptr<Core::DOFSets::DofSet> newdofset =
           std::make_shared<Core::DOFSets::TransparentDofSet>(actdisc_);
       (discriter->second)->replace_dof_set(newdofset);
@@ -320,7 +320,7 @@ Constraints::MPConstraint3::create_discretization_from_condition(
         -1, constraintnodecolvec.size(), constraintnodecolvec.data(), 0, newdis->get_comm());
 
     constraintnodecolvec.clear();
-    newdis->redistribute(constraintnoderowmap, constraintnodecolmap);
+    newdis->redistribute({constraintnoderowmap, constraintnodecolmap});
     // put new discretization into the map
     newdiscmap[(*conditer)->parameters().get<int>("ConditionID")] = newdis;
     // increase counter

--- a/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
+++ b/src/constraint/4C_constraint_multipointconstraint3penalty.cpp
@@ -55,7 +55,7 @@ Constraints::MPConstraint3Penalty::MPConstraint3Penalty(
     {
       std::shared_ptr<Core::LinAlg::Map> newcolnodemap =
           Core::Rebalance::compute_node_col_map(*actdisc_, *discriter->second);
-      actdisc_->redistribute(*(actdisc_->node_row_map()), *newcolnodemap);
+      actdisc_->redistribute({*actdisc_->node_row_map(), *newcolnodemap});
       std::shared_ptr<Core::DOFSets::DofSet> newdofset =
           std::make_shared<Core::DOFSets::TransparentDofSet>(actdisc_);
       (discriter->second)->replace_dof_set(newdofset);
@@ -321,7 +321,7 @@ Constraints::MPConstraint3Penalty::create_discretization_from_condition(
         -1, constraintnodecolvec.size(), constraintnodecolvec.data(), 0, newdis->get_comm());
 
     constraintnodecolvec.clear();
-    newdis->redistribute(constraintnoderowmap, constraintnodecolmap);
+    newdis->redistribute({constraintnoderowmap, constraintnodecolmap});
     // put new discretization into the map
     newdiscmap[(*conditer)->parameters().get<int>("ConditionID")] = newdis;
     // increase counter

--- a/src/contact/src/4C_contact_interface.cpp
+++ b/src/contact/src/4C_contact_interface.cpp
@@ -468,7 +468,11 @@ void CONTACT::Interface::fill_complete_new(const bool isFinalParallelDistributio
   }
 
   // fill_complete the interface discretization
-  discret().fill_complete(isFinalParallelDistribution, false, false);
+  discret().fill_complete({
+      .assign_degrees_of_freedom = isFinalParallelDistribution,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // check whether crosspoints / edge nodes shall be considered or not
   initialize_cross_points();

--- a/src/contact/src/4C_contact_interface.cpp
+++ b/src/contact/src/4C_contact_interface.cpp
@@ -1046,13 +1046,9 @@ void CONTACT::Interface::redistribute()
   // (note that nothing is actually redistributed in here)
   const auto& [roweles, coleles] = discret().build_element_row_column(*rownodes, *colnodes);
 
-  // export nodes and elements to the row map
-  discret().export_row_nodes(*rownodes);
-  discret().export_row_elements(*roweles);
-
-  // export nodes and elements to the column map (create ghosting)
-  discret().export_column_nodes(*colnodes);
-  discret().export_column_elements(*coleles);
+  // Redistribute but do NOT call fill_complete at all
+  discret().redistribute(
+      {*rownodes, *colnodes}, {*roweles, *coleles}, {.fill_complete = std::nullopt});
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/contact/src/4C_contact_interface_roundrobin.cpp
+++ b/src/contact/src/4C_contact_interface_roundrobin.cpp
@@ -353,14 +353,9 @@ void CONTACT::Interface::round_robin_change_ownership()
   std::shared_ptr<Core::LinAlg::Map> rownodesfull = Core::LinAlg::merge_map(noderowmap, SRN, false);
   std::shared_ptr<Core::LinAlg::Map> rowelesfull = Core::LinAlg::merge_map(elerowmap, SRE, false);
 
-  // to discretization
-  // export nodes and elements to the row map
-  discret().export_row_nodes(*rownodesfull);
-  discret().export_row_elements(*rowelesfull);
-
-  // export nodes and elements to the col map
-  discret().export_column_nodes(*colnodesfull);
-  discret().export_column_elements(*colelesfull);
+  // Redistribute but do NOT fill_complete
+  discret().redistribute({*rownodesfull, *colnodesfull}, {*rowelesfull, *colelesfull},
+      {.fill_complete = std::nullopt});
 
   // ********************************************
   // call the (very) expensive FILLCOMPLETE()!

--- a/src/contact/tests/4C_contact_element_reference_configuration_test.cpp
+++ b/src/contact/tests/4C_contact_element_reference_configuration_test.cpp
@@ -64,7 +64,7 @@ namespace
           std::make_shared<CONTACT::Element>(testtet4ele->id() + 1, testtet4ele->owner(),
               testtet4ele->shape(), testtet4ele->num_node(), testtet4ele->node_ids(), false, false);
       testdis_->add_element(testcontacttri3ele);
-      testdis_->fill_complete(false, false, false);
+      testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
     }
   };
 

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -1444,10 +1444,10 @@ void Core::Binstrategy::BinningStrategy::standard_discretization_ghosting(
   std::shared_ptr<Core::LinAlg::Map> roweles;
   std::tie(roweles, stdelecolmap) =
       discret->build_element_row_column(*newnoderowmap, *stdnodecolmap);
-  discret->export_row_nodes(*newnoderowmap);
-  discret->export_row_elements(*roweles);
-  discret->export_column_nodes(*stdnodecolmap);
-  discret->export_column_elements(*stdelecolmap);
+
+  discret->redistribute(
+      {*newnoderowmap, *stdnodecolmap}, {*roweles, *stdelecolmap}, {.fill_complete = std::nullopt});
+
   // in case we have a state vector, we need to build the dof map to enable its rebuild
   if (disnp == nullptr)
   {

--- a/src/core/binstrategy/4C_binstrategy.cpp
+++ b/src/core/binstrategy/4C_binstrategy.cpp
@@ -114,7 +114,7 @@ Core::Binstrategy::BinningStrategy::BinningStrategy(const Teuchos::ParameterList
       binning_params, "spatial_approximation_type");
   bindis_->set_writer(std::make_shared<Core::IO::DiscretizationWriter>(
       bindis_, output_control, spatial_approximation_type));
-  bindis_->fill_complete(false, false, false);
+  bindis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
   visbindis_ = std::make_shared<Core::FE::Discretization>("bins", comm_, 3);
   // create discretization writer
@@ -588,7 +588,7 @@ void Core::Binstrategy::BinningStrategy::determine_boundary_row_bins()
   boundaryrowbins_.clear();
 
   // fill discret if necessary to obtain bin row map
-  if (!bindis_->filled()) bindis_->fill_complete(false, false, false);
+  if (!bindis_->filled()) bindis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
   // determine maximal possible number of neighbors
   size_t nummaxneighbors = 26;
@@ -785,7 +785,11 @@ void Core::Binstrategy::BinningStrategy::write_bin_output(int const step, double
   std::shared_ptr<Core::DOFSets::IndependentDofSet> independentdofset =
       std::make_shared<Core::DOFSets::IndependentDofSet>(true);
   visbindis_->replace_dof_set(independentdofset);
-  visbindis_->fill_complete(true, true, false);
+  visbindis_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = true,
+      .do_boundary_conditions = false,
+  });
 
   // create vector that shows ghosting
   std::shared_ptr<Core::LinAlg::Vector<double>> ownedghostsvec =
@@ -1447,11 +1451,15 @@ void Core::Binstrategy::BinningStrategy::standard_discretization_ghosting(
   // in case we have a state vector, we need to build the dof map to enable its rebuild
   if (disnp == nullptr)
   {
-    discret->fill_complete(false, false, false);
+    discret->fill_complete(Core::FE::OptionsFillComplete::none());
   }
   else
   {
-    discret->fill_complete(true, false, false);
+    discret->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
     std::shared_ptr<Core::LinAlg::Vector<double>> old;
     old = disnp;
     disnp = Core::LinAlg::create_vector(*discret->dof_row_map(), true);

--- a/src/core/binstrategy/4C_binstrategy_utils.cpp
+++ b/src/core/binstrategy/4C_binstrategy_utils.cpp
@@ -51,7 +51,11 @@ namespace Core::Binstrategy::Utils
     discret.export_column_nodes(nodecolmap);
 
     // fillcomplete discret with extended ghosting
-    discret.fill_complete(assigndegreesoffreedom, initelements, doboundaryconditions);
+    discret.fill_complete({
+        .assign_degrees_of_freedom = assigndegreesoffreedom,
+        .init_elements = initelements,
+        .do_boundary_conditions = doboundaryconditions,
+    });
 
 #ifdef FOUR_C_ENABLE_ASSERTIONS
     // print distribution after standard ghosting

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -1176,7 +1176,7 @@ void Core::Conditions::PeriodicBoundaryConditions::redistribute_and_create_dof_c
     // redistribute the nodes
     // this contains a call to fill_complete and assigns the same
     // degree of freedom to the matching nodes
-    discret_->redistribute(*newrownodemap, *newcolnodemap);
+    discret_->redistribute({*newrownodemap, *newcolnodemap});
   }
 }
 
@@ -1372,7 +1372,7 @@ void Core::Conditions::PeriodicBoundaryConditions::balance_load()
   const Core::LinAlg::Map newnodecolmap(-1, newnodegraph->col_map().num_my_elements(),
       newnodegraph->col_map().my_global_elements(), 0, discret_->get_comm());
 
-  discret_->redistribute(newnoderowmap, newnodecolmap, {.assign_degrees_of_freedom = false});
+  discret_->redistribute({newnoderowmap, newnodecolmap}, {.assign_degrees_of_freedom = false});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_periodic.cpp
@@ -823,7 +823,7 @@ void Core::Conditions::PeriodicBoundaryConditions::redistribute_and_create_dof_c
     // accessing the noderowmap requires a 'completed' discretization
     if (!discret_->filled())
     {
-      discret_->fill_complete(false, false, false);
+      discret_->fill_complete(Core::FE::OptionsFillComplete::none());
     }
 
     // a list of all nodes on this proc
@@ -1372,7 +1372,8 @@ void Core::Conditions::PeriodicBoundaryConditions::balance_load()
   const Core::LinAlg::Map newnodecolmap(-1, newnodegraph->col_map().num_my_elements(),
       newnodegraph->col_map().my_global_elements(), 0, discret_->get_comm());
 
-  discret_->redistribute({newnoderowmap, newnodecolmap}, {.assign_degrees_of_freedom = false});
+  discret_->redistribute({newnoderowmap, newnodecolmap},
+      {.fill_complete = FE::OptionsFillComplete{.assign_degrees_of_freedom = false}});
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/core/fem/src/condition/4C_fem_condition_point_coupling_redistribution.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_point_coupling_redistribution.cpp
@@ -147,7 +147,7 @@ void redistribute(const std::vector<int>& rank_to_hold_condition,
   // accessing the noderowmap requires a 'completed' discretization
   if (!discret.filled())
   {
-    discret.fill_complete(false, false, false);
+    discret.fill_complete(Core::FE::OptionsFillComplete::none());
   }
 
   // get all currently owned node gids of this proc
@@ -243,9 +243,6 @@ void redistribute(const std::vector<int>& rank_to_hold_condition,
           .col_map = new_col_node_map,
       },
       {
-          .assign_degrees_of_freedom = true,
-          .init_elements = true,
-          .do_boundary_conditions = true,
           .do_extended_ghosting = true,
       });
 

--- a/src/core/fem/src/condition/4C_fem_condition_point_coupling_redistribution.cpp
+++ b/src/core/fem/src/condition/4C_fem_condition_point_coupling_redistribution.cpp
@@ -237,11 +237,17 @@ void redistribute(const std::vector<int>& rank_to_hold_condition,
       new_col_node_block_map.my_global_elements(), 0, discret.get_comm());
 
   // rearrange node/element distribution according to target layout (accept extended ghosting)
-  discret.redistribute(new_row_node_map, new_col_node_map,
-      {.assign_degrees_of_freedom = true,
+  discret.redistribute(
+      {
+          .row_map = new_row_node_map,
+          .col_map = new_col_node_map,
+      },
+      {
+          .assign_degrees_of_freedom = true,
           .init_elements = true,
           .do_boundary_conditions = true,
-          .do_extended_ghosting = true});
+          .do_extended_ghosting = true,
+      });
 
   if (myrank == 0)
     std::cout << "\nparallel redistributed discretization due to point coupling condition(s)"

--- a/src/core/fem/src/discretization/4C_fem_discretization.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization.hpp
@@ -342,6 +342,15 @@ namespace Core::FE
     bool do_extended_ghosting = false;
   };
 
+  /**
+   * This struct is used to bundle row and column maps as arguments.
+   */
+  struct RowColMaps
+  {
+    const Core::LinAlg::Map& row_map;
+    const Core::LinAlg::Map& col_map;
+  };
+
   /*!
   \brief A class to manage a discretization in parallel
 
@@ -1535,48 +1544,28 @@ namespace Core::FE
 
     //! @name Parallel (re)distribution
 
-    /*!
-    \brief Redistribute the discretization according to provided maps
-           (Filled()==NOT true prerequisite)
+    /**
+     * @brief Redistribute the discretization according to provided maps
+     *
+     * This function takes the desired node and element row and column maps and redistributes
+     * the discretization accordingly. For additional options see OptionsRedistribution.
+     *
+     * @post filled()==true
+     */
+    void redistribute(const RowColMaps& node_maps, const RowColMaps& element_maps,
+        OptionsRedistribution options = {});
 
-    Steps taken in this method are:<br>
-    - build element maps (row and column)
-    - do export of row/col nodes and row/col elements
-    - call Fillcomplete(assigndegreesoffreedom,initelements,doboundaryconditions)
+    /**
+     * @brief Redistribute the discretization according to provided maps
+     *
+     * Compared to the other overload, this function only takes node maps and computes the
+     * element maps internally using build_element_row_column(). For additional options see
+     * OptionsRedistribution.
+     *
+     * @post filled()==true
+     */
+    void redistribute(const RowColMaps& node_maps, OptionsRedistribution options = {});
 
-    \param noderowmap (in): new node map the discretization shall have on exit
-    \param nodecolmap (in): new column map the discretization shall have on exit
-    \param options_redistribution (in): options for redistribution
-
-    \note Filled()==true is a prerequisite, Filled()==true on exit
-    */
-    void redistribute(const Core::LinAlg::Map& noderowmap, const Core::LinAlg::Map& nodecolmap,
-        OptionsRedistribution options_redistribution = {});
-
-    /*!
-    \brief Redistribute the discretization according to provided maps
-           (Filled()==NOT true prerequisite)
-
-    \param noderowmap (in): new node map the discretization shall have on exit
-    \param nodecolmap (in): new column map the discretization shall have on exit
-    \param elerowmap  (in): new element row map the discretization shall have on exit
-    \param elecolmap  (in): new element column map the discretization shall have on exit
-
-    \param assigndegreesoffreedom (in) : if true, resets existing dofsets and performs
-                                         assigning of degrees of freedoms to nodes and
-                                         elements.
-    \param initelements           (in) : if true, build element register classes and
-                                         call initialize() on each type of finite element
-                                         present
-    \param doboundaryconditions   (in) : if true, build geometry of boundary conditions
-                                         present.
-
-    \note Filled()==true is a prerequisite, Filled()==true on exit
-    */
-    void redistribute(const Core::LinAlg::Map& noderowmap, const Core::LinAlg::Map& nodecolmap,
-        const Core::LinAlg::Map& elerowmap, const Core::LinAlg::Map& elecolmap,
-        bool assigndegreesoffreedom = true, bool initelements = true,
-        bool doboundaryconditions = true, bool killdofs = true, bool killcond = true);
 
     /*!
       \brief Ghost elements on processors according to provided element column map

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.cpp
@@ -31,13 +31,12 @@ Core::FE::DiscretizationFaces::DiscretizationFaces(
 /*----------------------------------------------------------------------*
  |  Finalize construction (public)                          schott 03/12|
  *----------------------------------------------------------------------*/
-int Core::FE::DiscretizationFaces::fill_complete_faces(bool assigndegreesoffreedom,
-    bool initelements, bool doboundaryconditions, bool createinternalfaces)
+int Core::FE::DiscretizationFaces::fill_complete_faces(
+    OptionsFillComplete options, bool createinternalfaces)
 
 {
   // call standard FillComplete of base class
-  Core::FE::Discretization::fill_complete(
-      assigndegreesoffreedom, initelements, doboundaryconditions);
+  Core::FE::Discretization::fill_complete(options);
 
   if (createinternalfaces)
   {

--- a/src/core/fem/src/discretization/4C_fem_discretization_faces.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_faces.hpp
@@ -155,15 +155,8 @@ namespace Core::FE
     - build internal faces elements
     - build maps and pointers for internal faces
 
-    \param assigndegreesoffreedom (in) : if true, resets existing dofsets and performs
-                                         assigning of degrees of freedoms to nodes and
-                                         elements.
-    \param initelements (in) : if true, build element register classes and call initialize()
-                               on each type of finite element present
-    \param doboundaryconditions (in) : if true, build geometry of boundary conditions
-                                       present.
+    \param options (in) : options struct to set flags for specific tasks
     \param createinternalfaces (in) : if true, build geometry of internal faces.
-    \param createboundaryfaces (in) : if true,
 
     \note In order to receive a fully functional discretization, this method must be called
           with all parameters set to true (the default). The parameters though can be
@@ -173,8 +166,7 @@ namespace Core::FE
 
     \note Sets Filled()=true
     */
-    int fill_complete_faces(bool assigndegreesoffreedom = true, bool initelements = true,
-        bool doboundaryconditions = true, bool createinternalfaces = false);
+    int fill_complete_faces(OptionsFillComplete options, bool createinternalfaces = false);
 
     /*!
     \brief Get flag indicating whether create_internal_faces_extension() has been called

--- a/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_fillcomplete.cpp
@@ -45,8 +45,7 @@ void Core::FE::Discretization::reset(bool killdofs, bool killcond)
 }
 
 
-int Core::FE::Discretization::fill_complete(
-    bool assigndegreesoffreedom, bool initelements, bool doboundaryconditions)
+int Core::FE::Discretization::fill_complete(OptionsFillComplete options)
 {
   // my processor id
   const int myrank = Core::Communication::my_mpi_rank(get_comm());
@@ -63,7 +62,7 @@ int Core::FE::Discretization::fill_complete(
   }
 
   // set all maps to nullptr
-  reset(assigndegreesoffreedom, doboundaryconditions);
+  reset(options.assign_degrees_of_freedom, options.do_boundary_conditions);
 
   // (re)build map of nodes noderowmap_, nodecolmap_, noderowptr and nodecolptr
   build_node_row_map();
@@ -85,7 +84,7 @@ int Core::FE::Discretization::fill_complete(
   filled_ = true;
 
   // Assign degrees of freedom to elements and nodes
-  if (assigndegreesoffreedom)
+  if (options.assign_degrees_of_freedom)
   {
     if (myrank == 0)
     {
@@ -97,7 +96,7 @@ int Core::FE::Discretization::fill_complete(
   }
 
   // call element routines to initialize
-  if (initelements)
+  if (options.init_elements)
   {
     if (myrank == 0)
     {
@@ -109,7 +108,7 @@ int Core::FE::Discretization::fill_complete(
   }
 
   // (Re)build the geometry of the boundary conditions
-  if (doboundaryconditions)
+  if (options.do_boundary_conditions)
   {
     if (myrank == 0)
     {

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.cpp
@@ -31,11 +31,10 @@ Core::FE::DiscretizationHDG::DiscretizationHDG(
 /*----------------------------------------------------------------------*
  |  Finalize construction (public)                     kronbichler 12/13|
  *----------------------------------------------------------------------*/
-int Core::FE::DiscretizationHDG::fill_complete(
-    bool assigndegreesoffreedom, bool initelements, bool doboundaryconditions)
+int Core::FE::DiscretizationHDG::fill_complete(OptionsFillComplete options)
 {
   // call FillCompleteFaces of base class with create_faces set to true
-  this->fill_complete_faces(assigndegreesoffreedom, initelements, doboundaryconditions, true);
+  this->fill_complete_faces(options, true);
 
   // get the correct face orientation from the owner. since the elements in general do not allow
   // packing, extract the node ids, communicate them, and change the node ids in the element

--- a/src/core/fem/src/discretization/4C_fem_discretization_hdg.hpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_hdg.hpp
@@ -85,8 +85,7 @@ namespace Core::FE
 
     \note Sets Filled()=true
     */
-    int fill_complete(bool assigndegreesoffreedom = true, bool initelements = true,
-        bool doboundaryconditions = true) override;
+    int fill_complete(OptionsFillComplete options = {}) override;
 
     /*!
      * this function has the same functionality as the function in the base class,

--- a/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
+++ b/src/core/fem/src/discretization/4C_fem_discretization_partition.cpp
@@ -23,8 +23,7 @@ void Core::FE::Discretization::export_row_nodes(
 
   // destroy all ghosted nodes
   const int myrank = Core::Communication::my_mpi_rank(get_comm());
-  std::map<int, std::shared_ptr<Core::Nodes::Node>>::iterator curr;
-  for (curr = node_.begin(); curr != node_.end();)
+  for (auto curr = node_.begin(); curr != node_.end();)
   {
     if (curr->second->owner() != myrank)
       node_.erase(curr++);
@@ -43,7 +42,7 @@ void Core::FE::Discretization::export_row_nodes(
   exporter.do_export(node_);
 
   // update all ownership flags
-  for (curr = node_.begin(); curr != node_.end(); ++curr) curr->second->set_owner(myrank);
+  for (auto& val : node_ | std::views::values) val->set_owner(myrank);
 
   // maps and pointers are no longer correct and need rebuilding
   reset(killdofs, killcond);
@@ -56,8 +55,7 @@ void Core::FE::Discretization::export_column_nodes(
 {
   // destroy all ghosted nodes
   const int myrank = Core::Communication::my_mpi_rank(get_comm());
-  std::map<int, std::shared_ptr<Core::Nodes::Node>>::iterator curr;
-  for (curr = node_.begin(); curr != node_.end();)
+  for (auto curr = node_.begin(); curr != node_.end();)
   {
     if (curr->second->owner() != myrank)
       node_.erase(curr++);
@@ -193,8 +191,7 @@ void Core::FE::Discretization::export_row_elements(
 
   // destroy all ghosted elements
   const int myrank = Core::Communication::my_mpi_rank(get_comm());
-  std::map<int, std::shared_ptr<Core::Elements::Element>>::iterator curr;
-  for (curr = element_.begin(); curr != element_.end();)
+  for (auto curr = element_.begin(); curr != element_.end();)
   {
     if (curr->second->owner() != myrank)
       element_.erase(curr++);
@@ -228,8 +225,7 @@ void Core::FE::Discretization::export_column_elements(
 {
   // destroy all ghosted elements
   const int myrank = Core::Communication::my_mpi_rank(get_comm());
-  std::map<int, std::shared_ptr<Core::Elements::Element>>::iterator curr;
-  for (curr = element_.begin(); curr != element_.end();)
+  for (auto curr = element_.begin(); curr != element_.end();)
   {
     if (curr->second->owner() != myrank)
       element_.erase(curr++);
@@ -519,44 +515,30 @@ Core::FE::Discretization::build_element_row_column(const Core::LinAlg::Map& node
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Discretization::redistribute(const Core::LinAlg::Map& noderowmap,
-    const Core::LinAlg::Map& nodecolmap, OptionsRedistribution options_redistribution)
+void Core::FE::Discretization::redistribute(
+    const RowColMaps& node_maps, OptionsRedistribution options)
 {
   // build the overlapping and non-overlapping element maps
   const auto& [elerowmap, elecolmap] =
-      build_element_row_column(noderowmap, nodecolmap, options_redistribution.do_extended_ghosting);
+      build_element_row_column(node_maps.row_map, node_maps.col_map, options.do_extended_ghosting);
 
-  // export nodes and elements to the new maps
-  export_row_nodes(noderowmap, options_redistribution.kill_dofs, options_redistribution.kill_cond);
-  export_column_nodes(
-      nodecolmap, options_redistribution.kill_dofs, options_redistribution.kill_cond);
-  export_row_elements(
-      *elerowmap, options_redistribution.kill_dofs, options_redistribution.kill_cond);
-  export_column_elements(
-      *elecolmap, options_redistribution.kill_dofs, options_redistribution.kill_cond);
-
-  // these exports have set Filled()=false as all maps are invalid now
-  int err = fill_complete(options_redistribution.assign_degrees_of_freedom,
-      options_redistribution.init_elements, options_redistribution.do_boundary_conditions);
-
-  if (err) FOUR_C_THROW("fill_complete() returned err={}", err);
+  redistribute(node_maps, {.row_map = *elerowmap, .col_map = *elecolmap}, options);
 }
 
 /*----------------------------------------------------------------------*
  *----------------------------------------------------------------------*/
-void Core::FE::Discretization::redistribute(const Core::LinAlg::Map& noderowmap,
-    const Core::LinAlg::Map& nodecolmap, const Core::LinAlg::Map& elerowmap,
-    const Core::LinAlg::Map& elecolmap, bool assigndegreesoffreedom, bool initelements,
-    bool doboundaryconditions, bool killdofs, bool killcond)
+void Core::FE::Discretization::redistribute(
+    const RowColMaps& node_maps, const RowColMaps& element_maps, OptionsRedistribution options)
 {
   // export nodes and elements to the new maps
-  export_row_nodes(noderowmap, killdofs, killcond);
-  export_column_nodes(nodecolmap, killdofs, killcond);
-  export_row_elements(elerowmap, killdofs, killcond);
-  export_column_elements(elecolmap, killdofs, killcond);
+  export_row_nodes(node_maps.row_map, options.kill_dofs, options.kill_cond);
+  export_column_nodes(node_maps.col_map, options.kill_dofs, options.kill_cond);
+  export_row_elements(element_maps.row_map, options.kill_dofs, options.kill_cond);
+  export_column_elements(element_maps.col_map, options.kill_dofs, options.kill_cond);
 
   // these exports have set Filled()=false as all maps are invalid now
-  int err = fill_complete(assigndegreesoffreedom, initelements, doboundaryconditions);
+  int err = fill_complete(
+      options.assign_degrees_of_freedom, options.init_elements, options.do_boundary_conditions);
 
   if (err) FOUR_C_THROW("fill_complete() returned err={}", err);
 }
@@ -785,7 +767,11 @@ void Core::FE::Discretization::setup_ghosting(
   graph = nullptr;
 
   // Redistribute discretization to match the new maps.
-  redistribute(noderowmap, nodecolmap,
+  redistribute(
+      {
+          .row_map = noderowmap,
+          .col_map = nodecolmap,
+      },
       {.assign_degrees_of_freedom = assigndegreesoffreedom,
           .init_elements = initelements,
           .do_boundary_conditions = doboundaryconditions});

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -200,11 +200,8 @@ void Core::FE::DiscretizationCreatorBase::finalize(
     const Core::FE::Discretization& sourcedis, Core::FE::Discretization& targetdis) const
 {
   // export according to previously filled maps
-  targetdis.export_row_nodes(*targetnoderowmap_);
-  targetdis.export_column_nodes(*targetnodecolmap_);
-  targetdis.export_row_elements(*targetelerowmap_);
-  targetdis.export_column_elements(*targetelecolmap_);
-  targetdis.fill_complete(Core::FE::OptionsFillComplete::none());
+  targetdis.redistribute({*targetnoderowmap_, *targetnodecolmap_},
+      {*targetelerowmap_, *targetelecolmap_}, {.fill_complete = OptionsFillComplete::none()});
 
   // extra work for NURBS discretizations
 

--- a/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
+++ b/src/core/fem/src/general/utils/4C_fem_general_utils_createdis.cpp
@@ -165,7 +165,11 @@ Core::FE::DiscretizationCreatorBase::create_matching_discretization(
   // make auxiliary discretization have the same dofs as the coupling discretization
   if (clonedofs)
     targetdis->replace_dof_set(std::make_shared<Core::DOFSets::IndependentDofSet>(), false);
-  targetdis->fill_complete(assigndegreesoffreedom, initelements, doboundaryconditions);
+  targetdis->fill_complete({
+      .assign_degrees_of_freedom = assigndegreesoffreedom,
+      .init_elements = initelements,
+      .do_boundary_conditions = doboundaryconditions,
+  });
 
   // at the end, we do several checks to ensure that we really have generated
   // an identical discretization
@@ -200,7 +204,7 @@ void Core::FE::DiscretizationCreatorBase::finalize(
   targetdis.export_column_nodes(*targetnodecolmap_);
   targetdis.export_row_elements(*targetelerowmap_);
   targetdis.export_column_elements(*targetelecolmap_);
-  targetdis.fill_complete(false, false, false);
+  targetdis.fill_complete(Core::FE::OptionsFillComplete::none());
 
   // extra work for NURBS discretizations
 

--- a/src/core/fem/src/geometry/4C_fem_geometry_periodic_boundingbox.cpp
+++ b/src/core/fem/src/geometry/4C_fem_geometry_periodic_boundingbox.cpp
@@ -168,7 +168,12 @@ void Core::Geo::MeshFree::BoundingBox::setup_bounding_box_discretization(
   {
     boxdiscret_ = boundingbox_dis;
 
-    if (boxdiscret_->filled() == false) boxdiscret_->fill_complete(true, false, false);
+    if (boxdiscret_->filled() == false)
+      boxdiscret_->fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = false,
+          .do_boundary_conditions = false,
+      });
 
     // create fully overlapping boundingbox discret
     std::shared_ptr<Core::LinAlg::Map> rednodecolmap =
@@ -180,7 +185,11 @@ void Core::Geo::MeshFree::BoundingBox::setup_bounding_box_discretization(
     boxdiscret_->export_column_nodes(*rednodecolmap);
     boxdiscret_->export_column_elements(*redelecolmap);
 
-    boxdiscret_->fill_complete(true, false, false);
+    boxdiscret_->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
   }
 
   if (boundingbox_dis == nullptr or boxdiscret_->num_my_col_elements() == 0)

--- a/src/core/fem/tests/discretization/4C_fem_discretization_nodal_coordinates_test.cpp
+++ b/src/core/fem/tests/discretization/4C_fem_discretization_nodal_coordinates_test.cpp
@@ -32,7 +32,7 @@ namespace
 
       Core::IO::cout.setup(false, false, false, Core::IO::standard, comm_, 0, 0, "dummyFilePrefix");
 
-      test_discretization_->fill_complete(false, false, false);
+      test_discretization_->fill_complete(Core::FE::OptionsFillComplete::none());
     }
 
     void TearDown() override { Core::IO::cout.close(); }

--- a/src/core/fem/tests/discretization/4C_fem_discretization_nodal_coordinates_test.np3.cpp
+++ b/src/core/fem/tests/discretization/4C_fem_discretization_nodal_coordinates_test.np3.cpp
@@ -34,7 +34,7 @@ namespace
 
       Core::IO::cout.setup(false, false, false, Core::IO::standard, comm_, 0, 0, "dummyFilePrefix");
 
-      test_discretization_->fill_complete(false, false, false);
+      test_discretization_->fill_complete(Core::FE::OptionsFillComplete::none());
     }
 
     void TearDown() override { Core::IO::cout.close(); }

--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -184,7 +184,7 @@ void Core::IO::DiscretizationReader::read_mesh(int step)
   dis_->unpack_my_nodes(*nodedata);
   dis_->unpack_my_elements(*elementdata);
 
-  dis_->setup_ghosting(true, false, false);
+  dis_->setup_ghosting({true, false, false});
 
   dis_->fill_complete();
 

--- a/src/core/io/src/4C_io.cpp
+++ b/src/core/io/src/4C_io.cpp
@@ -238,8 +238,7 @@ void Core::IO::DiscretizationReader::read_history_data(int step)
   // so everything should be OK
   dis_->unpack_my_nodes(*nodedata);
   dis_->unpack_my_elements(*elementdata);
-  dis_->redistribute(noderowmap, nodecolmap, elerowmap, elecolmap);
-  return;
+  dis_->redistribute({noderowmap, nodecolmap}, {elerowmap, elecolmap});
 }
 
 /*----------------------------------------------------------------------*/

--- a/src/core/io/src/4C_io_meshreader.cpp
+++ b/src/core/io/src/4C_io_meshreader.cpp
@@ -548,7 +548,7 @@ namespace
         Core::IO::cout << "Complete discretization " << std::left << std::setw(16)
                        << target_discretization.name() << " in...." << Core::IO::flush;
 
-      int err = target_discretization.fill_complete(false, false, false);
+      int err = target_discretization.fill_complete(Core::FE::OptionsFillComplete::none());
       if (err) FOUR_C_THROW("dis_->fill_complete() returned {}", err);
 
       if (!myrank) Core::IO::cout << time.totalElapsedTime(true) << " secs" << Core::IO::endl;

--- a/src/core/rebalance/src/4C_rebalance.cpp
+++ b/src/core/rebalance/src/4C_rebalance.cpp
@@ -51,11 +51,7 @@ do_rebalance_discretization(const Core::LinAlg::Graph& graph,
               *rowmap,
               *colmap,
           },
-          {
-              .assign_degrees_of_freedom = false,
-              .init_elements = false,
-              .do_boundary_conditions = false,
-          });
+          {.fill_complete = Core::FE::OptionsFillComplete::none()});
 
       std::shared_ptr<Core::LinAlg::MultiVector<double>> coordinates =
           discretization.build_node_coordinates();
@@ -81,7 +77,7 @@ do_rebalance_discretization(const Core::LinAlg::Graph& graph,
               *rowmap,
               *colmap,
           },
-          {.do_boundary_conditions = false});
+          {.fill_complete = Core::FE::OptionsFillComplete{.do_boundary_conditions = false}});
 
       std::shared_ptr<const Core::LinAlg::Graph> enriched_graph =
           Core::Rebalance::build_monolithic_node_graph(discretization,
@@ -144,9 +140,7 @@ void Core::Rebalance::rebalance_discretization(Core::FE::Discretization& discret
   if (rebalanceMethod == Core::Rebalance::RebalanceType::monolithic)
     options_redistribution.do_extended_ghosting = true;
 
-  options_redistribution.assign_degrees_of_freedom = false;
-  options_redistribution.init_elements = false;
-  options_redistribution.do_boundary_conditions = false;
+  options_redistribution.fill_complete = FE::OptionsFillComplete::none();
 
   discretization.redistribute({*rowmap, *colmap}, options_redistribution);
 

--- a/src/core/rebalance/src/4C_rebalance.cpp
+++ b/src/core/rebalance/src/4C_rebalance.cpp
@@ -46,10 +46,16 @@ do_rebalance_discretization(const Core::LinAlg::Graph& graph,
       colmap = std::make_shared<Core::LinAlg::Map>(
           -1, graph.col_map().num_my_elements(), graph.col_map().my_global_elements(), 0, comm);
 
-      discretization.redistribute(*rowmap, *colmap,
-          {.assign_degrees_of_freedom = false,
+      discretization.redistribute(
+          {
+              *rowmap,
+              *colmap,
+          },
+          {
+              .assign_degrees_of_freedom = false,
               .init_elements = false,
-              .do_boundary_conditions = false});
+              .do_boundary_conditions = false,
+          });
 
       std::shared_ptr<Core::LinAlg::MultiVector<double>> coordinates =
           discretization.build_node_coordinates();
@@ -70,7 +76,12 @@ do_rebalance_discretization(const Core::LinAlg::Graph& graph,
       colmap = std::make_shared<Core::LinAlg::Map>(
           -1, graph.col_map().num_my_elements(), graph.col_map().my_global_elements(), 0, comm);
 
-      discretization.redistribute(*rowmap, *colmap, {.do_boundary_conditions = false});
+      discretization.redistribute(
+          {
+              *rowmap,
+              *colmap,
+          },
+          {.do_boundary_conditions = false});
 
       std::shared_ptr<const Core::LinAlg::Graph> enriched_graph =
           Core::Rebalance::build_monolithic_node_graph(discretization,
@@ -137,7 +148,7 @@ void Core::Rebalance::rebalance_discretization(Core::FE::Discretization& discret
   options_redistribution.init_elements = false;
   options_redistribution.do_boundary_conditions = false;
 
-  discretization.redistribute(*rowmap, *colmap, options_redistribution);
+  discretization.redistribute({*rowmap, *colmap}, options_redistribution);
 
   print_parallel_distribution(discretization);
 }

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -240,7 +240,7 @@ void Core::Rebalance::match_element_distribution_of_matching_discretizations(
     ////////////////////////////////////////
     // FINISH
     ////////////////////////////////////////
-    int err = dis_to_rebalance.fill_complete(false, false, false);
+    int err = dis_to_rebalance.fill_complete(Core::FE::OptionsFillComplete::none());
 
     if (err) FOUR_C_THROW("fill_complete() returned err={}", err);
 
@@ -523,7 +523,7 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
     ////////////////////////////////////////
     // FINISH
     ////////////////////////////////////////
-    int err = dis_to_rebalance.fill_complete(false, false, false);
+    int err = dis_to_rebalance.fill_complete(Core::FE::OptionsFillComplete::none());
 
     if (err) FOUR_C_THROW("fill_complete() returned err={}", err);
 

--- a/src/core/rebalance/src/4C_rebalance_binning_based.cpp
+++ b/src/core/rebalance/src/4C_rebalance_binning_based.cpp
@@ -230,19 +230,14 @@ void Core::Rebalance::match_element_distribution_of_matching_discretizations(
     ////////////////////////////////////////
     // REBALANCE
     ////////////////////////////////////////
-    // export the nodes
-    dis_to_rebalance.export_row_nodes(rebalanced_noderowmap, false, false);
-    dis_to_rebalance.export_column_nodes(rebalanced_nodecolmap, false, false);
-    // export the elements
-    dis_to_rebalance.export_row_elements(rebalanced_elerowmap, false, false);
-    dis_to_rebalance.export_column_elements(rebalanced_elecolmap, false, false);
 
-    ////////////////////////////////////////
-    // FINISH
-    ////////////////////////////////////////
-    int err = dis_to_rebalance.fill_complete(Core::FE::OptionsFillComplete::none());
-
-    if (err) FOUR_C_THROW("fill_complete() returned err={}", err);
+    dis_to_rebalance.redistribute({rebalanced_noderowmap, rebalanced_nodecolmap},
+        {rebalanced_elerowmap, rebalanced_elecolmap},
+        {
+            .fill_complete = Core::FE::OptionsFillComplete::none(),
+            .kill_dofs = false,
+            .kill_cond = false,
+        });
 
     // print to screen
     Core::Rebalance::print_parallel_distribution(dis_to_rebalance);
@@ -512,20 +507,13 @@ void Core::Rebalance::match_element_distribution_of_matching_conditioned_element
     ////////////////////////////////////////
     // REBALANCE
     ////////////////////////////////////////
-    // export the nodes
-    dis_to_rebalance.export_row_nodes(rebalanced_noderowmap, false, false);
-    dis_to_rebalance.export_column_nodes(rebalanced_nodecolmap, false, false);
-    // export the elements
-    dis_to_rebalance.export_row_elements(rebalanced_elerowmap, false, false);
-    dis_to_rebalance.export_column_elements(rebalanced_elecolmap, false, false);
-
-
-    ////////////////////////////////////////
-    // FINISH
-    ////////////////////////////////////////
-    int err = dis_to_rebalance.fill_complete(Core::FE::OptionsFillComplete::none());
-
-    if (err) FOUR_C_THROW("fill_complete() returned err={}", err);
+    dis_to_rebalance.redistribute({rebalanced_noderowmap, rebalanced_nodecolmap},
+        {rebalanced_elerowmap, rebalanced_elecolmap},
+        {
+            .fill_complete = Core::FE::OptionsFillComplete::none(),
+            .kill_dofs = false,
+            .kill_cond = false,
+        });
 
     // print to screen
     print_parallel_distribution(dis_to_rebalance);

--- a/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
+++ b/src/coupling/src/adapter/4C_coupling_adapter_volmortar.cpp
@@ -184,8 +184,16 @@ void Coupling::Adapter::MortarVolCoupl::create_aux_dofsets(Core::FE::Discretizat
   // 2. dofs 2
   // 3. auxiliary dofs 1
   // 4. auxiliary dofs 2
-  dis1.fill_complete(true, false, false);
-  dis2.fill_complete(true, false, false);
+  dis1.fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  dis2.fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }
 
 /*----------------------------------------------------------------------*

--- a/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
+++ b/src/coupling/src/volmortar/4C_coupling_volmortar.cpp
@@ -1145,8 +1145,16 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
   int dofseta = dis1_->add_dof_set(dofsetaux);
   dofsetaux = std::make_shared<Core::DOFSets::DofSetPredefinedDoFNumber>(dim_, 0, 0, true);
   int dofsetb = dis2_->add_dof_set(dofsetaux);
-  dis1_->fill_complete(true, false, false);
-  dis2_->fill_complete(true, false, false);
+  dis1_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  dis2_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   double omega = 1.0;
   double nu = 0.0;
@@ -1451,8 +1459,16 @@ void Coupling::VolMortar::VolMortarCoupl::mesh_init()
       }
     }
 
-    dis1_->fill_complete(false, true, true);
-    dis2_->fill_complete(false, true, true);
+    dis1_->fill_complete({
+        .assign_degrees_of_freedom = false,
+        .init_elements = true,
+        .do_boundary_conditions = true,
+    });
+    dis2_->fill_complete({
+        .assign_degrees_of_freedom = false,
+        .init_elements = true,
+        .do_boundary_conditions = true,
+    });
 
     // last check:
     std::shared_ptr<Core::LinAlg::Vector<double>> checka =
@@ -1629,8 +1645,16 @@ void Coupling::VolMortar::VolMortarCoupl::perform_cut(
   }
 
   // complete dis
-  sauxdis->fill_complete(true, false, false);
-  mauxdis->fill_complete(true, false, false);
+  sauxdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  mauxdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   //--------------------------------------------------------------------------------------
   // Initialize the cut wizard

--- a/src/ehl/4C_ehl_base.cpp
+++ b/src/ehl/4C_ehl_base.cpp
@@ -187,8 +187,16 @@ void EHL::Base::setup_discretizations(
   // 2. lubrication dofs
   // 3. structure auxiliary dofs
   // 4. lubrication auxiliary dofs
-  structdis->fill_complete(true, false, false);
-  lubricationdis->fill_complete(true, false, false);
+  structdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  lubricationdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }
 
 /*----------------------------------------------------------------------*

--- a/src/elch/4C_elch_dyn.cpp
+++ b/src/elch/4C_elch_dyn.cpp
@@ -88,7 +88,7 @@ void elch_dyn(int restart)
 
       // now me may redistribute or ghost the scatra discretization
       // finalize discretization
-      scatradis->fill_complete(true, true, true);
+      scatradis->fill_complete();
 
       // now we can call init() on the base algorithm
       // scatra time integrator is constructed and initialized inside
@@ -96,7 +96,7 @@ void elch_dyn(int restart)
 
       // now me may redistribute or ghost the scatra discretization
       // finalize discretization
-      scatradis->fill_complete(true, true, true);
+      scatradis->fill_complete();
 
       // only now we must call setup() on the base algorithm.
       // all objects relying on the parallel distribution are
@@ -158,7 +158,7 @@ void elch_dyn(int restart)
       const auto& fdyn = (problem->fluid_dynamic_params());
 
       std::shared_ptr<Core::FE::Discretization> aledis = problem->get_dis("ale");
-      if (!aledis->filled()) aledis->fill_complete(false, false, false);
+      if (!aledis->filled()) aledis->fill_complete(Core::FE::OptionsFillComplete::none());
       // is ALE needed or not?
       const auto withale =
           Teuchos::getIntegralValue<ElCh::ElchMovingBoundary>(elchcontrol, "MOVINGBOUNDARY");
@@ -172,7 +172,11 @@ void elch_dyn(int restart)
           Core::FE::clone_discretization<ALE::Utils::AleCloneStrategy>(
               *fluiddis, *aledis, Global::Problem::instance()->cloning_material_map());
 
-          aledis->fill_complete(true, true, false);
+          aledis->fill_complete({
+              .assign_degrees_of_freedom = true,
+              .init_elements = true,
+              .do_boundary_conditions = false,
+          });
           // setup material in every ALE element
           Teuchos::ParameterList params;
           params.set<std::string>("action", "setup_material");

--- a/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
+++ b/src/fbi/4C_fbi_immersed_geometry_coupler.cpp
@@ -169,7 +169,11 @@ void FBI::FBIGeometryCoupler::extend_beam_ghosting(Core::FE::Discretization& dis
   discretization.export_column_nodes(newnodecolmap);
   discretization.export_column_elements(newelecolmap);
 
-  discretization.fill_complete(true, false, false);
+  discretization.fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }
 
 /*----------------------------------------------------------------------*/
@@ -292,7 +296,7 @@ void FBI::FBIGeometryCoupler::prepare_pair_creation(
     discretizations[1]->export_column_elements(newelecolmap);
 
     std::dynamic_pointer_cast<Core::FE::DiscretizationFaces>(discretizations[1])
-        ->fill_complete_faces(true, true, true, edgebased_fluidstabilization_);
+        ->fill_complete_faces({}, edgebased_fluidstabilization_);
   }
 
   element_senddata.clear();

--- a/src/fbi/4C_fbi_immersed_geometry_coupler_binning.cpp
+++ b/src/fbi/4C_fbi_immersed_geometry_coupler_binning.cpp
@@ -59,7 +59,7 @@ void FBI::FBIBinningGeometryCoupler::partition_geometry(
   binstrategy_->distribute_elements_to_bins_using_ele_aabb(*discretizations[0],
       discretizations[0]->my_row_element_range(), bintoelemap_, structure_displacement);
 
-  binstrategy_->bin_discret()->fill_complete(false, false, false);
+  binstrategy_->bin_discret()->fill_complete(Core::FE::OptionsFillComplete::none());
 
   std::set<int> colbins;
 
@@ -184,7 +184,7 @@ void FBI::FBIBinningGeometryCoupler::set_binning(
     std::shared_ptr<Core::Binstrategy::BinningStrategy> binning)
 {
   binstrategy_ = binning;
-  binstrategy_->bin_discret()->fill_complete(false, false, false);
+  binstrategy_->bin_discret()->fill_complete(Core::FE::OptionsFillComplete::none());
   binrowmap_ =
       std::make_shared<Core::LinAlg::Map>(*(binstrategy_->bin_discret()->element_row_map()));
 };

--- a/src/fluid/4C_fluid_discret_extractor.cpp
+++ b/src/fluid/4C_fluid_discret_extractor.cpp
@@ -254,10 +254,10 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
       printf("| Distribute inflow discretization according to the initial nodemaps");
     }
 
-    childdiscret_->redistribute(*newrownodemap, *newcolnodemap,
-        {.assign_degrees_of_freedom = false,
-            .init_elements = false,
-            .do_boundary_conditions = false});
+    childdiscret_->redistribute(
+        {*newrownodemap, *newcolnodemap}, {.assign_degrees_of_freedom = false,
+                                              .init_elements = false,
+                                              .do_boundary_conditions = false});
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
     {
@@ -354,7 +354,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
         parentdiscret_, true));  // true: parallel
     // and assign the dofs to nodes
     // remark: nothing is redistributed here
-    childdiscret_->redistribute(*newrownodemap, *newcolnodemap,
+    childdiscret_->redistribute({*newrownodemap, *newcolnodemap},
         {.assign_degrees_of_freedom = true, .init_elements = true, .do_boundary_conditions = true});
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
@@ -391,7 +391,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
       std::cout << "| Redistributing .";
     }
     // redistribute accordingly to the adapted rowmap
-    childdiscret_->redistribute(*sepcondrownodes, *sepcondcolnodes,
+    childdiscret_->redistribute({*sepcondrownodes, *sepcondcolnodes},
         {.assign_degrees_of_freedom = false, .init_elements = false});
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)

--- a/src/fluid/4C_fluid_discret_extractor.cpp
+++ b/src/fluid/4C_fluid_discret_extractor.cpp
@@ -255,9 +255,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
     }
 
     childdiscret_->redistribute(
-        {*newrownodemap, *newcolnodemap}, {.assign_degrees_of_freedom = false,
-                                              .init_elements = false,
-                                              .do_boundary_conditions = false});
+        {*newrownodemap, *newcolnodemap}, {.fill_complete = Core::FE::OptionsFillComplete::none()});
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
     {
@@ -354,8 +352,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
         parentdiscret_, true));  // true: parallel
     // and assign the dofs to nodes
     // remark: nothing is redistributed here
-    childdiscret_->redistribute({*newrownodemap, *newcolnodemap},
-        {.assign_degrees_of_freedom = true, .init_elements = true, .do_boundary_conditions = true});
+    childdiscret_->redistribute({*newrownodemap, *newcolnodemap});
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
     {
@@ -392,7 +389,8 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
     }
     // redistribute accordingly to the adapted rowmap
     childdiscret_->redistribute({*sepcondrownodes, *sepcondcolnodes},
-        {.assign_degrees_of_freedom = false, .init_elements = false});
+        {.fill_complete = Core::FE::OptionsFillComplete{
+             .assign_degrees_of_freedom = false, .init_elements = false}});
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
     {
@@ -437,7 +435,7 @@ FLD::FluidDiscretExtractor::FluidDiscretExtractor(std::shared_ptr<Core::FE::Disc
     // call fill_complete() to assign the dof
     // remark: equal redistribute(*newrownodemap,*newcolnodemap,true,true,true) as
     //         it also calls fill_complete() at the end
-    childdiscret_->fill_complete(true, true, true);
+    childdiscret_->fill_complete();
 
     if (Core::Communication::my_mpi_rank(childdiscret_->get_comm()) == 0)
     {

--- a/src/fluid/4C_fluid_xwall.cpp
+++ b/src/fluid/4C_fluid_xwall.cpp
@@ -399,7 +399,7 @@ void FLD::XWall::init_wall_dist()
 
   // do not assign any dofs to save memory
   // only the nodes are needed in this discretization
-  commondis->fill_complete(false, false, false);
+  commondis->fill_complete(Core::FE::OptionsFillComplete::none());
 
   // also build a fully overlapping map of enriched nodes here:
   std::vector<int> colvec;  // node col map
@@ -629,7 +629,7 @@ void FLD::XWall::setup_x_wall_dis()
       std::make_shared<Core::DOFSets::TransparentDofSet>(discret_, parallel);
 
   xwdiscret_->replace_dof_set(newdofset);
-  xwdiscret_->fill_complete(true, true, true);
+  xwdiscret_->fill_complete();
 
   // redistribute and treat periodic bc if parallel
   if (parallel)
@@ -650,12 +650,13 @@ void FLD::XWall::setup_x_wall_dis()
 
     // rebuild of the system with new maps
     xwdiscret_->redistribute(
-        {*rownodes, *colnodes}, {.assign_degrees_of_freedom = false, .init_elements = false});
+        {*rownodes, *colnodes}, {.fill_complete = Core::FE::OptionsFillComplete{
+                                     .assign_degrees_of_freedom = false, .init_elements = false}});
 
     Core::Conditions::PeriodicBoundaryConditions pbc(xwdiscret_, false);
     pbc.update_dofs_for_periodic_boundary_conditions();
     xwdiscret_->replace_dof_set(newdofset);
-    xwdiscret_->fill_complete(true, true, true);
+    xwdiscret_->fill_complete();
   }
 
   return;

--- a/src/fluid/4C_fluid_xwall.cpp
+++ b/src/fluid/4C_fluid_xwall.cpp
@@ -650,7 +650,7 @@ void FLD::XWall::setup_x_wall_dis()
 
     // rebuild of the system with new maps
     xwdiscret_->redistribute(
-        *rownodes, *colnodes, {.assign_degrees_of_freedom = false, .init_elements = false});
+        {*rownodes, *colnodes}, {.assign_degrees_of_freedom = false, .init_elements = false});
 
     Core::Conditions::PeriodicBoundaryConditions pbc(xwdiscret_, false);
     pbc.update_dofs_for_periodic_boundary_conditions();

--- a/src/fluid_xfluid/4C_fluid_xfluid.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid.cpp
@@ -117,7 +117,11 @@ void FLD::XFluid::add_additional_scalar_dofset_and_coupling()
         "!= 1?");
 
   // assign degrees of freedom (as a new dofset has been added!)
-  xdiscret_->fill_complete(true, false, false);
+  xdiscret_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   xdiscret_->get_dof_set_proxy()->print_all_dofsets(xdiscret_->get_comm());
 

--- a/src/fluid_xfluid/4C_fluid_xfluid_state_creator.cpp
+++ b/src/fluid_xfluid/4C_fluid_xfluid_state_creator.cpp
@@ -206,7 +206,11 @@ void FLD::XFluidStateCreator::create_new_cut_state(
   dofset->set_min_gid(minnumdofsets_);         // set the minimal GID of xfem dis
   xdiscret->replace_dof_set(0, dofset, true);  // fluid dofset has nds = 0
 
-  xdiscret->fill_complete(true, false, false);
+  xdiscret->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // print all dofsets
   xdiscret->get_dof_set_proxy()->print_all_dofsets(xdiscret->get_comm());

--- a/src/fpsi/4C_fpsi_monolithic.cpp
+++ b/src/fpsi/4C_fpsi_monolithic.cpp
@@ -90,7 +90,11 @@ FPSI::MonolithicBase::MonolithicBase(MPI_Comm comm, const Teuchos::ParameterList
   {
     FOUR_C_THROW("unexpected numbers of dofsets in fluid field");
   }
-  fluid_field()->discretization()->fill_complete(true, false, false);
+  fluid_field()->discretization()->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }  // MonolithicBase
 /*----------------------------------------------------------------------*/
 /*----------------------------------------------------------------------*/

--- a/src/fpsi/4C_fpsi_utils.cpp
+++ b/src/fpsi/4C_fpsi_utils.cpp
@@ -117,8 +117,8 @@ std::shared_ptr<FPSI::FpsiBase> FPSI::InterfaceUtils::setup_discretizations(MPI_
   }
 
 
-  fluiddis->fill_complete(true, true, true);
-  aledis->fill_complete(true, true, true);
+  fluiddis->fill_complete();
+  aledis->fill_complete();
 
   // 3.- Create ALE elements if the ale discretization is empty
   if (aledis->num_global_nodes() == 0)  // ALE discretization still empty

--- a/src/fs3i/4C_fs3i_biofilm_fsi.cpp
+++ b/src/fs3i/4C_fs3i_biofilm_fsi.cpp
@@ -803,7 +803,11 @@ void FS3I::BiofilmFSI::struct_ale_solve()
       ale_to_struct_field(ale_->write_access_dispnp());
   std::shared_ptr<Core::FE::Discretization> structdis = fsi_->structure_field()->discretization();
   Core::Geo::update_reference_config_with_disp(*structdis, *structdisp);
-  structdis->fill_complete(false, true, true);
+  structdis->fill_complete({
+      .assign_degrees_of_freedom = false,
+      .init_elements = true,
+      .do_boundary_conditions = true,
+  });
 
   // change nodes reference position also for the struct ale field
   Core::Geo::update_reference_config_with_disp(*structaledis, *ale_->write_access_dispnp());

--- a/src/fs3i/4C_fs3i_partitioned.cpp
+++ b/src/fs3i/4C_fs3i_partitioned.cpp
@@ -221,10 +221,26 @@ void FS3I::PartFS3I::init()
   if (not(volume_coupling_objects_.size() == 2))
     FOUR_C_THROW("Unexpected size of volmortar object vector!");
 
-  fluiddis->fill_complete(true, false, false);
-  structdis->fill_complete(true, false, false);
-  fluidscatradis->fill_complete(true, false, false);
-  structscatradis->fill_complete(true, false, false);
+  fluiddis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  structdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  fluidscatradis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  structscatradis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // Note: in the scatra fields we have now the following dof-sets:
   // structure dofset 0: structure dofset
@@ -362,8 +378,16 @@ std::shared_ptr<Coupling::Adapter::MortarVolCoupl> FS3I::PartFS3I::create_vol_mo
   // 2. scatra dofs
   // 3. structure auxiliary dofs
   // 4. scatra auxiliary dofs
-  masterdis->fill_complete(true, false, false);
-  slavedis->fill_complete(true, false, false);
+  masterdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  slavedis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
 
   // Scheme: non matching meshes --> volumetric mortar coupling...

--- a/src/fsi/src/4C_fsi_dyn.cpp
+++ b/src/fsi/src/4C_fsi_dyn.cpp
@@ -261,7 +261,7 @@ void fsi_immersed_drt()
 
   if (structdis->has_condition("PointCoupling"))
   {
-    structdis->fill_complete(false, false, false);
+    structdis->fill_complete(Core::FE::OptionsFillComplete::none());
     Teuchos::ParameterList binning_params = Global::Problem::instance()->binning_strategy_params();
     Core::Utils::add_enum_class_to_parameter_list<Core::FE::ShapeFunctionType>(
         "spatial_approximation_type", Global::Problem::instance()->spatial_approximation_type(),
@@ -400,7 +400,7 @@ void fsi_ale_drt()
 
   if (structdis->has_condition("PointCoupling"))
   {
-    structdis->fill_complete(false, false, false);
+    structdis->fill_complete(Core::FE::OptionsFillComplete::none());
     Teuchos::ParameterList binning_params = Global::Problem::instance()->binning_strategy_params();
     Core::Utils::add_enum_class_to_parameter_list<Core::FE::ShapeFunctionType>(
         "spatial_approximation_type", Global::Problem::instance()->spatial_approximation_type(),
@@ -720,7 +720,7 @@ void xfsi_drt()
     aledis = problem->get_dis("ale");
     if (aledis == nullptr) FOUR_C_THROW("XFSI DYNAMIC: ALE discretization empty!!!");
 
-    aledis->fill_complete(true, true, true);
+    aledis->fill_complete();
 
     // Create ALE elements if the ale discretization is empty
     if (aledis->num_global_nodes() == 0)  // ALE discretization still empty
@@ -873,7 +873,7 @@ void xfpsi_drt()
     aledis = problem->get_dis("ale");
     if (aledis == nullptr) FOUR_C_THROW("Ale discretization empty!");
 
-    aledis->fill_complete(true, true, true);
+    aledis->fill_complete();
 
     // 3.- Create ALE elements if the ale discretization is empty
     if (aledis->num_global_nodes() == 0)  // ALE discretization still empty

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_mortarmonolithic_structuresplit.cpp
@@ -296,7 +296,11 @@ void FSI::MortarMonolithicStructureSplit::setup_system()
     {
       // mesh_init possibly modifies reference configuration of slave side --> recompute element
       // volume in initialize_elements()
-      structure_field()->discretization()->fill_complete(false, true, true);
+      structure_field()->discretization()->fill_complete({
+          .assign_degrees_of_freedom = false,
+          .init_elements = true,
+          .do_boundary_conditions = true,
+      });
       // set up sliding ale utils
       slideale_ = std::make_shared<FSI::Utils::SlideAleUtils>(structure_field()->discretization(),
           fluid_field()->discretization(), *coupsfm_, false, aleproj_);

--- a/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
+++ b/src/fsi/src/monolithic/model_evaluator/4C_fsi_slidingmonolithic_structuresplit.cpp
@@ -294,7 +294,11 @@ void FSI::SlidingMonolithicStructureSplit::setup_system()
     {
       // mesh_init possibly modifies reference configuration of slave side --> recompute element
       // volume in initialize_elements()
-      structure_field()->discretization()->fill_complete(false, true, true);
+      structure_field()->discretization()->fill_complete({
+          .assign_degrees_of_freedom = false,
+          .init_elements = true,
+          .do_boundary_conditions = true,
+      });
       // set up sliding ale utils
       slideale_ = std::make_shared<FSI::Utils::SlideAleUtils>(structure_field()->discretization(),
           fluid_field()->discretization(), *coupsfm_, false, aleproj_);

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -1722,7 +1722,7 @@ void Global::read_knots(Global::Problem& problem, Core::IO::InputFile& input)
       // vector values
       if (!dis->filled())
       {
-        dis->fill_complete(false, false, false);
+        dis->fill_complete(Core::FE::OptionsFillComplete::none());
       }
 
       // the smallest gid in the discretisation determines the access

--- a/src/global_data/4C_global_data_read.cpp
+++ b/src/global_data/4C_global_data_read.cpp
@@ -917,7 +917,7 @@ void Global::read_micro_fields(Global::Problem& problem, const std::filesystem::
         Core::Rebalance::rebalance_node_maps(*nodeGraph, rebalanceParams, nodeWeights, edgeWeights);
 
     // rebuild the discretization with new maps
-    macro_dis->redistribute(*rownodes, *colnodes);
+    macro_dis->redistribute({*rownodes, *colnodes});
   }
 
   // make sure that we read the micro discretizations only on the processors on

--- a/src/lubrication/src/4C_lubrication_dyn.cpp
+++ b/src/lubrication/src/4C_lubrication_dyn.cpp
@@ -55,7 +55,11 @@ void lubrication_dyn(int restart)
     FOUR_C_THROW("lub discretization has illegal number of dofsets!");
 
   // finalize discretization
-  lubricationdis->fill_complete(true, false, false);
+  lubricationdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // get linear solver id from LUBRICATION DYNAMIC
   const int linsolvernumber = lubricationdyn.get<int>("LINEAR_SOLVER");

--- a/src/mat/4C_mat_scatra_multiscale_gp.cpp
+++ b/src/mat/4C_mat_scatra_multiscale_gp.cpp
@@ -210,7 +210,11 @@ void Mat::ScatraMultiScaleGP::init()
       FOUR_C_THROW("Micro-scale discretization has illegal number of dofsets!");
 
     // finalize discretization
-    microdis->fill_complete(true, false, false);
+    microdis->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
 
     // get solver number
     const int linsolvernumber = sdyn_micro->get<int>("LINEAR_SOLVER");

--- a/src/mortar/src/4C_mortar_interface.cpp
+++ b/src/mortar/src/4C_mortar_interface.cpp
@@ -563,7 +563,7 @@ void Mortar::Interface::fill_complete(
     discret().replace_dof_set(mrtrdofset);
     // do not assign dofs yet, we'll do this below after
     // shuffling around of nodes and elements (saves time)
-    discret().fill_complete(false, false, false);
+    discret().fill_complete(Core::FE::OptionsFillComplete::none());
   }
 
   // check whether crosspoints / edge nodes shall be considered or not
@@ -587,7 +587,11 @@ void Mortar::Interface::fill_complete(
       output_control, spatial_approximation_type);
 
   // make sure discretization is complete
-  discret().fill_complete(isFinalParallelDistribution, false, false);
+  discret().fill_complete({
+      .assign_degrees_of_freedom = isFinalParallelDistribution,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // ghost also parent elements according to the ghosting strategy of the interface (atm just for
   // poro)
@@ -1504,7 +1508,11 @@ void Mortar::Interface::extend_interface_ghosting(const bool isFinalParallelDist
        * initialization of elements, if we know, that the discretization will be redistributed
        * again.
        */
-      discret().fill_complete(false, isFinalParallelDistribution, false);
+      discret().fill_complete({
+          .assign_degrees_of_freedom = false,
+          .init_elements = isFinalParallelDistribution,
+          .do_boundary_conditions = false,
+      });
 
       // Create the binning strategy
       std::shared_ptr<Core::Binstrategy::BinningStrategy> binningstrategy = setup_binning_strategy(

--- a/src/mortar/src/4C_mortar_interface.cpp
+++ b/src/mortar/src/4C_mortar_interface.cpp
@@ -1213,13 +1213,8 @@ void Mortar::Interface::redistribute()
     // (note that nothing is actually redistributed in here)
     auto const& [roweles, coleles] = discret().build_element_row_column(*rownodes, *colnodes);
 
-    // export nodes and elements to the row map
-    discret().export_row_nodes(*rownodes);
-    discret().export_row_elements(*roweles);
-
-    // export nodes and elements to the column map (create ghosting)
-    discret().export_column_nodes(*colnodes);
-    discret().export_column_elements(*coleles);
+    discret().redistribute(
+        {*rownodes, *colnodes}, {*roweles, *coleles}, {.fill_complete = std::nullopt});
   }
 }
 

--- a/src/particle_wall/4C_particle_wall.cpp
+++ b/src/particle_wall/4C_particle_wall.cpp
@@ -607,7 +607,11 @@ void PARTICLEWALL::WallHandlerDiscretCondition::init_wall_discretization()
   walldiscretization_->replace_dof_set(newdofset);
 
   // finalize wall discretization construction
-  walldiscretization_->fill_complete(true, false, false);
+  walldiscretization_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }
 
 void PARTICLEWALL::WallHandlerDiscretCondition::setup_wall_discretization() const
@@ -755,7 +759,11 @@ void PARTICLEWALL::WallHandlerBoundingBox::init_wall_discretization()
   walldiscretization_->export_column_elements(*elecolmap);
 
   // finalize wall discretization construction
-  walldiscretization_->fill_complete(true, false, false);
+  walldiscretization_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }
 
 void PARTICLEWALL::WallHandlerBoundingBox::setup_wall_discretization() const

--- a/src/poroelast/4C_poroelast_base.cpp
+++ b/src/poroelast/4C_poroelast_base.cpp
@@ -537,8 +537,8 @@ void PoroElast::PoroBase::replace_dof_sets()
     structdis->replace_dof_set(1, fluiddofsetproxy);
   }
 
-  fluiddis->fill_complete(true, true, true);
-  structdis->fill_complete(true, true, true);
+  fluiddis->fill_complete();
+  structdis->fill_complete();
 
   // for the new time integration setup() has to be called after structdis->fill_complete to make
   // sure all pointers connected to structdis are updated

--- a/src/poroelast/4C_poroelast_utils.cpp
+++ b/src/poroelast/4C_poroelast_utils.cpp
@@ -247,7 +247,7 @@ void PoroElast::Utils::create_volume_ghosting(Core::FE::Discretization& idiscret
   // 4 In case we use
   std::shared_ptr<Core::FE::DiscretizationFaces> facediscret =
       std::dynamic_pointer_cast<Core::FE::DiscretizationFaces>(voldis[1]);
-  if (facediscret != nullptr) facediscret->fill_complete_faces(true, true, true, true);
+  if (facediscret != nullptr) facediscret->fill_complete_faces({}, true);
 }
 
 void PoroElast::Utils::reconnect_parent_pointers(Core::FE::Discretization& idiscret,

--- a/src/poroelast/4C_poroelast_utils_setup.hpp
+++ b/src/poroelast/4C_poroelast_utils_setup.hpp
@@ -151,8 +151,16 @@ namespace PoroElast
         // 2. fluiddis dofs
         // 3. structure auxiliary dofs
         // 4. fluiddis auxiliary dofs
-        structdis->fill_complete(true, false, false);
-        fluiddis->fill_complete(true, false, false);
+        structdis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
+        fluiddis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
       }
     }
   }  // namespace Utils

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils.cpp
@@ -202,7 +202,7 @@ void PoroElastScaTra::Utils::create_volume_ghosting(Core::FE::Discretization& id
   // 4 In case we use
   std::shared_ptr<Core::FE::DiscretizationFaces> facediscret =
       std::dynamic_pointer_cast<Core::FE::DiscretizationFaces>(voldis[1]);
-  if (facediscret != nullptr) facediscret->fill_complete_faces(true, true, true, true);
+  if (facediscret != nullptr) facediscret->fill_complete_faces({}, true);
 }
 
 FOUR_C_NAMESPACE_CLOSE

--- a/src/poroelast_scatra/4C_poroelast_scatra_utils_setup.hpp
+++ b/src/poroelast_scatra/4C_poroelast_scatra_utils_setup.hpp
@@ -148,9 +148,21 @@ namespace PoroElastScaTra
         // 2. fluiddis dofs
         // 3. scatradis dofs
         // 4. auxiliary dofs
-        structdis->fill_complete(true, false, false);
-        fluiddis->fill_complete(true, false, false);
-        scatradis->fill_complete(true, false, false);
+        structdis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
+        fluiddis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
+        scatradis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
       }
     }
   }  // namespace Utils

--- a/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
+++ b/src/porofluid_pressure_based/4C_porofluid_pressure_based_utils.cpp
@@ -298,7 +298,11 @@ PoroPressureBased::create_fully_overlapping_artery_discretization(
 
   // ghost on all procs.
   Core::Rebalance::ghost_discretization_on_all_procs(*artsearchdis);
-  artsearchdis->fill_complete(false, false, doboundaryconditions);
+  artsearchdis->fill_complete({
+      .assign_degrees_of_freedom = false,
+      .init_elements = false,
+      .do_boundary_conditions = doboundaryconditions,
+  });
 
   return artsearchdis;
 }

--- a/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
+++ b/src/porofluid_pressure_based_elast_scatra/4C_porofluid_pressure_based_elast_scatra_utils.cpp
@@ -205,9 +205,21 @@ PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast_scat
   ndsporofluid_scatra = fluiddis->add_dof_set(scatradofset);
   if (ndsporofluid_scatra != 3) FOUR_C_THROW("unexpected dof sets in fluid field");
 
-  structdis->fill_complete(true, false, false);
-  fluiddis->fill_complete(true, false, false);
-  scatradis->fill_complete(true, false, false);
+  structdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  fluiddis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  scatradis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   std::map<int, std::set<int>> nearby_ele_pairs;
   if (artery_coupl)
@@ -248,7 +260,11 @@ PoroPressureBased::setup_discretizations_and_field_coupling_porofluid_elast_scat
     if (artdis->add_dof_set(artscatradofset) != 2)
       FOUR_C_THROW("unexpected dof sets in artery field");
 
-    artscatradis->fill_complete(true, false, false);
+    artscatradis->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
   }
 
   return nearby_ele_pairs;

--- a/src/post/4C_post_common.cpp
+++ b/src/post/4C_post_common.cpp
@@ -544,9 +544,9 @@ void PostProblem::read_meshes()
           }
 
           if (Core::Communication::num_mpi_ranks(nurbsdis->get_comm()) != 1)
-            nurbsdis->setup_ghosting(false, false, false);
+            nurbsdis->setup_ghosting(Core::FE::OptionsFillComplete::none());
           else
-            nurbsdis->fill_complete(false, false, false);
+            nurbsdis->fill_complete(Core::FE::OptionsFillComplete::none());
 
 
           if (!(nurbsdis->filled()))
@@ -569,7 +569,7 @@ void PostProblem::read_meshes()
         {
           // setup of parallel layout: create ghosting of already distributed nodes+elems
           if (Core::Communication::num_mpi_ranks(currfield.discretization()->get_comm()) != 1)
-            currfield.discretization()->setup_ghosting(true, true, true);
+            currfield.discretization()->setup_ghosting();
           else
             currfield.discretization()->fill_complete();
 

--- a/src/red_airways/4C_red_airways_implicitintegration.cpp
+++ b/src/red_airways/4C_red_airways_implicitintegration.cpp
@@ -106,7 +106,7 @@ Airway::RedAirwayImplicitTimeInt::RedAirwayImplicitTimeInt(
 
     // make search discret fully overlapping on all procs
     Core::Rebalance::ghost_discretization_on_all_procs(*discret_);
-    discret_->fill_complete(false, false, false);
+    discret_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     // Get elements and nodes that need to be ghosted to have correct neighbor search
     // independent of number of procs

--- a/src/scatra/4C_scatra_dyn.cpp
+++ b/src/scatra/4C_scatra_dyn.cpp
@@ -62,8 +62,8 @@ void scatra_dyn(int restart)
 
   // ensure that all dofs are assigned in the right order;
   // this creates dof numbers with fluid dof < scatra dof
-  fluiddis->fill_complete(true, true, true);
-  scatradis->fill_complete(true, true, true);
+  fluiddis->fill_complete();
+  scatradis->fill_complete();
 
   // determine coupling type
   const auto fieldcoupling = Teuchos::getIntegralValue<Inpar::ScaTra::FieldCoupling>(
@@ -136,7 +136,11 @@ void scatra_dyn(int restart)
       creator.copy_conditions(*scatradis, *scatradis, conditions_to_copy);
 
       // finalize discretization
-      scatradis->fill_complete(true, false, true);
+      scatradis->fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = false,
+          .do_boundary_conditions = true,
+      });
 
       // now we can call init() on the base algo.
       // time integrator is initialized inside
@@ -160,7 +164,11 @@ void scatra_dyn(int restart)
       }
 
       // assign degrees of freedom and rebuild geometries
-      scatradis->fill_complete(true, false, true);
+      scatradis->fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = false,
+          .do_boundary_conditions = true,
+      });
 
       // now we must call setup()
       scatraonly.setup();
@@ -244,8 +252,8 @@ void scatra_dyn(int restart)
         creator.copy_conditions(*scatradis, *scatradis, conditions_to_copy);
 
         // build the element and node maps
-        scatradis->fill_complete(false, false, false);
-        fluiddis->fill_complete(false, false, false);
+        scatradis->fill_complete(Core::FE::OptionsFillComplete::none());
+        fluiddis->fill_complete(Core::FE::OptionsFillComplete::none());
 
         // build auxiliary dofsets, i.e. pseudo dofs on each discretization
         const int ndofpernode_scatra = scatradis->num_dof(0, scatradis->l_row_node(0));
@@ -271,8 +279,16 @@ void scatra_dyn(int restart)
         // 2. scatra dofs
         // 3. fluid auxiliary dofs
         // 4. scatra auxiliary dofs
-        fluiddis->fill_complete(true, false, false);
-        scatradis->fill_complete(true, false, false);
+        fluiddis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
+        scatradis->fill_complete({
+            .assign_degrees_of_freedom = true,
+            .init_elements = false,
+            .do_boundary_conditions = false,
+        });
       }
 
       // init algo (init fluid time integrator and scatra time integrator inside)
@@ -298,8 +314,16 @@ void scatra_dyn(int restart)
 
       // ensure that all dofs are assigned in the right order;
       // this creates dof numbers with fluid dof < scatra dof
-      fluiddis->fill_complete(true, false, true);
-      scatradis->fill_complete(true, false, true);
+      fluiddis->fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = false,
+          .do_boundary_conditions = true,
+      });
+      scatradis->fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = false,
+          .do_boundary_conditions = true,
+      });
 
       // setup algo
       //(setup fluid time integrator and scatra time integrator inside)

--- a/src/scatra/4C_scatra_timint_elch_scl.cpp
+++ b/src/scatra/4C_scatra_timint_elch_scl.cpp
@@ -1071,7 +1071,7 @@ void ScaTra::ScaTraTimIntElchSCL::redistribute_micro_discretization()
   Core::LinAlg::Map new_node_col_map(
       -1, static_cast<int>(my_col_nodes.size()), my_col_nodes.data(), 0, micro_dis->get_comm());
 
-  micro_dis->redistribute(new_node_row_map, new_node_col_map);
+  micro_dis->redistribute({new_node_row_map, new_node_col_map});
 }
 
 /*----------------------------------------------------------------------*

--- a/src/scatra/4C_scatra_timint_heterogeneous_reaction_strategy.cpp
+++ b/src/scatra/4C_scatra_timint_heterogeneous_reaction_strategy.cpp
@@ -100,7 +100,11 @@ void ScaTra::HeterogeneousReactionStrategy::setup_meshtying()
       scatratimint_->discretization()->name(), com, Global::Problem::instance()->n_dim());
 
   // call complete without assigning degrees of freedom
-  discret_->fill_complete(false, true, false);
+  discret_->fill_complete({
+      .assign_degrees_of_freedom = false,
+      .init_elements = true,
+      .do_boundary_conditions = false,
+  });
 
   std::shared_ptr<Core::FE::Discretization> scatradis = scatratimint_->discretization();
 
@@ -152,7 +156,7 @@ void ScaTra::HeterogeneousReactionStrategy::setup_meshtying()
     }
 
     // done. Rebuild all maps and boundary condition geometries
-    discret_->fill_complete(true, true, true);
+    discret_->fill_complete();
 
     if (Core::Communication::my_mpi_rank(com) == 0 and Core::Communication::num_mpi_ranks(com) > 1)
       std::cout << "parallel distribution of auxiliary discr. with standard ghosting" << std::endl;

--- a/src/ssi/4C_ssi_coupling.cpp
+++ b/src/ssi/4C_ssi_coupling.cpp
@@ -224,8 +224,16 @@ void SSI::SSICouplingNonMatchingBoundary::init(const int ndim,
   // 2. scatra dofs
   // 3. structure auxiliary dofs
   // 4. scatra auxiliary dofs
-  structdis_->fill_complete(true, false, false);
-  scatradis_->fill_complete(true, false, false);
+  structdis_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  scatradis_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // setup mortar adapter for surface volume coupling
   adaptermeshtying_ = std::make_shared<Coupling::Adapter::CouplingMortar>(
@@ -351,8 +359,16 @@ void SSI::SSICouplingNonMatchingVolume::init(const int ndim,
   // 2. scatra dofs
   // 3. structure auxiliary dofs
   // 4. scatra auxiliary dofs
-  structdis->fill_complete(true, false, false);
-  scatradis->fill_complete(true, false, false);
+  structdis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
+  scatradis->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 
   // Scheme: non matching meshes --> volumetric mortar coupling...
   volcoupl_structurescatra_ = std::make_shared<Coupling::Adapter::MortarVolCoupl>();

--- a/src/ssi/4C_ssi_dyn.cpp
+++ b/src/ssi/4C_ssi_dyn.cpp
@@ -92,9 +92,9 @@ void ssi_drt()
     }
 
     // 3.1.1 initial fill_complete
-    problem->get_dis("structure")->fill_complete(true, true, true);
-    problem->get_dis("scatra")->fill_complete(true, true, true);
-    if (is_scatra_manifold) problem->get_dis("scatra_manifold")->fill_complete(true, true, true);
+    problem->get_dis("structure")->fill_complete();
+    problem->get_dis("scatra")->fill_complete();
+    if (is_scatra_manifold) problem->get_dis("scatra_manifold")->fill_complete();
 
     // 3.1.2 init the chosen ssi algorithm
     // Construct time integrators of subproblems inside.
@@ -103,9 +103,19 @@ void ssi_drt()
     // now we can finally fill our discretizations
     // reinitialization of the structural elements is
     // vital for parallelization here!
-    problem->get_dis("structure")->fill_complete(true, true, true);
-    problem->get_dis("scatra")->fill_complete(true, false, true);
-    if (is_scatra_manifold) problem->get_dis("scatra_manifold")->fill_complete(true, false, true);
+    problem->get_dis("structure")->fill_complete();
+    problem->get_dis("scatra")->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = true,
+    });
+    if (is_scatra_manifold)
+      problem->get_dis("scatra_manifold")
+          ->fill_complete({
+              .assign_degrees_of_freedom = true,
+              .init_elements = false,
+              .do_boundary_conditions = true,
+          });
 
     Core::Rebalance::print_parallel_distribution(*problem->get_dis("structure"));
     Core::Rebalance::print_parallel_distribution(*problem->get_dis("scatra"));

--- a/src/ssti/4C_ssti_algorithm.cpp
+++ b/src/ssti/4C_ssti_algorithm.cpp
@@ -60,9 +60,9 @@ void SSTI::SSTIAlgorithm::init(MPI_Comm comm, const Teuchos::ParameterList& ssti
   // get the global problem
   Global::Problem* problem = Global::Problem::instance();
 
-  problem->get_dis("structure")->fill_complete(true, true, true);
-  problem->get_dis("scatra")->fill_complete(true, true, true);
-  problem->get_dis("thermo")->fill_complete(true, true, true);
+  problem->get_dis("structure")->fill_complete();
+  problem->get_dis("scatra")->fill_complete();
+  problem->get_dis("thermo")->fill_complete();
 
   // clone scatra discretization from structure discretization first. Afterwards, clone thermo
   // discretization from scatra discretization
@@ -137,9 +137,17 @@ void SSTI::SSTIAlgorithm::init(MPI_Comm comm, const Teuchos::ParameterList& ssti
   // now we can finally fill our discretizations
   // reinitialization of the structural elements is
   // vital for parallelization here!
-  problem->get_dis("structure")->fill_complete(true, true, true);
-  problem->get_dis("scatra")->fill_complete(true, false, true);
-  problem->get_dis("thermo")->fill_complete(true, false, true);
+  problem->get_dis("structure")->fill_complete();
+  problem->get_dis("scatra")->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = true,
+  });
+  problem->get_dis("thermo")->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = true,
+  });
 
   isinit_ = true;
 }

--- a/src/structure/4C_structure_timint.cpp
+++ b/src/structure/4C_structure_timint.cpp
@@ -1790,7 +1790,7 @@ void Solid::TimInt::set_restart_state(std::shared_ptr<Core::LinAlg::Vector<doubl
   // so everything should be OK
   discret_->unpack_my_nodes(*nodedata);
   discret_->unpack_my_elements(*elementdata);
-  discret_->redistribute(noderowmap, nodecolmap);
+  discret_->redistribute({noderowmap, nodecolmap});
 }
 /*----------------------------------------------------------------------*/
 /* Read and set restart values for constraints */

--- a/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
+++ b/src/structure_new/src/utils/4C_structure_new_monitor_dbc.cpp
@@ -55,7 +55,11 @@ void Solid::MonitorDbc::init(const std::shared_ptr<Solid::TimeInt::BaseDataIO>& 
     create_reaction_force_condition(*tagged_cond, discret);
 
   // build geometry
-  discret.fill_complete(false, false, true);
+  discret.fill_complete({
+      .assign_degrees_of_freedom = false,
+      .init_elements = false,
+      .do_boundary_conditions = true,
+  });
 
   discret_ptr_ = &discret;
   gstate_ptr_ = &gstate;

--- a/src/tsi/4C_tsi_utils.cpp
+++ b/src/tsi/4C_tsi_utils.cpp
@@ -124,7 +124,7 @@ void TSI::Utils::setup_tsi(MPI_Comm comm)
     structdis->fill_complete();
     Core::LinAlg::Map nc = *(structdis->node_col_map());
     Core::LinAlg::Map nr = *(structdis->node_row_map());
-    structdis->redistribute(nr, nc);
+    structdis->redistribute({nr, nc});
   }
 
   // access the thermo discretization

--- a/src/tsi/4C_tsi_utils.cpp
+++ b/src/tsi/4C_tsi_utils.cpp
@@ -184,8 +184,8 @@ void TSI::Utils::setup_tsi(MPI_Comm comm)
     if (structdis->add_dof_set(thermodofset) != 1)
       FOUR_C_THROW("unexpected dof sets in structure field");
 
-    structdis->fill_complete(true, true, true);
-    thermdis->fill_complete(true, true, true);
+    structdis->fill_complete();
+    thermdis->fill_complete();
 
     TSI::Utils::set_material_pointers_matching_grid(*structdis, *thermdis);
   }
@@ -221,8 +221,16 @@ void TSI::Utils::setup_tsi(MPI_Comm comm)
     // 2. thermo dofs
     // 3. structure auxiliary dofs
     // 4. thermo auxiliary dofs
-    structdis->fill_complete(true, false, false);
-    thermdis->fill_complete(true, false, false);
+    structdis->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
+    thermdis->fill_complete({
+        .assign_degrees_of_freedom = true,
+        .init_elements = false,
+        .do_boundary_conditions = false,
+    });
   }
 
 }  // setup_tsi()

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -583,10 +583,10 @@ void XFEM::MeshVolCoupling::create_auxiliary_discretization()
     newnodecolmap = std::make_shared<Core::LinAlg::Map>(
         -1, colnodes.size(), colnodes.data(), 0, aux_coup_dis_->get_comm());
 
-    aux_coup_dis_->redistribute(*newnoderowmap, *newnodecolmap,
-        {.assign_degrees_of_freedom = false,
-            .init_elements = false,
-            .do_boundary_conditions = false});
+    aux_coup_dis_->redistribute(
+        {*newnoderowmap, *newnodecolmap}, {.assign_degrees_of_freedom = false,
+                                              .init_elements = false,
+                                              .do_boundary_conditions = false});
 
     // make auxiliary discretization have the same dofs as the coupling discretization
     std::shared_ptr<Core::DOFSets::DofSet> newdofset =

--- a/src/xfem/4C_xfem_coupling_mesh.cpp
+++ b/src/xfem/4C_xfem_coupling_mesh.cpp
@@ -423,7 +423,7 @@ void XFEM::MeshVolCoupling::redistribute_embedded_discretization()
     cond_dis_->export_column_nodes(full_nodecolmap);
     cond_dis_->export_column_elements(full_elecolmap);
 
-    cond_dis_->fill_complete(true, true, true);
+    cond_dis_->fill_complete();
   }
 
   // STEP 3: reconnect all parentelement pointers in the cutter_dis_ faceelements
@@ -584,16 +584,14 @@ void XFEM::MeshVolCoupling::create_auxiliary_discretization()
         -1, colnodes.size(), colnodes.data(), 0, aux_coup_dis_->get_comm());
 
     aux_coup_dis_->redistribute(
-        {*newnoderowmap, *newnodecolmap}, {.assign_degrees_of_freedom = false,
-                                              .init_elements = false,
-                                              .do_boundary_conditions = false});
+        {*newnoderowmap, *newnodecolmap}, {.fill_complete = Core::FE::OptionsFillComplete::none()});
 
     // make auxiliary discretization have the same dofs as the coupling discretization
     std::shared_ptr<Core::DOFSets::DofSet> newdofset =
         std::make_shared<Core::DOFSets::TransparentIndependentDofSet>(cond_dis_, true);
     aux_coup_dis_->replace_dof_set(newdofset,
         false);  // do not call this with true (no replacement in static dofsets intended)
-    aux_coup_dis_->fill_complete(true, true, true);
+    aux_coup_dis_->fill_complete();
   }
 }
 

--- a/src/xfem/4C_xfem_discretization.cpp
+++ b/src/xfem/4C_xfem_discretization.cpp
@@ -37,7 +37,7 @@ int XFEM::DiscretizationXFEM::initial_fill_complete(const std::vector<int>& nds,
 {
   // Call from BaseClass
   int val = Core::FE::Discretization::fill_complete(
-      assigndegreesoffreedom, initelements, doboundaryconditions);
+      {assigndegreesoffreedom, initelements, doboundaryconditions});
 
   if (!assigndegreesoffreedom)
     FOUR_C_THROW(

--- a/src/xfem/4C_xfem_discretization_utils.cpp
+++ b/src/xfem/4C_xfem_discretization_utils.cpp
@@ -432,13 +432,7 @@ void XFEM::Utils::XFEMDiscretizationBuilder::redistribute(
 
   auto const& [roweles, coleles] = dis.build_element_row_column(*noderowmap, *nodecolmap);
 
-  dis.export_row_nodes(*noderowmap);
-  dis.export_row_elements(*roweles);
-
-  dis.export_column_nodes(*nodecolmap);
-  dis.export_column_elements(*coleles);
-
-  dis.fill_complete();
+  dis.redistribute({*noderowmap, *nodecolmap}, {*roweles, *coleles});
 }
 
 /*----------------------------------------------------------------------------*

--- a/src/xfem/4C_xfem_discretization_utils.cpp
+++ b/src/xfem/4C_xfem_discretization_utils.cpp
@@ -419,7 +419,7 @@ void XFEM::Utils::XFEMDiscretizationBuilder::redistribute(
 
   std::shared_ptr<Core::LinAlg::Map> nodecolmap =
       std::make_shared<Core::LinAlg::Map>(-1, nodecolvec.size(), nodecolvec.data(), 0, comm);
-  if (!dis.filled()) dis.redistribute(*noderowmap, *nodecolmap);
+  if (!dis.filled()) dis.redistribute({*noderowmap, *nodecolmap});
 
   Core::LinAlg::Map elerowmap(*dis.element_row_map());
   std::shared_ptr<const Core::LinAlg::Graph> nodegraph =

--- a/src/xfem/4C_xfem_multi_field_mapextractor.cpp
+++ b/src/xfem/4C_xfem_multi_field_mapextractor.cpp
@@ -587,7 +587,11 @@ void XFEM::MultiFieldMapExtractor::build_interface_coupling_dof_set()
   // set the new dof-set and finish the interface discretization
   idiscret_->replace_dof_set(0, icoupl_dofset_, true);
 
-  idiscret_->fill_complete(true, false, false);
+  idiscret_->fill_complete({
+      .assign_degrees_of_freedom = true,
+      .init_elements = false,
+      .do_boundary_conditions = false,
+  });
 }
 
 /*----------------------------------------------------------------------------*

--- a/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
+++ b/unittests/beam3/4C_beam3_euler_bernoulli_test.cpp
@@ -38,7 +38,7 @@ namespace
 
       // create 1 element discretization
       testdis_->add_element(testele_);
-      testdis_->fill_complete(false, false, false);
+      testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
       testele_->set_up_reference_geometry(xrefe_full);
     }

--- a/unittests/beam3/4C_beam3_kirchhoff_test.cpp
+++ b/unittests/beam3/4C_beam3_kirchhoff_test.cpp
@@ -36,7 +36,7 @@ namespace
 
       // create 1 element discretization
       testdis_->add_element(testele_);
-      testdis_->fill_complete(false, false, false);
+      testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
       // setup internal beam element parameters
       // different data layout is necessary to call this method

--- a/unittests/beam3/4C_beam3_reissner_test.cpp
+++ b/unittests/beam3/4C_beam3_reissner_test.cpp
@@ -58,7 +58,11 @@ namespace
 
       // create 1 element discretization
       testdis_->add_element(testele_);
-      testdis_->fill_complete(true, false, false);
+      testdis_->fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = false,
+          .do_boundary_conditions = false,
+      });
     }
 
    protected:

--- a/unittests/geometry_pair/4C_geometry_pair_line_to_surface_patch_geometry_test.hpp
+++ b/unittests/geometry_pair/4C_geometry_pair_line_to_surface_patch_geometry_test.hpp
@@ -109,7 +109,11 @@ namespace
         new_element->set_node_ids(n_nodes_volume, node_ids.data());
         discret.add_element(new_element);
       }
-      discret.fill_complete(true, true, false);
+      discret.fill_complete({
+          .assign_degrees_of_freedom = true,
+          .init_elements = true,
+          .do_boundary_conditions = false,
+      });
     }
 
     // Create the face elements.

--- a/unittests/io/4C_gridgenerator_test.cpp
+++ b/unittests/io/4C_gridgenerator_test.cpp
@@ -75,7 +75,7 @@ namespace
 
     Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*testdis_, inputData_, true);
 
-    testdis_->fill_complete(false, false, false);
+    testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     Core::Nodes::Node* lastNode = testdis_->l_row_node(testdis_->num_my_row_nodes() - 1);
     const auto nodePosition = lastNode->x();
@@ -98,7 +98,7 @@ namespace
 
     Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*testdis_, inputData_, true);
 
-    testdis_->fill_complete(false, false, false);
+    testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     Core::Nodes::Node* lastNode = testdis_->l_row_node(testdis_->num_my_row_nodes() - 1);
     const auto nodePosition = lastNode->x();
@@ -120,7 +120,7 @@ namespace
 
     Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*testdis_, inputData_, true);
 
-    testdis_->fill_complete(false, false, false);
+    testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     Core::Nodes::Node* lastNode = testdis_->l_row_node(testdis_->num_my_row_nodes() - 1);
     const auto nodePosition = lastNode->x();
@@ -143,7 +143,7 @@ namespace
 
     Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*testdis_, inputData_, true);
 
-    testdis_->fill_complete(false, false, false);
+    testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     Core::Nodes::Node* lastNode = testdis_->l_row_node(testdis_->num_my_row_nodes() - 1);
     const auto nodePosition = lastNode->x();

--- a/unittests/io/4C_gridgenerator_test.np3.cpp
+++ b/unittests/io/4C_gridgenerator_test.np3.cpp
@@ -76,7 +76,7 @@ namespace
 
     Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*testdis_, inputData_, true);
 
-    testdis_->fill_complete(false, false, false);
+    testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     Core::Nodes::Node* lastNode = testdis_->l_row_node(testdis_->num_my_row_nodes() - 1);
     const auto nodePosition = lastNode->x();
@@ -126,7 +126,7 @@ namespace
 
     Core::IO::GridGenerator::create_rectangular_cuboid_discretization(*testdis_, inputData_, true);
 
-    testdis_->fill_complete(false, false, false);
+    testdis_->fill_complete(Core::FE::OptionsFillComplete::none());
 
     Core::Nodes::Node* lastNode = testdis_->l_row_node(testdis_->num_my_row_nodes() - 1);
     const auto nodePosition = lastNode->x();


### PR DESCRIPTION
- Make the meaning of arguments more obvious at the call site by using option structs.
- Prefer to to use redistribute() instead of manual `export_xxx` calls.

Part of #1228 